### PR TITLE
Template activation: remove fake post type for registered templates

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -11,3 +11,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72141
 * https://github.com/WordPress/gutenberg/pull/72223
 * https://github.com/WordPress/gutenberg/pull/72285
+* https://github.com/WordPress/gutenberg/pull/72674

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
@@ -86,8 +86,8 @@ class Gutenberg_REST_Static_Templates_Controller extends WP_REST_Templates_Contr
 		$query_result = gutenberg_get_registered_block_templates( $query );
 		$templates    = array();
 		foreach ( $query_result as $template ) {
-			$item               = $this->prepare_item_for_response( $template, $request );
-			$templates[]        = $this->prepare_response_for_collection( $item );
+			$item        = $this->prepare_item_for_response( $template, $request );
+			$templates[] = $this->prepare_response_for_collection( $item );
 		}
 
 		return rest_ensure_response( $templates );

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
@@ -1,6 +1,11 @@
 <?php
 
 class Gutenberg_REST_Static_Templates_Controller extends WP_REST_Templates_Controller {
+	public function __construct() {
+		$this->rest_base = 'wp_registered_template';
+		$this->namespace = 'wp/v2';
+	}
+
 	public function register_routes() {
 		// Lists all templates.
 		register_rest_route(
@@ -82,7 +87,6 @@ class Gutenberg_REST_Static_Templates_Controller extends WP_REST_Templates_Contr
 		$templates    = array();
 		foreach ( $query_result as $template ) {
 			$item               = $this->prepare_item_for_response( $template, $request );
-			$item->data['type'] = 'wp_registered_template';
 			$templates[]        = $this->prepare_response_for_collection( $item );
 		}
 
@@ -97,8 +101,6 @@ class Gutenberg_REST_Static_Templates_Controller extends WP_REST_Templates_Contr
 		}
 
 		$item = $this->prepare_item_for_response( $template, $request );
-		// adjust the template type here instead
-		$item->data['type'] = 'wp_registered_template';
 		return rest_ensure_response( $item );
 	}
 }

--- a/lib/compat/wordpress-6.9/preload.php
+++ b/lib/compat/wordpress-6.9/preload.php
@@ -21,8 +21,6 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 				}
 			);
 		}
-
-		$paths[] = '/wp/v2/wp_registered_template?context=edit';
 	}
 
 	return $paths;

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -35,6 +35,9 @@ function gutenberg_maintain_templates_routes() {
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
 	$controller->register_routes();
 
+	$registered_template_controller = new Gutenberg_REST_Static_Templates_Controller();
+	$registered_template_controller->register_routes();
+
 	// Add the same field as wp_registered_template.
 	register_rest_field(
 		'wp_template',
@@ -79,12 +82,6 @@ add_action( 'init', 'gutenberg_setup_static_template' );
  * @global array $wp_post_types List of post types.
  */
 function gutenberg_setup_static_template() {
-	global $wp_post_types;
-	$wp_post_types['wp_registered_template']                        = clone $wp_post_types['wp_template'];
-	$wp_post_types['wp_registered_template']->name                  = 'wp_registered_template';
-	$wp_post_types['wp_registered_template']->rest_base             = 'wp_registered_template';
-	$wp_post_types['wp_registered_template']->rest_controller_class = 'Gutenberg_REST_Static_Templates_Controller';
-
 	register_setting(
 		'reading',
 		'active_templates',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -207,8 +207,6 @@ export const rootEntitiesConfig = [
 		name: 'registeredTemplate',
 		kind: 'root',
 		baseURL: '/wp/v2/wp_registered_template',
-		baseURLParams: { context: 'edit' },
-		plural: 'registeredTemplates',
 		key: 'id',
 	},
 ];

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -202,6 +202,15 @@ export const rootEntitiesConfig = [
 		plural: 'statuses',
 		key: 'slug',
 	},
+	{
+		label: __( 'Registered Templates' ),
+		name: 'registeredTemplate',
+		kind: 'root',
+		baseURL: '/wp/v2/wp_registered_template',
+		baseURLParams: { context: 'edit' },
+		plural: 'registeredTemplates',
+		key: 'id',
+	},
 ];
 
 export const deprecatedEntities = {

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -240,38 +240,13 @@ export const getTemplateId = createRegistrySelector(
 		// First see if the post/page has an assigned template and fetch it.
 		const currentTemplateSlug = editedEntity.template;
 		if ( currentTemplateSlug ) {
-			const userTemplates = select( STORE_NAME ).getEntityRecords(
-				'postType',
-				'wp_template',
-				{ per_page: -1 }
-			);
-			if ( ! userTemplates ) {
-				return;
-			}
-			const userTemplateWithSlug = userTemplates.find(
-				( { slug } ) => slug === currentTemplateSlug
-			);
-
-			if ( userTemplateWithSlug ) {
-				return userTemplateWithSlug.id;
-			}
-
-			const registeredTemplates = select( STORE_NAME ).getEntityRecords(
-				'postType',
-				'wp_registered_template',
-				{ per_page: -1 }
-			);
-
-			if ( ! registeredTemplates ) {
-				return;
-			}
-
-			const registeredTemplateWithSlug = registeredTemplates.find(
-				( { slug } ) => slug === currentTemplateSlug
-			);
-
-			if ( registeredTemplateWithSlug ) {
-				return registeredTemplateWithSlug.id;
+			const currentTemplate = select( STORE_NAME )
+				.getEntityRecords( 'postType', 'wp_template', {
+					per_page: -1,
+				} )
+				?.find( ( { slug } ) => slug === currentTemplateSlug );
+			if ( currentTemplate ) {
+				return currentTemplate.id;
 			}
 		}
 		// If no template is assigned, use the default template.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -329,7 +329,7 @@ export const getEntityRecords =
 			// the registered templates and rewrites IDs in the form of
 			// `theme-slug/template-slug`. When turned off, we only fetch
 			// database templates (posts). To fetch registered templates without
-			// edits applied, use the `wp_registered_template` entity.
+			// edits applied, use the `registeredTemplate` entity.
 			const { combinedTemplates = true } = query;
 
 			if (
@@ -899,10 +899,6 @@ export const getDefaultTemplateId =
 		// Endpoint may return an empty object if no template is found.
 		if ( id ) {
 			template.id = id;
-			template.type =
-				typeof id === 'string'
-					? 'wp_registered_template'
-					: 'wp_template';
 			registry.batch( () => {
 				dispatch.receiveDefaultTemplateId( query, id );
 				dispatch.receiveEntityRecords( 'postType', template.type, [

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -81,7 +81,6 @@ const DESIGN_POST_TYPES = [
 	'wp_template_part',
 	'wp_block',
 	'wp_navigation',
-	'wp_registered_template',
 ];
 
 function useEditorStyles( ...additionalStyles ) {

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -38,9 +38,8 @@ const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 function useAllDefaultTemplateTypes() {
 	const defaultTemplateTypes = useDefaultTemplateTypes();
 	const { records: staticRecords } = useEntityRecordsWithPermissions(
-		'postType',
-		'wp_registered_template',
-		{ per_page: -1 }
+		'root',
+		'registeredTemplate'
 	);
 	return [
 		...defaultTemplateTypes,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -93,9 +93,7 @@ export default function PageTemplates() {
 			combinedTemplates: false,
 		} );
 	const { records: staticRecords, isResolving: isLoadingStaticData } =
-		useEntityRecordsWithPermissions( 'postType', 'wp_registered_template', {
-			per_page: -1,
-		} );
+		useEntityRecordsWithPermissions( 'root', 'registeredTemplate' );
 
 	const activeTemplates = useMemo( () => {
 		const _active = [ ...staticRecords ].filter(
@@ -325,7 +323,7 @@ export default function PageTemplates() {
 				onChangeSelection={ onChangeSelection }
 				isItemClickable={ () => true }
 				onClickItem={ ( item ) => {
-					if ( item.type === 'wp_registered_template' ) {
+					if ( typeof item.id === 'string' ) {
 						setSelectedRegisteredTemplate( item );
 					} else {
 						history.navigate(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -38,13 +38,7 @@ export default function DataviewsTemplatesSidebarContent() {
 	const {
 		query: { activeView = 'active' },
 	} = useLocation();
-	const { records } = useEntityRecords(
-		'postType',
-		'wp_registered_template',
-		{
-			per_page: -1,
-		}
-	);
+	const { records } = useEntityRecords( 'root', 'registeredTemplate' );
 	const firstItemPerAuthorText = useMemo( () => {
 		const firstItemPerAuthor = records?.reduce( ( acc, template ) => {
 			const author = template.author_text;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -219,10 +219,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const defaultBlockContext = useMemo( () => {
 			const postContext = {};
 			// If it is a template, try to inherit the post type from the name.
-			if (
-				post.type === 'wp_template' ||
-				post.type === 'wp_registered_template'
-			) {
+			if ( post.type === 'wp_template' ) {
 				if ( post.slug === 'page' ) {
 					postContext.postType = 'page';
 				} else if ( post.slug === 'single' ) {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -734,7 +734,10 @@ export function updateEditorSettings( settings ) {
 export const setRenderingMode =
 	( mode ) =>
 	( { dispatch, registry, select } ) => {
-		if ( select.__unstableIsEditorReady() ) {
+		if (
+			select.__unstableIsEditorReady() &&
+			! select.getEditorSettings().isPreviewMode
+		) {
 			// We clear the block selection but we also need to clear the selection from the core store.
 			registry.dispatch( blockEditorStore ).clearSelectedBlock();
 			dispatch.editPost( { selection: undefined }, { undoIgnore: true } );

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -62,9 +62,7 @@ const duplicatePost: Action< BasePost > = {
 				return;
 			}
 
-			const isTemplate =
-				item.type === 'wp_template' ||
-				item.type === 'wp_registered_template';
+			const isTemplate = item.type === 'wp_template';
 
 			const newItemObject = {
 				status: isTemplate ? 'publish' : 'draft',
@@ -108,9 +106,7 @@ const duplicatePost: Action< BasePost > = {
 			try {
 				const newItem = await saveEntityRecord(
 					'postType',
-					item.type === 'wp_registered_template'
-						? 'wp_template'
-						: item.type,
+					item.type,
 					newItemObject,
 					{ throwOnError: true }
 				);
@@ -149,7 +145,7 @@ const duplicatePost: Action< BasePost > = {
 		return (
 			<form onSubmit={ createPage }>
 				<VStack spacing={ 3 }>
-					{ item.type === 'wp_registered_template' && (
+					{ typeof item.id === 'string' && (
 						<div>
 							{ __(
 								'You are about to duplicate a bundled template. Changes will not be live until you activate the new template.'

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,7 +46,6 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
-			'/wp/v2/templates/emptytheme//index?context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
 			// There are two separate settings OPTIONS requests. We should fix


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72578. Removes the `wp_registered_template` "post type". 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it doesn't exist, it was to work around getting an editor preview and having entities be automatically available in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead, we should create an entity manually. We get rid of any mention of the `wp_registered_template`.

There's a little fix we have to do in `setRenderingMode`: since these templates are not posts and not editable, we shouldn't call `editPost` because that will error (tries to get a post type entity). The fix is to check if the editor is in preview mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Everything should work as before and e2e tests should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
