### PR TITLE
Template activation: remove reset action

### DIFF
--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -23,11 +23,9 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { getItemTitle } from './utils';
-import type { CoreDataError, Template, TemplatePart } from '../types';
+import type { CoreDataError, TemplatePart } from '../types';
 
-const isTemplateRevertable = (
-	templateOrTemplatePart: Template | TemplatePart
-) => {
+const isTemplateRevertable = ( templateOrTemplatePart: TemplatePart ) => {
 	if ( ! templateOrTemplatePart ) {
 		return false;
 	}
@@ -48,7 +46,7 @@ const isTemplateRevertable = (
  *                                      reverting the template. Default true.
  */
 const revertTemplate = async (
-	template: TemplatePart | Template,
+	template: TemplatePart,
 	{ allowUndo = true } = {}
 ) => {
 	const noticeId = 'edit-site-template-reverted';
@@ -175,7 +173,7 @@ const revertTemplate = async (
 	}
 };
 
-const resetPostAction: Action< Template | TemplatePart > = {
+const resetPostAction: Action< TemplatePart > = {
 	id: 'reset-post',
 	label: __( 'Reset' ),
 	isEligible: ( item ) => {
@@ -225,26 +223,14 @@ const resetPostAction: Action< Template | TemplatePart > = {
 					}
 				);
 			} catch ( error ) {
-				let fallbackErrorMessage;
-				if ( items[ 0 ].type === 'wp_template' ) {
-					fallbackErrorMessage =
-						items.length === 1
-							? __(
-									'An error occurred while reverting the template.'
-							  )
-							: __(
-									'An error occurred while reverting the templates.'
-							  );
-				} else {
-					fallbackErrorMessage =
-						items.length === 1
-							? __(
-									'An error occurred while reverting the template part.'
-							  )
-							: __(
-									'An error occurred while reverting the template parts.'
-							  );
-				}
+				const fallbackErrorMessage =
+					items.length === 1
+						? __(
+								'An error occurred while reverting the template part.'
+						  )
+						: __(
+								'An error occurred while reverting the template parts.'
+						  );
 
 				const typedError = error as CoreDataError;
 				const errorMessage =

--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -22,7 +22,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { getItemTitle, isTemplateOrTemplatePart } from './utils';
+import { getItemTitle } from './utils';
 import type { CoreDataError, Template, TemplatePart } from '../types';
 
 const isTemplateRevertable = (
@@ -180,10 +180,9 @@ const resetPostAction: Action< Template | TemplatePart > = {
 	label: __( 'Reset' ),
 	isEligible: ( item ) => {
 		return (
-			isTemplateOrTemplatePart( item ) &&
+			item.type === 'wp_template_part' &&
 			item?.source === 'custom' &&
-			( Boolean( item.type === 'wp_template' && item?.plugin ) ||
-				item?.has_theme_file )
+			item?.has_theme_file
 		);
 	},
 	icon: backup,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See #71735. See https://github.com/WordPress/gutenberg/pull/67125#issuecomment-3302089424.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This action is no longer makes sense anymore, you can just deactivate or delete the template. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adjust eligibility.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It shouldn't appear, but should still appear for template parts.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
