### PR TITLE
Template activation: initialise old autosave and revisions endpoints

### DIFF
--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -30,9 +30,41 @@ function gutenberg_maintain_templates_routes() {
 	// This should later be changed in core so we don't need initialize
 	// WP_REST_Templates_Controller with a post type.
 	global $wp_post_types;
+	// Register the old templates endpoints. The WP_REST_Templates_Controller
+	// and sub-controllers used linked to the wp_template post type, but are no
+	// longer. They still require a post type object when contructing the class.
+	// To maintain backward and changes to these controller classes, we make use
+	// that the wp_template post type has the right information it needs.
 	$wp_post_types['wp_template']->rest_base = 'templates';
-	$controller                              = new Gutenberg_REST_Old_Templates_Controller( 'wp_template' );
+	// Store the classes so they can be restored.
+	$original_rest_controller_class           = $wp_post_types['wp_template']->rest_controller_class;
+	$original_autosave_rest_controller_class  = $wp_post_types['wp_template']->autosave_rest_controller_class;
+	$original_revisions_rest_controller_class = $wp_post_types['wp_template']->revisions_rest_controller_class;
+	// Temporarily set the old classes.
+	$wp_post_types['wp_template']->rest_controller_class           = 'WP_REST_Templates_Controller';
+	$wp_post_types['wp_template']->autosave_rest_controller_class  = 'WP_REST_Template_Autosaves_Controller';
+	$wp_post_types['wp_template']->revisions_rest_controller_class = 'WP_REST_Template_Revisions_Controller';
+	// Initialize the controllers. The order is important: the autosave
+	// controller needs both the templates and revisions controllers.
+	$controller                                    = new Gutenberg_REST_Old_Templates_Controller( 'wp_template' );
+	$wp_post_types['wp_template']->rest_controller = $controller;
+	$revisions_controller                          = new WP_REST_Template_Revisions_Controller( 'wp_template' );
+	$wp_post_types['wp_template']->revisions_rest_controller = $revisions_controller;
+	$autosaves_controller                                    = new WP_REST_Template_Autosaves_Controller( 'wp_template' );
+	// Unset the controller cache, it will be re-initialized when
+	// get_rest_controller is called.
+	$wp_post_types['wp_template']->rest_controller           = null;
+	$wp_post_types['wp_template']->revisions_rest_controller = null;
+	// Restore the original classes.
+	$wp_post_types['wp_template']->rest_controller_class           = $original_rest_controller_class;
+	$wp_post_types['wp_template']->autosave_rest_controller_class  = $original_autosave_rest_controller_class;
+	$wp_post_types['wp_template']->revisions_rest_controller_class = $original_revisions_rest_controller_class;
+	// Restore the original base.
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
+
+	// Register the old routes.
+	$autosaves_controller->register_routes();
+	$revisions_controller->register_routes();
 	$controller->register_routes();
 
 	// Add the same field as wp_registered_template.

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -31,10 +31,11 @@ function gutenberg_maintain_templates_routes() {
 	// WP_REST_Templates_Controller with a post type.
 	global $wp_post_types;
 	// Register the old templates endpoints. The WP_REST_Templates_Controller
-	// and sub-controllers used linked to the wp_template post type, but are no
-	// longer. They still require a post type object when contructing the class.
-	// To maintain backward and changes to these controller classes, we make use
-	// that the wp_template post type has the right information it needs.
+	// and sub-controllers used to be linked to the wp_template post type, but
+	// are no longer. They still require a post type object when contructing the
+	// class. To maintain backward and changes to these controller classes, we
+	// make use that the wp_template post type has the right information it
+	// needs.
 	$wp_post_types['wp_template']->rest_base = 'templates';
 	// Store the classes so they can be restored.
 	$original_rest_controller_class           = $wp_post_types['wp_template']->rest_controller_class;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Syncs back PHP changes in core from https://github.com/WordPress/wordpress-develop/pull/8063. See #71735.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The old autosave and revisions endpoints must be initialized for backwards compatibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Use the endpoints. There are unit tests for this in core.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
