### PR TITLE
Fix: Force LTR direction in Math block textarea for RTL languages

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -77,6 +77,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>
 							<TextareaControl
+								style={ { direction: 'ltr' } }
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'LaTeX math syntax' ) }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -77,7 +77,6 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>
 							<TextareaControl
-								style={ { direction: 'ltr' } }
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'LaTeX math syntax' ) }

--- a/packages/block-library/src/math/editor.scss
+++ b/packages/block-library/src/math/editor.scss
@@ -2,4 +2,6 @@
 
 .wp-block-math__textarea-control textarea {
 	font-family: $font-family-mono;
+	/*rtl:ignore*/
+	direction: ltr;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #72553

This PR forces the Math block's textarea to render with left-to-right (LTR) direction, even when the site language is RTL.

## Why?
Math formulas are universally written left-to-right. In RTL languages like Arabic or Hebrew, the default input direction causes confusion and makes formulas hard to read and write. This fix ensures consistent behavior for all users.

## How?
Added `style={{ direction: 'ltr' }}` to the `TextareaControl` component inside `packages/block-library/src/math/edit.js`.

## Testing Instructions
1. Set the site language to an RTL language (e.g., Arabic).
2. Create or edit a post/page.
3. Insert a Math block.
4. Type a formula like `x^2 + y^2`.
5. Confirm that the input flows left-to-right and is readable.

### Testing Instructions for Keyboard
- Use Tab to navigate to the Math block.
- Use arrow keys to move within the textarea.
- Confirm that keyboard navigation behaves consistently in LTR mode.

## Screenshots or screencast

|Before|After|
Before:
<img width="415" height="210" alt="image" src="https://github.com/user-attachments/assets/955c5bb0-2530-4e35-8b32-323281eb14b2" />

After: 
<img width="870" height="273" alt="image" src="https://github.com/user-attachments/assets/b652ea2f-8d09-4a6e-ae9c-0d87d3124462" />


