### PR TITLE
fix: add exports field to create-block-interactive-template

### DIFF
--- a/packages/create-block-interactive-template/package.json
+++ b/packages/create-block-interactive-template/package.json
@@ -24,6 +24,7 @@
 		"npm": ">=8.19.2"
 	},
 	"exports": {
+		".": "./index.js",
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {


### PR DESCRIPTION
What?
Closes #72639

Fixes the broken @wordpress/create-block-interactive-template by adding a missing "exports" field to its package.json. This resolves the error thrown when using the template with create-block.

Why?
Currently, when using the interactive template with npx @wordpress/create-block, the CLI fails with the error:
<img width="1330" height="128" alt="image" src="https://github.com/user-attachments/assets/f90bcd6c-3138-4937-b300-f8bbd273144c" />

Code
Invalid plugin template downloaded. Error: No "exports" main defined...
This happens because the published package lacks an "exports" field, which is required for Node.js to resolve the entry point correctly. Adding this field restores compatibility with the CLI and allows the template to be used as intended.

How?
Added the following to packages/create-block-interactive-template/package.json:
```
json
"exports": {
  ".": "./index.js"
}
```
This ensures the template can be resolved properly when downloaded and used by create-block.

Testing Instructions
Rebuild Gutenberg to apply the fix:
```bash
pnpm build
```
Navigate to the Gutenberg repo root:
```
bash
cd path/to/gutenberg
```
Run the create-block CLI directly using Node:
```
bash
node ./packages/create-block/lib/index.js my-block --template @wordpress/create-block-interactive-template
```
Confirm that:
- The block scaffolds successfully
- No error about "exports" appears
- The plugin folder my-block is created with expected files
<img width="1408" height="794" alt="block" src="https://github.com/user-attachments/assets/59b3de29-d4c0-4ad1-a860-61bff2b39eb7" />

Testing Instructions for Keyboard
Not applicable — this PR does not affect UI or accessibility.