### PR TITLE
Block Editor: Add Enter key navigation from Accordion Heading to Panel

### DIFF
--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -9,7 +9,8 @@
 	"usesContext": [
 		"core/accordion-icon-position",
 		"core/accordion-show-icon",
-		"core/accordion-heading-level"
+		"core/accordion-heading-level",
+		"clientId"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -9,8 +9,7 @@
 	"usesContext": [
 		"core/accordion-icon-position",
 		"core/accordion-show-icon",
-		"core/accordion-heading-level",
-		"clientId"
+		"core/accordion-heading-level"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -9,9 +9,18 @@ import {
 	RichText,
 	getTypographyClassesAndStyles as useTypographyProps,
 	useSettings,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { ENTER } from '@wordpress/keycodes';
 
-export default function Edit( { attributes, setAttributes, context } ) {
+export default function Edit( {
+	attributes,
+	setAttributes,
+	context,
+	clientId,
+} ) {
 	const { title } = attributes;
 	const {
 		'core/accordion-icon-position': iconPosition,
@@ -46,6 +55,63 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
+	const { selectBlock, insertBlock } = useDispatch( blockEditorStore );
+
+	const { panelClientId, firstPanelBlockClientId } = useSelect(
+		( select ) => {
+			const { getBlock, getBlockParents, getBlocks } =
+				select( blockEditorStore );
+
+			const parents = getBlockParents( clientId );
+			const accordionItemId = parents.find( ( parentId ) => {
+				const block = getBlock( parentId );
+				return block?.name === 'core/accordion-item';
+			} );
+
+			if ( ! accordionItemId ) {
+				return {
+					panelClientId: null,
+					firstPanelBlockClientId: null,
+				};
+			}
+
+			const accordionItem = getBlock( accordionItemId );
+			const panelBlock = accordionItem?.innerBlocks?.find(
+				( block ) => block.name === 'core/accordion-panel'
+			);
+
+			if ( ! panelBlock ) {
+				return {
+					panelClientId: null,
+					firstPanelBlockClientId: null,
+				};
+			}
+
+			const panelBlocks = getBlocks( panelBlock.clientId );
+			const firstBlock = panelBlocks?.[ 0 ];
+
+			return {
+				panelClientId: panelBlock.clientId,
+				firstPanelBlockClientId: firstBlock?.clientId,
+			};
+		},
+		[ clientId ]
+	);
+
+	const handleKeyDown = ( event ) => {
+		if ( event.keyCode === ENTER && ! event.shiftKey ) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			if ( firstPanelBlockClientId ) {
+				selectBlock( firstPanelBlockClientId );
+			} else if ( panelClientId ) {
+				const newParagraphBlock = createBlock( 'core/paragraph' );
+				insertBlock( newParagraphBlock, 0, panelClientId, true );
+			}
+		}
+	};
+
 	return (
 		<TagName { ...blockProps }>
 			<button
@@ -69,6 +135,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 					onChange={ ( newTitle ) =>
 						setAttributes( { title: newTitle } )
 					}
+					onKeyDown={ handleKeyDown }
 					placeholder={ __( 'Accordion title' ) }
 					className="wp-block-accordion-heading__toggle-title"
 					style={ {


### PR DESCRIPTION
<html><head></head><body><h2>What?</h2>
<p>Closes #72576</p>
<p>Adds Enter key navigation from Accordion Heading to Accordion Panel content, enabling a seamless keyboard editing workflow similar to Post Title → first paragraph navigation.</p>
<h2>Why?</h2>
<p>Currently, when editing an Accordion block, users must perform multiple keyboard interactions (Tab, arrow keys, or mouse clicks) to navigate from the Accordion Heading to the Panel content. This creates friction in the editing workflow and is inconsistent with other block navigation patterns in the editor.</p>
<p>This enhancement improves:</p>
<ul>
<li><strong>Keyboard-only editing workflow</strong> - Reduces steps needed to create accordion content</li>
<li><strong>Accessibility</strong> - Makes accordion editing more efficient for keyboard users and screen reader users</li>
<li><strong>Consistency</strong> - Aligns with existing Post Title navigation pattern</li>
<li><strong>User experience</strong> - Faster content creation for FAQs, documentation, and collapsible sections</li>
</ul>
<h2>How?</h2>
<p>The implementation adds keyboard navigation logic to the Accordion Heading block:</p>
<ol>
<li><strong>Added <code>clientId</code> to <code>usesContext</code></strong> in <code>block.json</code> to enable block hierarchy traversal</li>
<li><strong>Implemented <code>onKeyDown</code> handler</strong> that detects Enter key press (excluding Shift+Enter)</li>
<li><strong>Used <code>useSelect</code> hook</strong> to find the parent <code>accordion-item</code> and child <code>accordion-panel</code> blocks</li>
<li><strong>Navigation logic</strong>:
<ul>
<li>If Panel contains blocks → focus the first block</li>
<li>If Panel is empty → insert a new Paragraph block and focus it</li>
</ul>
</li>
<li><strong>Imported necessary dependencies</strong>:
<ul>
<li><code>useSelect</code>, <code>useDispatch</code> from <code>@wordpress/data</code></li>
<li><code>createBlock</code> from <code>@wordpress/blocks</code></li>
<li><code>ENTER</code> from <code>@wordpress/keycodes</code></li>
</ul>
</li>
</ol>
<h2>Testing Instructions</h2>
<ol>
<li>Open a post or page in the editor</li>
<li>Insert an <strong>Accordion</strong> block (<code>/accordion</code>)</li>
<li>Click on the <strong>Accordion Heading</strong> to edit it</li>
<li>Type some text (e.g., "What is WordPress?")</li>
<li>Press <strong>Enter</strong></li>
<li>✅ <strong>Expected</strong>: Cursor should automatically move to the Accordion Panel content area</li>
<li>Start typing - you should be editing inside the panel</li>
<li>Click back on the heading, press <strong>Enter</strong> again</li>
<li>✅ <strong>Expected</strong>: Focus should move to the first block in the panel</li>
</ol>
<h3>Test with Empty Panel</h3>
<ol>
<li>Insert a new Accordion block</li>
<li>Click on the heading and type text</li>
<li>Press <strong>Enter</strong></li>
<li>✅ <strong>Expected</strong>: A new paragraph block should be created in the panel and focused automatically</li>
</ol>
<h3>Test with Multiple Blocks in Panel</h3>
<ol>
<li>Create an accordion with multiple blocks in the panel (paragraph, list, image, etc.)</li>
<li>Click on the heading and press <strong>Enter</strong></li>
<li>✅ <strong>Expected</strong>: First block in the panel should be focused (not the second or third)</li>
</ol>
<h3>Testing Instructions for Keyboard</h3>
<p>This feature is specifically designed for keyboard navigation. Test the complete workflow using only keyboard:</p>
<ol>
<li>Use <strong>Tab</strong> to navigate to the Accordion block</li>
<li>Press <strong>Enter</strong> or <strong>Space</strong> to select it</li>
<li>Type text in the heading (should focus automatically)</li>
<li>Press <strong>Enter</strong> key</li>
<li>✅ <strong>Expected</strong>: Focus moves to panel without using Tab or mouse</li>
<li>Type content in the panel</li>
<li>Press <strong>Escape</strong> to deselect</li>
<li>Use <strong>arrow keys</strong> to navigate back to heading</li>
<li>Press <strong>Enter</strong> again</li>
<li>✅ <strong>Expected</strong>: Focus returns to the first panel block</li>
</ol>
<h3>Additional Keyboard Tests</h3>
<ul>
<li><strong>Shift+Enter</strong> in heading → Should do nothing (line breaks are disabled)</li>
<li><strong>Tab</strong> from heading → Should follow normal tab order (not affected by this PR)</li>
<li><strong>Nested accordions</strong> → Enter should navigate to the correct panel (the one directly associated with the heading)</li>
</ul>
<h2>Screenshots or screencast</h2>

https://github.com/user-attachments/assets/1ee15a45-c703-4c45-b060-184cc5d4ea6d



<h3>Workflow Demonstration</h3>
<p><strong>Before:</strong>
User must manually Tab multiple times or use mouse to navigate from heading to panel content.</p>
<p><strong>After:</strong>
User simply presses Enter to navigate from heading to panel, creating a fluid editing experience.</p>

Before | After
-- | --
Multiple keyboard interactions required:<br>1. Type in heading<br>2. Press Tab (multiple times)<br>3. Navigate to panel<br>4. Start typing | Single keyboard interaction:<br>1. Type in heading<br>2. Press Enter<br>3. Immediately start typing in panel




<hr>
<h3>Technical Notes</h3>
<ul>
<li>Uses <code>onKeyDown</code> handler instead of <code>onSplit</code> because <code>disableLineBreaks</code> on the RichText component prevents split events</li>
<li>Maintains all existing accordion functionality and styling</li>
<li>No breaking changes - purely additive enhancement</li>
<li>Follows existing Gutenberg navigation patterns (similar to Post Title implementation)</li>
<li>Minimal performance impact - <code>useSelect</code> is properly memoized</li>
</ul>
<h3>Accessibility Improvements</h3>
<p>✅ Keyboard-only users can now edit accordions more efficiently<br>
✅ Reduces cognitive load by providing predictable navigation<br>
✅ Screen readers naturally announce focus changes<br>
✅ No new accessibility barriers introduced<br>
✅ Maintains proper focus management throughout</p>
<hr>
<p><strong>Related:</strong> This enhancement was discussed in issue #72576 and aligns with the goal of improving keyboard navigation consistency across all Gutenberg blocks.</p></body></html>