### PR TITLE
Packages: Do not limit the exports of the template packages

### DIFF
--- a/packages/create-block-interactive-template/package.json
+++ b/packages/create-block-interactive-template/package.json
@@ -23,9 +23,6 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
-	"exports": {
-		"./package.json": "./package.json"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/create-block-tutorial-template/package.json
+++ b/packages/create-block-tutorial-template/package.json
@@ -23,9 +23,6 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
-	"exports": {
-		"./package.json": "./package.json"
-	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
Closes #72639

Just a small PR to remove the "exports" from the template packages.
The exports field is more important for "built" packages. For this one it's fine to allow importing everything. Now It's probably possible to just export "index.js" as well but I'm not entirely sure how these packages are used, so this is also fine.

I'm not entirely sure how to test this without publishing the package, maybe `npm link` can work.