### PR TITLE
Add documentation and schema for contentRole block support

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -608,6 +608,22 @@ When the block declares support for `color.text`, the attributes definition is e
     }
     ```
 
+### contentRole
+
+_**Note:** Since WordPress 6.9._
+
+-   Type: `boolean`
+-   Default value: `false`
+
+This value signals that a block contains user-editable content. When set to true, the block is considered a content block. Content blocks remain editable even when their parent container has content-only locking applied.
+
+```js
+supports: {
+	// Declare support for content role.
+	contentRole: true
+}
+```
+
 ## customClassName
 
 -   Type: `boolean`

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -650,6 +650,11 @@
 					"description": "This property indicates whether the block can split when the Enter key is pressed or when blocks are pasted.",
 					"type": "boolean",
 					"default": false
+				},
+				"contentRole": {
+					"description": "This value signals that a block contains user-editable content. When set to true, the block is considered a content block. Content blocks remain editable even when their parent container has content-only locking applied.",
+					"type": "boolean",
+					"default": false
 				}
 			},
 			"additionalProperties": true


### PR DESCRIPTION
## What? Why?

The `contentRole` support, newly added in version 6.9, has been [added to many core blocks](https://github.com/search?q=repo%3AWordPress%2Fgutenberg%20%22%5C%22contentRole%5C%22%3A%20true%22&type=code). This block support is working very well and can essentially be considered a stable API. Let's document this API.

## How? 

Welcome your feedback on how we can provide a better explanation!

## Testing Instructions

Nothing.