### PR TITLE
Template activation: rename new endpoints

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -11,4 +11,5 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72141
 * https://github.com/WordPress/gutenberg/pull/72223
 * https://github.com/WordPress/gutenberg/pull/72285
+* https://github.com/WordPress/gutenberg/pull/72700
 * https://github.com/WordPress/gutenberg/pull/72674

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php
@@ -2,7 +2,7 @@
 
 class Gutenberg_REST_Static_Templates_Controller extends WP_REST_Templates_Controller {
 	public function __construct() {
-		$this->rest_base = 'wp_registered_template';
+		$this->rest_base = 'registered-templates';
 		$this->namespace = 'wp/v2';
 	}
 

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/class-gutenberg-rest-old-templates-controller.php';
 add_filter( 'register_post_type_args', 'gutenberg_modify_wp_template_post_type_args', 10, 2 );
 function gutenberg_modify_wp_template_post_type_args( $args, $post_type ) {
 	if ( 'wp_template' === $post_type ) {
-		$args['rest_base']                       = 'wp_template';
+		$args['rest_base']                       = 'created-templates';
 		$args['rest_controller_class']           = 'WP_REST_Posts_Controller';
 		$args['autosave_rest_controller_class']  = null;
 		$args['revisions_rest_controller_class'] = null;
@@ -61,7 +61,7 @@ function gutenberg_maintain_templates_routes() {
 	$wp_post_types['wp_template']->autosave_rest_controller_class  = $original_autosave_rest_controller_class;
 	$wp_post_types['wp_template']->revisions_rest_controller_class = $original_revisions_rest_controller_class;
 	// Restore the original base.
-	$wp_post_types['wp_template']->rest_base = 'wp_template';
+	$wp_post_types['wp_template']->rest_base = 'created-templates';
 
 	// Register the old routes.
 	$autosaves_controller->register_routes();

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -21,7 +21,8 @@ function gutenberg_modify_wp_template_post_type_args( $args, $post_type ) {
 //    need to deprecate /templates eventually, but we'll still want to be able
 //    to lookup the active template for a specific slug, and probably get a list
 //    of all _active_ templates. For that we can keep /lookup.
-add_action( 'rest_api_init', 'gutenberg_maintain_templates_routes' );
+// Priority 100, after `create_initial_rest_routes`.
+add_action( 'rest_api_init', 'gutenberg_maintain_templates_routes', 100 );
 
 /**
  * @global array $wp_post_types List of post types.

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -206,7 +206,7 @@ export const rootEntitiesConfig = [
 		label: __( 'Registered Templates' ),
 		name: 'registeredTemplate',
 		kind: 'root',
-		baseURL: '/wp/v2/wp_registered_template',
+		baseURL: '/wp/v2/registered-templates',
 		key: 'id',
 	},
 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #72581.

```
/wp_template => /created-templates
/wp_registered_template => /registered-templates
```

<!-- In a few words, what is the PR actually doing? -->

## Why?

More descriptive endpoint names and use existing patterns (- vs _, using plural).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just a rename.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Things should work as before, e2e tests should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
