### PR TITLE
Global Styles: Fix the save panel changes

### DIFF
--- a/docs/private-apis.md
+++ b/docs/private-apis.md
@@ -81,7 +81,6 @@ Private exports:
 - `areGlobalStyleConfigsEqual`
 - `getBlockCSSSelector`
 - `getBlockSelectors`
-- `getGlobalStylesChanges`
 - `getLayoutStyles`
 - `toStyles`
 - `useGlobalSetting`

--- a/package-lock.json
+++ b/package-lock.json
@@ -53177,7 +53177,8 @@
 				"@wordpress/style-engine": "file:../style-engine",
 				"colord": "^2.9.2",
 				"deepmerge": "^4.3.0",
-				"is-plain-object": "^5.0.0"
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -25,4 +25,3 @@ export {
 	useHasBackgroundPanel,
 } from './background-panel';
 export { areGlobalStyleConfigsEqual } from './utils';
-export { default as getGlobalStylesChanges } from './get-global-styles-changes';

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -5,18 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { useContext } from '@wordpress/element';
+import { getGlobalStylesChanges } from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
  */
 import EntityRecordItem from './entity-record-item';
-import { unlock } from '../../lock-unlock';
-
-const { getGlobalStylesChanges, GlobalStylesContext } = unlock(
-	blockEditorPrivateApis
-);
 
 function getEntityDescription( entity, count ) {
 	switch ( entity ) {
@@ -35,20 +29,28 @@ function getEntityDescription( entity, count ) {
 }
 
 function GlobalStylesDescription( { record } ) {
-	const { user: currentEditorGlobalStyles } =
-		useContext( GlobalStylesContext );
-	const savedRecord = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecord(
-				record.kind,
-				record.name,
-				record.key
-			),
+	const { editedRecord, savedRecord } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord, getEntityRecord } =
+				select( coreStore );
+			return {
+				editedRecord: getEditedEntityRecord(
+					record.kind,
+					record.name,
+					record.key
+				),
+				savedRecord: getEntityRecord(
+					record.kind,
+					record.name,
+					record.key
+				),
+			};
+		},
 		[ record.kind, record.name, record.key ]
 	);
 
 	const globalStylesChanges = getGlobalStylesChanges(
-		currentEditorGlobalStyles,
+		editedRecord,
 		savedRecord,
 		{
 			maxResults: 10,

--- a/packages/global-styles-engine/package.json
+++ b/packages/global-styles-engine/package.json
@@ -41,7 +41,8 @@
 		"@wordpress/style-engine": "file:../style-engine",
 		"colord": "^2.9.2",
 		"deepmerge": "^4.3.0",
-		"is-plain-object": "^5.0.0"
+		"is-plain-object": "^5.0.0",
+		"memize": "^2.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/global-styles-engine/src/index.ts
+++ b/packages/global-styles-engine/src/index.ts
@@ -5,8 +5,9 @@ export { getStyle } from './settings/get-style';
 export { setStyle } from './settings/set-style';
 export { default as getPalettes } from './settings/get-palette';
 
-// Merge utility
+// Utilities.
 export { mergeGlobalStyles } from './core/merge';
+export { default as getGlobalStylesChanges } from './utils/get-global-styles-changes';
 
 // Core rendering
 export { generateGlobalStyles } from './core/render';

--- a/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
+++ b/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
@@ -3,7 +3,7 @@
  */
 import getGlobalStylesChanges, {
 	getGlobalStylesChangelist,
-} from '../get-global-styles-changes';
+} from '../utils/get-global-styles-changes';
 
 /**
  * WordPress dependencies

--- a/packages/global-styles-ui/src/screen-revisions/revisions-buttons.tsx
+++ b/packages/global-styles-ui/src/screen-revisions/revisions-buttons.tsx
@@ -6,18 +6,15 @@ import { Button, Composite } from '@wordpress/components';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-// @ts-expect-error: Not typed yet.
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { getGlobalStylesChanges } from '@wordpress/global-styles-engine';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
 import type { Revision } from './types';
 
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
-const { getGlobalStylesChanges } = unlock( blockEditorPrivateApis );
 
 interface ChangesSummaryProps {
 	revision: Revision;


### PR DESCRIPTION
## What?

#72464 Broke the save panel of Global Styles. It was not comparing the right changes together. It was using an outdated context.

This PR fixes that.

## Testing Instructions

- Open the global styles panel
- Modify paragraph block
- The save panel renders the right changes
- Try again with another block.