### PR TITLE
Accordion: Dont' show Add button in contentOnly mode

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -102,22 +102,22 @@ export default function Edit( {
 	return (
 		<>
 			{ isSingleSelected && ! isContentOnlyMode && (
-				<BlockControls>
-					<ToolbarGroup>
-						<HeadingLevelDropdown
-							value={ headingLevel }
-							options={ levelOptions }
-							onChange={ updateHeadingLevel }
-						/>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-			{ isSingleSelected && (
-				<BlockControls group="other">
-					<ToolbarButton onClick={ addAccordionItemBlock }>
-						{ __( 'Add' ) }
-					</ToolbarButton>
-				</BlockControls>
+				<>
+					<BlockControls>
+						<ToolbarGroup>
+							<HeadingLevelDropdown
+								value={ headingLevel }
+								options={ levelOptions }
+								onChange={ updateHeadingLevel }
+							/>
+						</ToolbarGroup>
+					</BlockControls>
+					<BlockControls group="other">
+						<ToolbarButton onClick={ addAccordionItemBlock }>
+							{ __( 'Add' ) }
+						</ToolbarButton>
+					</BlockControls>
+				</>
 			) }
 			<InspectorControls key="setting">
 				<ToolsPanel


### PR DESCRIPTION
- Related to #72052
- Discovered a problem during testing here: https://github.com/WordPress/gutenberg/pull/72695#issuecomment-3450963652

## What?

As I understand it, in the 6.9 release, blocks with a `contentRole` support can no longer add new items in contentOnly mode.
Accordingly, I'd like to hide the Add button when in contentOnly mode.

## Why?

Because nothing happens when the button is pressed.

## Testing Instructions

Insert blocks using the following HTML:

```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group">
	<!-- wp:accordion -->
	<div role="group" class="wp-block-accordion">
		<!-- wp:accordion-item -->
		<div class="wp-block-accordion-item">
			<!-- wp:accordion-heading -->
			<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
			<!-- /wp:accordion-heading -->

			<!-- wp:accordion-panel {"isSelected":true} -->
			<div role="region" class="wp-block-accordion-panel">
				<!-- wp:paragraph -->
				<p>Accordion Content</p>
				<!-- /wp:paragraph -->
			</div>
			<!-- /wp:accordion-panel -->
		</div>
		<!-- /wp:accordion-item -->
	</div>
	<!-- /wp:accordion -->
</div>
<!-- /wp:group -->
```

- Select the Accordion block.
- Confirm that the Add toolbar button isn't displayed.


## Screenshots or screencast <!-- if applicable -->

<img width="1113" height="568" alt="accordion" src="https://github.com/user-attachments/assets/5eaa35ac-866f-445b-a7c9-80cda7b7d161" />
