### PR TITLE
FIX PHPUnit failure in previous WordPress version

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -188,7 +188,7 @@ jobs:
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
-                    # On PRs: Only test PHP 8.3, single-site
+                    # On PRs: Only test PHP 8.3, single-site, latest WP
                     - event: 'pull_request'
                       php: '7.2'
                     - event: 'pull_request'
@@ -203,6 +203,8 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '7.3'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -188,7 +188,7 @@ jobs:
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
-                    # On PRs: Only test PHP 8.3, single-site, latest WP
+                    # On PRs: Only test PHP 8.3, single-site
                     - event: 'pull_request'
                       php: '7.2'
                     - event: 'pull_request'
@@ -203,8 +203,6 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '7.3'
                       wordpress: 'previous major version'

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Test `gutenberg_override_script`.
+ *
+ * @package gutenberg
+ */
+
+class Override_Script_Test extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		wp_register_script(
+			'gutenberg-dummy-script',
+			'https://example.com/original',
+			array( 'original-dependency' ),
+			'original-version',
+			false
+		);
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		wp_deregister_script( 'gutenberg-dummy-script' );
+	}
+
+	/**
+	 * Tests that script is localized.
+	 */
+	public function test_localizes_script() {
+		global $wp_scripts;
+
+		gutenberg_override_script(
+			$wp_scripts,
+			'gutenberg-dummy-script',
+			'https://example.com/',
+			array( 'dependency' ),
+			'version',
+			false
+		);
+
+		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
+	}
+
+	/**
+	 * Tests that script properties are overridden.
+	 */
+	public function test_replaces_registered_properties() {
+		global $wp_scripts;
+
+		gutenberg_override_script(
+			$wp_scripts,
+			'gutenberg-dummy-script',
+			'https://example.com/updated',
+			array( 'updated-dependency' ),
+			'updated-version',
+			true
+		);
+
+		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
+		$this->assertEquals( 'https://example.com/updated', $script->src );
+		$this->assertEquals( array( 'updated-dependency' ), $script->deps );
+		$this->assertEquals( 'updated-version', $script->ver );
+		$this->assertSame( 1, $script->args );
+	}
+
+	/**
+	 * Tests that new script registers normally if no handle by the name.
+	 */
+	public function test_registers_new_script() {
+		global $wp_scripts;
+
+		gutenberg_override_script(
+			$wp_scripts,
+			'gutenberg-second-dummy-script',
+			'https://example.com/',
+			array( 'dependency' ),
+			'version',
+			true
+		);
+
+		$script = $wp_scripts->query( 'gutenberg-second-dummy-script', 'registered' );
+		$this->assertEquals( 'https://example.com/', $script->src );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
+		$this->assertEquals( 'version', $script->ver );
+		$this->assertSame( 1, $script->args );
+	}
+}


### PR DESCRIPTION
See: https://wordpress.slack.com/archives/C02QB2JS7/p1761569221602209

## What?

It appears that the PHP unit tests are failing on the trunk branch in previous WordPress versions.

Reverting one of the unit tests seems to have solved the problem. See: https://github.com/WordPress/gutenberg/pull/72705#discussion_r2465911251

## Testing Instructions

All CIs should be ✅.