### PR TITLE
Notes: always open histroy sidebar if note is resolved

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -128,8 +128,9 @@ function NotesSidebar( { postId, mode } ) {
 		const prevArea = await getActiveComplementaryArea( 'core' );
 		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
 
-		// If the notes sidebar is not already active, enable the floating sidebar.
-		if ( ! activeNotesArea ) {
+		if ( currentThread?.status === 'approved' ) {
+			enableComplementaryArea( 'core', collabHistorySidebarName );
+		} else if ( ! activeNotesArea ) {
 			enableComplementaryArea(
 				'core',
 				showFloatingSidebar


### PR DESCRIPTION
Fixes #72697

## What?

If the note is resolved, clicking the "View notes" button does nothing. In this case, the archive sidebar should be opened.

## Testing Instructions

- Insert blocks and notes on them.
- Resolve some of the notes.
- Click the "View notes " toolbar button.
- Verify that the appropriate sidebar opens depending on the resolution status.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/7f91509b-90d6-4fbc-b0bb-ac22cc749417


