### PR TITLE
Breadcrumbs: Fix date archives with `plain` permalinks

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -184,13 +184,9 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		if ( ! $year ) {
 			$m = get_query_var( 'm' );
 			if ( $m ) {
-				$year = substr( $m, 0, 4 );
-				if ( strlen( $m ) >= 6 ) {
-					$month = (int) substr( $m, 4, 2 );
-				}
-				if ( strlen( $m ) >= 8 ) {
-					$day = (int) substr( $m, 6, 2 );
-				}
+				$year  = substr( $m, 0, 4 );
+				$month = substr( $m, 4, 2 );
+				$day   = (int) substr( $m, 6, 2 );
 			}
 		}
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -179,6 +179,21 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		$month = get_query_var( 'monthnum' );
 		$day   = get_query_var( 'day' );
 
+		// Fallback to 'm' query var for plain permalinks.
+		// Plain permalinks use ?m=YYYYMMDD format instead of separate query vars.
+		if ( ! $year ) {
+			$m = get_query_var( 'm' );
+			if ( $m ) {
+				$year = substr( $m, 0, 4 );
+				if ( strlen( $m ) >= 6 ) {
+					$month = (int) substr( $m, 4, 2 );
+				}
+				if ( strlen( $m ) >= 8 ) {
+					$day = (int) substr( $m, 6, 2 );
+				}
+			}
+		}
+
 		if ( $year ) {
 			if ( $month ) {
 				// Year is linked if we have month.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I observed that with `plain` permalinks the date-archives breadcrumbs didn't work. This is because plain permalinks use `?m=YYYYMMDD` format instead of separate query vars. This PR fixes that by also checking `m` similarly with [single_month_title](https://developer.wordpress.org/reference/functions/single_month_title/) in core.

## Testing Instructions
1. Test breadcrumbs in date archive pages with both pretty and plain permalinks
2. Observe that they work as expected.
