### PR TITLE
Notes: Fix strange default sidebar animation

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -179,7 +179,7 @@ function NotesSidebar( { postId, mode } ) {
 					commentLastUpdated={ commentLastUpdated }
 				/>
 			</PluginSidebar>
-			{ showFloatingSidebar && (
+			{ isLargeViewport && (
 				<PluginSidebar
 					isPinnable={ false }
 					header={ false }


### PR DESCRIPTION
## What?
Closes #72686

PR fixes the strange animation of the default sidebar when "Show Template" mode is engaged.

Unmounting the floating notes sidebar was triggering the animation; this could be a more general issue with the complementary area animation. The list view has a similar issue #69240.

## Testing Instructions
1. Open a post or page.
2. Enable  "Show Template" mode.
3. Reload the browser window.
4. Reload your browser.
5. Confirm that the initial rendering of the sidebar isn't animated.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/2f0a2dc8-0593-460f-a868-6cee389e5e48

