### PR TITLE
Block Bindings: Hide Attributes panel for Date, Nav Link, and Nav Submenu blocks

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -526,7 +526,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
-	hasSupport() {
-		return true;
+	hasSupport( name ) {
+		return ! [
+			'core/post-date',
+			'core/navigation-link',
+			'core/navigation-submenu',
+		].includes( name );
 	},
 };

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -60,7 +60,7 @@ test.describe( 'Post Data source', () => {
 			// Check the fields registered by other sources are there.
 		} );
 
-		test( 'should include post data fields in UI to connect attributes on date blocks', async ( {
+		test( 'should not render Attributes panel for date blocks', async ( {
 			editor,
 			page,
 		} ) => {
@@ -77,15 +77,9 @@ test.describe( 'Post Data source', () => {
 					},
 				},
 			} );
-			await page
-				.getByRole( 'button', {
-					name: 'datetime',
-				} )
-				.click();
-			const postDataMenuItem = page.getByRole( 'menuitem', {
-				name: 'Post Data',
-			} );
-			await expect( postDataMenuItem ).toBeVisible();
+			await expect(
+				page.getByLabel( 'Attributes options' )
+			).toBeHidden();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Do not render the "Attributes" panel in the block inspector for the Date, Navigation Link, and Navigation Submenu blocks.

## Why?

This is a workaround to prevent those blocks' attributes to be bound to incompatible sources. For example, binding the Date block' `datetime` attribute to any value provided by a block bindings source that's not a date/time will break that block. The same applies to the Navigation Link and Navigation Submenu blocks' `url` attribute -- it should only be bound to URLs. (Block bindings support for those blocks was only added during the 6.9 cycle, so the Attributes panel wasn't shown for them in 6.8.)

In the long term, the fix should probably involve a `format` field in a block's `attributes` definition in `block.json` ([see](https://github.com/WordPress/gutenberg/issues/72446#issuecomment-3451124708)). Barring that, this workaround will at least prevent blocks being broken by being bound badly.

## How?
By using the Attributes panel's `hasSupport` predicate and filtering by block name.

## Testing Instructions
- In the editor, insert a Date block, as well as its Post Date and Modified Date variations. Verify that the Attributes panel isn't shown in the block inspector for them.
- In the Site Editor, edit a Navigation menu, using various Page Link blocks and Submenus. Verify that the Attributes panel isn't shown for them either.

(In all those cases, the functionality that uses block bindings for those blocks is provided through different parts of the UI instead; e.g. for the Date block, it's through its block variations.)

## Screenshots or screencast

Shown here for the Post Date block variation:

|Before|After|
|-|-|
| <img width="279" height="603" alt="image" src="https://github.com/user-attachments/assets/4d0bed53-70b8-462b-b12f-a3a801446fe6" /> | <img width="280" height="414" alt="image" src="https://github.com/user-attachments/assets/0e1d5a0f-fb6a-4bce-925c-15f9d53d332e" /> |
