### PR TITLE
Template activation: allow duplicates of 'custom' plugin templates to be activated

### DIFF
--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -38,13 +38,7 @@ export const useSetActiveTemplateAction = () => {
 					return false;
 				}
 
-				// If it's not a created template but a registered template,
-				// only allow activating (so when it's inactive).
-				if ( typeof item.id !== 'number' ) {
-					return item._isActive === false;
-				}
-
-				return ! item._isCustom;
+				return true;
 			},
 			async callback( items ) {
 				const deactivate = items.some( ( item ) => item._isActive );

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -38,6 +38,12 @@ export const useSetActiveTemplateAction = () => {
 					return false;
 				}
 
+				// If it's not a created template but a registered template,
+				// only allow activating (so when it's inactive).
+				if ( typeof item.id !== 'number' ) {
+					return item._isActive === false;
+				}
+
 				return true;
 			},
 			async callback( items ) {

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -157,7 +157,7 @@ export const activeField = {
 	render: function Render( { item } ) {
 		const activeLabel = item._isCustom
 			? __( 'Active when used' )
-			: __( 'Inactive' );
+			: __( 'Active' );
 		const activeIntent = item._isCustom ? 'info' : 'success';
 		const isActive = item._isActive;
 		return (

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -155,23 +155,14 @@ export const activeField = {
 	type: 'boolean',
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
-		if ( item._isCustom ) {
-			return (
-				<Badge
-					intent="info"
-					title={ __(
-						'Custom templates cannot be active nor inactive.'
-					) }
-				>
-					{ __( 'N/A' ) }
-				</Badge>
-			);
-		}
-
+		const activeLabel = item._isCustom
+			? __( 'Active when used' )
+			: __( 'Inactive' );
+		const activeIntent = item._isCustom ? 'info' : 'success';
 		const isActive = item._isActive;
 		return (
-			<Badge intent={ isActive ? 'success' : 'default' }>
-				{ isActive ? __( 'Active' ) : __( 'Inactive' ) }
+			<Badge intent={ isActive ? activeIntent : 'default' }>
+				{ isActive ? activeLabel : __( 'Inactive' ) }
 			</Badge>
 		);
 	},
@@ -181,17 +172,20 @@ export const useThemeField = () => {
 	const activeTheme = useSelect( ( select ) =>
 		select( coreStore ).getCurrentTheme()
 	);
-	return {
-		label: __( 'Compatible Theme' ),
-		id: 'theme',
-		getValue: ( { item } ) => item.theme,
-		render: function Render( { item } ) {
-			if ( item.theme === activeTheme.stylesheet ) {
-				return <Badge intent="success">{ item.theme }</Badge>;
-			}
-			return <Badge intent="error">{ item.theme }</Badge>;
-		},
-	};
+	return useMemo(
+		() => ( {
+			label: __( 'Compatible Theme' ),
+			id: 'theme',
+			getValue: ( { item } ) => item.theme,
+			render: function Render( { item } ) {
+				if ( item.theme === activeTheme.stylesheet ) {
+					return <Badge intent="success">{ item.theme }</Badge>;
+				}
+				return <Badge intent="error">{ item.theme }</Badge>;
+			},
+		} ),
+		[ activeTheme ]
+	);
 };
 
 export const slugField = {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -93,7 +93,12 @@ export default function PageTemplates() {
 			combinedTemplates: false,
 		} );
 	const { records: staticRecords, isResolving: isLoadingStaticData } =
-		useEntityRecordsWithPermissions( 'root', 'registeredTemplate' );
+		useEntityRecordsWithPermissions( 'root', 'registeredTemplate', {
+			// This should not be needed, the endpoint returns all registered
+			// templates, but it's not possible right now to turn off pagination
+			// for entity configs.
+			per_page: -1,
+		} );
 
 	const activeTemplates = useMemo( () => {
 		const _active = [ ...staticRecords ];

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -121,37 +121,55 @@ export default function PageTemplates() {
 		return _active;
 	}, [ userRecords, staticRecords, activeTemplatesOption, activeTheme ] );
 
-	let _records;
 	let isLoadingData;
 	if ( activeView === 'active' ) {
-		_records = activeTemplates;
 		isLoadingData = isLoadingUserRecords || isLoadingStaticData;
 	} else if ( activeView === 'user' ) {
-		_records = userRecords;
 		isLoadingData = isLoadingUserRecords;
 	} else {
-		_records = staticRecords;
 		isLoadingData = isLoadingStaticData;
 	}
 
 	const records = useMemo( () => {
-		return _records.map( ( record ) => ( {
-			...record,
-			_isActive: !! activeTemplates.find(
-				( template ) => template.id === record.id
-			),
-			_isCustom:
-				// For registered templates, the is_custom field is defined.
+		function isCustom( record ) {
+			// For registered templates, the is_custom field is defined.
+			return (
 				record.is_custom ??
 				// For user templates it's custom if the is_wp_suggestion meta
 				// field is not set and the slug is not found in the default
 				// template types.
 				( ! record.meta?.is_wp_suggestion &&
-					! defaultTemplateTypes.find(
+					! defaultTemplateTypes.some(
 						( type ) => type.slug === record.slug
-					) ),
+					) )
+			);
+		}
+
+		let _records;
+		if ( activeView === 'active' ) {
+			// Don't show active custom templates in the active view.
+			_records = activeTemplates.filter(
+				( record ) => ! isCustom( record )
+			);
+		} else if ( activeView === 'user' ) {
+			_records = userRecords;
+		} else {
+			_records = staticRecords;
+		}
+		return _records.map( ( record ) => ( {
+			...record,
+			_isActive: activeTemplates.some(
+				( template ) => template.id === record.id
+			),
+			_isCustom: isCustom( record ),
 		} ) );
-	}, [ _records, activeTemplates, defaultTemplateTypes ] );
+	}, [
+		activeTemplates,
+		defaultTemplateTypes,
+		userRecords,
+		staticRecords,
+		activeView,
+	] );
 
 	const users = useSelect(
 		( select ) => {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -96,9 +96,7 @@ export default function PageTemplates() {
 		useEntityRecordsWithPermissions( 'root', 'registeredTemplate' );
 
 	const activeTemplates = useMemo( () => {
-		const _active = [ ...staticRecords ].filter(
-			( record ) => ! record.is_custom
-		);
+		const _active = [ ...staticRecords ];
 		if ( activeTemplatesOption ) {
 			for ( const activeSlug in activeTemplatesOption ) {
 				const activeId = activeTemplatesOption[ activeSlug ];

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -38,7 +38,12 @@ export default function DataviewsTemplatesSidebarContent() {
 	const {
 		query: { activeView = 'active' },
 	} = useLocation();
-	const { records } = useEntityRecords( 'root', 'registeredTemplate' );
+	const { records } = useEntityRecords( 'root', 'registeredTemplate', {
+		// This should not be needed, the endpoint returns all registered
+		// templates, but it's not possible right now to turn off pagination for
+		// entity configs.
+		per_page: -1,
+	} );
 	const firstItemPerAuthorText = useMemo( () => {
 		const firstItemPerAuthor = records?.reduce( ( acc, template ) => {
 			const author = template.author_text;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See #72475. See #72580.

**All registered templates were editable before: so you need to be able to duplicate and activate.**

Example: the `Page No Title` is a custom template, which is in a sort of grey area in terms of "Active" status. I've opted for "Active when used" for custom templates, because they may be used for certain pages, and plugins may render templates their own way.

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/bae39975-d47e-48fb-807c-54b6b3f7c729" />

Users can duplicate these templates (previously edit), which means this duplicate can now be activated and receive the "Active when used" status, while the original theme/plugin (registered) template will become "Inactive".

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/75580ae1-b8e3-4b30-af09-5fb128e874c5" />

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/af3e2156-161b-455d-903d-8c71dea3ccd3" />

This PR essentially removes custom behavior for custom (ugh) templates: they can be activated, we just label the status differently.

> [!NOTE]  
> Plugins can opt-out of showing the special custom template status by adding the slug to `default_template_types`. When added to this filter, these templates will now receive the regular "Active" status like theme templates types.

> [!NOTE]  
> When plugins register templates that fit in [the template hierarchy](https://developer.wordpress.org/themes/classic-themes/basics/template-hierarchy/), they should not be marked as custom templates. This is currently a pre-6.9 limit where only [a narrow set of template slugs are considered default templates](https://github.com/WordPress/wordpress-develop/blob/73e822f2c0f74aee28433b7e824c530b7d76486d/src/wp-includes/block-template-utils.php#L142). This is incorrect: any slug that matches the hierarchy should be considered a default template. When we fix this in the future, these templates will automatically no longer be marked as custom.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Backwards compatibility: **All registered templates were editable before: so you need to be able to duplicate and activate.**

It also simplifies things and makes things easy to reason about: all templates can be activated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

When testing the 2025 theme:

* Check that the "Page No Title" template is marked "Active when used". Now duplicate it, make an edit, and activate it. This duplicate should now show "Active when used". Go back to the theme template, and the original "Page No Title" should be inactive. Now create a page and change the template. You should see the edited version, and not the original theme template. Note that in the future we could allow duplicating and changing the slug so it can be a separate custom template.

When testing Woo:

* Registered templates should either be "Active" or "Active when used", none of them should be "Inactive". You should be able to duplicate and activate, see testing instructions above.

TODO: add some e2e tests for these custom template flows.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
