### PR TITLE
Breadcrumbs: Add 404, search and `paged` support for archives

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -17,9 +17,8 @@
  * @return string Returns the post breadcrumb for hierarchical post types.
  */
 function render_block_core_breadcrumbs( $attributes, $content, $block ) {
-	// Exclude breadcrumbs from special contexts like search, 404, etc.
-	// until they are explicitly supported.
-	if ( is_search() || is_404() || is_home() || is_front_page() ) {
+	// Exclude breadcrumbs from special contexts.
+	if ( is_home() || is_front_page() ) {
 		return '';
 	}
 
@@ -33,8 +32,23 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		);
 	}
 
-	// Handle archive pages (taxonomy, post type, date, author archives).
-	if ( is_archive() ) {
+	// Handle search results.
+	if ( is_search() ) {
+		$search_query       = get_search_query();
+		$breadcrumb_items[] = sprintf(
+			'<span aria-current="page">%s</span>',
+			/* translators: %s: search query */
+			sprintf( esc_html__( 'Search results for: "%s"' ), esc_html( $search_query ) )
+		);
+		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+	} elseif ( is_404() ) {
+		// Handle 404 pages.
+		$breadcrumb_items[] = sprintf(
+			'<span aria-current="page">%s</span>',
+			esc_html__( '404 Not Found' )
+		);
+	} elseif ( is_archive() ) {
+		// Handle archive pages (taxonomy, post type, date, author archives).
 		$archive_breadcrumbs = block_core_breadcrumbs_get_archive_breadcrumbs();
 		if ( ! empty( $archive_breadcrumbs ) ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, $archive_breadcrumbs );
@@ -100,6 +114,48 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	);
 
 	return $breadcrumb_html;
+}
+
+/**
+ * Adds pagination breadcrumb if on a paged view.
+ *
+ * Converts the last breadcrumb item to a link and adds "Page X" as the current page.
+ *
+ * @since 6.9.0
+ *
+ * @param array $breadcrumb_items Array of breadcrumb HTML items.
+ *
+ * @return array Modified breadcrumb items with pagination if applicable.
+ */
+function block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items ) {
+	$paged = get_query_var( 'paged' );
+
+	if ( $paged && $paged > 1 ) {
+		// Get the last breadcrumb item (the current page).
+		$last_item = array_pop( $breadcrumb_items );
+
+		if ( $last_item ) {
+			// Get URL for page 1.
+			$current_url = get_pagenum_link( 1 );
+
+			// Convert span to link by replacing the opening/closing tags.
+			$linked_item        = str_replace(
+				array( '<span aria-current="page">', '</span>' ),
+				array( '<a href="' . esc_url( $current_url ) . '">', '</a>' ),
+				$last_item
+			);
+			$breadcrumb_items[] = $linked_item;
+		}
+
+		// Add the "Page X" as the current page.
+		$breadcrumb_items[] = sprintf(
+			'<span aria-current="page">%s</span>',
+			/* translators: %s: page number */
+			sprintf( esc_html__( 'Page %s' ), number_format_i18n( $paged ) )
+		);
+	}
+
+	return $breadcrumb_items;
 }
 
 /**
@@ -227,6 +283,9 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			}
 		}
 
+		// Add pagination breadcrumb if on a paged date archive.
+		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+
 		return $breadcrumb_items;
 	}
 
@@ -274,6 +333,9 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			esc_html( $author->display_name )
 		);
 	}
+
+	// Add pagination breadcrumb if on a paged archive.
+	$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
 
 	return $breadcrumb_items;
 }

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -128,9 +128,8 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
  * @return array Modified breadcrumb items with pagination if applicable.
  */
 function block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items ) {
-	$paged = get_query_var( 'paged' );
-
-	if ( $paged && $paged > 1 ) {
+	$paged = (int) get_query_var( 'paged' );
+	if ( $paged > 1 ) {
 		// Get the last breadcrumb item (the current page).
 		$last_item = array_pop( $breadcrumb_items );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498

This PR does 3 things:
1. Adds 404 support  `Home / 404 Not Found`
2. Search support `Home / Search results for: "a"`
3. Adds pagination support for `archive` templates (author, taxonomies, post type, date) and `search`. Pagination results appear like this: `Home / Books / Page 2`.

## Testing Instructions
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various pages in the front end.
3. Test 404
4. Test searching something
5. For testing pagination it's easier if you set the number of posts to `one` in reading settings. Then test `archive` templates (author, taxonomies, post type, date) and `search`, by going to the next page


### Sample screenshots

<img width="994" height="229" alt="Screenshot 2025-10-27 at 5 16 16 PM" src="https://github.com/user-attachments/assets/7d9062de-90c7-455b-a969-c1f75844f0fa" />
<img width="994" height="229" alt="Screenshot 2025-10-27 at 5 16 34 PM" src="https://github.com/user-attachments/assets/3a9c00d3-de60-4979-aeab-14998fab0e1c" />
<img width="994" height="229" alt="Screenshot 2025-10-27 at 5 16 42 PM" src="https://github.com/user-attachments/assets/559aa683-4b19-4fc5-8f32-f0818a25112f" />