### PR TITLE
Blocks: Introduce `format` in attribute definitions, use for Block Bindings

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -50,10 +50,12 @@ export default function BlockBindingsAttributeControl( {
 				getBlockType,
 			} = unlock( select( blocksStore ) );
 
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
+			const blockAttribute =
+				getBlockType( blockName ).attributes?.[ attribute ];
+			const _attributeType = blockAttribute?.type;
 			const attributeType =
 				_attributeType === 'rich-text' ? 'string' : _attributeType;
+			const attributeFormat = blockAttribute?.format;
 
 			const sourceFields = {};
 			Object.entries( getAllBlockBindingsSources() ).forEach(
@@ -66,7 +68,11 @@ export default function BlockBindingsAttributeControl( {
 						return;
 					}
 					const compatibleFieldsList = fieldsList.filter(
-						( field ) => field.type === attributeType
+						( field ) =>
+							attributeType === field.type &&
+							( attributeFormat
+								? attributeFormat === field.format
+								: true )
 					);
 					if ( compatibleFieldsList.length ) {
 						sourceFields[ sourceName ] = compatibleFieldsList;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -118,11 +118,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
-	hasSupport( name ) {
-		return ! [
-			'core/post-date',
-			'core/navigation-link',
-			'core/navigation-submenu',
-		].includes( name );
+	hasSupport() {
+		return true;
 	},
 };

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -35,6 +35,7 @@
 		},
 		"url": {
 			"type": "string",
+			"format": "uri",
 			"role": "content"
 		},
 		"title": {

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -30,6 +30,7 @@
 		},
 		"url": {
 			"type": "string",
+			"format": "uri",
 			"role": "content"
 		},
 		"title": {

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -9,6 +9,7 @@
 	"attributes": {
 		"datetime": {
 			"type": "string",
+			"format": "date-time",
 			"role": "content"
 		},
 		"textAlign": {

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -16,16 +16,19 @@ const postDataFields = [
 		label: __( 'Post Date' ),
 		args: { field: 'date' },
 		type: 'string',
+		format: 'date-time',
 	},
 	{
 		label: __( 'Post Modified Date' ),
 		args: { field: 'modified' },
 		type: 'string',
+		format: 'date-time',
 	},
 	{
 		label: __( 'Post Link' ),
 		args: { field: 'link' },
 		type: 'string',
+		format: 'uri',
 	},
 ];
 

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -163,16 +163,19 @@ describe( 'post-data bindings', () => {
 					label: 'Post Date',
 					args: { field: 'date' },
 					type: 'string',
+					format: 'date-time',
 				},
 				{
 					label: 'Post Modified Date',
 					args: { field: 'modified' },
 					type: 'string',
+					format: 'date-time',
 				},
 				{
 					label: 'Post Link',
 					args: { field: 'link' },
 					type: 'string',
+					format: 'uri',
 				},
 			] );
 		} );

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -144,6 +144,18 @@
 								}
 							]
 						},
+						"format": {
+							"description": "The format provides additional information about the attribute's shape.",
+							"type": "string",
+							"enum": [
+								"date-time",
+								"uri",
+								"email",
+								"ip",
+								"uuid",
+								"hex-color"
+							]
+						},
 						"enum": {
 							"description": "An attribute can be defined as one of a fixed set of values. This is specified by an enum, which contains an array of allowed values:",
 							"type": "array",

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -52,7 +52,7 @@ test.describe( 'Post Data source', () => {
 			// Check the fields registered by other sources are there.
 		} );
 
-		test( 'should not render Attributes panel for date blocks', async ( {
+		test( 'should include post data fields in UI to connect attributes on date blocks', async ( {
 			editor,
 			page,
 		} ) => {
@@ -69,9 +69,15 @@ test.describe( 'Post Data source', () => {
 					},
 				},
 			} );
-			await expect(
-				page.getByLabel( 'Attributes options' )
-			).toBeHidden();
+			await page
+				.getByRole( 'button', {
+					name: 'datetime',
+				} )
+				.click();
+			const postDataMenuItem = page.getByRole( 'menuitem', {
+				name: 'Post Data',
+			} );
+			await expect( postDataMenuItem ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Introduce a new `format` field for use in attribute definitions (e.g. in `block.json`), and use it to filter block bindings source items based on `format` compatibility with bound attribute.

Fixes https://github.com/WordPress/gutenberg/issues/72446. Reverts https://github.com/WordPress/gutenberg/pull/72712.

## Why?
To remove incompatible source items from the block bindings UI for a given block bindings source.

For example, when we show the available items from the `core/post-data` list for the Date block's `datetime` attribute, we only want to show the `date` and `modified` source items, but not `link` (which is an `url` and thus incompatible with a `datetime` field).

## How?
By introducing a `format` field in attribute definitions, and adding block bindings code to peruse it.

## Testing Instructions
- In the editor, insert a Date block.
- In the block inspector, open the "Attributes" panel.
- Click on the `datetime` attribute to expand the dropdown menu. It should contain the "Post Data" source.
- Verify that there are two items available from that source: Post Date and Modified Date.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="700" height="240" alt="image" src="https://github.com/user-attachments/assets/0ff48979-e403-497b-92c4-b58e5f6ee53c" /> | <img width="657" height="188" alt="image" src="https://github.com/user-attachments/assets/91f32b42-84a5-49ef-9b83-dca315c3e825" /> |

## TODO

- [ ] Add unit test coverage (to `packages/editor/src/bindings/test/post-data.js` (?)).