### PR TITLE
Make loadView synchronous

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -4,7 +4,7 @@
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { __ } from '@wordpress/i18n';
 import { loadView } from '@wordpress/views';
-import { resolveSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -21,11 +21,10 @@ import { getDefaultView } from '../post-list/view-utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-async function isListView( query ) {
+function isListView( query ) {
 	const { activeView = 'all' } = query;
-	const postTypeObject =
-		await resolveSelect( coreStore ).getPostType( 'page' );
-	const view = await loadView( {
+	const postTypeObject = select( coreStore ).getPostType( 'page' );
+	const view = loadView( {
 		kind: 'postType',
 		name: 'page',
 		slug: activeView,
@@ -61,12 +60,12 @@ export const pagesRoute = {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? <PostList postType="page" /> : undefined;
 		},
-		async preview( { query, siteData } ) {
+		preview( { query, siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			if ( ! isBlockTheme ) {
 				return undefined;
 			}
-			const isList = await isListView( query );
+			const isList = isListView( query );
 			return isList ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
@@ -77,8 +76,8 @@ export const pagesRoute = {
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
-		async edit( { query } ) {
-			const isList = await isListView( query );
+		edit( { query } ) {
+			const isList = isListView( query );
 			const hasQuickEdit = ! isList && !! query.quickEdit;
 			return hasQuickEdit ? (
 				<PostEdit postType="page" postId={ query.postId } />
@@ -86,12 +85,12 @@ export const pagesRoute = {
 		},
 	},
 	widths: {
-		async content( { query } ) {
-			const isList = await isListView( query );
+		content( { query } ) {
+			const isList = isListView( query );
 			return isList ? 380 : undefined;
 		},
-		async edit( { query } ) {
-			const isList = await isListView( query );
+		edit( { query } ) {
+			const isList = isListView( query );
 			const hasQuickEdit = ! isList && !! query.quickEdit;
 			return hasQuickEdit ? 380 : undefined;
 		},

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -12,9 +12,9 @@ import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-uns
 import PageTemplates from '../page-templates';
 import { getDefaultView } from '../page-templates/view-utils';
 
-async function isTemplateListView( query ) {
+function isTemplateListView( query ) {
 	const { activeView = 'active' } = query;
-	const view = await loadView( {
+	const view = loadView( {
 		kind: 'postType',
 		name: 'wp_template',
 		slug: activeView,
@@ -39,12 +39,12 @@ export const templatesRoute = {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? <PageTemplates /> : undefined;
 		},
-		async preview( { query, siteData } ) {
+		preview( { query, siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			if ( ! isBlockTheme ) {
 				return undefined;
 			}
-			const isListView = await isTemplateListView( query );
+			const isListView = isTemplateListView( query );
 			return isListView ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
@@ -57,8 +57,8 @@ export const templatesRoute = {
 		},
 	},
 	widths: {
-		async content( { query } ) {
-			const isListView = await isTemplateListView( query );
+		content( { query } ) {
+			const isListView = isTemplateListView( query );
 			return isListView ? 380 : undefined;
 		},
 	},

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -12,8 +12,6 @@ import {
 	useContext,
 	useSyncExternalStore,
 	useMemo,
-	useState,
-	useEffect,
 } from '@wordpress/element';
 import {
 	addQueryArgs,
@@ -21,7 +19,7 @@ import {
 	getPath,
 	buildQueryString,
 } from '@wordpress/url';
-import { useEvent, usePrevious } from '@wordpress/compose';
+import { useEvent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -165,66 +163,50 @@ export default function useMatch(
 	matcher: RouteRecognizer,
 	pathArg: string,
 	matchResolverArgs: Record< string, any >
-): Match | undefined {
+): Match {
 	const { query: rawQuery = {} } = location;
-	const [ resolvedMatch, setMatch ] = useState< Match | undefined >();
 
-	useEffect( () => {
+	return useMemo( () => {
 		const { [ pathArg ]: path = '/', ...query } = rawQuery;
-		const ret = matcher.recognize( path )?.[ 0 ];
-		async function resolveMatch( result: any ) {
-			const matchedRoute = result.handler as Route;
-			const resolveFunctions = async (
-				record: Record< string, any > = {}
-			) => {
-				const entries = await Promise.all(
-					Object.entries( record ).map( async ( [ key, value ] ) => {
-						if ( typeof value === 'function' ) {
-							return [
-								key,
-								await value( {
-									query,
-									params: result.params,
-									...matchResolverArgs,
-								} ),
-							];
-						}
-						return [ key, value ];
-					} )
-				);
-				return Object.fromEntries( entries );
-			};
-			const [ resolvedAreas, resolvedWidths ] = await Promise.all( [
-				resolveFunctions( matchedRoute.areas ),
-				resolveFunctions( matchedRoute.widths ),
-			] );
-			setMatch( {
-				name: matchedRoute.name,
-				areas: resolvedAreas,
-				widths: resolvedWidths,
-				params: result.params,
-				query,
-				path: addQueryArgs( path, query ),
-			} );
-		}
-
-		if ( ! ret ) {
-			setMatch( {
+		const result = matcher.recognize( path )?.[ 0 ];
+		if ( ! result ) {
+			return {
 				name: '404',
 				path: addQueryArgs( path, query ),
 				areas: {},
 				widths: {},
 				query,
 				params: {},
-			} );
-		} else {
-			resolveMatch( ret );
+			};
 		}
 
-		return () => setMatch( undefined );
+		const matchedRoute = result.handler as Route;
+		const resolveFunctions = ( record: Record< string, any > = {} ) => {
+			return Object.fromEntries(
+				Object.entries( record ).map( ( [ key, value ] ) => {
+					if ( typeof value === 'function' ) {
+						return [
+							key,
+							value( {
+								query,
+								params: result.params,
+								...matchResolverArgs,
+							} ),
+						];
+					}
+					return [ key, value ];
+				} )
+			);
+		};
+		return {
+			name: matchedRoute.name,
+			areas: resolveFunctions( matchedRoute.areas ),
+			widths: resolveFunctions( matchedRoute.widths ),
+			params: result.params,
+			query,
+			path: addQueryArgs( path, query ),
+		};
 	}, [ matcher, rawQuery, pathArg, matchResolverArgs ] );
-
-	return resolvedMatch;
 }
 
 export function RouterProvider( {
@@ -255,20 +237,14 @@ export function RouterProvider( {
 		return ret;
 	}, [ routes ] );
 	const match = useMatch( location, matcher, pathArg, matchResolverArgs );
-	const previousMatch = usePrevious( match );
 	const config = useMemo(
 		() => ( { beforeNavigate, pathArg } ),
 		[ beforeNavigate, pathArg ]
 	);
-	const renderedMatch = match || previousMatch;
-
-	if ( ! renderedMatch ) {
-		return null;
-	}
 
 	return (
 		<ConfigContext.Provider value={ config }>
-			<RoutesContext.Provider value={ renderedMatch }>
+			<RoutesContext.Provider value={ match }>
 				{ children }
 			</RoutesContext.Provider>
 		</ConfigContext.Provider>

--- a/packages/views/README.md
+++ b/packages/views/README.md
@@ -23,13 +23,13 @@ npm install @wordpress/views --save
 
 ### loadView
 
-Async function for loading view state in route loaders with optional URL parameters.
+Function for loading view state in route loaders with optional URL parameters.
 
 _Usage_
 
 ```typescript
 // In route loader
-const view = await loadView( {
+const view = loadView( {
 	kind: 'taxonomy',
 	name: 'category',
 	slug: 'all',
@@ -49,7 +49,7 @@ _Parameters_
 
 _Returns_
 
--   Promise resolving to the loaded view object.
+-   The loaded view object.
 
 ### useView
 

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -13,13 +13,13 @@ import { generatePreferenceKey } from './preference-keys';
 import type { ViewConfig } from './types';
 
 /**
- * Async function for loading view state in route loaders with optional URL parameters.
+ * Function for loading view state in route loaders with optional URL parameters.
  *
  * @example
  *
  * ```typescript
  * // In route loader
- * const view = await loadView( {
+ * const view = loadView( {
  * 	kind: 'taxonomy',
  * 	name: 'category',
  * 	slug: 'all',
@@ -35,9 +35,9 @@ import type { ViewConfig } from './types';
  * @param config.defaultView Default view configuration.
  * @param config.queryParams Object with `page` and/or `search` from URL.
  *
- * @return Promise resolving to the loaded view object.
+ * @return The loaded view object.
  */
-export async function loadView( config: ViewConfig ) {
+export function loadView( config: ViewConfig ) {
 	const { kind, name, slug, defaultView, queryParams } = config;
 	const preferenceKey = generatePreferenceKey( kind, name, slug );
 	const persistedView: View | undefined = select( preferencesStore ).get(

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -29,6 +29,8 @@ test.describe( 'Dataviews List Layout', () => {
 		// Go to the pages page, as it has the list layout enabled by default.
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+		// Wait for the page list to be fully rendered
+		await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 	} );
 
 	test( 'Items list is reachable via TAB', async ( { page } ) => {

--- a/test/e2e/specs/site-editor/homepage-settings.spec.js
+++ b/test/e2e/specs/site-editor/homepage-settings.spec.js
@@ -23,6 +23,8 @@ test.describe( 'Homepage Settings via Editor', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+		// Wait for the page list to be fully rendered
+		await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -37,6 +37,8 @@ test.describe( 'Page List', () => {
 		// Go to the pages page, as it has the list layout enabled by default.
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+		// Wait for the page list to be fully rendered
+		await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 	} );
 
 	test( 'Persists filter/search when switching layout', async ( {

--- a/test/e2e/specs/site-editor/pages-view-persistence.spec.js
+++ b/test/e2e/specs/site-editor/pages-view-persistence.spec.js
@@ -25,6 +25,8 @@ test.describe( 'Pages View Persistence', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+		// Wait for the page list to be fully rendered
+		await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 
 		const resetButton = page.getByRole( 'button', { name: 'Reset view' } );
 		if ( await resetButton.isVisible() ) {

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -5,6 +5,8 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
+	// Wait for the page list to be fully rendered
+	await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 	await page.getByRole( 'button', { name: 'Add page' } ).click();
 	await page
 		.locator( 'role=dialog[name="Draft new: page"i]' )

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -55,12 +55,99 @@ test.describe( 'Templates', () => {
 		await page.getByRole( 'button', { name: 'Layout' } ).click();
 		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 
-		// Confirm the table is visible
-		await expect( page.getByRole( 'table' ) ).toContainText( 'Index' );
+		// Confirm the table view is visible within Templates region
+		const templatesRegion = page.locator( '[aria-label="Templates"]' );
+		await expect( templatesRegion.getByRole( 'table' ) ).toContainText(
+			'Index'
+		);
 
 		// The search should still contain the search term
 		await expect(
 			page.getByRole( 'searchbox', { name: 'Search' } )
 		).toHaveValue( 'Index' );
+	} );
+
+	test( 'View persistence', async ( { page, admin, requestUtils } ) => {
+		// Create additional templates for pagination testing
+		await requestUtils.createTemplate( 'wp_template', {
+			slug: 'test-template-1',
+			title: 'Test Template 1',
+			content: 'test content 1',
+		} );
+
+		await test.step( 'Navigate to templates page', async () => {
+			await admin.visitSiteEditor( { postType: 'wp_template' } );
+			await expect(
+				page.locator( '[aria-label="Templates"]' )
+			).toBeVisible();
+		} );
+
+		await test.step( 'Can switch to Table view', async () => {
+			// Switch to Table view
+			await page.getByRole( 'button', { name: 'Layout' } ).click();
+			await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
+			// Verify table view is active within Templates region
+			const templatesRegion = page.locator( '[aria-label="Templates"]' );
+			await expect( templatesRegion.getByRole( 'table' ) ).toBeVisible();
+		} );
+
+		await test.step( 'Verify Reset view button appears when switching from default view', async () => {
+			await expect(
+				page.getByRole( 'button', { name: 'Reset view' } )
+			).toBeVisible();
+		} );
+
+		await test.step( 'Verify layout persists after page reload', async () => {
+			// Reload the page
+			await page.reload();
+
+			// Wait for templates to be visible again
+			const templatesRegion = page.locator( '[aria-label="Templates"]' );
+
+			// Verify Table view persists within Templates region
+			await expect( templatesRegion.getByRole( 'table' ) ).toBeVisible();
+
+			// Reset view button should still be visible
+			await expect(
+				page.getByRole( 'button', { name: 'Reset view' } )
+			).toBeVisible();
+		} );
+
+		await test.step( 'Verify search parameter appears in URL', async () => {
+			// Search for a template
+			await page
+				.getByRole( 'searchbox', { name: 'Search' } )
+				.fill( 'archive' );
+
+			// Verify URL contains search parameter
+			await expect( page ).toHaveURL( /search=archive/ );
+
+			// Verify search persists after reload
+			await page.reload();
+			await expect(
+				page.getByRole( 'searchbox', { name: 'Search' } )
+			).toHaveValue( 'archive' );
+		} );
+
+		await test.step( 'Reset view returns to defaults', async () => {
+			// Click Reset view button
+			await page.getByRole( 'button', { name: 'Reset view' } ).click();
+
+			// Grid view should be active (default) - verify table is hidden within Templates region
+			const templatesRegion = page.locator( '[aria-label="Templates"]' );
+			await expect( templatesRegion.getByRole( 'table' ) ).toBeHidden();
+
+			// Reset view button should be hidden
+			await expect(
+				page.getByRole( 'button', { name: 'Reset view' } )
+			).toBeHidden();
+
+			// Verify Grid view is active
+			await page.getByRole( 'button', { name: 'Layout' } ).click();
+			await expect(
+				page.getByRole( 'menuitemradio', { name: 'Grid' } )
+			).toBeChecked();
+		} );
 	} );
 } );

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -417,6 +417,8 @@ test.describe( 'Site Editor Performance', () => {
 
 			await admin.visitSiteEditor();
 			await page.getByRole( 'button', { name: 'Pages' } ).click();
+			// Wait for the page list to be fully rendered
+			await page.getByRole( 'region', { name: 'Pages' } ).waitFor();
 
 			// Check if we're dealing with the old URL structure.
 			const path = new URL( page.url() ).searchParams.get( 'path' );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

The loadView function was marked async but doesn't await anything - it synchronously reads from the preferences store (which is a Redux store with preloaded data). Using `async` forced the entire router to become asynchronous when the data is synchronously available, which slowed down [the Site Editor `navigate` metric](https://www.codevitals.run/project/gutenberg/site-editor-navigate).

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Address [a performance regression](https://github.com/WordPress/gutenberg/pull/72113#issuecomment-3382176185) in [the site editor navigate metric](https://www.codevitals.run/project/gutenberg/site-editor-navigate).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The performance regression comes from treating synchronous data (preferences store) as async, forcing the router to add unnecessary overhead. Making loadView synchronous eliminates this artificial latency.
  
  
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to Templates page
  2. Switch to List view → verify "Reset view" button appears
  3. Refresh page → verify List view persists
  4. Click page 2 → verify URL has pageNumber=2
  5. Search for "archive" → verify URL has search=archive
  6. Click "Reset view" → verify back to default Grid view
  7. Click through a few templates → verify navigation is fast

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
