### PR TITLE
Template activation: redirect to 'Create Templates' after duplication

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -359,11 +359,6 @@ export default function PageTemplates() {
 					<duplicateAction.RenderModal
 						items={ [ selectedRegisteredTemplate ] }
 						closeModal={ () => setSelectedRegisteredTemplate() }
-						onActionPerformed={ ( [ item ] ) => {
-							history.navigate(
-								`/${ item.type }/${ item.id }?canvas=edit`
-							);
-						} }
 					/>
 				</Modal>
 			) }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -39,7 +39,8 @@ import {
 } from './fields';
 import { defaultLayouts, getDefaultView } from './view-utils';
 
-const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
+const { usePostActions, usePostFields, templateTitleField } =
+	unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 
@@ -210,6 +211,10 @@ export default function PageTemplates() {
 		[ history, path, view?.type ]
 	);
 
+	const postTypeFields = usePostFields( {
+		postType: TEMPLATE_POST_TYPE,
+	} );
+	const dateField = postTypeFields.find( ( field ) => field.id === 'date' );
 	const themeField = useThemeField();
 	const fields = useMemo( () => {
 		const _fields = [
@@ -221,6 +226,9 @@ export default function PageTemplates() {
 		];
 		if ( activeView === 'user' ) {
 			_fields.push( themeField );
+			if ( dateField ) {
+				_fields.push( dateField );
+			}
 		}
 		const elements = [];
 		for ( const author in users ) {
@@ -234,7 +242,7 @@ export default function PageTemplates() {
 			elements,
 		} );
 		return _fields;
-	}, [ users, activeView, themeField ] );
+	}, [ users, activeView, themeField, dateField ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( records, view, fields );

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -251,6 +251,7 @@ export default function PageTemplates() {
 							typeof newItem.title === 'string'
 								? newItem.title
 								: newItem.title?.rendered;
+						history.navigate( `/template?activeView=user` );
 						createSuccessNotice(
 							sprintf(
 								// translators: %s: Title of the created post or template, e.g: "Hello world".

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -28,6 +28,13 @@ const DEFAULT_VIEW = {
 export function getDefaultView( activeView ) {
 	return {
 		...DEFAULT_VIEW,
+		sort:
+			activeView === 'user'
+				? {
+						field: 'date',
+						direction: 'desc',
+				  }
+				: DEFAULT_VIEW.sort,
 		filters: ! [ 'active', 'user' ].includes( activeView )
 			? [
 					{

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -30,7 +30,7 @@ test.describe( 'Site editor browser history', () => {
 		// Navigate back to the template list
 		await page.goBack();
 		await expect( page ).toHaveURL(
-			'/wp-admin/site-editor.php?p=%2Ftemplate'
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
 		);
 
 		// Navigate back to the dashboard

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -24,6 +24,13 @@ test.describe( 'Site editor browser history', () => {
 			.click();
 		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
 		await expect( page ).toHaveURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
+		);
+		await page
+			.getByRole( 'button', { name: 'Index (Copy)' } )
+			.first()
+			.click();
+		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor\.php\?p=%2Fwp_template%2F\d+&canvas=edit$/
 		);
 
@@ -32,9 +39,13 @@ test.describe( 'Site editor browser history', () => {
 		await expect( page ).toHaveURL(
 			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
 		);
-
+		await page.goBack();
+		await expect( page ).toHaveURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate'
+		);
 		// Navigate back to the dashboard
 		await page.goBack();
+		await expect( page ).toHaveURL( '/wp-admin/site-editor.php' );
 		await page.goBack();
 		await expect( page ).toHaveURL( '/wp-admin/index.php' );
 	} );

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -54,6 +54,13 @@ test.describe( 'Block template registration', () => {
 		// Verify the template contents are rendered in the editor.
 		await page.getByText( 'Plugin Template' ).click();
 		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
+		await page.waitForURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
+		);
+		await page
+			.getByRole( 'button', { name: 'Plugin Template (Copy)' } )
+			.first()
+			.click();
 		await expect(
 			editor.canvas.getByText( 'This is a plugin-registered template.' )
 		).toBeVisible();
@@ -196,6 +203,13 @@ test.describe( 'Block template registration', () => {
 		);
 		await page.getByText( 'Plugin Template' ).click();
 		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
+		await page.waitForURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
+		);
+		await page
+			.getByRole( 'button', { name: 'Plugin Template (Copy)' } )
+			.first()
+			.click();
 		await expect(
 			editor.canvas.getByText( 'This is a plugin-registered template.' )
 		).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72587

<!-- In a few words, what is the PR actually doing? -->

When duplicating a template, redirect to the "created templates" tab. Additionally, we should sort the "created templates" (aka database templates) by date by default (just like normal posts) so that the newly created/duplicated templates shows first.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because you will not be able to find it in the theme or active templates tab.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to the theme templates or active templates tab. Use the data view action to duplicate a template. You should land in the "created templates" tab. Perhaps in the future we should sort them by date so that it's the first template in the list.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
