### PR TITLE
Switch from selector to useBlockEditingMode for AllowedBlocksControl

### DIFF
--- a/packages/block-editor/src/hooks/allowed-blocks.js
+++ b/packages/block-editor/src/hooks/allowed-blocks.js
@@ -3,25 +3,17 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../store';
 import { PrivateInspectorControlsAllowedBlocks } from '../components/inspector-controls/groups';
 import BlockAllowedBlocksControl from '../components/block-allowed-blocks/allowed-blocks-control';
+import { useBlockEditingMode } from '../components/block-editing-mode';
 
 function BlockEditAllowedBlocksControlPure( { clientId } ) {
-	const isContentOnly = useSelect(
-		( select ) => {
-			return (
-				select( blockEditorStore ).getBlockEditingMode( clientId ) ===
-				'contentOnly'
-			);
-		},
-		[ clientId ]
-	);
+	const blockEditingMode = useBlockEditingMode();
+	const isContentOnly = blockEditingMode === 'contentOnly';
 
 	if ( isContentOnly ) {
 		return null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Minor perf - useBlockEditingMode is faster than a useSelect.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Perf

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
instead of useSelect -> getBlockEditingMode, use useBlockEditingMode which gets the information from context (faster)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
