### PR TITLE
Template activation: fix undefined array key PHP warning

### DIFF
--- a/backport-changelog/6.9/10425.md
+++ b/backport-changelog/6.9/10425.md
@@ -1,0 +1,7 @@
+https://github.com/WordPress/wordpress-develop/pull/10425
+10425
+
+* https://github.com/WordPress/gutenberg/pull/72700
+* https://github.com/WordPress/gutenberg/pull/72674
+* https://github.com/WordPress/gutenberg/pull/72636
+* https://github.com/WordPress/gutenberg/pull/72729

--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -11,6 +11,3 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72141
 * https://github.com/WordPress/gutenberg/pull/72223
 * https://github.com/WordPress/gutenberg/pull/72285
-* https://github.com/WordPress/gutenberg/pull/72700
-* https://github.com/WordPress/gutenberg/pull/72674
-* https://github.com/WordPress/gutenberg/pull/72636

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -258,7 +258,7 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	//////////////////////////////
 
 	$object_id         = get_queried_object_id();
-	$specific_template = $object_id && get_post( $object_id ) ? get_page_template_slug( $object_id ) : null;
+	$specific_template = $object_id ? get_page_template_slug( $object_id ) : null;
 	$active_templates  = (array) get_option( 'active_templates', array() );
 
 	// We expect one template for each slug. Use the active template if it is

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -257,8 +257,8 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	// START CORE MODIFICATIONS //
 	//////////////////////////////
 
-	$object            = get_queried_object();
-	$specific_template = $object ? get_page_template_slug( $object ) : null;
+	$object_id         = get_queried_object_id();
+	$specific_template = $object_id && get_post( $object_id ) ? get_page_template_slug( $object_id ) : null;
 	$active_templates  = (array) get_option( 'active_templates', array() );
 
 	// We expect one template for each slug. Use the active template if it is
@@ -314,7 +314,7 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	);
 	$templates = array_merge( $templates, gutenberg_get_registered_block_templates( $query ) );
 
-	if ( $specific_template ) {
+	if ( $specific_template && in_array( $specific_template, $remaining_slugs, true ) ) {
 		$templates = array_merge( $templates, get_block_templates( array( 'slug__in' => array( $specific_template ) ) ) );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://core.trac.wordpress.org/ticket/62755#comment:11

* It's possible that `get_queried_object` does not return a post. We should double check that it's a post before getting the slug. This doesn't actually fix anything, but it would be good practice.
* When adding the template from the queried post, make sure it's actually in the array of requested slugs. If it's not, the sorting will log a warning.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Avoid PHP warnings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
