### PR TITLE
Real-time collaboration: Ensure block attribute is Y.Text

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -294,16 +294,17 @@ export function mergeCrdtBlocks(
 							if (
 								isRichText &&
 								'string' === typeof attributeValue &&
-								currentAttributes.has( attributeName )
+								currentAttributes.has( attributeName ) &&
+								currentAttributes.get(
+									attributeName
+								) instanceof Y.Text
 							) {
 								// Rich text values are stored as persistent Y.Text instances.
 								// Update the value with a delta in place.
-								const blockYText = currentAttributes.get(
-									attributeName
-								) as Y.Text;
-
 								mergeRichTextUpdate(
-									blockYText,
+									currentAttributes.get(
+										attributeName
+									) as Y.Text,
 									attributeValue,
 									cursorPosition
 								);

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -17,6 +17,18 @@ jest.mock( 'uuid', () => ( {
 } ) );
 
 /**
+ * Mock @wordpress/blocks module
+ */
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: jest.fn( () => [
+		{
+			name: 'core/paragraph',
+			attributes: { content: { type: 'rich-text' } },
+		},
+	] ),
+} ) );
+
+/**
  * Internal dependencies
  */
 import {
@@ -269,7 +281,48 @@ describe( 'crdt-blocks', () => {
 			const contentAttr = (
 				block.get( 'attributes' ) as YBlockAttributes
 			 ).get( 'content' ) as Y.Text;
+			expect( contentAttr ).toBeInstanceOf( Y.Text );
 			expect( contentAttr.toString() ).toBe( 'Rich text content' );
+		} );
+
+		it( 'creates Y.Text for rich-text attributes even when the block name changes', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/freeform',
+					attributes: { content: 'Freeform text' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const block = yblocks.get( 0 );
+			const contentAttr = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' );
+			expect( block.get( 'name' ) ).toBe( 'core/freeform' );
+			expect( typeof contentAttr ).toBe( 'string' );
+			expect( contentAttr ).toBe( 'Freeform text' );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Updated text' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( yblocks.length ).toBe( 1 );
+
+			const updatedBlock = yblocks.get( 0 );
+			const updatedContentAttr = (
+				updatedBlock.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( updatedBlock.get( 'name' ) ).toBe( 'core/paragraph' );
+			expect( updatedContentAttr ).toBeInstanceOf( Y.Text );
+			expect( updatedContentAttr.toString() ).toBe( 'Updated text' );
 		} );
 
 		it( 'removes duplicate clientIds', () => {


### PR DESCRIPTION

## What?

Real-time collaboration: Ensure block attribute from CRDT doc is a `Y.Text` instance before passing it to `mergeRichTextUpdate`.

## Why?

Our assumption that an attribute is represented in the CRDT doc as a `Y.Text` instance was based on the _incoming_ block name, which may have changed. For example, a block can be transformed from `core/freeform` to `core/paragraph` (both of which carry a `content` attribute).

When this happens, we can encounter a fatal error in `mergeRichTextUpdate` by assuming a primitive string is a `Y.Text` instance.

## How?

1. Use an `instanceof` check.
2. Add a test case.

## Testing Instructions

1. Check out this branch.
2. Add a "Classic" block.
3. Click "Convert to blocks."

