### PR TITLE
Notes: Update delete confirmation message

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -816,7 +816,9 @@ const CommentBoard = ( {
 					onCancel={ handleCancel }
 					confirmButtonText={ __( 'Delete' ) }
 				>
-					{ __( 'Are you sure you want to delete this note?' ) }
+					{ __(
+						"Are you sure you want to delete this note? This will also delete all of this note's replies."
+					) }
 				</ConfirmDialog>
 			) }
 		</VStack>


### PR DESCRIPTION
## What?
Closes #72722

PR updates text copy for note delete confirmation message, to inform users that deleting a parent note also deletes all its replies.

## Why?
See #72722.

## Testing Instructions
1. Open post with notes.
2. Delete a note.
3. Confirm that the delete modal message has been updated.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="603" height="169" alt="CleanShot 2025-10-28 at 09 47 02" src="https://github.com/user-attachments/assets/0e73fdd0-a912-457c-a6f1-18cedc80c495" />
