### PR TITLE
Block Bindings: Untangle sources code

### DIFF
--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -11,90 +11,23 @@ const NAVIGATION_BLOCK_TYPES = [
 	'core/navigation-submenu',
 ];
 
-/**
- * Gets a list of post data fields with their values and labels
- * to be consumed in the needed callbacks.
- * If the value is not available based on context, like in templates,
- * it falls back to the default value, label, or key.
- *
- * @param {Object} select   The select function from the data store.
- * @param {Object} context  The context provided.
- * @param {string} clientId The block client ID used to read attributes.
- * @return {Object} List of post data fields with their value and label.
- *
- * @example
- * ```js
- * {
- *     field_1_key: {
- *         label: 'Field 1 Label',
- *         value: 'Field 1 Value',
- *     },
- *     field_2_key: {
- *         label: 'Field 2 Label',
- *         value: 'Field 2 Value',
- *     },
- *     ...
- * }
- * ```
- */
-function getPostDataFields( select, context, clientId ) {
-	const { getEditedEntityRecord } = select( coreDataStore );
-	const { getBlockAttributes, getBlockName } = select( blockEditorStore );
-
-	let entityDataValues, dataFields;
-
-	/*
-	 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
-	 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
-	 */
-	const blockName = getBlockName?.( clientId );
-	const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
-
-	let postId, postType;
-
-	if ( isNavigationBlock ) {
-		// Navigation blocks: read from block attributes
-		const blockAttributes = getBlockAttributes?.( clientId );
-		postId = blockAttributes?.id;
-		postType = blockAttributes?.type;
-	} else {
-		// All other blocks: use context
-		postId = context?.postId;
-		postType = context?.postType;
-	}
-
-	// Try to get the current entity data values using resolved identifiers.
-	if ( postType && postId ) {
-		entityDataValues = getEditedEntityRecord(
-			'postType',
-			postType,
-			postId
-		);
-		dataFields = {
-			date: {
-				label: __( 'Post Date' ),
-				value: entityDataValues?.date,
-				type: 'string',
-			},
-			modified: {
-				label: __( 'Post Modified Date' ),
-				value: entityDataValues?.modified,
-				type: 'string',
-			},
-			link: {
-				label: __( 'Post Link' ),
-				value: entityDataValues?.link,
-				type: 'string',
-			},
-		};
-	}
-
-	if ( ! Object.keys( dataFields || {} ).length ) {
-		return null;
-	}
-
-	return dataFields;
-}
+const postDataFields = [
+	{
+		label: __( 'Post Date' ),
+		args: { field: 'date' },
+		type: 'string',
+	},
+	{
+		label: __( 'Post Modified Date' ),
+		args: { field: 'modified' },
+		type: 'string',
+	},
+	{
+		label: __( 'Post Link' ),
+		args: { field: 'link' },
+		type: 'string',
+	},
+];
 
 /**
  * @type {WPBlockBindingsSource}
@@ -102,15 +35,50 @@ function getPostDataFields( select, context, clientId ) {
 export default {
 	name: 'core/post-data',
 	getValues( { select, context, bindings, clientId } ) {
-		const dataFields = getPostDataFields( select, context, clientId );
+		const allowedFields = postDataFields.map(
+			( field ) => field.args.field
+		);
+
+		/*
+		 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
+		 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
+		 */
+		const { getBlockAttributes, getBlockName } = select( blockEditorStore );
+		const blockName = getBlockName?.( clientId );
+		const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
+
+		let postId, postType;
+
+		if ( isNavigationBlock ) {
+			// Navigation blocks: read from block attributes
+			const blockAttributes = getBlockAttributes?.( clientId );
+			postId = blockAttributes?.id;
+			postType = blockAttributes?.type;
+		} else {
+			// All other blocks: use context
+			postId = context?.postId;
+			postType = context?.postType;
+		}
+
+		const { getEditedEntityRecord } = select( coreDataStore );
+		const entityDataValues = getEditedEntityRecord(
+			'postType',
+			postType,
+			postId
+		);
 
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
-			// Use the value, the field label, or the field key.
-			const fieldKey = source.args.field;
-			const { value: fieldValue, label: fieldLabel } =
-				dataFields?.[ fieldKey ] || {};
-			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
+			if ( ! allowedFields.includes( source.args.field ) ) {
+				newValues[ attributeName ] = {};
+				continue;
+			}
+
+			newValues[ attributeName ] =
+				entityDataValues?.[ source.args.field ] ??
+				postDataFields.find(
+					( field ) => field.args.field === source.args.field
+				).label;
 		}
 		return newValues;
 	},
@@ -136,7 +104,7 @@ export default {
 			newData
 		);
 	},
-	canUserEditValue( { select, context, args } ) {
+	canUserEditValue( { select, context } ) {
 		const { getBlockName, getSelectedBlockClientId } =
 			select( blockEditorStore );
 		const clientId = getSelectedBlockClientId();
@@ -158,14 +126,6 @@ export default {
 			return false;
 		}
 
-		const fieldValue = getPostDataFields( select, context, undefined )?.[
-			args.field
-		]?.value;
-		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
-		if ( fieldValue === undefined ) {
-			return false;
-		}
-
 		// Check that the user has the capability to edit post data.
 		const canUserEdit = select( coreDataStore ).canUser( 'update', {
 			kind: 'postType',
@@ -178,7 +138,7 @@ export default {
 
 		return true;
 	},
-	getFieldsList( { select, context } ) {
+	getFieldsList( { select } ) {
 		const selectedBlock = select( blockEditorStore ).getSelectedBlock();
 		if ( selectedBlock?.name !== 'core/post-date' ) {
 			return [];
@@ -187,15 +147,7 @@ export default {
 		if ( NAVIGATION_BLOCK_TYPES.includes( selectedBlock?.name ) ) {
 			return [];
 		}
-		const clientId = select( blockEditorStore ).getSelectedBlockClientId();
-		const postDataFields = getPostDataFields( select, context, clientId );
-		if ( ! postDataFields ) {
-			return [];
-		}
-		return Object.entries( postDataFields ).map( ( [ key, field ] ) => ( {
-			label: field.label,
-			type: field.type,
-			args: { field: key },
-		} ) );
+
+		return postDataFields;
 	},
 };

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -68,16 +68,16 @@ export default {
 		);
 
 		const newValues = {};
-		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
-			if ( ! allowedFields.includes( source.args.field ) ) {
+		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
+			if ( ! allowedFields.includes( binding.args.field ) ) {
 				newValues[ attributeName ] = {};
 				continue;
 			}
 
 			newValues[ attributeName ] =
-				entityDataValues?.[ source.args.field ] ??
+				entityDataValues?.[ binding.args.field ] ??
 				postDataFields.find(
-					( field ) => field.args.field === source.args.field
+					( field ) => field.args.field === binding.args.field
 				).label;
 		}
 		return newValues;

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -35,41 +35,40 @@ import { unlock } from '../lock-unlock';
  * ```
  */
 function getPostMetaFields( select, context ) {
-	const { getEditedEntityRecord } = select( coreDataStore );
 	const { getRegisteredPostMeta } = unlock( select( coreDataStore ) );
 
-	let entityMetaValues;
-	// Try to get the current entity meta values.
-	if ( context?.postType && context?.postId ) {
-		entityMetaValues = getEditedEntityRecord(
-			'postType',
-			context?.postType,
-			context?.postId
-		).meta;
-	}
-
 	const registeredFields = getRegisteredPostMeta( context?.postType );
-	const metaFields = {};
-	Object.entries( registeredFields || {} ).forEach( ( [ key, props ] ) => {
+	const metaFields = [];
+	Object.entries( registeredFields ).forEach( ( [ key, props ] ) => {
 		// Don't include footnotes or private fields.
-		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
-			metaFields[ key ] = {
-				label: props.title || key,
-				value:
-					// When using the entity value, an empty string IS a valid value.
-					entityMetaValues?.[ key ] ??
-					// When using the default, an empty string IS NOT a valid value.
-					( props.default || undefined ),
-				type: props.type,
-			};
+		if ( key === 'footnotes' || key.charAt( 0 ) === '_' ) {
+			return;
 		}
+
+		metaFields.push( {
+			label: props.title || key,
+			args: { key },
+			type: props.type,
+		} );
 	} );
 
-	if ( ! Object.keys( metaFields || {} ).length ) {
-		return null;
-	}
-
 	return metaFields;
+}
+
+function getValue( { select, context, args } ) {
+	const { getEditedEntityRecord } = select( coreDataStore );
+	const entityMetaValues = getEditedEntityRecord(
+		'postType',
+		context?.postType,
+		context?.postId
+	).meta;
+
+	const metaFields = getPostMetaFields( select, context );
+	const metaField = metaFields.find(
+		( field ) => field.args.key === args.key
+	);
+
+	return entityMetaValues?.[ args.key ] ?? metaField?.label ?? args.key;
 }
 
 /**
@@ -78,15 +77,17 @@ function getPostMetaFields( select, context ) {
 export default {
 	name: 'core/post-meta',
 	getValues( { select, context, bindings } ) {
-		const metaFields = getPostMetaFields( select, context );
+		if ( ! context?.postType || ! context?.postId ) {
+			return {};
+		}
 
 		const newValues = {};
-		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
-			// Use the value, the field label, or the field key.
-			const fieldKey = source.args.key;
-			const { value: fieldValue, label: fieldLabel } =
-				metaFields?.[ fieldKey ] || {};
-			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
+		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
+			newValues[ attributeName ] = getValue( {
+				select,
+				context,
+				args: binding.args,
+			} );
 		}
 		return newValues;
 	},
@@ -116,10 +117,8 @@ export default {
 			return false;
 		}
 
-		const fieldValue = getPostMetaFields( select, context )?.[ args.key ]
-			?.value;
 		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
-		if ( fieldValue === undefined ) {
+		if ( getValue( { select, context, args } ) === undefined ) {
 			return false;
 		}
 		// Check that custom fields metabox is not enabled.
@@ -142,14 +141,6 @@ export default {
 		return true;
 	},
 	getFieldsList( { select, context } ) {
-		const metaFields = getPostMetaFields( select, context );
-		if ( ! metaFields ) {
-			return [];
-		}
-		return Object.entries( metaFields ).map( ( [ key, field ] ) => ( {
-			label: field.label,
-			type: field.type,
-			args: { key },
-		} ) );
+		return getPostMetaFields( select, context );
 	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -153,6 +153,12 @@ export default {
 		return true;
 	},
 	getFieldsList( { select, context } ) {
-		return getPostMetaFields( select, context ); // TODO: Remove defaults.
+		const metaFields = getPostMetaFields( select, context );
+		// Remove 'default' property from meta fields.
+		return metaFields.map(
+			( { default: defaultProp, ...otherProps } ) => ( {
+				...otherProps,
+			} )
+		);
 	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -77,10 +77,6 @@ function getValue( { select, context, args } ) {
 export default {
 	name: 'core/post-meta',
 	getValues( { select, context, bindings } ) {
-		if ( ! context?.postType || ! context?.postId ) {
-			return {};
-		}
-
 		const newValues = {};
 		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
 			newValues[ attributeName ] = getValue( {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -145,5 +145,5 @@ export default {
 	},
 	getFieldsList( { select, context } ) {
 		return getPostMetaFields( select, context ); // TODO: Remove defaults.
-	}
+	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -120,10 +120,14 @@ export default {
 			return false;
 		}
 
-		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
-		if ( getValue( { select, context, args } ) === undefined ) {
+		const metaFields = getPostMetaFields( select, context );
+		const hasMatchingMetaField = metaFields.some(
+			( field ) => field.args.key === args.key
+		);
+		if ( ! hasMatchingMetaField ) {
 			return false;
 		}
+
 		// Check that custom fields metabox is not enabled.
 		const areCustomFieldsEnabled =
 			select( editorStore ).getEditorSettings().enableCustomFields;

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -48,6 +48,7 @@ function getPostMetaFields( select, context ) {
 		metaFields.push( {
 			label: props.title || key,
 			args: { key },
+			default: props.default,
 			type: props.type,
 		} );
 	} );
@@ -56,17 +57,23 @@ function getPostMetaFields( select, context ) {
 }
 
 function getValue( { select, context, args } ) {
+	const metaFields = getPostMetaFields( select, context );
+	const metaField = metaFields.find(
+		( field ) => field.args.key === args.key
+	);
+
+	// Without a postId, we cannot look up a meta value.
+	if ( ! context?.postId ) {
+		// Return the default value for the meta field if available.
+		return metaField?.default || metaField?.label || args.key;
+	}
+
 	const { getEditedEntityRecord } = select( coreDataStore );
 	const entityMetaValues = getEditedEntityRecord(
 		'postType',
 		context?.postType,
 		context?.postId
 	).meta;
-
-	const metaFields = getPostMetaFields( select, context );
-	const metaField = metaFields.find(
-		( field ) => field.args.key === args.key
-	);
 
 	return entityMetaValues?.[ args.key ] ?? metaField?.label ?? args.key;
 }
@@ -137,6 +144,6 @@ export default {
 		return true;
 	},
 	getFieldsList( { select, context } ) {
-		return getPostMetaFields( select, context );
-	},
+		return getPostMetaFields( select, context ); // TODO: Remove defaults.
+	}
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -68,6 +68,11 @@ function getValue( { select, context, args } ) {
 		return metaField?.default || metaField?.label || args.key;
 	}
 
+	// If the meta field was not found, it's either protected, inaccessible, or simply doesn't exist.
+	if ( ! metaField ) {
+		return args.key;
+	}
+
 	const { getEditedEntityRecord } = select( coreDataStore );
 	const entityMetaValues = getEditedEntityRecord(
 		'postType',

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -62,15 +62,15 @@ function getValue( { select, context, args } ) {
 		( field ) => field.args.key === args.key
 	);
 
-	// Without a postId, we cannot look up a meta value.
-	if ( ! context?.postId ) {
-		// Return the default value for the meta field if available.
-		return metaField?.default || metaField?.label || args.key;
-	}
-
 	// If the meta field was not found, it's either protected, inaccessible, or simply doesn't exist.
 	if ( ! metaField ) {
 		return args.key;
+	}
+
+	// Without a postId, we cannot look up a meta value.
+	if ( ! context?.postId ) {
+		// Return the default value for the meta field if available.
+		return metaField.default || metaField.label || args.key;
 	}
 
 	const { getEditedEntityRecord } = select( coreDataStore );


### PR DESCRIPTION
## What?
Untangle code of Block Bindings `core/post-data` and `core/post-meta` sources.

## Why?
The code has gotten a bit messy lately. We should set a good example in the code of these sources since people will refer to these files when implementing their own sources.

Additionally, cleaner separation of listing available fields vs. fetching field values (see "How" section below) might pay off when we'll finally fix the `useSelect` issue 🤞 

## How?
Principles of information parsimony and separation of concerns.

I tried to make it so that `getFieldsList` only returns field labels, types, and arguments, but not field values; the latter can be obtained through `getValues).

I also turned a few fairly implicit fallbacks (think `return a ?? b ?? c`) into more explicit conditions (e.g. `if ( ! context?.postId ) {...}` or `if ( ! metaField ) {...}`, to make it clearer under what circumstances these things can happen.

## Testing Instructions
Smoke-test block bindings functionality.
Additionally, we have exhaustive e2e test coverage; verify that all tests are passing in CI.

## See also

https://github.com/WordPress/gutenberg/pull/72799 adds unit test coverage for the `core/post-meta` source. I've ran it against this PR, and all unit tests pass ✅ 

## Follow-up

I still have to handle `core/term-data`. AFAIK, there's less test coverage for that source, so I'd like to handle that separately (in order to reduce the risk of having to revert this PR). Furthermore, the `core/post-data` source took quite a bit of work, so I'd like to land it already 😅 