### PR TITLE
Build: Cleanup the build script

### DIFF
--- a/bin/packages/lib/package-utils.mjs
+++ b/bin/packages/lib/package-utils.mjs
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+/**
+ * Shared cache for package.json files to avoid redundant reads.
+ * Cache is keyed by the full package name from package.json's name field.
+ */
+const packageJsonCache = new Map();
+
+/**
+ * @typedef  {Object} PackageJson
+ *
+ * @property {string}                 name                    Package name.
+ * @property {string}                 version                 Package version.
+ * @property {string}                 [description]           Package description.
+ * @property {string}                 [author]                Package author.
+ * @property {string}                 [license]               Package license.
+ * @property {string}                 [main]                  Main entry point.
+ * @property {string}                 [module]                ES module entry point.
+ * @property {string}                 [react-native]          React Native entry point.
+ * @property {Record<string, string>} [dependencies]          Runtime dependencies.
+ * @property {Record<string, string>} [devDependencies]       Development dependencies.
+ * @property {Record<string, string>} [peerDependencies]      Peer dependencies.
+ * @property {string[]}               [wpScript]              WordPress script handles for dependency extraction.
+ * @property {Record<string, string>} [wpScriptModuleExports] WordPress script module exports.
+ * @property {Object}                 [sideEffects]           Side effects configuration for tree shaking.
+ * @property {string}                 [publishConfig]         NPM publish configuration.
+ * @property {Record<string, string>} [scripts]               NPM scripts.
+ * @property {string[]}               [files]                 Files to include in package.
+ * @property {string}                 [repository]            Repository URL.
+ * @property {string[]}               [keywords]              Package keywords.
+ */
+
+/**
+ * Get package.json info using Node's module resolution.
+ * Resolves the package using import.meta.resolve and reads its package.json.
+ *
+ * @param {string} fullPackageName The full package name (e.g., '@wordpress/blocks').
+ * @return {PackageJson|null} Package.json object or null if not found.
+ */
+export function getPackageInfo( fullPackageName ) {
+	if ( packageJsonCache.has( fullPackageName ) ) {
+		return packageJsonCache.get( fullPackageName );
+	}
+
+	try {
+		const resolved = import.meta.resolve(
+			`${ fullPackageName }/package.json`
+		);
+		const packageJson = JSON.parse(
+			readFileSync( fileURLToPath( resolved ), 'utf8' )
+		);
+		packageJsonCache.set( packageJson.name, packageJson );
+		return packageJson;
+	} catch ( error ) {
+		packageJsonCache.set( fullPackageName, null );
+		return null;
+	}
+}
+
+/**
+ * Get package.json info from an explicit file path.
+ * Reads the package.json file and caches it by its name field.
+ *
+ * @param {string} packageJsonPath Absolute path to package.json file.
+ * @return {PackageJson|null} Package.json object or null if not found.
+ */
+export function getPackageInfoFromFile( packageJsonPath ) {
+	try {
+		const packageJson = JSON.parse(
+			readFileSync( packageJsonPath, 'utf8' )
+		);
+		// Cache by the actual name from package.json
+		packageJsonCache.set( packageJson.name, packageJson );
+		return packageJson;
+	} catch ( error ) {
+		return null;
+	}
+}
+
+/**
+ * Convert kebab-case string to camelCase.
+ *
+ * @param {string} str String in kebab-case format.
+ * @return {string} String in camelCase format.
+ */
+export function kebabToCamelCase( str ) {
+	return str.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
+}

--- a/bin/packages/lib/php-generator.mjs
+++ b/bin/packages/lib/php-generator.mjs
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
+
+/**
+ * Get PHP replacements from root package.json.
+ *
+ * @param {string} rootDir Root directory path.
+ * @return {Promise<Object>} Replacements object with {{PREFIX}}, {{VERSION}}, {{VERSION_CONSTANT}}.
+ */
+export async function getPhpReplacements( rootDir ) {
+	const rootPackageJson = JSON.parse(
+		await readFile( path.join( rootDir, 'package.json' ), 'utf8' )
+	);
+	const prefix = rootPackageJson.wpPlugin?.prefix || 'gutenberg';
+	const version = rootPackageJson.version;
+	const versionConstant =
+		prefix.toUpperCase().replace( /-/g, '_' ) + '_VERSION';
+
+	return {
+		'{{PREFIX}}': prefix,
+		'{{VERSION}}': version,
+		'{{VERSION_CONSTANT}}': versionConstant,
+	};
+}
+
+/**
+ * Generate a PHP file from a template with replacements.
+ *
+ * @param {string} templateName Template file name.
+ * @param {string} outputPath   Full output path.
+ * @param {Object} replacements Replacements object (e.g. {'{{PREFIX}}': 'gutenberg'}).
+ */
+export async function generatePhpFromTemplate(
+	templateName,
+	outputPath,
+	replacements
+) {
+	// Templates directory
+	const templatesDir = path.join( __dirname, '..', 'templates' );
+
+	// Read template
+	const template = await readFile(
+		path.join( templatesDir, templateName ),
+		'utf8'
+	);
+
+	// Apply all replacements
+	let content = template;
+	for ( const [ placeholder, value ] of Object.entries( replacements ) ) {
+		// Use regex to replace all occurrences (like /{{PREFIX}}/g)
+		const regex = new RegExp( placeholder.replace( /[{}]/g, '\\$&' ), 'g' );
+		content = content.replace( regex, value );
+	}
+
+	// Write output file
+	await mkdir( path.dirname( outputPath ), { recursive: true } );
+	await writeFile( outputPath, content, 'utf8' );
+}

--- a/bin/packages/lib/wordpress-externals-plugin.mjs
+++ b/bin/packages/lib/wordpress-externals-plugin.mjs
@@ -1,0 +1,288 @@
+/**
+ * External dependencies
+ */
+import { writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { getPackageInfo, kebabToCamelCase } from './package-utils.mjs';
+
+/**
+ * Create WordPress externals plugin for esbuild.
+ * This plugin handles WordPress package externals and vendor libraries,
+ * treating them as external dependencies available via global variables.
+ *
+ * @return {Function} Function that creates the esbuild plugin instance.
+ */
+export function createWordpressExternalsPlugin() {
+	/**
+	 * WordPress externals plugin for esbuild.
+	 *
+	 * @param {string}        assetName         Base name for the asset file (e.g., 'index.min').
+	 * @param {string}        buildFormat       Build format: 'iife' for classic scripts, 'esm' for modules.
+	 * @param {Array<string>} extraDependencies Additional dependencies to include in the asset file.
+	 * @return {Object} esbuild plugin object.
+	 */
+	return function wordpressExternalsPlugin(
+		assetName = 'index.min',
+		buildFormat = 'iife',
+		extraDependencies = []
+	) {
+		return {
+			name: 'wordpress-externals',
+			/** @param {import('esbuild').PluginBuild} build */
+			setup( build ) {
+				const dependencies = new Set();
+				const moduleDependencies = new Map();
+
+				/**
+				 * Check if a package import is a script module.
+				 * A package is considered a script module if it has wpScriptModuleExports
+				 * and the specific import path (root or subpath) is declared in wpScriptModuleExports.
+				 *
+				 * @param {import('./package-utils.mjs').PackageJson} packageJson Package.json object.
+				 * @param {string|null}                               subpath     Subpath after package name, or null for root import.
+				 * @return {boolean} True if the import is a script module.
+				 */
+				function isScriptModuleImport( packageJson, subpath ) {
+					const { wpScriptModuleExports } = packageJson;
+
+					if ( ! wpScriptModuleExports ) {
+						return false;
+					}
+
+					// Root import: @wordpress/package-name
+					if ( ! subpath ) {
+						if ( typeof wpScriptModuleExports === 'string' ) {
+							return true;
+						}
+						if (
+							typeof wpScriptModuleExports === 'object' &&
+							wpScriptModuleExports[ '.' ]
+						) {
+							return true;
+						}
+						return false;
+					}
+
+					// Subpath import: @wordpress/package-name/subpath
+					if (
+						typeof wpScriptModuleExports === 'object' &&
+						wpScriptModuleExports[ `./${ subpath }` ]
+					) {
+						return true;
+					}
+
+					return false;
+				}
+
+				// Map of vendor packages to their global variables and handles
+				const vendorExternals = {
+					react: { global: 'React', handle: 'react' },
+					'react-dom': { global: 'ReactDOM', handle: 'react-dom' },
+					'react/jsx-runtime': {
+						global: 'ReactJSXRuntime',
+						handle: 'react-jsx-runtime',
+					},
+					'react/jsx-dev-runtime': {
+						global: 'ReactJSXRuntime',
+						handle: 'react-jsx-runtime',
+					},
+					moment: { global: 'moment', handle: 'moment' },
+					lodash: { global: 'lodash', handle: 'lodash' },
+					'lodash-es': { global: 'lodash', handle: 'lodash' },
+					jquery: { global: 'jQuery', handle: 'jquery' },
+				};
+
+				for ( const [ packageName, config ] of Object.entries(
+					vendorExternals
+				) ) {
+					build.onResolve(
+						{
+							filter: new RegExp(
+								`^${ packageName.replace(
+									/[.*+?^${}()|[\]\\]/g,
+									'\\$&'
+								) }$`
+							),
+						},
+						/** @param {import('esbuild').OnResolveArgs} args */
+						( args ) => {
+							dependencies.add( config.handle );
+
+							return {
+								path: args.path,
+								namespace: 'vendor-external',
+								pluginData: { global: config.global },
+							};
+						}
+					);
+				}
+
+				build.onResolve(
+					{ filter: /^@wordpress\// },
+					/** @param {import('esbuild').OnResolveArgs} args */
+					( args ) => {
+						// Extract package name and subpath from import
+						// e.g., '@wordpress/blocks/sub/path' → packageName='@wordpress/blocks', subpath='sub/path'
+						const parts = args.path.split( '/' );
+						const packageName =
+							parts.length >= 2
+								? `${ parts[ 0 ] }/${ parts[ 1 ] }`
+								: args.path;
+						const subpath =
+							parts.length > 2
+								? parts.slice( 2 ).join( '/' )
+								: null;
+						const shortName = parts[ 1 ]; // 'blocks' from '@wordpress/blocks'
+						const wpHandle = `wp-${ shortName }`;
+
+						const packageJson = getPackageInfo( packageName );
+
+						if ( ! packageJson ) {
+							return undefined;
+						}
+
+						let isScriptModule = isScriptModuleImport(
+							packageJson,
+							subpath
+						);
+						let isScript = !! packageJson.wpScript;
+						if ( isScriptModule && isScript ) {
+							// If the package is both a script and a script module, rely on the format being built
+							isScript = buildFormat === 'iife';
+							isScriptModule = buildFormat === 'esm';
+						}
+
+						const kind =
+							args.kind === 'dynamic-import'
+								? 'dynamic'
+								: 'static';
+
+						if ( isScriptModule ) {
+							if ( kind === 'static' ) {
+								moduleDependencies.set( args.path, 'static' );
+							} else if (
+								! moduleDependencies.has( args.path )
+							) {
+								moduleDependencies.set( args.path, 'dynamic' );
+							}
+
+							return {
+								path: args.path,
+								external: true,
+							};
+						}
+
+						if ( isScript ) {
+							dependencies.add( wpHandle );
+
+							return {
+								path: args.path,
+								namespace: 'wordpress-external',
+							};
+						}
+
+						return undefined;
+					}
+				);
+
+				build.onLoad(
+					{ filter: /.*/, namespace: 'vendor-external' },
+					/** @param {import('esbuild').OnLoadArgs} args */
+					( args ) => {
+						const global = args.pluginData.global;
+
+						return {
+							contents: `module.exports = window.${ global };`,
+							loader: 'js',
+						};
+					}
+				);
+
+				build.onLoad(
+					{ filter: /.*/, namespace: 'wordpress-external' },
+					/** @param {import('esbuild').OnLoadArgs} args */
+					( args ) => {
+						const wpGlobal = kebabToCamelCase(
+							args.path.replace( '@wordpress/', '' )
+						);
+
+						return {
+							contents: `module.exports = window.wp.${ wpGlobal };`,
+							loader: 'js',
+						};
+					}
+				);
+
+				build.onEnd(
+					/** @param {import('esbuild').BuildResult} result */
+					async ( result ) => {
+						if ( result.errors.length > 0 ) {
+							return;
+						}
+
+						// Merge discovered dependencies with extra dependencies
+						const allDependencies = new Set( [
+							...dependencies,
+							...extraDependencies,
+						] );
+
+						const dependenciesString = Array.from( allDependencies )
+							.sort()
+							.map( ( dep ) => `'${ dep }'` )
+							.join( ', ' );
+
+						// Format module dependencies as array of arrays with 'id' and 'import' keys
+						const moduleDependenciesArray = Array.from(
+							moduleDependencies.entries()
+						)
+							.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+							.map(
+								( [ dep, kind ] ) =>
+									`array('id' => '${ dep }', 'import' => '${ kind }')`
+							);
+
+						const moduleDependenciesString =
+							moduleDependenciesArray.length > 0
+								? moduleDependenciesArray.join( ', ' )
+								: '';
+
+						const version = Date.now();
+
+						const parts = [
+							`'dependencies' => array(${ dependenciesString })`,
+						];
+						if ( moduleDependenciesString ) {
+							parts.push(
+								`'module_dependencies' => array(${ moduleDependenciesString })`
+							);
+						}
+						parts.push( `'version' => '${ version }'` );
+						const assetContent = `<?php return array(${ parts.join(
+							', '
+						) });`;
+
+						const outputDir =
+							build.initialOptions.outdir ||
+							path.dirname(
+								build.initialOptions.outfile || 'build'
+							);
+
+						const assetFilePath = path.join(
+							outputDir,
+							`${ assetName }.asset.php`
+						);
+
+						await mkdir( path.dirname( assetFilePath ), {
+							recursive: true,
+						} );
+						await writeFile( assetFilePath, assetContent );
+					}
+				);
+			},
+		};
+	};
+}

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -2,7 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"esModuleInterop": true,
 		"target": "ES6",
 		"lib": [ "ES6", "ES2020.string" ],
@@ -41,7 +42,6 @@
 		"packages/build-vendors.mjs",
 		"packages/build.mjs",
 		"packages/check-build-type-declaration-files.js",
-		"packages/dependency-graph.js",
 		"packages/lint-staged-typecheck.js",
 		"plugin/cli.js",
 		"plugin/commands/common.js",


### PR DESCRIPTION
Related #72032 

## What?

Refactors the package build tool to be fully portable and removes hardcoded path assumptions.

  ## Why?

A few things that were solved 

  - Package paths were computed relative to the script location instead of the project root. This means the build tool was not usable as an npm dependency.
  - Hardcoded `@wordpress/` prefix assumptions instead of reading actual package names
  - Use package resolution for the dependency extraction plugin (to support wordpress packages in node_modules)

## How?

-  Changed from script-relative paths to working-directory-relative paths, making the tool portable.
- **Local packages**: Read directly from filesystem using `getPackageInfoFromFile()`
- **Dependencies**: Use Node's module resolution with `getPackageInfo()`
- Both share a unified cache for performance.
- Extracted externals plugin to its own file
- Extracted php generator (and consolidated code)

## Testing Instructions

Built tool is run in CI, so e2e tests should pass basically/