### PR TITLE
Fix TS types for `e2e-test-utils-playwright` package

### DIFF
--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -30,7 +30,10 @@
 	],
 	"main": "./build/index.js",
 	"exports": {
-		".": "./build/index.js",
+		".": {
+			"types": "./build-types/index.d.ts",
+			"default": "./build/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"types": "./build-types",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
TS Types for `@wordpress/e2e-test-utils-playwright` [are broken](https://arethetypeswrong.github.io/?p=%40wordpress%2Fe2e-test-utils-playwright%401.33.0) as mentioned in https://github.com/WordPress/gutenberg/pull/72251#discussion_r2468887751

This PR fixes the `exports` field to ensure that TS is able to locate the types.

## Why?
The TS types in production are broken.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
- Checkout the PR
- Use [arethetypeswrong](https://arethetypeswrong.github.io/) CLI and run `attw --pack .` in the package directory
- Confirm that you see no problems reported.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="585" height="461" alt="Screenshot 2025-10-28 at 4 29 41 PM" src="https://github.com/user-attachments/assets/4e63ea04-15fa-47ef-9d54-b81293ddc8ae" />|<img width="596" height="393" alt="Screenshot 2025-10-28 at 4 30 00 PM" src="https://github.com/user-attachments/assets/9a3b9287-d0ea-40a4-b3e2-b3515703e09c" />|
