### PR TITLE
Sync package versions from `wp/latest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51215,7 +51215,7 @@
 		},
 		"packages/block-directory": {
 			"name": "@wordpress/block-directory",
-			"version": "5.33.0",
+			"version": "5.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -51352,7 +51352,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "9.33.0",
+			"version": "9.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -51964,7 +51964,7 @@
 		},
 		"packages/customize-widgets": {
 			"name": "@wordpress/customize-widgets",
-			"version": "5.33.0",
+			"version": "5.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -52252,7 +52252,7 @@
 		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
-			"version": "8.33.0",
+			"version": "8.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52299,7 +52299,7 @@
 		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
-			"version": "6.33.0",
+			"version": "6.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -52363,7 +52363,7 @@
 		},
 		"packages/edit-widgets": {
 			"name": "@wordpress/edit-widgets",
-			"version": "6.33.0",
+			"version": "6.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -52406,7 +52406,7 @@
 		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
-			"version": "14.33.0",
+			"version": "14.33.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@floating-ui/react-dom": "2.0.8",
@@ -52591,7 +52591,7 @@
 		},
 		"packages/fields": {
 			"name": "@wordpress/fields",
-			"version": "0.25.0",
+			"version": "0.25.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51215,7 +51215,7 @@
 		},
 		"packages/block-directory": {
 			"name": "@wordpress/block-directory",
-			"version": "5.33.1",
+			"version": "5.33.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52047,7 +52047,7 @@
 		},
 		"packages/dataviews": {
 			"name": "@wordpress/dataviews",
-			"version": "10.0.0",
+			"version": "10.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
@@ -52252,7 +52252,7 @@
 		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
-			"version": "8.33.1",
+			"version": "8.33.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52299,7 +52299,7 @@
 		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
-			"version": "6.33.1",
+			"version": "6.33.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -52406,7 +52406,7 @@
 		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
-			"version": "14.33.1",
+			"version": "14.33.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@floating-ui/react-dom": "2.0.8",
@@ -52591,7 +52591,7 @@
 		},
 		"packages/fields": {
 			"name": "@wordpress/fields",
-			"version": "0.25.1",
+			"version": "0.25.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -53888,7 +53888,7 @@
 		},
 		"packages/views": {
 			"name": "@wordpress/views",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/data": "file:../data",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "5.33.0",
+	"version": "5.33.1",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "5.33.1",
+	"version": "5.33.2",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "9.33.0",
+	"version": "9.33.1",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"version": "5.33.0",
+	"version": "5.33.1",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 10.1.0 (2025-10-21)
+
 ### Enhancements
 
 - DataForm: update spacing for regular and card layouts. [#72249](https://github.com/WordPress/gutenberg/pull/72249).

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dataviews",
-	"version": "10.0.0",
+	"version": "10.1.0-prerelease",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dataviews",
-	"version": "10.1.0-prerelease",
+	"version": "10.1.0",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "8.33.0",
+	"version": "8.33.1",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "8.33.1",
+	"version": "8.33.2",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "6.33.0",
+	"version": "6.33.1",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "6.33.1",
+	"version": "6.33.2",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-widgets",
-	"version": "6.33.0",
+	"version": "6.33.1",
 	"description": "Widgets Page module for WordPress..",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "14.33.0",
+	"version": "14.33.1",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "14.33.1",
+	"version": "14.33.2",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/fields",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/fields",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/views",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "View persistence and management for WordPress DataViews.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What?
Syncs package versions in the `wp/6.9` branch to be up to date.

<!-- In a few words, what is the PR actually doing? -->

## Why?
As `wp/6.9` was forked from `release/21.9` right before WordPress 6.9-beta1 and not right after Gutenberg 21.9, it doesn't contain the version bumps that happened on the `wp/latest` branch in between Gutenberg 21.9 and WordPress 6.9-beta1 launches.

This results in [the npm package release workflow failing for 6.9](https://github.com/WordPress/gutenberg/actions/runs/18871919351/job/53852177149#step:11:203) because some of the new package versions' workflow tries to release already existing versions.

## How?
Cherry picking the commits that bump versions during the time window between Gutenberg 21.9 and WordPress 6.9-Beta1

## Testing Instructions
Verify that the version bumps match the last package in npmjs.com.

## Versions updated
- block-directory -> 5.33.2
- block-library -> 9.33.1
- customize-widgets -> 5.33.1
- dataviews -> 10.1.0
- edit-post -> 8.33.2
- edit-site -> 6.33.2
- edit-widgets -> 6.33.1
- editor -> 14.33.2
- fields -> 0.25.2
- views -> 1.0.1