### PR TITLE
[Create block templates] Add main properties to the template package.json files

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
+## Unreleased
+
+-   Add `main` property to `package.json` to address install errors ([#72746](https://github.com/WordPress/gutenberg/pull/72746))
+
 ## 2.8.0 (2024-09-19)
 
 ### Enhancements

--- a/packages/create-block-interactive-template/package.json
+++ b/packages/create-block-interactive-template/package.json
@@ -23,6 +23,7 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
+	"main": "index.js",
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-   Add `main` property to `package.json` to address install errors ([#72746](https://github.com/WordPress/gutenberg/pull/72746))
 
 ## 4.33.0 (2025-10-17)
 

--- a/packages/create-block-tutorial-template/package.json
+++ b/packages/create-block-tutorial-template/package.json
@@ -23,6 +23,7 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
+	"main": "index.js",
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When running create-block with either the `@wordpress/create-block-interactive-template` or `@wordpress/create-block-tutorial-template` templates, the following error occurs:

```bash
Invalid plugin template downloaded. Error: No "exports" main defined in /var/folders/b5/0n0753r97jj7wvpmccw8phr40000gn/T/wp-create-block-neaxHf/node_modules/@wordpress/create-block-interactive-template/package.json
```
<!-- In a few words, what is the PR actually doing? -->

## Why?
The packages do not work.

## How?
This PR adds the `main` property to both package to address this issue.

## Testing Instructions
This is hard to test locally as it works as expected.

I am not able to 100% confirm that this is the fix as I think it needs to be published to NPM to check properly but I am not running into this error when using templates that do have the `main` property defined:

```bash
npx @wordpress/create-block@latest preset-block-bindings --template @block-developer-cookbook/preset-block-bindings
```
