### PR TITLE
Testing: Update guidance around unique element IDs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,16 +93,7 @@ const restrictedSyntax = [
 	{
 		selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
 		message:
-			'Do not use string literals for IDs; use withInstanceId instead.',
-	},
-	{
-		// Discourage the usage of `Math.random()` as it's a code smell
-		// for UUID generation, for which we already have a higher-order
-		// component: `withInstanceId`.
-		selector:
-			'CallExpression[callee.object.name="Math"][callee.property.name="random"]',
-		message:
-			'Do not use Math.random() to generate unique IDs; use withInstanceId instead. (If you’re not generating unique IDs: ignore this message.)',
+			'Do not use string literals for IDs; use React useId hook instead.',
 	},
 	{
 		selector:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,8 +92,7 @@ const restrictedSyntax = [
 	},
 	{
 		selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
-		message:
-			'Do not use string literals for IDs; use React useId hook instead.',
+		message: 'Do not use string literals for IDs; use useId hook instead.',
 	},
 	{
 		selector:

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -30,8 +30,6 @@ const globalTips = [
 
 function Tips() {
 	const [ randomIndex ] = useState(
-		// Disable Reason: I'm not generating an HTML id.
-		// eslint-disable-next-line no-restricted-syntax
 		Math.floor( Math.random() * globalTips.length )
 	);
 

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -228,9 +228,7 @@ export function useColorRandomizer( blockName?: string ): [ () => void ] | [] {
 			return;
 		}
 
-		/* eslint-disable no-restricted-syntax */
 		const randomRotationValue = Math.floor( Math.random() * 225 );
-		/* eslint-enable no-restricted-syntax */
 
 		const newColors = themeColors.map( ( colorObject ) => {
 			const { color } = colorObject;

--- a/packages/jest-preset-default/scripts/setup-globals.js
+++ b/packages/jest-preset-default/scripts/setup-globals.js
@@ -17,7 +17,6 @@ global.window.setImmediate = function ( callback ) {
 global.window.requestAnimationFrame = function requestAnimationFrame(
 	callback
 ) {
-	// eslint-disable-next-line no-restricted-syntax
 	const randomDelay = Math.round( ( Math.random() * 1_000 ) / 60 );
 
 	return setTimeout( () => callback( Date.now() ), randomDelay );

--- a/packages/react-native-editor/.eslintrc.js
+++ b/packages/react-native-editor/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
 			{
 				selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
 				message:
-					'Do not use string literals for IDs; use React useId hook instead.',
+					'Do not use string literals for IDs; use useId hook instead.',
 			},
 			{
 				selector:

--- a/packages/react-native-editor/.eslintrc.js
+++ b/packages/react-native-editor/.eslintrc.js
@@ -48,16 +48,7 @@ module.exports = {
 			{
 				selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
 				message:
-					'Do not use string literals for IDs; use withInstanceId instead.',
-			},
-			{
-				// Discourage the usage of `Math.random()` as it's a code smell
-				// for UUID generation, for which we already have a higher-order
-				// component: `withInstanceId`.
-				selector:
-					'CallExpression[callee.object.name="Math"][callee.property.name="random"]',
-				message:
-					'Do not use Math.random() to generate unique IDs; use withInstanceId instead. (If you’re not generating unique IDs: ignore this message.)',
+					'Do not use string literals for IDs; use React useId hook instead.',
 			},
 			{
 				selector:

--- a/packages/sync/src/providers/webrtc-http-stream-signaling.js
+++ b/packages/sync/src/providers/webrtc-http-stream-signaling.js
@@ -178,7 +178,6 @@ function setupSignalEventHandlers( signalCon, url ) {
  */
 function setupHttpSignal( httpClient ) {
 	if ( httpClient.shouldConnect && httpClient.ws === null ) {
-		// eslint-disable-next-line no-restricted-syntax
 		const subscriberId = Math.floor( 100000 + Math.random() * 900000 );
 		const url = httpClient.url;
 		const eventSource = new window.EventSource(

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -53,8 +53,6 @@ export function deserializeCrdtDoc(
 		// Overwrite the client ID (which is from a previous session) with a random
 		// client ID. Deserialized documents should not be used directly. Instead,
 		// their state should be applied to another in-use document.
-		//
-		// eslint-disable-next-line no-restricted-syntax
 		ydoc.clientID = Math.floor( Math.random() * 1000000000 );
 
 		return ydoc;


### PR DESCRIPTION
## What?

Updates lint rules to reflect updated standards around unique IDs.

## Why?

[`withInstanceId`](https://github.com/WordPress/gutenberg/tree/trunk/packages/compose/src/higher-order/with-instance-id) was originally created to address a need for standardized unique ID creation, but should ideally be phased out:

- We should prefer hooks over higher-order components as much as possible (see also [`useInstanceId`](https://github.com/WordPress/gutenberg/tree/trunk/packages/compose/src/hooks/use-instance-id))
- React now provides a built-in [`useId` hook](https://react.dev/reference/react/useId) which serves this purpose

## How?

- Replaces ESLint recommendation of `withInstanceId` with React `useId`
- Removes lint rule around `Math.random`. While this may have been an issue historically, it creates a lot of false positive, and there should now be general knowledge of `useId` for creating unique IDs that (in combination with the syntax linter around string assignment of IDs) most issues should be avoidable

## Testing Instructions

Lint checks should pass.