### PR TITLE
Upgrade Playwright to v1.56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.55.0",
+				"@playwright/test": "1.56.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -9238,13 +9238,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-			"integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+			"version": "1.56.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.55.0"
+				"playwright": "1.56.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -39227,13 +39227,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-			"integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+			"version": "1.56.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.55.0"
+				"playwright-core": "1.56.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -39246,9 +39246,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-			"integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+			"version": "1.56.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -54126,7 +54126,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.55.0",
+				"@playwright/test": "^1.56.1",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.55.0",
+		"@playwright/test": "1.56.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -94,7 +94,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.55.0",
+		"@playwright/test": "^1.56.1",
 		"@wordpress/env": "^10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -156,7 +156,6 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const paragraphs = patternBlocks.first().getByRole( 'document', {
 				name: 'Block: Paragraph',
-				includeHidden: true,
 			} );
 			// Ensure the first pattern is selected.
 			await patternBlocks.first().selectText();
@@ -455,11 +454,9 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const patternBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Pattern',
-				includeHidden: true,
 			} );
 			const paragraphs = editor.canvas.getByRole( 'document', {
 				name: 'Block: Paragraph',
-				includeHidden: true,
 			} );
 			const blockWithOverrides = paragraphs.filter( {
 				hasText: 'Pattern Overrides',
@@ -623,7 +620,6 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const paragraphBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Paragraph',
-				includeHidden: true,
 			} );
 			await expect( headingBlock ).toHaveText( 'Outer heading (edited)' );
 			await expect( headingBlock ).not.toHaveAttribute( 'inert', 'true' );
@@ -994,7 +990,6 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 		const headingBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Heading',
-			includeHidden: true,
 		} );
 		const paragraphBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Paragraph',
@@ -1079,7 +1074,6 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 		const paragraphBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Paragraph',
-			includeHidden: true,
 		} );
 		const resetButton = page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -1144,7 +1138,6 @@ test.describe( 'Pattern Overrides', () => {
 
 		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
-			includeHidden: true,
 		} );
 		await editor.selectBlocks( imageBlock );
 		await imageBlock

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -596,10 +596,7 @@ test.describe( 'Synced pattern', () => {
 
 		await expect(
 			editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Paragraph',
-					includeHidden: true,
-				} )
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
 				.filter( { hasText: 'Awesome Paragraph modified' } )
 		).toHaveCount( 2 );
 	} );


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.56.

I've also reverted test changes related to [`inert` elements](https://github.com/WordPress/gutenberg/pull/71285#issuecomment-3209301152). Ref: https://github.com/microsoft/playwright/pull/36947#issuecomment-3209227522.

## What's new?
https://playwright.dev/docs/release-notes#version-156

## Testing Instructions

- Run any e2e test locally; the command should download new browsers and run the test successfully.
- CI checks are green.
