### PR TITLE
Build: Support third-party plugin scripts properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"npm": ">=10.2.3"
 	},
 	"wpPlugin": {
-		"prefix": "gutenberg",
+		"name": "gutenberg",
 		"scriptGlobal": "wp",
 		"packageNamespace": "wordpress"
 	},

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
 		"npm": ">=10.2.3"
 	},
 	"wpPlugin": {
-		"prefix": "gutenberg"
+		"prefix": "gutenberg",
+		"scriptGlobal": "wp",
+		"packageNamespace": "wordpress"
 	},
 	"config": {
 		"IS_GUTENBERG_PLUGIN": true

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -155,6 +155,52 @@ The package scope to match for global exposure (without `@` prefix). Only packag
 }
 ```
 
+### `wpPlugin.handlePrefix`
+
+The prefix used for WordPress script handles in `.asset.php` files (e.g., `wp-data`, `my-plugin-editor`). Defaults to `packageNamespace`:
+
+```json
+{
+	"wpPlugin": {
+		"scriptGlobal": "myPlugin",
+		"packageNamespace": "my-plugin",
+		"handlePrefix": "mp"
+	}
+}
+```
+
+With this configuration:
+- `@my-plugin/editor` → `window.myPlugin.editor` with handle `mp-editor`
+- `@my-plugin/data` → `window.myPlugin.data` with handle `mp-data`
+
+### `wpPlugin.externalNamespaces`
+
+Additional package namespaces to externalize (consume as externals, not expose). Each namespace must be an object with `global` and optional `handlePrefix`:
+
+```json
+{
+	"wpPlugin": {
+		"externalNamespaces": {
+			"woo": {
+				"global": "woo",
+				"handlePrefix": "woocommerce"
+			},
+			"acme": {
+				"global": "acme",
+				"handlePrefix": "acme-plugin"
+			}
+		}
+	}
+}
+```
+
+This allows your packages to consume third-party dependencies as externals:
+- `import { Cart } from '@woo/cart'` → `window.woo.cart` with handle `woocommerce-cart`
+- `import { Button } from '@acme/ui'` → `window.acme.ui` with handle `acme-plugin-ui`
+- Dependencies are tracked in `.asset.php` files
+
+If `handlePrefix` is omitted, it defaults to the namespace key (e.g., `"woo"` → `woo-cart`).
+
 ### Example: WordPress Core (Gutenberg)
 
 ```json

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -126,6 +126,76 @@ Files to copy with optional PHP transformations:
 }
 ```
 
+## Root Configuration
+
+Configure your root `package.json` with a `wpPlugin` object to control global namespace and externalization behavior:
+
+### `wpPlugin.scriptGlobal`
+
+The global variable name for your packages (e.g., `"wp"`, `"myPlugin"`). Set to `false` to disable global exposure:
+
+```json
+{
+	"wpPlugin": {
+		"scriptGlobal": "myPlugin"
+	}
+}
+```
+
+### `wpPlugin.packageNamespace`
+
+The package scope to match for global exposure (without `@` prefix). Only packages matching `@{packageNamespace}/*` will expose globals:
+
+```json
+{
+	"wpPlugin": {
+		"scriptGlobal": "myPlugin",
+		"packageNamespace": "my-plugin"
+	}
+}
+```
+
+### Example: WordPress Core (Gutenberg)
+
+```json
+{
+	"wpPlugin": {
+		"scriptGlobal": "wp",
+		"packageNamespace": "wordpress"
+	}
+}
+```
+
+This configuration:
+- Packages like `@wordpress/data` expose `window.wp.data`
+- Packages like `@wordpress/block-editor` expose `window.wp.blockEditor`
+- All packages can consume `@wordpress/*` as externals
+
+### Example: Third-Party Plugin
+
+```json
+{
+	"wpPlugin": {
+		"scriptGlobal": "acme",
+		"packageNamespace": "acme"
+	}
+}
+```
+
+This configuration:
+- Packages like `@acme/editor` expose `window.acme.editor`
+- Packages like `@acme/data` expose `window.acme.data`
+- All packages can still consume `@wordpress/*` → `window.wp.*`
+- All packages can still consume vendors (react, lodash) → `window.React`, `window.lodash`
+
+### Behavior
+
+- **Packages with `wpScript: true` matching the namespace**: Bundled with global exposure
+- **Packages with `wpScript: true` not matching the namespace**: Bundled without global exposure
+- **Dependencies**: `@wordpress/*` packages are always externalized to `wp.*` globals
+- **Vendors**: React, lodash, jQuery, moment are always externalized to their standard globals
+- **Asset files**: `.asset.php` files are always generated for WordPress dependency management
+
 ## Output Structure
 
 The built tool generates several files in the `build/` directory, but the primary output is the PHP registration file.

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -65,6 +65,8 @@ const ROOT_PACKAGE_JSON = getPackageInfoFromFile( path.join( ROOT_DIR, 'package.
 const WP_PLUGIN_CONFIG = ROOT_PACKAGE_JSON.wpPlugin || {};
 const SCRIPT_GLOBAL = WP_PLUGIN_CONFIG.scriptGlobal;
 const PACKAGE_NAMESPACE = WP_PLUGIN_CONFIG.packageNamespace;
+const HANDLE_PREFIX = WP_PLUGIN_CONFIG.handlePrefix || PACKAGE_NAMESPACE;
+const EXTERNAL_NAMESPACES = WP_PLUGIN_CONFIG.externalNamespaces || {};
 
 
 const baseDefine = {
@@ -85,7 +87,9 @@ const getDefine = ( scriptDebug ) => ( {
  */
 const wordpressExternalsPlugin = createWordpressExternalsPlugin(
 	PACKAGE_NAMESPACE,
-	SCRIPT_GLOBAL
+	SCRIPT_GLOBAL,
+	EXTERNAL_NAMESPACES,
+	HANDLE_PREFIX
 );
 
 /**

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -61,6 +61,11 @@ function getAllPackages() {
 }
 
 const PACKAGES = getAllPackages();
+const ROOT_PACKAGE_JSON = getPackageInfoFromFile( path.join( ROOT_DIR, 'package.json' ) );
+const WP_PLUGIN_CONFIG = ROOT_PACKAGE_JSON.wpPlugin || {};
+const SCRIPT_GLOBAL = WP_PLUGIN_CONFIG.scriptGlobal;
+const PACKAGE_NAMESPACE = WP_PLUGIN_CONFIG.packageNamespace;
+
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
@@ -76,9 +81,12 @@ const getDefine = ( scriptDebug ) => ( {
 } );
 
 /**
- * Initialize WordPress externals plugin.
+ * Initialize WordPress externals plugin with custom namespace configuration.
  */
-const wordpressExternalsPlugin = createWordpressExternalsPlugin();
+const wordpressExternalsPlugin = createWordpressExternalsPlugin(
+	PACKAGE_NAMESPACE,
+	SCRIPT_GLOBAL
+);
 
 /**
  * Create emotion babel plugin for esbuild.
@@ -263,7 +271,15 @@ async function bundlePackage( packageName ) {
 		const entryPoint = resolveEntryPoint( packageDir, packageJson );
 		const outputDir = path.join( BUILD_DIR, 'scripts', packageName );
 		const target = browserslistToEsbuild();
-		const globalName = `wp.${ camelCase( packageName ) }`;
+
+		// Check if package matches the namespace and should expose a global
+		const packageFullName = packageJson.name;
+		const matchesNamespace = packageFullName.startsWith( `@${ PACKAGE_NAMESPACE }/` );
+		const shouldExposeGlobal = matchesNamespace && SCRIPT_GLOBAL !== false;
+
+		const globalName = shouldExposeGlobal
+			? `${ SCRIPT_GLOBAL }.${ camelCase( packageName ) }`
+			: undefined;
 
 		const baseConfig = {
 			entryPoints: [ entryPoint ],
@@ -276,7 +292,7 @@ async function bundlePackage( packageName ) {
 		};
 
 		// For packages with default exports, add a footer to properly expose the default
-		if ( packageJson.wpScriptDefaultExport ) {
+		if ( packageJson.wpScriptDefaultExport && globalName ) {
 			baseConfig.footer = {
 				js: `if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`,
 			};

--- a/packages/wp-build/src/php-generator.mjs
+++ b/packages/wp-build/src/php-generator.mjs
@@ -27,13 +27,13 @@ export async function getPhpReplacements( rootDir ) {
 	}
 
 	// @ts-expect-error specific override to package.json
-	const prefix = rootPackageJson.wpPlugin?.prefix || 'gutenberg';
+	const name = rootPackageJson.wpPlugin?.name || 'gutenberg';
 	const version = rootPackageJson.version;
 	const versionConstant =
-		prefix.toUpperCase().replace( /-/g, '_' ) + '_VERSION';
+		name.toUpperCase().replace( /-/g, '_' ) + '_VERSION';
 
 	return {
-		'{{PREFIX}}': prefix,
+		'{{PREFIX}}': name,
 		'{{VERSION}}': version,
 		'{{VERSION_CONSTANT}}': versionConstant,
 	};

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -17,9 +17,16 @@ import { getPackageInfo } from './package-utils.mjs';
  *
  * @param {string} packageNamespace Custom package namespace (e.g., 'wordpress', 'my-plugin').
  * @param {string|false} scriptGlobal Global variable name (e.g., 'wp', 'myPlugin') or false to disable globals.
+ * @param {Object} externalNamespaces Additional namespaces to externalize (e.g., { 'woo': { global: 'woo', handlePrefix: 'woocommerce' } }).
+ * @param {string} handlePrefix Handle prefix for main package (e.g., 'wp', 'mp'). Defaults to packageNamespace.
  * @return {Function} Function that creates the esbuild plugin instance.
  */
-export function createWordpressExternalsPlugin( packageNamespace, scriptGlobal ) {
+export function createWordpressExternalsPlugin(
+	packageNamespace,
+	scriptGlobal,
+	externalNamespaces = {},
+	handlePrefix
+) {
 	/**
 	 * WordPress externals plugin for esbuild.
 	 *
@@ -115,7 +122,17 @@ export function createWordpressExternalsPlugin( packageNamespace, scriptGlobal )
 						namespace: packageNamespace,
 						pattern: new RegExp( `^@${ packageNamespace }/` ),
 						globalName: scriptGlobal,
-						handlePrefix: packageNamespace,
+						handlePrefix: handlePrefix || packageNamespace,
+					} );
+				}
+
+				// Add additional external namespaces from configuration
+				for ( const [ namespace, config ] of Object.entries( externalNamespaces ) ) {
+					packageExternals.push( {
+						namespace,
+						pattern: new RegExp( `^@${ namespace }/` ),
+						globalName: config.global,
+						handlePrefix: config.handlePrefix || namespace,
 					} );
 				}
 

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -15,9 +15,11 @@ import { getPackageInfo } from './package-utils.mjs';
  * This plugin handles WordPress package externals and vendor libraries,
  * treating them as external dependencies available via global variables.
  *
+ * @param {string} packageNamespace Custom package namespace (e.g., 'wordpress', 'my-plugin').
+ * @param {string|false} scriptGlobal Global variable name (e.g., 'wp', 'myPlugin') or false to disable globals.
  * @return {Function} Function that creates the esbuild plugin instance.
  */
-export function createWordpressExternalsPlugin() {
+export function createWordpressExternalsPlugin( packageNamespace, scriptGlobal ) {
 	/**
 	 * WordPress externals plugin for esbuild.
 	 *
@@ -97,6 +99,26 @@ export function createWordpressExternalsPlugin() {
 					jquery: { global: 'jQuery', handle: 'jquery' },
 				};
 
+				// Build list of package namespace configurations
+				const packageExternals = [
+					{
+						namespace: 'wordpress',
+						pattern: /^@wordpress\//,
+						globalName: 'wp',
+						handlePrefix: 'wp',
+					},
+				];
+
+				// Add custom namespace if different from wordpress and scriptGlobal is not false
+				if ( packageNamespace && packageNamespace !== 'wordpress' && scriptGlobal !== false ) {
+					packageExternals.push( {
+						namespace: packageNamespace,
+						pattern: new RegExp( `^@${ packageNamespace }/` ),
+						globalName: scriptGlobal,
+						handlePrefix: packageNamespace,
+					} );
+				}
+
 				for ( const [ packageName, config ] of Object.entries(
 					vendorExternals
 				) ) {
@@ -117,71 +139,75 @@ export function createWordpressExternalsPlugin() {
 					);
 				}
 
-				build.onResolve(
-					{ filter: /^@wordpress\// },
-					/** @param {import('esbuild').OnResolveArgs} args */
-					( args ) => {
-						// Extract package name and subpath from import
-						// e.g., '@wordpress/blocks/sub/path' → packageName='@wordpress/blocks', subpath='sub/path'
-						const parts = args.path.split( '/' );
-						let packageName = args.path;
-						let subpath = null;
-						if ( parts.length > 2 ) {
-							packageName = parts.slice( 0, 2 ).join( '/' );
-							subpath = parts.slice( 2 ).join( '/' );
-						}
-						const shortName = parts[ 1 ]; // 'blocks' from '@wordpress/blocks'
-						const wpHandle = `wp-${ shortName }`;
+				// Handle package namespace externals (wordpress and custom)
+				for ( const externalConfig of packageExternals ) {
+					build.onResolve(
+						{ filter: externalConfig.pattern },
+						/** @param {import('esbuild').OnResolveArgs} args */
+						( args ) => {
+							// Extract package name and subpath from import
+							// e.g., '@wordpress/blocks/sub/path' → packageName='@wordpress/blocks', subpath='sub/path'
+							const parts = args.path.split( '/' );
+							let packageName = args.path;
+							let subpath = null;
+							if ( parts.length > 2 ) {
+								packageName = parts.slice( 0, 2 ).join( '/' );
+								subpath = parts.slice( 2 ).join( '/' );
+							}
+							const shortName = parts[ 1 ];
+							const handle = `${ externalConfig.handlePrefix }-${ shortName }`;
 
-						const packageJson = getPackageInfo( packageName );
+							const packageJson = getPackageInfo( packageName );
 
-						if ( ! packageJson ) {
-							return undefined;
-						}
-
-						let isScriptModule = isScriptModuleImport(
-							packageJson,
-							subpath
-						);
-						let isScript = !! packageJson.wpScript;
-						if ( isScriptModule && isScript ) {
-							// If the package is both a script and a script module, rely on the format being built
-							isScript = buildFormat === 'iife';
-							isScriptModule = buildFormat === 'esm';
-						}
-
-						const kind =
-							args.kind === 'dynamic-import'
-								? 'dynamic'
-								: 'static';
-
-						if ( isScriptModule ) {
-							if ( kind === 'static' ) {
-								moduleDependencies.set( args.path, 'static' );
-							} else if (
-								! moduleDependencies.has( args.path )
-							) {
-								moduleDependencies.set( args.path, 'dynamic' );
+							if ( ! packageJson ) {
+								return undefined;
 							}
 
-							return {
-								path: args.path,
-								external: true,
-							};
+							let isScriptModule = isScriptModuleImport(
+								packageJson,
+								subpath
+							);
+							let isScript = !! packageJson.wpScript;
+							if ( isScriptModule && isScript ) {
+								// If the package is both a script and a script module, rely on the format being built
+								isScript = buildFormat === 'iife';
+								isScriptModule = buildFormat === 'esm';
+							}
+
+							const kind =
+								args.kind === 'dynamic-import'
+									? 'dynamic'
+									: 'static';
+
+							if ( isScriptModule ) {
+								if ( kind === 'static' ) {
+									moduleDependencies.set( args.path, 'static' );
+								} else if (
+									! moduleDependencies.has( args.path )
+								) {
+									moduleDependencies.set( args.path, 'dynamic' );
+								}
+
+								return {
+									path: args.path,
+									external: true,
+								};
+							}
+
+							if ( isScript ) {
+								dependencies.add( handle );
+
+								return {
+									path: args.path,
+									namespace: 'package-external',
+									pluginData: { globalName: externalConfig.globalName },
+								};
+							}
+
+							return undefined;
 						}
-
-						if ( isScript ) {
-							dependencies.add( wpHandle );
-
-							return {
-								path: args.path,
-								namespace: 'wordpress-external',
-							};
-						}
-
-						return undefined;
-					}
-				);
+					);
+				}
 
 				build.onLoad(
 					{ filter: /.*/, namespace: 'vendor-external' },
@@ -197,15 +223,17 @@ export function createWordpressExternalsPlugin() {
 				);
 
 				build.onLoad(
-					{ filter: /.*/, namespace: 'wordpress-external' },
+					{ filter: /.*/, namespace: 'package-external' },
 					/** @param {import('esbuild').OnLoadArgs} args */
 					( args ) => {
-						const wpGlobal = camelCase(
-							args.path.replace( '@wordpress/', '' )
-						);
+						const globalName = args.pluginData.globalName;
+						// Extract package name after '@namespace/' prefix
+						// e.g., '@wordpress/blocks' or '@my-plugin/data'
+						const packagePath = args.path.split( '/' ).slice( 1 ).join( '/' );
+						const camelCasedName = camelCase( packagePath );
 
 						return {
-							contents: `module.exports = window.wp.${ wpGlobal };`,
+							contents: `module.exports = window.${ globalName }.${ camelCasedName };`,
 							loader: 'js',
 						};
 					}


### PR DESCRIPTION
Refs #72032 

## What?

This PR adds custom namespace support to `@wordpress/build`, allowing third-party plugins to expose their own global variables (e.g., `window.myPlugin.*`) instead of being restricted to the `wp.*`. It also allows disabling global generation.

## Why?

Currently, `@wordpress/build` is hardcoded to use the `wp` namespace for all packages. This limits third-party plugins that want to:
  - Use their own global namespace for better separation
  - Control which packages expose globals vs being bundled
  - Maintain the same externalization benefits as WordPress core

  ## How?

  - Added `wpPlugin.scriptGlobal` and `wpPlugin.packageNamespace` configuration to root `package.json`
  - Updated `build.mjs` to conditionally set `globalName` based on package namespace matching
  - Refactored `wordpress-externals-plugin.mjs` to use unified configuration for both WordPress and custom namespaces
  - Updated README with configuration examples and usage instructions

  **Configuration example:**
  ```json
  {
    "wpPlugin": {
      "scriptGlobal": "myPlugin",
      "packageNamespace": "my-plugin"
    }
  }
```

  Behavior:
  - Packages matching @{packageNamespace}/* with wpScript: true → expose window.{scriptGlobal}.*
  - Other packages with wpScript: true → bundle without globals
  - @wordpress/* always externalized to wp.* (backwards compatible)
  - Vendors (React, lodash) always externalized

  Testing Instructions

  - Verify build completes successfully
  - Check that existing WordPress packages still generate wp.* globals correctly