### PR TITLE
DimensionsTool: When aspectRatio is updated, update lastAspectRatio.

### DIFF
--- a/packages/block-editor/src/components/dimensions-tool/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -90,6 +90,10 @@ function DimensionsTool( {
 	const aspectRatioValue = width && height ? 'custom' : lastAspectRatio;
 
 	const showScaleControl = aspectRatio || ( width && height );
+
+	useEffect( () => {
+		setLastAspectRatio( aspectRatio );
+	}, [ aspectRatio ] );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/dimensions-tool/test/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/test/index.js
@@ -599,7 +599,7 @@ describe( 'DimensionsTool', () => {
 			expect( aspectRatioSelect ).toHaveValue( 'custom' );
 
 			await user.clear( widthInput, '' );
-			expect( aspectRatioSelect ).toHaveValue( '16/9' );
+			expect( aspectRatioSelect ).toHaveValue( 'auto' );
 
 			expect( onChange.mock.calls ).toStrictEqual( [
 				[ { aspectRatio: '16/9', scale: 'cover', width: '8px' } ],

--- a/packages/block-editor/src/components/dimensions-tool/test/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/test/index.js
@@ -604,7 +604,7 @@ describe( 'DimensionsTool', () => {
 			expect( onChange.mock.calls ).toStrictEqual( [
 				[ { aspectRatio: '16/9', scale: 'cover', width: '8px' } ],
 				[ { scale: 'cover', width: '8px', height: '6px' } ],
-				[ { aspectRatio: '16/9', scale: 'cover', height: '6px' } ],
+				[ { height: '6px' } ],
 			] );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71816

<!-- In a few words, what is the PR actually doing? -->
When aspectRatio is updated, update lastAspectRatio.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The lastAspectRatio is not updated when all attributes are reset using the reset button or when attributes are updated externally.
Since lastAspectRatio is displayed as a select option, it appears as if it hasn't been updated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a image block. 
3. Change the aspectRatio and then press the reset button.
4. You can then verify that everything has been reset correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/c559a131-31ea-43ca-864e-9d74cb40ad22

### After

https://github.com/user-attachments/assets/4dfc081c-814c-451e-b2c0-1be0bc3efaaf