### PR TITLE
Template activation: inserting template through /templates should always result in active template

### DIFF
--- a/backport-changelog/6.9/10425.md
+++ b/backport-changelog/6.9/10425.md
@@ -1,5 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10425
-10425
 
 * https://github.com/WordPress/gutenberg/pull/72700
 * https://github.com/WordPress/gutenberg/pull/72674

--- a/backport-changelog/6.9/10432.md
+++ b/backport-changelog/6.9/10432.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10432
+
+* https://github.com/WordPress/gutenberg/pull/72770

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -483,8 +483,7 @@ function gutenberg_locate_block_template( $template, $type, array $templates ) {
 // `inject_ignored_hooked_blocks_metadata_attributes`.
 add_action( 'rest_pre_insert_wp_template', 'gutenberg_set_active_template_theme', 9, 2 );
 function gutenberg_set_active_template_theme( $changes, $request ) {
-	$template = $request['id'] ? get_block_template( $request['id'], 'wp_template' ) : null;
-	if ( $template ) {
+	if ( str_starts_with( $request->get_route(), '/wp/v2/templates' ) ) {
 		return $changes;
 	}
 	$changes->tax_input = array(

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -480,8 +480,15 @@ function gutenberg_locate_block_template( $template, $type, array $templates ) {
 // We need to set the theme for the template when it's created. See:
 // https://github.com/WordPress/wordpress-develop/blob/b2c8d8d2c8754cab5286b06efb4c11e2b6aa92d5/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php#L571-L578
 // Priority 9 so it runs before default hooks like
-// `inject_ignored_hooked_blocks_metadata_attributes`.
-add_action( 'rest_pre_insert_wp_template', 'gutenberg_set_active_template_theme', 9, 2 );
+// `inject_ignored_hooked_blocks_metadata_attributes`. Unfortunately, core is
+// also using priority 9, so we have to delay adding the filter so it runs after
+// core.
+add_action(
+	'init',
+	function () {
+		add_action( 'rest_pre_insert_wp_template', 'gutenberg_set_active_template_theme', 9, 2 );
+	}
+);
 function gutenberg_set_active_template_theme( $changes, $request ) {
 	if ( str_starts_with( $request->get_route(), '/wp/v2/templates' ) ) {
 		return $changes;

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -480,15 +480,9 @@ function gutenberg_locate_block_template( $template, $type, array $templates ) {
 // We need to set the theme for the template when it's created. See:
 // https://github.com/WordPress/wordpress-develop/blob/b2c8d8d2c8754cab5286b06efb4c11e2b6aa92d5/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php#L571-L578
 // Priority 9 so it runs before default hooks like
-// `inject_ignored_hooked_blocks_metadata_attributes`. Unfortunately, core is
-// also using priority 9, so we have to delay adding the filter so it runs after
-// core.
-add_action(
-	'init',
-	function () {
-		add_action( 'rest_pre_insert_wp_template', 'gutenberg_set_active_template_theme', 9, 2 );
-	}
-);
+// `inject_ignored_hooked_blocks_metadata_attributes`.
+remove_action( 'rest_pre_insert_wp_template', 'wp_assign_new_template_to_theme', 9 );
+add_action( 'rest_pre_insert_wp_template', 'gutenberg_set_active_template_theme', 9, 2 );
 function gutenberg_set_active_template_theme( $changes, $request ) {
 	if ( str_starts_with( $request->get_route(), '/wp/v2/templates' ) ) {
 		return $changes;

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -40,13 +40,10 @@ test.describe( 'Templates', () => {
 	} );
 
 	test( 'Filtering', async ( { requestUtils, admin, page } ) => {
-		const template = await requestUtils.createTemplate( 'wp_template', {
+		await requestUtils.createTemplate( 'wp_template', {
 			slug: 'date',
 			title: 'Date Archives',
 			content: 'hi',
-		} );
-		await requestUtils.updateSiteSettings( {
-			active_templates: { date: template.wp_id },
 		} );
 		await admin.visitSiteEditor( { postType: 'wp_template' } );
 		// Global search.


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

To condition to distinguish between routes in `rest_pre_insert_wp_template` is wrong.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need to maintain backwards compatibility: all templates created through `/templates` should automatically activate.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We should check the route instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
