### PR TITLE
Template activation: update sidebar icons

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useAddedBy } from '../page-templates/hooks';
-import { layout } from '@wordpress/icons';
+import { addTemplate, published } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -62,14 +62,14 @@ export default function DataviewsTemplatesSidebarContent() {
 		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
 			<SidebarNavigationItem
 				to="/template"
-				icon={ layout }
+				icon={ published }
 				aria-current={ activeView === 'active' }
 			>
 				{ __( 'Active templates' ) }
 			</SidebarNavigationItem>
 			<SidebarNavigationItem
 				to={ addQueryArgs( '/template', { activeView: 'user' } ) }
-				icon={ layout }
+				icon={ addTemplate }
 				aria-current={ activeView === 'user' }
 			>
 				{

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useAddedBy } from '../page-templates/hooks';
-import { addTemplate, published } from '@wordpress/icons';
+import { commentAuthorAvatar, published } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -69,7 +69,7 @@ export default function DataviewsTemplatesSidebarContent() {
 			</SidebarNavigationItem>
 			<SidebarNavigationItem
 				to={ addQueryArgs( '/template', { activeView: 'user' } ) }
-				icon={ addTemplate }
+				icon={ commentAuthorAvatar }
 				aria-current={ activeView === 'user' }
 			>
 				{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Just updates the icons in the sidebar.

## Testing Instructions
Site Editor => Templates

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/2d045f93-13c6-4c12-bc03-f82d112b58b5" />|<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/8f40d73b-19b9-4258-93d2-6a7654faf888" />|
