### PR TITLE
Notes: Refine avatar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -1,8 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarButton } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	ToolbarButton,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -49,10 +53,16 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 		return null;
 	}
 
-	// Show up to 3 avatars, with overflow indicator.
+	// If there are more than 3 participants, show 2 avatars and a "+n" number.
 	const maxAvatars = 3;
-	const visibleParticipants = threadParticipants.slice( 0, maxAvatars );
-	const overflowCount = Math.max( 0, threadParticipants.length - maxAvatars );
+	const isOverflow = threadParticipants.length > maxAvatars;
+	const visibleParticipants = isOverflow
+		? threadParticipants.slice( 0, maxAvatars - 1 )
+		: threadParticipants;
+	const overflowCount = Math.max(
+		0,
+		threadParticipants.length - visibleParticipants.length
+	);
 	const threadHasMoreParticipants = threadParticipants.length > 100;
 
 	// If we hit the comment limit, show "100+" instead of exact overflow count.
@@ -65,19 +75,6 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 					overflowCount
 			  );
 
-	const overflowTitle =
-		threadHasMoreParticipants && overflowCount > 0
-			? __( '100+ participants' )
-			: sprintf(
-					// translators: %s: Number of participants.
-					_n(
-						'+%s more participant',
-						'+%s more participants',
-						overflowCount
-					),
-					overflowCount
-			  );
-
 	return (
 		<CommentIconToolbarSlotFill.Fill>
 			<ToolbarButton
@@ -86,15 +83,14 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 				onClick={ onClick }
 				showTooltip
 			>
-				<div className="comment-avatar-stack">
-					{ visibleParticipants.map( ( participant, index ) => (
+				<HStack spacing="1">
+					{ visibleParticipants.map( ( participant ) => (
 						<img
 							key={ participant.id }
 							src={ participant.avatar }
 							alt={ participant.name }
 							className="comment-avatar"
 							style={ {
-								zIndex: maxAvatars - index,
 								borderColor: getAvatarBorderColor(
 									participant.id
 								),
@@ -102,15 +98,9 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 						/>
 					) ) }
 					{ overflowCount > 0 && (
-						<div
-							className="comment-avatar-overflow"
-							style={ { zIndex: 0 } }
-							title={ overflowTitle }
-						>
-							{ overflowText }
-						</div>
+						<Text weight={ 500 }>{ overflowText }</Text>
 					) }
-				</div>
+				</HStack>
 			</ToolbarButton>
 		</CommentIconToolbarSlotFill.Fill>
 	);

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -155,28 +155,10 @@
 	bottom: $grid-unit-10;
 }
 
-// Comment avatar indicators.
-.comment-avatar-indicator {
-	position: relative;
-	padding: 4px;
-	min-width: auto;
-	background: transparent;
-	border: none;
-}
-
-.comment-avatar-stack {
-	display: flex;
-	align-items: center;
-	position: relative;
-	height: $icon-size;
-}
-
 .comment-avatar {
 	width: $icon-size;
-	height: $icon-size;
 	border-radius: $radius-round;
-	margin-left: -6px;
-	flex-shrink: 0;
+	margin-left: -12px;
 	border-width: var(--wp-admin-border-width-focus);
 	border-style: solid;
 	padding: var(--wp-admin-border-width-focus);
@@ -185,21 +167,4 @@
 	&:first-child {
 		margin-left: 0;
 	}
-}
-
-.comment-avatar-overflow {
-	width: fit-content;
-	height: $icon-size;
-	border-radius: 4rem;
-	padding: 0 4px;
-	background: #757575;
-	color: $white;
-	border: 2px solid $white;
-	margin-left: -6px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-size: 10px;
-	font-weight: 600;
-	flex-shrink: 0;
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -78,6 +78,7 @@
 	border-width: var(--wp-admin-border-width-focus);
 	border-style: solid;
 	padding: var(--wp-admin-border-width-focus);
+	background: $white;
 }
 
 .editor-collab-sidebar-panel__comment-status {
@@ -174,21 +175,15 @@
 	width: $icon-size;
 	height: $icon-size;
 	border-radius: $radius-round;
-	border: 2px solid $white;
 	margin-left: -6px;
 	flex-shrink: 0;
+	border-width: var(--wp-admin-border-width-focus);
+	border-style: solid;
+	padding: var(--wp-admin-border-width-focus);
+	background: $white;
 
 	&:first-child {
 		margin-left: 0;
-		border-color: #de6e55;
-	}
-
-	&:nth-child(2) {
-		border-color: #599637;
-	}
-
-	&:nth-child(3) {
-		border-color: #3858e9;
 	}
 }
 


### PR DESCRIPTION
- Closes: https://github.com/WordPress/gutenberg/issues/72738
- Follow-up: https://github.com/WordPress/gutenberg/pull/71917

## What?

~This pull request applies a consistent style to the design of the note avatars.~ This pull request modifies the avatars and toolbar buttons based on the design.

## How?

- Toolbar:
  - Add padding between border and circle.
  - Reverse the way the avatars **overlap.
  - If there are more than 3 participants, show two avatars and overflow text
- Sidebar:
  - Add white background to avatar image. This prevents a gray background from being exposed between the border and the avatar when the notebook is not open.

## Screenshots or screencast <!-- if applicable -->

### Sidebar
|Before|After|
|-|-|
| <img width="422" height="499" alt="sidebar-before" src="https://github.com/user-attachments/assets/d7fc0224-6f7e-4535-bd45-3e27d3bd4614" /> | <img width="422" height="499" alt="sidebar-after" src="https://github.com/user-attachments/assets/b4f9deed-7d10-4368-92e2-c68180dcc409" /> |

### Toolbar

#### 1 participant

<img width="409" height="57" alt="image" src="https://github.com/user-attachments/assets/153a60a5-d603-4748-9426-0805f13e8469" />

#### 2 participants

<img width="430" height="58" alt="image" src="https://github.com/user-attachments/assets/b6a1ea9e-ff85-4ccc-820f-bedc47d2a6df" />

#### 3 participants

<img width="444" height="62" alt="image" src="https://github.com/user-attachments/assets/f55d3051-0e19-4dd9-9324-64a6e1454ce8" />

#### More than 4 participants

<img width="446" height="58" alt="image" src="https://github.com/user-attachments/assets/019301b8-3a7a-41fe-b474-5b36cddc2263" />
