### PR TITLE
Template activation: change type label + add document panel

### DIFF
--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -189,7 +189,7 @@ export const useThemeField = () => {
 };
 
 export const slugField = {
-	label: __( 'Template Type' ),
+	label: __( 'Type' ),
 	id: 'slug',
 	getValue: ( { item } ) => item.slug,
 	render: function Render( { item } ) {

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -22,6 +22,7 @@ import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
 import PostSyncStatus from '../post-sync-status';
 import PostTemplatePanel from '../post-template/panel';
+import TemplateTypePanel from '../template-type-panel';
 import PostURLPanel from '../post-url/panel';
 import BlogTitle from '../blog-title';
 import PostsPerPage from '../posts-per-page';
@@ -77,8 +78,9 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostStatusPanel />
 										<PostSchedulePanel />
 										<PostURLPanel />
-										<PostAuthorPanel />
+										{ /* <PostAuthorPanel /> */ }
 										<PostTemplatePanel />
+										<TemplateTypePanel />
 										<PostDiscussionPanel />
 										<PrivatePostLastRevision />
 										<PageAttributesPanel />

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -78,7 +78,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostStatusPanel />
 										<PostSchedulePanel />
 										<PostURLPanel />
-										{ /* <PostAuthorPanel /> */ }
+										<PostAuthorPanel />
 										<PostTemplatePanel />
 										<TemplateTypePanel />
 										<PostDiscussionPanel />

--- a/packages/editor/src/components/template-type-panel/index.js
+++ b/packages/editor/src/components/template-type-panel/index.js
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
+import {
+	store as coreStore,
+	privateApis as corePrivateApis,
+} from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelRow from '../post-panel-row';
+import { store as editorStore } from '../../store';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import { unlock } from '../../lock-unlock';
+
+const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
+
+/**
+ * Hook that returns default template types from the current theme.
+ * This is duplicated from edit-site package to avoid cross-package dependencies.
+ *
+ * @return {Array} Array of default template type objects.
+ */
+function useDefaultTemplateTypes() {
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getCurrentTheme()?.default_template_types || [],
+		[]
+	);
+}
+
+/**
+ * Hook that returns all default template types, combining theme-provided
+ * template types with registered templates from the entity store.
+ * This is duplicated from edit-site package to avoid cross-package dependencies.
+ *
+ * @return {Array} Array of template type objects with slug, title, and description.
+ */
+function useAllDefaultTemplateTypes() {
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	const { records: staticRecords } = useEntityRecordsWithPermissions(
+		'root',
+		'registeredTemplate'
+	);
+	return [
+		...defaultTemplateTypes,
+		...( staticRecords
+			?.filter( ( record ) => ! record.is_custom )
+			.map( ( record ) => {
+				return {
+					slug: record.slug,
+					title: record.title.rendered,
+					description: record.description,
+				};
+			} ) ?? [] ),
+	];
+}
+
+/**
+ * Renders the template type panel in the document sidebar.
+ * This panel displays the template type (e.g., "Single", "Archive", "Custom")
+ * for wp_template post types only, matching the display in dataviews.
+ *
+ * @return {React.ReactNode|null} The rendered TemplateTypePanel component or null.
+ */
+export default function TemplateTypePanel() {
+	const { postType, templateSlug } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+		const _postType = getCurrentPostType();
+		const _postId = getCurrentPostId();
+		const template =
+			_postType === TEMPLATE_POST_TYPE
+				? getEditedEntityRecord(
+						'postType',
+						TEMPLATE_POST_TYPE,
+						_postId
+				  )
+				: null;
+
+		return {
+			postType: _postType,
+			templateSlug: template?.slug,
+		};
+	}, [] );
+
+	console.log( postType, templateSlug );
+
+	const defaultTemplateTypes = useAllDefaultTemplateTypes();
+
+	// Only show this panel for wp_template (not wp_template_part)
+	if ( postType !== TEMPLATE_POST_TYPE ) {
+		return null;
+	}
+
+	// Find the matching template type
+	const defaultTemplateType = defaultTemplateTypes.find(
+		( type ) => type.slug === templateSlug
+	);
+
+	// Display the template type title, or "Custom" if not found
+	const templateTypeLabel =
+		defaultTemplateType?.title || _x( 'Custom', 'template type' );
+
+	return (
+		<PostPanelRow label={ __( 'Type' ) }>
+			<span>{ templateTypeLabel }</span>
+		</PostPanelRow>
+	);
+}

--- a/packages/editor/src/components/template-type-panel/index.js
+++ b/packages/editor/src/components/template-type-panel/index.js
@@ -3,10 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
-import {
-	store as coreStore,
-	privateApis as corePrivateApis,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -14,40 +11,27 @@ import {
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
-import { unlock } from '../../lock-unlock';
-
-const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 
 /**
- * Hook that returns default template types from the current theme.
- * This is duplicated from edit-site package to avoid cross-package dependencies.
+ * Hook that returns all default template types. This is duplicated from
+ * edit-site package.
  *
- * @return {Array} Array of default template type objects.
+ * @return {Array} Array of template type objects with slug, title, and
+ * description.
  */
-function useDefaultTemplateTypes() {
-	return useSelect(
+function useAllDefaultTemplateTypes() {
+	const defaultTemplateTypes = useSelect(
 		( select ) =>
 			select( coreStore ).getCurrentTheme()?.default_template_types || [],
 		[]
 	);
-}
-
-/**
- * Hook that returns all default template types, combining theme-provided
- * template types with registered templates from the entity store.
- * This is duplicated from edit-site package to avoid cross-package dependencies.
- *
- * @return {Array} Array of template type objects with slug, title, and description.
- */
-function useAllDefaultTemplateTypes() {
-	const defaultTemplateTypes = useDefaultTemplateTypes();
-	const { records: staticRecords } = useEntityRecordsWithPermissions(
+	const { records: registeredTemplates } = useEntityRecords(
 		'root',
 		'registeredTemplate'
 	);
 	return [
 		...defaultTemplateTypes,
-		...( staticRecords
+		...( registeredTemplates
 			?.filter( ( record ) => ! record.is_custom )
 			.map( ( record ) => {
 				return {
@@ -59,13 +43,6 @@ function useAllDefaultTemplateTypes() {
 	];
 }
 
-/**
- * Renders the template type panel in the document sidebar.
- * This panel displays the template type (e.g., "Single", "Archive", "Custom")
- * for wp_template post types only, matching the display in dataviews.
- *
- * @return {React.ReactNode|null} The rendered TemplateTypePanel component or null.
- */
 export default function TemplateTypePanel() {
 	const { postType, templateSlug } = useSelect( ( select ) => {
 		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
@@ -87,8 +64,6 @@ export default function TemplateTypePanel() {
 		};
 	}, [] );
 
-	console.log( postType, templateSlug );
-
 	const defaultTemplateTypes = useAllDefaultTemplateTypes();
 
 	// Only show this panel for wp_template (not wp_template_part)
@@ -107,7 +82,9 @@ export default function TemplateTypePanel() {
 
 	return (
 		<PostPanelRow label={ __( 'Type' ) }>
-			<span>{ templateTypeLabel }</span>
+			<div className="editor-template-type-panel__value">
+				{ templateTypeLabel }
+			</div>
 		</PostPanelRow>
 	);
 }

--- a/packages/editor/src/components/template-type-panel/style.scss
+++ b/packages/editor/src/components/template-type-panel/style.scss
@@ -1,0 +1,6 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.editor-template-type-panel__value {
+	// Match padding on tertiary buttons for alignment.
+	padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -42,6 +42,7 @@
 @use "./components/post-sync-status/style.scss" as *;
 @use "./components/post-taxonomies/style.scss" as *;
 @use "./components/post-template/style.scss" as *;
+@use "./components/template-type-panel/style.scss" as *;
 @use "./components/post-text-editor/style.scss" as *;
 @use "./components/post-title/style.scss" as *;
 @use "./components/post-url/style.scss" as *;

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -52,7 +52,7 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 				.getByRole( 'button', { name: 'saveEntityRecord test' } )
 				.first()
 		).toBeVisible();
-		await expect( page.getByText( 'Template typeIndex' ) ).toBeVisible();
+		await expect( page.getByText( 'TypeIndex' ) ).toBeVisible();
 		await page.evaluate( async () => {
 			return await window.wp.data
 				.dispatch( 'core' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See #71735. The same "Type" field we display in the data views of templates should be visible in the document panel of the editor. For now we don't allow editing it, but we could in the future.

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/49838815-1b48-408b-a75c-2184fe53bc72" />


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/pull/67125#issuecomment-3302089424

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We just add an extra panel, copied in the style of other panels.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Site Editor > Templates (see grid items)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
