### PR TITLE
Accordion Heading: Update description

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -20,7 +20,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 
 ## Accordion Heading
 
-Toggles the accordion panel. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-heading))
+Displays a heading that toggles the accordion panel. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-heading))
 
 -	**Name:** core/accordion-heading
 -	**Category:** design

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -4,7 +4,7 @@
 	"name": "core/accordion-heading",
 	"title": "Accordion Heading",
 	"category": "design",
-	"description": "Toggles the accordion panel.",
+	"description": "Displays a heading that toggles the accordion panel.",
 	"parent": [ "core/accordion-item" ],
 	"usesContext": [
 		"core/accordion-icon-position",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses this discussion: https://github.com/WordPress/gutenberg/pull/72602#discussion_r2472458726

Updates the Accordion Heading description from:

```
Toggles the accordion panel.
```

to:

```
Displays a heading that toggles the accordion panel.
```

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Accordion Heading displays a heading, so we should mention it in the block description.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the block description. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
