### PR TITLE
Tests: Try fixing "should refresh the page when stylesheet loading fails" e2e test

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
@@ -88,7 +88,8 @@ $wrapper_attributes = get_block_wrapper_attributes();
 	<div
 		data-testid="hydrated"
 		data-wp-interactive="test/router-styles"
-		data-wp-bind--hidden="state.undefined"
+		data-wp-bind--hidden="!state.hydrated"
+		data-wp-init="callbacks.setHydrated"
 		hidden
 	>
 		Hydrated

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getElement } from '@wordpress/interactivity';
+import { store, getElement, withSyncEvent } from '@wordpress/interactivity';
 
 const { state } = store( 'test/router-styles', {
 	state: {
@@ -10,7 +10,7 @@ const { state } = store( 'test/router-styles', {
 		hydrated: false,
 	},
 	actions: {
-		*navigate( e ) {
+		navigate: withSyncEvent( function* ( e ) {
 			e.preventDefault();
 			state.clientSideNavigation = false;
 			const { actions } = yield import(
@@ -18,7 +18,7 @@ const { state } = store( 'test/router-styles', {
 			);
 			yield actions.navigate( e.target.href );
 			state.clientSideNavigation = true;
-		},
+		} ),
 		*prefetch() {
 			state.prefetching = true;
 			const { ref } = getElement();

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
@@ -7,6 +7,7 @@ const { state } = store( 'test/router-styles', {
 	state: {
 		clientSideNavigation: false,
 		prefetching: false,
+		hydrated: false,
 	},
 	actions: {
 		*navigate( e ) {
@@ -26,6 +27,11 @@ const { state } = store( 'test/router-styles', {
 			);
 			yield actions.prefetch( ref.href );
 			state.prefetching = false;
+		},
+	},
+	callbacks: {
+		setHydrated() {
+			state.hydrated = true;
 		},
 	},
 } );

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -304,10 +304,13 @@ test.describe( 'Router styles', () => {
 		// The route handler is removed after navigation to simulate a
 		// temporary error.
 		const linkPattern = '**/router-styles-red/style-from-link.css*';
-		await page.route( linkPattern, async ( route ) => {
-			await route.abort( 'failed' );
-			await page.unrouteAll( { behavior: 'ignoreErrors' } );
-		} );
+		await page.route(
+			linkPattern,
+			async ( route ) => {
+				await route.abort( 'failed' );
+			},
+			{ times: 1 }
+		);
 
 		// Navigate to the page with the Red block
 		await page.getByTestId( 'link red' ).click();

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -300,17 +300,26 @@ test.describe( 'Router styles', () => {
 		await expect( red ).toHaveCSS( 'color', COLOR_WRAPPER );
 		await expect( redBlock ).toBeHidden();
 
-		// Setup a route handler to make requests to the red stylesheet fail.
-		// The route handler is removed after navigation to simulate a
-		// temporary error.
+		/*
+		 * Set up a route handler to make requests to the red stylesheet fail.
+		 * The route handler only aborts the request the first time to simulate
+		 * a temporary error. It is later removed at the end of the test.
+		 *
+		 * This approach uses a variable to determine whether to abort or continue
+		 * the request. Other approaches, like removing the route handler during
+		 * execution or using the `times` option, proved unreliable and made the
+		 * test flaky.
+		 */
+		let intercepted = false;
 		const linkPattern = '**/router-styles-red/style-from-link.css*';
-		await page.route(
-			linkPattern,
-			async ( route ) => {
+		await page.route( linkPattern, async ( route ) => {
+			if ( ! intercepted ) {
+				intercepted = true;
 				await route.abort( 'failed' );
-			},
-			{ times: 1 }
-		);
+			} else {
+				await route.continue();
+			}
+		} );
 
 		// Navigate to the page with the Red block
 		await page.getByTestId( 'link red' ).click();
@@ -318,6 +327,8 @@ test.describe( 'Router styles', () => {
 		await expect( csn ).toBeHidden();
 		await expect( red ).toHaveCSS( 'color', COLOR_RED );
 		await expect( redBlock ).toBeVisible();
+
+		await page.unroute( linkPattern );
 	} );
 
 	test( 'should not apply preloaded styles in current page', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71722 

Tries to fix (again) the flaky "should refresh the page when stylesheet loading fails" e2e test. The previous attempt was #72329.

This approach keeps the route handler, but modifies it to use a variable to determine whether to abort or continue the request. It seems more reliable than using `page.unroute` in the route handler or passing `{ times: 1 }` as options.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/interactivity/router-styles.spec.ts --grep "should refresh the page when stylesheet loading fails" --repeat-each 20
```