### PR TITLE
Notes: Fix 'Add note' form position

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -149,8 +149,10 @@ export function Comments( {
 
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
-		setSelectedThread( blockCommentId ?? undefined );
-	}, [ blockCommentId ] );
+		// Fallback to 'new-note-thread' when showing the comment board for a new note.
+		const fallback = showCommentBoard ? 'new-note-thread' : null;
+		setSelectedThread( blockCommentId ?? fallback );
+	}, [ blockCommentId, showCommentBoard ] );
 
 	const setBlockRef = useCallback( ( id, blockRef ) => {
 		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: blockRef } ) );


### PR DESCRIPTION
## What?
Closes #72779

PR 'Add note' form position when displaying floating sidebar and correctly recalucate offsets. The `calculateAllOffsets` uses the selected thread state, so it should match the fake ID of the 'Add note' form.

## Testing Instructions
1. Create a post.
2. Add blocks.
3. Add a large note for every other block.
4. Select blocks in between without notes and click on the "Add note" block options item.
5. The form should be correctly positioned.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/dc3d65a1-c6c1-495e-9d78-8adb7fca05af

