### PR TITLE
Fix: Fit Text flash during the binary search on the initial enabling.

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -101,19 +101,22 @@ function useFitText( { fitText, name, clientId } ) {
 
 		// Only hide/show on initial application to prevent flash on every keystroke
 		if ( shouldHideOnCalculation ) {
+			// Save the original visibility value before hiding
+			const previousVisibility = element.style.visibility;
+
 			// Hide element during calculation to prevent flash
 			// eslint-disable-next-line react-compiler/react-compiler
-			element.style.opacity = '0';
+			element.style.visibility = 'hidden';
 
 			// Wait for browser to render the hidden state
 			window.requestAnimationFrame( () => {
 				// Now do the calculation while hidden
 				optimizeFitText( element, blockSelector, applyStylesFn );
 
-				// Wait 100ms for browser to fully render the new font size
+				// Wait 10ms for browser to render the new font size
 				setTimeout( () => {
-					// Finally, show the element with the correct size
-					element.style.removeProperty( 'opacity' );
+					// Restore the original visibility value
+					element.style.visibility = previousVisibility;
 				}, 10 );
 			} );
 		} else {

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -123,14 +123,12 @@ function useFitText( { fitText, name, clientId } ) {
 			currentElement.style.visibility = 'hidden';
 			// Wait for browser to render the hidden state
 			calculateFrameId = window.requestAnimationFrame( () => {
-				// Apply fit text while hidden
 				applyFitText();
 
 				// Using a timeout instead of requestAnimationFrame, because
 				// with requestAnimationFrame a flash of very high size
 				// can still occur although rare.
 				showTimeoutId = setTimeout( () => {
-					// Restore the original visibility value
 					currentElement.style.visibility = previousVisibility;
 				}, 10 );
 			} );

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -3,7 +3,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useEffect, useCallback, useRef } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -61,7 +61,6 @@ function addAttributes( settings ) {
 function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
-	const isInitialApplication = useRef( true );
 
 	// Monitor block attribute changes
 	// Any attribute may change the available space.
@@ -95,34 +94,7 @@ function useFitText( { fitText, name, clientId } ) {
 			styleElement.textContent = css;
 		};
 
-		// Capture element reference and initial state flag
-		const element = blockElement;
-		const shouldHideOnCalculation = isInitialApplication.current;
-
-		// Only hide/show on initial application to prevent flash on every keystroke
-		if ( shouldHideOnCalculation ) {
-			// Save the original visibility value before hiding
-			const previousVisibility = element.style.visibility;
-
-			// Hide element during calculation to prevent flash
-			// eslint-disable-next-line react-compiler/react-compiler
-			element.style.visibility = 'hidden';
-
-			// Wait for browser to render the hidden state
-			window.requestAnimationFrame( () => {
-				// Now do the calculation while hidden
-				optimizeFitText( element, blockSelector, applyStylesFn );
-
-				// Wait 10ms for browser to render the new font size
-				setTimeout( () => {
-					// Restore the original visibility value
-					element.style.visibility = previousVisibility;
-				}, 10 );
-			} );
-		} else {
-			// Subsequent calls: apply directly without hiding
-			optimizeFitText( element, blockSelector, applyStylesFn );
-		}
+		optimizeFitText( blockElement, blockSelector, applyStylesFn );
 	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
 
 	useEffect( () => {
@@ -135,14 +107,24 @@ function useFitText( { fitText, name, clientId } ) {
 			return;
 		}
 
-		// Reset flag when fit text is enabled
-		isInitialApplication.current = true;
+		// Capture element reference before async operations
+		const element = blockElement;
+		const previousVisibility = element.style.visibility;
 
-		// Apply initially
-		applyFitText();
+		window.requestAnimationFrame( () => {
+			element.style.visibility = 'hidden';
+			// Wait for browser to render the hidden state
+			window.requestAnimationFrame( () => {
+				// Apply fit text while hidden
+				applyFitText();
 
-		// Mark as no longer initial after first application
-		isInitialApplication.current = false;
+				// Wait 10ms for browser to render the new font size
+				setTimeout( () => {
+					// Restore the original visibility value
+					element.style.visibility = previousVisibility;
+				}, 10 );
+			} );
+		} );
 
 		// Store current element value for cleanup
 		const currentElement = blockElement;

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -3,7 +3,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -61,6 +61,7 @@ function addAttributes( settings ) {
 function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
+	const isInitialApplication = useRef( true );
 
 	// Monitor block attribute changes
 	// Any attribute may change the available space.
@@ -94,7 +95,31 @@ function useFitText( { fitText, name, clientId } ) {
 			styleElement.textContent = css;
 		};
 
-		optimizeFitText( blockElement, blockSelector, applyStylesFn );
+		// Capture element reference and initial state flag
+		const element = blockElement;
+		const shouldHideOnCalculation = isInitialApplication.current;
+
+		// Only hide/show on initial application to prevent flash on every keystroke
+		if ( shouldHideOnCalculation ) {
+			// Hide element during calculation to prevent flash
+			// eslint-disable-next-line react-compiler/react-compiler
+			element.style.opacity = '0';
+
+			// Wait for browser to render the hidden state
+			window.requestAnimationFrame( () => {
+				// Now do the calculation while hidden
+				optimizeFitText( element, blockSelector, applyStylesFn );
+
+				// Wait 100ms for browser to fully render the new font size
+				setTimeout( () => {
+					// Finally, show the element with the correct size
+					element.style.removeProperty( 'opacity' );
+				}, 10 );
+			} );
+		} else {
+			// Subsequent calls: apply directly without hiding
+			optimizeFitText( element, blockSelector, applyStylesFn );
+		}
 	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
 
 	useEffect( () => {
@@ -107,8 +132,14 @@ function useFitText( { fitText, name, clientId } ) {
 			return;
 		}
 
+		// Reset flag when fit text is enabled
+		isInitialApplication.current = true;
+
 		// Apply initially
 		applyFitText();
+
+		// Mark as no longer initial after first application
+		isInitialApplication.current = false;
 
 		// Store current element value for cleanup
 		const currentElement = blockElement;

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -107,27 +107,34 @@ function useFitText( { fitText, name, clientId } ) {
 			return;
 		}
 
-		// Capture element reference before async operations
-		const element = blockElement;
-		const previousVisibility = element.style.visibility;
+		// Store current element value for cleanup
+		const currentElement = blockElement;
+		const previousVisibility = currentElement.style.visibility;
 
-		window.requestAnimationFrame( () => {
-			element.style.visibility = 'hidden';
+		// Store IDs for cleanup
+		let hideFrameId = null;
+		let calculateFrameId = null;
+		let showTimeoutId = null;
+
+		// We are hiding the element doing the calculation of fit text
+		// and then showing it again to avoid the user noticing a flash of potentially
+		// big fitText while the binary search is happening.
+		hideFrameId = window.requestAnimationFrame( () => {
+			currentElement.style.visibility = 'hidden';
 			// Wait for browser to render the hidden state
-			window.requestAnimationFrame( () => {
+			calculateFrameId = window.requestAnimationFrame( () => {
 				// Apply fit text while hidden
 				applyFitText();
 
-				// Wait 10ms for browser to render the new font size
-				setTimeout( () => {
+				// Using a timeout instead of requestAnimationFrame, because
+				// with requestAnimationFrame a flash of very high size
+				// can still occur although rare.
+				showTimeoutId = setTimeout( () => {
 					// Restore the original visibility value
-					element.style.visibility = previousVisibility;
+					currentElement.style.visibility = previousVisibility;
 				}, 10 );
 			} );
 		} );
-
-		// Store current element value for cleanup
-		const currentElement = blockElement;
 
 		// Watch for size changes
 		let resizeObserver;
@@ -138,6 +145,17 @@ function useFitText( { fitText, name, clientId } ) {
 
 		// Cleanup function
 		return () => {
+			// Cancel pending async operations
+			if ( hideFrameId !== null ) {
+				window.cancelAnimationFrame( hideFrameId );
+			}
+			if ( calculateFrameId !== null ) {
+				window.cancelAnimationFrame( calculateFrameId );
+			}
+			if ( showTimeoutId !== null ) {
+				clearTimeout( showTimeoutId );
+			}
+
 			if ( resizeObserver ) {
 				resizeObserver.disconnect();
 			}


### PR DESCRIPTION
This PR tries to fix an issue raised by @mcsf where, when 'Fit text' is enabled, a temporary flash of a very large font size may be noticeable.

I tried other solutions (which are still stashed):
- Direct hide and show without requestAnimationFrame. This did not work; the flash was still there.

- Getting a better initial estimate for the binary search based on the parent width. In some cases, we could still get a flash, and the advantage was not worth the complexity.

- Cloning the element, positioning it in the current position with absolute positioning (so it does not take space in the container), hiding our element, doing the calculation, showing it, and removing the clone. This also did not work; the flash was still there. That was when I noticed we needed requestAnimationFrame calls / a wait, and in that case, this solution provides the same result without as much complexity.

Before:

https://github.com/user-attachments/assets/4ea5e6f9-83d3-4f41-9606-eab0029584fd



After:

https://github.com/user-attachments/assets/7f5dd473-8a64-44a1-9f8b-59464ff2842c




## Testing Instructions
Create multiple paragraphs with different text sizes, and another one staying in the placeholder state (e.g., "aa" and "aaaaaaaaaaaaaaaaaa").

Try to disable and enable 'Fit text' on all the paragraphs and verify there is no flash of a large font size.

Type in the different paragraphs with 'Fit text' enabled, and verify things still work and there is no noticeable hide/show effect (this logic should only apply when 'Fit text' is enabled).

