### PR TITLE
Template activation: disallow editing/trashing of non-database templates

### DIFF
--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -36,6 +36,7 @@ const renamePost: Action< PostWithPermissions > = {
 			return false;
 		}
 
+		// Non-database template cannot be edited.
 		if ( post.type === 'wp_template' && typeof post.id === 'string' ) {
 			return false;
 		}

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -35,6 +35,11 @@ const renamePost: Action< PostWithPermissions > = {
 		if ( post.status === 'trash' ) {
 			return false;
 		}
+
+		if ( post.type === 'wp_template' && typeof post.id === 'string' ) {
+			return false;
+		}
+
 		// Templates, template parts and patterns have special checks for renaming.
 		if (
 			! [

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -31,6 +31,11 @@ const trashPost: Action< PostWithPermissions > = {
 			return false;
 		}
 
+		// Non-database template cannot be trashed.
+		if ( item.type === 'wp_template' && typeof item.id === 'string' ) {
+			return false;
+		}
+
 		return (
 			!! item.status &&
 			! [ 'auto-draft', 'trash' ].includes( item.status ) &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72475.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Registered templates cannot be trashed or edited.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

These templates have a string ID, so we can check the type of the ID.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Click "Edit Site" on the front-end. When landing in the template editor, no actions should be available from the three-dot menu in the document panel.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
