### PR TITLE
Template activation: allow editing descriptions of created templates

### DIFF
--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -33,10 +33,7 @@ export default function PostExcerpt( {
 			const postType = getCurrentPostType();
 			// This special case is unfortunate, but the REST API of wp_template and wp_template_part
 			// support the excerpt field through the "description" field rather than "excerpt".
-			const _usedAttribute = [
-				'wp_template',
-				'wp_template_part',
-			].includes( postType )
+			const _usedAttribute = [ 'wp_template_part' ].includes( postType )
 				? 'description'
 				: 'excerpt';
 			return {

--- a/packages/editor/src/components/post-excerpt/panel.js
+++ b/packages/editor/src/components/post-excerpt/panel.js
@@ -21,7 +21,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import PostExcerptForm from './index';
 import PostExcerptCheck from './check';
 import PluginPostExcerpt from './plugin';
-import { TEMPLATE_ORIGINS } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { getTemplateInfo } from '../../utils/get-template-info';
 
@@ -111,6 +110,7 @@ function PrivateExcerpt() {
 				getEditedPostAttribute,
 				isEditorPanelEnabled,
 			} = select( editorStore );
+			const postId = getCurrentPostId();
 			const postType = getCurrentPostType();
 			const isTemplateOrTemplatePart = [
 				'wp_template',
@@ -121,9 +121,11 @@ function PrivateExcerpt() {
 			// handle proper labeling and some flows where we should always render them as text.
 			const _shouldBeUsedAsDescription =
 				isTemplateOrTemplatePart || isPattern;
-			const _usedAttribute = isTemplateOrTemplatePart
-				? 'description'
-				: 'excerpt';
+			const _usedAttribute =
+				postType === 'wp_template_part' ||
+				( postType === 'wp_template' && typeof postId === 'string' )
+					? 'description'
+					: 'excerpt';
 			const _excerpt = getEditedPostAttribute( _usedAttribute );
 			// We need to fetch the entity in this case to check if we'll allow editing.
 			const template =
@@ -131,7 +133,7 @@ function PrivateExcerpt() {
 				select( coreStore ).getEntityRecord(
 					'postType',
 					postType,
-					getCurrentPostId()
+					postId
 				);
 			const fallback =
 				! _excerpt && isTemplateOrTemplatePart
@@ -157,10 +159,8 @@ function PrivateExcerpt() {
 					_shouldRender &&
 					( ! _shouldBeUsedAsDescription ||
 						isPattern ||
-						( template &&
-							template.source === TEMPLATE_ORIGINS.custom &&
-							! template.has_theme_file &&
-							template.is_custom ) ),
+						( postType === 'wp_template' &&
+							typeof postId !== 'string' ) ),
 			};
 		}, [] );
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See #71735.

<!-- In a few words, what is the PR actually doing? -->

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/c28ec2aa-f10d-42b1-b972-4214c19faa0c" />


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These are just templates in the database of which the excerpt is editable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Registered templates (with a string ID) have to remain non-editable, while user created templates (in the database) have an integer ID and can be edited.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Site Editor > Create or duplicate a template > Document panel > Edit description

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
