### PR TITLE
WIP: Explore `mediaRoles` in block config

### DIFF
--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Block compatibility functions for WordPress 7.0
+ *
+ * Adds support for the `mediaRoles` property in block.json metadata.
+ * This ensures that the mediaRoles property is passed to JavaScript
+ * when blocks are registered via register_block_type_from_metadata().
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Filters the settings determined from the block type metadata.
+ *
+ * WordPress core doesn't yet support the mediaRoles property in block.json.
+ * This filter adds it to the registered block type so it gets passed to JavaScript.
+ *
+ * @param WP_Block_Type $block_type Block type object.
+ * @param array         $metadata   Block metadata from block.json.
+ * @return WP_Block_Type Modified block type with mediaRoles if present.
+ */
+function gutenberg_add_media_roles_to_block_type( $block_type, $metadata ) {
+	// Check if mediaRoles exists in the metadata.
+	if ( isset( $metadata['mediaRoles'] ) && is_array( $metadata['mediaRoles'] ) ) {
+		// Add mediaRoles as a public property on the block type.
+		// This will be included when the block type is passed to JavaScript.
+		$block_type->media_roles = $metadata['mediaRoles'];
+	}
+
+	return $block_type;
+}
+
+add_filter( 'register_block_type_args', 'gutenberg_add_media_roles_to_block_type', 10, 2 );

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds mediaRoles to the block type REST API response.
+ * @since 7.0.0
+ *
+ * @param WP_REST_Response $response   The response object.
+ * @param WP_Block_Type    $block_type Block type object.
+ * @return WP_REST_Response Modified response with mediaRoles if present.
+ */
+function gutenberg_add_media_roles_to_rest_response( $response, $block_type ) {
+	if ( isset( $block_type->media_roles ) ) {
+		$response->data['media_roles'] = $block_type->media_roles;
+	}
+	return $response;
+}
+add_filter( 'rest_prepare_block_type', 'gutenberg_add_media_roles_to_rest_response', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -92,7 +92,9 @@ require __DIR__ . '/compat/wordpress-6.9/preload.php';
 require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
 
 // WordPress 7.0 compat.
+require __DIR__ . '/compat/wordpress-7.0/blocks.php';
 require __DIR__ . '/compat/wordpress-7.0/php-only-blocks.php';
+require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -3,86 +3,73 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { privateApis as blocksPrivateApis } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { getMediaRoleAttributes } = unlock( blocksPrivateApis );
 
 // Maximum number of images to display in a list view row.
 const MAX_IMAGES = 3;
-const IMAGE_GETTERS = {
-	'core/image': ( { clientId, attributes } ) => {
-		if ( attributes.url ) {
-			return {
-				url: attributes.url,
-				alt: attributes.alt || '',
-				clientId,
-			};
-		}
-	},
-	'core/cover': ( { clientId, attributes } ) => {
-		if ( attributes.backgroundType === 'image' && attributes.url ) {
-			return {
-				url: attributes.url,
-				alt: attributes.alt || '',
-				clientId,
-			};
-		}
-	},
-	'core/media-text': ( { clientId, attributes } ) => {
-		if ( attributes.mediaType === 'image' && attributes.mediaUrl ) {
-			return {
-				url: attributes.mediaUrl,
-				alt: attributes.mediaAlt || '',
-				clientId,
-			};
-		}
-	},
-	'core/gallery': ( { innerBlocks } ) => {
-		const images = [];
-		const getValues = !! innerBlocks?.length
-			? IMAGE_GETTERS[ innerBlocks[ 0 ].name ]
-			: undefined;
-		if ( ! getValues ) {
-			return images;
-		}
-
-		for ( const innerBlock of innerBlocks ) {
-			const img = getValues( innerBlock );
-			if ( img ) {
-				images.push( img );
-			}
-			if ( images.length >= MAX_IMAGES ) {
-				return images;
-			}
-		}
-
-		return images;
-	},
-};
 
 function getImagesFromBlock( block, isExpanded ) {
-	const getImages = IMAGE_GETTERS[ block.name ];
-	const images = !! getImages ? getImages( block ) : undefined;
-
-	if ( ! images ) {
+	// Don't show images for expanded blocks (inner blocks shown separately).
+	if ( isExpanded && block.innerBlocks?.length ) {
 		return [];
 	}
-
-	if ( ! Array.isArray( images ) ) {
-		return [ images ];
+	const images = [];
+	// First, try to get an image from the block itself.
+	const blockImage = getImageFromMediaBlock( block );
+	if ( blockImage ) {
+		images.push( blockImage );
 	}
+	// Recursively check direct inner blocks.
+	// TODO: this is intentional for the first draft as we might not even want to
+	// support this for every block with child blocks. This covers the `gallery` block
+	// but also adds the `image` info for other blocks, like a `Group` with an Image block.
+	if ( block.innerBlocks?.length ) {
+		for ( const innerBlock of block.innerBlocks ) {
+			const innerImage = getImageFromMediaBlock( innerBlock );
+			if ( innerImage ) {
+				images.push( innerImage );
+			}
+			if ( images.length >= MAX_IMAGES ) {
+				break;
+			}
+		}
+	}
+	return images;
+}
 
-	return isExpanded ? [] : images;
+function getImageFromMediaBlock( block ) {
+	const mediaAttributes = getMediaRoleAttributes(
+		block.name,
+		block.attributes
+	);
+	// Only show images in list view and only when there are media attributes and a url.
+	if (
+		! mediaAttributes ||
+		mediaAttributes.type !== 'image' ||
+		! mediaAttributes.url
+	) {
+		return null;
+	}
+	return {
+		url: mediaAttributes.url,
+		alt: mediaAttributes.alt || '',
+		clientId: block.clientId,
+	};
 }
 
 /**
  * Get a block's preview images for display within a list view row.
  *
- * TODO: Currently only supports images from the core/image and core/gallery
- * blocks. This should be expanded to support other blocks that have images,
- * potentially via an API that blocks can opt into / provide their own logic.
+ * Uses the `mediaRoles` block config to generically extract media information
+ * from any block that defines media roles.
  *
  * @param {Object}  props            Hook properties.
  * @param {string}  props.clientId   The block's clientId.
@@ -90,10 +77,8 @@ function getImagesFromBlock( block, isExpanded ) {
  * @return {Array} Images.
  */
 export default function useListViewImages( { clientId, isExpanded } ) {
-	const { block } = useSelect(
-		( select ) => {
-			return { block: select( blockEditorStore ).getBlock( clientId ) };
-		},
+	const block = useSelect(
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
 	);
 	const images = useMemo( () => {

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -63,6 +63,11 @@
 			"clientNavigation": true
 		}
 	},
+	"mediaRoles": {
+		"id": "id",
+		"url": "src",
+		"type": { "value": "audio" }
+	},
 	"editorStyle": "wp-block-audio-editor",
 	"style": "wp-block-audio"
 }

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -148,6 +148,12 @@
 		},
 		"allowedBlocks": true
 	},
+	"mediaRoles": {
+		"id": "id",
+		"url": "url",
+		"alt": "alt",
+		"type": { "attribute": "backgroundType" }
+	},
 	"selectors": {
 		"filter": {
 			"duotone": ".wp-block-cover > .wp-block-cover__image-background, .wp-block-cover > .wp-block-cover__video-background"

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -131,6 +131,12 @@
 			"__experimentalSkipSerialization": true
 		}
 	},
+	"mediaRoles": {
+		"id": "id",
+		"url": "url",
+		"alt": "alt",
+		"type": { "value": "image" }
+	},
 	"selectors": {
 		"border": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder",
 		"shadow": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -143,6 +143,12 @@
 		},
 		"allowedBlocks": true
 	},
+	"mediaRoles": {
+		"id": "mediaId",
+		"url": "mediaUrl",
+		"alt": "mediaAlt",
+		"type": { "attribute": "mediaType" }
+	},
 	"editorStyle": "wp-block-media-text-editor",
 	"style": "wp-block-media-text"
 }

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -97,6 +97,11 @@
 			"clientNavigation": true
 		}
 	},
+	"mediaRoles": {
+		"id": "id",
+		"url": "src",
+		"type": { "value": "video" }
+	},
 	"editorStyle": "wp-block-video-editor",
 	"style": "wp-block-video"
 }

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { lock } from '../lock-unlock';
-import { isContentBlock } from './utils';
+import { isContentBlock, getMediaRoleAttributes } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -177,4 +177,4 @@ export {
 } from './constants';
 
 export const privateApis = {};
-lock( privateApis, { isContentBlock } );
+lock( privateApis, { isContentBlock, getMediaRoleAttributes } );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -186,6 +186,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 		'variations',
 		'blockHooks',
 		'allowedBlocks',
+		'mediaRoles',
 	];
 
 	const settings = Object.fromEntries(

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,6 +17,7 @@ import {
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
 	isContentBlock,
+	getMediaRoleAttributes,
 } from '../utils';
 
 const noop = () => {};
@@ -512,5 +513,125 @@ describe( 'isUnmodifiedBlock', () => {
 			},
 		} );
 		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getMediaRoleAttributes', () => {
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should return null if block has no mediaRoles', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				url: { type: 'string' },
+			},
+			title: 'Test block',
+		} );
+
+		const result = getMediaRoleAttributes( 'core/test-block', {
+			url: 'https://example.com/image.jpg',
+		} );
+
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null when `type` is not defined', () => {
+		registerBlockType( 'core/image-block', {
+			attributes: {
+				id: { type: 'number' },
+				url: { type: 'string' },
+				alt: { type: 'string' },
+			},
+			mediaRoles: {
+				id: 'id',
+				url: 'url',
+				alt: 'alt',
+			},
+			title: 'Image block',
+		} );
+
+		const result = getMediaRoleAttributes( 'core/image-block', {
+			id: 123,
+			url: 'https://example.com/image.jpg',
+			alt: 'Test image',
+		} );
+
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should resolve object config with value property as literal value', () => {
+		registerBlockType( 'core/video-block', {
+			attributes: {
+				id: { type: 'number' },
+				src: { type: 'string' },
+			},
+			mediaRoles: {
+				id: 'id',
+				url: 'src',
+				type: { value: 'video' },
+			},
+			title: 'Video block',
+		} );
+
+		const result = getMediaRoleAttributes( 'core/video-block', {
+			id: 456,
+			src: 'https://example.com/video.mp4',
+		} );
+
+		expect( result ).toEqual( {
+			id: 456,
+			url: 'https://example.com/video.mp4',
+			type: 'video',
+		} );
+	} );
+
+	it( 'should resolve object config with attribute property', () => {
+		registerBlockType( 'core/media-text-block', {
+			attributes: {
+				mediaId: { type: 'number' },
+				mediaUrl: { type: 'string' },
+				mediaType: { type: 'string' },
+			},
+			mediaRoles: {
+				id: 'mediaId',
+				url: 'mediaUrl',
+				type: { attribute: 'mediaType' },
+			},
+			title: 'Media Text block',
+		} );
+
+		const result = getMediaRoleAttributes( 'core/media-text-block', {
+			mediaId: 789,
+			mediaUrl: 'https://example.com/media.jpg',
+			mediaType: 'image',
+		} );
+
+		expect( result ).toEqual( {
+			id: 789,
+			url: 'https://example.com/media.jpg',
+			type: 'image',
+		} );
+	} );
+
+	it( 'should skip null or undefined config values but still return null if type is missing', () => {
+		registerBlockType( 'core/skip-null-block', {
+			attributes: {
+				id: { type: 'number' },
+			},
+			mediaRoles: {
+				id: 'id',
+				url: null,
+			},
+			title: 'Skip null block',
+		} );
+
+		const result = getMediaRoleAttributes( 'core/skip-null-block', {
+			id: 123,
+		} );
+
+		expect( result ).toBeNull();
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -433,6 +433,56 @@ export function isContentBlock( name ) {
 }
 
 /**
+ * Get media-related attributes from a block by resolving the mediaRoles.
+ * Returns an object with resolved media role values or null,
+ * if the block doesn't define mediaRoles or if no values are resolved.
+ *
+ * Note: Currently only supports core blocks (block names starting with 'core/').
+ *
+ * @param {string} blockName  The block's name.
+ * @param {Object} attributes The block's attributes.
+ *
+ * @return {Object|null} Object with resolved media role values or null.
+ */
+export function getMediaRoleAttributes( blockName, attributes ) {
+	// Only process core blocks.
+	if ( ! blockName.startsWith( 'core/' ) ) {
+		return null;
+	}
+	const blockType = getBlockType( blockName );
+	const mediaRoles = blockType?.mediaRoles;
+	if ( ! mediaRoles ) {
+		return null;
+	}
+	const resolved = Object.entries( mediaRoles ).reduce(
+		( accumulator, [ role, config ] ) => {
+			if ( ! config ) {
+				return accumulator;
+			}
+			// Check for static value first. This only applies to `type` for now.
+			if ( typeof config === 'object' && !! config.value ) {
+				accumulator[ role ] = config.value;
+			} else {
+				accumulator[ role ] =
+					attributes[
+						typeof config === 'string' ? config : config.attribute
+					];
+			}
+			return accumulator;
+		},
+		{}
+	);
+	// Type should always be defined.
+	if (
+		! [ 'image', 'video', 'audio' ].includes( resolved.type ) ||
+		! Object.keys( resolved ).length
+	) {
+		return null;
+	}
+	return resolved;
+}
+
+/**
  * Return a new object with the specified keys omitted.
  *
  * @param {Object} object Original object.

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -66,31 +66,18 @@ function bootstrappedBlockTypes( state = {}, action ) {
 			// Don't overwrite if already set. It covers the case when metadata
 			// was initialized from the server.
 			if ( serverDefinition ) {
-				// The `blockHooks` prop is not yet included in the server provided
+				// The `mediaRoles` prop is not yet included in the server provided
 				// definitions and needs to be polyfilled. This can be removed when the
-				// minimum supported WordPress is >= 6.4.
+				// minimum supported WordPress is >= 7.0.
+				// This change should be handled in `get_block_editor_server_block_settings` in core.
 				if (
-					serverDefinition.blockHooks === undefined &&
-					blockType.blockHooks
+					serverDefinition.mediaRoles === undefined &&
+					blockType.mediaRoles
 				) {
 					newDefinition = {
 						...serverDefinition,
 						...newDefinition,
-						blockHooks: blockType.blockHooks,
-					};
-				}
-
-				// The `allowedBlocks` prop is not yet included in the server provided
-				// definitions and needs to be polyfilled. This can be removed when the
-				// minimum supported WordPress is >= 6.5.
-				if (
-					serverDefinition.allowedBlocks === undefined &&
-					blockType.allowedBlocks
-				) {
-					newDefinition = {
-						...serverDefinition,
-						...newDefinition,
-						allowedBlocks: blockType.allowedBlocks,
+						mediaRoles: blockType.mediaRoles,
 					};
 				}
 			} else {

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -13,11 +13,18 @@ import { __, _x } from '@wordpress/i18n';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
+import {
+	getBlockType,
+	privateApis as blocksPrivateApis,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { fetchMedia } from './media-util';
+import { unlock } from '../../lock-unlock';
+
+const { getMediaRoleAttributes } = unlock( blocksPrivateApis );
 
 function flattenBlocks( blocks ) {
 	const result = [];
@@ -33,46 +40,36 @@ function flattenBlocks( blocks ) {
 /**
  * Determine whether a block has external media.
  *
- * Different blocks use different attribute names (and potentially
- * different logic as well) in determining whether the media is
- * present, and whether it's external.
+ * Uses the generic `getMediaRoleAttributes` utility to work with any block
+ * that defines `mediaRoles` in block.json.
  *
  * @param {{name: string, attributes: Object}} block The block.
- * @return {boolean?} Whether the block has external media
+ * @return {boolean} Whether the block has external media
  */
 function hasExternalMedia( block ) {
-	if ( block.name === 'core/image' || block.name === 'core/cover' ) {
-		return block.attributes.url && ! block.attributes.id;
-	}
-
-	if ( block.name === 'core/media-text' ) {
-		return block.attributes.mediaUrl && ! block.attributes.mediaId;
-	}
-
-	return undefined;
+	const mediaAttributes = getMediaRoleAttributes(
+		block.name,
+		block.attributes
+	);
+	// Only handle `image` type for now.
+	return (
+		mediaAttributes?.type === 'image' &&
+		!! mediaAttributes?.url &&
+		! mediaAttributes?.id
+	);
 }
 
 /**
  * Retrieve media info from a block.
  *
- * Different blocks use different attribute names, so we need this
- * function to normalize things into a consistent naming scheme.
+ * Uses the generic `getMediaRoleAttributes` utility to work with any block
+ * that defines `mediaRoles` in block.json.
  *
  * @param {{name: string, attributes: Object}} block The block.
  * @return {{url: ?string, alt: ?string, id: ?number}} The media info for the block.
  */
 function getMediaInfo( block ) {
-	if ( block.name === 'core/image' || block.name === 'core/cover' ) {
-		const { url, alt, id } = block.attributes;
-		return { url, alt, id };
-	}
-
-	if ( block.name === 'core/media-text' ) {
-		const { mediaUrl: url, mediaAlt: alt, mediaId: id } = block.attributes;
-		return { url, alt, id };
-	}
-
-	return {};
+	return getMediaRoleAttributes( block.name, block.attributes ) || {};
 }
 
 // Image component to represent a single image in the upload dialog.
@@ -141,24 +138,28 @@ export default function MaybeUploadMediaPanel() {
 	/**
 	 * Update an individual block to point to newly-added library media.
 	 *
-	 * Different blocks use different attribute names, so we need this
-	 * function to ensure we modify the correct attributes for each type.
+	 * Uses the block's `mediaRoles` configuration to determine which
+	 * attributes need to be updated.
 	 *
 	 * @param {{name: string, attributes: Object}} block The block.
 	 * @param {{id: number, url: string}}          media Media library file info.
 	 */
 	function updateBlockWithUploadedMedia( block, media ) {
-		if ( block.name === 'core/image' || block.name === 'core/cover' ) {
-			updateBlockAttributes( block.clientId, {
-				id: media.id,
-				url: media.url,
-			} );
+		const blockType = getBlockType( block.name );
+		const mediaRoles = blockType?.mediaRoles;
+		if ( ! mediaRoles ) {
+			return;
 		}
-
-		if ( block.name === 'core/media-text' ) {
+		// Update only if `id` and `url` attributes are found to update.
+		const isEligibleToUpdate =
+			mediaRoles.id &&
+			Object.hasOwn( blockType.attributes, mediaRoles.id ) &&
+			mediaRoles.url &&
+			Object.hasOwn( blockType.attributes, mediaRoles.url );
+		if ( isEligibleToUpdate ) {
 			updateBlockAttributes( block.clientId, {
-				mediaId: media.id,
-				mediaUrl: media.url,
+				[ mediaRoles.id ]: media.id,
+				[ mediaRoles.url ]: media.url,
 			} );
 		}
 	}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -1003,6 +1003,46 @@
 		"render": {
 			"description": "Template file loaded on the server when rendering a block.",
 			"type": "string"
+		},
+		"mediaRoles": {
+			"description": "Maps semantic media role names to block attributes. Allows generic media handling across blocks with different attribute naming conventions. Supported roles: id (media ID), url (media source URL), alt (alternative text), type (media type: image/video/audio).",
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Maps to the attribute containing the media attachment ID.",
+					"type": "string"
+				},
+				"url": {
+					"description": "Maps to the attribute containing the media source URL.",
+					"type": "string"
+				},
+				"alt": {
+					"description": "Maps to the attribute containing alternative text for the media.",
+					"type": "string"
+				},
+				"type": {
+					"description": "Maps to the media type (image, video, or audio). Can be a static value or reference an attribute.",
+					"oneOf": [
+						{ "type": "string" },
+						{
+							"type": "object",
+							"properties": {
+								"value": {
+									"description": "Static media type value",
+									"type": "string",
+									"enum": ["image", "video", "audio"]
+								},
+								"attribute": {
+									"description": "Dynamic attribute reference containing media type",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						}
+					]
+				}
+			},
+			"additionalProperties": false
 		}
 	},
 	"required": [ "apiVersion", "name", "title" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
An exploration related to: https://github.com/WordPress/gutenberg/issues/65186 and https://github.com/WordPress/gutenberg/issues/70714.

I spent some time exploring the above issues that are about adding some semantic info in media blocks that could potentially normalize some behaviors across blocks, that right now have very specific handling per block.

I didn't want to spend much time for it and start some discussions about whether such an API could be valuable and worths the effort. 

### Initially the obvious use cases for me that can use this, are the cases handled in this POC:
1. List view images. With this approach we can detect images from more blocks besides the already hardcoded ones. You can see in the small video below for example that we can show images that are children of `Group` or more images in `Cover`, if they have more images nested. **Is this something we would want though design wise**? 🤔 This opens of course the opportunity to show images from 3rd party blocks too.
2. We can support uploading external images in `post publish panel` even from 3rd party blocks that use the API.

### Possible use cases without exploring them
1. Integrate with media inserter for handling preview and probably insert different blocks than the default ones (`Image`, `Video` and `Audio` blocks`.
2. Could this be useful in some way to pattern content only editing? --cc @ramonjd 
3. Could this be helpful in block transforms in any way
4. Could this be helpful in drag and drop functionality? We have for example some logic for detecting image blocks in `useOnBlockDrop` to create a gallery with `core/image` hardcoded checks.


### Current suggestion rationale and alternatives

Media blocks would need to identify at least these roles: `url`, `id`(persisted data), `alt`(for images) and `type`(image|video|audio). `type` is an important part because different media types have different tags and handling.

#### Approaches that I considered 
1. At first I considered using the existing `role` prop of block attributes, but many of them already have the `content` role applied. We could consider media roles as content, but not being explicit can lead to bugs and unwanted behaviors. Another alternative is to make `role` also accept and array of roles (ex `['content', 'mediaId']`). It's doable but didn't chose this for start because it feels to me right now that `content` has been overused for content only editing and might entangle things more. That is a concern I already have and it's worth discussing on its own, although I don't have a clear way forward to solve this.. Another main obstacle for this approach or even having a new prop in block attributes like `mediaRole` is that block need to define their `type` media role but don't have such an attribute. Adding a new attribute in blocks just for this doesn't seem like a good approach.
2. I considered using a block supports but it didn't seem a good approach for the above point of adding more attributes in a block without any good reason.

#### Current suggestion

I ended up trying this with a new top level `mediaRoles` prop in block config. I'm not sure about the name either since this prop is a map of the media roles to each block's related attributes. This solves the `type` media role for blocks without adding any new attributes.

### Questions
1. Would an API like this (with any approach and not necessarily the suggested one) make sense to introduce? TBH I'm still not sure, unless we validate a bit more use cases or we deem that the already implemented two ones provide enough value.
2. Since such an API is about adding semantic info in some block attributes we should consider if and how could we scale in the future. **What other cases of block attributes would benefit from a more specific role?**

--cc @WordPress/gutenberg-core @youknowriad @mcsf @Mamaduka @mtias 



## Screenshots
### List view

https://github.com/user-attachments/assets/c6ff9ea0-8897-4914-9674-54a46bae369a

