### PR TITLE
Fix: DataViews modal actions in list layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)
+
 ## 10.2.0 (2025-10-29)
 
 ### Enhancements

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -106,12 +106,11 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
+						text={ label }
 						size="small"
 						onClick={ () => setIsModalOpen( true ) }
 						variant="link"
-					>
-						{ label }
-					</Button>
+					/>
 				}
 			>
 				{ isModalOpen && (

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -805,7 +805,10 @@ export const actions: Action< SpaceObject >[] = [
 	{
 		id: 'secondary',
 		label: 'Secondary action',
-		callback() {},
+		callback() {
+			// eslint-disable-next-line no-console
+			console.log( 'Perform secondary action.' );
+		},
 	},
 ];
 


### PR DESCRIPTION
## What?

This PR fixes an issue by which modal actions in list layout wouldn't trigger the modal.

## How?

Use the `text` property of the button to render text instead of using children.

## Testing Instructions

- Open the storybook, go to the the story "DataViews > Default".
- Switch to list layout.
- Click on the delete action.

The expectation is that it opens the delete modal.

