### PR TITLE
Template activation: skip gutenberg_get_registered_block_templates query when no slugs are left to find

### DIFF
--- a/backport-changelog/6.9/10432.md
+++ b/backport-changelog/6.9/10432.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10432
 
 * https://github.com/WordPress/gutenberg/pull/72770
+* https://github.com/WordPress/gutenberg/pull/72795

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -309,10 +309,12 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	}
 
 	// For any remaining slugs, use the static template.
-	$query     = array(
-		'slug__in' => $remaining_slugs,
-	);
-	$templates = array_merge( $templates, gutenberg_get_registered_block_templates( $query ) );
+	if ( ! empty( $remaining_slugs ) ) {
+		$query     = array(
+			'slug__in' => $remaining_slugs,
+		);
+		$templates = array_merge( $templates, gutenberg_get_registered_block_templates( $query ) );
+	}
 
 	if ( $specific_template && in_array( $specific_template, $remaining_slugs, true ) ) {
 		$templates = array_merge( $templates, get_block_templates( array( 'slug__in' => array( $specific_template ) ) ) );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72786. Cc @bacoords.

<!-- In a few words, what is the PR actually doing? -->

When no slugs are left to find (because they were all found in the database), skip the registered templates query instead of calling it with `slug__in` set to an empty array. This could confuse plugins in thinking they need to return _all_ registered templates.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prevents the function that gets registered templates from returning all registered templates. If it returns templates that have slugs that were not requested, there will be PHP warnings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check `$remaining_slugs`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Install Woo. Create a front-page template in the site editor and set it active. The front page should have no PHP warnings.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
