### PR TITLE
Fix: Make fit text work, when navigating with the interactivity api.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -55,9 +55,14 @@ function getElementIdentifier( element ) {
  * @param {HTMLElement} element Element with fit text enabled.
  */
 function initializeFitText( element ) {
-	// Skip if already initialized (element already has an ID)
-	if ( element.dataset.fitTextId ) {
+	// Check if already initialized by looking for active observer
+	if ( element.dataset.fitTextId && resizeObservers.has( element.dataset.fitTextId ) ) {
 		return;
+	}
+
+	// If has ID but no observer, clear stale ID
+	if ( element.dataset.fitTextId ) {
+		delete element.dataset.fitTextId;
 	}
 
 	const elementId = getElementIdentifier( element );
@@ -120,30 +125,13 @@ window.addEventListener( 'load', initializeAllFitText );
 // Watch for dynamically added/removed fit-text elements (e.g., from Interactivity API navigation)
 if ( window.MutationObserver ) {
 	const observer = new window.MutationObserver( ( mutations ) => {
-		// Collect all added element references in this batch to detect moves vs removals
-		const addedElements = new Set();
 		for ( const mutation of mutations ) {
-			if ( mutation.addedNodes.length > 0 ) {
-				for ( const node of mutation.addedNodes ) {
-					if ( node.nodeType === 1 ) {
-						addedElements.add( node );
-					}
-				}
-			}
-		}
-
-		for ( const mutation of mutations ) {
-			// Handle removed nodes first (cleanup)
+			// Handle removed nodes (cleanup)
 			if ( mutation.removedNodes.length > 0 ) {
 				for ( const node of mutation.removedNodes ) {
 					// Skip non-element nodes
 					if ( node.nodeType !== 1 ) {
 						continue;
-					}
-
-					// IMPORTANT: Only cleanup if element is NOT being re-added (i.e., truly removed)
-					if ( addedElements.has( node ) ) {
-						continue; // Element is being moved, not removed
 					}
 
 					// Check if removed node itself is a fit-text element
@@ -157,10 +145,7 @@ if ( window.MutationObserver ) {
 					);
 					if ( removedFitTextElements?.length > 0 ) {
 						removedFitTextElements.forEach( ( el ) => {
-							// Only cleanup if not being re-added
-							if ( ! addedElements.has( el ) ) {
-								cleanupFitText( el.dataset.fitTextId );
-							}
+							cleanupFitText( el.dataset.fitTextId );
 						} );
 					}
 				}
@@ -176,38 +161,13 @@ if ( window.MutationObserver ) {
 
 					// Check if the node itself is a fit-text element
 					if ( node.classList?.contains( 'has-fit-text' ) ) {
-						// If already initialized and observer exists, skip
-						if (
-							node.dataset.fitTextId &&
-							resizeObservers.has( node.dataset.fitTextId )
-						) {
-							continue;
-						}
-						// Has ID but no observer (was cleaned up or moved), clear ID to reinit
-						if ( node.dataset.fitTextId ) {
-							delete node.dataset.fitTextId;
-						}
 						initializeFitText( node );
 					}
 
 					// Check for fit-text elements within the added node
-					const fitTextElements =
-						node.querySelectorAll?.( '.has-fit-text' );
+					const fitTextElements = node.querySelectorAll?.( '.has-fit-text' );
 					if ( fitTextElements?.length > 0 ) {
-						fitTextElements.forEach( ( el ) => {
-							// If already initialized and observer exists, skip
-							if (
-								el.dataset.fitTextId &&
-								resizeObservers.has( el.dataset.fitTextId )
-							) {
-								return;
-							}
-							// Has ID but no observer, clear ID to reinit
-							if ( el.dataset.fitTextId ) {
-								delete el.dataset.fitTextId;
-							}
-							initializeFitText( el );
-						} );
+						fitTextElements.forEach( initializeFitText );
 					}
 				}
 			}

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -55,12 +55,13 @@ function getElementIdentifier( element ) {
  * @param {HTMLElement} element Element with fit text enabled.
  */
 function initializeFitText( element ) {
-	// Check if already initialized by looking for active observer
-	if ( element.dataset.fitTextId && resizeObservers.has( element.dataset.fitTextId ) ) {
+	if (
+		element.dataset.fitTextId &&
+		resizeObservers.has( element.dataset.fitTextId )
+	) {
 		return;
 	}
 
-	// If has ID but no observer, clear stale ID
 	if ( element.dataset.fitTextId ) {
 		delete element.dataset.fitTextId;
 	}
@@ -79,7 +80,6 @@ function initializeFitText( element ) {
 		optimizeFitText( element, elementSelector, applyStylesFn );
 	};
 
-	// Initial sizing
 	applyFitText();
 
 	// Watch for parent container resize
@@ -105,13 +105,11 @@ function initializeAllFitText() {
  * @param {string} elementId The fit-text-id of the removed element.
  */
 function cleanupFitText( elementId ) {
-	// Remove the style element
 	const styleElement = document.getElementById( `fit-text-${ elementId }` );
 	if ( styleElement ) {
 		styleElement.remove();
 	}
 
-	// Disconnect and remove the ResizeObserver
 	const observer = resizeObservers.get( elementId );
 	if ( observer ) {
 		observer.disconnect();
@@ -119,27 +117,22 @@ function cleanupFitText( elementId ) {
 	}
 }
 
-// Initialize on page load
 window.addEventListener( 'load', initializeAllFitText );
 
 // Watch for dynamically added/removed fit-text elements (e.g., from Interactivity API navigation)
 if ( window.MutationObserver ) {
 	const observer = new window.MutationObserver( ( mutations ) => {
 		for ( const mutation of mutations ) {
-			// Handle removed nodes (cleanup)
 			if ( mutation.removedNodes.length > 0 ) {
 				for ( const node of mutation.removedNodes ) {
-					// Skip non-element nodes
 					if ( node.nodeType !== 1 ) {
 						continue;
 					}
 
-					// Check if removed node itself is a fit-text element
 					if ( node.dataset?.fitTextId ) {
 						cleanupFitText( node.dataset.fitTextId );
 					}
 
-					// Check for fit-text elements within removed node
 					const removedFitTextElements = node.querySelectorAll?.(
 						'.has-fit-text[data-fit-text-id]'
 					);
@@ -151,21 +144,18 @@ if ( window.MutationObserver ) {
 				}
 			}
 
-			// Handle added nodes (initialization)
 			if ( mutation.addedNodes.length > 0 ) {
 				for ( const node of mutation.addedNodes ) {
-					// Skip non-element nodes
 					if ( node.nodeType !== 1 ) {
 						continue;
 					}
 
-					// Check if the node itself is a fit-text element
 					if ( node.classList?.contains( 'has-fit-text' ) ) {
 						initializeFitText( node );
 					}
 
-					// Check for fit-text elements within the added node
-					const fitTextElements = node.querySelectorAll?.( '.has-fit-text' );
+					const fitTextElements =
+						node.querySelectorAll?.( '.has-fit-text' );
 					if ( fitTextElements?.length > 0 ) {
 						fitTextElements.forEach( initializeFitText );
 					}
@@ -174,7 +164,6 @@ if ( window.MutationObserver ) {
 		}
 	} );
 
-	// Start observing after page load
 	window.addEventListener( 'load', () => {
 		observer.observe( document.body, {
 			childList: true,

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -89,41 +89,26 @@ function initializeAllFitText() {
 // Initialize on page load
 window.addEventListener( 'load', initializeAllFitText );
 
-// Re-initialize after Interactivity API router navigation
-// The router uses popstate for back/forward and renders new content into router regions
+// Re-initialize after Interactivity API navigation
+// The Interactivity API router uses history.pushState/replaceState for navigation,
+// so we wrap these methods to detect when navigation occurs.
+const originalPushState = window.history.pushState;
+const originalReplaceState = window.history.replaceState;
+
+window.history.pushState = function ( ...args ) {
+	const result = originalPushState.apply( this, args );
+	// Small delay to ensure router has finished rendering
+	setTimeout( initializeAllFitText, 100 );
+	return result;
+};
+
+window.history.replaceState = function ( ...args ) {
+	const result = originalReplaceState.apply( this, args );
+	setTimeout( initializeAllFitText, 100 );
+	return result;
+};
+
+// Handle back/forward navigation
 window.addEventListener( 'popstate', () => {
-	// Small delay to let the router finish rendering
 	setTimeout( initializeAllFitText, 100 );
 } );
-
-// Watch for DOM changes in router regions to catch client-side navigation
-if ( window.MutationObserver ) {
-	const observer = new window.MutationObserver( ( mutations ) => {
-		// Check if any mutations affected elements with router region attributes
-		const hasRouterChanges = mutations.some( ( mutation ) => {
-			// Check if mutation is in a router region
-			if ( mutation.target.nodeType === 1 ) {
-				const target = mutation.target;
-				return (
-					target.hasAttribute( 'data-wp-router-region' ) ||
-					target.closest( '[data-wp-router-region]' )
-				);
-			}
-			return false;
-		} );
-
-		if ( hasRouterChanges ) {
-			// Debounce re-initialization
-			clearTimeout( observer.timer );
-			observer.timer = setTimeout( initializeAllFitText, 100 );
-		}
-	} );
-
-	// Start observing after page load
-	window.addEventListener( 'load', () => {
-		observer.observe( document.body, {
-			childList: true,
-			subtree: true,
-		} );
-	} );
-}

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -49,6 +49,11 @@ function getElementIdentifier( element ) {
  * @param {HTMLElement} element Element with fit text enabled.
  */
 function initializeFitText( element ) {
+	// Skip if already initialized (element already has an ID)
+	if ( element.dataset.fitTextId ) {
+		return;
+	}
+
 	const elementId = getElementIdentifier( element );
 
 	const applyFitText = () => {
@@ -81,4 +86,44 @@ function initializeAllFitText() {
 	elements.forEach( initializeFitText );
 }
 
+// Initialize on page load
 window.addEventListener( 'load', initializeAllFitText );
+
+// Re-initialize after Interactivity API router navigation
+// The router uses popstate for back/forward and renders new content into router regions
+window.addEventListener( 'popstate', () => {
+	// Small delay to let the router finish rendering
+	setTimeout( initializeAllFitText, 100 );
+} );
+
+// Watch for DOM changes in router regions to catch client-side navigation
+if ( window.MutationObserver ) {
+	const observer = new window.MutationObserver( ( mutations ) => {
+		// Check if any mutations affected elements with router region attributes
+		const hasRouterChanges = mutations.some( ( mutation ) => {
+			// Check if mutation is in a router region
+			if ( mutation.target.nodeType === 1 ) {
+				const target = mutation.target;
+				return (
+					target.hasAttribute( 'data-wp-router-region' ) ||
+					target.closest( '[data-wp-router-region]' )
+				);
+			}
+			return false;
+		} );
+
+		if ( hasRouterChanges ) {
+			// Debounce re-initialization
+			clearTimeout( observer.timer );
+			observer.timer = setTimeout( initializeAllFitText, 100 );
+		}
+	} );
+
+	// Start observing after page load
+	window.addEventListener( 'load', () => {
+		observer.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+	} );
+}

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -89,26 +89,46 @@ function initializeAllFitText() {
 // Initialize on page load
 window.addEventListener( 'load', initializeAllFitText );
 
-// Re-initialize after Interactivity API navigation
-// The Interactivity API router uses history.pushState/replaceState for navigation,
-// so we wrap these methods to detect when navigation occurs.
-const originalPushState = window.history.pushState;
-const originalReplaceState = window.history.replaceState;
+// Watch for dynamically added fit-text elements (e.g., from Interactivity API navigation)
+if ( window.MutationObserver ) {
+	const observer = new window.MutationObserver( ( mutations ) => {
+		// Only process mutations that added nodes
+		for ( const mutation of mutations ) {
+			if ( mutation.addedNodes.length === 0 ) {
+				continue;
+			}
 
-window.history.pushState = function ( ...args ) {
-	const result = originalPushState.apply( this, args );
-	// Small delay to ensure router has finished rendering
-	setTimeout( initializeAllFitText, 100 );
-	return result;
-};
+			// Check each added node
+			for ( const node of mutation.addedNodes ) {
+				// Skip non-element nodes
+				if ( node.nodeType !== 1 ) {
+					continue;
+				}
 
-window.history.replaceState = function ( ...args ) {
-	const result = originalReplaceState.apply( this, args );
-	setTimeout( initializeAllFitText, 100 );
-	return result;
-};
+				// Check if the node itself is a fit-text element
+				if (
+					node.classList?.contains( 'has-fit-text' ) &&
+					! node.dataset.fitTextId
+				) {
+					initializeFitText( node );
+				}
 
-// Handle back/forward navigation
-window.addEventListener( 'popstate', () => {
-	setTimeout( initializeAllFitText, 100 );
-} );
+				// Check for fit-text elements within the added node
+				const fitTextElements = node.querySelectorAll?.(
+					'.has-fit-text:not([data-fit-text-id])'
+				);
+				if ( fitTextElements?.length > 0 ) {
+					fitTextElements.forEach( initializeFitText );
+				}
+			}
+		}
+	} );
+
+	// Start observing after page load
+	window.addEventListener( 'load', () => {
+		observer.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+	} );
+}

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -14,6 +14,12 @@ import { optimizeFitText } from './fit-text-utils';
 let idCounter = 0;
 
 /**
+ * Map to store ResizeObserver for each element, keyed by fit-text-id.
+ * Allows cleanup when elements are removed.
+ */
+const resizeObservers = new Map();
+
+/**
  * Get or create a unique style element for a fit text element.
  *
  * @param {string} elementId Unique identifier for the element.
@@ -75,6 +81,8 @@ function initializeFitText( element ) {
 	if ( window.ResizeObserver && element.parentElement ) {
 		const resizeObserver = new window.ResizeObserver( applyFitText );
 		resizeObserver.observe( element.parentElement );
+		// Store observer for cleanup
+		resizeObservers.set( elementId, resizeObserver );
 	}
 }
 
@@ -86,39 +94,121 @@ function initializeAllFitText() {
 	elements.forEach( initializeFitText );
 }
 
+/**
+ * Clean up resources for a removed fit-text element.
+ *
+ * @param {string} elementId The fit-text-id of the removed element.
+ */
+function cleanupFitText( elementId ) {
+	// Remove the style element
+	const styleElement = document.getElementById( `fit-text-${ elementId }` );
+	if ( styleElement ) {
+		styleElement.remove();
+	}
+
+	// Disconnect and remove the ResizeObserver
+	const observer = resizeObservers.get( elementId );
+	if ( observer ) {
+		observer.disconnect();
+		resizeObservers.delete( elementId );
+	}
+}
+
 // Initialize on page load
 window.addEventListener( 'load', initializeAllFitText );
 
-// Watch for dynamically added fit-text elements (e.g., from Interactivity API navigation)
+// Watch for dynamically added/removed fit-text elements (e.g., from Interactivity API navigation)
 if ( window.MutationObserver ) {
 	const observer = new window.MutationObserver( ( mutations ) => {
-		// Only process mutations that added nodes
+		// Collect all added element references in this batch to detect moves vs removals
+		const addedElements = new Set();
 		for ( const mutation of mutations ) {
-			if ( mutation.addedNodes.length === 0 ) {
-				continue;
+			if ( mutation.addedNodes.length > 0 ) {
+				for ( const node of mutation.addedNodes ) {
+					if ( node.nodeType === 1 ) {
+						addedElements.add( node );
+					}
+				}
+			}
+		}
+
+		for ( const mutation of mutations ) {
+			// Handle removed nodes first (cleanup)
+			if ( mutation.removedNodes.length > 0 ) {
+				for ( const node of mutation.removedNodes ) {
+					// Skip non-element nodes
+					if ( node.nodeType !== 1 ) {
+						continue;
+					}
+
+					// IMPORTANT: Only cleanup if element is NOT being re-added (i.e., truly removed)
+					if ( addedElements.has( node ) ) {
+						continue; // Element is being moved, not removed
+					}
+
+					// Check if removed node itself is a fit-text element
+					if ( node.dataset?.fitTextId ) {
+						cleanupFitText( node.dataset.fitTextId );
+					}
+
+					// Check for fit-text elements within removed node
+					const removedFitTextElements = node.querySelectorAll?.(
+						'.has-fit-text[data-fit-text-id]'
+					);
+					if ( removedFitTextElements?.length > 0 ) {
+						removedFitTextElements.forEach( ( el ) => {
+							// Only cleanup if not being re-added
+							if ( ! addedElements.has( el ) ) {
+								cleanupFitText( el.dataset.fitTextId );
+							}
+						} );
+					}
+				}
 			}
 
-			// Check each added node
-			for ( const node of mutation.addedNodes ) {
-				// Skip non-element nodes
-				if ( node.nodeType !== 1 ) {
-					continue;
-				}
+			// Handle added nodes (initialization)
+			if ( mutation.addedNodes.length > 0 ) {
+				for ( const node of mutation.addedNodes ) {
+					// Skip non-element nodes
+					if ( node.nodeType !== 1 ) {
+						continue;
+					}
 
-				// Check if the node itself is a fit-text element
-				if (
-					node.classList?.contains( 'has-fit-text' ) &&
-					! node.dataset.fitTextId
-				) {
-					initializeFitText( node );
-				}
+					// Check if the node itself is a fit-text element
+					if ( node.classList?.contains( 'has-fit-text' ) ) {
+						// If already initialized and observer exists, skip
+						if (
+							node.dataset.fitTextId &&
+							resizeObservers.has( node.dataset.fitTextId )
+						) {
+							continue;
+						}
+						// Has ID but no observer (was cleaned up or moved), clear ID to reinit
+						if ( node.dataset.fitTextId ) {
+							delete node.dataset.fitTextId;
+						}
+						initializeFitText( node );
+					}
 
-				// Check for fit-text elements within the added node
-				const fitTextElements = node.querySelectorAll?.(
-					'.has-fit-text:not([data-fit-text-id])'
-				);
-				if ( fitTextElements?.length > 0 ) {
-					fitTextElements.forEach( initializeFitText );
+					// Check for fit-text elements within the added node
+					const fitTextElements =
+						node.querySelectorAll?.( '.has-fit-text' );
+					if ( fitTextElements?.length > 0 ) {
+						fitTextElements.forEach( ( el ) => {
+							// If already initialized and observer exists, skip
+							if (
+								el.dataset.fitTextId &&
+								resizeObservers.has( el.dataset.fitTextId )
+							) {
+								return;
+							}
+							// Has ID but no observer, clear ID to reinit
+							if ( el.dataset.fitTextId ) {
+								delete el.dataset.fitTextId;
+							}
+							initializeFitText( el );
+						} );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes an issue where fit-text is not working when navigating using the Interactivity API and in any case where fit-text blocks may be added dynamically with JavaScript. Props to @luisherranz for reporting this.

## Solution
Instead of running once and assuming all fit-text blocks are static, we add a mutation observer. It just listens to node additions and removals after the load and checks if the node has or contains fit-text blocks. If it does and the node is removed, it cleans up the fit-text observer; if the node was added and has fit-text, it performs its initialization.

### Other alternatives:
* Overwrite the `push`/`pop` methods of the navigation so we could catch and try to get an `onNavigate` event and then do the fit-text init. This is not very reliable, as when the navigation happens, requests to the server may still be in progress and the DOM may not be ready.

* Try to use the Interactivity API directly. I guess we would need to add some invisible element which uses the Interactivity API as a way to try to subscribe to the navigation events on the Interactivity API. I tried that locally but my solution was going in a very hacky way.

cc: @luisherranz for thoughts on the current solution and in case you know a simpler alternative.

## Testing Instructions
1.  Enable the "Interactivity API: Full-page client-side navigation" experiment.
2.  Add a new post with fit-text, load the blog page, and see that the post with fit-text works well.
3.  Navigate to that post (e.g., click the post title) and verify fit-text still looks as expected (on trunk, it does not work).