### PR TITLE
Block Bindings: Add unit test coverage for sources

### DIFF
--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -106,7 +106,7 @@ describe( 'post-meta bindings', () => {
 		} );
 
 		describe( 'getFieldsList', () => {
-			it( 'should return the list of available meta fields, with correct fallbacks for labels', () => {
+			it( 'should return the list of available meta fields, with correct fallbacks for labels, and exclude protected fields', () => {
 				const fields = postMetaBindings.getFieldsList( {
 					select,
 					context,

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -38,6 +38,9 @@ describe( 'post-meta bindings', () => {
 				title: 'Movie Field Label',
 				default: 'Movie field default value',
 			},
+			_protected_field: {
+				default: 'Protected field value',
+			},
 		} );
 
 		lock( selectReturn, { getRegisteredPostMeta } );
@@ -133,6 +136,16 @@ describe( 'post-meta bindings', () => {
 				select,
 				context: { postType: 'movie', postId: 123 },
 				args: { key: 'inaccessible_field' },
+			} );
+
+			expect( canUser ).toBe( false );
+		} );
+
+		it( 'should return false when meta field is protected', () => {
+			const canUser = postMetaBindings.canUserEditValue( {
+				select,
+				context: { postType: 'movie', postId: 123 },
+				args: { key: '_protected_field' },
 			} );
 
 			expect( canUser ).toBe( false );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -136,6 +136,20 @@ describe( 'post-meta bindings', () => {
 
 				expect( values.content ).toBe( 'inaccessible_field' );
 			} );
+
+			it( 'should fall back to the key when meta field is protected', () => {
+				const values = postMetaBindings.getValues( {
+					select,
+					context,
+					bindings: {
+						content: {
+							args: { key: '_protected_field' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( '_protected_field' );
+			} );
 		} );
 
 		describe( 'canUserEditValue', () => {

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -32,17 +32,20 @@ describe( 'post-meta bindings', () => {
 		};
 
 		const getRegisteredPostMeta = () => ( {
-			field_without_label_or_default: {},
+			field_without_label_or_default: { type: 'string' },
 			field_with_label_only: {
 				title: 'Field With Label Only',
 				default: '', // If there's no default set, getRegisteredPostMeta() will return an empty string.
+				type: 'string',
 			},
 			movie_field: {
 				title: 'Movie Field Label',
 				default: 'Movie field default value',
+				type: 'string',
 			},
 			_protected_field: {
 				default: 'Protected field default value',
+				type: 'string',
 			},
 		} );
 
@@ -99,6 +102,33 @@ describe( 'post-meta bindings', () => {
 				expect( values.content ).toBe(
 					'field_without_label_or_default'
 				);
+			} );
+		} );
+
+		describe( 'getFieldsList', () => {
+			it( 'should return the list of available meta fields, with correct fallbacks for labels', () => {
+				const fields = postMetaBindings.getFieldsList( {
+					select,
+					context,
+				} );
+
+				expect( fields ).toEqual( [
+					{
+						label: 'field_without_label_or_default',
+						type: 'string',
+						args: { key: 'field_without_label_or_default' },
+					},
+					{
+						label: 'Field With Label Only',
+						type: 'string',
+						args: { key: 'field_with_label_only' },
+					},
+					{
+						label: 'Movie Field Label',
+						type: 'string',
+						args: { key: 'movie_field' },
+					},
+				] );
 			} );
 		} );
 	} );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -9,14 +9,16 @@ import { lock } from '../../lock-unlock';
 import postMetaBindings from '../post-meta';
 
 describe( 'post-meta bindings', () => {
-	let select, selectReturn;
+	let context, select, selectReturn;
+
 	beforeAll( () => {
 		const getEditedEntityRecord = ( kind, type, id ) => ( {
-			meta: id
-				? {
-						movie_field: 'Test Movie Value',
-				  }
-				: {},
+			meta:
+				id === 123
+					? {
+							movie_field: 'Test Movie Value',
+					  }
+					: {},
 		} );
 
 		const getEditorSettings = () => ( {
@@ -48,12 +50,16 @@ describe( 'post-meta bindings', () => {
 		select = () => selectReturn;
 	} );
 
-	describe( 'getValues', () => {
-		describe( 'when no postId is provided in context', () => {
+	describe( 'when no postId is provided in context', () => {
+		beforeAll( () => {
+			context = { postType: 'movie' };
+		} );
+
+		describe( 'getValues', () => {
 			it( 'should return the meta default value if it is defined', () => {
 				const values = postMetaBindings.getValues( {
 					select,
-					context: { postType: 'movie' },
+					context,
 					bindings: {
 						content: {
 							args: { key: 'movie_field' },
@@ -67,7 +73,7 @@ describe( 'post-meta bindings', () => {
 			it( 'should fall back to the field label if the meta default value is not defined', () => {
 				const values = postMetaBindings.getValues( {
 					select,
-					context: { postType: 'movie' },
+					context,
 					bindings: {
 						content: {
 							args: { key: 'field_with_label_only' },
@@ -81,7 +87,7 @@ describe( 'post-meta bindings', () => {
 			it( 'should fall back to the field key if the field label is not defined', () => {
 				const values = postMetaBindings.getValues( {
 					select,
-					context: { postType: 'movie' },
+					context,
 					bindings: {
 						content: {
 							args: { key: 'field_without_label_or_default' },
@@ -94,12 +100,18 @@ describe( 'post-meta bindings', () => {
 				);
 			} );
 		} );
+	} );
 
-		describe( 'when postId is provided in context', () => {
+	describe( 'when postId is provided in context', () => {
+		beforeAll( () => {
+			context = { postType: 'movie', postId: 123 };
+		} );
+
+		describe( 'getValues', () => {
 			it( 'should return the meta value if it is defined', () => {
 				const values = postMetaBindings.getValues( {
 					select,
-					context: { postType: 'movie', postId: 123 },
+					context,
 					bindings: {
 						content: {
 							args: { key: 'movie_field' },
@@ -113,7 +125,7 @@ describe( 'post-meta bindings', () => {
 			it( 'should fall back to the key when meta field is not accessible', () => {
 				const values = postMetaBindings.getValues( {
 					select,
-					context: { postType: 'movie', postId: 123 },
+					context,
 					bindings: {
 						content: {
 							args: { key: 'inaccessible_field' },
@@ -124,31 +136,31 @@ describe( 'post-meta bindings', () => {
 				expect( values.content ).toBe( 'inaccessible_field' );
 			} );
 		} );
-	} );
 
-	describe( 'canUserEditValue', () => {
-		beforeAll( () => {
-			select = () => ( { ...selectReturn, canUser: () => true } );
-		} );
-
-		it( 'should return false when meta field is not accessible', () => {
-			const canUser = postMetaBindings.canUserEditValue( {
-				select,
-				context: { postType: 'movie', postId: 123 },
-				args: { key: 'inaccessible_field' },
+		describe( 'canUserEditValue', () => {
+			beforeAll( () => {
+				select = () => ( { ...selectReturn, canUser: () => true } );
 			} );
 
-			expect( canUser ).toBe( false );
-		} );
+			it( 'should return false when meta field is not accessible', () => {
+				const canUser = postMetaBindings.canUserEditValue( {
+					select,
+					context,
+					args: { key: 'inaccessible_field' },
+				} );
 
-		it( 'should return false when meta field is protected', () => {
-			const canUser = postMetaBindings.canUserEditValue( {
-				select,
-				context: { postType: 'movie', postId: 123 },
-				args: { key: '_protected_field' },
+				expect( canUser ).toBe( false );
 			} );
 
-			expect( canUser ).toBe( false );
+			it( 'should return false when meta field is protected', () => {
+				const canUser = postMetaBindings.canUserEditValue( {
+					select,
+					context,
+					args: { key: '_protected_field' },
+				} );
+
+				expect( canUser ).toBe( false );
+			} );
 		} );
 	} );
 } );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import { lock } from '../../lock-unlock';
+
+/**
+ * Internal dependencies
+ */
+import postMetaBindings from '../post-meta';
+
+describe( 'post-meta bindings', () => {
+	describe( 'getValues', () => {
+		describe( 'when no postId is provided in context', () => {
+			it( 'should return the meta default value if it is defined', () => {
+				const getEditedEntityRecord = ( kind, type, id ) => ( {
+					meta: id
+						? {
+								movie_field: 'Test Movie Value',
+						  }
+						: {},
+				} );
+
+				const selectReturn = {
+					getEditedEntityRecord,
+				};
+
+				const getRegisteredPostMeta = () => ( {
+					movie_field: {
+						label: 'Movie Field Label',
+						default: 'Movie field default value',
+					},
+				} );
+
+				lock( selectReturn, { getRegisteredPostMeta } );
+
+				const values = postMetaBindings.getValues( {
+					select: () => selectReturn,
+					context: { postType: 'movie' },
+					bindings: {
+						content: {
+							args: { key: 'movie_field' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( 'Movie field default value' );
+			} );
+		} );
+	} );
+} );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -9,39 +9,44 @@ import { lock } from '../../lock-unlock';
 import postMetaBindings from '../post-meta';
 
 describe( 'post-meta bindings', () => {
+	let select, selectReturn;
+	beforeAll( () => {
+		const getEditedEntityRecord = ( kind, type, id ) => ( {
+			meta: id
+				? {
+						movie_field: 'Test Movie Value',
+				  }
+				: {},
+		} );
+
+		const getEditorSettings = () => ( {
+			enableCustomFields: false,
+		} );
+
+		selectReturn = {
+			getEditedEntityRecord,
+			getEditorSettings,
+		};
+
+		const getRegisteredPostMeta = () => ( {
+			field_without_label_or_default: {},
+			field_with_label_only: {
+				title: 'Field With Label Only',
+				default: '', // If there's no default set, getRegisteredPostMeta() will return an empty string.
+			},
+			movie_field: {
+				title: 'Movie Field Label',
+				default: 'Movie field default value',
+			},
+		} );
+
+		lock( selectReturn, { getRegisteredPostMeta } );
+
+		select = () => selectReturn;
+	} );
+
 	describe( 'getValues', () => {
 		describe( 'when no postId is provided in context', () => {
-			let select, selectReturn;
-			beforeAll( () => {
-				const getEditedEntityRecord = ( kind, type, id ) => ( {
-					meta: id
-						? {
-								movie_field: 'Test Movie Value',
-						  }
-						: {},
-				} );
-
-				selectReturn = {
-					getEditedEntityRecord,
-				};
-
-				const getRegisteredPostMeta = () => ( {
-					field_without_label_or_default: {},
-					field_with_label_only: {
-						title: 'Field With Label Only',
-						default: '', // If there's no default set, getRegisteredPostMeta() will return an empty string.
-					},
-					movie_field: {
-						title: 'Movie Field Label',
-						default: 'Movie field default value',
-					},
-				} );
-
-				lock( selectReturn, { getRegisteredPostMeta } );
-
-				select = () => selectReturn;
-			} );
-
 			it( 'should return the meta default value if it is defined', () => {
 				const values = postMetaBindings.getValues( {
 					select,
@@ -85,6 +90,55 @@ describe( 'post-meta bindings', () => {
 					'field_without_label_or_default'
 				);
 			} );
+		} );
+
+		describe( 'when postId is provided in context', () => {
+			it( 'should return the meta value if it is defined', () => {
+				const values = postMetaBindings.getValues( {
+					select,
+					context: { postType: 'movie', postId: 123 },
+					bindings: {
+						content: {
+							args: { key: 'movie_field' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( 'Test Movie Value' );
+			} );
+
+			it( 'should fall back to the key when meta field is not accessible', () => {
+				const values = postMetaBindings.getValues( {
+					select,
+					context: { postType: 'movie', postId: 123 },
+					bindings: {
+						content: {
+							args: { key: 'inaccessible_field' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( 'inaccessible_field' );
+			} );
+		} );
+	} );
+
+	describe( 'canUserEditValue', () => {
+		beforeAll( () => {
+			const canUser = () => true;
+
+			selectReturn.canUser = canUser;
+			select = () => selectReturn;
+		} );
+
+		it( 'should return false when meta field is not accessible', () => {
+			const canUser = postMetaBindings.canUserEditValue( {
+				select,
+				context: { postType: 'movie', postId: 123 },
+				args: { key: 'inaccessible_field' },
+			} );
+
+			expect( canUser ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -17,6 +17,7 @@ describe( 'post-meta bindings', () => {
 				id === 123
 					? {
 							movie_field: 'Test Movie Value',
+							_protected_field: 'Protected field value',
 					  }
 					: {},
 		} );
@@ -41,7 +42,7 @@ describe( 'post-meta bindings', () => {
 				default: 'Movie field default value',
 			},
 			_protected_field: {
-				default: 'Protected field value',
+				default: 'Protected field default value',
 			},
 		} );
 

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -26,6 +26,7 @@ describe( 'post-meta bindings', () => {
 				};
 
 				const getRegisteredPostMeta = () => ( {
+					field_without_label_or_default: {},
 					field_with_label_only: {
 						title: 'Field With Label Only',
 					},
@@ -66,6 +67,20 @@ describe( 'post-meta bindings', () => {
 				} );
 
 				expect( values.content ).toBe( 'Field With Label Only' );
+			} );
+
+			it( 'should fall back to the field key if the field label is not defined', () => {
+				const values = postMetaBindings.getValues( {
+					select,
+					context: { postType: 'movie' },
+					bindings: {
+						content: {
+							args: { key: 'field_without_label_or_default' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( 'field_without_label_or_default' );
 			} );
 		} );
 	} );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -125,10 +125,7 @@ describe( 'post-meta bindings', () => {
 
 	describe( 'canUserEditValue', () => {
 		beforeAll( () => {
-			const canUser = () => true;
-
-			selectReturn.canUser = canUser;
-			select = () => selectReturn;
+			select = () => ( { ...selectReturn, canUser: () => true } );
 		} );
 
 		it( 'should return false when meta field is not accessible', () => {

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -11,7 +11,8 @@ import postMetaBindings from '../post-meta';
 describe( 'post-meta bindings', () => {
 	describe( 'getValues', () => {
 		describe( 'when no postId is provided in context', () => {
-			it( 'should return the meta default value if it is defined', () => {
+			let select, selectReturn;
+			beforeAll( () => {
 				const getEditedEntityRecord = ( kind, type, id ) => ( {
 					meta: id
 						? {
@@ -20,21 +21,28 @@ describe( 'post-meta bindings', () => {
 						: {},
 				} );
 
-				const selectReturn = {
+				selectReturn = {
 					getEditedEntityRecord,
 				};
 
 				const getRegisteredPostMeta = () => ( {
+					field_with_label_only: {
+						title: 'Field With Label Only',
+					},
 					movie_field: {
-						label: 'Movie Field Label',
+						title: 'Movie Field Label',
 						default: 'Movie field default value',
 					},
 				} );
 
 				lock( selectReturn, { getRegisteredPostMeta } );
 
+				select = () => selectReturn;
+			} );
+
+			it( 'should return the meta default value if it is defined', () => {
 				const values = postMetaBindings.getValues( {
-					select: () => selectReturn,
+					select,
 					context: { postType: 'movie' },
 					bindings: {
 						content: {
@@ -44,6 +52,20 @@ describe( 'post-meta bindings', () => {
 				} );
 
 				expect( values.content ).toBe( 'Movie field default value' );
+			} );
+
+			it( 'should fall back to the field label if the meta default value is not defined', () => {
+				const values = postMetaBindings.getValues( {
+					select,
+					context: { postType: 'movie' },
+					bindings: {
+						content: {
+							args: { key: 'field_with_label_only' },
+						},
+					},
+				} );
+
+				expect( values.content ).toBe( 'Field With Label Only' );
 			} );
 		} );
 	} );

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -29,6 +29,7 @@ describe( 'post-meta bindings', () => {
 					field_without_label_or_default: {},
 					field_with_label_only: {
 						title: 'Field With Label Only',
+						default: '', // If there's no default set, getRegisteredPostMeta() will return an empty string.
 					},
 					movie_field: {
 						title: 'Movie Field Label',
@@ -80,7 +81,9 @@ describe( 'post-meta bindings', () => {
 					},
 				} );
 
-				expect( values.content ).toBe( 'field_without_label_or_default' );
+				expect( values.content ).toBe(
+					'field_without_label_or_default'
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
## What?
Add unit test coverage for block bindings sources.

## Why?
See https://github.com/WordPress/gutenberg/pull/72739#issuecomment-3456834773:

> We currently have e2e coverage in `test/e2e/specs/editor/various/block-bindings/post-meta.spec.js`, but from a quick glance, most of those are really testing the `core/post-meta` source and should thus be turned into unit tests. (It's currently pretty hard to pinpoint where the source is returning the wrong value(s), plus the e2e tests take a lot longer to run; furthermore, both @cbravobernal and I have found that the Block Bindings related e2e tests seem to have a bug that causes them to fail locally, even if they pass in CI.)

## How?

Note that there are some "natural" mappings, e.g.:
- Editing a Movie CPT template maps to providing no `postId` in context (and editing a Movie CPT post maps to providing a `postId`).
- Tests that check the content of a Paragraph block that's connected to a block bindings source are essentially testing the functionality of `getValues`.
- Checking the labels in the sources list in the Attributes panel corresponds to checking the return value of `getFieldsList`.

| End-to-end tests | Unit tests |
|-----------------|-----------|
| **Post Meta source › Movie CPT template › Block attributes values** | **when no postId is provided in context › getValues** |
| should not be possible to edit connected blocks | *(not specific to post-meta source)* |
| should show the default value if it is defined | should return the meta default value if it is defined |
| should fall back to the field label if the default value is not defined | should fall back to the field label if the meta default value is not defined |
| should fall back to the field key if the field label is not defined | should fall back to the field key if the field label is not defined |
| **Post Meta source › Movie CPT template › Attributes panel** | **when no postId is provided in context › getFieldsList** |
| should show the field label if it is defined | should return the list of available meta fields, with correct fallbacks for labels |
| should fall back to the field key if the field label is not defined | should return the list of available meta fields, with correct fallbacks for labels |
| **Post Meta source › Movie CPT post** | **when postId is provided in context › getValues** |
| should show the custom field value of that specific post | should return the meta value if it is defined |
| should fall back to the key when custom field is not accessible | should fall back to the key when meta field is not accessible |
| should not show ~or edit~ the value of a protected field | should fall back to the key when meta field is protected |
| should not show or edit the value of a field with `show_in_rest` set to false | *(covered by "inaccessible" case)* |
| | **when postId is provided in context › canUserEditValue** |
| should be possible to edit the value of the connected custom fields | should return false when meta field is not accessible |
| should not ~show or~ edit the value of a protected field | should return false when meta field is protected |

## Testing Instructions

To run the new unit tests locally:

```sh
npm run test:unit -- packages/editor/src/bindings/test/post-meta.js
```

To run the corresponding e2e tests locally:

```sh
npm run test:e2e -- test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
```

Note that the e2e tests will most likely fail when run locally (even though the file is unchanged on this branch)! This is a known issue, although the reason is still unclear. It seems like the Post Meta source isn't always available during e2e tests. They do however pass in CI.

## Follow-up

I think we should consider removing some of the e2e tests, specifically the ones that are basically just a thin wrapper around a check for the return value of a function such as `getValues` and `getFieldsList`. When working on https://github.com/WordPress/gutenberg/pull/72739, I found that they were obfuscating the underlying issue, rather than helping to pinpoint it.