### PR TITLE
Only add pattern override block control for selected block

### DIFF
--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -43,9 +43,11 @@ const withPatternOverrideControls = createHigherOrderComponent(
 			<>
 				<BlockEdit key="edit" { ...props } />
 				{ props.isSelected && isSupportedBlock && (
-					<ControlsWithStoreSubscription { ...props } />
+					<>
+						<ControlsWithStoreSubscription { ...props } />
+						<PatternOverridesBlockControls />
+					</>
 				) }
-				{ isSupportedBlock && <PatternOverridesBlockControls /> }
 			</>
 		);
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
The pattern override block control was adding a subscription to every block. I think it's only supposed to be added to the selected block.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Performance. This gives a ~15% improvement to the inserter hover metric.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Only run this subscription for the selected block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a synced pattern
- Add a pattern override (Block inspector -> Advanced -> Enable Override
- Save it
- Add it to a post
- Check that the block toolbar has the correct icon and is purple

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Testing locally running the Hovering Items test 5x on this branch and trunk gives it a ~15% improvement which is consistent with the CI results: 

`│ inserterHover        │ '1.99 ms +3.02% -3.02%'                  │ '2.3 ms +6.96% -5.22%'      │ '-13.48%' `

  perf/pattern-overrides-block-controls branch:
  - Run 1: 1.26 ms
  - Run 2: 1.26 ms
  - Run 3: 1.28 ms
  - Run 4: 1.22 ms
  - Run 5: 1.27 ms
  - Average: 1.258 ms

  trunk:
  - Run 1: 1.49 ms
  - Run 2: 1.50 ms
  - Run 3: 1.46 ms
  - Run 4: 1.41 ms
  - Run 5: 1.51 ms
  - Average: 1.474 ms


**Before**

https://github.com/user-attachments/assets/ef6fb203-514b-4cfc-acf5-27fa3a7154b4

**After**


https://github.com/user-attachments/assets/0d884d05-8123-4e22-954c-18dbef7bdd82

