### PR TITLE
Fix: DataViews modal actions in list layout (#72793)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)
+
+## 10.2.0 (2025-10-29)
+
 ### Enhancements
 
 - DataViews: keep icon-only buttons on mobile for bulk actions. [#72761](https://github.com/WordPress/gutenberg/pull/72761)

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -106,12 +106,11 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
+						text={ label }
 						size="small"
 						onClick={ () => setIsModalOpen( true ) }
 						variant="link"
-					>
-						{ label }
-					</Button>
+					/>
 				}
 			>
 				{ isModalOpen && (

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -805,7 +805,10 @@ export const actions: Action< SpaceObject >[] = [
 	{
 		id: 'secondary',
 		label: 'Secondary action',
-		callback() {},
+		callback() {
+			// eslint-disable-next-line no-console
+			console.log( 'Perform secondary action.' );
+		},
 	},
 ];
 


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/72793