### PR TITLE
Build: Bundle CSS in package transpilation phase

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -97,50 +97,6 @@ const wordpressExternalsPlugin = createWordpressExternalsPlugin(
 );
 
 /**
- * Create emotion babel plugin for esbuild.
- * This plugin enables emotion's babel transformations for proper CSS-in-JS handling.
- *
- * @return {Object} esbuild plugin.
- */
-function emotionBabelPlugin() {
-	return babel( {
-		filter: /\.[jt]sx?$/,
-		config: {
-			plugins: [ '@emotion/babel-plugin' ],
-		},
-	} );
-}
-
-/**
- * Plugin to externalize all imports except CSS/SCSS files.
- * This allows bundling to resolve CSS imports while keeping JS imports as-is.
- *
- * @return {Object} esbuild plugin.
- */
-function externalizeExceptCssPlugin() {
-	return {
-		name: 'externalize-except-css',
-		setup( build ) {
-			// Externalize all non-CSS imports
-			build.onResolve( { filter: /.*/ }, ( args ) => {
-				// Skip entry points
-				if ( args.kind === 'entry-point' ) {
-					return null;
-				}
-
-				// Let CSS/SCSS files be processed by sassPlugin
-				if ( args.path.match( /\.(css|scss)$/ ) ) {
-					return null;
-				}
-
-				// Externalize everything else (keep imports as-is)
-				return { path: args.path, external: true };
-			} );
-		},
-	};
-}
-
-/**
  * Normalize path separators for cross-platform compatibility.
  *
  * @param {string} p Path to normalize.
@@ -849,10 +805,35 @@ async function transpilePackage( packageName ) {
 	// Check if this is the components package that needs emotion babel plugin.
 	// Ideally we should remove this exception and move away from emotion.
 	const needsEmotionPlugin = packageName === 'components';
-	const basePlugins = needsEmotionPlugin ? [ emotionBabelPlugin() ] : [];
+	const emotionPlugin = babel( {
+		filter: /\.[jt]sx?$/,
+		config: {
+			plugins: [ '@emotion/babel-plugin' ],
+		},
+	} );
+	const externalizeAllExceptCssPlugin = {
+		name: 'externalize-except-css',
+		setup( build ) {
+			// Externalize all non-CSS imports
+			build.onResolve( { filter: /.*/ }, ( args ) => {
+				// Skip entry points
+				if ( args.kind === 'entry-point' ) {
+					return null;
+				}
+
+				// Let CSS/SCSS files be processed by sassPlugin
+				if ( args.path.match( /\.(css|scss)$/ ) ) {
+					return null;
+				}
+
+				// Externalize everything else (keep imports as-is)
+				return { path: args.path, external: true };
+			} );
+		},
+	};
 	const plugins = [
-		...basePlugins,
-		externalizeExceptCssPlugin(),
+		needsEmotionPlugin && emotionPlugin,
+		externalizeAllExceptCssPlugin,
 		// Handle CSS modules (.module.css and .module.scss)
 		sassPlugin( {
 			embedded: true,
@@ -877,7 +858,7 @@ async function transpilePackage( packageName ) {
 				path.join( PACKAGES_DIR, 'base-styles' ),
 			],
 		} ),
-	];
+	].filter( Boolean );
 
 	if ( packageJson.main ) {
 		builds.push(

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -37,16 +37,19 @@ const PACKAGES_DIR = path.join( ROOT_DIR, 'packages' );
 const BUILD_DIR = path.join( ROOT_DIR, 'build' );
 
 const SOURCE_EXTENSIONS = '{js,ts,tsx}';
-const ASSET_EXTENSIONS = '{json,module.css}';
+const ASSET_EXTENSIONS = 'json';
 const IGNORE_PATTERNS = [
 	'**/benchmark/**',
 	'**/{__mocks__,__tests__,test}/**',
 	'**/{storybook,stories}/**',
 	'**/*.native.*',
+	'**/*.ios.*',
+	'**/*.android.*',
 ];
 const TEST_FILE_PATTERNS = [
 	/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,
 	/\.(spec|test)\.(js|ts|tsx)$/,
+	/\.(native|ios|android)\.(js|ts|tsx)$/,
 ];
 
 /**
@@ -61,13 +64,14 @@ function getAllPackages() {
 }
 
 const PACKAGES = getAllPackages();
-const ROOT_PACKAGE_JSON = getPackageInfoFromFile( path.join( ROOT_DIR, 'package.json' ) );
+const ROOT_PACKAGE_JSON = getPackageInfoFromFile(
+	path.join( ROOT_DIR, 'package.json' )
+);
 const WP_PLUGIN_CONFIG = ROOT_PACKAGE_JSON.wpPlugin || {};
 const SCRIPT_GLOBAL = WP_PLUGIN_CONFIG.scriptGlobal;
 const PACKAGE_NAMESPACE = WP_PLUGIN_CONFIG.packageNamespace;
 const HANDLE_PREFIX = WP_PLUGIN_CONFIG.handlePrefix || PACKAGE_NAMESPACE;
 const EXTERNAL_NAMESPACES = WP_PLUGIN_CONFIG.externalNamespaces || {};
-
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
@@ -105,6 +109,35 @@ function emotionBabelPlugin() {
 			plugins: [ '@emotion/babel-plugin' ],
 		},
 	} );
+}
+
+/**
+ * Plugin to externalize all imports except CSS/SCSS files.
+ * This allows bundling to resolve CSS imports while keeping JS imports as-is.
+ *
+ * @return {Object} esbuild plugin.
+ */
+function externalizeExceptCssPlugin() {
+	return {
+		name: 'externalize-except-css',
+		setup( build ) {
+			// Externalize all non-CSS imports
+			build.onResolve( { filter: /.*/ }, ( args ) => {
+				// Skip entry points
+				if ( args.kind === 'entry-point' ) {
+					return null;
+				}
+
+				// Let CSS/SCSS files be processed by sassPlugin
+				if ( args.path.match( /\.(css|scss)$/ ) ) {
+					return null;
+				}
+
+				// Externalize everything else (keep imports as-is)
+				return { path: args.path, external: true };
+			} );
+		},
+	};
 }
 
 /**
@@ -278,7 +311,9 @@ async function bundlePackage( packageName ) {
 
 		// Check if package matches the namespace and should expose a global
 		const packageFullName = packageJson.name;
-		const matchesNamespace = packageFullName.startsWith( `@${ PACKAGE_NAMESPACE }/` );
+		const matchesNamespace = packageFullName.startsWith(
+			`@${ PACKAGE_NAMESPACE }/`
+		);
 		const shouldExposeGlobal = matchesNamespace && SCRIPT_GLOBAL !== false;
 
 		const globalName = shouldExposeGlobal
@@ -814,7 +849,35 @@ async function transpilePackage( packageName ) {
 	// Check if this is the components package that needs emotion babel plugin.
 	// Ideally we should remove this exception and move away from emotion.
 	const needsEmotionPlugin = packageName === 'components';
-	const plugins = needsEmotionPlugin ? [ emotionBabelPlugin() ] : [];
+	const basePlugins = needsEmotionPlugin ? [ emotionBabelPlugin() ] : [];
+	const plugins = [
+		...basePlugins,
+		externalizeExceptCssPlugin(),
+		// Handle CSS modules (.module.css and .module.scss)
+		sassPlugin( {
+			embedded: true,
+			filter: /\.module\.(css|scss)$/,
+			transform: postcssModules( {
+				generateScopedName: '[name]__[local]__[hash:base64:5]',
+			} ),
+			type: 'style',
+			loadPaths: [
+				'node_modules',
+				path.join( PACKAGES_DIR, 'base-styles' ),
+			],
+		} ),
+		// Handle regular CSS/SCSS files
+		// Note: .module.css and .module.scss already handled by plugin above
+		sassPlugin( {
+			embedded: true,
+			filter: /\.(css|scss)$/,
+			type: 'style',
+			loadPaths: [
+				'node_modules',
+				path.join( PACKAGES_DIR, 'base-styles' ),
+			],
+		} ),
+	];
 
 	if ( packageJson.main ) {
 		builds.push(
@@ -822,7 +885,7 @@ async function transpilePackage( packageName ) {
 				entryPoints: srcFiles,
 				outdir: buildDir,
 				outbase: srcDir,
-				bundle: false,
+				bundle: true,
 				platform: 'node',
 				format: 'cjs',
 				sourcemap: true,
@@ -854,7 +917,7 @@ async function transpilePackage( packageName ) {
 				entryPoints: srcFiles,
 				outdir: buildModuleDir,
 				outbase: srcDir,
-				bundle: false,
+				bundle: true,
 				platform: 'neutral',
 				format: 'esm',
 				sourcemap: true,


### PR DESCRIPTION
Related #72032 
Follow-up #72673 

### What?

This PR enables CSS/SCSS module imports during the transpilation phase by switching from bundle: false to bundle: true with automatic externalization of all dependencies except CSS/SCSS files.

Previously, CSS module imports (.module.css and .module.scss) were left as non-standard JavaScript imports in the transpiled output, which would end up in published npm packages and fail without webpack or other bundlers.

The PR also allows importing any CSS or SASS file.

###  Why?

CSS module imports in source files were being preserved as-is during transpilation, resulting in invalid imports like import styles from "./style.module.css" in the published npm packages. These imports don't work in Node.js or browser environments without a bundler that understands CSS imports.

###  How?

1. Added externalizeExceptCssPlugin() - A custom esbuild plugin that marks all imports as external except CSS/SCSS files, allowing esbuild to process CSS while preserving JavaScript module imports.

###  Testing Instructions

Run the build and check the "build-module" folder of theme package. You can see the CSS bundled within the theme-provider.js file but all the JS files are still kept unbundled.