### PR TITLE
Fix unresolvable typedefs in dependency-extraction-webpack-plugin

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -30,8 +30,8 @@
 	"main": "lib/index.js",
 	"exports": {
 		".": {
-			"default": "./lib/index.js",
-			"types": "./lib/types.d.ts"
+			"types": "./lib/types.d.ts",
+			"default": "./lib/index.js"
 		},
 		"./lib/util": "./lib/util.js",
 		"./package.json": "./package.json"

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -29,7 +29,10 @@
 	],
 	"main": "lib/index.js",
 	"exports": {
-		".": "./lib/index.js",
+		".": {
+			"default": "./lib/index.js",
+			"types": "./lib/types.d.ts"
+		},
 		"./lib/util": "./lib/util.js",
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72806

Fixes the exports field of the package.json file so that TypeScript can resolve its typedefs again.

## Why?
TypeScript cannot currently resolve the plugin's typedefs

## How?
I added the typedefs to the exports field of the plugin's package.json file

## Testing Instructions
1. Make a TypeScript project using the Node16 moduleResolution mode
2. Try to import: `import DependencyExtractionWebpackPlugin from "@wordpress/dependency-extraction-webpack-plugin";`
3. Run tsc
4. If you didn't get an error, then it's fixed
