### PR TITLE
Real-time collaboration: Improve type safety with YMapWrap

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -11,6 +11,11 @@ import { getBlockTypes } from '@wordpress/blocks';
 import { RichTextData } from '@wordpress/rich-text';
 import { Y, Delta } from '@wordpress/sync';
 
+/**
+ * Internal dependencies
+ */
+import { createYMap, type YMapRecord, type YMapWrap } from './crdt-utils';
+
 interface BlockAttributes {
 	[ key: string ]: unknown;
 }
@@ -20,34 +25,33 @@ interface BlockType {
 	attributes?: Record< string, { type?: string } >;
 }
 
+// A block as represented in Gutenberg's data store.
 export interface Block {
 	attributes: BlockAttributes;
 	clientId?: string;
 	innerBlocks: Block[];
-	originalContent?: string; // unserializable
+	isValid?: boolean;
+	name: string;
+	originalContent?: string;
 	validationIssues?: string[]; // unserializable
+}
+
+// A block as represented in the CRDT document (Y.Map).
+interface YBlockRecord extends YMapRecord {
+	attributes: YBlockAttributes;
+	clientId: string;
+	innerBlocks: YBlocks;
+	isValid?: boolean;
+	originalContent?: string;
 	name: string;
 }
 
-export type YBlock = Y.Map<
-	/* name, clientId, and originalContent are strings. */
-	| string
-	/* validationIssues? is an array of strings. */
-	| string[]
-	/* attributes is a Y.Map< unknown >. */
-	| YBlockAttributes
-	/* innerBlocks is a Y.Array< YBlock >. */
-	| YBlocks
->;
-
+export type YBlock = YMapWrap< YBlockRecord >;
 export type YBlocks = Y.Array< YBlock >;
-export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
-// The Y.Map type is not easy to work with. The generic type it accepts represents
-// the possible values of the map, which are varied in our case. This type is
-// accurate, but will require aggressive type narrowing when the map values are
-// accessed -- or type casting with `as`.
-// export type YBlock = Y.Map< Block[ keyof Block ] >;
+// Block attribute schema cannot be known at compile time, so we use Y.Map.
+// Attribute values will be typed as the union of `Y.Text` and `unknown`.
+export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
@@ -63,13 +67,10 @@ function makeBlockAttributesSerializable(
 	return newAttributes;
 }
 
-function makeBlocksSerializable( blocks: Block[] | YBlocks ): Block[] {
-	return blocks.map( ( block: Block | YBlock ) => {
-		const blockAsJson = block instanceof Y.Map ? block.toJSON() : block;
-		const { name, innerBlocks, attributes, ...rest } = blockAsJson;
+function makeBlocksSerializable( blocks: Block[] ): Block[] {
+	return blocks.map( ( block: Block ) => {
+		const { name, innerBlocks, attributes, ...rest } = block;
 		delete rest.validationIssues;
-		delete rest.originalContent;
-		// delete rest.isValid
 		return {
 			...rest,
 			name,
@@ -97,10 +98,10 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 		Object.assign( {}, yblockAsJson, overwrites )
 	);
 	const inners = gblock.innerBlocks || [];
-	const yinners = yblock.get( 'innerBlocks' ) as YBlocks;
+	const yinners = yblock.get( 'innerBlocks' );
 	return (
 		res &&
-		inners.length === yinners.length &&
+		inners.length === yinners?.length &&
 		inners.every( ( block: Block, i: number ) =>
 			areBlocksEqual( block, yinners.get( i ) )
 		)
@@ -142,35 +143,40 @@ function createNewYAttributeValue(
 }
 
 function createNewYBlock( block: Block ): YBlock {
-	return new Y.Map(
-		Object.entries( block ).map( ( [ key, value ] ) => {
-			switch ( key ) {
-				case 'attributes': {
-					return [ key, createNewYAttributeMap( block.name, value ) ];
-				}
+	return createYMap< YBlockRecord >(
+		Object.fromEntries(
+			Object.entries( block ).map( ( [ key, value ] ) => {
+				switch ( key ) {
+					case 'attributes': {
+						return [
+							key,
+							createNewYAttributeMap( block.name, value ),
+						];
+					}
 
-				case 'innerBlocks': {
-					const innerBlocks = new Y.Array();
+					case 'innerBlocks': {
+						const innerBlocks = new Y.Array();
 
-					// If not an array, set to empty Y.Array.
-					if ( ! Array.isArray( value ) ) {
+						// If not an array, set to empty Y.Array.
+						if ( ! Array.isArray( value ) ) {
+							return [ key, innerBlocks ];
+						}
+
+						innerBlocks.insert(
+							0,
+							value.map( ( innerBlock: Block ) =>
+								createNewYBlock( innerBlock )
+							)
+						);
+
 						return [ key, innerBlocks ];
 					}
 
-					innerBlocks.insert(
-						0,
-						value.map( ( innerBlock: Block ) =>
-							createNewYBlock( innerBlock )
-						)
-					);
-
-					return [ key, innerBlocks ];
+					default:
+						return [ key, value ];
 				}
-
-				default:
-					return [ key, value ];
-			}
-		} )
+			} )
+		)
 	);
 }
 
@@ -262,9 +268,7 @@ export function mergeCrdtBlocks(
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
-					const currentAttributes = yblock.get(
-						key
-					) as YBlockAttributes;
+					const currentAttributes = yblock.get( key );
 
 					// If attributes are not set on the yblock, use the new values.
 					if ( ! currentAttributes ) {
@@ -286,6 +290,8 @@ export function mergeCrdtBlocks(
 								return;
 							}
 
+							const currentAttribute =
+								currentAttributes.get( attributeName );
 							const isRichText = isRichTextAttribute(
 								block.name,
 								attributeName
@@ -295,16 +301,12 @@ export function mergeCrdtBlocks(
 								isRichText &&
 								'string' === typeof attributeValue &&
 								currentAttributes.has( attributeName ) &&
-								currentAttributes.get(
-									attributeName
-								) instanceof Y.Text
+								currentAttribute instanceof Y.Text
 							) {
 								// Rich text values are stored as persistent Y.Text instances.
 								// Update the value with a delta in place.
 								mergeRichTextUpdate(
-									currentAttributes.get(
-										attributeName
-									) as Y.Text,
+									currentAttribute,
 									attributeValue,
 									cursorPosition
 								);
@@ -335,7 +337,13 @@ export function mergeCrdtBlocks(
 
 				case 'innerBlocks': {
 					// Recursively merge innerBlocks
-					const yInnerBlocks = yblock.get( key ) as Y.Array< YBlock >;
+					let yInnerBlocks = yblock.get( key );
+
+					if ( ! ( yInnerBlocks instanceof Y.Array ) ) {
+						yInnerBlocks = new Y.Array< YBlock >();
+						yblock.set( key, yInnerBlocks );
+					}
+
 					mergeCrdtBlocks(
 						yInnerBlocks,
 						value ?? [],
@@ -372,7 +380,11 @@ export function mergeCrdtBlocks(
 	for ( let j = 0; j < yblocks.length; j++ ) {
 		const yblock: YBlock = yblocks.get( j );
 
-		let clientId: string = yblock.get( 'clientId' ) as string;
+		let clientId = yblock.get( 'clientId' );
+
+		if ( ! clientId ) {
+			continue;
+		}
 
 		if ( knownClientIds.has( clientId ) ) {
 			clientId = uuidv4();

--- a/packages/core-data/src/utils/crdt-utils.ts
+++ b/packages/core-data/src/utils/crdt-utils.ts
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * A YMapRecord represents the shape of the data stored in a Y.Map.
+ */
+export type YMapRecord = Record< string, unknown >;
+
+/**
+ * A wrapper around Y.Map to provide type safety. The generic type accepted by
+ * Y.Map represents the union of possible values of the map, which are varied in
+ * many cases. This type is accurate, but its non-specificity requires aggressive
+ * type narrowing or type casting / destruction with `as`.
+ *
+ * This type provides type enhancements so that the correct value type can be
+ * inferred based on the provided key. It is just a type wrap / overlay, and
+ * does not change the runtime behavior of Y.Map.
+ *
+ * This interface cannot extend Y.Map directly due to the limitations of
+ * TypeScript's structural typing. One negative consequence of this is that
+ * `instanceof` checks against Y.Map continue to work at runtime but will blur
+ * the type at compile time. To navigate this, use the `isYMap` function below.
+ */
+export interface YMapWrap< T extends YMapRecord > extends Y.AbstractType< T > {
+	delete: < K extends keyof T >( key: K ) => void;
+	forEach: (
+		callback: (
+			value: T[ keyof T ],
+			key: keyof T,
+			map: YMapWrap< T >
+		) => void
+	) => void;
+	has: < K extends keyof T >( key: K ) => boolean;
+	get: < K extends keyof T >( key: K ) => T[ K ] | undefined;
+	set: < K extends keyof T >( key: K, value: T[ K ] ) => void;
+	toJSON: () => T;
+	// add types for other Y.Map methods as needed
+}
+
+/**
+ * Get or create a root-level Map for the given Y.Doc. Use this instead of
+ * doc.getMap() for additional type safety.
+ *
+ * @param doc Y.Doc
+ * @param key Map key
+ */
+export function getRootMap< T extends YMapRecord >(
+	doc: Y.Doc,
+	key: string
+): YMapWrap< T > {
+	return doc.getMap< T >( key ) as unknown as YMapWrap< T >;
+}
+
+/**
+ * Create a new Y.Map (provided with YMapWrap type), optionally initialized with
+ * data. Use this instead of `new Y.Map()` for additional type safety.
+ *
+ * @param partial Partial data to initialize the map with.
+ */
+export function createYMap< T extends YMapRecord >(
+	partial: Partial< T > = {}
+): YMapWrap< T > {
+	return new Y.Map( Object.entries( partial ) ) as unknown as YMapWrap< T >;
+}
+
+/**
+ * Type guard to check if a value is a Y.Map without losing type information.
+ *
+ * @param value Value to check.
+ */
+export function isYMap< T extends YMapRecord >(
+	value: unknown
+): value is YMapWrap< T > {
+	return value instanceof Y.Map;
+}

--- a/packages/core-data/src/utils/crdt-utils.ts
+++ b/packages/core-data/src/utils/crdt-utils.ts
@@ -71,7 +71,7 @@ export function createYMap< T extends YMapRecord >(
  * @param value Value to check.
  */
 export function isYMap< T extends YMapRecord >(
-	value: unknown
+	value: YMapWrap< T > | undefined
 ): value is YMapWrap< T > {
 	return value instanceof Y.Map;
 }

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -27,13 +27,40 @@ import {
 	WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from '../sync';
 import type { WPSelection } from '../types';
+import {
+	createYMap,
+	getRootMap,
+	isYMap,
+	type YMapRecord,
+	type YMapWrap,
+} from './crdt-utils';
 
+// Changes that can be applied to a post entity record.
 export type PostChanges = Partial< Post > & {
 	blocks?: Block[];
 	excerpt?: Post[ 'excerpt' ] | string;
 	selection?: WPSelection;
 	title?: Post[ 'title' ] | string;
 };
+
+// A post record as represented in the CRDT document (Y.Map).
+export interface YPostRecord extends YMapRecord {
+	author: number;
+	blocks: YBlocks;
+	comment_status: string;
+	date: string | null;
+	excerpt: string;
+	featured_media: number;
+	format: string;
+	meta: YMapWrap< YMapRecord >;
+	ping_status: string;
+	slug: string;
+	status: string;
+	sticky: boolean;
+	tags: number[];
+	template: string;
+	title: string;
+}
 
 // Properties that are allowed to be synced for a post.
 const allowedPostProperties = new Set< string >( [
@@ -44,8 +71,8 @@ const allowedPostProperties = new Set< string >( [
 	'excerpt',
 	'featured_media',
 	'format',
-	'ping_status',
 	'meta',
+	'ping_status',
 	'slug',
 	'status',
 	'sticky',
@@ -71,7 +98,7 @@ export function defaultApplyChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: ObjectData
 ): void {
-	const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+	const ymap = getRootMap( ydoc, CRDT_RECORD_MAP_KEY );
 
 	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
 		// Cannot serialize function values, so cannot sync them.
@@ -79,17 +106,12 @@ export function defaultApplyChangesToCRDTDoc(
 			return;
 		}
 
-		// Set the value in the root document.
-		function setValue< T = unknown >( updatedValue: T ): void {
-			ymap.set( key, updatedValue );
-		}
-
 		switch ( key ) {
 			// Add support for additional data types here.
 
 			default: {
 				const currentValue = ymap.get( key );
-				mergeValue( currentValue, newValue, setValue );
+				updateMapValue( ymap, key, currentValue, newValue );
 			}
 		}
 	} );
@@ -109,31 +131,28 @@ export function applyPostChangesToCRDTDoc(
 	changes: PostChanges,
 	_postType: Type // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void {
-	const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
 
-	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
+	Object.keys( changes ).forEach( ( key ) => {
 		if ( ! allowedPostProperties.has( key ) ) {
 			return;
 		}
+
+		const newValue = changes[ key ];
 
 		// Cannot serialize function values, so cannot sync them.
 		if ( 'function' === typeof newValue ) {
 			return;
 		}
 
-		// Set the value in the root document.
-		function setValue< T = unknown >( updatedValue: T ): void {
-			ymap.set( key, updatedValue );
-		}
-
 		switch ( key ) {
 			case 'blocks': {
-				let currentBlocks = ymap.get( 'blocks' ) as YBlocks;
+				let currentBlocks = ymap.get( key );
 
 				// Initialize.
 				if ( ! ( currentBlocks instanceof Y.Array ) ) {
 					currentBlocks = new Y.Array< YBlock >();
-					setValue( currentBlocks );
+					ymap.set( key, currentBlocks );
 				}
 
 				// Block[] from local changes.
@@ -151,23 +170,21 @@ export function applyPostChangesToCRDTDoc(
 			}
 
 			case 'excerpt': {
-				const currentValue = ymap.get( 'excerpt' ) as
-					| string
-					| undefined;
+				const currentValue = ymap.get( 'excerpt' );
 				const rawNewValue = getRawValue( newValue );
 
-				mergeValue( currentValue, rawNewValue, setValue );
+				updateMapValue( ymap, key, currentValue, rawNewValue );
 				break;
 			}
 
 			// "Meta" is overloaded term; here, it refers to post meta.
 			case 'meta': {
-				let metaMap = ymap.get( 'meta' ) as Y.Map< unknown >;
+				let metaMap = ymap.get( 'meta' );
 
 				// Initialize.
-				if ( ! ( metaMap instanceof Y.Map ) ) {
-					metaMap = new Y.Map();
-					setValue( metaMap );
+				if ( ! isYMap( metaMap ) ) {
+					metaMap = createYMap< YMapRecord >();
+					ymap.set( 'meta', metaMap );
 				}
 
 				// Iterate over each meta property in the new value and merge it if it
@@ -178,12 +195,11 @@ export function applyPostChangesToCRDTDoc(
 							return;
 						}
 
-						mergeValue(
+						updateMapValue(
+							metaMap,
+							metaKey,
 							metaMap.get( metaKey ), // current value in CRDT
-							metaValue, // new value from changes
-							( updatedMetaValue: unknown ): void => {
-								metaMap.set( metaKey, updatedMetaValue );
-							}
+							metaValue // new value from changes
 						);
 					}
 				);
@@ -197,13 +213,13 @@ export function applyPostChangesToCRDTDoc(
 					break;
 				}
 
-				const currentValue = ymap.get( 'slug' ) as string;
-				mergeValue( currentValue, newValue, setValue );
+				const currentValue = ymap.get( key );
+				updateMapValue( ymap, key, currentValue, newValue );
 				break;
 			}
 
 			case 'title': {
-				const currentValue = ymap.get( 'title' ) as string | undefined;
+				const currentValue = ymap.get( key );
 
 				// Copy logic from prePersistPostType to ensure that the "Auto
 				// Draft" template title is not synced.
@@ -212,22 +228,22 @@ export function applyPostChangesToCRDTDoc(
 					rawNewValue = '';
 				}
 
-				mergeValue( currentValue, rawNewValue, setValue );
+				updateMapValue( ymap, key, currentValue, rawNewValue );
 				break;
 			}
 
-			// Add support for additional data types here.
+			// Add support for additional properties here.
 
 			default: {
 				const currentValue = ymap.get( key );
-				mergeValue( currentValue, newValue, setValue );
+				updateMapValue( ymap, key, currentValue, newValue );
 			}
 		}
 	} );
 }
 
 export function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
-	return crdtDoc.getMap( CRDT_RECORD_MAP_KEY ).toJSON();
+	return getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
 }
 
 /**
@@ -245,7 +261,7 @@ export function getPostChangesFromCRDTDoc(
 	editedRecord: Post,
 	_postType: Type // eslint-disable-line @typescript-eslint/no-unused-vars
 ): PostChanges {
-	const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
 
 	let allowedMetaChanges: Post[ 'meta' ] = {};
 
@@ -391,19 +407,25 @@ function getRawValue( value?: unknown ): string | undefined {
 	return undefined;
 }
 
-function haveValuesChanged< ValueType = any >(
-	currentValue: ValueType,
-	newValue: ValueType
+function haveValuesChanged< ValueType >(
+	currentValue: ValueType | undefined,
+	newValue: ValueType | undefined
 ): boolean {
 	return ! fastDeepEqual( currentValue, newValue );
 }
 
-function mergeValue< ValueType = any >(
-	currentValue: ValueType,
-	newValue: ValueType,
-	setValue: ( value: ValueType ) => void
+function updateMapValue< T extends YMapRecord, K extends keyof T >(
+	map: YMapWrap< T >,
+	key: K,
+	currentValue: T[ K ] | undefined,
+	newValue: T[ K ] | undefined
 ): void {
-	if ( haveValuesChanged< ValueType >( currentValue, newValue ) ) {
-		setValue( newValue );
+	if ( undefined === newValue ) {
+		map.delete( key );
+		return;
+	}
+
+	if ( haveValuesChanged< T[ K ] >( currentValue, newValue ) ) {
+		map.set( key, newValue );
 	}
 }

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -19,17 +19,17 @@ import {
 	applyPostChangesToCRDTDoc,
 	getPostChangesFromCRDTDoc,
 	type PostChanges,
+	type YPostRecord,
 } from '../crdt';
 import type { YBlock, YBlocks } from '../crdt-blocks';
+import { createYMap, getRootMap, type YMapWrap } from '../crdt-utils';
 import type { Post, Type } from '../../entity-types';
 
 describe( 'crdt', () => {
 	let doc: Y.Doc;
-	let map: Y.Map< string | object | YBlocks >;
 
 	beforeEach( () => {
 		doc = new Y.Doc();
-		map = doc.getMap( CRDT_RECORD_MAP_KEY );
 		jest.clearAllMocks();
 	} );
 
@@ -39,6 +39,12 @@ describe( 'crdt', () => {
 
 	describe( 'applyPostChangesToCRDTDoc', () => {
 		const mockPostType = {} as Type;
+
+		let map: YMapWrap< YPostRecord >;
+
+		beforeEach( () => {
+			map = getRootMap< YPostRecord >( doc, CRDT_RECORD_MAP_KEY );
+		} );
 
 		it( 'applies simple property changes', () => {
 			const changes = {
@@ -164,7 +170,7 @@ describe( 'crdt', () => {
 				},
 			};
 
-			const metaMap = new Y.Map< unknown >();
+			const metaMap = createYMap();
 			metaMap.set( 'some_meta', 'old value' );
 			map.set( 'meta', metaMap );
 
@@ -180,7 +186,7 @@ describe( 'crdt', () => {
 				},
 			};
 
-			const metaMap = new Y.Map< unknown >();
+			const metaMap = createYMap();
 			metaMap.set( 'some_meta', 'old value' );
 			map.set( 'meta', metaMap );
 
@@ -201,9 +207,9 @@ describe( 'crdt', () => {
 
 			applyPostChangesToCRDTDoc( doc, changes, mockPostType );
 
-			const metaMap = map.get( 'meta' ) as Y.Map< unknown >;
+			const metaMap = map.get( 'meta' );
 			expect( metaMap ).toBeInstanceOf( Y.Map );
-			expect( metaMap.get( 'custom_field' ) ).toBe( 'value' );
+			expect( metaMap?.get( 'custom_field' ) ).toBe( 'value' );
 		} );
 	} );
 
@@ -216,7 +222,10 @@ describe( 'crdt', () => {
 			},
 		} as unknown as Type;
 
+		let map: YMapWrap< YPostRecord >;
+
 		beforeEach( () => {
+			map = getRootMap< YPostRecord >( doc, CRDT_RECORD_MAP_KEY );
 			map.set( 'title', 'CRDT Title' );
 			map.set( 'status', 'draft' );
 			map.set( 'date', '2025-01-01' );
@@ -305,9 +314,9 @@ describe( 'crdt', () => {
 		} );
 
 		it( 'includes meta in changes', () => {
-			map.set( 'meta', {
-				public_meta: 'new value',
-			} );
+			const metaMap = createYMap();
+			metaMap.set( 'public_meta', 'new value' );
+			map.set( 'meta', metaMap );
 
 			const editedRecord = {
 				meta: {
@@ -327,9 +336,9 @@ describe( 'crdt', () => {
 		} );
 
 		it( 'includes non-single meta in changes', () => {
-			map.set( 'meta', {
-				public_meta: [ 'value', 'value 2' ],
-			} );
+			const metaMap = createYMap();
+			metaMap.set( 'public_meta', [ 'value', 'value 2' ] );
+			map.set( 'meta', metaMap );
 
 			const editedRecord = {
 				meta: {
@@ -349,10 +358,13 @@ describe( 'crdt', () => {
 		} );
 
 		it( 'excludes disallowed meta keys in changes', () => {
-			map.set( 'meta', {
-				public_meta: 'new value',
-				[ WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]: 'exclude me',
-			} );
+			const metaMap = createYMap();
+			metaMap.set( 'public_meta', 'new value' );
+			metaMap.set(
+				WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
+				'exclude me'
+			);
+			map.set( 'meta', metaMap );
 
 			const editedRecord = {
 				meta: {


### PR DESCRIPTION
## What?

Improve the type safety of `Y.Map`.

## Why?

The typings for `Y.Map` have limitations. By default, the type of `Y.Map` values is the union of all possible values of the map. This type is accurate, but its non-specificity requires aggressive type narrowing or type casting / destruction with `as`—usually the latter. [Preventable bugs](https://github.com/WordPress/gutenberg/pull/72566) [sneak in](https://github.com/WordPress/gutenberg/pull/72731).

## How?

This PR introduces `YMapWrap`, which can infer the correct value type based on the provided key. It is just a type overlay and does not change the runtime behavior of `Y.Map`. Using this type, we can remove almost all of uses of `as` in the CRDT code.

We also benefit from more clearly representing the data structure encoded in the CRDT document. See `YPostRecord` and `YBlockRecord`.

## Testing Instructions

These changes are covered by existing tests, but you can check out this branch and confirm the added type safety by trying to introduce type bugs.

### Before

```ts
interface SomeRecord {
  foo: string;
  bar: number;
}

const doc = new Y.Doc();
const someRecordMap = doc.getMap( 'some_record' );

someRecordMap.set( 'foo', 1234 ); // no error!
someRecordMap.get( 'bar' ) // return type: string | number | undefined
```

### After

```ts
interface SomeRecord {
  foo: string;
  bar: number;
}

const doc = new Y.Doc();
const someRecordMap = getMap< SomeRecord >( doc, 'some_record' );

someRecordMap.set( 'foo', 1234 ); // TS Error: Argument of type 'number' is not assignable....
someRecordMap.get( 'bar' ) // return type: number | undefined
```
