### PR TITLE
Classic Block: Disable lock, renaming, blockVisibility, html support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -382,7 +382,7 @@ Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/freeform
 -	**Category:** text
--	**Supports:** ~~blockVisibility~~, ~~className~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~
+-	**Supports:** ~~blockVisibility~~, ~~className~~, ~~customClassName~~, ~~html~~, ~~lock~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** content
 
 ## Gallery

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -382,7 +382,7 @@ Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/freeform
 -	**Category:** text
--	**Supports:** ~~className~~, ~~customClassName~~, ~~reusable~~
+-	**Supports:** ~~blockVisibility~~, ~~className~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** content
 
 ## Gallery

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -13,6 +13,7 @@
 		}
 	},
 	"supports": {
+		"html": false,
 		"className": false,
 		"customClassName": false,
 		"lock": false,

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -15,7 +15,10 @@
 	"supports": {
 		"className": false,
 		"customClassName": false,
-		"reusable": false
+		"lock": false,
+		"reusable": false,
+		"renaming": false,
+		"blockVisibility": false
 	},
 	"editorStyle": "wp-block-freeform-editor"
 }


### PR DESCRIPTION
## What?

Disables the following three supports from the Classic block:

- `blockVisibility`
- `renaming`
- `lock`
- `html`

## Why?

The Classic block, by its nature, doesn't retain HTML comments like `<!-- wp:paragraph --><!-- /wp:paragraph -->`, meaning it cannot save attributes. Therefore, while these three block supports may appear to work temporarily, the data will be lost when the browser is reloaded.

## How?

Simply disable the support via block.json.

Regarding the Notes feature, it's not a block support, so it's not addressed in this PR. How to disable the Notes feature is being discussed separately in #72520.

> [!NOTE]
> I will add the `Backport to WP 6.9 Beta/RC` label to this pull request, but the bug where html, renaming, and locking don't work has existed for a long time. Personally, I think it's acceptable to fix these issues simultaneously during the beta phase, but if that's not acceptable, I will only disable the blockVisibility support.

## Testing Instructions

- Create a Classic Block: Simply open the code editor, delete all contents, and enter `Hello World`
- Open the block settings dropdown menu.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="542" height="653" alt="image" src="https://github.com/user-attachments/assets/c3e76aef-945c-4654-b46c-3292c5071629" /> | <img width="549" height="499" alt="image" src="https://github.com/user-attachments/assets/fc14ec77-7166-4201-a45f-efa62d415159" /> |