### PR TITLE
DataViews: Pass styles to the column.

### DIFF
--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -41,6 +41,7 @@ export default function DataViewsFooter() {
 				expanded={ false }
 				justify="end"
 				className="dataviews-footer"
+				style={ view.layout?.styles?.__default__ }
 			>
 				{ hasBulkActions && <BulkActionsFooter /> }
 				<DataViewsPagination />

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -7,7 +7,13 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
 
 /**
@@ -88,6 +94,8 @@ function DefaultUI( {
 	search = true,
 	searchLabel = undefined,
 }: DefaultUIProps ) {
+	const { view } = useContext( DataViewsContext );
+
 	return (
 		<>
 			<HStack
@@ -95,6 +103,7 @@ function DefaultUI( {
 				justify="space-between"
 				className="dataviews__view-actions"
 				spacing={ 1 }
+				style={ view.layout?.styles?.__default__ }
 			>
 				<HStack
 					justify="start"

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -98,6 +98,20 @@ function TableColumnField< Item >( {
 	);
 }
 
+function getColumnStyles( view: ViewTableType, columnId: string ) {
+	const stylesById = view.layout?.styles ?? {};
+	const defaultStyles = stylesById.__default__ ?? {};
+	const columnStyles = stylesById[ columnId ] ?? {};
+	const { align, ...mergedStyles } = {
+		...defaultStyles,
+		...columnStyles,
+	};
+	return {
+		...mergedStyles,
+		textAlign: align,
+	};
+}
+
 function TableRow< Item >( {
 	hasBulkActions,
 	item,
@@ -194,7 +208,10 @@ function TableRow< Item >( {
 			} }
 		>
 			{ hasBulkActions && (
-				<td className="dataviews-view-table__checkbox-column">
+				<td
+					className="dataviews-view-table__checkbox-column"
+					style={ getColumnStyles( view, '__bulk_actions__' ) }
+				>
 					<div className="dataviews-view-table__cell-content-wrapper">
 						<DataViewsSelectionCheckbox
 							item={ item }
@@ -208,7 +225,7 @@ function TableRow< Item >( {
 				</td>
 			) }
 			{ hasPrimaryColumn && (
-				<td>
+				<td style={ getColumnStyles( view, '__primary__' ) }>
 					<ColumnPrimary
 						item={ item }
 						level={ level }
@@ -224,24 +241,14 @@ function TableRow< Item >( {
 				</td>
 			) }
 			{ columns.map( ( column: string ) => {
-				// Explicit picks the supported styles.
-				const { width, maxWidth, minWidth, align } =
-					view.layout?.styles?.[ column ] ?? {};
-
+				const columnStyles = getColumnStyles( view, column );
 				return (
-					<td
-						key={ column }
-						style={ {
-							width,
-							maxWidth,
-							minWidth,
-						} }
-					>
+					<td key={ column } style={ columnStyles }>
 						<TableColumnField
 							fields={ fields }
 							item={ item }
 							column={ column }
-							align={ align }
+							align={ columnStyles.textAlign }
 						/>
 					</td>
 				);
@@ -380,6 +387,10 @@ function ViewTable< Item >( {
 							<th
 								className="dataviews-view-table__checkbox-column"
 								scope="col"
+								style={ getColumnStyles(
+									view,
+									'__bulk_actions__'
+								) }
 							>
 								<BulkSelectionCheckbox
 									selection={ selection }
@@ -391,7 +402,10 @@ function ViewTable< Item >( {
 							</th>
 						) }
 						{ hasPrimaryColumn && (
-							<th scope="col">
+							<th
+								scope="col"
+								style={ getColumnStyles( view, '__primary__' ) }
+							>
 								{ titleField && (
 									<ColumnHeaderMenu
 										ref={ headerMenuRef(
@@ -410,18 +424,10 @@ function ViewTable< Item >( {
 							</th>
 						) }
 						{ columns.map( ( column, index ) => {
-							// Explicit picks the supported styles.
-							const { width, maxWidth, minWidth, align } =
-								view.layout?.styles?.[ column ] ?? {};
 							return (
 								<th
 									key={ column }
-									style={ {
-										width,
-										maxWidth,
-										minWidth,
-										textAlign: align,
-									} }
+									style={ getColumnStyles( view, column ) }
 									aria-sort={
 										view.sort?.direction &&
 										view.sort?.field === column
@@ -456,6 +462,7 @@ function ViewTable< Item >( {
 											! isHorizontalScrollEnd,
 									}
 								) }
+								style={ getColumnStyles( view, '__actions__' ) }
 							>
 								<span className="dataviews-view-table-header">
 									{ __( 'Actions' ) }

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -268,6 +268,7 @@ function TableRow< Item >( {
 							isActionsColumnSticky,
 					} ) }
 					onClick={ ( e ) => e.stopPropagation() }
+					style={ getColumnStyles( view, '__actions__' ) }
 				>
 					<ItemActions item={ item } actions={ actions } />
 				</td>

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -363,6 +363,13 @@ export const WithCard = () => {
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'image',
+		layout: {
+			styles: {
+				__default__: {
+					paddingInlineStart: '10px',
+				},
+			},
+		},
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -366,7 +366,7 @@ export const WithCard = () => {
 		layout: {
 			styles: {
 				__default__: {
-					paddingInlineStart: '10px',
+					paddingInline: '100px',
 				},
 			},
 		},

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -226,6 +226,13 @@ export interface ViewTable extends ViewBase {
 
 export interface ViewList extends ViewBase {
 	type: 'list';
+
+	layout?: {
+		/**
+		 * The styles for the list.
+		 */
+		styles?: Record< string, ColumnStyle >;
+	};
 }
 
 export interface ViewGrid extends ViewBase {
@@ -241,6 +248,11 @@ export interface ViewGrid extends ViewBase {
 		 * The preview size of the grid.
 		 */
 		previewSize?: number;
+
+		/**
+		 * The styles for the list.
+		 */
+		styles?: Record< string, ColumnStyle >;
 	};
 }
 
@@ -257,6 +269,11 @@ export interface ViewPickerGrid extends ViewBase {
 		 * The preview size of the grid.
 		 */
 		previewSize?: number;
+
+		/**
+		 * The styles for the list.
+		 */
+		styles?: Record< string, ColumnStyle >;
 	};
 }
 

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -188,27 +188,18 @@ interface ViewBase {
 	infiniteScrollEnabled?: boolean;
 }
 
-export interface ColumnStyle {
-	/**
-	 * The width of the field column.
-	 */
-	width?: string | number;
-
-	/**
-	 * The minimum width of the field column.
-	 */
-	maxWidth?: string | number;
-
-	/**
-	 * The maximum width of the field column.
-	 */
-	minWidth?: string | number;
-
-	/**
-	 * The alignment of the field column, defaults to left.
-	 */
-	align?: 'start' | 'center' | 'end';
-}
+export type ColumnStyle =
+	// Allow any valid inline CSS style for td/th
+	Omit< React.CSSProperties, 'textAlign' > & {
+		/**
+		 * Logical alignment; mapped to CSS textAlign where applicable.
+		 */
+		align?: 'start' | 'center' | 'end';
+		/**
+		 * Optional textAlign passthrough if ever needed for headers.
+		 */
+		textAlign?: React.CSSProperties[ 'textAlign' ];
+	};
 
 export type Density = 'compact' | 'balanced' | 'comfortable';
 


### PR DESCRIPTION
WIP/Experiment

## What?

This PR is experimental (and naive), allowing consumers to control CSS styles for `<td>` and `<th>`. 

## Why?
`<DataView>` styles are not modifiable without using CSS overrides that make use of internal component classnames. This is not future-friendly.

### What would you want to change them for?
As an example, as a consumer, maybe my mobile container padding is `10px`. I should be able to set my DataViews' padding to match.

## How?

It utilizes the `view.layout` property, which already exists to provide styles to `<th>` and `<th>`.

## Considerations

### Magic variables
I've introduced some `magic` properties to represent the ability to style _internal_ columns like bulk actions.

These are:
- `__default__` Applies as base to all columns.
- `__primary__` Applies to the Primary column.
- `__actions__` Applies to the Actions column.

I don't contend this is the best approach; however, the current code loops through the `column` looking for `style.[column_id]`. This makes it work with minimal changes and decent backward compatibility.

### Theming

The default layout could be retrieved from a global theming context.

### Problems

This works for the table. How do we get consistent padding for `DefaultUI`... 🤔 



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
