### PR TITLE
Block Transforms: Add default transform for allowedBlocks attribute

### DIFF
--- a/packages/block-editor/src/hooks/allowed-blocks.js
+++ b/packages/block-editor/src/hooks/allowed-blocks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -63,4 +63,92 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/allowedBlocks/attribute',
 	addAttribute
+);
+
+/**
+ * Add transforms to preserve allowedBlocks on block transformations.
+ *
+ * @param {Object} result  The transformed block.
+ * @param {Array}  source  Original blocks transformed.
+ * @param {number} index   Index of the transformed block.
+ * @param {Array}  results All blocks that resulted from the transformation.
+ * @return {Object} Modified transformed block.
+ */
+export function addTransforms( result, source, index, results ) {
+	if ( ! hasBlockSupport( result.name, 'allowedBlocks' ) ) {
+		return result;
+	}
+
+	// If the condition verifies we are probably in the presence of a wrapping transform
+	// e.g: nesting paragraphs in a group or columns and in that case the attribute should not be kept.
+	if (
+		source.length !== 1 &&
+		results.length === 1 &&
+		result.innerBlocks.length === source.length
+	) {
+		return result;
+	}
+
+	// If we are transforming one block to multiple blocks or multiple blocks to one block,
+	// we ignore the attribute during the transform.
+	if (
+		( results.length === 1 && source.length > 1 ) ||
+		( results.length > 1 && source.length === 1 )
+	) {
+		return result;
+	}
+
+	// If we are transforming multiple blocks to multiple blocks with different counts,
+	// we ignore the attribute during the transform.
+	if (
+		results.length > 1 &&
+		source.length > 1 &&
+		results.length !== source.length
+	) {
+		return result;
+	}
+
+	// If the target block already has allowedBlocks, we don't need to preserve
+	// the source allowedBlocks.
+	if ( result.attributes.allowedBlocks ) {
+		return result;
+	}
+
+	const sourceAllowedBlocks = source[ index ]?.attributes?.allowedBlocks;
+
+	if ( ! sourceAllowedBlocks ) {
+		return result;
+	}
+
+	const blockType = getBlockType( result.name );
+	const destinationAllowedBlocks = blockType?.allowedBlocks || [];
+
+	if ( ! destinationAllowedBlocks.length ) {
+		return {
+			...result,
+			attributes: {
+				...result.attributes,
+				allowedBlocks: sourceAllowedBlocks,
+			},
+		};
+	}
+
+	// Filter out any source allowed blocks that are not defined in the destination allowed blocks.
+	const filteredSourceAllowedBlocks = sourceAllowedBlocks.filter( ( block ) =>
+		destinationAllowedBlocks.includes( block )
+	);
+
+	return {
+		...result,
+		attributes: {
+			...result.attributes,
+			allowedBlocks: filteredSourceAllowedBlocks,
+		},
+	};
+}
+
+addFilter(
+	'blocks.switchToBlockType.transformedBlock',
+	'core/allowedBlocks/addTransforms',
+	addTransforms
 );

--- a/packages/block-editor/src/hooks/test/allowed-blocks.js
+++ b/packages/block-editor/src/hooks/test/allowed-blocks.js
@@ -1,0 +1,278 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	getBlockTypes,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { addTransforms } from '../allowed-blocks';
+
+describe( 'allowedBlocks', () => {
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'addTransforms()', () => {
+		it( 'should not preserve allowedBlocks in wrapping transforms', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/paragraph', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/paragraph' ] },
+					innerBlocks: [],
+				},
+			];
+			const result = {
+				name: 'core/bar',
+				attributes: {},
+				innerBlocks: source,
+			};
+
+			const transformed = addTransforms( result, source, 0, [ result ] );
+
+			expect( transformed.attributes.allowedBlocks ).toBeUndefined();
+		} );
+
+		it( 'should not preserve allowedBlocks in one-to-many transforms', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/paragraph', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+			];
+			const results = [
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+			];
+
+			const transformed = addTransforms(
+				results[ 0 ],
+				source,
+				0,
+				results
+			);
+
+			expect( transformed.attributes.allowedBlocks ).toBeUndefined();
+		} );
+
+		it( 'should not preserve allowedBlocks in many-to-one transforms', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/paragraph', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/paragraph' ] },
+					innerBlocks: [],
+				},
+			];
+			const result = {
+				name: 'core/bar',
+				attributes: {},
+				innerBlocks: [],
+			};
+
+			const transformed = addTransforms( result, source, 0, [ result ] );
+
+			expect( transformed.attributes.allowedBlocks ).toBeUndefined();
+		} );
+
+		it( 'should not preserve allowedBlocks in many-to-many transforms with different counts', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/paragraph', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/paragraph' ] },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/heading' ] },
+					innerBlocks: [],
+				},
+			];
+			const results = [
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+			];
+
+			const [ firstTransformed, secondTransformed ] = results.map(
+				( result, index ) =>
+					addTransforms( result, source, index, results )
+			);
+
+			expect( firstTransformed.attributes.allowedBlocks ).toBeUndefined();
+			expect(
+				secondTransformed.attributes.allowedBlocks
+			).toBeUndefined();
+		} );
+
+		it( 'should preserve allowedBlocks in many-to-many transforms with same counts', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/image', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/paragraph' ] },
+					innerBlocks: [],
+				},
+			];
+			const results = [
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+				{ name: 'core/bar', attributes: {}, innerBlocks: [] },
+			];
+
+			const [ firstTransformed, secondTransformed ] = results.map(
+				( result, index ) =>
+					addTransforms( result, source, index, results )
+			);
+
+			expect( firstTransformed.attributes.allowedBlocks ).toEqual( [
+				'core/image',
+				'core/heading',
+			] );
+			expect( secondTransformed.attributes.allowedBlocks ).toEqual( [
+				'core/paragraph',
+			] );
+		} );
+
+		it( "should filter allowedBlocks based on destination block's allowedBlocks", () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+				allowedBlocks: [ 'core/paragraph' ],
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [
+							'core/paragraph',
+							'core/heading',
+							'core/image',
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			const result = {
+				name: 'core/bar',
+				attributes: {},
+				innerBlocks: [],
+			};
+
+			const transformed = addTransforms( result, source, 0, [ result ] );
+
+			expect( transformed.attributes.allowedBlocks ).toEqual( [
+				'core/paragraph',
+			] );
+		} );
+
+		it( 'should not override existing allowedBlocks in target block', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+				supports: { allowedBlocks: true },
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: { allowedBlocks: [ 'core/paragraph' ] },
+					innerBlocks: [],
+				},
+			];
+			const result = {
+				name: 'core/bar',
+				attributes: { allowedBlocks: [ 'core/heading' ] },
+				innerBlocks: [],
+			};
+
+			const transformed = addTransforms( result, source, 0, [ result ] );
+
+			expect( transformed.attributes.allowedBlocks ).toEqual( [
+				'core/heading',
+			] );
+		} );
+
+		it( 'should not preserve allowedBlocks when target block does not support allowedBlocks', () => {
+			registerBlockType( 'core/bar', {
+				title: 'Bar',
+			} );
+
+			const source = [
+				{
+					name: 'core/foo',
+					attributes: {
+						allowedBlocks: [ 'core/paragraph', 'core/heading' ],
+					},
+					innerBlocks: [],
+				},
+			];
+			const result = {
+				name: 'core/bar',
+				attributes: {},
+				innerBlocks: [],
+			};
+			const transformed = addTransforms( result, source, 0, [ result ] );
+
+			expect( transformed.attributes.allowedBlocks ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/block-library/src/utils/get-transformed-attributes.js
+++ b/packages/block-library/src/utils/get-transformed-attributes.js
@@ -27,14 +27,8 @@ export function getTransformedAttributes(
 
 	const transformedAttributes = {};
 
-	// Handle attributes derived from block support. The custom class name
-	// attribute is handled in the `core/customClassName/addTransforms` hook.
-	if (
-		hasBlockSupport( newBlockType, 'allowedBlocks' ) &&
-		attributes.allowedBlocks
-	) {
-		transformedAttributes.allowedBlocks = attributes.allowedBlocks;
-	}
+	// Handle attributes derived from block support. The custom class name and
+	// allowed blocks attribute is handled separately.
 	if ( hasBlockSupport( newBlockType, 'anchor' ) && attributes.anchor ) {
 		transformedAttributes.anchor = attributes.anchor;
 	}


### PR DESCRIPTION
- Part of: #72195
- Related to #72462

## What?

This pull request uses the `blocks.switchToBlockType.transformedBlock` hook to ensure that the `allowedBlocks` attribute is preserved by default for all block transformations.

## Why?

Without this default filter, we would need to add processing to preserve the allowedBlocks for each individual block transformation.

## How?

The logic is almost identical to the logic of the existing `blocks.switchToBlockType.transformedBlock` hooks.

The only difference is that when `allowedBlocks` (not `attributes.allowedBlocks`) is defined in the target block, it excludes any blocks that are not included in that list. See [this unit test](https://github.com/WordPress/gutenberg/pull/72814/files#diff-4c4f1d0518b17e613660e9b3c5030a4ed3ad30afebfe0ad8cfeb87215d149225R195) for more details.
**
## Testing Instructions

- While the core block transformations that can be tested are limited, insert a Media & Text block.
- Open the Advanced panel and click the "Manage allowed blocks" button.
- Deselect all blocks, and select some blocks.
-  Transform to the Cover block.
- Open the Advanced panel and click the "Manage allowed blocks" button.
- Confirm that the selected (allowed) blocks are preserved.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/de0a9058-9bb9-4e17-bd14-73c17eee6c04