### PR TITLE
block-editor: Remove types from package.json exports

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -27,7 +27,6 @@
 	"module": "build-module/index.js",
 	"exports": {
 		".": {
-			"types": "./build-types/index.d.ts",
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As mentioned in https://github.com/WordPress/gutenberg/pull/72259#discussion_r2471705739, the types and imports for `@wordpress/block-editor` are broken. So we are removing the `types` field from the exports in package.json for the package.

## Why?
To fix the broken types in production

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
- Importing the package, ESLint should be happy

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
