### PR TITLE
fix: notes help text

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -291,9 +291,16 @@ export function Comments( {
 					setShowCommentBoard={ setShowCommentBoard }
 					commentSidebarRef={ commentSidebarRef }
 				/>
-				<Text as="p">{ __( 'No notes available.' ) }</Text>
+				<Text as="p">
+					{ __(
+						'No notes have been created yet for this post. To start discussing edits, find “Add note 💬” in a block’s Options menu.'
+					) }
+				</Text>
+				<hr />
 				<Text as="p" variant="muted">
-					{ __( 'Only logged in users can see Notes.' ) }
+					{ __(
+						'Notes are private and only visible to those with the capability to edit or review their associated post.'
+					) }
 				</Text>
 			</>
 		);

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -293,7 +293,7 @@ export function Comments( {
 				/>
 				<Text as="p">
 					{ __(
-						'No notes have been created yet for this post. To start discussing edits, find “Add note 💬” in a block’s Options menu.'
+						'No notes have been created yet for this post. To start discussing edits, find “Add note” in a block’s Options menu.'
 					) }
 				</Text>
 				<hr />


### PR DESCRIPTION
## What?
Closes #72771

## Why?
This PR solves the confusion created by note help text. 

**Confusion :** 
The message made me think it was a bug, that the system thought I wasn't logged in. I thought I had to do something to enable notes.

## How?
By adding the appropriate help message suggested by @dmsnell

## Testing Instructions
1. Open a post or page.
2. Open notes. 

## Screenshots or screencast

| Before | After |
|:--:|:--:|
| <img width="345" height="193" alt="Before: Notes sidebar message" src="https://github.com/user-attachments/assets/96c0ab67-4a0f-46b4-9f73-e8e9937f5066" /> | <img width="354" height="337" alt="After: Improved Notes sidebar message" src="https://github.com/user-attachments/assets/5382d08b-73f8-4e0a-9cbc-0ae71791d13a" /> |
