### PR TITLE
Block Editor: Fix padding appender last block focus

### DIFF
--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -59,9 +59,9 @@ export function usePaddingAppender( enabled ) {
 			const { ownerDocument } = node;
 			// Adds the listener on the document so that in the iframed editor clicks below the
 			// padding can be handled as they too should be treated as intent to append.
-			ownerDocument.addEventListener( 'mousedown', onMouseDown );
+			ownerDocument.addEventListener( 'pointerdown', onMouseDown );
 			return () => {
-				ownerDocument.removeEventListener( 'mousedown', onMouseDown );
+				ownerDocument.removeEventListener( 'pointerdown', onMouseDown );
 			};
 		},
 		[ registry ]

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -41,13 +41,31 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			},
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
-			{ name: 'core/image' },
-			{ name: 'core/paragraph' },
-		] );
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/image' },
+				{ name: 'core/paragraph' },
+			] );
 
 		await expect(
 			editor.canvas.locator( '[data-type="core/paragraph"]' )
+		).toBeFocused();
+
+		// Clear block selection.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.focus();
+		await body.click( {
+			position: {
+				x: box.width / 2,
+				y: box.height - 10,
+			},
+		} );
+
+		await expect(
+			editor.canvas.locator( '[data-type="core/paragraph"]' ),
+			'should select and focus the newly inserted paragraph block on second click'
 		).toBeFocused();
 	} );
 


### PR DESCRIPTION
## What?
Possible regression after #66402.

PR tries to fix a regression where focus isn't transferred to the last default block in the canvas when clicking "padding appender".

## How?
Switch to the `pointerdown` event in `usePaddingAppender`, so that it can correctly prevent default behavior for `preventFocusCapture`.

## Testing Instructions
1. Create a post.
2. Add an image block.
3. Click on the space below the block.
4. Confirm that the default block is inserted.
5. Click on the title.
6. Repeat step three.
7. Confirm that the last paragraph block is selected, and focus moves into it.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/eaeee3b7-3c3d-4be5-9901-697bb6901dff



