### PR TITLE
Notes: Remove the pin/unpin button from the sidebar header

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -157,6 +157,11 @@ function NotesSidebar( { postId, mode } ) {
 				identifier={ collabHistorySidebarName }
 				name={ collabHistorySidebarName }
 				title={ __( 'Notes' ) }
+				header={
+					<h2 className="interface-complementary-area-header__title">
+						{ __( 'Notes' ) }
+					</h2>
+				}
 				icon={ commentIcon }
 				closeLabel={ __( 'Close Notes' ) }
 			>

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -19,30 +19,6 @@ test.describe( 'Block Comments', () => {
 		await requestUtils.deleteAllComments( 'note' );
 	} );
 
-	test( 'can pin and unpin comments sidebar', async ( {
-		editor,
-		page,
-		blockCommentUtils,
-	} ) => {
-		const topBarButton = await blockCommentUtils.openBlockCommentSidebar();
-		await page
-			.getByRole( 'button', { name: 'Unpin from toolbar' } )
-			.click();
-		await expect( topBarButton ).toBeHidden();
-
-		await editor.openDocumentSettingsSidebar();
-		await page
-			.getByRole( 'region', {
-				name: 'Editor top bar',
-			} )
-			.getByRole( 'button', { name: 'Options' } )
-			.click();
-		await page.getByRole( 'menuitemcheckbox', { name: 'Notes' } ).click();
-		await page.getByRole( 'button', { name: 'Pin to toolbar' } ).click();
-
-		await expect( topBarButton ).toBeVisible();
-	} );
-
 	test( 'should move focus to add a new note form', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Part of #72750.

PR removes "pin/unpin" control from Notes sidebar header.

## Testing Instructions
1. Open the post or page.
2. Open the Notes sidebar.
3. Confirm that the "Unpin" button isn't rendered next to "Close notes".

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|<img width="286" height="390" alt="CleanShot 2025-10-30 at 13 27 43" src="https://github.com/user-attachments/assets/b5dbe09f-7875-4645-ad5a-1189b139b0d7" />|<img width="286" height="478" alt="CleanShot 2025-10-30 at 13 27 59" src="https://github.com/user-attachments/assets/f04028d9-e714-44da-8ccf-b7aa74e1d33a" />|
