### PR TITLE
Editor: Change the name of the 'Plugins' menu group

### DIFF
--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -112,7 +112,7 @@ export default function MoreMenu() {
 						<ModeSwitcher />
 						<ActionItem.Slot
 							name="core/plugin-more-menu"
-							label={ __( 'Sidebars' ) }
+							label={ __( 'Panels' ) }
 							fillProps={ { onClick: onClose } }
 						/>
 						<MenuGroup label={ __( 'Tools' ) }>

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -112,7 +112,7 @@ export default function MoreMenu() {
 						<ModeSwitcher />
 						<ActionItem.Slot
 							name="core/plugin-more-menu"
-							label={ __( 'Plugins' ) }
+							label={ __( 'Sidebars' ) }
 							fillProps={ { onClick: onClose } }
 						/>
 						<MenuGroup label={ __( 'Tools' ) }>


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/72750#issuecomment-3466695763.

PR renames Options' "Plugins" menu group to "Sidebars".

## Testing Instructions
1. Open a post or page.
2. Open the main Options menu.
3. Confirm the name change.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="298" height="656" alt="CleanShot 2025-10-30 at 13 33 18" src="https://github.com/user-attachments/assets/25586bbb-0d86-4190-8855-d75089083876" />|<img width="302" height="654" alt="CleanShot 2025-10-30 at 13 34 15" src="https://github.com/user-attachments/assets/dd6eba59-1e56-4692-8a82-6fce2664d904" />|


