### PR TITLE
Remove old polyfills for server block definitions

### DIFF
--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -466,49 +466,6 @@ describe( 'blocks', () => {
 			} );
 		} );
 
-		// This test can be removed once the polyfill for blockHooks gets removed.
-		it( 'should polyfill blockHooks using metadata on the client when not set on the server', () => {
-			const blockName = 'tests/hooked-block';
-			unstable__bootstrapServerSideBlockDefinitions( {
-				[ blockName ]: {
-					category: 'widgets',
-				},
-			} );
-
-			const blockType = {
-				title: 'block title',
-			};
-			registerBlockType(
-				{
-					name: blockName,
-					blockHooks: {
-						'tests/block': 'firstChild',
-					},
-					category: 'ignored',
-				},
-				blockType
-			);
-			expect( getBlockType( blockName ) ).toEqual( {
-				apiVersion: 1,
-				name: blockName,
-				save: expect.any( Function ),
-				title: 'block title',
-				category: 'widgets',
-				icon: { src: BLOCK_ICON_DEFAULT },
-				attributes: {},
-				providesContext: {},
-				usesContext: [],
-				keywords: [],
-				selectors: {},
-				supports: {},
-				styles: [],
-				variations: [],
-				blockHooks: {
-					'tests/block': 'firstChild',
-				},
-			} );
-		} );
-
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -62,60 +62,24 @@ function bootstrappedBlockTypes( state = {}, action ) {
 		case 'ADD_BOOTSTRAPPED_BLOCK_TYPE':
 			const { name, blockType } = action;
 			const serverDefinition = state[ name ];
-			let newDefinition;
 			// Don't overwrite if already set. It covers the case when metadata
 			// was initialized from the server.
 			if ( serverDefinition ) {
-				// The `blockHooks` prop is not yet included in the server provided
-				// definitions and needs to be polyfilled. This can be removed when the
-				// minimum supported WordPress is >= 6.4.
-				if (
-					serverDefinition.blockHooks === undefined &&
-					blockType.blockHooks
-				) {
-					newDefinition = {
-						...serverDefinition,
-						...newDefinition,
-						blockHooks: blockType.blockHooks,
-					};
-				}
-
-				// The `allowedBlocks` prop is not yet included in the server provided
-				// definitions and needs to be polyfilled. This can be removed when the
-				// minimum supported WordPress is >= 6.5.
-				if (
-					serverDefinition.allowedBlocks === undefined &&
-					blockType.allowedBlocks
-				) {
-					newDefinition = {
-						...serverDefinition,
-						...newDefinition,
-						allowedBlocks: blockType.allowedBlocks,
-					};
-				}
-			} else {
-				newDefinition = Object.fromEntries(
-					Object.entries( blockType )
-						.filter(
-							( [ , value ] ) =>
-								value !== null && value !== undefined
-						)
-						.map( ( [ key, value ] ) => [
-							camelCase( key ),
-							value,
-						] )
-				);
-				newDefinition.name = name;
+				return state;
 			}
+			const newDefinition = Object.fromEntries(
+				Object.entries( blockType )
+					.filter(
+						( [ , value ] ) => value !== null && value !== undefined
+					)
+					.map( ( [ key, value ] ) => [ camelCase( key ), value ] )
+			);
+			newDefinition.name = name;
+			return {
+				...state,
+				[ name ]: newDefinition,
+			};
 
-			if ( newDefinition ) {
-				return {
-					...state,
-					[ name ]: newDefinition,
-				};
-			}
-
-			return state;
 		case 'REMOVE_BLOCK_TYPES':
 			return omit( state, action.names );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on https://github.com/WordPress/gutenberg/pull/72792 I noticed some old polyfills for server block definitions (`allowedBlocks and blockHooks`) for 6.4 and 6.4 WP versions. This is mostly needed because of the hardcoded values in this [function](https://developer.wordpress.org/reference/functions/get_block_editor_server_block_settings/).

This PR removes this code.


## Testing Instructions
1. Everything should work as before
2. An example is the blocks that define `allowedBlocks` in block.json like `core/list` and should still only allow `core/list-item` blocks.

