### PR TITLE
Starter content: Change alignment and copy

### DIFF
--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -116,7 +116,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									scope="core"
 									featureName="enableChoosePatternModal"
 									help={ __(
-										'Shows starter patterns when creating a new page.'
+										'Pick from starter content when creating a new page.'
 									) }
 									label={ __( 'Show starter patterns' ) }
 								/>

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Flex, FlexItem, Modal, ToggleControl } from '@wordpress/components';
+import { Flex, FlexItem, Modal, CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import {
@@ -119,16 +119,15 @@ function StartPageOptionsModal( { onClose } ) {
 			</div>
 			<Flex
 				className="editor-start-page-options__modal__actions"
-				justify="flex-end"
+				justify="flex-start"
 				expanded={ false }
 			>
 				<FlexItem>
-					<ToggleControl
+					<CheckboxControl
 						__nextHasNoMarginBottom
 						checked={ showStartPatterns }
-						label={ __( 'Show starter patterns' ) }
-						help={ __(
-							'Shows starter patterns when creating a new page.'
+						label={ __(
+							'Always show starter patterns for new pages'
 						) }
 						onChange={ ( newValue ) => {
 							setShowStartPatterns( newValue );

--- a/packages/editor/src/components/start-page-options/style.scss
+++ b/packages/editor/src/components/start-page-options/style.scss
@@ -3,7 +3,7 @@
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
-$actions-height: 92px;
+$actions-height: 72px;
 
 .editor-start-page-options__modal {
 	.editor-start-page-options__modal__actions {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72754

Updating the starter content modal toggle and using a checkbox instead to be more in line with what we have on other places (pre-publish checks). See https://github.com/WordPress/gutenberg/issues/72754 for more information.

Text updates are the following:

**Checkbox label:**

> Always show starter patterns for new pages

**Preferences labels:**

> **Show starter patterns**
Pick from starter content when creating a new page

I updated the footer height to 72px as the header has that height, and it should make it look more balanced.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Visual alignment: the toggle is right-aligned, while the pattern grid above is left-aligned. This creates a visual disconnect and makes the control feel unrelated to the content it affects. It also can look a bit unbalanced, and out of place depending on the size of the patterns grid on top. Right-alignment usually implies action buttons (like “save” or “cancel”), not preferences. I assume we're inheriting the alignment from the modal styles, and that's why it's located there.
- Toggle: It often carries "immediate visible effect" implications, which is not the case here. We're trying with an existing pattern using a checkbox.

## Testing Instructions

1. Create a page.
2. Confirm that you see the starter content modal. 
3. Confirm that the checkbox work, untick it and close the modal. Confirm that the texts are the ones in the description.
4. Go to the preferences, confirm that the toggle has the copy updated and it works as it should.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1467" height="773" alt="Screenshot 2025-10-28 at 17 55 30" src="https://github.com/user-attachments/assets/7fcccad0-6cf4-4beb-a223-35e37535fcef" /><!-- Before screenshot here -->|<img width="1468" height="774" alt="Screenshot 2025-10-30 at 11 11 51" src="https://github.com/user-attachments/assets/bb1b83c0-ce2e-4ecb-82c8-1bf942f6acd3" />|


