### PR TITLE
components: Expose TS types of props for public components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Expose the TS types for props of public components ([#72831](https://github.com/WordPress/gutenberg/pull/72831)).
+
 ## 30.7.0 (2025-10-29)
 
 ### Bug Fixes

--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -120,4 +120,6 @@ export const AlignmentMatrixControl = Object.assign(
 	}
 );
 
+export type { AlignmentMatrixControlProps };
+
 export default AlignmentMatrixControl;

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -104,4 +104,6 @@ function UnforwardedAnglePickerControl(
  */
 export const AnglePickerControl = forwardRef( UnforwardedAnglePickerControl );
 
+export type { AnglePickerControlProps };
+
 export default AnglePickerControl;

--- a/packages/components/src/animate/index.tsx
+++ b/packages/components/src/animate/index.tsx
@@ -69,4 +69,6 @@ export function Animate( { type, options = {}, children }: AnimateProps ) {
 	} );
 }
 
+export type { AnimateProps };
+
 export default Animate;

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -446,6 +446,8 @@ export function useAutocompleteProps( options: UseAutocompleteProps ) {
 	};
 }
 
+export type { AutocompleteProps };
+
 export default function Autocomplete( {
 	children,
 	isSelected,

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -166,4 +166,6 @@ export const BaseControl = Object.assign(
 	}
 );
 
+export type { BaseControlProps };
+
 export default BaseControl;

--- a/packages/components/src/border-box-control/index.ts
+++ b/packages/components/src/border-box-control/index.ts
@@ -1,3 +1,5 @@
 export { default as BorderBoxControl } from './border-box-control/component';
 export { useBorderBoxControl } from './border-box-control/hook';
 export { hasSplitBorders, isEmptyBorder, isDefinedBorder } from './utils';
+
+export type { BorderBoxControlProps } from './types';

--- a/packages/components/src/border-control/index.ts
+++ b/packages/components/src/border-control/index.ts
@@ -1,2 +1,4 @@
 export { default as BorderControl } from './border-control/component';
 export { useBorderControl } from './border-control/hook';
+
+export type { BorderControlProps } from './types';

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -234,4 +234,7 @@ function BoxControl( {
 }
 
 export { applyValueToSides } from './utils';
+
+export type { BoxControlProps };
+
 export default BoxControl;

--- a/packages/components/src/button-group/index.tsx
+++ b/packages/components/src/button-group/index.tsx
@@ -54,4 +54,6 @@ function UnforwardedButtonGroup(
  */
 export const ButtonGroup = forwardRef( UnforwardedButtonGroup );
 
+export type { ButtonGroupProps };
+
 export default ButtonGroup;

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -304,4 +304,7 @@ export function UnforwardedButton(
  * ```
  */
 export const Button = forwardRef( UnforwardedButton );
+
+export type { ButtonProps };
+
 export default Button;

--- a/packages/components/src/card/index.ts
+++ b/packages/components/src/card/index.ts
@@ -4,3 +4,10 @@ export { default as CardDivider, useCardDivider } from './card-divider';
 export { default as CardFooter, useCardFooter } from './card-footer';
 export { default as CardHeader, useCardHeader } from './card-header';
 export { default as CardMedia, useCardMedia } from './card-media';
+export type {
+	Props as CardProps,
+	BodyProps as CardBodyProps,
+	FooterProps as CardFooterProps,
+	HeaderProps as CardHeaderProps,
+	MediaProps as CardMediaProps,
+} from './types';

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -155,4 +155,6 @@ export function CheckboxControl(
 	);
 }
 
+export type { CheckboxControlProps };
+
 export default CheckboxControl;

--- a/packages/components/src/clipboard-button/index.tsx
+++ b/packages/components/src/clipboard-button/index.tsx
@@ -19,6 +19,8 @@ import type { WordPressComponentProps } from '../context';
 
 const TIMEOUT = 4000;
 
+export type { ClipboardButtonProps };
+
 export default function ClipboardButton( {
 	className,
 	children,

--- a/packages/components/src/color-indicator/index.tsx
+++ b/packages/components/src/color-indicator/index.tsx
@@ -44,4 +44,6 @@ function UnforwardedColorIndicator(
  */
 export const ColorIndicator = forwardRef( UnforwardedColorIndicator );
 
+export type { ColorIndicatorProps };
+
 export default ColorIndicator;

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -366,4 +366,6 @@ function UnforwardedColorPalette(
  */
 export const ColorPalette = forwardRef( UnforwardedColorPalette );
 
+export type { ColorPaletteProps };
+
 export default ColorPalette;

--- a/packages/components/src/color-picker/index.ts
+++ b/packages/components/src/color-picker/index.ts
@@ -2,3 +2,5 @@
  * Internal dependencies
  */
 export { LegacyAdapter as ColorPicker } from './legacy-adapter';
+
+export type { ColorPickerProps } from './types';

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -405,4 +405,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }
 
+export type { ComboboxControlProps };
+
 export default ComboboxControl;

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -249,3 +249,5 @@ export const Composite = Object.assign(
 		} ),
 	}
 );
+
+export type { CompositeProps } from './types';

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -4,3 +4,5 @@
 import ConfirmDialog from './component';
 
 export { ConfirmDialog };
+
+export type { ConfirmDialogProps } from './types';

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -208,4 +208,6 @@ export function CustomGradientPicker( {
 	);
 }
 
+export type { CustomGradientPickerProps };
+
 export default CustomGradientPicker;

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -212,4 +212,6 @@ function CustomSelectControl< T extends CustomSelectOption >(
 	);
 }
 
+export type { CustomSelectProps };
+
 export default CustomSelectControl;

--- a/packages/components/src/dashicon/index.tsx
+++ b/packages/components/src/dashicon/index.tsx
@@ -48,4 +48,6 @@ function Dashicon( {
 	return <span className={ iconClass } style={ styles } { ...extraProps } />;
 }
 
+export type { DashiconProps };
+
 export default Dashicon;

--- a/packages/components/src/date-time/index.ts
+++ b/packages/components/src/date-time/index.ts
@@ -7,3 +7,4 @@ import { default as DateTimePicker } from './date-time';
 
 export { DatePicker, TimePicker };
 export default DateTimePicker;
+export type { DatePickerProps, TimeInputProps, TimePickerProps } from './types';

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -129,4 +129,6 @@ export function DimensionControl( props: DimensionControlProps ) {
 	);
 }
 
+export type { DimensionControlProps };
+
 export default DimensionControl;

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -89,4 +89,6 @@ function Disabled( {
 Disabled.Context = Context;
 Disabled.Consumer = Consumer;
 
+export type { DisabledProps };
+
 export default Disabled;

--- a/packages/components/src/disclosure/index.tsx
+++ b/packages/components/src/disclosure/index.tsx
@@ -40,4 +40,7 @@ const UnforwardedDisclosureContent = (
 };
 
 export const DisclosureContent = forwardRef( UnforwardedDisclosureContent );
+
+export type { DisclosureContentProps };
+
 export default DisclosureContent;

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -259,4 +259,6 @@ export function Draggable( {
 	);
 }
 
+export type { DraggableProps };
+
 export default Draggable;

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -137,4 +137,6 @@ export function DropZoneComponent( {
 	);
 }
 
+export type { DropZoneProps };
+
 export default DropZoneComponent;

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -304,4 +304,6 @@ export const DropdownMenu = contextConnectWithoutRef(
 	'DropdownMenu'
 );
 
+export type { DropdownMenuProps };
+
 export default DropdownMenu;

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -182,4 +182,6 @@ const UnconnectedDropdown = (
  */
 export const Dropdown = contextConnect( UnconnectedDropdown, 'Dropdown' );
 
+export type { DropdownProps };
+
 export default Dropdown;

--- a/packages/components/src/duotone-picker/index.ts
+++ b/packages/components/src/duotone-picker/index.ts
@@ -1,2 +1,4 @@
 export { default as DuotonePicker } from './duotone-picker';
 export { default as DuotoneSwatch } from './duotone-swatch';
+
+export type { DuotonePickerProps } from './types';

--- a/packages/components/src/elevation/index.ts
+++ b/packages/components/src/elevation/index.ts
@@ -1,2 +1,4 @@
 export { default as Elevation } from './component';
 export * from './hook';
+
+export type { ElevationProps } from './types';

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -93,4 +93,6 @@ function UnforwardedExternalLink(
  */
 export const ExternalLink = forwardRef( UnforwardedExternalLink );
 
+export type { ExternalLinkProps };
+
 export default ExternalLink;

--- a/packages/components/src/flex/index.ts
+++ b/packages/components/src/flex/index.ts
@@ -1,3 +1,5 @@
 export { default as Flex, useFlex } from './flex';
 export { default as FlexItem, useFlexItem } from './flex-item';
 export { default as FlexBlock, useFlexBlock } from './flex-block';
+
+export type { FlexProps } from './types';

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -305,4 +305,6 @@ export function FocalPointPicker( {
 	);
 }
 
+export type { FocalPointPickerProps };
+
 export default FocalPointPicker;

--- a/packages/components/src/focusable-iframe/index.tsx
+++ b/packages/components/src/focusable-iframe/index.tsx
@@ -8,6 +8,8 @@ import deprecated from '@wordpress/deprecated';
  */
 import type { FocusableIframeProps } from './types';
 
+export type { FocusableIframeProps };
+
 export default function FocusableIframe( {
 	iframeRef,
 	...props

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -297,4 +297,6 @@ const UnforwardedFontSizePicker = (
 
 export const FontSizePicker = forwardRef( UnforwardedFontSizePicker );
 
+export type { FontSizePickerProps };
+
 export default FontSizePicker;

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -82,4 +82,6 @@ export function FormFileUpload( {
 	);
 }
 
+export type { FormFileUploadProps };
+
 export default FormFileUpload;

--- a/packages/components/src/form-toggle/index.tsx
+++ b/packages/components/src/form-toggle/index.tsx
@@ -80,4 +80,6 @@ function UnforwardedFormToggle(
  */
 export const FormToggle = forwardRef( UnforwardedFormToggle );
 
+export type { FormToggleProps };
+
 export default FormToggle;

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -779,4 +779,6 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }
 
+export type { FormTokenFieldProps };
+
 export default FormTokenField;

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -245,4 +245,6 @@ export function GradientPicker( {
 	);
 }
 
+export type { GradientPickerComponentProps as GradientPickerProps };
+
 export default GradientPicker;

--- a/packages/components/src/grid/index.ts
+++ b/packages/components/src/grid/index.ts
@@ -1,2 +1,4 @@
 export { default as Grid } from './component';
 export { default as useGrid } from './hook';
+
+export type { GridProps } from './types';

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -177,4 +177,6 @@ function Guide( {
 	);
 }
 
+export type { GuideProps };
+
 export default Guide;

--- a/packages/components/src/heading/index.ts
+++ b/packages/components/src/heading/index.ts
@@ -1,2 +1,4 @@
 export { default as Heading } from './component';
 export { useHeading } from './hook';
+
+export type { HeadingProps } from './types';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -17,17 +17,22 @@ export {
 	default as __experimentalAlignmentMatrixControl,
 	default as AlignmentMatrixControl,
 } from './alignment-matrix-control';
+export type { AlignmentMatrixControlProps } from './alignment-matrix-control';
 export {
 	default as Animate,
 	getAnimateClassName as __unstableGetAnimateClassName,
 } from './animate';
+export type { AnimateProps } from './animate';
 export { __unstableMotion, __unstableAnimatePresence } from './animation';
 export { default as AnglePickerControl } from './angle-picker-control';
+export type { AnglePickerControlProps } from './angle-picker-control';
 export {
 	default as Autocomplete,
 	useAutocompleteProps as __unstableUseAutocompleteProps,
 } from './autocomplete';
+export type { AutocompleteProps } from './autocomplete';
 export { default as BaseControl, useBaseControlProps } from './base-control';
+export type { BaseControlProps } from './base-control';
 export {
 	/** @deprecated Import `BorderBoxControl` instead. */
 	BorderBoxControl as __experimentalBorderBoxControl,
@@ -36,19 +41,24 @@ export {
 	isDefinedBorder as __experimentalIsDefinedBorder,
 	isEmptyBorder as __experimentalIsEmptyBorder,
 } from './border-box-control';
+export type { BorderBoxControlProps } from './border-box-control';
 export {
 	/** @deprecated Import `BorderControl` instead. */
 	BorderControl as __experimentalBorderControl,
 	BorderControl,
 } from './border-control';
+export type { BorderControlProps } from './border-control';
 export {
 	/** @deprecated Import `BoxControl` instead. */
 	default as __experimentalBoxControl,
 	default as BoxControl,
 	applyValueToSides as __experimentalApplyValueToSides,
 } from './box-control';
+export type { BoxControlProps } from './box-control';
 export { default as Button } from './button';
+export type { ButtonProps } from './button';
 export { default as ButtonGroup } from './button-group';
+export type { ButtonGroupProps } from './button-group';
 export {
 	Card,
 	CardBody,
@@ -57,13 +67,27 @@ export {
 	CardHeader,
 	CardMedia,
 } from './card';
+export type {
+	CardProps,
+	CardBodyProps,
+	CardFooterProps,
+	CardHeaderProps,
+	CardMediaProps,
+} from './card';
 export { default as CheckboxControl } from './checkbox-control';
+export type { CheckboxControlProps } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
+export type { ClipboardButtonProps } from './clipboard-button';
 export { default as __experimentalPaletteEdit } from './palette-edit';
+export type { PaletteEditProps } from './palette-edit';
 export { default as ColorIndicator } from './color-indicator';
+export type { ColorIndicatorProps } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
+export type { ColorPaletteProps } from './color-palette';
 export { ColorPicker } from './color-picker';
+export type { ColorPickerProps } from './color-picker';
 export { default as ComboboxControl } from './combobox-control';
+export type { ComboboxControlProps } from './combobox-control';
 export {
 	Composite as __unstableComposite,
 	CompositeGroup as __unstableCompositeGroup,
@@ -71,36 +95,68 @@ export {
 	useCompositeState as __unstableUseCompositeState,
 } from './composite/legacy';
 export { Composite } from './composite';
+export type { CompositeProps } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
+export type { ConfirmDialogProps } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';
+export type { CustomSelectProps } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
+export type { DashiconProps } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
+export type {
+	DatePickerProps,
+	TimeInputProps,
+	TimePickerProps,
+} from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
+export type { DimensionControlProps } from './dimension-control';
 export { default as Disabled } from './disabled';
+export type { DisabledProps } from './disabled';
 export { DisclosureContent as __unstableDisclosureContent } from './disclosure';
+export type { DisclosureContentProps } from './disclosure';
 export { Divider as __experimentalDivider } from './divider';
+export type { DividerProps } from './divider';
 export { default as Draggable } from './draggable';
+export type { DraggableProps } from './draggable';
 export { default as DropZone } from './drop-zone';
+export type { DropZoneProps } from './drop-zone';
 export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as Dropdown } from './dropdown';
+export type { DropdownProps } from './dropdown';
 export { default as __experimentalDropdownContentWrapper } from './dropdown/dropdown-content-wrapper';
 export { default as DropdownMenu } from './dropdown-menu';
+export type { DropdownMenuProps } from './dropdown-menu';
 export { DuotoneSwatch, DuotonePicker } from './duotone-picker';
+export type { DuotonePickerProps } from './duotone-picker';
 export { Elevation as __experimentalElevation } from './elevation';
+export type { ElevationProps } from './elevation';
 export { default as ExternalLink } from './external-link';
+export type { ExternalLinkProps } from './external-link';
 export { Flex, FlexBlock, FlexItem } from './flex';
+export type { FlexProps } from './flex';
 export { default as FocalPointPicker } from './focal-point-picker';
+export type { FocalPointPickerProps } from './focal-point-picker';
 export { default as FocusableIframe } from './focusable-iframe';
+export type { FocusableIframeProps } from './focusable-iframe';
 export { default as FontSizePicker } from './font-size-picker';
+export type { FontSizePickerProps } from './font-size-picker';
 export { default as FormFileUpload } from './form-file-upload';
+export type { FormFileUploadProps } from './form-file-upload';
 export { default as FormToggle } from './form-toggle';
+export type { FormToggleProps } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
+export type { FormTokenFieldProps } from './form-token-field';
 export { default as GradientPicker } from './gradient-picker';
+export type { GradientPickerProps } from './gradient-picker';
 export { default as CustomGradientPicker } from './custom-gradient-picker';
+export type { CustomGradientPickerProps } from './custom-gradient-picker';
 export { Grid as __experimentalGrid } from './grid';
+export type { GridProps } from './grid';
 export { default as Guide } from './guide';
+export type { GuideProps } from './guide';
 export { default as GuidePage } from './guide/page';
 export { Heading as __experimentalHeading } from './heading';
+export type { HeadingProps } from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export type { IconType } from './icon';
@@ -109,17 +165,26 @@ export {
 	ItemGroup as __experimentalItemGroup,
 	Item as __experimentalItem,
 } from './item-group';
+export type { ItemGroupProps } from './item-group';
 export { default as __experimentalInputControl } from './input-control';
+export type { InputControlProps } from './input-control';
 export { default as __experimentalInputControlPrefixWrapper } from './input-control/input-prefix-wrapper';
 export { default as __experimentalInputControlSuffixWrapper } from './input-control/input-suffix-wrapper';
 export { default as KeyboardShortcuts } from './keyboard-shortcuts';
+export type { KeyboardShortcutsProps } from './keyboard-shortcuts';
 export { default as MenuGroup } from './menu-group';
+export type { MenuGroupProps } from './menu-group';
 export { default as MenuItem } from './menu-item';
+export type { MenuItemProps } from './menu-item';
 export { default as MenuItemsChoice } from './menu-items-choice';
+export type { MenuItemsChoiceProps } from './menu-items-choice';
 export { default as Modal } from './modal';
+export type { ModalProps } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
+export type { NavigableContainerProps } from './navigable-container';
 export { default as __experimentalNavigation } from './navigation';
+export type { NavigationProps } from './navigation';
 export { default as __experimentalNavigationBackButton } from './navigation/back-button';
 export { default as __experimentalNavigationGroup } from './navigation/group';
 export { default as __experimentalNavigationItem } from './navigation/item';
@@ -142,44 +207,71 @@ export {
 	/** @deprecated Import `useNavigator` instead. */
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
+export type { NavigatorProps } from './navigator';
 export { default as Notice } from './notice';
+export type { NoticeProps } from './notice';
 export { default as __experimentalNumberControl } from './number-control';
+export type { NumberControlProps } from './number-control';
 export { default as NoticeList } from './notice/list';
 export { default as Panel } from './panel';
+export type { PanelProps } from './panel';
 export { default as PanelBody } from './panel/body';
 export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
+export type { PlaceholderProps } from './placeholder';
 export { default as Popover } from './popover';
+export type { PopoverProps } from './popover';
 export { default as ProgressBar } from './progress-bar';
+export type { ProgressBarProps } from './progress-bar';
 export { default as QueryControls } from './query-controls';
+export type { QueryControlsProps } from './query-controls';
 export { default as __experimentalRadio } from './radio-group/radio';
 export { default as __experimentalRadioGroup } from './radio-group';
+export type { RadioGroupProps } from './radio-group';
 export { default as RadioControl } from './radio-control';
+export type { RadioControlProps } from './radio-control';
 export { default as RangeControl } from './range-control';
+export type { RangeControlProps } from './range-control';
 export { default as ResizableBox } from './resizable-box';
+export type { ResizableBoxProps } from './resizable-box';
 export { default as ResponsiveWrapper } from './responsive-wrapper';
+export type { ResponsiveWrapperProps } from './responsive-wrapper';
 export { default as SandBox } from './sandbox';
+export type { SandBoxProps } from './sandbox';
 export { default as SearchControl } from './search-control';
+export type { SearchControlProps } from './search-control';
 export { default as SelectControl } from './select-control';
+export type { SelectControlProps } from './select-control';
 export { default as Snackbar } from './snackbar';
+export type { SnackbarProps } from './snackbar';
 export { default as SnackbarList } from './snackbar/list';
 export { Spacer as __experimentalSpacer } from './spacer';
 export { Scrollable as __experimentalScrollable } from './scrollable';
+export type { ScrollableProps } from './scrollable';
 export { default as Spinner } from './spinner';
 export { Surface as __experimentalSurface } from './surface';
+export type { SurfaceProps } from './surface';
 export { default as TabPanel } from './tab-panel';
+export type { TabPanelProps } from './tab-panel';
 export { Text as __experimentalText } from './text';
+export type { TextProps } from './text';
 export { default as TextControl } from './text-control';
+export type { TextControlProps } from './text-control';
 export { default as TextareaControl } from './textarea-control';
+export type { TextareaControlProps } from './textarea-control';
 export { default as TextHighlight } from './text-highlight';
+export type { TextHighlightProps } from './text-highlight';
 export { default as Tip } from './tip';
+export type { TipProps } from './tip';
 export { default as ToggleControl } from './toggle-control';
+export type { ToggleControlProps } from './toggle-control';
 export {
 	ToggleGroupControl as __experimentalToggleGroupControl,
 	ToggleGroupControlOption as __experimentalToggleGroupControlOption,
 	ToggleGroupControlOptionIcon as __experimentalToggleGroupControlOptionIcon,
 } from './toggle-group-control';
+export type { ToggleGroupControlProps } from './toggle-group-control';
 export {
 	Toolbar,
 	ToolbarButton,
@@ -188,28 +280,42 @@ export {
 	ToolbarGroup,
 	ToolbarItem,
 } from './toolbar';
+export type {
+	ToolbarProps,
+	ToolbarButtonProps,
+	ToolbarGroupProps,
+	ToolbarItemProps,
+} from './toolbar';
 export {
 	ToolsPanel as __experimentalToolsPanel,
 	ToolsPanelItem as __experimentalToolsPanelItem,
 	ToolsPanelContext as __experimentalToolsPanelContext,
 } from './tools-panel';
+export type { ToolsPanelProps } from './tools-panel';
 export { default as Tooltip } from './tooltip';
+export type { TooltipProps } from './tooltip';
 export {
 	default as __experimentalTreeGrid,
 	TreeGridRow as __experimentalTreeGridRow,
 	TreeGridCell as __experimentalTreeGridCell,
 	TreeGridItem as __experimentalTreeGridItem,
 } from './tree-grid';
+export type { TreeGridProps } from './tree-grid';
 export { default as TreeSelect } from './tree-select';
+export type { TreeSelectProps } from './tree-select';
 export { Truncate as __experimentalTruncate } from './truncate';
+export type { TruncateProps } from './truncate';
 export {
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
 } from './unit-control';
+export type { UnitControlProps } from './unit-control';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';
+export type { VisuallyHiddenProps } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';
+export type { VStackProps } from './v-stack';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {
 	createSlotFill,
@@ -219,8 +325,11 @@ export {
 	useSlot as __experimentalUseSlot,
 	useSlotFills as __experimentalUseSlotFills,
 } from './slot-fill';
+export type { FillProps } from './slot-fill';
 export { default as __experimentalStyleProvider } from './style-provider';
+export type { StyleProviderProps } from './style-provider';
 export { ZStack as __experimentalZStack } from './z-stack';
+export type { ZStackProps } from './z-stack';
 
 // Higher-Order Components.
 export {

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -144,4 +144,6 @@ export function UnforwardedInputControl(
  */
 export const InputControl = forwardRef( UnforwardedInputControl );
 
+export type { InputControlProps };
+
 export default InputControl;

--- a/packages/components/src/item-group/index.ts
+++ b/packages/components/src/item-group/index.ts
@@ -1,2 +1,4 @@
 export { default as Item } from './item';
 export { default as ItemGroup } from './item-group';
+
+export type { ItemGroupProps } from './types';

--- a/packages/components/src/keyboard-shortcuts/index.tsx
+++ b/packages/components/src/keyboard-shortcuts/index.tsx
@@ -90,4 +90,6 @@ function KeyboardShortcuts( {
 	);
 }
 
+export type { KeyboardShortcutsProps };
+
 export default KeyboardShortcuts;

--- a/packages/components/src/menu-group/index.tsx
+++ b/packages/components/src/menu-group/index.tsx
@@ -60,4 +60,6 @@ export function MenuGroup( props: MenuGroupProps ) {
 	);
 }
 
+export type { MenuGroupProps };
+
 export default MenuGroup;

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -110,4 +110,6 @@ function UnforwardedMenuItem(
  */
 export const MenuItem = forwardRef( UnforwardedMenuItem );
 
+export type { MenuItemProps };
+
 export default MenuItem;

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -81,4 +81,6 @@ function MenuItemsChoice( {
 	);
 }
 
+export type { MenuItemsChoiceProps };
+
 export default MenuItemsChoice;

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -415,4 +415,6 @@ function UnforwardedModal(
  */
 export const Modal = forwardRef( UnforwardedModal );
 
+export type { ModalProps };
+
 export default Modal;

--- a/packages/components/src/navigable-container/index.tsx
+++ b/packages/components/src/navigable-container/index.tsx
@@ -3,3 +3,5 @@
  */
 export { default as NavigableMenu } from './menu';
 export { default as TabbableContainer } from './tabbable';
+
+export type { NavigableContainerProps } from './types';

--- a/packages/components/src/navigation/index.tsx
+++ b/packages/components/src/navigation/index.tsx
@@ -149,4 +149,6 @@ export function Navigation( {
 	);
 }
 
+export type { NavigationProps };
+
 export default Navigation;

--- a/packages/components/src/navigator/index.tsx
+++ b/packages/components/src/navigator/index.tsx
@@ -129,3 +129,5 @@ export const Navigator = Object.assign( TopLevelNavigator, {
 		displayName: 'Navigator.BackButton',
 	} ),
 } );
+
+export type { NavigatorProps } from './types';

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -172,4 +172,6 @@ function Notice( {
 	);
 }
 
+export type { NoticeProps };
+
 export default Notice;

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -282,4 +282,6 @@ function UnforwardedNumberControl(
 
 export const NumberControl = forwardRef( UnforwardedNumberControl );
 
+export type { NumberControlProps };
+
 export default NumberControl;

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -629,4 +629,6 @@ export function PaletteEdit( {
 	);
 }
 
+export type { PaletteEditProps };
+
 export default PaletteEdit;

--- a/packages/components/src/panel/index.tsx
+++ b/packages/components/src/panel/index.tsx
@@ -45,4 +45,6 @@ function UnforwardedPanel(
  */
 export const Panel = forwardRef( UnforwardedPanel );
 
+export type { PanelProps };
+
 export default Panel;

--- a/packages/components/src/placeholder/index.tsx
+++ b/packages/components/src/placeholder/index.tsx
@@ -109,4 +109,6 @@ export function Placeholder(
 	);
 }
 
+export type { PlaceholderProps };
+
 export default Placeholder;

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -569,4 +569,6 @@ export const Popover = Object.assign(
 	}
 );
 
+export type { PopoverProps };
+
 export default Popover;

--- a/packages/components/src/progress-bar/index.tsx
+++ b/packages/components/src/progress-bar/index.tsx
@@ -61,4 +61,6 @@ function UnforwardedProgressBar(
  */
 export const ProgressBar = forwardRef( UnforwardedProgressBar );
 
+export type { ProgressBarProps };
+
 export default ProgressBar;

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -204,4 +204,6 @@ export function QueryControls( {
 	);
 }
 
+export type { QueryControlsProps };
+
 export default QueryControls;

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -161,4 +161,6 @@ export function RadioControl(
 	);
 }
 
+export type { RadioControlProps };
+
 export default RadioControl;

--- a/packages/components/src/radio-group/index.tsx
+++ b/packages/components/src/radio-group/index.tsx
@@ -74,4 +74,7 @@ function UnforwardedRadioGroup(
  * @deprecated Use `RadioControl` or `ToggleGroupControl` instead.
  */
 export const RadioGroup = forwardRef( UnforwardedRadioGroup );
+
+export type { RadioGroupProps };
+
 export default RadioGroup;

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -410,4 +410,6 @@ function UnforwardedRangeControl(
  */
 export const RangeControl = forwardRef( UnforwardedRangeControl );
 
+export type { RangeControlProps };
+
 export default RangeControl;

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -87,7 +87,7 @@ const HANDLE_STYLES = {
 	bottomLeft: HANDLE_STYLES_OVERRIDES,
 };
 
-type ResizableBoxProps = ResizableProps & {
+export type ResizableBoxProps = ResizableProps & {
 	children: ReactNode;
 	showHandle?: boolean;
 	__experimentalShowTooltip?: boolean;

--- a/packages/components/src/responsive-wrapper/index.tsx
+++ b/packages/components/src/responsive-wrapper/index.tsx
@@ -63,4 +63,6 @@ function ResponsiveWrapper( {
 	);
 }
 
+export type { ResponsiveWrapperProps };
+
 export default ResponsiveWrapper;

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -292,4 +292,6 @@ function SandBox( {
 	);
 }
 
+export type { SandBoxProps };
+
 export default SandBox;

--- a/packages/components/src/scrollable/index.ts
+++ b/packages/components/src/scrollable/index.ts
@@ -1,3 +1,5 @@
 export { default as Scrollable } from './component';
 
 export * from './hook';
+
+export type { ScrollableProps } from './types';

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -157,4 +157,6 @@ function UnforwardedSearchControl(
  */
 export const SearchControl = forwardRef( UnforwardedSearchControl );
 
+export type { SearchControlProps };
+
 export default SearchControl;

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -188,4 +188,6 @@ export const SelectControl = forwardRef( UnforwardedSelectControl ) as <
 	> & { ref?: React.Ref< HTMLSelectElement > }
 ) => React.JSX.Element | null;
 
+export type { SelectControlProps };
+
 export default SelectControl;

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -96,3 +96,5 @@ export function createSlotFill( key: SlotKey ) {
 		Slot: SlotComponent,
 	};
 }
+
+export type { FillProps } from './types';

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -207,4 +207,6 @@ function UnforwardedSnackbar(
  */
 export const Snackbar = forwardRef( UnforwardedSnackbar );
 
+export type { SnackbarProps };
+
 export default Snackbar;

--- a/packages/components/src/style-provider/index.tsx
+++ b/packages/components/src/style-provider/index.tsx
@@ -45,4 +45,6 @@ export function StyleProvider( props: StyleProviderProps ) {
 	return <CacheProvider value={ cache }>{ children }</CacheProvider>;
 }
 
+export type { StyleProviderProps };
+
 export default StyleProvider;

--- a/packages/components/src/surface/index.ts
+++ b/packages/components/src/surface/index.ts
@@ -1,2 +1,4 @@
 export { default as Surface } from './component';
 export * from './hook';
+
+export type { SurfaceProps } from './types';

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -246,4 +246,7 @@ const UnforwardedTabPanel = (
 };
 
 export const TabPanel = forwardRef( UnforwardedTabPanel );
+
+export type { TabPanelProps };
+
 export default TabPanel;

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -152,3 +152,5 @@ export const Tabs = Object.assign(
 		} ),
 	}
 );
+
+export type { TabsProps } from './types';

--- a/packages/components/src/text-control/index.tsx
+++ b/packages/components/src/text-control/index.tsx
@@ -95,4 +95,6 @@ function UnforwardedTextControl(
  */
 export const TextControl = forwardRef( UnforwardedTextControl );
 
+export type { TextControlProps };
+
 export default TextControl;

--- a/packages/components/src/text-highlight/index.tsx
+++ b/packages/components/src/text-highlight/index.tsx
@@ -42,4 +42,6 @@ export const TextHighlight = ( props: TextHighlightProps ) => {
 	} );
 };
 
+export type { TextHighlightProps };
+
 export default TextHighlight;

--- a/packages/components/src/text/index.ts
+++ b/packages/components/src/text/index.ts
@@ -1,2 +1,4 @@
 export { default as Text } from './component';
 export { default as useText } from './hook';
+
+export type { Props as TextProps } from './types';

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -89,4 +89,6 @@ function UnforwardedTextareaControl(
  */
 export const TextareaControl = forwardRef( UnforwardedTextareaControl );
 
+export type { TextareaControlProps };
+
 export default TextareaControl;

--- a/packages/components/src/tip/index.tsx
+++ b/packages/components/src/tip/index.tsx
@@ -19,4 +19,6 @@ export function Tip( props: TipProps ) {
 	);
 }
 
+export type { TipProps };
+
 export default Tip;

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -133,4 +133,6 @@ function UnforwardedToggleControl(
  */
 export const ToggleControl = forwardRef( UnforwardedToggleControl );
 
+export type { ToggleControlProps };
+
 export default ToggleControl;

--- a/packages/components/src/toggle-group-control/index.ts
+++ b/packages/components/src/toggle-group-control/index.ts
@@ -1,3 +1,5 @@
 export { ToggleGroupControl } from './toggle-group-control';
 export { ToggleGroupControlOption } from './toggle-group-control-option';
 export { ToggleGroupControlOptionIcon } from './toggle-group-control-option-icon';
+
+export type { ToggleGroupControlProps } from './types';

--- a/packages/components/src/toolbar/index.ts
+++ b/packages/components/src/toolbar/index.ts
@@ -1,6 +1,10 @@
 export { default as Toolbar } from './toolbar';
+export type { ToolbarProps } from './toolbar';
 export { default as ToolbarButton } from './toolbar-button';
+export type { ToolbarButtonProps } from './toolbar-button';
 export { default as ToolbarContext } from './toolbar-context';
 export { default as ToolbarDropdownMenu } from './toolbar-dropdown-menu';
 export { default as ToolbarGroup } from './toolbar-group';
+export type { ToolbarGroupProps } from './toolbar-group';
 export { default as ToolbarItem } from './toolbar-item';
+export type { ToolbarItemProps } from './toolbar-item';

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -132,4 +132,5 @@ function UnforwardedToolbarButton(
  * ```
  */
 export const ToolbarButton = forwardRef( UnforwardedToolbarButton );
+export type { ToolbarButtonProps };
 export default ToolbarButton;

--- a/packages/components/src/toolbar/toolbar-group/index.tsx
+++ b/packages/components/src/toolbar/toolbar-group/index.tsx
@@ -116,4 +116,6 @@ function ToolbarGroup( {
 	);
 }
 
+export type { ToolbarGroupProps };
+
 export default ToolbarGroup;

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -58,4 +58,5 @@ function UnforwardedToolbarItem(
 }
 
 export const ToolbarItem = forwardRef( UnforwardedToolbarItem );
+export type { ToolbarItemProps };
 export default ToolbarItem;

--- a/packages/components/src/toolbar/toolbar/index.tsx
+++ b/packages/components/src/toolbar/toolbar/index.tsx
@@ -102,4 +102,5 @@ function UnforwardedToolbar(
  * ```
  */
 export const Toolbar = forwardRef( UnforwardedToolbar );
+export type { ToolbarProps };
 export default Toolbar;

--- a/packages/components/src/tools-panel/index.ts
+++ b/packages/components/src/tools-panel/index.ts
@@ -1,3 +1,5 @@
 export { default as ToolsPanel } from './tools-panel';
 export { default as ToolsPanelItem } from './tools-panel-item';
 export { ToolsPanelContext } from './context';
+
+export type { ToolsPanelProps } from './types';

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -159,4 +159,6 @@ function UnforwardedTooltip(
 }
 export const Tooltip = forwardRef( UnforwardedTooltip );
 
+export type { TooltipProps };
+
 export default Tooltip;

--- a/packages/components/src/tree-grid/index.tsx
+++ b/packages/components/src/tree-grid/index.tsx
@@ -387,6 +387,8 @@ function UnforwardedTreeGrid(
  */
 export const TreeGrid = forwardRef( UnforwardedTreeGrid );
 
+export type { TreeGridProps };
+
 export default TreeGrid;
 export { default as TreeGridRow } from './row';
 export { default as TreeGridCell } from './cell';

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -119,4 +119,6 @@ export function TreeSelect( props: TreeSelectProps ) {
 	);
 }
 
+export type { TreeSelectProps };
+
 export default TreeSelect;

--- a/packages/components/src/truncate/index.ts
+++ b/packages/components/src/truncate/index.ts
@@ -1,2 +1,4 @@
 export { default as Truncate } from './component';
 export { default as useTruncate } from './hook';
+
+export type { TruncateProps } from './types';

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -263,4 +263,7 @@ function UnforwardedUnitControl(
 export const UnitControl = forwardRef( UnforwardedUnitControl );
 
 export { parseQuantityAndUnitFromRawValue, useCustomUnits } from './utils';
+
+export type { UnitControlProps };
+
 export default UnitControl;

--- a/packages/components/src/v-stack/index.ts
+++ b/packages/components/src/v-stack/index.ts
@@ -1,2 +1,4 @@
 export { default as VStack } from './component';
 export { useVStack } from './hook';
+
+export type { VStackProps } from './types';

--- a/packages/components/src/visually-hidden/index.ts
+++ b/packages/components/src/visually-hidden/index.ts
@@ -1,1 +1,3 @@
 export { default as VisuallyHidden } from './component';
+
+export type { VisuallyHiddenProps } from './types';

--- a/packages/components/src/z-stack/index.ts
+++ b/packages/components/src/z-stack/index.ts
@@ -1,1 +1,3 @@
 export { default as ZStack } from './component';
+
+export type { ZStackProps } from './types';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As a part of #72032, we have added the `exports` field to many packages including `components`. This prevents what was previously possible, i.e. to import component types from `/build-types` sub-path. But, once you define `exports` for a package, you can't import from the sub-paths that are not defined in `exports` field, thus making it impossible to import type, should you need them.
So, to ensure that any consumer component is able to import and use the types for component props, we are exposing them from the root.

## Why?
To allow importing of TS types for component props.

## How?
- The PR exposes the TS types for the props only for the components that are public. Thereforce you see the explicit exports rather than the wildcard (`export * from '...'`)
- It does not expose any internal types defined in the `types.ts` files
- It does not expose the types for private components like `Badge`, `DateCalendar`, etc,

## Testing Instructions
Just verify that only the public components are exposed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
