### PR TITLE
Breadcrumbs: Add `archive` link if enabled in posts

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -276,10 +276,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  */
 function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	$post_type_object = get_post_type_object( $post_type );
-	if ( ! $post_type_object || ! $post_type_object->has_archive ) {
-		return null;
-	}
-	$archive_link = get_post_type_archive_link( $post_type );
+	$archive_link     = get_post_type_archive_link( $post_type );
 	if ( ! $archive_link ) {
 		return null;
 	}

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -283,10 +283,9 @@ function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	if ( ! $archive_link ) {
 		return null;
 	}
-	return sprintf(
-		'<a href="%s">%s</a>',
-		esc_url( $archive_link ),
-		esc_html( $post_type_object->labels->archives )
+	return block_core_breadcrumbs_create_link(
+		$archive_link,
+		$post_type_object->labels->name
 	);
 }
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -276,17 +276,18 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  */
 function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	$post_type_object = get_post_type_object( $post_type );
-	if ( $post_type_object && $post_type_object->has_archive ) {
-		$archive_link = get_post_type_archive_link( $post_type );
-		if ( $archive_link ) {
-			return sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( $archive_link ),
-				esc_html( $post_type_object->labels->name )
-			);
-		}
+	if ( ! $post_type_object || ! $post_type_object->has_archive ) {
+		return null;
 	}
-	return null;
+	$archive_link = get_post_type_archive_link( $post_type );
+	if ( ! $archive_link ) {
+		return null;
+	}
+	return sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( $archive_link ),
+		esc_html( $post_type_object->labels->archives )
+	);
 }
 
 /**

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -268,7 +268,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  * Returns the post type archive link item if the post type has archive enabled,
  * otherwise returns null.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param string $post_type The post type name.
  *

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -285,7 +285,7 @@ function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	}
 	return block_core_breadcrumbs_create_link(
 		$archive_link,
-		$post_type_object->labels->name
+		$post_type_object->labels->archives
 	);
 }
 
@@ -463,7 +463,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		if ( $post_type_object ) {
 			// Add post type (current if not paginated, link if paginated).
 			$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-				$post_type_object->labels->name,
+				$post_type_object->labels->archives,
 				$is_paged
 			);
 		}

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -26,9 +26,9 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 
 	if ( $attributes['showHomeLink'] ) {
 		if ( ! $is_home_or_front_page ) {
-			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-				home_url( '/' ),
-				__( 'Home' )
+			$breadcrumb_items[] = array(
+				'label' => __( 'Home' ),
+				'url'   => home_url( '/' ),
 			);
 		} else {
 			$breadcrumb_items[] = block_core_breadcrumbs_create_item( __( 'Home' ), block_core_breadcrumbs_is_paged() );
@@ -53,8 +53,8 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		}
 	} elseif ( is_404() ) {
 		// Handle 404 pages.
-		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
-			__( 'Page not found' )
+		$breadcrumb_items[] = array(
+			'label' => __( 'Page not found' ),
 		);
 	} elseif ( is_archive() ) {
 		// Handle archive pages (taxonomy, post type, date, author archives).
@@ -112,17 +112,17 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		$title    = block_core_breadcrumbs_get_post_title( $post );
 
 		if ( $is_paged ) {
-			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-				get_permalink( $post ),
-				$title,
-				true
+			$breadcrumb_items[] = array(
+				'label'      => $title,
+				'url'        => get_permalink( $post ),
+				'allow_html' => true,
 			);
 
 			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item( 'page' );
 		} else {
-			$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
-				$title,
-				true
+			$breadcrumb_items[] = array(
+				'label'      => $title,
+				'allow_html' => true,
 			);
 		}
 	}
@@ -150,7 +150,11 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			'',
 			array_map(
 				static function ( $item ) {
-					return '<li>' . $item . '</li>';
+					$label = ! empty( $item['allow_html'] ) ? wp_kses_post( $item['label'] ) : esc_html( $item['label'] );
+					if ( ! empty( $item['url'] ) ) {
+						return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a></li>';
+					}
+					return '<li><span aria-current="page">' . $label . '</span></li>';
 				},
 				$breadcrumb_items
 			)
@@ -177,52 +181,20 @@ function block_core_breadcrumbs_is_paged() {
  *
  * @since 7.0.0
  * @param string $query_var Optional. Query variable to get current page number. Default 'paged'.
- * @return string The "Page X" breadcrumb HTML.
+ * @return array The "Page X" breadcrumb item data.
  */
 function block_core_breadcrumbs_create_page_number_item( $query_var = 'paged' ) {
 	$paged = (int) get_query_var( $query_var );
 
-	return block_core_breadcrumbs_create_current_item(
-		/* translators: %s: page number */
-		sprintf( __( 'Page %s' ), number_format_i18n( $paged ) )
+	return array(
+		'label' => sprintf(
+			/* translators: %s: page number */
+			__( 'Page %s' ),
+			number_format_i18n( $paged )
+		),
 	);
 }
 
-/**
- * Creates a breadcrumb link item.
- *
- * @since 7.0.0
- *
- * @param string $url        The URL for the link (will be escaped).
- * @param string $text       The link text (will be escaped).
- * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
- *
- * @return string The breadcrumb link HTML.
- */
-function block_core_breadcrumbs_create_link( $url, $text, $allow_html = false ) {
-	return sprintf(
-		'<a href="%s">%s</a>',
-		esc_url( $url ),
-		$allow_html ? wp_kses_post( $text ) : esc_html( $text )
-	);
-}
-
-/**
- * Creates a breadcrumb current page item.
- *
- * @since 7.0.0
- *
- * @param string $text       The text content (will be escaped).
- * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
- *
- * @return string The breadcrumb current page HTML.
- */
-function block_core_breadcrumbs_create_current_item( $text, $allow_html = false ) {
-	return sprintf(
-		'<span aria-current="page">%s</span>',
-		$allow_html ? wp_kses_post( $text ) : esc_html( $text )
-	);
-}
 
 /**
  * Creates a breadcrumb item that's either a link or current page item.
@@ -232,17 +204,21 @@ function block_core_breadcrumbs_create_current_item( $text, $allow_html = false 
  *
  * @since 7.0.0
  *
- * @param string $text       The text content (will be escaped).
+ * @param string $text       The text content.
  * @param bool   $is_paged   Whether we're on a paginated view.
  * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
  *
- * @return string The breadcrumb HTML.
+ * @return array The breadcrumb item data.
  */
 function block_core_breadcrumbs_create_item( $text, $is_paged = false, $allow_html = false ) {
+	$item = array( 'label' => $text );
 	if ( $is_paged ) {
-		return block_core_breadcrumbs_create_link( get_pagenum_link( 1 ), $text, $allow_html );
+		$item['url'] = get_pagenum_link( 1 );
 	}
-	return block_core_breadcrumbs_create_current_item( $text, $allow_html );
+	if ( $allow_html ) {
+		$item['allow_html'] = true;
+	}
+	return $item;
 }
 
 /**
@@ -272,7 +248,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  *
  * @param string $post_type The post type name.
  *
- * @return string|null The archive breadcrumb item HTML, or null if not available.
+ * @return array|null The archive breadcrumb item data, or null if not available.
  */
 function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	$post_type_object = get_post_type_object( $post_type );
@@ -280,9 +256,9 @@ function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
 	if ( ! $archive_link ) {
 		return null;
 	}
-	return block_core_breadcrumbs_create_link(
-		$archive_link,
-		$post_type_object->labels->archives
+	return array(
+		'label' => $post_type_object->labels->archives,
+		'url'   => $archive_link,
 	);
 }
 
@@ -294,7 +270,7 @@ function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
  * @param int    $post_id   The post ID.
  * @param string $post_type The post type name.
  *
- * @return array Array of breadcrumb HTML items.
+ * @return array Array of breadcrumb item data.
  */
 function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
@@ -308,10 +284,10 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	$ancestors = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
-		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-			get_permalink( $ancestor_id ),
-			block_core_breadcrumbs_get_post_title( $ancestor_id ),
-			true
+		$breadcrumb_items[] = array(
+			'label'      => block_core_breadcrumbs_get_post_title( $ancestor_id ),
+			'url'        => get_permalink( $ancestor_id ),
+			'allow_html' => true,
 		);
 	}
 	return $breadcrumb_items;
@@ -327,7 +303,7 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
  * @param int    $term_id  The term ID.
  * @param string $taxonomy The taxonomy name.
  *
- * @return array Array of breadcrumb HTML items for ancestors.
+ * @return array Array of breadcrumb item data for ancestors.
  */
 function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) {
 	$breadcrumb_items = array();
@@ -339,9 +315,9 @@ function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) 
 		foreach ( $term_ancestors as $ancestor_id ) {
 			$ancestor_term = get_term( $ancestor_id, $taxonomy );
 			if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
-				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-					get_term_link( $ancestor_term ),
-					$ancestor_term->name
+				$breadcrumb_items[] = array(
+					'label' => $ancestor_term->name,
+					'url'   => get_term_link( $ancestor_term ),
 				);
 			}
 		}
@@ -358,7 +334,7 @@ function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) 
  *
  * @since 7.0.0
  *
- * @return array Array of breadcrumb HTML items.
+ * @return array Array of breadcrumb item data.
  */
 function block_core_breadcrumbs_get_archive_breadcrumbs() {
 	$breadcrumb_items = array();
@@ -385,16 +361,16 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		if ( $year ) {
 			if ( $month ) {
 				// Year is linked if we have month.
-				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-					get_year_link( $year ),
-					$year
+				$breadcrumb_items[] = array(
+					'label' => $year,
+					'url'   => get_year_link( $year ),
 				);
 
 				if ( $day ) {
 					// Month is linked if we have day.
-					$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-						get_month_link( $year, $month ),
-						date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) )
+					$breadcrumb_items[] = array(
+						'label' => date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ),
+						'url'   => get_month_link( $year, $month ),
 					);
 					// Add day (current if not paginated, link if paginated).
 					$breadcrumb_items[] = block_core_breadcrumbs_create_item(
@@ -493,7 +469,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
  * @param int    $post_id   The post ID.
  * @param string $post_type The post type name.
  *
- * @return array Array of breadcrumb HTML items.
+ * @return array Array of breadcrumb item data.
  */
 function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
@@ -587,9 +563,9 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 			$breadcrumb_items,
 			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy_name )
 		);
-		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-			get_term_link( $term ),
-			$term->name
+		$breadcrumb_items[] = array(
+			'label' => $term->name,
+			'url'   => get_term_link( $term ),
 		);
 	}
 	return $breadcrumb_items;

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -206,17 +206,13 @@ function block_core_breadcrumbs_create_page_number_item( $query_var = 'paged' ) 
  *
  * @param string $text       The text content.
  * @param bool   $is_paged   Whether we're on a paginated view.
- * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
  *
  * @return array The breadcrumb item data.
  */
-function block_core_breadcrumbs_create_item( $text, $is_paged = false, $allow_html = false ) {
+function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
 	$item = array( 'label' => $text );
 	if ( $is_paged ) {
 		$item['url'] = get_pagenum_link( 1 );
-	}
-	if ( $allow_html ) {
-		$item['allow_html'] = true;
 	}
 	return $item;
 }

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -102,7 +102,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 
 		// Build breadcrumb trail.
 		if ( ! $show_terms ) {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) );
 		} else {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
@@ -263,18 +263,52 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
 }
 
 /**
+ * Generates post type archive breadcrumb item.
+ *
+ * Returns the post type archive link item if the post type has archive enabled,
+ * otherwise returns null.
+ *
+ * @since 6.9.0
+ *
+ * @param string $post_type The post type name.
+ *
+ * @return string|null The archive breadcrumb item HTML, or null if not available.
+ */
+function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
+	$post_type_object = get_post_type_object( $post_type );
+	if ( $post_type_object && $post_type_object->has_archive ) {
+		$archive_link = get_post_type_archive_link( $post_type );
+		if ( $archive_link ) {
+			return sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $archive_link ),
+				esc_html( $post_type_object->labels->name )
+			);
+		}
+	}
+	return null;
+}
+
+/**
  * Generates breadcrumb items from hierarchical post type ancestors.
  *
  * @since 7.0.0
  *
- * @param int $post_id   The post ID.
+ * @param int    $post_id   The post ID.
+ * @param string $post_type The post type name.
  *
  * @return array Array of breadcrumb HTML items.
  */
-function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) {
+function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
-	$ancestors        = get_post_ancestors( $post_id );
-	$ancestors        = array_reverse( $ancestors );
+
+	$archive_item = block_core_breadcrumbs_get_post_type_archive_item( $post_type );
+	if ( $archive_item ) {
+		$breadcrumb_items[] = $archive_item;
+	}
+
+	$ancestors = get_post_ancestors( $post_id );
+	$ancestors = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
 		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
@@ -466,6 +500,12 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
  */
 function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
+
+	$archive_item = block_core_breadcrumbs_get_post_type_archive_item( $post_type );
+	if ( $archive_item ) {
+		$breadcrumb_items[] = $archive_item;
+	}
+
 	// Get public taxonomies for this post type.
 	$taxonomies = wp_filter_object_list(
 		get_object_taxonomies( $post_type, 'objects' ),
@@ -476,7 +516,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	);
 
 	if ( empty( $taxonomies ) ) {
-		return array();
+		return $breadcrumb_items;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498

This PR adds the `archive` link if enabled in posts, as it seems like a good default to have for the breadcrumbs. 



## Testing Instructions
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various pages in the front end.
3. Test with custom post types with `has_archive` enabled and disabled.


## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added @justintadlock's [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in the main header.
Above is x3p0-breadcrumbs/ and below is the core block.

### CPT with terms

<img width="621" height="122" alt="Screenshot 2025-11-17 at 9 21 49 AM" src="https://github.com/user-attachments/assets/97be66b9-dd63-4894-92e9-f63e3d8091c3" />


### CPT without terms
<img width="621" height="122" alt="Screenshot 2025-11-17 at 9 24 45 AM" src="https://github.com/user-attachments/assets/99cf6cf1-7ac6-43e0-97fd-b6cdb38e924b" />


### Hierarchical CPT with ancestors

<img width="621" height="122" alt="Screenshot 2025-11-17 at 9 26 00 AM" src="https://github.com/user-attachments/assets/33128cea-530c-4a26-9cbf-8e2bdcb4c226" />




