### PR TITLE
Hide add note in distraction free mode

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -167,30 +167,28 @@ function NotesSidebar( { postId, mode } ) {
 			{ ! isDistractionFree && (
 				<AddCommentMenuItem onClick={ openTheSidebar } />
 			) }
-			{ ! isDistractionFree && (
-				<PluginSidebar
-					identifier={ collabHistorySidebarName }
-					name={ collabHistorySidebarName }
-					title={ __( 'All notes' ) }
-					header={
-						<h2 className="interface-complementary-area-header__title">
-							{ __( 'All notes' ) }
-						</h2>
-					}
-					icon={ commentIcon }
-					closeLabel={ __( 'Close Notes' ) }
-				>
-					<NotesSidebarContent
-						comments={ resultComments }
-						showCommentBoard={ showCommentBoard }
-						setShowCommentBoard={ setShowCommentBoard }
-						commentSidebarRef={ commentSidebarRef }
-						reflowComments={ reflowComments }
-						commentLastUpdated={ commentLastUpdated }
-					/>
-				</PluginSidebar>
-			) }
-			{ isLargeViewport && ! isDistractionFree && (
+			<PluginSidebar
+				identifier={ collabHistorySidebarName }
+				name={ collabHistorySidebarName }
+				title={ __( 'All notes' ) }
+				header={
+					<h2 className="interface-complementary-area-header__title">
+						{ __( 'All notes' ) }
+					</h2>
+				}
+				icon={ commentIcon }
+				closeLabel={ __( 'Close Notes' ) }
+			>
+				<NotesSidebarContent
+					comments={ resultComments }
+					showCommentBoard={ showCommentBoard }
+					setShowCommentBoard={ setShowCommentBoard }
+					commentSidebarRef={ commentSidebarRef }
+					reflowComments={ reflowComments }
+					commentLastUpdated={ commentLastUpdated }
+				/>
+			</PluginSidebar>
+			{ isLargeViewport && (
 				<PluginSidebar
 					isPinnable={ false }
 					header={ false }
@@ -218,17 +216,22 @@ function NotesSidebar( { postId, mode } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const { postId, mode, editorMode } = useSelect( ( select ) => {
-		const { getCurrentPostId, getRenderingMode, getEditorMode } =
-			select( editorStore );
-		return {
-			postId: getCurrentPostId(),
-			mode: getRenderingMode(),
-			editorMode: getEditorMode(),
-		};
-	}, [] );
+	const { postId, mode, editorMode, isDistractionFree } = useSelect(
+		( select ) => {
+			const { getCurrentPostId, getRenderingMode, getEditorMode } =
+				select( editorStore );
+			const { getSettings } = select( blockEditorStore );
+			return {
+				postId: getCurrentPostId(),
+				mode: getRenderingMode(),
+				editorMode: getEditorMode(),
+				isDistractionFree: getSettings().isDistractionFree,
+			};
+		},
+		[]
+	);
 
-	if ( ! postId || typeof postId !== 'number' ) {
+	if ( ! postId || typeof postId !== 'number' || isDistractionFree ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -99,6 +99,12 @@ function NotesSidebar( { postId, mode } ) {
 		};
 	}, [] );
 
+	const isDistractionFree = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().isDistractionFree,
+		[]
+	);
+
 	const {
 		resultComments,
 		unresolvedSortedThreads,
@@ -152,35 +158,39 @@ function NotesSidebar( { postId, mode } ) {
 
 	return (
 		<>
-			{ blockCommentId && (
+			{ blockCommentId && ! isDistractionFree && (
 				<CommentAvatarIndicator
 					thread={ currentThread }
 					onClick={ openTheSidebar }
 				/>
 			) }
-			<AddCommentMenuItem onClick={ openTheSidebar } />
-			<PluginSidebar
-				identifier={ collabHistorySidebarName }
-				name={ collabHistorySidebarName }
-				title={ __( 'All notes' ) }
-				header={
-					<h2 className="interface-complementary-area-header__title">
-						{ __( 'All notes' ) }
-					</h2>
-				}
-				icon={ commentIcon }
-				closeLabel={ __( 'Close Notes' ) }
-			>
-				<NotesSidebarContent
-					comments={ resultComments }
-					showCommentBoard={ showCommentBoard }
-					setShowCommentBoard={ setShowCommentBoard }
-					commentSidebarRef={ commentSidebarRef }
-					reflowComments={ reflowComments }
-					commentLastUpdated={ commentLastUpdated }
-				/>
-			</PluginSidebar>
-			{ isLargeViewport && (
+			{ ! isDistractionFree && (
+				<AddCommentMenuItem onClick={ openTheSidebar } />
+			) }
+			{ ! isDistractionFree && (
+				<PluginSidebar
+					identifier={ collabHistorySidebarName }
+					name={ collabHistorySidebarName }
+					title={ __( 'All notes' ) }
+					header={
+						<h2 className="interface-complementary-area-header__title">
+							{ __( 'All notes' ) }
+						</h2>
+					}
+					icon={ commentIcon }
+					closeLabel={ __( 'Close Notes' ) }
+				>
+					<NotesSidebarContent
+						comments={ resultComments }
+						showCommentBoard={ showCommentBoard }
+						setShowCommentBoard={ setShowCommentBoard }
+						commentSidebarRef={ commentSidebarRef }
+						reflowComments={ reflowComments }
+						commentLastUpdated={ commentLastUpdated }
+					/>
+				</PluginSidebar>
+			) }
+			{ isLargeViewport && ! isDistractionFree && (
 				<PluginSidebar
 					isPinnable={ false }
 					header={ false }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -99,12 +99,6 @@ function NotesSidebar( { postId, mode } ) {
 		};
 	}, [] );
 
-	const isDistractionFree = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree,
-		[]
-	);
-
 	const {
 		resultComments,
 		unresolvedSortedThreads,
@@ -158,15 +152,13 @@ function NotesSidebar( { postId, mode } ) {
 
 	return (
 		<>
-			{ blockCommentId && ! isDistractionFree && (
+			{ blockCommentId && (
 				<CommentAvatarIndicator
 					thread={ currentThread }
 					onClick={ openTheSidebar }
 				/>
 			) }
-			{ ! isDistractionFree && (
-				<AddCommentMenuItem onClick={ openTheSidebar } />
-			) }
+			<AddCommentMenuItem onClick={ openTheSidebar } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
 				name={ collabHistorySidebarName }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/72824

## Why?
When working in Distraction-Free Mode, the Add Notes option in the Block Toolbar does not display the New Note form or trigger any visible action.

## How?
Visually hide the Add note button

## Testing Instructions
1. Open a post or page.
2. Switch to distraction free mode.

## Screenshots or screencast 

https://github.com/user-attachments/assets/bee20967-63d0-4c57-88d8-781ca09ae93c


