### PR TITLE
Heading block: Make background padding more specific to block

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,9 +1,3 @@
-// The .wp-block-accordion selector is needed to make this CSS stronger
-// than the default heading padding when background color is applied.
-.wp-block-accordion .wp-block-accordion-heading {
-	padding: 0;
-}
-
 .wp-block-accordion-heading__toggle {
 	font-family: inherit;
 	font-size: inherit;

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -6,7 +6,7 @@ h3,
 h4,
 h5,
 h6 {
-	&.wp-block-heading.has-background {
+	&:where(.wp-block-heading).has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}
 	&.has-text-align-right[style*="writing-mode"]:where([style*="vertical-rl"]),

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -6,7 +6,7 @@ h3,
 h4,
 h5,
 h6 {
-	&.has-background {
+	&.wp-block-heading.has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}
 	&.has-text-align-right[style*="writing-mode"]:where([style*="vertical-rl"]),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72776

An alternative fix to https://github.com/WordPress/gutenberg/pull/72046

This makes the `.has-background` padding more specific to the heading block, rather than to the heading element tags (`h1`, `h2`, `h3`, etc), to prevent it from being applied to other blocks that use heading elements (e.g. the Accordion Heading).

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent these specific styles from being applied to other blocks, and allow other blocks to override padding via theme.json.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the `.wp-block-heading` class to the existing `.has-background` padding CSS rule. Also removes a previous fix for the Accordion Heading block that should no longer be required.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert an Accordion block
2. Apply a background to an Accordion Heading block
3. Make sure that there is no additional padding applied in the editor or on the front end when the background color is applied
4. Add the below theme.json snippet to your theme's theme.json file
5. Ensure that the padding from theme.json is applied correctly to the Accordion Heading block

Example theme.json snippet:

```
"blocks": {
    "core/accordion-heading": {
        "spacing": {
            "padding": {
                "left": "0.3em",
                "right": "0.3em"
            }
        }
    }
}
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1715" height="903" alt="image" src="https://github.com/user-attachments/assets/ad778984-f41a-4ae2-8d54-824a8de2de0e" /> | <img width="1715" height="903" alt="image" src="https://github.com/user-attachments/assets/5c854e86-a06e-4d77-8f8f-6a5a956b4415" /> |
