### PR TITLE
Breadcrumbs: Add home page handling and `show last item` attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -93,7 +93,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showHomeLink
+-	**Attributes:** prefersTaxonomy, separator, showHomeLink, showLastItem, showOnHomePage
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -19,6 +19,14 @@
 		"showHomeLink": {
 			"type": "boolean",
 			"default": true
+		},
+		"showLastItem": {
+			"type": "boolean",
+			"default": true
+		},
+		"showOnHomePage": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "templateSlug" ],

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -260,11 +260,14 @@ export default function BreadcrumbEdit( {
 			<InspectorControls group="advanced">
 				<CheckboxControl
 					__nextHasNoMarginBottom
-					label={ __( 'Show on home page' ) }
+					label={ __( 'Show on homepage' ) }
 					checked={ showOnHomePage }
 					onChange={ ( value ) =>
 						setAttributes( { showOnHomePage: value } )
 					}
+					help={ __(
+						'If this breadcrumbs block appears in a template or template part that’s shown on the homepage, enable this option to display the breadcrumb trail. Otherwise, this setting has no effect.'
+					) }
 				/>
 				<CheckboxControl
 					__nextHasNoMarginBottom

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -28,7 +28,13 @@ export default function BreadcrumbEdit( {
 	setAttributes,
 	context: { postId, postType, templateSlug },
 } ) {
-	const { separator, showHomeLink, prefersTaxonomy } = attributes;
+	const {
+		separator,
+		showHomeLink,
+		showLastItem,
+		prefersTaxonomy,
+		showOnHomePage,
+	} = attributes;
 	const {
 		post,
 		isPostTypeHierarchical,
@@ -160,9 +166,11 @@ export default function BreadcrumbEdit( {
 							</a>
 						</li>
 					) ) }
-					<li>
-						<span aria-current="page">{ __( 'Current' ) }</span>
-					</li>
+					{ showLastItem && (
+						<li>
+							<span aria-current="page">{ __( 'Current' ) }</span>
+						</li>
+					) }
 				</ol>
 			</nav>
 		);
@@ -176,6 +184,7 @@ export default function BreadcrumbEdit( {
 						setAttributes( {
 							separator: separatorDefaultValue,
 							showHomeLink: true,
+							showLastItem: true,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -197,6 +206,25 @@ export default function BreadcrumbEdit( {
 								setAttributes( { showHomeLink: value } )
 							}
 							checked={ showHomeLink }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Show last item' ) }
+						isShownByDefault
+						hasValue={ () => ! showLastItem }
+						onDeselect={ () =>
+							setAttributes( {
+								showLastItem: true,
+							} )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show last item' ) }
+							onChange={ ( value ) =>
+								setAttributes( { showLastItem: value } )
+							}
+							checked={ showLastItem }
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
@@ -230,6 +258,17 @@ export default function BreadcrumbEdit( {
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls group="advanced">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Show on home page' ) }
+					checked={ showOnHomePage }
+					onChange={ ( value ) =>
+						setAttributes( { showOnHomePage: value } )
+					}
+					help={ __(
+						'Display breadcrumbs on the site front page and blog posts index.'
+					) }
+				/>
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Prefer taxonomy terms' ) }

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -265,9 +265,6 @@ export default function BreadcrumbEdit( {
 					onChange={ ( value ) =>
 						setAttributes( { showOnHomePage: value } )
 					}
-					help={ __(
-						'Display breadcrumbs on the site front page and blog posts index.'
-					) }
 				/>
 				<CheckboxControl
 					__nextHasNoMarginBottom

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -17,23 +17,34 @@
  * @return string Returns the post breadcrumb for hierarchical post types.
  */
 function render_block_core_breadcrumbs( $attributes, $content, $block ) {
-	// Exclude breadcrumbs from special contexts.
-	if ( is_home() || is_front_page() ) {
+	$is_home_or_front_page = is_home() || is_front_page();
+	if ( ! $attributes['showOnHomePage'] && $is_home_or_front_page ) {
 		return '';
 	}
 
 	$breadcrumb_items = array();
 
 	if ( $attributes['showHomeLink'] ) {
-		$breadcrumb_items[] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( home_url() ),
-			esc_html__( 'Home' )
-		);
+		// On home/front page, show as current page instead of link.
+		if ( $is_home_or_front_page ) {
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				esc_html__( 'Home' )
+			);
+		} else {
+			$breadcrumb_items[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( home_url() ),
+				esc_html__( 'Home' )
+			);
+		}
 	}
 
-	// Handle search results.
-	if ( is_search() ) {
+	// Handle home and front page.
+	if ( $is_home_or_front_page ) {
+		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+	} elseif ( is_search() ) {
+		// Handle search results.
 		$search_query       = get_search_query();
 		$breadcrumb_items[] = sprintf(
 			'<span aria-current="page">%s</span>',
@@ -90,6 +101,11 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			$title = __( '(no title)' );
 		}
 		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', $title );
+	}
+
+	// Remove last item if disabled.
+	if ( ! $attributes['showLastItem'] && ! empty( $breadcrumb_items ) ) {
+		array_pop( $breadcrumb_items );
 	}
 
 	if ( empty( $breadcrumb_items ) ) {

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -34,7 +34,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		} else {
 			$breadcrumb_items[] = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( home_url() ),
+				esc_url( home_url( '/' ) ),
 				esc_html__( 'Home' )
 			);
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498 and https://github.com/WordPress/gutenberg/issues/72649

<!-- In a few words, what is the PR actually doing? -->

This PR does a couple of things:
1. Add front page / home handling with a new attribute that checks whether to render the block in that case. In the case of `is_home() && is_paged()` it also shows the page trail. This setting is only useful when the user would want to have a single breadcrumbs block in the site header and is similar to `Prefer taxonomy terms` setting. That's the reason I've added it under `advanced`. We could leave it there or we could consider a different design for showing/editing these two attributes. --cc @jasmussen 
<img width="286" height="609" alt="Screenshot 2025-10-30 at 3 57 12 PM" src="https://github.com/user-attachments/assets/5257c930-ea25-4a7b-a856-077fcc18e73e" />

2. Adds a new attribute whether to show the last breadcrumb item. 

## Testing Instructions
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various pages in the front end.
4. Test front page visibility based on the new attribute (inspector controls).
5. Test by updating the value of `show last item` attribute
6. For testing pagination it's easier if you set the number of posts to `one` in reading settings. 

## Screenshots or screencast <!-- if applicable -->

<img width="668" height="116" alt="Screenshot 2025-10-30 at 3 48 03 PM" src="https://github.com/user-attachments/assets/bf7ae57a-c65c-4465-96a8-e173e6ad6a30" />

