### PR TITLE
Fix: Don't load fit text front end scripts on the editor.

### DIFF
--- a/backport-changelog/6.9/10437.md
+++ b/backport-changelog/6.9/10437.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10437
+
+* https://github.com/WordPress/gutenberg/pull/72842

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -244,7 +244,7 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
  * @return string                Filtered block content.
  */
 function gutenberg_render_typography_support( $block_content, $block ) {
-	if ( ! empty( $block['attrs']['fitText'] ) ) {
+	if ( ! is_admin() && ! empty( $block['attrs']['fitText'] ) ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 	}
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -244,7 +244,7 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
  * @return string                Filtered block content.
  */
 function gutenberg_render_typography_support( $block_content, $block ) {
-	if ( ! is_admin() && ! empty( $block['attrs']['fitText'] ) ) {
+	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 	}
 

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -304,6 +304,61 @@ test.describe( 'Fit Text', () => {
 				},
 			] );
 		} );
+
+		test( 'should not load frontend script when editing a saved post with fit text', async ( {
+			admin,
+			editor,
+			page,
+		} ) => {
+			// Create a post with fit text
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			// Save the post
+			const postId = await editor.publishPost();
+
+			// Navigate to edit the saved post
+			await admin.editPost( postId );
+
+			// Wait for the editor to load
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
+			await expect( headingBlock ).toBeVisible();
+			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
+
+			// Verify the post still has the fitText attribute
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: 'Test Heading',
+						level: 2,
+						fitText: true,
+					},
+				},
+			] );
+
+			// Check that the frontend script module is NOT loaded in the editor
+			const frontendScriptLoaded = await page.evaluate( () => {
+				// Check for script modules with the fit-text-frontend path
+				const scripts = Array.from(
+					document.querySelectorAll( 'script[type="module"]' )
+				);
+				return scripts.some( ( script ) =>
+					script.src.includes( 'fit-text-frontend' )
+				);
+			} );
+
+			// Verify the frontend script did not load in the editor
+			expect( frontendScriptLoaded ).toBe( false );
+		} );
 	} );
 
 	test.describe( 'Frontend functionality', () => {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -310,7 +310,6 @@ test.describe( 'Fit Text', () => {
 			editor,
 			page,
 		} ) => {
-			// Create a post with fit text
 			await editor.insertBlock( {
 				name: 'core/heading',
 				attributes: {
@@ -320,20 +319,16 @@ test.describe( 'Fit Text', () => {
 				},
 			} );
 
-			// Save the post
 			const postId = await editor.publishPost();
 
-			// Navigate to edit the saved post
 			await admin.editPost( postId );
 
-			// Wait for the editor to load
+
 			const headingBlock = editor.canvas.locator(
 				'[data-type="core/heading"]'
 			);
 			await expect( headingBlock ).toBeVisible();
-			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 
-			// Verify the post still has the fitText attribute
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/heading',
@@ -347,7 +342,6 @@ test.describe( 'Fit Text', () => {
 
 			// Check that the frontend script module is NOT loaded in the editor
 			const frontendScriptLoaded = await page.evaluate( () => {
-				// Check for script modules with the fit-text-frontend path
 				const scripts = Array.from(
 					document.querySelectorAll( 'script[type="module"]' )
 				);
@@ -355,8 +349,6 @@ test.describe( 'Fit Text', () => {
 					script.src.includes( 'fit-text-frontend' )
 				);
 			} );
-
-			// Verify the frontend script did not load in the editor
 			expect( frontendScriptLoaded ).toBe( false );
 		} );
 	} );

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -323,7 +323,6 @@ test.describe( 'Fit Text', () => {
 
 			await admin.editPost( postId );
 
-
 			const headingBlock = editor.canvas.locator(
 				'[data-type="core/heading"]'
 			);


### PR DESCRIPTION
This PR fixes an issue where the FitText frontend script (`fit-text-frontend.js`) was incorrectly being enqueued and loaded in the block editor when editing posts that contain blocks with the `fitText` attribute enabled. It had no big impact has the script does not do anything on the editor (the classes the script searches are not there) but still it's useless bytes we are sending.
We are enqueuing using exactly the same pattern as in other blocks, like file. image, or form I suspect in some of theses cases the front end script is also loading on the editor when it is non needed, something we can try to improve after.

## Testing Instructions

### 1. Verify E2E tests pass

Run the FitText e2e tests:
```bash
npm run test:e2e -- test/e2e/specs/editor/blocks/fit-text.spec.js
```

All tests should pass, including the new test "should not load frontend script when editing a saved post with fit text".

### 2. Verify the fix prevents the issue

**Revert the fix to see the failure:**
```bash
git checkout trunk -- lib/block-supports/typography.php
```

Run the e2e test again:
```bash
npm run test:e2e -- test/e2e/specs/editor/blocks/fit-text.spec.js -g "should not load frontend script"
```

The test should now **fail**, demonstrating that without the fix, the frontend script loads in the editor.

**Restore the fix:**
```bash
git checkout HEAD -- lib/block-supports/typography.php
```

### 3. Manual verification (optional)

**Add a temporary alert for visual confirmation:**

Add this line at the end of `packages/block-editor/src/utils/fit-text-frontend.js` (after line 84):
```javascript
alert('fit-text-frontend.js loaded');
```

**Test with this PR's changes:**
1. Create a new post
2. Add a Heading or Paragraph block
3. Enable "Fit text" in the Typography settings
4. Save the post
5. Reload/reopen the post in the editor
6. **Expected:** No alert appears (script did not load in editor)
7. View the post on the frontend
8. **Expected:** Alert appears (script loads correctly on frontend)

**Test on trunk (without fix):**
1. Checkout trunk: `git checkout trunk`
2. Repeat steps 1-5 above
3. **Expected:** Alert appears when editing (bug - script incorrectly loads in editor)

**Verify fit text still works, on this branch on both the editor and front end.**

** Test with customizer **
Use a theme with customizer support like "Twenty Sixteen", add post with fit text, and then open the customizer navigate to that post and verify fit text still works.
