### PR TITLE
Block Notes: Adjust note date tooltip position.

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -94,7 +94,7 @@ function CommentAuthorInfo( { avatar, name, date, userId } ) {
 					{ name ?? currentUserName }
 				</span>
 				{ date && (
-					<Tooltip placement="bottom" text={ tooltipText }>
+					<Tooltip text={ tooltipText }>
 						<time
 							dateTime={ commentDateTime }
 							className="editor-collab-sidebar-panel__user-time"

--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -94,7 +94,7 @@ function CommentAuthorInfo( { avatar, name, date, userId } ) {
 					{ name ?? currentUserName }
 				</span>
 				{ date && (
-					<Tooltip placement="top" text={ tooltipText }>
+					<Tooltip placement="bottom" text={ tooltipText }>
 						<time
 							dateTime={ commentDateTime }
 							className="editor-collab-sidebar-panel__user-time"


### PR DESCRIPTION
This fixes an issue where the note date tooltip would cover the comment author information.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72823


## Testing Instructions
1. Open a post
2. Add a note to a block
3. In the Notes sidebar panel, activate a note.
4. Hover over the note date / time since posted. Confirm that the tooltip shows up beneath the note author info.
