### PR TITLE
Try: Enable `@view-transition { navigation: auto }` for wp-admin

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -72,3 +72,9 @@ function gutenberg_pre_init() {
 
 	require_once __DIR__ . '/lib/load.php';
 }
+
+add_action( 'admin_enqueue_scripts', function () {
+	wp_register_style( 'admin-inline-style', false );
+	wp_enqueue_style( 'admin-inline-style' );
+	wp_add_inline_style( 'admin-inline-style', '@view-transition { navigation: auto; }' );
+} );


### PR DESCRIPTION
## What?
Experiments with `@view-transition { navigation: auto; }` in all of wp-admin.

This PR just aims to test the water and get feedback. DO NOT MERGE. 

## Why?
Mostly as a one-liner experiment, and to get feedback.

Note that there is already a much more [feature-rich feature plugin for view transitions](https://wordpress.org/plugins/view-transitions/), but the goal here isn't to reach that, but rather to see how far we can get with a single line of CSS.

## How?
Just registering and enqueuing a dummy style across all of WP admin.
Note that view transitions aren't supported on some browsers just yet, but this can be seen as a progressive visual enhancement.
This is not production-ready -  if we're to do it right, it will just be added to one of the global WP admin stylesheets. 

## Testing Instructions
* Open wp-admin
* Navigate between screens
* Observe smooth transitions between screens 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Before:


https://github.com/user-attachments/assets/ab20656d-d241-4ebf-a720-1b052ac26cb6



After:

https://github.com/user-attachments/assets/ec7830b4-bad2-43b7-bbf0-165a2f7cdfb0

