### PR TITLE
Remove useSelect subscription for data that does not need to be reactive

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -61,11 +61,9 @@ const EditWithGeneratedProps = ( props ) => {
 	const registry = useRegistry();
 	const blockType = getBlockType( name );
 	const blockContext = useContext( BlockContext );
-	const registeredSources = useSelect(
-		( select ) =>
-			unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
-		[]
-	);
+	// Get block bindings sources imperatively (no observer - it's a static registry).
+	const { getAllBlockBindingsSources } = unlock( useSelect( blocksStore ) );
+	const registeredSources = getAllBlockBindingsSources();
 	const { bindableAttributes } = useContext( PrivateBlockContext );
 
 	const { blockBindings, context, hasPatternOverrides } = useMemo( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
`getAllBlockBindingsSources()` was called via `useSelect` with empty dependencies in `EditWithGeneratedProps`, which wraps every block. This creates a new observer on `core/blocks` for every block. While the blocksStore rarely updates, it's cleaner to not need an extra observer for every block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We can get the value without needing it to be a subscription. This would only show up as a performance issue for tests that include many blocks on them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace the `useSelect( ( selector ) => {}, [] )` which creates a subscription in favor of `const { getAllBlockBindingsSources } = unlock( useSelect( blocksStore ) );` which does not create a the subscription. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no changes from trunk

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
