### PR TITLE
Latest Comments: Add option to exclude post author

### DIFF
--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -26,6 +26,10 @@
 			"type": "string",
 			"default": "excerpt",
 			"enum": [ "none", "excerpt", "full" ]
+		},
+		"excludePostAuthor": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -32,7 +32,7 @@ const MIN_COMMENTS = 1;
 const MAX_COMMENTS = 100;
 
 export default function LatestComments( { attributes, setAttributes } ) {
-	const { commentsToShow, displayAvatar, displayDate, displayContent } =
+	const { commentsToShow, displayAvatar, displayDate, displayContent, excludePostAuthor } =
 		attributes;
 
 	const serverSideAttributes = {
@@ -56,6 +56,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 							displayAvatar: true,
 							displayDate: true,
 							displayContent: 'excerpt',
+							excludePostAuthor: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -121,6 +122,27 @@ export default function LatestComments( { attributes, setAttributes } ) {
 									displayContent: value,
 								} )
 							}
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => excludePostAuthor }
+						label={ __( 'Exclude post author' ) }
+						onDeselect={ () =>
+							setAttributes( { excludePostAuthor: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Exclude post author' ) }
+							checked={ excludePostAuthor }
+							onChange={ () =>
+								setAttributes( {
+									excludePostAuthor: ! excludePostAuthor,
+								} )
+							}
+							help={ __( 'Hide comments from the post author.' ) }
 						/>
 					</ToolsPanelItem>
 

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -50,6 +50,8 @@ function render_block_core_latest_comments( $attributes ) {
 		$display_content = isset( $attributes['displayContent'] ) ? $attributes['displayContent'] : 'excerpt';
 	}
 
+	$exclude_post_author = isset( $attributes['excludePostAuthor'] ) ? $attributes['excludePostAuthor'] : false;
+
 	$comments = get_comments(
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
 		apply_filters(
@@ -62,6 +64,23 @@ function render_block_core_latest_comments( $attributes ) {
 			array()
 		)
 	);
+
+	if ( $exclude_post_author && ! empty( $comments ) ) {
+		$comments = array_filter(
+			$comments,
+			function ( $comment ) {
+				$post = get_post( $comment->comment_post_ID );
+				if ( ! $post ) {
+					return true;
+				}
+				$post_author_id = (int) $post->post_author;
+
+				$comment_author_id = (int) $comment->user_id;
+
+				return $comment_author_id === 0 || $comment_author_id !== $post_author_id;
+			}
+		);
+	}
 
 	$list_items_markup = '';
 	if ( ! empty( $comments ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #72845

Adds an "Exclude post author" option to the Latest Comments block, allowing users to filter out comments made by the post author from the displayed list.

## Why?

Currently, the Latest Comments block displays all comments including replies from the blog author. For blogs where authors actively reply to comments, this can clutter the "Latest Comments" list with the author's own responses instead of highlighting community engagement and reader feedback. This feature gives users control over whether to show or hide the post author's comments in the Latest Comments block.

## How?

- Added `excludePostAuthor` boolean attribute to `block.json` (default: `false`)
- Added a ToggleControl in `edit.js` settings panel to control the filtering option
- Implemented filtering logic in `index.php` using `array_filter()` to exclude comments where `comment.user_id` matches `post.post_author`
- Filtering only applies when `excludePostAuthor` is set to `true`
- Comments from non-registered users (`user_id = 0`) are always preserved regardless of the setting
- No database queries are modified; filtering is performed in memory after retrieving comments

## Testing Instructions

### Basic Functionality:

1. Create or open a post with comments
2. As the post author, add some replies to existing comments (you must be logged in as the post author)
3. Insert a **Latest Comments** block
4. Open the block settings panel on the right sidebar
5. Verify you see a new toggle labeled **"Exclude post author"** with help text "Hide comments from the post author."
6. By default (unchecked), all comments should be visible including the post author's replies
7. **Check** the "Exclude post author" toggle
8. The post author's replies should disappear from the preview, showing only visitor comments
9. **Uncheck** the toggle
10. The post author's replies should reappear
11. Save the post and view it on the frontend
12. Verify the filtering works correctly on the frontend as well

### Edge Cases:

13. **Non-registered users**: Add comments without being logged in - these should always display regardless of the toggle setting
14. **Multiple posts with different authors**: Create posts by different authors and verify each post correctly filters only that specific post author's comments
15. **All comments from author**: Create a scenario where all comments are from the post author, enable the filter, and verify the "No comments to show." message appears
16. **Backward compatibility**: Open an existing Latest Comments block (one created before this change) and verify it still works with all comments shown by default

### Testing Instructions for Keyboard

1. Insert a Latest Comments block
2. Press `Tab` to navigate through the block toolbar to the settings panel
3. Continue pressing `Tab` until you reach the "Exclude post author" toggle
4. Press `Space` or `Enter` to toggle the checkbox on/off
5. Verify the block preview updates accordingly when toggled
6. Verify focus remains on or near the toggle after activation
7. Use a screen reader to verify the toggle label, state, and help text are properly announced
8. Ensure all other keyboard navigation (Display avatar, Display date, Display content, Number of comments) continues to work correctly

## Screenshots or screencast
<img width="279" height="548" alt="Screenshot 2025-10-31 at 2 20 50 AM" src="https://github.com/user-attachments/assets/c248be1e-d566-4d01-bc32-5ac5716def24" />


### Settings Panel View:
- Display avatar: [Toggle]
- Display date: [Toggle]
- Display content: [Dropdown]
- **Exclude post author: [Toggle]** ← New
- Number of comments: [Slider]

## Additional Notes

- This is a new feature; no deprecation logic is needed
- Default value is `false` to maintain existing behavior (show all comments)
- No performance impact - filtering is done in memory on already-fetched comments
- Works seamlessly with existing Latest Comments block features (display content options, avatar, date, etc.)