### PR TITLE
Real-time collaboration: Fix persisted document meta and add tests

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -294,8 +294,8 @@ export function getPostChangesFromCRDTDoc(
 				}
 
 				case 'date': {
-					// Do not sync an empty date if our current value is a "floating" date.
-					// Borrowing logic from the isEditedPostDateFloating selector.
+					// Do not overwrite a "floating" date. Borrowing logic from the
+					// isEditedPostDateFloating selector.
 					const currentDateIsFloating =
 						[ 'draft', 'auto-draft', 'pending' ].includes(
 							ymap.get( 'status' ) as string
@@ -303,7 +303,7 @@ export function getPostChangesFromCRDTDoc(
 						( null === currentValue ||
 							editedRecord.modified === currentValue );
 
-					if ( ! newValue && currentDateIsFloating ) {
+					if ( currentDateIsFloating ) {
 						return false;
 					}
 

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -269,7 +269,7 @@ describe( 'crdt', () => {
 			expect( changes ).not.toHaveProperty( 'status' );
 		} );
 
-		it( 'does not sync empty date for floating dates', () => {
+		it( 'does not overwrite null floating date', () => {
 			map.set( 'status', 'draft' );
 			map.set( 'date', '' );
 
@@ -279,13 +279,52 @@ describe( 'crdt', () => {
 				modified: '2025-01-01',
 			} as unknown as Post;
 
-			const changes = getPostChangesFromCRDTDoc(
+			const changesWithEmptyDate = getPostChangesFromCRDTDoc(
 				doc,
 				editedRecord,
 				mockPostType
 			);
 
-			expect( changes ).not.toHaveProperty( 'date' );
+			expect( changesWithEmptyDate ).not.toHaveProperty( 'date' );
+
+			map.set( 'date', '2025-01-02' );
+
+			const changesWithDefinedDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithDefinedDate ).not.toHaveProperty( 'date' );
+		} );
+
+		it( 'does not overwrite defined floating date', () => {
+			map.set( 'status', 'draft' );
+			map.set( 'date', '' );
+
+			const editedRecord = {
+				status: 'draft',
+				date: '2025-01-01', // matches modified
+				modified: '2025-01-01',
+			} as unknown as Post;
+
+			const changesWithEmptyDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithEmptyDate ).not.toHaveProperty( 'date' );
+
+			map.set( 'date', '2025-01-02' );
+
+			const changesWithDefinedDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithDefinedDate ).not.toHaveProperty( 'date' );
 		} );
 
 		it( 'includes blocks in changes', () => {

--- a/packages/sync/src/test/utils.ts
+++ b/packages/sync/src/test/utils.ts
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import * as Y from 'yjs';
+import * as buffer from 'lib0/buffer';
+import { describe, expect, it, beforeEach } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import { createYjsDoc, serializeCrdtDoc, deserializeCrdtDoc } from '../utils';
+import {
+	CRDT_DOC_META_PERSISTENCE_KEY,
+	CRDT_DOC_VERSION,
+	CRDT_STATE_MAP_KEY,
+	CRDT_STATE_VERSION_KEY,
+} from '../config';
+
+describe( 'utils', () => {
+	describe( 'createYjsDoc', () => {
+		it( 'creates a Y.Doc with metadata', () => {
+			const documentMeta = {
+				userId: '123',
+				entityType: 'post',
+			};
+
+			const ydoc = createYjsDoc( documentMeta );
+
+			expect( ydoc ).toBeInstanceOf( Y.Doc );
+			expect( ydoc.meta ).toBeDefined();
+			expect( ydoc.meta?.get( 'userId' ) ).toBe( '123' );
+			expect( ydoc.meta?.get( 'entityType' ) ).toBe( 'post' );
+		} );
+
+		it( 'creates a Y.Doc with empty metadata', () => {
+			const ydoc = createYjsDoc();
+
+			expect( ydoc ).toBeInstanceOf( Y.Doc );
+			expect( ydoc.meta ).toBeDefined();
+			expect( ydoc.meta?.size ).toBe( 0 );
+		} );
+
+		it( 'sets the CRDT document version in the state map', () => {
+			const ydoc = createYjsDoc( {} );
+			const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
+
+			expect( stateMap.get( CRDT_STATE_VERSION_KEY ) ).toBe(
+				CRDT_DOC_VERSION
+			);
+		} );
+	} );
+
+	describe( 'serializeCrdtDoc', () => {
+		let testDoc: Y.Doc;
+
+		beforeEach( () => {
+			testDoc = createYjsDoc();
+		} );
+
+		it( 'serializes a CRDT doc with data', () => {
+			const ymap = testDoc.getMap( 'testMap' );
+			ymap.set( 'title', 'Test Title' );
+			ymap.set( 'content', 'Test Content' );
+
+			const serialized = serializeCrdtDoc( testDoc );
+			const parsed = JSON.parse( serialized );
+
+			expect( parsed ).toHaveProperty( 'document' );
+			expect( typeof parsed.document ).toBe( 'string' );
+			expect( parsed.document.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	describe( 'deserializeCrdtDoc', () => {
+		let originalDoc: Y.Doc;
+		let serialized: string;
+
+		beforeEach( () => {
+			originalDoc = createYjsDoc();
+			const ymap = originalDoc.getMap( 'testMap' );
+			ymap.set( 'title', 'Test Title' );
+			ymap.set( 'count', 42 );
+			serialized = serializeCrdtDoc( originalDoc );
+		} );
+
+		it( 'restores the data from the serialized doc', () => {
+			const deserialized = deserializeCrdtDoc( serialized );
+
+			expect( deserialized ).toBeInstanceOf( Y.Doc );
+
+			const ymap = deserialized!.getMap( 'testMap' );
+			expect( ymap.get( 'title' ) ).toBe( 'Test Title' );
+			expect( ymap.get( 'count' ) ).toBe( 42 );
+		} );
+
+		it( 'marks the document as from persistence', () => {
+			const deserialized = deserializeCrdtDoc( serialized );
+
+			expect( deserialized ).toBeInstanceOf( Y.Doc );
+			expect( deserialized!.meta ).toBeDefined();
+			expect(
+				deserialized!.meta?.get( CRDT_DOC_META_PERSISTENCE_KEY )
+			).toBe( true );
+		} );
+
+		it( 'assigns a random client ID to the deserialized document', () => {
+			const deserialized = deserializeCrdtDoc( serialized );
+
+			expect( deserialized ).toBeInstanceOf( Y.Doc );
+
+			// Client ID should not match the original.
+			expect( deserialized!.clientID ).not.toBe( originalDoc.clientID );
+		} );
+
+		it( 'returns null for invalid JSON', () => {
+			const result = deserializeCrdtDoc( 'invalid json {' );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for JSON missing document property', () => {
+			const invalidSerialized = JSON.stringify( { data: 'test' } );
+			const result = deserializeCrdtDoc( invalidSerialized );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for corrupted CRDT data', () => {
+			const corruptedSerialized = JSON.stringify( {
+				document: buffer.toBase64(
+					new Uint8Array( [ 1, 2, 3, 4, 5 ] )
+				),
+			} );
+			const result = deserializeCrdtDoc( corruptedSerialized );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'preserves the CRDT state version', () => {
+			const deserialized = deserializeCrdtDoc( serialized );
+
+			expect( deserialized ).toBeInstanceOf( Y.Doc );
+
+			const stateMap = deserialized!.getMap( CRDT_STATE_MAP_KEY );
+			expect( stateMap.get( CRDT_STATE_VERSION_KEY ) ).toBe(
+				CRDT_DOC_VERSION
+			);
+		} );
+	} );
+
+	describe( 'serialization round-trip', () => {
+		it( 'maintains data integrity through serialize/deserialize cycle', () => {
+			const originalDoc = createYjsDoc( {} );
+			const ymap = originalDoc.getMap( 'data' );
+			ymap.set( 'string', 'value' );
+			ymap.set( 'number', 123 );
+			ymap.set( 'boolean', true );
+
+			const serialized = serializeCrdtDoc( originalDoc );
+			const deserialized = deserializeCrdtDoc( serialized );
+
+			expect( deserialized ).not.toBeNull();
+
+			const deserializedMap = deserialized!.getMap( 'data' );
+			expect( deserializedMap.get( 'string' ) ).toBe( 'value' );
+			expect( deserializedMap.get( 'number' ) ).toBe( 123 );
+			expect( deserializedMap.get( 'boolean' ) ).toBe( true );
+		} );
+
+		it( 'handles multiple serialize/deserialize cycles', () => {
+			const doc = createYjsDoc();
+			doc.getMap( 'test' ).set( 'value', 'original' );
+
+			// Cycle 1
+			let serialized = serializeCrdtDoc( doc );
+			let deserialized = deserializeCrdtDoc( serialized );
+			expect( deserialized ).not.toBeNull();
+
+			// Cycle 2
+			serialized = serializeCrdtDoc( deserialized! );
+			deserialized = deserializeCrdtDoc( serialized );
+			expect( deserialized ).not.toBeNull();
+
+			// Verify data is still intact
+			expect( deserialized!.getMap( 'test' ).get( 'value' ) ).toBe(
+				'original'
+			);
+		} );
+	} );
+} );

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -15,7 +15,11 @@ import {
 } from './config';
 import type { CRDTDoc } from './types';
 
-export function createYjsDoc( documentMeta: Record< string, unknown > ): Y.Doc {
+interface DocumentMeta {
+	[ key: string ]: boolean | number | string;
+}
+
+export function createYjsDoc( documentMeta: DocumentMeta = {} ): Y.Doc {
 	// Meta is not synced and does not get persisted with the document.
 	const metaMap = new Map< string, unknown >(
 		Object.entries( documentMeta )
@@ -42,11 +46,12 @@ export function deserializeCrdtDoc(
 		const { document } = JSON.parse( serializedCrdtDoc );
 
 		// Mark this document as from persistence.
-		const docMetaMap = new Map< string, boolean >();
-		docMetaMap.set( CRDT_DOC_META_PERSISTENCE_KEY, true );
+		const docMeta = {
+			[ CRDT_DOC_META_PERSISTENCE_KEY ]: true,
+		};
 
 		// Apply the document as an update against a new (temporary) Y.Doc.
-		const ydoc = createYjsDoc( { meta: docMetaMap } );
+		const ydoc = createYjsDoc( docMeta );
 		const yupdate = buffer.fromBase64( document );
 		Y.applyUpdateV2( ydoc, yupdate );
 

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -46,7 +46,7 @@ export function deserializeCrdtDoc(
 		const { document } = JSON.parse( serializedCrdtDoc );
 
 		// Mark this document as from persistence.
-		const docMeta = {
+		const docMeta: DocumentMeta = {
 			[ CRDT_DOC_META_PERSISTENCE_KEY ]: true,
 		};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix the inspection of persisted CRDT documents to correctly detect changes. Add type safety and tests to prevent recurrence.

## Why?

- Bug 1 accidentally nested CRDT document meta in a `meta` property. As a result, persisted CRDT documents were not correctly identified as being from persistence, resulting in incorrect merge behavior and CRDT document invalidation.
- Bug 2 incorrectly merged some "floating dates," which meant that some persisted CRDT documents were incorrectly invalidated.

## How?

- Provide the CRDT document meta correctly.
   - Introduce a type that will prevent this bug in the future.
- Do not merge "floating dates."
- Add tests to cover the functions in question.

