### PR TITLE
Pin full-length commit SHA for 3rd-party actions

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -86,7 +86,7 @@ jobs:
             has-flaky-test-report: ${{ !!steps.merge-flaky-tests-reports.outputs.artifact-id }}
         steps:
             - name: Merge failures artifacts
-              uses: actions/upload-artifact/merge@v5
+              uses: actions/upload-artifact/merge@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
               # Don't fail the job if there aren't any artifacts to merge.
               continue-on-error: true
               with:
@@ -97,7 +97,7 @@ jobs:
 
             - name: Merge flaky tests reports
               id: merge-flaky-tests-reports
-              uses: actions/upload-artifact/merge@v5
+              uses: actions/upload-artifact/merge@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
               continue-on-error: true
               with:
                   name: flaky-tests-report
@@ -122,7 +122,7 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
-            - uses: actions/download-artifact@v6.0.0
+            - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
               # Don't fail the job if there isn't any flaky tests report.
               continue-on-error: true
               with:

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -13,7 +13,7 @@ jobs:
         permissions:
             pull-requests: write
         steps:
-            - uses: mheap/github-action-required-labels@v5
+            - uses: mheap/github-action-required-labels@fb29a14a076b0f74099f6198f77750e8fc236016 # v5.5.0
               with:
                   mode: exactly
                   count: 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR changes the version numbers specified for 3rd party GitHub Action scripts to SHA values. Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.

No actions are being upgraded in this PR.

Previously #29485.

<!-- In a few words, what is the PR actually doing? -->

## Why?
This is recommended in the [GitHub Actions best security hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions).
