### PR TITLE
Unsupported Block: Disable lock, renaming, blockVisibility support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -512,7 +512,7 @@ Your site doesn’t include support for this block. ([Source](https://github.com
 
 -	**Name:** core/missing
 -	**Category:** text
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), ~~blockVisibility~~, ~~className~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** originalContent, originalName, originalUndelimitedContent
 
 ## More

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -23,7 +23,10 @@
 		"customClassName": false,
 		"inserter": false,
 		"html": false,
+		"lock": false,
 		"reusable": false,
+		"renaming": false,
+		"blockVisibility": false,
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
Related to:

- #72812
- #72520

## What? Why?

This pull request disables block supports that do not work in the Unsupported block.

## How?

Simply disable the support via block.json.

Regarding the Notes feature, it's not a block support, so it's not addressed in this PR. How to disable the Notes feature is being discussed separately in #72520.

> [!NOTE]
> I will add the `Backport to WP 6.9 Beta/RC` label to this pull request, but the bug where lock and renaming block support don't work has existed for a long time. Personally, I think it's acceptable to fix these issues simultaneously during the beta phase, but if that's not acceptable.

## Testing Instructions

- Open the code editor and insert the following HTML: `<!-- wp:test /-->`
- Back to the visual editor
- Open the block settings dropdown menu

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="616" height="590" alt="image" src="https://github.com/user-attachments/assets/2a1a2349-9b62-4911-8a13-e18a3b3e3111" /> | <img width="623" height="490" alt="image" src="https://github.com/user-attachments/assets/618fcd69-f9e9-401b-9165-95b4256fe754" /> |
