### PR TITLE
Disable Notes in Code Editor

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -83,10 +83,6 @@ function NotesSidebar( { postId, mode } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
-	const editorMode = useSelect( ( select ) => {
-		return select( editorStore ).getEditorMode();
-	}, [] );
-
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
 	const blockCommentId = useSelect( ( select ) => {
@@ -112,11 +108,6 @@ function NotesSidebar( { postId, mode } ) {
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();
 	const backgroundColor = GlobalStyles?.styles?.color?.background;
-
-	// Hide Notes sidebar in Code Editor mode.
-	if ( editorMode === 'text' ) {
-		return null;
-	}
 
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId
@@ -206,15 +197,22 @@ function NotesSidebar( { postId, mode } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const { postId, mode } = useSelect( ( select ) => {
-		const { getCurrentPostId, getRenderingMode } = select( editorStore );
+	const { postId, mode, editorMode } = useSelect( ( select ) => {
+		const { getCurrentPostId, getRenderingMode, getEditorMode } =
+			select( editorStore );
 		return {
 			postId: getCurrentPostId(),
 			mode: getRenderingMode(),
+			editorMode: getEditorMode(),
 		};
 	}, [] );
 
 	if ( ! postId || typeof postId !== 'number' ) {
+		return null;
+	}
+
+	// Hide Notes sidebar in Code Editor mode since block-level commenting.
+	if ( editorMode === 'text' ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -83,6 +83,10 @@ function NotesSidebar( { postId, mode } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
+	const editorMode = useSelect( ( select ) => {
+		return select( editorStore ).getEditorMode();
+	}, [] );
+
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
 	const blockCommentId = useSelect( ( select ) => {
@@ -108,6 +112,11 @@ function NotesSidebar( { postId, mode } ) {
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();
 	const backgroundColor = GlobalStyles?.styles?.color?.background;
+
+	// Hide Notes sidebar in Code Editor mode.
+	if ( editorMode === 'text' ) {
+		return null;
+	}
 
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId


### PR DESCRIPTION
## What?
Closes #72828

Hides the Notes sidebar and the Notes option from the Options menu when the editor is in Code Editor mode, as block-level commenting is not applicable without visual block rendering.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when switching to Code Editor mode, the Notes sidebar remains visible. This creates confusion and functional limitations:

- It's unclear which block the notes are associated with, since the visual block structure is not available in Code Editor view
- The "Add Notes" button is missing because the Block Toolbar is not accessible in this mode
- Users are unable to add new notes or clearly identify the block context of existing notes

Block-level commenting requires visual blocks to function properly, so the Notes sidebar should be hidden when in Code Editor mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Added `useSelect` hook to detect the current editor mode using `getEditorMode()` from `editorStore`
2. Check if `editorMode === 'text'`
3. Return `null` early when in Code Editor mode, which hides Notes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the editor
2. Add a few blocks and optionally add Notes to some blocks
3. Verify the Notes sidebar is visible and functional in Visual Editor mode
4. Switch to Code Editor mode (via the editor mode switcher or keyboard shortcut)
5. Notes feature disabled from the Options menu, and the Notes sidebar is also deactivated.
6. Switch back to Visual Editor mode
7. Verify that the Notes sidebar reappears and functions normally

## Video 

https://github.com/user-attachments/assets/07aa47c7-27cb-485c-8d7b-74ee40e75c8f



