### PR TITLE
Shortcut keys for Notes submit

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -46,6 +46,21 @@ function CommentForm( {
 		inputComment === thread?.content?.raw ||
 		! sanitizeCommentString( inputComment ).length;
 
+	const handleSubmit = () => {
+		if ( ! isDisabled ) {
+			onSubmit( inputComment );
+			setInputComment( '' );
+		}
+	};
+
+	const handleKeyDown = ( event ) => {
+		// Submit on ⌘ + Enter (Mac) or Ctrl + Enter (Windows/Linux)
+		if ( event.key === 'Enter' && ( event.metaKey || event.ctrlKey ) ) {
+			event.preventDefault();
+			handleSubmit();
+		}
+	};
+
 	return (
 		<VStack
 			className="editor-collab-sidebar-panel__comment-form"
@@ -61,6 +76,7 @@ function CommentForm( {
 					updateComment( comment.target.value );
 					debouncedCommentUpdated();
 				} }
+				onKeyDown={ handleKeyDown }
 				rows={ 1 }
 				maxRows={ 20 }
 			/>
@@ -72,10 +88,7 @@ function CommentForm( {
 					size="compact"
 					accessibleWhenDisabled
 					variant="primary"
-					onClick={ () => {
-						onSubmit( inputComment );
-						setInputComment( '' );
-					} }
+					onClick={ handleSubmit }
 					disabled={ isDisabled }
 				>
 					<Truncate>{ submitButtonText }</Truncate>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72721

This PR adds keyboard shortcut support for submitting notes and note replies in the collaboration sidebar. Users can now submit notes by pressing `⌘ + Enter` (Mac) or `Ctrl + Enter` (Windows/Linux), which aligns with common patterns in many modern applications.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many apps let users submit forms using ⌘ + Enter or Ctrl + Enter, offering a faster, familiar workflow. Currently, users must click the submit button to post notes or replies, which slows them down. Adding keyboard submission improves efficiency and aligns with user expectations from platforms like GitHub, Slack, and Discord.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a post or page in the WordPress editor
2. Enable the collaboration/notes feature if needed
3. Select a block and click to add a new note, or reply to an existing note
4. Type some text in the note/reply textarea
5. Press `⌘ + Enter` (Mac) or `Ctrl + Enter` (Windows/Linux)
6. Verify that the note/reply is submitted successfully
7. Try the keyboard shortcut when the textarea is empty or contains only whitespace - it should not submit (respects disabled state)
8. Verify that clicking the submit button still works as before

## Video <!-- if applicable -->



https://github.com/user-attachments/assets/266316d9-93ae-4b17-9856-7922877cda97

