### PR TITLE
TextareaControl: Add `min-height` to `textarea`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
+
 ## 30.7.0 (2025-10-29)
 
 ### Bug Fixes

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -46,6 +46,9 @@ export const StyledTextarea = styled.textarea`
 	// "Standard" metrics are 10px 12px, but subtracts 1px each to account for the border width.
 	padding: 9px 11px;
 
+	// Matching the 20px line-height + the 9px top and bottom padding.
+	min-height: 38px;
+
 	${ inputStyleNeutral };
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */


### PR DESCRIPTION
## What?
This PR adds `min-height` to the `textarea` element of `TextareaControl`.

## Why?
To avoid the textarea element looking bad if height was resized to the lowest possible point.

This was influenced by [this real-life example](https://github.com/WordPress/gutenberg/pull/72791#pullrequestreview-3403349975).

## How?
Just adding a calculated min-height.

## Testing Instructions
* Load Storybook
* Go to `TextareaControl`
* Resize height down and verify it looks good.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/869ba3e5-f917-4ceb-b51c-700cb1d0b8ab



After:


https://github.com/user-attachments/assets/26de51f4-8e7d-4362-acce-55e951d7bfda

