### PR TITLE
Notes: Add form submission shortcut

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -31,7 +31,6 @@ function CommentForm( {
 	labelText,
 	reflowComments = noop,
 } ) {
-	const formRef = useRef();
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
 	);
@@ -50,7 +49,6 @@ function CommentForm( {
 
 	return (
 		<VStack
-			ref={ formRef }
 			className="editor-collab-sidebar-panel__comment-form"
 			spacing="4"
 			as="form"
@@ -64,7 +62,7 @@ function CommentForm( {
 					isKeyboardEvent.primary( event, 'Enter' ) &&
 					! isDisabled
 				) {
-					formRef.current.requestSubmit();
+					event.target.parentNode.requestSubmit();
 				}
 			} }
 		>

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -57,14 +57,6 @@ function CommentForm( {
 				onSubmit( inputComment );
 				setInputComment( '' );
 			} }
-			onKeyDown={ ( event ) => {
-				if (
-					isKeyboardEvent.primary( event, 'Enter' ) &&
-					! isDisabled
-				) {
-					event.target.parentNode.requestSubmit();
-				}
-			} }
 		>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
 				{ labelText ?? __( 'Note' ) }
@@ -78,6 +70,14 @@ function CommentForm( {
 				} }
 				rows={ 1 }
 				maxRows={ 20 }
+				onKeyDown={ ( event ) => {
+					if (
+						isKeyboardEvent.primary( event, 'Enter' ) &&
+						! isDisabled
+					) {
+						event.target.parentNode.requestSubmit();
+					}
+				} }
 			/>
 			<HStack spacing="2" justify="flex-end" wrap>
 				<Button size="compact" variant="tertiary" onClick={ onCancel }>

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId, useDebounce } from '@wordpress/compose';
+import { isKeyboardEvent } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ function CommentForm( {
 	labelText,
 	reflowComments = noop,
 } ) {
+	const formRef = useRef();
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
 	);
@@ -48,8 +50,23 @@ function CommentForm( {
 
 	return (
 		<VStack
+			ref={ formRef }
 			className="editor-collab-sidebar-panel__comment-form"
 			spacing="4"
+			as="form"
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				onSubmit( inputComment );
+				setInputComment( '' );
+			} }
+			onKeyDown={ ( event ) => {
+				if (
+					isKeyboardEvent.primary( event, 'Enter' ) &&
+					! isDisabled
+				) {
+					formRef.current.requestSubmit();
+				}
+			} }
 		>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
 				{ labelText ?? __( 'Note' ) }
@@ -72,10 +89,7 @@ function CommentForm( {
 					size="compact"
 					accessibleWhenDisabled
 					variant="primary"
-					onClick={ () => {
-						onSubmit( inputComment );
-						setInputComment( '' );
-					} }
+					type="submit"
 					disabled={ isDisabled }
 				>
 					<Truncate>{ submitButtonText }</Truncate>

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -785,7 +785,7 @@ test.describe( 'Block Comments', () => {
 			} );
 			const thread = page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'listitem', {
+				.getByRole( 'treeitem', {
 					name: 'Note: A test comment',
 				} );
 

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -282,7 +282,7 @@ test.describe( 'Block Comments', () => {
 		await expect( replyTextbox ).toBeVisible();
 	} );
 
-	test.describe( 'Keyboard navigation', () => {
+	test.describe( 'Keyboard', () => {
 		const KEY_COMBINATIONS = [
 			{
 				keyToExpand: 'Enter',
@@ -767,6 +767,41 @@ test.describe( 'Block Comments', () => {
 					.getByRole( 'region', { name: 'Editor settings' } )
 					.getByRole( 'button', { name: 'Actions' } )
 			).toBeFocused();
+		} );
+
+		test( 'can add a note using form shortcut', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			const thread = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'listitem', {
+					name: 'Note: A test comment',
+				} );
+
+			await textbox.fill( '' );
+			await pageUtils.pressKeys( 'primary+Enter' );
+			await expect(
+				textbox,
+				`doesn't sumbit an empty form and focus remains in the textbox`
+			).toBeFocused();
+
+			await textbox.fill( 'A test comment' );
+			await pageUtils.pressKeys( 'primary+Enter' );
+
+			await expect( thread ).toBeVisible();
+			// Should focus the newly added comment thread.
+			await expect( thread ).toBeFocused();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/72721.
Alternative to #72864. I'm trying to use native form functionality.

PR adds keyboard shortcut for submitting the notes form - CMD + Enter (Mac) or CTRL + Enter (Windows).

## Why?
Matches comment keyboard shortcut behavior in apps.

## Testing Instructions
PR contains e2e test for the new behavior.

1. Open a post or page.
2. Add a block.
3. Click on the "Add note" options menu item.
4. Try submitting a note in the disabled state. Nothing should happen.
5. Type some note text.
6. Press CMD + Enter (Mac) or CTRL + Enter (Windows).
7. The note should be submitted.

### Testing Instructions for Keyboard
Same.
