### PR TITLE
Breadcrumbs: Add fallback for posts with no title

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -85,7 +85,11 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
 		// Add current post title (not linked).
-		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
+		$title = get_the_title( $post );
+		if ( empty( $title ) ) {
+			$title = __( '(no title)' );
+		}
+		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', $title );
 	}
 
 	if ( empty( $breadcrumb_items ) ) {
@@ -172,10 +176,14 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	$ancestors        = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
+		$title = get_the_title( $ancestor_id );
+		if ( empty( $title ) ) {
+			$title = __( '(no title)' );
+		}
 		$breadcrumb_items[] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( get_permalink( $ancestor_id ) ),
-			get_the_title( $ancestor_id )
+			$title
 		);
 	}
 	return $breadcrumb_items;

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -86,7 +86,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		}
 		// Add current post title (not linked).
 		$title = get_the_title( $post );
-		if ( empty( $title ) ) {
+		if ( strlen( $title ) === 0 ) {
 			$title = __( '(no title)' );
 		}
 		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', $title );
@@ -177,7 +177,7 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 
 	foreach ( $ancestors as $ancestor_id ) {
 		$title = get_the_title( $ancestor_id );
-		if ( empty( $title ) ) {
+		if ( strlen( $title ) === 0 ) {
 			$title = __( '(no title)' );
 		}
 		$breadcrumb_items[] = sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR handles the case of published posts with no title. Caught by @tyxla 



## Testing Instructions
1. In a published page with **no** title insert the breadcrumbs block.
2. Observe the front-end that displays the fallback.


## Screenshots or screencast <!-- if applicable -->
<img width="519" height="55" alt="Screenshot 2025-10-31 at 12 38 04 PM" src="https://github.com/user-attachments/assets/b4d200a1-900f-419e-8f7a-e0114159fec0" />
