### PR TITLE
Notes: spotlight block when clicking add/view notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -45,6 +45,13 @@ export function AddComment( {
 		};
 	}, [] );
 	const blockElement = useBlockElement( clientId );
+	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
+
+	const unselectThread = () => {
+		setShowCommentBoard( false );
+		blockElement?.focus();
+		toggleBlockSpotlight( clientId, false );
+	};
 
 	if ( ! showCommentBoard || ! clientId || undefined !== blockCommentId ) {
 		return null;
@@ -85,10 +92,7 @@ export function AddComment( {
 					focusCommentThread( id, commentSidebarRef.current );
 					setShowCommentBoard( false );
 				} }
-				onCancel={ () => {
-					setShowCommentBoard( false );
-					blockElement?.focus();
-				} }
+				onCancel={ unselectThread }
 				reflowComments={ reflowComments }
 				submitButtonText={ __( 'Add note' ) }
 				labelText={ __( 'New note' ) }

--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -80,6 +80,7 @@ export function AddComment( {
 				if ( event.currentTarget.contains( event.relatedTarget ) ) {
 					return;
 				}
+				toggleBlockSpotlight( clientId, false );
 				setShowCommentBoard( false );
 			} }
 		>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -31,6 +31,7 @@ import {
 } from './hooks';
 import { focusCommentThread } from './utils';
 import PostTypeSupportCheck from '../post-type-support-check';
+import { unlock } from '../../lock-unlock';
 
 function NotesSidebarContent( {
 	showCommentBoard,
@@ -80,18 +81,22 @@ function NotesSidebar( { postId, mode } ) {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
-	const blockCommentId = useSelect( ( select ) => {
+	const { clientId, blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
-		const clientId = getSelectedBlockClientId();
-		return clientId
-			? getBlockAttributes( clientId )?.metadata?.noteId
-			: null;
+		const _clientId = getSelectedBlockClientId();
+		return {
+			clientId: _clientId,
+			blockCommentId: _clientId
+				? getBlockAttributes( _clientId )?.metadata?.noteId
+				: null,
+		};
 	}, [] );
 
 	const {
@@ -142,6 +147,7 @@ function NotesSidebar( { postId, mode } ) {
 			// Focus a comment thread when there's a selected block with a comment.
 			! blockCommentId ? 'textarea' : undefined
 		);
+		toggleBlockSpotlight( clientId, true );
 	}
 
 	return (


### PR DESCRIPTION
Closes #72861

## What?

This PR spotlights (makes all blocks except the selected one semi-transparent) the block when the "View notes" or "Add notes" button is clicked.

## Why?

To match the visual effect when a note is clicked directly. The block should be spotlighted when the note is opened and focused.

## Testing Instructions

### Add note

- Click the "Add note" in the block toolbar dropdown.
- The block should be spotlighted.
- Click the Cancel button.
- The spotlight state on the block should be deactivated.

### View note

- Add notes to comments and click the "View notes" toolbar button.
- The block should be spotlighted.
- Click the Cancel button.
- The spotlight state on the block should be deactivated.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f8a8fc77-7414-467d-8d78-ea9271f7765e


