### PR TITLE
Breadcrumb: Some code quality improvements

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -25,23 +25,20 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$breadcrumb_items = array();
 
 	if ( $attributes['showHomeLink'] ) {
-		if ( $is_home_or_front_page ) {
-			$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
+		if ( ! $is_home_or_front_page ) {
+			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+				home_url( '/' ),
 				__( 'Home' )
 			);
 		} else {
-			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
-				home_url( '/' ),
-				esc_html__( 'Home' )
-			);
+			$breadcrumb_items[] = block_core_breadcrumbs_create_item( __( 'Home' ), block_core_breadcrumbs_is_paged() );
 		}
 	}
 
 	// Handle home and front page.
 	if ( $is_home_or_front_page ) {
-		$is_paged = block_core_breadcrumbs_is_paged();
-		$breadcrumb_items = block_core_breadcrumbs_create_item( $text, $is_paged );
-		if ( $is_paged ) {
+		// This check is explicitly nested in order not to execute the `else` branch.
+		if ( block_core_breadcrumbs_is_paged() ) {
 			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item();
 		}
 	} elseif ( is_search() ) {

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -25,16 +25,13 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$breadcrumb_items = array();
 
 	if ( $attributes['showHomeLink'] ) {
-		// On home/front page, show as current page instead of link.
 		if ( $is_home_or_front_page ) {
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				esc_html__( 'Home' )
+			$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
+				__( 'Home' )
 			);
 		} else {
-			$breadcrumb_items[] = sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( home_url( '/' ) ),
+			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+				home_url( '/' ),
 				esc_html__( 'Home' )
 			);
 		}
@@ -42,32 +39,24 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 
 	// Handle home and front page.
 	if ( $is_home_or_front_page ) {
-		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+		$is_paged = block_core_breadcrumbs_is_paged();
+		$breadcrumb_items = block_core_breadcrumbs_create_item( $text, $is_paged );
+		if ( $is_paged ) {
+			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item();
+		}
 	} elseif ( is_search() ) {
-		$search_query = esc_html( wp_trim_words( get_search_query(), 10 ) );
-		$paged_item   = block_core_breadcrumbs_get_paged_item();
-		if ( $paged_item ) {
-			// If paginated, add search results as a link to page 1.
-			$breadcrumb_items[] = sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( get_pagenum_link( 1 ) ),
-				/* translators: %s: search query */
-				sprintf( esc_html__( 'Search results for: "%s"' ), $search_query )
-			);
-			// Add the "Page X" as the current page.
-			$breadcrumb_items[] = $paged_item;
-		} else {
-			// Not paginated, add search results as current page.
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				/* translators: %s: search query */
-				sprintf( esc_html__( 'Search results for: "%s"' ), $search_query )
-			);
+		// Handle search results.
+		$is_paged = block_core_breadcrumbs_is_paged();
+		/* translators: %s: search query */
+		$text = esc_html( sprintf( __( 'Search results for: "%s"' ), wp_trim_words( get_search_query(), 10 ) ) );
+		$breadcrumb_items[] = block_core_breadcrumbs_create_item( $text, $is_paged );
+		// Add the "Page X" as the current page if paginated.
+		if ( $is_paged ) {
+			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item();
 		}
 	} elseif ( is_404() ) {
 		// Handle 404 pages.
-		$breadcrumb_items[] = sprintf(
-			'<span aria-current="page">%s</span>',
+		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
 			esc_html__( 'Page not found' )
 		);
 	} elseif ( is_archive() ) {
@@ -112,7 +101,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		if ( strlen( $title ) === 0 ) {
 			$title = __( '(no title)' );
 		}
-		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', $title );
+		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( $title );
 	}
 
 	// Remove last item if disabled.
@@ -149,22 +138,84 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 }
 
 /**
- * Returns pagination breadcrumb item if on a paged view.
+ * Checks if we're on a paginated view (page 2 or higher).
  *
  * @since 6.9.0
  *
- * @return string|null The "Page X" breadcrumb HTML if paged > 1, null otherwise.
+ * @return bool True if paged > 1, false otherwise.
  */
-function block_core_breadcrumbs_get_paged_item() {
+function block_core_breadcrumbs_is_paged() {
 	$paged = (int) get_query_var( 'paged' );
-	if ( $paged <= 1 ) {
-		return null;
-	}
+	return $paged > 1;
+}
+
+/**
+ * Creates a "Page X" breadcrumb item for paginated views.
+ *
+ * @since 6.9.0
+ *
+ * @return string The "Page X" breadcrumb HTML.
+ */
+function block_core_breadcrumbs_create_page_number_item() {
+	$paged = (int) get_query_var( 'paged' );
+	/* translators: %s: page number */
+	return block_core_breadcrumbs_create_current_item(
+		esc_html( sprintf( __( 'Page %s' ), number_format_i18n( $paged ) ) )
+	);
+}
+
+/**
+ * Creates a breadcrumb link item.
+ *
+ * @since 6.9.0
+ *
+ * @param string $url  The URL for the link (will be escaped).
+ * @param string $text The link text (should already be escaped).
+ *
+ * @return string The breadcrumb link HTML.
+ */
+function block_core_breadcrumbs_create_link( $url, $text ) {
+	return sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( $url ),
+		$text
+	);
+}
+
+/**
+ * Creates a breadcrumb current page item.
+ *
+ * @since 6.9.0
+ *
+ * @param string $text The text content (should already be escaped).
+ *
+ * @return string The breadcrumb current page HTML.
+ */
+function block_core_breadcrumbs_create_current_item( $text ) {
 	return sprintf(
 		'<span aria-current="page">%s</span>',
-		/* translators: %s: page number */
-		sprintf( esc_html__( 'Page %s' ), number_format_i18n( $paged ) )
+		$text
 	);
+}
+
+/**
+ * Creates a breadcrumb item that's either a link or current page item.
+ *
+ * When paginated (is_paged is true), creates a link to page 1.
+ * Otherwise, creates a span marked as the current page.
+ *
+ * @since 6.9.0
+ *
+ * @param string $text     The text content (should already be escaped).
+ * @param bool   $is_paged Whether we're on a paginated view.
+ *
+ * @return string The breadcrumb HTML.
+ */
+function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
+	if ( $is_paged ) {
+		return block_core_breadcrumbs_create_link( get_pagenum_link( 1 ), $text );
+	}
+	return block_core_breadcrumbs_create_current_item( $text );
 }
 
 /**
@@ -186,9 +237,8 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 		if ( strlen( $title ) === 0 ) {
 			$title = __( '(no title)' );
 		}
-		$breadcrumb_items[] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( get_permalink( $ancestor_id ) ),
+		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+			get_permalink( $ancestor_id ),
 			$title
 		);
 	}
@@ -217,9 +267,8 @@ function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) 
 		foreach ( $term_ancestors as $ancestor_id ) {
 			$ancestor_term = get_term( $ancestor_id, $taxonomy );
 			if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
-				$breadcrumb_items[] = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( get_term_link( $ancestor_term ) ),
+				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+					get_term_link( $ancestor_term ),
 					esc_html( $ancestor_term->name )
 				);
 			}
@@ -259,72 +308,46 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			}
 		}
 
-		$paged_item = block_core_breadcrumbs_get_paged_item();
+		$is_paged = block_core_breadcrumbs_is_paged();
 
 		if ( $year ) {
 			if ( $month ) {
 				// Year is linked if we have month.
-				$breadcrumb_items[] = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( get_year_link( $year ) ),
+				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+					get_year_link( $year ),
 					esc_html( $year )
 				);
 
 				if ( $day ) {
 					// Month is linked if we have day.
-					$breadcrumb_items[] = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( get_month_link( $year, $month ) ),
+					$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+						get_month_link( $year, $month ),
 						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
 					);
 					// Add day (current if not paginated, link if paginated).
-					if ( $paged_item ) {
-						$breadcrumb_items[] = sprintf(
-							'<a href="%s">%s</a>',
-							esc_url( get_pagenum_link( 1 ) ),
-							esc_html( $day )
-						);
-					} else {
-						$breadcrumb_items[] = sprintf(
-							'<span aria-current="page">%s</span>',
-							esc_html( $day )
-						);
-					}
+					$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+						esc_html( $day ),
+						$is_paged
+					);
 				} else {
 					// Add month (current if not paginated, link if paginated).
-					if ( $paged_item ) {
-						$breadcrumb_items[] = sprintf(
-							'<a href="%s">%s</a>',
-							esc_url( get_pagenum_link( 1 ) ),
-							esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
-						);
-					} else {
-						$breadcrumb_items[] = sprintf(
-							'<span aria-current="page">%s</span>',
-							esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
-						);
-					}
+					$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) ),
+						$is_paged
+					);
 				}
 			} else {
 				// Add year (current if not paginated, link if paginated).
-				if ( $paged_item ) {
-					$breadcrumb_items[] = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( get_pagenum_link( 1 ) ),
-						esc_html( $year )
-					);
-				} else {
-					$breadcrumb_items[] = sprintf(
-						'<span aria-current="page">%s</span>',
-						esc_html( $year )
-					);
-				}
+				$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+					esc_html( $year ),
+					$is_paged
+				);
 			}
 		}
 
 		// Add pagination breadcrumb if on a paged date archive.
-		if ( $paged_item ) {
-			$breadcrumb_items[] = $paged_item;
+		if ( $is_paged ) {
+			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item();
 		}
 
 		return $breadcrumb_items;
@@ -337,7 +360,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		return array();
 	}
 
-	$paged_item = block_core_breadcrumbs_get_paged_item();
+	$is_paged = block_core_breadcrumbs_is_paged();
 
 	// Taxonomy archive (category, tag, custom taxonomy).
 	if ( $queried_object instanceof WP_Term ) {
@@ -351,18 +374,10 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		);
 
 		// Add current term (current if not paginated, link if paginated).
-		if ( $paged_item ) {
-			$breadcrumb_items[] = sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( get_pagenum_link( 1 ) ),
-				esc_html( $term->name )
-			);
-		} else {
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				esc_html( $term->name )
-			);
-		}
+		$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+			esc_html( $term->name ),
+			$is_paged
+		);
 	} elseif ( is_post_type_archive() ) {
 		// Post type archive.
 		$post_type = get_query_var( 'post_type' );
@@ -372,40 +387,24 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		$post_type_object = get_post_type_object( $post_type );
 		if ( $post_type_object ) {
 			// Add post type (current if not paginated, link if paginated).
-			if ( $paged_item ) {
-				$breadcrumb_items[] = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( get_pagenum_link( 1 ) ),
-					esc_html( $post_type_object->labels->name )
-				);
-			} else {
-				$breadcrumb_items[] = sprintf(
-					'<span aria-current="page">%s</span>',
-					esc_html( $post_type_object->labels->name )
-				);
-			}
+			$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+				esc_html( $post_type_object->labels->name ),
+				$is_paged
+			);
 		}
 	} elseif ( is_author() ) {
 		// Author archive.
 		$author = $queried_object;
 		// Add author (current if not paginated, link if paginated).
-		if ( $paged_item ) {
-			$breadcrumb_items[] = sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( get_pagenum_link( 1 ) ),
-				esc_html( $author->display_name )
-			);
-		} else {
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				esc_html( $author->display_name )
-			);
-		}
+		$breadcrumb_items[] = block_core_breadcrumbs_create_item(
+			esc_html( $author->display_name ),
+			$is_paged
+		);
 	}
 
 	// Add pagination breadcrumb if on a paged archive.
-	if ( $paged_item ) {
-		$breadcrumb_items[] = $paged_item;
+	if ( $is_paged ) {
+		$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item();
 	}
 
 	return $breadcrumb_items;
@@ -459,9 +458,8 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 			$breadcrumb_items,
 			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy_name )
 		);
-		$breadcrumb_items[] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( get_term_link( $term ) ),
+		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+			get_term_link( $term ),
 			esc_html( $term->name )
 		);
 	}

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -48,7 +48,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		// Handle search results.
 		$is_paged = block_core_breadcrumbs_is_paged();
 		/* translators: %s: search query */
-		$text               = esc_html( sprintf( __( 'Search results for: "%s"' ), wp_trim_words( get_search_query(), 10 ) ) );
+		$text               = sprintf( __( 'Search results for: "%s"' ), wp_trim_words( get_search_query(), 10 ) );
 		$breadcrumb_items[] = block_core_breadcrumbs_create_item( $text, $is_paged );
 		// Add the "Page X" as the current page if paginated.
 		if ( $is_paged ) {
@@ -57,7 +57,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	} elseif ( is_404() ) {
 		// Handle 404 pages.
 		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item(
-			esc_html__( 'Page not found' )
+			__( 'Page not found' )
 		);
 	} elseif ( is_archive() ) {
 		// Handle archive pages (taxonomy, post type, date, author archives).
@@ -97,7 +97,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
 		// Add current post title (not linked).
-		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( block_core_breadcrumbs_get_post_title( $post ) );
+		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( block_core_breadcrumbs_get_post_title( $post ), true );
 	}
 
 	// Remove last item if disabled.
@@ -156,7 +156,7 @@ function block_core_breadcrumbs_create_page_number_item() {
 	$paged = (int) get_query_var( 'paged' );
 	return block_core_breadcrumbs_create_current_item(
 		/* translators: %s: page number */
-		esc_html( sprintf( __( 'Page %s' ), number_format_i18n( $paged ) ) )
+		sprintf( __( 'Page %s' ), number_format_i18n( $paged ) )
 	);
 }
 
@@ -165,16 +165,17 @@ function block_core_breadcrumbs_create_page_number_item() {
  *
  * @since 6.9.0
  *
- * @param string $url  The URL for the link (will be escaped).
- * @param string $text The link text (should already be escaped).
+ * @param string $url        The URL for the link (will be escaped).
+ * @param string $text       The link text (will be escaped).
+ * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
  *
  * @return string The breadcrumb link HTML.
  */
-function block_core_breadcrumbs_create_link( $url, $text ) {
+function block_core_breadcrumbs_create_link( $url, $text, $allow_html = false ) {
 	return sprintf(
 		'<a href="%s">%s</a>',
 		esc_url( $url ),
-		$text
+		$allow_html ? wp_kses_post( $text ) : esc_html( $text )
 	);
 }
 
@@ -183,14 +184,15 @@ function block_core_breadcrumbs_create_link( $url, $text ) {
  *
  * @since 6.9.0
  *
- * @param string $text The text content (should already be escaped).
+ * @param string $text       The text content (will be escaped).
+ * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
  *
  * @return string The breadcrumb current page HTML.
  */
-function block_core_breadcrumbs_create_current_item( $text ) {
+function block_core_breadcrumbs_create_current_item( $text, $allow_html = false ) {
 	return sprintf(
 		'<span aria-current="page">%s</span>',
-		$text
+		$allow_html ? wp_kses_post( $text ) : esc_html( $text )
 	);
 }
 
@@ -202,16 +204,17 @@ function block_core_breadcrumbs_create_current_item( $text ) {
  *
  * @since 6.9.0
  *
- * @param string $text     The text content (should already be escaped).
- * @param bool   $is_paged Whether we're on a paginated view.
+ * @param string $text       The text content (will be escaped).
+ * @param bool   $is_paged   Whether we're on a paginated view.
+ * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
  *
  * @return string The breadcrumb HTML.
  */
-function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
+function block_core_breadcrumbs_create_item( $text, $is_paged = false, $allow_html = false ) {
 	if ( $is_paged ) {
-		return block_core_breadcrumbs_create_link( get_pagenum_link( 1 ), $text );
+		return block_core_breadcrumbs_create_link( get_pagenum_link( 1 ), $text, $allow_html );
 	}
-	return block_core_breadcrumbs_create_current_item( $text );
+	return block_core_breadcrumbs_create_current_item( $text, $allow_html );
 }
 
 /**
@@ -219,12 +222,12 @@ function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
  *
  * @since 6.9.0
  *
- * @param int|WP_Post $post The post ID or post object.
+ * @param int|WP_Post $post_id_or_object The post ID or post object.
  *
  * @return string The post title or fallback text.
  */
-function block_core_breadcrumbs_get_post_title( $post ) {
-	$title = get_the_title( $post );
+function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
+	$title = get_the_title( $post_id_or_object );
 	if ( strlen( $title ) === 0 ) {
 		$title = __( '(no title)' );
 	}
@@ -248,7 +251,8 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	foreach ( $ancestors as $ancestor_id ) {
 		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 			get_permalink( $ancestor_id ),
-			block_core_breadcrumbs_get_post_title( $ancestor_id )
+			block_core_breadcrumbs_get_post_title( $ancestor_id ),
+			true
 		);
 	}
 	return $breadcrumb_items;
@@ -278,7 +282,7 @@ function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) 
 			if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
 				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 					get_term_link( $ancestor_term ),
-					esc_html( $ancestor_term->name )
+					$ancestor_term->name
 				);
 			}
 		}
@@ -324,31 +328,31 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 				// Year is linked if we have month.
 				$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 					get_year_link( $year ),
-					esc_html( $year )
+					$year
 				);
 
 				if ( $day ) {
 					// Month is linked if we have day.
 					$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 						get_month_link( $year, $month ),
-						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
+						date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) )
 					);
 					// Add day (current if not paginated, link if paginated).
 					$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-						esc_html( $day ),
+						$day,
 						$is_paged
 					);
 				} else {
 					// Add month (current if not paginated, link if paginated).
 					$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) ),
+						date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ),
 						$is_paged
 					);
 				}
 			} else {
 				// Add year (current if not paginated, link if paginated).
 				$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-					esc_html( $year ),
+					$year,
 					$is_paged
 				);
 			}
@@ -384,7 +388,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 
 		// Add current term (current if not paginated, link if paginated).
 		$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-			esc_html( $term->name ),
+			$term->name,
 			$is_paged
 		);
 	} elseif ( is_post_type_archive() ) {
@@ -397,7 +401,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		if ( $post_type_object ) {
 			// Add post type (current if not paginated, link if paginated).
 			$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-				esc_html( $post_type_object->labels->name ),
+				$post_type_object->labels->name,
 				$is_paged
 			);
 		}
@@ -406,7 +410,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		$author = $queried_object;
 		// Add author (current if not paginated, link if paginated).
 		$breadcrumb_items[] = block_core_breadcrumbs_create_item(
-			esc_html( $author->display_name ),
+			$author->display_name,
 			$is_paged
 		);
 	}
@@ -469,7 +473,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 		);
 		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 			get_term_link( $term ),
-			esc_html( $term->name )
+			$term->name
 		);
 	}
 	return $breadcrumb_items;

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -48,7 +48,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		// Handle search results.
 		$is_paged = block_core_breadcrumbs_is_paged();
 		/* translators: %s: search query */
-		$text = esc_html( sprintf( __( 'Search results for: "%s"' ), wp_trim_words( get_search_query(), 10 ) ) );
+		$text               = esc_html( sprintf( __( 'Search results for: "%s"' ), wp_trim_words( get_search_query(), 10 ) ) );
 		$breadcrumb_items[] = block_core_breadcrumbs_create_item( $text, $is_paged );
 		// Add the "Page X" as the current page if paginated.
 		if ( $is_paged ) {
@@ -97,11 +97,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
 		// Add current post title (not linked).
-		$title = get_the_title( $post );
-		if ( strlen( $title ) === 0 ) {
-			$title = __( '(no title)' );
-		}
-		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( $title );
+		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( block_core_breadcrumbs_get_post_title( $post ) );
 	}
 
 	// Remove last item if disabled.
@@ -158,8 +154,8 @@ function block_core_breadcrumbs_is_paged() {
  */
 function block_core_breadcrumbs_create_page_number_item() {
 	$paged = (int) get_query_var( 'paged' );
-	/* translators: %s: page number */
 	return block_core_breadcrumbs_create_current_item(
+		/* translators: %s: page number */
 		esc_html( sprintf( __( 'Page %s' ), number_format_i18n( $paged ) ) )
 	);
 }
@@ -219,6 +215,23 @@ function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
 }
 
 /**
+ * Gets a post title with fallback for empty titles.
+ *
+ * @since 6.9.0
+ *
+ * @param int|WP_Post $post The post ID or post object.
+ *
+ * @return string The post title or fallback text.
+ */
+function block_core_breadcrumbs_get_post_title( $post ) {
+	$title = get_the_title( $post );
+	if ( strlen( $title ) === 0 ) {
+		$title = __( '(no title)' );
+	}
+	return $title;
+}
+
+/**
  * Generates breadcrumb items from hierarchical post type ancestors.
  *
  * @since 6.9.0
@@ -233,13 +246,9 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	$ancestors        = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
-		$title = get_the_title( $ancestor_id );
-		if ( strlen( $title ) === 0 ) {
-			$title = __( '(no title)' );
-		}
 		$breadcrumb_items[] = block_core_breadcrumbs_create_link(
 			get_permalink( $ancestor_id ),
-			$title
+			block_core_breadcrumbs_get_post_title( $ancestor_id )
 		);
 	}
 	return $breadcrumb_items;

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -44,19 +44,31 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	if ( $is_home_or_front_page ) {
 		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
 	} elseif ( is_search() ) {
-		// Handle search results.
-		$search_query       = get_search_query();
-		$breadcrumb_items[] = sprintf(
-			'<span aria-current="page">%s</span>',
-			/* translators: %s: search query */
-			sprintf( esc_html__( 'Search results for: "%s"' ), esc_html( $search_query ) )
-		);
-		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+		$search_query = esc_html( wp_trim_words( get_search_query(), 10 ) );
+		$paged_item   = block_core_breadcrumbs_get_paged_item();
+		if ( $paged_item ) {
+			// If paginated, add search results as a link to page 1.
+			$breadcrumb_items[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_pagenum_link( 1 ) ),
+				/* translators: %s: search query */
+				sprintf( esc_html__( 'Search results for: "%s"' ), $search_query )
+			);
+			// Add the "Page X" as the current page.
+			$breadcrumb_items[] = $paged_item;
+		} else {
+			// Not paginated, add search results as current page.
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				/* translators: %s: search query */
+				sprintf( esc_html__( 'Search results for: "%s"' ), $search_query )
+			);
+		}
 	} elseif ( is_404() ) {
 		// Handle 404 pages.
 		$breadcrumb_items[] = sprintf(
 			'<span aria-current="page">%s</span>',
-			esc_html__( '404 Not Found' )
+			esc_html__( 'Page not found' )
 		);
 	} elseif ( is_archive() ) {
 		// Handle archive pages (taxonomy, post type, date, author archives).
@@ -137,44 +149,22 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 }
 
 /**
- * Adds pagination breadcrumb if on a paged view.
- *
- * Converts the last breadcrumb item to a link and adds "Page X" as the current page.
+ * Returns pagination breadcrumb item if on a paged view.
  *
  * @since 6.9.0
  *
- * @param array $breadcrumb_items Array of breadcrumb HTML items.
- *
- * @return array Modified breadcrumb items with pagination if applicable.
+ * @return string|null The "Page X" breadcrumb HTML if paged > 1, null otherwise.
  */
-function block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items ) {
+function block_core_breadcrumbs_get_paged_item() {
 	$paged = (int) get_query_var( 'paged' );
-	if ( $paged > 1 ) {
-		// Get the last breadcrumb item (the current page).
-		$last_item = array_pop( $breadcrumb_items );
-
-		if ( $last_item ) {
-			// Get URL for page 1.
-			$current_url = get_pagenum_link( 1 );
-
-			// Convert span to link by replacing the opening/closing tags.
-			$linked_item        = str_replace(
-				array( '<span aria-current="page">', '</span>' ),
-				array( '<a href="' . esc_url( $current_url ) . '">', '</a>' ),
-				$last_item
-			);
-			$breadcrumb_items[] = $linked_item;
-		}
-
-		// Add the "Page X" as the current page.
-		$breadcrumb_items[] = sprintf(
-			'<span aria-current="page">%s</span>',
-			/* translators: %s: page number */
-			sprintf( esc_html__( 'Page %s' ), number_format_i18n( $paged ) )
-		);
+	if ( $paged <= 1 ) {
+		return null;
 	}
-
-	return $breadcrumb_items;
+	return sprintf(
+		'<span aria-current="page">%s</span>',
+		/* translators: %s: page number */
+		sprintf( esc_html__( 'Page %s' ), number_format_i18n( $paged ) )
+	);
 }
 
 /**
@@ -269,6 +259,8 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			}
 		}
 
+		$paged_item = block_core_breadcrumbs_get_paged_item();
+
 		if ( $year ) {
 			if ( $month ) {
 				// Year is linked if we have month.
@@ -285,29 +277,55 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 						esc_url( get_month_link( $year, $month ) ),
 						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
 					);
-					// Current day.
-					$breadcrumb_items[] = sprintf(
-						'<span aria-current="page">%s</span>',
-						esc_html( $day )
-					);
+					// Add day (current if not paginated, link if paginated).
+					if ( $paged_item ) {
+						$breadcrumb_items[] = sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( get_pagenum_link( 1 ) ),
+							esc_html( $day )
+						);
+					} else {
+						$breadcrumb_items[] = sprintf(
+							'<span aria-current="page">%s</span>',
+							esc_html( $day )
+						);
+					}
 				} else {
-					// Current month.
-					$breadcrumb_items[] = sprintf(
-						'<span aria-current="page">%s</span>',
-						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
-					);
+					// Add month (current if not paginated, link if paginated).
+					if ( $paged_item ) {
+						$breadcrumb_items[] = sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( get_pagenum_link( 1 ) ),
+							esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
+						);
+					} else {
+						$breadcrumb_items[] = sprintf(
+							'<span aria-current="page">%s</span>',
+							esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
+						);
+					}
 				}
 			} else {
-				// Current year only.
-				$breadcrumb_items[] = sprintf(
-					'<span aria-current="page">%s</span>',
-					esc_html( $year )
-				);
+				// Add year (current if not paginated, link if paginated).
+				if ( $paged_item ) {
+					$breadcrumb_items[] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_pagenum_link( 1 ) ),
+						esc_html( $year )
+					);
+				} else {
+					$breadcrumb_items[] = sprintf(
+						'<span aria-current="page">%s</span>',
+						esc_html( $year )
+					);
+				}
 			}
 		}
 
 		// Add pagination breadcrumb if on a paged date archive.
-		$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+		if ( $paged_item ) {
+			$breadcrumb_items[] = $paged_item;
+		}
 
 		return $breadcrumb_items;
 	}
@@ -318,6 +336,8 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 	if ( ! $queried_object ) {
 		return array();
 	}
+
+	$paged_item = block_core_breadcrumbs_get_paged_item();
 
 	// Taxonomy archive (category, tag, custom taxonomy).
 	if ( $queried_object instanceof WP_Term ) {
@@ -330,11 +350,19 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy )
 		);
 
-		// Add current term.
-		$breadcrumb_items[] = sprintf(
-			'<span aria-current="page">%s</span>',
-			esc_html( $term->name )
-		);
+		// Add current term (current if not paginated, link if paginated).
+		if ( $paged_item ) {
+			$breadcrumb_items[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_pagenum_link( 1 ) ),
+				esc_html( $term->name )
+			);
+		} else {
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				esc_html( $term->name )
+			);
+		}
 	} elseif ( is_post_type_archive() ) {
 		// Post type archive.
 		$post_type = get_query_var( 'post_type' );
@@ -343,22 +371,42 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		}
 		$post_type_object = get_post_type_object( $post_type );
 		if ( $post_type_object ) {
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				esc_html( $post_type_object->labels->name )
-			);
+			// Add post type (current if not paginated, link if paginated).
+			if ( $paged_item ) {
+				$breadcrumb_items[] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_pagenum_link( 1 ) ),
+					esc_html( $post_type_object->labels->name )
+				);
+			} else {
+				$breadcrumb_items[] = sprintf(
+					'<span aria-current="page">%s</span>',
+					esc_html( $post_type_object->labels->name )
+				);
+			}
 		}
 	} elseif ( is_author() ) {
 		// Author archive.
-		$author             = $queried_object;
-		$breadcrumb_items[] = sprintf(
-			'<span aria-current="page">%s</span>',
-			esc_html( $author->display_name )
-		);
+		$author = $queried_object;
+		// Add author (current if not paginated, link if paginated).
+		if ( $paged_item ) {
+			$breadcrumb_items[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_pagenum_link( 1 ) ),
+				esc_html( $author->display_name )
+			);
+		} else {
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				esc_html( $author->display_name )
+			);
+		}
 	}
 
 	// Add pagination breadcrumb if on a paged archive.
-	$breadcrumb_items = block_core_breadcrumbs_maybe_add_paged( $breadcrumb_items );
+	if ( $paged_item ) {
+		$breadcrumb_items[] = $paged_item;
+	}
 
 	return $breadcrumb_items;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/72714

This PR addresses some feedback from there:
1. Changes the title for `404` to `Page not found`
2. Trims the search query to 10 words 
3. Refactors the `paged` breadcrumbs code not to do any string manipulation and handle each case explicitly. Some more helper functions could be considered there (maybe for getting the markup for the current item) but we can look into it after we've added the whole of the main functionality that is wanted. It'd be a simple change..

## Testing Instructions
1. Insert Breadcrumbs blocks and observe the change in `404` breadcrumb item
2. Search something quite long and see the truncated breadcrumb item
3. Test that `paged` cases work exactly as before and as expected.
4. It's easier to review by hiding whitespace

