### PR TITLE
Fix typo in README.md comment

### DIFF
--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -61,7 +61,7 @@ const EditPostDocumentSettingPanel = () => {
 		return postTypeObject?.viewable;
 	}, [] );
 
-	// If the post type is not viewable, then do not render my the fill.
+	// If the post type is not viewable, then do not render the fill.
 	if ( ! isViewable ) {
 		return null;
 	}

--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -61,7 +61,7 @@ const EditPostDocumentSettingPanel = () => {
 		return postTypeObject?.viewable;
 	}, [] );
 
-	// If the post type is not viewable, then do not render the fill.
+	// If the post type is not viewable, then do not render the plugin.
 	if ( ! isViewable ) {
 		return null;
 	}


### PR DESCRIPTION
## What?

Fix a typo in code example on https://developer.wordpress.org/block-editor/reference-guides/slotfills/ 

