### PR TITLE
eslint-plugin: Disable redundant import rules for TypeScript files

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Disabled `import/no-unresolved`, `import/default`, and `import/named` checks for TypeScript files when TypeScript is installed, since these issues are [already checked by TypeScript](https://typescript-eslint.io/troubleshooting/typed-linting/performance/).
+
 ## 22.20.0 (2025-10-29)
 
 ## 22.19.0 (2025-10-17)

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -68,6 +68,12 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': 'error',
 				'@typescript-eslint/method-signature-style': 'error',
+				// TypeScript already checks for these types of issues, so don't
+				// waste time checking them again.
+				// See: https://typescript-eslint.io/troubleshooting/typed-linting/performance/
+				'import/no-unresolved': 'off',
+				'import/default': 'off',
+				'import/named': 'off',
 			},
 		},
 	];

--- a/packages/i18n/src/sprintf.ts
+++ b/packages/i18n/src/sprintf.ts
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: `eslint-plugin-import` doesn't support `exports` (https://github.com/import-js/eslint-plugin-import/issues/1810)
-// eslint-disable-next-line import/no-unresolved
 import _sprintf from '@tannin/sprintf';
 
 /**

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -4,15 +4,12 @@
 import Vips from 'wasm-vips';
 
 // @ts-expect-error
-// eslint-disable-next-line import/no-unresolved
 import VipsModule from 'wasm-vips/vips.wasm';
 
 // @ts-expect-error
-// eslint-disable-next-line import/no-unresolved
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
 
 // @ts-expect-error
-// eslint-disable-next-line import/no-unresolved
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 /**


### PR DESCRIPTION
## What?

Updates the default ESLint configuration to avoid running various redundant rules from `eslint-plugin-import` for TypeScript files:

- `import/no-unresolved`
- `import/default`
- `import/named`

Tangentially related to #72136

## Why?

Makes the lint check more performant by avoiding redundant checks.

See: https://typescript-eslint.io/troubleshooting/typed-linting/performance/

Furthermore, the default resolver with `eslint-plugin-import` lacks support for modern package semantics, so this helps avoid these issues in TypeScript files. This is a workaround, as we should ideally update the configuration to use a better resolver (see #72136).

## How?

Overrides default rules to disable, specific to files matching `*.ts` or `*.tsx`.

Default rules configured here:

https://github.com/WordPress/gutenberg/blob/234e7b1960ecf60a696a42a521b0325f8855beb8/packages/eslint-plugin/configs/recommended-with-formatting.js#L33-L40

## Testing Instructions

Verify lint passes: `npm run lint:js`

For bonus points, introduce a change which would cause a real issue and verify that TypeScript will catch it:

```diff
diff --git a/packages/i18n/src/sprintf.ts b/packages/i18n/src/sprintf.ts
index 266a5db14e..df9cf942d2 100644
--- a/packages/i18n/src/sprintf.ts
+++ b/packages/i18n/src/sprintf.ts
@@ -3,3 +3,3 @@
  */
-import _sprintf from '@tannin/sprintf';
+import _sprintf from '@tannin/sprintf/wrong';
 ```

```
npm exec tsc -- --build
packages/i18n/src/sprintf.ts:4:22 - error TS2307: Cannot find module '@tannin/sprintf/wrong' or its corresponding type declarations.

4 import _sprintf from '@tannin/sprintf/wrong';
                       ~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```