### PR TITLE
Change sidebar title - Change Notes to All notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -162,10 +162,10 @@ function NotesSidebar( { postId, mode } ) {
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
 				name={ collabHistorySidebarName }
-				title={ __( 'Notes' ) }
+				title={ __( 'All notes' ) }
 				header={
 					<h2 className="interface-complementary-area-header__title">
-						{ __( 'Notes' ) }
+						{ __( 'All notes' ) }
 					</h2>
 				}
 				icon={ commentIcon }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Block Comments', () => {
 		// Close the pinned notes sidebar.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Notes', exact: true } )
+			.getByRole( 'button', { name: 'All notes', exact: true } )
 			.click();
 		await editor.clickBlockOptionsMenuItem( 'Add note' );
 		await expect( form ).toBeFocused();
@@ -630,7 +630,7 @@ class BlockCommentUtils {
 	async openBlockCommentSidebar() {
 		const toggleButton = this.#page
 			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Notes', exact: true } );
+			.getByRole( 'button', { name: 'All notes', exact: true } );
 
 		const isClosed =
 			( await toggleButton.getAttribute( 'aria-expanded' ) ) === 'false';


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/72785

Changes the sidebar title text.

<img width="785" height="446" alt="image" src="https://github.com/user-attachments/assets/e0b284eb-1c25-40bf-97f0-5f6f0fa235f3" />
