### PR TITLE
Prevent Esc from executing changes in category and archive widgets.

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -70,7 +70,7 @@ function render_block_core_archives( $attributes ) {
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 
 		// Inject the dropdown script immediately after the select dropdown.
-		$block_content .= build_dropdown_script_block_core_archives( $dropdown_id );
+		$block_content .= block_core_archives_build_dropdown_script( $dropdown_id );
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',
@@ -118,7 +118,7 @@ function render_block_core_archives( $attributes ) {
  *
  * @return string Returns the dropdown onChange redirection script.
  */
-function build_dropdown_script_block_core_archives( $dropdown_id ) {
+function block_core_archives_build_dropdown_script( $dropdown_id ) {
 	ob_start();
 
 	$exports = array( $dropdown_id, home_url() );

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -66,8 +66,11 @@ function render_block_core_archives( $attributes ) {
 		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
 		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-		<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
+		<select id="' . $dropdown_id . '" name="archive-dropdown">
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
+
+		// Inject the dropdown script immediately after the select dropdown.
+		$block_content .= build_dropdown_script_block_core_archives( $dropdown_id );
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',
@@ -103,6 +106,57 @@ function render_block_core_archives( $attributes ) {
 		'<ul %1$s>%2$s</ul>',
 		$wrapper_attributes,
 		$archives
+	);
+}
+
+/**
+ * Generates the inline script for an archives dropdown field.
+ *
+ * @since 6.9.0
+ *
+ * @param string $dropdown_id ID of the dropdown field.
+ *
+ * @return string Returns the dropdown onChange redirection script.
+ */
+function build_dropdown_script_block_core_archives( $dropdown_id ) {
+	ob_start();
+
+	$exports = array( $dropdown_id, home_url() );
+	?>
+	<script>
+	( ( [ dropdownId, homeUrl ] ) => {
+		const dropdown = document.getElementById( dropdownId );
+		function onSelectChange() {
+			setTimeout( () => {
+				if ( 'escape' === dropdown.dataset.lastkey ) {
+					return;
+				}
+				if ( dropdown.value && parseInt( dropdown.value ) > 0 && dropdown instanceof HTMLSelectElement ) {
+					const url = new URL( homeUrl );
+					url.searchParams.set( dropdown.name, dropdown.value );
+					location.href = url.href;
+				}
+			}, 250 );
+		}
+		function onKeyUp( event ) {
+			if ( 'Escape' === event.key ) {
+				dropdown.dataset.lastkey = 'escape';
+			} else {
+				delete dropdown.dataset.lastkey;
+			}
+		}
+		function onClick() {
+			delete dropdown.dataset.lastkey;
+		}
+		dropdown.addEventListener( 'keyup', onKeyUp );
+		dropdown.addEventListener( 'click', onClick );
+		dropdown.addEventListener( 'change', onSelectChange );
+	} )( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
+	</script>
+	<?php
+	return wp_get_inline_script_tag(
+		trim( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) ) .
+		"\n//# sourceURL=" . rawurlencode( __FUNCTION__ )
 	);
 }
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -66,7 +66,7 @@ function render_block_core_archives( $attributes ) {
 		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
 		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-		<select id="' . $dropdown_id . '" name="archive-dropdown">
+		<select id="' . esc_attr( $dropdown_id ) . '" name="archive-dropdown">
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 
 		// Inject the dropdown script immediately after the select dropdown.

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -131,10 +131,8 @@ function block_core_archives_build_dropdown_script( $dropdown_id ) {
 				if ( 'escape' === dropdown.dataset.lastkey ) {
 					return;
 				}
-				if ( dropdown.value && parseInt( dropdown.value ) > 0 && dropdown instanceof HTMLSelectElement ) {
-					const url = new URL( homeUrl );
-					url.searchParams.set( dropdown.name, dropdown.value );
-					location.href = url.href;
+				if ( dropdown.value ) {
+					location.href = dropdown.value;
 				}
 			}, 250 );
 		}

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -104,14 +104,32 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	?>
 	<script>
 	( ( [ dropdownId, homeUrl ] ) => {
-		document.getElementById( dropdownId ).addEventListener( 'change', ( event ) => {
-			const dropdown = /** @type {HTMLSelectElement} */ ( event.target );
-			if ( dropdown.value && dropdown.value !== '-1' ) {
-				const url = new URL( homeUrl );
-				url.searchParams.set( dropdown.name, dropdown.value );
-				location.href = url.href;
+		const dropdown = document.getElementById( dropdownId );
+		function onSelectChange() {
+			setTimeout( () => {
+				if ( 'escape' === dropdown.dataset.lastkey ) {
+					return;
+				}
+				if ( dropdown.value && parseInt( dropdown.value ) > 0 && dropdown instanceof HTMLSelectElement ) {
+					const url = new URL( homeUrl );
+					url.searchParams.set( dropdown.name, dropdown.value );
+					location.href = url.href;
+				}
+			}, 250 );
+		}
+		function onKeyUp( event ) {
+			if ( 'Escape' === event.key ) {
+				dropdown.dataset.lastkey = 'escape';
+			} else {
+				delete dropdown.dataset.lastkey;
 			}
-		} );
+		}
+		function onClick() {
+			delete dropdown.dataset.lastkey;
+		}
+		dropdown.addEventListener( 'keyup', onKeyUp );
+		dropdown.addEventListener( 'click', onClick );
+		dropdown.addEventListener( 'change', onSelectChange );
 	} )( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 	</script>
 	<?php

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -110,7 +110,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 				if ( 'escape' === dropdown.dataset.lastkey ) {
 					return;
 				}
-				if ( dropdown.value && parseInt( dropdown.value ) > 0 && dropdown instanceof HTMLSelectElement ) {
+				if ( dropdown.value && dropdown instanceof HTMLSelectElement ) {
 					const url = new URL( homeUrl );
 					url.searchParams.set( dropdown.name, dropdown.value );
 					location.href = url.href;


### PR DESCRIPTION
Updates the block archives and category widgets to match the behavior in core.

See: https://core.trac.wordpress.org/ticket/63531

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://core.trac.wordpress.org/ticket/63531

This updates the block archives and category widgets dropdown behavior to match that in core.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

See the core ticket for testing instructions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
