### PR TITLE
Notes: focus action button when comment editing is cancelled or comment is updated

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -12,6 +12,7 @@ import {
 	useEffect,
 	useCallback,
 	useMemo,
+	useRef,
 } from '@wordpress/element';
 import {
 	__experimentalText as Text,
@@ -660,7 +661,7 @@ const CommentBoard = ( {
 } ) => {
 	const [ actionState, setActionState ] = useState( false );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
-
+	const actionButtonRef = useRef( null );
 	const handleConfirmDelete = () => {
 		onDelete( thread );
 		setActionState( false );
@@ -670,6 +671,7 @@ const CommentBoard = ( {
 	const handleCancel = () => {
 		setActionState( false );
 		setShowConfirmDialog( false );
+		actionButtonRef.current?.focus();
 	};
 
 	// Check if this is a resolution comment by checking metadata.
@@ -755,6 +757,7 @@ const CommentBoard = ( {
 								<Menu.TriggerButton
 									render={
 										<Button
+											ref={ actionButtonRef }
 											size="small"
 											icon={ moreVertical }
 											label={ __( 'Actions' ) }
@@ -788,6 +791,7 @@ const CommentBoard = ( {
 							content: value,
 						} );
 						setActionState( false );
+						actionButtonRef.current?.focus();
 					} }
 					onCancel={ () => handleCancel() }
 					thread={ thread }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -613,6 +613,48 @@ test.describe( 'Block Comments', () => {
 				} )
 			).toBeFocused();
 		} );
+
+		test( 'should focus action button when comment editing is cancelled or comment is updated', async ( {
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/heading',
+				attributes: { content: 'Testing block comments' },
+				comment: 'test comment before edit',
+			} );
+
+			// Test focus on action button when comment editing is cancelled.
+			await blockCommentUtils.clickBlockCommentActionMenuItem( 'Edit' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Cancel' } )
+				.first()
+				.click();
+
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'button', { name: 'Actions' } )
+			).toBeFocused();
+
+			// Test focus on action button when comment is updated.
+			await blockCommentUtils.clickBlockCommentActionMenuItem( 'Edit' );
+			await page
+				.getByRole( 'textbox', { name: 'Note' } )
+				.first()
+				.fill( 'Test comment after edit.' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Update' } )
+				.click();
+
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'button', { name: 'Actions' } )
+			).toBeFocused();
+		} );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #72871

## What?

Prevents focus loss when a note editing is canceled or updated, and returns focus to the action button.

## Why?

Accessibility.

## How?

## Testing Instructions

- Add a note to a block.
- Click the Action button and click the Edit button.
  - Click the Cancel button
  - Update text and click the Update button.
- The Action button should get focused.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/59e44318-4331-403a-a97a-97663ee5e7a0


