### PR TITLE
Command Palette: Decode HTML entities in menu url

### DIFF
--- a/backport-changelog/6.9/10446.md
+++ b/backport-changelog/6.9/10446.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10446
+
+* https://github.com/WordPress/gutenberg/pull/72898

--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -31,7 +31,7 @@ function gutenberg_enqueue_command_palette_assets() {
 			if ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) {
 				$menu_url = $menu_slug;
 			} elseif ( ! empty( menu_page_url( $menu_slug, false ) ) ) {
-				$menu_url = menu_page_url( $menu_slug, false );
+				$menu_url = html_entity_decode( menu_page_url( $menu_slug, false ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 			}
 
 			if ( $menu_url ) {
@@ -60,7 +60,7 @@ function gutenberg_enqueue_command_palette_assets() {
 					if ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) {
 						$submenu_url = $submenu_slug;
 					} elseif ( ! empty( menu_page_url( $submenu_slug, false ) ) ) {
-						$submenu_url = menu_page_url( $submenu_slug, false );
+						$submenu_url = html_entity_decode( menu_page_url( $submenu_slug, false ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 					}
 
 					if ( $submenu_url ) {


### PR DESCRIPTION
Closes https://core.trac.wordpress.org/ticket/64177

## What? Why?

The Command Palette automatically registers navigation commands based on the global variables `$menu` and `$submenu`. The `menu_page_url()` function uses `esc_url` internally, so the escaped HTML entities need to be decoded for correct navigation.

## How?

Add `html_entity_decode()`.

## Testing Instructions

- Install [the Web Stories plugin](https://wordpress.org/plugins/web-stories/).
- Launch the Command Palette.
- Execute the "Go to: Stories > Dashboard" command:
- Make sure you have navigated to the correct URL.
  - Before: http://localhost:8888/wp-admin/edit.php?post_type=web-story#038;page=stories-dashboard
  - After: http://localhost:8888/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/templates-gallery
