### PR TITLE
Fix: Hide  input popover when editing Math block as HTML

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -13,7 +13,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,7 +22,12 @@ import { unlock } from '../lock-unlock';
 
 const { Badge } = unlock( componentsPrivateApis );
 
-export default function MathEdit( { attributes, setAttributes, isSelected } ) {
+export default function MathEdit( {
+	attributes,
+	setAttributes,
+	isSelected,
+	clientId,
+} ) {
 	const { latex } = attributes;
 	const [ blockRef, setBlockRef ] = useState();
 	const [ error, setError ] = useState( null );
@@ -30,6 +35,17 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 	const initialLatex = useRef( attributes.latex );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
+
+	// Check if block is in HTML editing mode
+	const { isEditingAsHTML } = useSelect(
+		( select ) => {
+			const { getBlockMode } = select( blockEditorStore );
+			return {
+				isEditingAsHTML: getBlockMode( clientId ) === 'html',
+			};
+		},
+		[ clientId ]
+	);
 
 	useEffect( () => {
 		import( '@wordpress/latex-to-mathml' ).then( ( module ) => {
@@ -67,7 +83,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 			) : (
 				'\u200B'
 			) }
-			{ isSelected && (
+			{ isSelected && ! isEditingAsHTML && (
 				<Popover
 					placement="bottom-start"
 					offset={ 8 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #72899

Fixes the issue where the LaTeX input textarea appears in the upper left corner when switching to 'Edit as HTML' mode in the Math block.

## Why?
When a user selects "Edit as HTML" from the Math block options, the LaTeX input popover (TextareaControl) continues to display because it only checks if the block is selected (`isSelected`), not whether it's in HTML editing mode. This causes the textarea to appear in an incorrect position (upper left corner) instead of being hidden during HTML editing.

## How?
- Added `useSelect` hook to check the block's editing mode using `getBlockMode` selector from `blockEditorStore`
- Added `clientId` prop to the component to identify the current block
- Updated the conditional rendering logic to hide the Popover when `isEditingAsHTML` is `true`
- The popover now only displays when the block is selected AND not in HTML editing mode

## Testing Instructions
1. Open a post or page in the block editor
2. Insert a Math block
3. Enter a LaTeX formula (e.g., `x^2` or `\frac{a}{b}`)
4. Click the three-dot menu (⋮) on the block toolbar
5. Select "Edit as HTML" from the options
6. ✅ Verify that the LaTeX input popover is hidden
7. The HTML textarea should display the block markup without the LaTeX input appearing in the corner
8. Click "Edit visually" to switch back
9. ✅ Verify that the LaTeX input popover appears again when the block is selected

### Testing Instructions for Keyboard
1. Open a post or page in the block editor
2. Insert a Math block using `/math` or the inserter
3. Type a LaTeX formula (e.g., `x^2`)
4. Press `Shift + Alt + Z` (Windows/Linux) or `Ctrl + Option + Z` (Mac) to open the block toolbar
5. Use arrow keys to navigate to the options menu (⋮) and press `Enter`
6. Use arrow keys to navigate to "Edit as HTML" and press `Enter`
7. ✅ Verify that the LaTeX input popover is hidden and focus moves to the HTML textarea
8. Press `Shift + Alt + Z` / `Ctrl + Option + Z` again and select "Edit visually"
9. ✅ Verify that the LaTeX input popover appears again and is accessible via keyboard

## Screenshots or screencast


https://github.com/user-attachments/assets/3a22b296-e353-45ba-a052-08fec8111461


The LaTeX input popover is properly hidden when editing the block as HTML.|