### PR TITLE
Fix: Prevent crash when switching to HTML edit with text selection

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -24,6 +24,10 @@ const title = __( 'Highlight' );
 const EMPTY_ARRAY = [];
 
 function getComputedStyleProperty( element, property ) {
+	if ( ! element || ! element.ownerDocument ) {
+		return null;
+	}
+
 	const { ownerDocument } = element;
 	const { defaultView } = ownerDocument;
 	const style = defaultView.getComputedStyle( element );
@@ -41,6 +45,10 @@ function getComputedStyleProperty( element, property ) {
 }
 
 function fillComputedColors( element, { color, backgroundColor } ) {
+	if ( ! element ) {
+		return;
+	}
+
 	if ( ! color && ! backgroundColor ) {
 		return;
 	}
@@ -66,14 +74,15 @@ function TextColorEdit( {
 		'color.palette'
 	);
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
-	const colorIndicatorStyle = useMemo(
-		() =>
-			fillComputedColors(
-				contentRef.current,
-				getActiveColors( value, name, colors )
-			),
-		[ contentRef, value, colors ]
-	);
+	const colorIndicatorStyle = useMemo( () => {
+		if ( ! contentRef.current ) {
+			return undefined;
+		}
+		return fillComputedColors(
+			contentRef.current,
+			getActiveColors( value, name, colors )
+		);
+	}, [ contentRef, value, colors ] );
 
 	const hasColorsToChoose = !! colors.length || allowCustomControl;
 	if ( ! hasColorsToChoose && ! isActive ) {


### PR DESCRIPTION
## What?
Closes #72897

Fixes crash when switching to "Edit as HTML" mode while text with inline background/text color formatting is selected.

## Why?
When a user selects text with inline formatting (background color or text color) and immediately clicks "Edit as HTML" without deselecting the text first, the component crashes with:
```
TypeError: Cannot destructure property 'ownerDocument' of 't' as it is undefined.
```

This happens because when switching to HTML mode, the `contentRef.current` becomes `null`, but the `useMemo` hook still tries to compute colors by accessing DOM properties.

## How?
- Added null check in `getComputedStyleProperty` before accessing `element.ownerDocument`
- Added null check in `fillComputedColors` before processing the element
- Added guard in `useMemo` to return `undefined` if `contentRef.current` is null
- This prevents the component from trying to access DOM properties when the element no longer exists

## Testing Instructions
1. Open a post or page in the block editor
2. Insert a Paragraph block and add some text (e.g., "Hello World")
3. Select all or part of the text
4. Click the highlight/background color button in the toolbar
5. Choose any background color
6. **Important**: Keep the text selected (do not click elsewhere)
7. Click the three-dot menu (⋮) on the block toolbar
8. Click "Edit as HTML"
9. ✅ Verify the block does NOT crash and switches to HTML mode successfully
10. Click "Edit visually" to return to visual mode
11. ✅ Verify the formatting is still preserved

### Testing Instructions for Keyboard
1. Open a post or page in the block editor
2. Insert a Paragraph block and type some text
3. Select the text using `Shift + Arrow keys`
4. Press `Shift + Alt + H` (Windows/Linux) or `Ctrl + Option + H` (Mac) to open the formatting toolbar
5. Navigate to the highlight button and press `Enter`
6. Select a color using arrow keys and `Enter`
7. With text still selected, press `Shift + Alt + Z` / `Ctrl + Option + Z` to open block toolbar
8. Navigate to "Edit as HTML" and press `Enter`
9. ✅ Verify the block does NOT crash
10. Switch back to visual editing
11. ✅ Verify formatting is preserved

## Screenshots or screencast

https://github.com/user-attachments/assets/d2cdb8eb-5597-411e-88a4-aae3c8bc276c

