### PR TITLE
Adjust empty notes sidebar message

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -317,9 +317,11 @@ export function Comments( {
 					setShowCommentBoard={ setShowCommentBoard }
 					commentSidebarRef={ commentSidebarRef }
 				/>
-				<Text as="p">{ __( 'No notes available.' ) }</Text>
+				<Text as="p">{ __( 'Select a block to insert a Note.' ) }</Text>
 				<Text as="p" variant="muted">
-					{ __( 'Only logged in users can see Notes.' ) }
+					{ __(
+						'Notes are private. Only you and other editors can see them.'
+					) }
 				</Text>
 			</>
 		);

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -317,7 +317,7 @@ export function Comments( {
 					setShowCommentBoard={ setShowCommentBoard }
 					commentSidebarRef={ commentSidebarRef }
 				/>
-				<Text as="p">{ __( 'Select a block to insert a Note.' ) }</Text>
+				<Text as="p">{ __( 'Select a block to insert a note.' ) }</Text>
 				<Text as="p" variant="muted">
 					{ __(
 						'Notes are private. Only you and other editors can see them.'


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/72771
