### PR TITLE
Add keyboard shortcuts for Notes feature

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -4,11 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useState, useRef } from '@wordpress/element';
+import { useState, useRef, useCallback, useEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -79,25 +80,31 @@ function NotesSidebarContent( {
 
 function NotesSidebar( { postId, mode } ) {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
-	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const [ pendingFocus, setPendingFocus ] = useState( null );
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
-	const { clientId, blockCommentId } = useSelect( ( select ) => {
-		const { getBlockAttributes, getSelectedBlockClientId } =
-			select( blockEditorStore );
-		const _clientId = getSelectedBlockClientId();
-		return {
-			clientId: _clientId,
-			blockCommentId: _clientId
-				? getBlockAttributes( _clientId )?.metadata?.noteId
-				: null,
-		};
-	}, [] );
+	const { clientId, blockCommentId, activeComplementaryArea } = useSelect(
+		( select ) => {
+			const { getBlockAttributes, getSelectedBlockClientId } =
+				select( blockEditorStore );
+			const { getActiveComplementaryArea } = select( interfaceStore );
+			const _clientId = getSelectedBlockClientId();
+			return {
+				clientId: _clientId,
+				blockCommentId: _clientId
+					? getBlockAttributes( _clientId )?.metadata?.noteId
+					: null,
+				activeComplementaryArea: getActiveComplementaryArea( 'core' ),
+			};
+		},
+		[]
+	);
 
 	const {
 		resultComments,
@@ -119,9 +126,32 @@ function NotesSidebar( { postId, mode } ) {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 
-	async function openTheSidebar() {
-		const prevArea = await getActiveComplementaryArea( 'core' );
-		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
+	// Handle pending focus actions after sidebar opens
+	useEffect( () => {
+		if ( pendingFocus && SIDEBARS.includes( activeComplementaryArea ) ) {
+			setShowCommentBoard( ! blockCommentId );
+			focusCommentThread(
+				blockCommentId,
+				commentSidebarRef.current,
+				! blockCommentId ? 'textarea' : undefined
+			);
+			if ( clientId ) {
+				toggleBlockSpotlight( clientId, true );
+			}
+			setPendingFocus( null );
+		}
+	}, [
+		pendingFocus,
+		activeComplementaryArea,
+		blockCommentId,
+		clientId,
+		toggleBlockSpotlight,
+	] );
+
+	const openTheSidebar = useCallback( () => {
+		const activeNotesArea = SIDEBARS.find(
+			( name ) => name === activeComplementaryArea
+		);
 
 		if ( currentThread?.status === 'approved' ) {
 			enableComplementaryArea( 'core', collabHistorySidebarName );
@@ -134,21 +164,93 @@ function NotesSidebar( { postId, mode } ) {
 			);
 		}
 
-		const currentArea = await getActiveComplementaryArea( 'core' );
-		// Bail out if the current active area is not one of note sidebars.
-		if ( ! SIDEBARS.includes( currentArea ) ) {
+		const currentArea = activeComplementaryArea;
+		if ( ! SIDEBARS.includes( currentArea ) && ! activeNotesArea ) {
 			return;
 		}
 
-		setShowCommentBoard( ! blockCommentId );
-		focusCommentThread(
-			blockCommentId,
-			commentSidebarRef.current,
-			// Focus a comment thread when there's a selected block with a comment.
-			! blockCommentId ? 'textarea' : undefined
+		setPendingFocus( true );
+	}, [
+		activeComplementaryArea,
+		currentThread,
+		enableComplementaryArea,
+		showFloatingSidebar,
+	] );
+
+	const toggleNotesSidebar = useCallback( () => {
+		const isNotesSidebarOpen =
+			activeComplementaryArea === collabHistorySidebarName;
+
+		if ( isNotesSidebarOpen ) {
+			disableComplementaryArea( 'core' );
+			if ( clientId ) {
+				toggleBlockSpotlight( clientId, false );
+			}
+		} else {
+			enableComplementaryArea( 'core', collabHistorySidebarName );
+		}
+	}, [
+		activeComplementaryArea,
+		clientId,
+		disableComplementaryArea,
+		enableComplementaryArea,
+		toggleBlockSpotlight,
+	] );
+
+	const addNoteToBlock = useCallback( () => {
+		if ( ! clientId ) {
+			return;
+		}
+
+		const isNotesSidebarOpen = SIDEBARS.includes(
+			activeComplementaryArea
 		);
-		toggleBlockSpotlight( clientId, true );
-	}
+
+		if ( ! isNotesSidebarOpen ) {
+			const sidebarToOpen = showFloatingSidebar
+				? collabSidebarName
+				: collabHistorySidebarName;
+			enableComplementaryArea( 'core', sidebarToOpen );
+			setPendingFocus( true );
+		} else {
+			setShowCommentBoard( ! blockCommentId );
+			focusCommentThread(
+				blockCommentId,
+				commentSidebarRef.current,
+				! blockCommentId ? 'textarea' : undefined
+			);
+			toggleBlockSpotlight( clientId, true );
+		}
+	}, [
+		activeComplementaryArea,
+		blockCommentId,
+		clientId,
+		enableComplementaryArea,
+		showFloatingSidebar,
+		toggleBlockSpotlight,
+	] );
+
+	useShortcut(
+		'core/editor/add-note',
+		( event ) => {
+			event.preventDefault();
+			addNoteToBlock();
+		},
+		{
+			bindGlobal: true,
+		}
+	);
+
+	useShortcut(
+		'core/editor/toggle-notes-sidebar',
+		( event ) => {
+			event.preventDefault();
+			toggleNotesSidebar();
+		},
+		{
+			bindGlobal: true,
+		}
+	);
 
 	return (
 		<>

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -100,6 +100,26 @@ function EditorKeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/editor/add-note',
+			category: 'block',
+			description: __( 'Add a note to the selected block.' ),
+			keyCombination: {
+				modifier: 'primaryAlt',
+				character: 'm',
+			},
+		} );
+
+		registerShortcut( {
+	name: 'core/editor/toggle-notes-sidebar',
+	category: 'global',
+	description: __( 'Show or hide the Notes panel.' ),
+	keyCombination: {
+		modifier: 'primaryAlt',
+		character: 'n',
+	},
+} );
+
+		registerShortcut( {
 			name: 'core/editor/keyboard-shortcuts',
 			category: 'main',
 			description: __( 'Display these keyboard shortcuts.' ),


### PR DESCRIPTION
## What?
closes  #72718 

Adds keyboard shortcuts for the Notes feature to streamline note creation and sidebar management.

## Why?
Currently, creating a new block note requires three clicks: clicking the block, opening the options menu, and clicking "Add note". This PR adds keyboard shortcuts to improve accessibility and workflow efficiency:
- A shortcut to quickly add a note to the selected block
- A shortcut to toggle the Notes sidebar open/closed

This addresses the workflow improvement request and follows patterns used in similar collaborative tools like Google Docs.

## How?
- Registered two new keyboard shortcuts in `register-shortcuts.js`:
  - `core/editor/add-note`: `⌘ + Option + M` (Mac) / `Ctrl + Alt + M` (Windows/Linux)
  - `core/editor/toggle-notes-sidebar`: `⌘ + Option + N` (Mac) / `Ctrl + Alt + N` (Windows/Linux)
- Implemented shortcut handlers in `notes-sidebar.js` using the `useShortcut` hook
- The "add note" shortcut opens the appropriate Notes sidebar and shows the comment input for immediate typing
- The "toggle sidebar" shortcut opens/closes the "All notes" panel
- Note: Used `N` for toggle to avoid conflict with `⌘ + Shift + M` (code editor toggle)

## Testing Instructions

### Testing "Add Note" shortcut (`⌘ + Option + M`)
1. Open a post or page in the block editor
2. Insert a Paragraph block and add some text
3. Ensure the block is selected
4. Press `⌘ + Option + M` (Mac) or `Ctrl + Alt + M` (Windows/Linux)
5. ✅ Verify the Notes sidebar opens with a comment input box ready for typing
6. Type a note and verify it saves correctly
7. Select a different block
8. Press `⌘ + Option + M` again
9. ✅ Verify a new note input appears for the newly selected block

### Testing "Toggle Notes Sidebar" shortcut (`⌘ + Option + N`)
1. With a post or page open in the block editor
2. Press `⌘ + Option + N` (Mac) or `Ctrl + Alt + N` (Windows/Linux)
3. ✅ Verify the "All notes" sidebar opens on the right side
4. Press the same shortcut again
5. ✅ Verify the "All notes" sidebar closes
6. Press the shortcut once more
7. ✅ Verify the sidebar opens again

### Testing with existing notes
1. Create a block with an existing note
2. Select that block
3. Press `⌘ + Option + M` / `Ctrl + Alt + M`
4. ✅ Verify the Notes sidebar opens and focuses on the existing note thread
5. Add a reply to the note
6. ✅ Verify the reply is saved

### Testing edge cases
1. Press `⌘ + Option + M` without selecting any block
2. ✅ Verify nothing happens (graceful handling)
3. Press `⌘ + Option + N` in Code Editor mode
4. ✅ Verify the shortcut works (or doesn't work, depending on expected behavior)

### Testing Instructions for Keyboard
1. Navigate through the editor using `Tab` and arrow keys
2. Select a block using keyboard navigation
3. Press `⌘ + Option + M` / `Ctrl + Alt + M`
4. ✅ Verify Notes sidebar opens and comment textarea receives focus
5. Type a note using only the keyboard
6. Press `Tab` to navigate to "Add note" button and press `Enter`
7. ✅ Verify the note is saved
8. Press `⌘ + Option + N` / `Ctrl + Alt + N`
9. ✅ Verify sidebar closes and focus returns to the editor
10. Press `Shift + Option + H` (Mac) or `Shift + Alt + H` (Windows/Linux) to open keyboard shortcuts help
11. ✅ Verify the new shortcuts appear in the help modal:
    - "Add a note to the selected block" in the Block category
    - "Show or hide the Notes panel" in the Global category

## Screenshots or screencast

https://github.com/user-attachments/assets/f998ba95-1814-48cf-b532-d442fb1da751



## Related

Addresses workflow improvement for the Notes feature by reducing friction in the note creation process.