### PR TITLE
iAPI: Show warnings when store path fails to resolve

### DIFF
--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -230,10 +230,12 @@ const resolve = ( path: string, namespace: string ) => {
 		const result = pathParts.reduce( ( acc, key ) => acc[ key ], current );
 
 		// Show a warning when path is invalid or resolves to undefined.
-		if ( typeof result === 'undefined' ) {
-			warn(
-				`"${ path }" in "${ namespace }" namespace resolved to "undefined".`
-			);
+		if ( globalThis.SCRIPT_DEBUG ) {
+			if ( typeof result === 'undefined' ) {
+				warn(
+					`"${ path }" in "${ namespace }" namespace resolved to "undefined".`
+				);
+			}
 		}
 
 		return result;
@@ -241,7 +243,11 @@ const resolve = ( path: string, namespace: string ) => {
 		if ( e === PENDING_GETTER ) {
 			return PENDING_GETTER;
 		}
-		warn( `Failed to resolve "${ path }" in "${ namespace }" namespace.` );
+		if ( globalThis.SCRIPT_DEBUG ) {
+			warn(
+				`Failed to resolve "${ path }" in "${ namespace }" namespace.`
+			);
+		}
 	}
 };
 

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -232,6 +232,7 @@ const resolve = ( path: string, namespace: string ) => {
 		if ( e === PENDING_GETTER ) {
 			return PENDING_GETTER;
 		}
+		warn( `Failed to resolve "${ path }" in "${ namespace }" namespace.` );
 	}
 };
 

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -227,7 +227,16 @@ const resolve = ( path: string, namespace: string ) => {
 
 	try {
 		const pathParts = path.split( '.' );
-		return pathParts.reduce( ( acc, key ) => acc[ key ], current );
+		const result = pathParts.reduce( ( acc, key ) => acc[ key ], current );
+
+		// Show a warning when path is invalid or resolves to undefined.
+		if ( typeof result === 'undefined' ) {
+			warn(
+				`"${ path }" in "${ namespace }" namespace resolved to "undefined".`
+			);
+		}
+
+		return result;
 	} catch ( e ) {
 		if ( e === PENDING_GETTER ) {
 			return PENDING_GETTER;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72683, #72272

<!-- In a few words, what is the PR actually doing? -->

## Why?
When a path used for the Interactivity API directives failed to resolve in the given store namespace, the errors were silently ignored. This caused confusion and unexpected behaviors. 

## How?
We now show a warning to the user letting them know a path was unresolved and to expect things to break.

## Testing Instructions
TBD
