### PR TITLE
Add “Show More” / “Show Less” toggle in Note.

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -39,7 +39,11 @@ import {
 import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
-import { focusCommentThread, getCommentExcerpt, isCommentTrimmed } from './utils';
+import {
+	focusCommentThread,
+	getCommentExcerpt,
+	isCommentTrimmed,
+} from './utils';
 import { useFloatingThread } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -714,11 +718,11 @@ const CommentBoard = ( {
 			? actions.filter( ( item ) => item.isEligible( thread ) )
 			: [];
 
-	const [expanded, setExpanded] = useState(false);
+	const [ expanded, setExpanded ] = useState( false );
 	const MAX_LENGTH = 16;
-	const handleComment = (comment) => {
-		return expanded ? comment : getCommentExcerpt(comment, MAX_LENGTH);
-	}
+	const handleComment = ( comment ) => {
+		return expanded ? comment : getCommentExcerpt( comment, MAX_LENGTH );
+	};
 
 	return (
 		<VStack spacing="2">
@@ -836,22 +840,22 @@ const CommentBoard = ( {
 										// translators: %1$s: action label ("Marked as resolved" or "Reopened"); %2$s: note text.
 										__( '%1$s: %2$s' ),
 										actionText,
-										handleComment(content)
+										handleComment( content )
 									);
 								}
 								// If no content, just show the action.
 								return actionText;
 						  } )()
-						: handleComment(thread.content?.raw) }
+						: handleComment( thread.content?.raw ) }
 				</p>
 			) }
-			{ isCommentTrimmed(thread.content?.raw, MAX_LENGTH) && (
+			{ isCommentTrimmed( thread.content?.raw, MAX_LENGTH ) && (
 				<Button
 					variant="tertiary"
 					size="small"
-					onClick={() => setExpanded(!expanded)}
+					onClick={ () => setExpanded( ! expanded ) }
 				>
-					{ expanded ? __('Show Less') : __('Show More') }
+					{ expanded ? __( 'Show Less' ) : __( 'Show More' ) }
 				</Button>
 			) }
 			{ 'delete' === actionState && (

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import {
 	useState,
-	RawHTML,
 	useEffect,
 	useCallback,
 	useMemo,
@@ -40,7 +39,7 @@ import {
 import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
-import { focusCommentThread, getCommentExcerpt } from './utils';
+import { focusCommentThread, getCommentExcerpt, isCommentTrimmed } from './utils';
 import { useFloatingThread } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -715,6 +714,12 @@ const CommentBoard = ( {
 			? actions.filter( ( item ) => item.isEligible( thread ) )
 			: [];
 
+	const [expanded, setExpanded] = useState(false);
+	const MAX_LENGTH = 16;
+	const handleComment = (comment) => {
+		return expanded ? comment : getCommentExcerpt(comment, MAX_LENGTH);
+	}
+
 	return (
 		<VStack spacing="2">
 			<HStack alignment="left" spacing="3" justify="flex-start">
@@ -805,7 +810,7 @@ const CommentBoard = ( {
 					reflowComments={ reflowComments }
 				/>
 			) : (
-				<RawHTML
+				<p
 					className={ clsx(
 						'editor-collab-sidebar-panel__user-comment',
 						{
@@ -820,7 +825,7 @@ const CommentBoard = ( {
 									thread.meta._wp_note_status === 'resolved'
 										? __( 'Marked as resolved' )
 										: __( 'Reopened' );
-								const content = thread?.content?.raw;
+								const content = thread.content?.raw;
 
 								if (
 									content &&
@@ -831,14 +836,23 @@ const CommentBoard = ( {
 										// translators: %1$s: action label ("Marked as resolved" or "Reopened"); %2$s: note text.
 										__( '%1$s: %2$s' ),
 										actionText,
-										content
+										handleComment(content)
 									);
 								}
 								// If no content, just show the action.
 								return actionText;
 						  } )()
-						: thread?.content?.rendered }
-				</RawHTML>
+						: handleComment(thread.content?.raw) }
+				</p>
+			) }
+			{ isCommentTrimmed(thread.content?.raw, MAX_LENGTH) && (
+				<Button
+					variant="tertiary"
+					size="small"
+					onClick={() => setExpanded(!expanded)}
+				>
+					{ expanded ? __('Show Less') : __('Show More') }
+				</Button>
 			) }
 			{ 'delete' === actionState && (
 				<ConfirmDialog

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -67,9 +67,7 @@
 }
 
 .editor-collab-sidebar-panel__user-comment {
-	p:last-child {
-		margin-bottom: 0;
-	}
+	margin-bottom: 0;
 }
 
 .editor-collab-sidebar-panel__user-avatar {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -145,9 +145,11 @@
 		right: $grid-unit-10;
 	}
 }
+
 .editor-collab-sidebar-panel__skip-to-comment:focus {
 	top: $grid-unit-10;
 }
+
 .editor-collab-sidebar-panel__skip-to-block:focus {
 	top: auto;
 	bottom: $grid-unit-10;

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -44,15 +44,17 @@ export function getAvatarBorderColor( userId ) {
 }
 
 /**
- * Generates a comment excerpt from text based on word count type and length.
+ * Trims the comment text to an excerpt based on the word count type and length (default: 10).
  *
- * @param {string} text          - The comment text to generate excerpt from.
- * @param {number} excerptLength - The maximum length for the commentexcerpt.
- * @return {string} - The generated comment excerpt.
+ * @param {string} text          - The original comment text to trim.
+ * @param {number} excerptLength - The maximum length of the trimmed excerpt.
+ * @return {Object} - Is comment trimmed and the comment excerpt.
  */
-export function getCommentExcerpt( text, excerptLength = 10 ) {
+export function __trimComment( text, excerptLength = 10 ) {
+	let isTrimmed = false;
+	let trimmedExcerpt = '';
 	if ( ! text ) {
-		return '';
+		return { isTrimmed, trimmedExcerpt };
 	}
 
 	/*
@@ -63,7 +65,6 @@ export function getCommentExcerpt( text, excerptLength = 10 ) {
 	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
 
 	const rawText = text.trim();
-	let trimmedExcerpt = '';
 
 	if ( wordCountType === 'words' ) {
 		trimmedExcerpt = rawText.split( ' ', excerptLength ).join( ' ' );
@@ -88,7 +89,35 @@ export function getCommentExcerpt( text, excerptLength = 10 ) {
 		trimmedExcerpt = rawText.split( '', excerptLength ).join( '' );
 	}
 
-	const isTrimmed = trimmedExcerpt !== rawText;
+	if (trimmedExcerpt !== rawText) {
+		isTrimmed = true;
+	}
+
+	return { isTrimmed, trimmedExcerpt };
+}
+
+/**
+ *  Checks whether the given comment text would be trimmed
+ *  when generating an excerpt of the specified length (default: 10).
+ *
+ * @param {string} text          - The original comment text to check.
+ * @param {number} excerptLength - The maximum length of the trimmed excerpt.
+ * @return {boolean} - True if the comment is trimmed, false otherwise.
+ */
+export function isCommentTrimmed( text, excerptLength ) {
+	const { isTrimmed } = __trimComment(text, excerptLength);
+	return isTrimmed;
+}
+
+/**
+ * Generates a comment excerpt from text based on word count type and length (default: 10).
+ *
+ * @param {string} text          - The comment text to generate excerpt from.
+ * @param {number} excerptLength - The maximum length for the commentexcerpt.
+ * @return {string} - The generated comment excerpt.
+ */
+export function getCommentExcerpt( text, excerptLength ) {
+	const { isTrimmed, trimmedExcerpt } = __trimComment(text, excerptLength);
 	return isTrimmed ? trimmedExcerpt + '…' : trimmedExcerpt;
 }
 

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -89,7 +89,7 @@ export function __trimComment( text, excerptLength = 10 ) {
 		trimmedExcerpt = rawText.split( '', excerptLength ).join( '' );
 	}
 
-	if (trimmedExcerpt !== rawText) {
+	if ( trimmedExcerpt !== rawText ) {
 		isTrimmed = true;
 	}
 
@@ -105,7 +105,7 @@ export function __trimComment( text, excerptLength = 10 ) {
  * @return {boolean} - True if the comment is trimmed, false otherwise.
  */
 export function isCommentTrimmed( text, excerptLength ) {
-	const { isTrimmed } = __trimComment(text, excerptLength);
+	const { isTrimmed } = __trimComment( text, excerptLength );
 	return isTrimmed;
 }
 
@@ -117,7 +117,7 @@ export function isCommentTrimmed( text, excerptLength ) {
  * @return {string} - The generated comment excerpt.
  */
 export function getCommentExcerpt( text, excerptLength ) {
-	const { isTrimmed, trimmedExcerpt } = __trimComment(text, excerptLength);
+	const { isTrimmed, trimmedExcerpt } = __trimComment( text, excerptLength );
 	return isTrimmed ? trimmedExcerpt + '…' : trimmedExcerpt;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72822

## Uncertain Changes

- changed `RawHTML` to `p`
- changed `thread?.content?.rendered` to `thread.content?.raw`

## Notes

Ignored the following Git hook errors:
```
packages/editor/src/components/style-book/color-examples.tsx(11,2): error TS2305: Module '"@wordpress/block-editor"' has no exported member 'getColorClassName'.
packages/editor/src/components/style-book/color-examples.tsx(12,2): error TS2305: Module '"@wordpress/block-editor"' has no exported member '__experimentalGetGradientClass'.
packages/editor/src/components/style-book/color-examples.tsx(14,2): error TS2578: Unused '@ts-expect-error' directive.
packages/editor/src/components/style-book/examples.tsx(6,2): error TS2305: Module '"@wordpress/blocks"' has no exported member 'getBlockType'.
packages/editor/src/components/style-book/examples.tsx(7,2): error TS2305: Module '"@wordpress/blocks"' has no exported member 'getBlockTypes'.
packages/editor/src/components/style-book/examples.tsx(8,2): error TS2305: Module '"@wordpress/blocks"' has no exported member 'getBlockFromExample'.
packages/editor/src/components/style-book/examples.tsx(9,2): error TS2305: Module '"@wordpress/blocks"' has no exported member 'createBlock'.
packages/editor/src/components/style-book/examples.tsx(11,2): error TS2578: Unused '@ts-expect-error' directive. 
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="248" height="429" alt="image" src="https://github.com/user-attachments/assets/e764063f-cd7c-46c7-b9be-44b8350219a8" />|<img width="241" height="164" alt="image" src="https://github.com/user-attachments/assets/1c8f12e0-a06b-46e9-9a65-e8c12c1ec404" />|