### PR TITLE
Math: Fixing Edit as HTML feature and code editor sync

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -495,6 +495,7 @@ Display mathematical notation using LaTeX. ([Source](https://github.com/WordPres
 
 -	**Name:** core/math
 -	**Category:** text
+-	**Supports:** ~~html~~
 -	**Attributes:** latex, mathML
 
 ## Media & Text

--- a/packages/block-library/src/math/block.json
+++ b/packages/block-library/src/math/block.json
@@ -7,6 +7,9 @@
 	"description": "Display mathematical notation using LaTeX.",
 	"keywords": [ "equation", "formula", "latex", "mathematics" ],
 	"textdomain": "default",
+	"supports": {
+		"html": false
+	},
 	"attributes": {
 		"latex": {
 			"type": "string",

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -88,9 +88,9 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setAttributes( { latex: newLatex } );
 										return;
 									}
-									let nextMathML = '';
+									let newMathML = '';
 									try {
-										nextMathML = latexToMathML( newLatex, {
+										newMathML = latexToMathML( newLatex, {
 											displayMode: true,
 										} );
 										setError( null );
@@ -98,7 +98,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setError( err.message );
 									}
 									setAttributes( {
-										mathML: nextMathML,
+										mathML: newMathML,
 										latex: newLatex,
 									} );
 								} }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -13,7 +13,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,30 +22,14 @@ import { unlock } from '../lock-unlock';
 
 const { Badge } = unlock( componentsPrivateApis );
 
-export default function MathEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	clientId,
-} ) {
-	const { latex } = attributes;
+export default function MathEdit( { attributes, setAttributes, isSelected } ) {
+	const { latex, mathML } = attributes;
 	const [ blockRef, setBlockRef ] = useState();
 	const [ error, setError ] = useState( null );
 	const [ latexToMathML, setLatexToMathML ] = useState();
-	const initialLatex = useRef( attributes.latex );
+	const initialLatex = useRef( latex );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-
-	// Check if block is in HTML editing mode
-	const { isEditingAsHTML } = useSelect(
-		( select ) => {
-			const { getBlockMode } = select( blockEditorStore );
-			return {
-				isEditingAsHTML: getBlockMode( clientId ) === 'html',
-			};
-		},
-		[ clientId ]
-	);
 
 	useEffect( () => {
 		import( '@wordpress/latex-to-mathml' ).then( ( module ) => {
@@ -72,18 +56,18 @@ export default function MathEdit( {
 
 	return (
 		<div { ...blockProps }>
-			{ attributes.mathML ? (
+			{ mathML ? (
 				<math
 					// We can't spread block props on the math element because
 					// it only supports a limited amount of global attributes.
 					// For example, draggable will have no effect.
 					display="block"
-					dangerouslySetInnerHTML={ { __html: attributes.mathML } }
+					dangerouslySetInnerHTML={ { __html: mathML } }
 				/>
 			) : (
 				'\u200B'
 			) }
-			{ isSelected && ! isEditingAsHTML && (
+			{ isSelected && (
 				<Popover
 					placement="bottom-start"
 					offset={ 8 }
@@ -104,9 +88,9 @@ export default function MathEdit( {
 										setAttributes( { latex: newLatex } );
 										return;
 									}
-									let mathML = '';
+									let nextMathML = '';
 									try {
-										mathML = latexToMathML( newLatex, {
+										nextMathML = latexToMathML( newLatex, {
 											displayMode: true,
 										} );
 										setError( null );
@@ -114,7 +98,7 @@ export default function MathEdit( {
 										setError( err.message );
 									}
 									setAttributes( {
-										mathML,
+										mathML: nextMathML,
 										latex: newLatex,
 									} );
 								} }


### PR DESCRIPTION
## What?
Closes #72899

The Math component should not have Edit as HTML, as the whole Component is managed through attributes. Changes in the HTML won't reflect on the component. Also, little improvements as we can already destructure `latex`, we can also destructure `mathML`

## Why?
According to #72899, while editing as HTML, there is a visual glitch on the textarea. The solution could be removing such textarea, but in reality the true solution is completely removing the HTML editing feature.

## How?
Removing the supports

|Before|After|
|-|-|
|<img width="285" height="570" alt="image" src="https://github.com/user-attachments/assets/aa17770e-1ea3-4bf5-b18c-f3edd5e47200" />|<img width="285" height="529" alt="image" src="https://github.com/user-attachments/assets/bae47266-03c9-493d-aecb-a88184e0134a" />|
