### PR TITLE
Template activation: apply block hooks in new get_registered_block_templates fn

### DIFF
--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -174,6 +174,18 @@ function gutenberg_get_registered_block_templates( $query ) {
 		}
 	);
 
+	$matching_registered_templates = array_map(
+		function ( $template ) {
+			$template->content = apply_block_hooks_to_content(
+				$template->content,
+				$template,
+				'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+			);
+			return $template;
+		},
+		$matching_registered_templates
+	);
+
 	$query_result = array_merge( $query_result, $matching_registered_templates );
 
 	/**


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72794

Adds https://github.com/WordPress/wordpress-develop/pull/9418 for the new `get_registered_block_templates` function.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These hooks are not automatically applied when getting templates from the registry.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Applies it similarly to https://github.com/WordPress/wordpress-develop/pull/9418 for now. In the future we should ideally build this into the registry I think.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test Woo for according to the instructions in #72794 with WP 6.9 and this GB PR. Note that WP 6.8 will work because of a workaround.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
