### PR TITLE
DataViewsPicker: Add With Modal storybook story

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - DataForm: simplify form normalization. [#72848](https://github.com/WordPress/gutenberg/pull/72848)
+- DataViewsPicker: Add With Modal story. [#72913](https://github.com/WordPress/gutenberg/pull/72913)
 
 ### Bug fixes
 

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -7,6 +7,11 @@ import type { Meta } from '@storybook/react';
  * WordPress dependencies
  */
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import {
+	Modal,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,17 +29,49 @@ const meta = {
 
 export default meta;
 
-export const Default = ( {
-	perPageSizes = [ 10, 25, 50, 100 ],
-	isMultiselectable,
-	isGrouped,
-	infiniteScrollEnabled,
-}: {
+const storyArgs = {
+	perPageSizes: [ 10, 25, 50, 100 ],
+	isMultiselectable: false,
+	isGrouped: false,
+};
+
+const storyArgTypes = {
+	isMultiselectable: {
+		control: 'boolean',
+		description: 'Whether multiselection is supported',
+	},
+	perPageSizes: {
+		control: 'object',
+		description: 'Array of available page sizes',
+	},
+	isGrouped: {
+		control: 'boolean',
+		description: 'Whether the items are grouped or ungrouped',
+	},
+	infiniteScrollEnabled: {
+		control: 'boolean',
+		description:
+			'Whether the infinite scroll is enabled. Enabling this disables the "Is grouped" option',
+	},
+};
+
+interface PickerContentProps {
 	perPageSizes: number[];
 	isMultiselectable: boolean;
 	isGrouped: boolean;
 	infiniteScrollEnabled: boolean;
-} ) => {
+	actions?: ActionButton< SpaceObject >[];
+	selection?: string[];
+}
+
+const DataViewsPickerContent = ( {
+	perPageSizes = [ 10, 25, 50, 100 ],
+	isMultiselectable,
+	isGrouped,
+	infiniteScrollEnabled,
+	actions: customActions,
+	selection: customSelection,
+}: PickerContentProps ) => {
 	const [ view, setView ] = useState< View >( {
 		type: LAYOUT_PICKER_GRID,
 		fields: [],
@@ -61,9 +98,11 @@ export const Default = ( {
 		} ) );
 	}, [ isGrouped, infiniteScrollEnabled ] );
 
-	const [ selection, setSelection ] = useState< string[] >( [] );
+	const [ selection, setSelection ] = useState< string[] >(
+		customSelection || []
+	);
 
-	const actions: ActionButton< SpaceObject >[] = [
+	const actions: ActionButton< SpaceObject >[] = customActions || [
 		{
 			id: 'cancel',
 			label: 'Cancel',
@@ -138,31 +177,115 @@ export const Default = ( {
 	);
 };
 
-Default.args = {
-	perPageSizes: [ 10, 25, 50, 100 ],
-	isMultiselectable: false,
-	isGrouped: false,
+export const Default = ( {
+	perPageSizes = [ 10, 25, 50, 100 ],
+	isMultiselectable,
+	isGrouped,
+	infiniteScrollEnabled,
+}: {
+	perPageSizes: number[];
+	isMultiselectable: boolean;
+	isGrouped: boolean;
+	infiniteScrollEnabled: boolean;
+} ) => (
+	<DataViewsPickerContent
+		perPageSizes={ perPageSizes }
+		isMultiselectable={ isMultiselectable }
+		isGrouped={ isGrouped }
+		infiniteScrollEnabled={ infiniteScrollEnabled }
+	/>
+);
+
+Default.args = storyArgs;
+Default.argTypes = storyArgTypes;
+
+export const WithModal = ( {
+	perPageSizes = [ 10, 25, 50, 100 ],
+	isMultiselectable,
+	isGrouped,
+	infiniteScrollEnabled,
+}: {
+	perPageSizes: number[];
+	isMultiselectable: boolean;
+	isGrouped: boolean;
+	infiniteScrollEnabled: boolean;
+} ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( true );
+	const [ selectedItems, setSelectedItems ] = useState< SpaceObject[] >( [] );
+
+	const modalActions: ActionButton< SpaceObject >[] = [
+		{
+			id: 'cancel',
+			label: 'Cancel',
+			supportsBulk: isMultiselectable,
+			callback() {
+				setIsModalOpen( false );
+			},
+		},
+		{
+			id: 'confirm',
+			label: 'Confirm',
+			isPrimary: true,
+			supportsBulk: isMultiselectable,
+			callback( items ) {
+				setSelectedItems( items );
+				setIsModalOpen( false );
+			},
+		},
+	];
+
+	return (
+		<>
+			<HStack justify="left">
+				<Button
+					variant="primary"
+					onClick={ () => setIsModalOpen( true ) }
+				>
+					Open Picker Modal
+				</Button>
+				<Button
+					onClick={ () => setSelectedItems( [] ) }
+					disabled={ ! selectedItems.length }
+					accessibleWhenDisabled
+				>
+					Clear Selection
+				</Button>
+			</HStack>
+			{ selectedItems.length > 0 && (
+				<p>
+					Selected:{ ' ' }
+					{ selectedItems
+						.map( ( item ) => item.name.title )
+						.join( ', ' ) }
+				</p>
+			) }
+			{ isModalOpen && (
+				<Modal
+					title="Select Items"
+					onRequestClose={ () => setIsModalOpen( false ) }
+					isFullScreen={ false }
+					size="fill"
+				>
+					<div style={ { padding: '16px' } }>
+						<DataViewsPickerContent
+							perPageSizes={ perPageSizes }
+							isMultiselectable={ isMultiselectable }
+							isGrouped={ isGrouped }
+							infiniteScrollEnabled={ infiniteScrollEnabled }
+							actions={ modalActions }
+							selection={ selectedItems.map( ( item ) =>
+								String( item.id )
+							) }
+						/>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
 };
 
-Default.argTypes = {
-	isMultiselectable: {
-		control: 'boolean',
-		description: 'Whether multiselection is supported',
-	},
-	perPageSizes: {
-		control: 'object',
-		description: 'Array of available page sizes',
-	},
-	isGrouped: {
-		control: 'boolean',
-		description: 'Whether the items are grouped or ungrouped',
-	},
-	infiniteScrollEnabled: {
-		control: 'boolean',
-		description:
-			'Whether the infinite scroll is enabled. Enabling this disables the "Is grouped" option',
-	},
-};
+WithModal.args = storyArgs;
+WithModal.argTypes = storyArgTypes;
 
 function useInfiniteScroll( {
 	view,

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -210,7 +210,7 @@ export const WithModal = ( {
 	isGrouped: boolean;
 	infiniteScrollEnabled: boolean;
 } ) => {
-	const [ isModalOpen, setIsModalOpen ] = useState( true );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ selectedItems, setSelectedItems ] = useState< SpaceObject[] >( [] );
 
 	const modalActions: ActionButton< SpaceObject >[] = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #72336

This PR adds a With Modal storybook story for the DataViewsPicker component. It doesn't address any of the issues in #72336, but should hopefully make those issues easier to work on or debug.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the media library modal experiment in place and more folks starting to use the DataViewsPicker for a variety of use cases, it should help development of the picker to add a storybook entry for its use within a modal. As other use cases are explored (e.g. in #71128), I expect there'll be more of a use to quickly check how the component is working within a modal.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the DataViewsPicker story to add an additional story and share common components
* In the additional story, use a `Modal` component and output the selected items outside of the modal, to demonstrate picking behaviour

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Run `npm run storybook:dev` and then navigate to http://localhost:50240/?path=/story/dataviews-dataviewspicker--with-modal to try out the modal

Note when testing that there might be issues with the DataViewsPicker itself (i.e. the footer isn't sticky). The purpose of this PR isn't to fix those issues (they're raised in #72336), but make them easier to spot and test.

That said, if you find issues with the story itself, please let me know!

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c37b49c9-45b5-4235-bf32-3dd1158e4bd7