### PR TITLE
Try adding table view to data picker

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 - DataForm: make the card layout borderless. [#72514](https://github.com/WordPress/gutenberg/pull/72514)
 - DataViews: Simplify the view config properties section. [#73064](https://github.com/WordPress/gutenberg/pull/73064)
 - DataViews: Add a contextual menu to the table layout header. [#73104](https://github.com/WordPress/gutenberg/pull/73104)
+- DataViewsPicker: Add table layout support. [#72914](https://github.com/WordPress/gutenberg/pull/72914)
 
 ### Bug fixes
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -88,6 +88,7 @@ export function ViewTypeMenu() {
 									case 'grid':
 									case 'table':
 									case 'pickerGrid':
+									case 'pickerTable':
 										const viewWithoutLayout = { ...view };
 										if ( 'layout' in viewWithoutLayout ) {
 											delete viewWithoutLayout.layout;

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -186,3 +186,4 @@ export const LAYOUT_LIST = 'list';
 
 // Picker view layouts.
 export const LAYOUT_PICKER_GRID = 'pickerGrid';
+export const LAYOUT_PICKER_TABLE = 'pickerTable';

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -16,11 +16,13 @@ import ViewTable from './table';
 import ViewGrid from './grid';
 import ViewList from './list';
 import ViewPickerGrid from './picker-grid';
+import ViewPickerTable from './picker-table';
 import {
 	LAYOUT_GRID,
 	LAYOUT_LIST,
 	LAYOUT_TABLE,
 	LAYOUT_PICKER_GRID,
+	LAYOUT_PICKER_TABLE,
 } from '../constants';
 import PreviewSizePicker from './utils/preview-size-picker';
 import DensityPicker from './table/density-picker';
@@ -52,6 +54,14 @@ export const VIEW_LAYOUTS = [
 		component: ViewPickerGrid,
 		icon: category,
 		viewConfigOptions: PreviewSizePicker,
+		isPicker: true,
+	},
+	{
+		type: LAYOUT_PICKER_TABLE,
+		label: __( 'Table' ),
+		component: ViewPickerTable,
+		icon: blockTable,
+		viewConfigOptions: DensityPicker,
 		isPicker: true,
 	},
 ];

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -21,12 +21,8 @@ import {
  */
 import DataViewsContext from '../../components/dataviews-context';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import { useIsMultiselectPicker } from '../../components/dataviews-picker/footer';
 import { sortValues } from '../../constants';
-import {
-	useSomeItemHasAPossibleBulkAction,
-	useHasAPossibleBulkAction,
-	BulkSelectionCheckbox,
-} from '../../components/dataviews-bulk-actions';
 import type {
 	Action,
 	NormalizedField,
@@ -57,6 +53,7 @@ interface TableRowProps< Item > {
 	selection: string[];
 	getItemId: ( item: Item ) => string;
 	onChangeSelection: SetSelection;
+	multiselect: boolean;
 	posinset?: number;
 }
 
@@ -86,7 +83,6 @@ function TableColumnField< Item >( {
 
 function TableRow< Item >( {
 	item,
-	actions,
 	fields,
 	id,
 	view,
@@ -96,11 +92,11 @@ function TableRow< Item >( {
 	selection,
 	getItemId,
 	onChangeSelection,
+	multiselect,
 	posinset,
 }: TableRowProps< Item > ) {
 	const { paginationInfo } = useContext( DataViewsContext );
-	const hasPossibleBulkAction = useHasAPossibleBulkAction( actions, item );
-	const isSelected = hasPossibleBulkAction && selection.includes( id );
+	const isSelected = selection.includes( id );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const {
 		showTitle = true,
@@ -124,9 +120,8 @@ function TableRow< Item >( {
 	return (
 		<tr
 			className={ clsx( 'dataviews-view-table__row', {
-				'is-selected': hasPossibleBulkAction && isSelected,
+				'is-selected': isSelected,
 				'is-hovered': isHovered,
-				'has-bulk-actions': hasPossibleBulkAction,
 			} ) }
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
@@ -136,26 +131,16 @@ function TableRow< Item >( {
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : undefined }
 			onClick={ ( event ) => {
-				if ( ! hasPossibleBulkAction ) {
-					return;
-				}
-
 				if ( event.target instanceof HTMLElement ) {
-					// Don't select when clicking on the checkbox or primary column
-					const isCheckbox = event.target.closest(
-						'.dataviews-view-table__checkbox-column'
-					);
-					const isPrimary =
-						event.target.closest( 'td' )?.cellIndex === 1;
-
-					if ( ! isCheckbox && ! isPrimary ) {
+					if ( isSelected ) {
 						onChangeSelection(
-							selection.includes( id )
-								? selection.filter(
-										( itemId ) => id !== itemId
-								  )
-								: [ id ]
+							selection.filter( ( itemId ) => id !== itemId )
 						);
+					} else {
+						const newSelection = multiselect
+							? [ ...selection, id ]
+							: [ id ];
+						onChangeSelection( newSelection );
 					}
 				}
 			} }
@@ -168,7 +153,7 @@ function TableRow< Item >( {
 						onChangeSelection={ onChangeSelection }
 						getItemId={ getItemId }
 						titleField={ titleField }
-						disabled={ ! hasPossibleBulkAction }
+						disabled={ false }
 					/>
 				</div>
 			</td>
@@ -233,7 +218,7 @@ function ViewPickerTable< Item >( {
 	const headerMenuToFocusRef = useRef< HTMLButtonElement >();
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] =
 		useState< HTMLButtonElement >();
-	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
+	const isMultiselect = useIsMultiselectPicker( actions ) ?? false;
 
 	useEffect( () => {
 		if ( headerMenuToFocusRef.current ) {
@@ -309,20 +294,6 @@ function ViewPickerTable< Item >( {
 			>
 				<thead>
 					<tr className="dataviews-view-table__row">
-						{ hasBulkActions && (
-							<th
-								className="dataviews-view-table__checkbox-column"
-								scope="col"
-							>
-								<BulkSelectionCheckbox
-									selection={ selection }
-									onChangeSelection={ onChangeSelection }
-									data={ data }
-									actions={ actions }
-									getItemId={ getItemId }
-								/>
-							</th>
-						) }
 						{ hasPrimaryColumn && (
 							<th scope="col">
 								{ titleField && (
@@ -389,8 +360,7 @@ function ViewPickerTable< Item >( {
 									<td
 										colSpan={
 											columns.length +
-											( hasPrimaryColumn ? 1 : 0 ) +
-											( hasBulkActions ? 1 : 0 )
+											( hasPrimaryColumn ? 1 : 0 )
 										}
 										className="dataviews-view-table__group-header-cell"
 									>
@@ -419,6 +389,7 @@ function ViewPickerTable< Item >( {
 										selection={ selection }
 										getItemId={ getItemId }
 										onChangeSelection={ onChangeSelection }
+										multiselect={ isMultiselect }
 									/>
 								) ) }
 							</tbody>
@@ -441,6 +412,7 @@ function ViewPickerTable< Item >( {
 									selection={ selection }
 									getItemId={ getItemId }
 									onChangeSelection={ onChangeSelection }
+									multiselect={ isMultiselect }
 									posinset={
 										isInfiniteScroll ? index + 1 : undefined
 									}

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -1,0 +1,490 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+import {
+	useContext,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from '../../components/dataviews-context';
+import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import { sortValues } from '../../constants';
+import {
+	useSomeItemHasAPossibleBulkAction,
+	useHasAPossibleBulkAction,
+	BulkSelectionCheckbox,
+} from '../../components/dataviews-bulk-actions';
+import type {
+	Action,
+	NormalizedField,
+	ViewPickerTable as ViewPickerTableType,
+	ViewPickerTableProps,
+} from '../../types';
+import type { SetSelection } from '../../types/private';
+import ColumnHeaderMenu from '../table/column-header-menu';
+import ColumnPrimary from '../table/column-primary';
+import { useIsHorizontalScrollEnd } from '../table/use-is-horizontal-scroll-end';
+import getDataByGroup from '../utils/get-data-by-group';
+
+interface TableColumnFieldProps< Item > {
+	fields: NormalizedField< Item >[];
+	column: string;
+	item: Item;
+	align?: 'start' | 'center' | 'end';
+}
+
+interface TableRowProps< Item > {
+	hasBulkActions: boolean;
+	item: Item;
+	actions: Action< Item >[];
+	fields: NormalizedField< Item >[];
+	id: string;
+	view: ViewPickerTableType;
+	titleField?: NormalizedField< Item >;
+	mediaField?: NormalizedField< Item >;
+	descriptionField?: NormalizedField< Item >;
+	selection: string[];
+	getItemId: ( item: Item ) => string;
+	onChangeSelection: SetSelection;
+	posinset?: number;
+}
+
+function TableColumnField< Item >( {
+	item,
+	fields,
+	column,
+	align,
+}: TableColumnFieldProps< Item > ) {
+	const field = fields.find( ( f ) => f.id === column );
+
+	if ( ! field ) {
+		return null;
+	}
+
+	const className = clsx( 'dataviews-view-table__cell-content-wrapper', {
+		'dataviews-view-table__cell-align-end': align === 'end',
+		'dataviews-view-table__cell-align-center': align === 'center',
+	} );
+
+	return (
+		<div className={ className }>
+			<field.render item={ item } field={ field } />
+		</div>
+	);
+}
+
+function TableRow< Item >( {
+	hasBulkActions,
+	item,
+	actions,
+	fields,
+	id,
+	view,
+	titleField,
+	mediaField,
+	descriptionField,
+	selection,
+	getItemId,
+	onChangeSelection,
+	posinset,
+}: TableRowProps< Item > ) {
+	const { paginationInfo } = useContext( DataViewsContext );
+	const hasPossibleBulkAction = useHasAPossibleBulkAction( actions, item );
+	const isSelected = hasPossibleBulkAction && selection.includes( id );
+	const [ isHovered, setIsHovered ] = useState( false );
+	const {
+		showTitle = true,
+		showMedia = true,
+		showDescription = true,
+		infiniteScrollEnabled,
+	} = view;
+	const handleMouseEnter = () => {
+		setIsHovered( true );
+	};
+	const handleMouseLeave = () => {
+		setIsHovered( false );
+	};
+
+	const columns = view.fields ?? [];
+	const hasPrimaryColumn =
+		( titleField && showTitle ) ||
+		( mediaField && showMedia ) ||
+		( descriptionField && showDescription );
+
+	return (
+		<tr
+			className={ clsx( 'dataviews-view-table__row', {
+				'is-selected': hasPossibleBulkAction && isSelected,
+				'is-hovered': isHovered,
+				'has-bulk-actions': hasPossibleBulkAction,
+			} ) }
+			onMouseEnter={ handleMouseEnter }
+			onMouseLeave={ handleMouseLeave }
+			aria-setsize={
+				infiniteScrollEnabled ? paginationInfo.totalItems : undefined
+			}
+			aria-posinset={ posinset }
+			role={ infiniteScrollEnabled ? 'article' : undefined }
+			onClick={ ( event ) => {
+				if ( ! hasPossibleBulkAction ) {
+					return;
+				}
+
+				if ( event.target instanceof HTMLElement ) {
+					// Don't select when clicking on the checkbox or primary column
+					const isCheckbox = event.target.closest(
+						'.dataviews-view-table__checkbox-column'
+					);
+					const isPrimary =
+						event.target.closest( 'td' )?.cellIndex === 1;
+
+					if ( ! isCheckbox && ! isPrimary ) {
+						onChangeSelection(
+							selection.includes( id )
+								? selection.filter(
+										( itemId ) => id !== itemId
+								  )
+								: [ id ]
+						);
+					}
+				}
+			} }
+		>
+			{ hasBulkActions && (
+				<td className="dataviews-view-table__checkbox-column">
+					<div className="dataviews-view-table__cell-content-wrapper">
+						<DataViewsSelectionCheckbox
+							item={ item }
+							selection={ selection }
+							onChangeSelection={ onChangeSelection }
+							getItemId={ getItemId }
+							titleField={ titleField }
+							disabled={ ! hasPossibleBulkAction }
+						/>
+					</div>
+				</td>
+			) }
+			{ hasPrimaryColumn && (
+				<td>
+					<ColumnPrimary
+						item={ item }
+						titleField={ showTitle ? titleField : undefined }
+						mediaField={ showMedia ? mediaField : undefined }
+						descriptionField={
+							showDescription ? descriptionField : undefined
+						}
+						isItemClickable={ () => false }
+					/>
+				</td>
+			) }
+			{ columns.map( ( column: string ) => {
+				// Explicit picks the supported styles.
+				const { width, maxWidth, minWidth, align } =
+					view.layout?.styles?.[ column ] ?? {};
+
+				return (
+					<td
+						key={ column }
+						style={ {
+							width,
+							maxWidth,
+							minWidth,
+						} }
+					>
+						<TableColumnField
+							fields={ fields }
+							item={ item }
+							column={ column }
+							align={ align }
+						/>
+					</td>
+				);
+			} ) }
+		</tr>
+	);
+}
+
+function ViewPickerTable< Item >( {
+	actions,
+	data,
+	fields,
+	getItemId,
+	isLoading = false,
+	onChangeView,
+	onChangeSelection,
+	selection,
+	setOpenedFilter,
+	view,
+	className,
+	empty,
+}: ViewPickerTableProps< Item > ) {
+	const { containerRef } = useContext( DataViewsContext );
+	const headerMenuRefs = useRef<
+		Map< string, { node: HTMLButtonElement; fallback: string } >
+	>( new Map() );
+	const headerMenuToFocusRef = useRef< HTMLButtonElement >();
+	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] =
+		useState< HTMLButtonElement >();
+	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
+
+	useEffect( () => {
+		if ( headerMenuToFocusRef.current ) {
+			headerMenuToFocusRef.current.focus();
+			headerMenuToFocusRef.current = undefined;
+		}
+	} );
+
+	const tableNoticeId = useId();
+
+	// Note: We don't use isHorizontalScrollEnd for pickers as we don't have sticky actions column
+	useIsHorizontalScrollEnd( {
+		scrollContainerRef: containerRef,
+		enabled: false,
+	} );
+
+	if ( nextHeaderMenuToFocus ) {
+		// If we need to force focus, we short-circuit rendering here
+		// to prevent any additional work while we handle that.
+		// Clearing out the focus directive is necessary to make sure
+		// future renders don't cause unexpected focus jumps.
+		headerMenuToFocusRef.current = nextHeaderMenuToFocus;
+		setNextHeaderMenuToFocus( undefined );
+		return;
+	}
+
+	const onHide = ( field: NormalizedField< Item > ) => {
+		const hidden = headerMenuRefs.current.get( field.id );
+		const fallback = hidden
+			? headerMenuRefs.current.get( hidden.fallback )
+			: undefined;
+		setNextHeaderMenuToFocus( fallback?.node );
+	};
+
+	const hasData = !! data?.length;
+
+	const titleField = fields.find( ( field ) => field.id === view.titleField );
+	const mediaField = fields.find( ( field ) => field.id === view.mediaField );
+	const descriptionField = fields.find(
+		( field ) => field.id === view.descriptionField
+	);
+
+	const groupField = view.groupByField
+		? fields.find( ( f ) => f.id === view.groupByField )
+		: null;
+	const dataByGroup = groupField ? getDataByGroup( data, groupField ) : null;
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
+	const hasPrimaryColumn =
+		( titleField && showTitle ) ||
+		( mediaField && showMedia ) ||
+		( descriptionField && showDescription );
+	const columns = view.fields ?? [];
+	const headerMenuRef =
+		( column: string, index: number ) => ( node: HTMLButtonElement ) => {
+			if ( node ) {
+				headerMenuRefs.current.set( column, {
+					node,
+					fallback: columns[ index > 0 ? index - 1 : 1 ],
+				} );
+			} else {
+				headerMenuRefs.current.delete( column );
+			}
+		};
+	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
+
+	return (
+		<>
+			<table
+				className={ clsx( 'dataviews-view-table', className, {
+					[ `has-${ view.layout?.density }-density` ]:
+						view.layout?.density &&
+						[ 'compact', 'comfortable' ].includes(
+							view.layout.density
+						),
+				} ) }
+				aria-busy={ isLoading }
+				aria-describedby={ tableNoticeId }
+				role={ isInfiniteScroll ? 'feed' : undefined }
+			>
+				<thead>
+					<tr className="dataviews-view-table__row">
+						{ hasBulkActions && (
+							<th
+								className="dataviews-view-table__checkbox-column"
+								scope="col"
+							>
+								<BulkSelectionCheckbox
+									selection={ selection }
+									onChangeSelection={ onChangeSelection }
+									data={ data }
+									actions={ actions }
+									getItemId={ getItemId }
+								/>
+							</th>
+						) }
+						{ hasPrimaryColumn && (
+							<th scope="col">
+								{ titleField && (
+									<ColumnHeaderMenu
+										ref={ headerMenuRef(
+											titleField.id,
+											0
+										) }
+										fieldId={ titleField.id }
+										view={ view }
+										fields={ fields }
+										onChangeView={ onChangeView }
+										onHide={ onHide }
+										setOpenedFilter={ setOpenedFilter }
+										canMove={ false }
+									/>
+								) }
+							</th>
+						) }
+						{ columns.map( ( column, index ) => {
+							// Explicit picks the supported styles.
+							const { width, maxWidth, minWidth, align } =
+								view.layout?.styles?.[ column ] ?? {};
+							return (
+								<th
+									key={ column }
+									style={ {
+										width,
+										maxWidth,
+										minWidth,
+										textAlign: align,
+									} }
+									aria-sort={
+										view.sort?.direction &&
+										view.sort?.field === column
+											? sortValues[ view.sort.direction ]
+											: undefined
+									}
+									scope="col"
+								>
+									<ColumnHeaderMenu
+										ref={ headerMenuRef( column, index ) }
+										fieldId={ column }
+										view={ view }
+										fields={ fields }
+										onChangeView={ onChangeView }
+										onHide={ onHide }
+										setOpenedFilter={ setOpenedFilter }
+										canMove={
+											view.layout?.enableMoving ?? true
+										}
+									/>
+								</th>
+							);
+						} ) }
+					</tr>
+				</thead>
+				{ /* Render grouped data if groupByField is specified */ }
+				{ hasData && groupField && dataByGroup ? (
+					Array.from( dataByGroup.entries() ).map(
+						( [ groupName, groupItems ] ) => (
+							<tbody key={ `group-${ groupName }` }>
+								<tr className="dataviews-view-table__group-header-row">
+									<td
+										colSpan={
+											columns.length +
+											( hasPrimaryColumn ? 1 : 0 ) +
+											( hasBulkActions ? 1 : 0 )
+										}
+										className="dataviews-view-table__group-header-cell"
+									>
+										{ sprintf(
+											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+											__( '%1$s: %2$s' ),
+											groupField.label,
+											groupName
+										) }
+									</td>
+								</tr>
+								{ groupItems.map( ( item, index ) => (
+									<TableRow
+										key={ getItemId( item ) }
+										item={ item }
+										hasBulkActions={ hasBulkActions }
+										actions={ actions }
+										fields={ fields }
+										id={
+											getItemId( item ) ||
+											index.toString()
+										}
+										view={ view }
+										titleField={ titleField }
+										mediaField={ mediaField }
+										descriptionField={ descriptionField }
+										selection={ selection }
+										getItemId={ getItemId }
+										onChangeSelection={ onChangeSelection }
+									/>
+								) ) }
+							</tbody>
+						)
+					)
+				) : (
+					<tbody>
+						{ hasData &&
+							data.map( ( item, index ) => (
+								<TableRow
+									key={ getItemId( item ) }
+									item={ item }
+									hasBulkActions={ hasBulkActions }
+									actions={ actions }
+									fields={ fields }
+									id={ getItemId( item ) || index.toString() }
+									view={ view }
+									titleField={ titleField }
+									mediaField={ mediaField }
+									descriptionField={ descriptionField }
+									selection={ selection }
+									getItemId={ getItemId }
+									onChangeSelection={ onChangeSelection }
+									posinset={
+										isInfiniteScroll ? index + 1 : undefined
+									}
+								/>
+							) ) }
+					</tbody>
+				) }
+			</table>
+			<div
+				className={ clsx( {
+					'dataviews-loading': isLoading,
+					'dataviews-no-results': ! hasData && ! isLoading,
+				} ) }
+				id={ tableNoticeId }
+			>
+				{ ! hasData &&
+					( isLoading ? (
+						<p>
+							<Spinner />
+						</p>
+					) : (
+						empty
+					) ) }
+				{ hasData && isLoading && (
+					<p className="dataviews-loading-more">
+						<Spinner />
+					</p>
+				) }
+			</div>
+		</>
+	);
+}
+
+export default ViewPickerTable;

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -371,7 +371,8 @@ function ViewPickerTable< Item >( {
 									<td
 										colSpan={
 											columns.length +
-											( hasPrimaryColumn ? 1 : 0 )
+											( hasPrimaryColumn ? 1 : 0 ) +
+											1
 										}
 										className="dataviews-view-table__group-header-cell"
 									>

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -24,7 +24,6 @@ import DataViewsSelectionCheckbox from '../../components/dataviews-selection-che
 import { useIsMultiselectPicker } from '../../components/dataviews-picker/footer';
 import { sortValues } from '../../constants';
 import type {
-	Action,
 	NormalizedField,
 	ViewPickerTable as ViewPickerTableType,
 	ViewPickerTableProps,
@@ -43,7 +42,6 @@ interface TableColumnFieldProps< Item > {
 
 interface TableRowProps< Item > {
 	item: Item;
-	actions: Action< Item >[];
 	fields: NormalizedField< Item >[];
 	id: string;
 	view: ViewPickerTableType;
@@ -376,7 +374,6 @@ function ViewPickerTable< Item >( {
 									<TableRow
 										key={ getItemId( item ) }
 										item={ item }
-										actions={ actions }
 										fields={ fields }
 										id={
 											getItemId( item ) ||
@@ -402,7 +399,6 @@ function ViewPickerTable< Item >( {
 								<TableRow
 									key={ getItemId( item ) }
 									item={ item }
-									actions={ actions }
 									fields={ fields }
 									id={ getItemId( item ) || index.toString() }
 									view={ view }

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -131,15 +131,8 @@ function TableRow< Item >( {
 					{ ...props }
 				/>
 			) }
-			aria-label={
-				titleField
-					? titleField.getValue( { item } ) || __( '(no title)' )
-					: undefined
-			}
 			aria-selected={ isSelected }
-			aria-setsize={
-				infiniteScrollEnabled ? paginationInfo.totalItems : undefined
-			}
+			aria-setsize={ paginationInfo.totalItems || undefined }
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : 'option' }
 			onClick={ () => {
@@ -383,65 +376,57 @@ function ViewPickerTable< Item >( {
 				</thead>
 				{ /* Render grouped data if groupByField is specified */ }
 				{ hasData && groupField && dataByGroup ? (
-					<Composite
-						virtualFocus
-						orientation="vertical"
-						render={ ( { children } ) => <>{ children }</> }
-					>
-						{ Array.from( dataByGroup.entries() ).map(
-							( [ groupName, groupItems ] ) => (
-								<tbody
-									key={ `group-${ groupName }` }
-									role="group"
+					Array.from( dataByGroup.entries() ).map(
+						( [ groupName, groupItems ] ) => (
+							<Composite
+								key={ `group-${ groupName }` }
+								virtualFocus
+								orientation="vertical"
+								render={ <tbody role="group" /> }
+							>
+								<tr
+									className="dataviews-view-table__group-header-row"
+									role="presentation"
 								>
-									<tr
-										className="dataviews-view-table__group-header-row"
+									<td
+										colSpan={
+											columns.length +
+											( hasPrimaryColumn ? 1 : 0 ) +
+											1
+										}
+										className="dataviews-view-table__group-header-cell"
 										role="presentation"
 									>
-										<td
-											colSpan={
-												columns.length +
-												( hasPrimaryColumn ? 1 : 0 ) +
-												1
-											}
-											className="dataviews-view-table__group-header-cell"
-											role="presentation"
-										>
-											{ sprintf(
-												// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-												__( '%1$s: %2$s' ),
-												groupField.label,
-												groupName
-											) }
-										</td>
-									</tr>
-									{ groupItems.map( ( item, index ) => (
-										<TableRow
-											key={ getItemId( item ) }
-											item={ item }
-											fields={ fields }
-											id={
-												getItemId( item ) ||
-												index.toString()
-											}
-											view={ view }
-											titleField={ titleField }
-											mediaField={ mediaField }
-											descriptionField={
-												descriptionField
-											}
-											selection={ selection }
-											getItemId={ getItemId }
-											onChangeSelection={
-												onChangeSelection
-											}
-											multiselect={ isMultiselect }
-										/>
-									) ) }
-								</tbody>
-							)
-						) }
-					</Composite>
+										{ sprintf(
+											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+											__( '%1$s: %2$s' ),
+											groupField.label,
+											groupName
+										) }
+									</td>
+								</tr>
+								{ groupItems.map( ( item, index ) => (
+									<TableRow
+										key={ getItemId( item ) }
+										item={ item }
+										fields={ fields }
+										id={
+											getItemId( item ) ||
+											index.toString()
+										}
+										view={ view }
+										titleField={ titleField }
+										mediaField={ mediaField }
+										descriptionField={ descriptionField }
+										selection={ selection }
+										getItemId={ getItemId }
+										onChangeSelection={ onChangeSelection }
+										multiselect={ isMultiselect }
+									/>
+								) ) }
+							</Composite>
+						)
+					)
 				) : (
 					<Composite
 						render={ <tbody role="presentation" /> }
@@ -463,9 +448,7 @@ function ViewPickerTable< Item >( {
 									getItemId={ getItemId }
 									onChangeSelection={ onChangeSelection }
 									multiselect={ isMultiselect }
-									posinset={
-										isInfiniteScroll ? index + 1 : undefined
-									}
+									posinset={ index + 1 }
 								/>
 							) ) }
 					</Composite>

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -22,6 +22,7 @@ import {
 import DataViewsContext from '../../components/dataviews-context';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
 import { useIsMultiselectPicker } from '../../components/dataviews-picker/footer';
+import { BulkSelectionCheckbox } from '../../components/dataviews-bulk-actions';
 import { sortValues } from '../../constants';
 import type {
 	NormalizedField,
@@ -290,6 +291,20 @@ function ViewPickerTable< Item >( {
 			>
 				<thead>
 					<tr className="dataviews-view-table__row">
+						<th
+							className="dataviews-view-table__checkbox-column"
+							scope="col"
+						>
+							{ isMultiselect && (
+								<BulkSelectionCheckbox
+									selection={ selection }
+									onChangeSelection={ onChangeSelection }
+									data={ data }
+									actions={ actions }
+									getItemId={ getItemId }
+								/>
+							) }
+						</th>
 						{ hasPrimaryColumn && (
 							<th scope="col">
 								{ titleField && (

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -290,13 +290,18 @@ function ViewPickerTable< Item >( {
 	return (
 		<>
 			<table
-				className={ clsx( 'dataviews-view-table', className, {
-					[ `has-${ view.layout?.density }-density` ]:
-						view.layout?.density &&
-						[ 'compact', 'comfortable' ].includes(
-							view.layout.density
-						),
-				} ) }
+				className={ clsx(
+					'dataviews-view-table',
+					'dataviews-view-picker-table',
+					className,
+					{
+						[ `has-${ view.layout?.density }-density` ]:
+							view.layout?.density &&
+							[ 'compact', 'comfortable' ].includes(
+								view.layout.density
+							),
+					}
+				) }
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 				role={ isInfiniteScroll ? 'feed' : 'listbox' }

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -124,11 +124,12 @@ function TableRow< Item >( {
 			} ) }
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
+			aria-selected={ isSelected }
 			aria-setsize={
 				infiniteScrollEnabled ? paginationInfo.totalItems : undefined
 			}
 			aria-posinset={ posinset }
-			role={ infiniteScrollEnabled ? 'article' : undefined }
+			role={ infiniteScrollEnabled ? 'article' : 'option' }
 			onClick={ () => {
 				if ( isSelected ) {
 					onChangeSelection(
@@ -142,7 +143,10 @@ function TableRow< Item >( {
 				}
 			} }
 		>
-			<td className="dataviews-view-table__checkbox-column">
+			<td
+				className="dataviews-view-table__checkbox-column"
+				role="presentation"
+			>
 				<div className="dataviews-view-table__cell-content-wrapper">
 					<DataViewsSelectionCheckbox
 						item={ item }
@@ -156,7 +160,7 @@ function TableRow< Item >( {
 			</td>
 
 			{ hasPrimaryColumn && (
-				<td>
+				<td role="presentation">
 					<ColumnPrimary
 						item={ item }
 						titleField={ showTitle ? titleField : undefined }
@@ -181,6 +185,7 @@ function TableRow< Item >( {
 							maxWidth,
 							minWidth,
 						} }
+						role="presentation"
 					>
 						<TableColumnField
 							fields={ fields }
@@ -287,14 +292,14 @@ function ViewPickerTable< Item >( {
 				} ) }
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
-				role={ isInfiniteScroll ? 'feed' : undefined }
+				role={ isInfiniteScroll ? 'feed' : 'listbox' }
 			>
-				<thead>
-					<tr className="dataviews-view-table__row">
-						<th
-							className="dataviews-view-table__checkbox-column"
-							scope="col"
-						>
+				<thead role="presentation">
+					<tr
+						className="dataviews-view-table__row"
+						role="presentation"
+					>
+						<th className="dataviews-view-table__checkbox-column">
 							{ isMultiselect && (
 								<BulkSelectionCheckbox
 									selection={ selection }
@@ -306,7 +311,7 @@ function ViewPickerTable< Item >( {
 							) }
 						</th>
 						{ hasPrimaryColumn && (
-							<th scope="col">
+							<th>
 								{ titleField && (
 									<ColumnHeaderMenu
 										ref={ headerMenuRef(
@@ -366,8 +371,14 @@ function ViewPickerTable< Item >( {
 				{ hasData && groupField && dataByGroup ? (
 					Array.from( dataByGroup.entries() ).map(
 						( [ groupName, groupItems ] ) => (
-							<tbody key={ `group-${ groupName }` }>
-								<tr className="dataviews-view-table__group-header-row">
+							<tbody
+								key={ `group-${ groupName }` }
+								role="presentation"
+							>
+								<tr
+									className="dataviews-view-table__group-header-row"
+									role="presentation"
+								>
 									<td
 										colSpan={
 											columns.length +
@@ -375,6 +386,7 @@ function ViewPickerTable< Item >( {
 											1
 										}
 										className="dataviews-view-table__group-header-cell"
+										role="presentation"
 									>
 										{ sprintf(
 											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
@@ -407,7 +419,7 @@ function ViewPickerTable< Item >( {
 						)
 					)
 				) : (
-					<tbody>
+					<tbody role="presentation">
 						{ hasData &&
 							data.map( ( item, index ) => (
 								<TableRow

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -128,18 +128,16 @@ function TableRow< Item >( {
 			}
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : undefined }
-			onClick={ ( event ) => {
-				if ( event.target instanceof HTMLElement ) {
-					if ( isSelected ) {
-						onChangeSelection(
-							selection.filter( ( itemId ) => id !== itemId )
-						);
-					} else {
-						const newSelection = multiselect
-							? [ ...selection, id ]
-							: [ id ];
-						onChangeSelection( newSelection );
-					}
+			onClick={ () => {
+				if ( isSelected ) {
+					onChangeSelection(
+						selection.filter( ( itemId ) => id !== itemId )
+					);
+				} else {
+					const newSelection = multiselect
+						? [ ...selection, id ]
+						: [ id ];
+					onChangeSelection( newSelection );
 				}
 			} }
 		>

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -36,7 +36,6 @@ import type {
 import type { SetSelection } from '../../types/private';
 import ColumnHeaderMenu from '../table/column-header-menu';
 import ColumnPrimary from '../table/column-primary';
-import { useIsHorizontalScrollEnd } from '../table/use-is-horizontal-scroll-end';
 import getDataByGroup from '../utils/get-data-by-group';
 
 interface TableColumnFieldProps< Item > {
@@ -231,7 +230,6 @@ function ViewPickerTable< Item >( {
 	className,
 	empty,
 }: ViewPickerTableProps< Item > ) {
-	const { containerRef } = useContext( DataViewsContext );
 	const headerMenuRefs = useRef<
 		Map< string, { node: HTMLButtonElement; fallback: string } >
 	>( new Map() );
@@ -248,12 +246,6 @@ function ViewPickerTable< Item >( {
 	} );
 
 	const tableNoticeId = useId();
-
-	// Note: We don't use isHorizontalScrollEnd for pickers as we don't have sticky actions column
-	useIsHorizontalScrollEnd( {
-		scrollContainerRef: containerRef,
-		enabled: false,
-	} );
 
 	if ( nextHeaderMenuToFocus ) {
 		// If we need to force focus, we short-circuit rendering here

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -46,7 +46,6 @@ interface TableColumnFieldProps< Item > {
 }
 
 interface TableRowProps< Item > {
-	hasBulkActions: boolean;
 	item: Item;
 	actions: Action< Item >[];
 	fields: NormalizedField< Item >[];
@@ -86,7 +85,6 @@ function TableColumnField< Item >( {
 }
 
 function TableRow< Item >( {
-	hasBulkActions,
 	item,
 	actions,
 	fields,
@@ -162,20 +160,19 @@ function TableRow< Item >( {
 				}
 			} }
 		>
-			{ hasBulkActions && (
-				<td className="dataviews-view-table__checkbox-column">
-					<div className="dataviews-view-table__cell-content-wrapper">
-						<DataViewsSelectionCheckbox
-							item={ item }
-							selection={ selection }
-							onChangeSelection={ onChangeSelection }
-							getItemId={ getItemId }
-							titleField={ titleField }
-							disabled={ ! hasPossibleBulkAction }
-						/>
-					</div>
-				</td>
-			) }
+			<td className="dataviews-view-table__checkbox-column">
+				<div className="dataviews-view-table__cell-content-wrapper">
+					<DataViewsSelectionCheckbox
+						item={ item }
+						selection={ selection }
+						onChangeSelection={ onChangeSelection }
+						getItemId={ getItemId }
+						titleField={ titleField }
+						disabled={ ! hasPossibleBulkAction }
+					/>
+				</div>
+			</td>
+
 			{ hasPrimaryColumn && (
 				<td>
 					<ColumnPrimary
@@ -409,7 +406,6 @@ function ViewPickerTable< Item >( {
 									<TableRow
 										key={ getItemId( item ) }
 										item={ item }
-										hasBulkActions={ hasBulkActions }
 										actions={ actions }
 										fields={ fields }
 										id={
@@ -435,7 +431,6 @@ function ViewPickerTable< Item >( {
 								<TableRow
 									key={ getItemId( item ) }
 									item={ item }
-									hasBulkActions={ hasBulkActions }
 									actions={ actions }
 									fields={ fields }
 									id={ getItemId( item ) || index.toString() }

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Spinner } from '@wordpress/components';
+import { Spinner, Composite } from '@wordpress/components';
 import {
 	useContext,
 	useEffect,
@@ -117,13 +117,25 @@ function TableRow< Item >( {
 		( descriptionField && showDescription );
 
 	return (
-		<tr
-			className={ clsx( 'dataviews-view-table__row', {
-				'is-selected': isSelected,
-				'is-hovered': isHovered,
-			} ) }
-			onMouseEnter={ handleMouseEnter }
-			onMouseLeave={ handleMouseLeave }
+		<Composite.Item
+			key={ id }
+			render={ ( { children, ...props } ) => (
+				<tr
+					className={ clsx( 'dataviews-view-table__row', {
+						'is-selected': isSelected,
+						'is-hovered': isHovered,
+					} ) }
+					onMouseEnter={ handleMouseEnter }
+					onMouseLeave={ handleMouseLeave }
+					children={ children }
+					{ ...props }
+				/>
+			) }
+			aria-label={
+				titleField
+					? titleField.getValue( { item } ) || __( '(no title)' )
+					: undefined
+			}
 			aria-selected={ isSelected }
 			aria-setsize={
 				infiniteScrollEnabled ? paginationInfo.totalItems : undefined
@@ -155,6 +167,8 @@ function TableRow< Item >( {
 						getItemId={ getItemId }
 						titleField={ titleField }
 						disabled={ false }
+						aria-hidden
+						tabIndex={ -1 }
 					/>
 				</div>
 			</td>
@@ -196,7 +210,7 @@ function TableRow< Item >( {
 					</td>
 				);
 			} ) }
-		</tr>
+		</Composite.Item>
 	);
 }
 
@@ -369,57 +383,71 @@ function ViewPickerTable< Item >( {
 				</thead>
 				{ /* Render grouped data if groupByField is specified */ }
 				{ hasData && groupField && dataByGroup ? (
-					Array.from( dataByGroup.entries() ).map(
-						( [ groupName, groupItems ] ) => (
-							<tbody
-								key={ `group-${ groupName }` }
-								role="presentation"
-							>
-								<tr
-									className="dataviews-view-table__group-header-row"
-									role="presentation"
+					<Composite
+						virtualFocus
+						orientation="vertical"
+						render={ ( { children } ) => <>{ children }</> }
+					>
+						{ Array.from( dataByGroup.entries() ).map(
+							( [ groupName, groupItems ] ) => (
+								<tbody
+									key={ `group-${ groupName }` }
+									role="group"
 								>
-									<td
-										colSpan={
-											columns.length +
-											( hasPrimaryColumn ? 1 : 0 ) +
-											1
-										}
-										className="dataviews-view-table__group-header-cell"
+									<tr
+										className="dataviews-view-table__group-header-row"
 										role="presentation"
 									>
-										{ sprintf(
-											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-											__( '%1$s: %2$s' ),
-											groupField.label,
-											groupName
-										) }
-									</td>
-								</tr>
-								{ groupItems.map( ( item, index ) => (
-									<TableRow
-										key={ getItemId( item ) }
-										item={ item }
-										fields={ fields }
-										id={
-											getItemId( item ) ||
-											index.toString()
-										}
-										view={ view }
-										titleField={ titleField }
-										mediaField={ mediaField }
-										descriptionField={ descriptionField }
-										selection={ selection }
-										getItemId={ getItemId }
-										onChangeSelection={ onChangeSelection }
-										multiselect={ isMultiselect }
-									/>
-								) ) }
-							</tbody>
-						)
-					)
+										<td
+											colSpan={
+												columns.length +
+												( hasPrimaryColumn ? 1 : 0 ) +
+												1
+											}
+											className="dataviews-view-table__group-header-cell"
+											role="presentation"
+										>
+											{ sprintf(
+												// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+												__( '%1$s: %2$s' ),
+												groupField.label,
+												groupName
+											) }
+										</td>
+									</tr>
+									{ groupItems.map( ( item, index ) => (
+										<TableRow
+											key={ getItemId( item ) }
+											item={ item }
+											fields={ fields }
+											id={
+												getItemId( item ) ||
+												index.toString()
+											}
+											view={ view }
+											titleField={ titleField }
+											mediaField={ mediaField }
+											descriptionField={
+												descriptionField
+											}
+											selection={ selection }
+											getItemId={ getItemId }
+											onChangeSelection={
+												onChangeSelection
+											}
+											multiselect={ isMultiselect }
+										/>
+									) ) }
+								</tbody>
+							)
+						) }
+					</Composite>
 				) : (
-					<tbody role="presentation">
+					<Composite
+						render={ <tbody role="presentation" /> }
+						virtualFocus
+						orientation="vertical"
+					>
 						{ hasData &&
 							data.map( ( item, index ) => (
 								<TableRow
@@ -440,7 +468,7 @@ function ViewPickerTable< Item >( {
 									}
 								/>
 							) ) }
-					</tbody>
+					</Composite>
 				) }
 			</table>
 			<div

--- a/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
@@ -3,6 +3,28 @@
 // Add any picker-specific overrides here if needed in the future.
 
 .dataviews-view-table {
+	tbody:focus-visible {
+		// Only show one focus outline at a time. When focus is on a child element,
+		// hide the table's own focus outline.
+		&[aria-activedescendant] {
+			outline: none;
+		}
+
+		[data-active-item="true"] {
+			outline: 2px solid var(--wp-admin-theme-color);
+		}
+	}
+
+	.dataviews-selection-checkbox {
+		// Added specificity to override table styles.
+		.components-checkbox-control__input.components-checkbox-control__input {
+			// When the dataview is used as a picker, ensure the checkbox can't be clicked on.
+			// Only the row itself is clickable.
+			pointer-events: none;
+			opacity: 1;
+		}
+	}
+
 	// When used in picker context, ensure row selection works as expected
 	.dataviews-view-table__row {
 		cursor: pointer;

--- a/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
@@ -1,0 +1,23 @@
+// Picker-specific table styles
+// The table picker mainly reuses the regular table styles from ../table/style.scss
+// Add any picker-specific overrides here if needed in the future.
+
+.dataviews-view-table {
+	// When used in picker context, ensure row selection works as expected
+	.dataviews-view-table__row {
+		cursor: pointer;
+
+		&.is-selected {
+			// Ensure selected rows are visually distinct
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		}
+
+		&.is-hovered {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+		}
+
+		&.is-selected.is-hovered {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.12);
+		}
+	}
+}

--- a/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/style.scss
@@ -2,7 +2,7 @@
 // The table picker mainly reuses the regular table styles from ../table/style.scss
 // Add any picker-specific overrides here if needed in the future.
 
-.dataviews-view-table {
+.dataviews-view-picker-table {
 	tbody:focus-visible {
 		// Only show one focus outline at a time. When focus is on a child element,
 		// hide the table's own focus outline.

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -24,6 +24,7 @@ import type {
 	NormalizedField,
 	SortDirection,
 	ViewTable as ViewTableType,
+	ViewPickerTable as ViewPickerTableType,
 	Operator,
 } from '../../types';
 
@@ -31,9 +32,9 @@ const { Menu } = unlock( componentsPrivateApis );
 
 interface HeaderMenuProps< Item > {
 	fieldId: string;
-	view: ViewTableType;
+	view: ViewTableType | ViewPickerTableType;
 	fields: NormalizedField< Item >[];
-	onChangeView: ( view: ViewTableType ) => void;
+	onChangeView: ( view: ViewTableType | ViewPickerTableType ) => void;
 	onHide: ( field: NormalizedField< Item > ) => void;
 	setOpenedFilter: ( fieldId: string ) => void;
 	canMove?: boolean;

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -173,7 +173,7 @@ const DataViewsPickerContent = ( {
 				itemListLabel="Galactic Bodies"
 				defaultLayouts={ {
 					[ LAYOUT_PICKER_GRID ]: {},
-					[ LAYOUT_PICKER_TABLE ]: {},
+					[ LAYOUT_PICKER_TABLE ]: { perPage: 20 },
 				} }
 			/>
 		</>

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -138,13 +138,14 @@ const DataViewsPickerContent = ( {
 		setView,
 		data: shownData,
 		getItemId: ( item ) => item.id.toString(),
+		totalDataLength: data.length,
 	} );
 
 	return (
 		<>
 			{ infiniteScrollEnabled && (
 				<style>{ `
-					.dataviews-wrapper {
+					.dataviews-picker-wrapper {
 						height: 600px;
 						overflow: auto;
 					}
@@ -293,11 +294,13 @@ function useInfiniteScroll( {
 	setView,
 	data: shownData,
 	getItemId,
+	totalDataLength,
 }: {
 	view: View;
 	setView: ( view: View ) => void;
 	data: SpaceObject[];
 	getItemId: ( item: SpaceObject ) => string;
+	totalDataLength: number;
 } ): {
 	data: SpaceObject[];
 	paginationInfo: {
@@ -314,8 +317,8 @@ function useInfiniteScroll( {
 	);
 	const [ isLoadingMore, setIsLoadingMore ] = useState( false );
 
-	const totalItems = data.length;
-	const totalPages = Math.ceil( totalItems / 6 ); // perPage is 6.
+	const totalItems = totalDataLength;
+	const totalPages = Math.ceil( totalItems / ( view.perPage || 10 ) );
 	const currentPage = view.page || 1;
 	const hasMoreData = currentPage < totalPages;
 

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -17,7 +17,7 @@ import {
  * Internal dependencies
  */
 import DataViewsPicker from '../components/dataviews-picker/index';
-import { LAYOUT_PICKER_GRID } from '../constants';
+import { LAYOUT_PICKER_GRID, LAYOUT_PICKER_TABLE } from '../constants';
 import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 import type { ActionButton, View } from '../types';
 import { data, fields, type SpaceObject } from './dataviews.fixtures';
@@ -73,7 +73,6 @@ const DataViewsPickerContent = ( {
 	selection: customSelection,
 }: PickerContentProps ) => {
 	const [ view, setView ] = useState< View >( {
-		type: LAYOUT_PICKER_GRID,
 		fields: [],
 		titleField: 'title',
 		mediaField: 'image',
@@ -81,6 +80,7 @@ const DataViewsPickerContent = ( {
 		page: 1,
 		perPage: 10,
 		filters: [],
+		type: LAYOUT_PICKER_GRID,
 		groupByField: isGrouped ? 'type' : undefined,
 		infiniteScrollEnabled,
 	} );
@@ -171,6 +171,7 @@ const DataViewsPickerContent = ( {
 				itemListLabel="Galactic Bodies"
 				defaultLayouts={ {
 					[ LAYOUT_PICKER_GRID ]: {},
+					[ LAYOUT_PICKER_TABLE ]: {},
 				} }
 			/>
 		</>
@@ -329,7 +330,7 @@ function useInfiniteScroll( {
 			...view,
 			page: currentPage + 1,
 		} );
-	}, [ isLoadingMore, currentPage, totalPages, view ] );
+	}, [ isLoadingMore, currentPage, totalPages, view, setView ] );
 
 	// Initialize data on first load or when view changes significantly
 	useEffect( () => {
@@ -353,6 +354,8 @@ function useInfiniteScroll( {
 		view.perPage,
 		currentPage,
 		view.infiniteScrollEnabled,
+		shownData,
+		getItemId,
 	] );
 
 	const paginationInfo = {

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -33,6 +33,7 @@ const storyArgs = {
 	perPageSizes: [ 10, 25, 50, 100 ],
 	isMultiselectable: false,
 	isGrouped: false,
+	infiniteScrollEnabled: false,
 };
 
 const storyArgTypes = {
@@ -357,8 +358,6 @@ function useInfiniteScroll( {
 		view.perPage,
 		currentPage,
 		view.infiniteScrollEnabled,
-		shownData,
-		getItemId,
 	] );
 
 	const paginationInfo = {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -12,6 +12,7 @@
 @use "./dataviews-layouts/list/style.scss" as *;
 @use "./dataviews-layouts/table/style.scss" as *;
 @use "./dataviews-layouts/picker-grid/style.scss" as *;
+@use "./dataviews-layouts/picker-table/style.scss" as *;
 
 @use "./dataform-controls/style.scss" as *;
 @use "./dataform-layouts/panel/style.scss" as *;

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -269,7 +269,33 @@ export interface ViewPickerGrid extends ViewBase {
 	};
 }
 
-export type View = ViewList | ViewGrid | ViewTable | ViewPickerGrid;
+export interface ViewPickerTable extends ViewBase {
+	type: 'pickerTable';
+
+	layout?: {
+		/**
+		 * The styles for the columns.
+		 */
+		styles?: Record< string, ColumnStyle >;
+
+		/**
+		 * The density of the view.
+		 */
+		density?: Density;
+
+		/**
+		 * Whether the view allows column moving.
+		 */
+		enableMoving?: boolean;
+	};
+}
+
+export type View =
+	| ViewList
+	| ViewGrid
+	| ViewTable
+	| ViewPickerGrid
+	| ViewPickerTable;
 
 interface ActionBase< Item > {
 	/**
@@ -428,16 +454,24 @@ export interface ViewPickerGridProps< Item >
 	view: ViewPickerGrid;
 }
 
+export interface ViewPickerTableProps< Item >
+	extends Omit< ViewPickerBaseProps< Item >, 'view' > {
+	view: ViewPickerTable;
+}
+
 export type ViewProps< Item > =
 	| ViewTableProps< Item >
 	| ViewGridProps< Item >
 	| ViewListProps< Item >;
 
-export type ViewPickerProps< Item > = ViewPickerGridProps< Item >;
+export type ViewPickerProps< Item > =
+	| ViewPickerGridProps< Item >
+	| ViewPickerTableProps< Item >;
 
 export interface SupportedLayouts {
 	list?: Omit< ViewList, 'type' >;
 	grid?: Omit< ViewGrid, 'type' >;
 	table?: Omit< ViewTable, 'type' >;
 	pickerGrid?: Omit< ViewPickerGrid, 'type' >;
+	pickerTable?: Omit< ViewPickerTable, 'type' >;
 }

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -22,8 +22,9 @@ import { unlock } from '../../lock-unlock';
 
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 
-// Layout constant - matching the picker grid layout type
+// Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
+const LAYOUT_PICKER_TABLE = 'pickerTable';
 
 interface MediaUploadModalProps {
 	/**
@@ -301,6 +302,7 @@ export function MediaUploadModal( {
 	const defaultLayouts = useMemo(
 		() => ( {
 			[ LAYOUT_PICKER_GRID ]: {},
+			[ LAYOUT_PICKER_TABLE ]: {},
 		} ),
 		[]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

It'll be handy to have a table and maybe also a list view for when we implement #71128.

For now this just adds the table layout and it can be tested in storybook.

It essentially copies the table layout minus the inline clickable actions and any associated logic. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. check out locally and `npm run storybook:dev`
2. go to DataViewsPicker story and toggle the layout type (default should still be grid)


<img width="1129" height="780" alt="Screenshot 2025-11-03 at 4 27 07 pm" src="https://github.com/user-attachments/assets/1fe25227-b315-4484-b44d-b5589842d6e2" />
