### PR TITLE
DataViews list layout: use regular button for primary action

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- DatViews list layout: remove link variant from primary actions's button. [#72920](https://github.com/WordPress/gutenberg/pull/72920)
 - DataForm: simplify form normalization. [#72848](https://github.com/WordPress/gutenberg/pull/72848)
 
 ### Bug fixes

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -106,10 +106,9 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
+						__next40pxDefaultSize
 						text={ label }
-						size="small"
 						onClick={ () => setIsModalOpen( true ) }
-						variant="link"
 					/>
 				}
 			>
@@ -130,11 +129,10 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
-						size="small"
+						__next40pxDefaultSize
 						onClick={ () => {
 							primaryAction.callback( [ item ], { registry } );
 						} }
-						variant="link"
 					>
 						{ label }
 					</Button>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -106,8 +106,8 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
-						__next40pxDefaultSize
 						text={ label }
+						size="small"
 						onClick={ () => setIsModalOpen( true ) }
 					/>
 				}
@@ -129,7 +129,7 @@ function PrimaryActionGridCell< Item >( {
 					<Button
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
-						__next40pxDefaultSize
+						size="small"
 						onClick={ () => {
 							primaryAction.callback( [ item ], { registry } );
 						} }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/72417

## What?

Changes the styles of the primary action in list layout.

| 6.8 | 6.9 (current trunk) | This PR |
| --- | --- | --- |
| <img width="687" height="1230" alt="Screenshot 2025-10-29 at 10 20 47" src="https://github.com/user-attachments/assets/5f6dc875-f17c-48a8-b0c0-064d9c57494b" /> | <img width="687" height="1230" alt="Screenshot 2025-10-29 at 10 20 55" src="https://github.com/user-attachments/assets/bb8319cd-117a-45e0-8909-bf52d38df250" />     |  <img width="690" height="1012" alt="Screenshot 2025-11-03 at 10 42 24" src="https://github.com/user-attachments/assets/87579fae-038b-473d-a1dd-941c75d25c35" /> |

## How?

Removes the "small" and "link" props from the button.

## Testing Instructions

Visit the site editor, switch to any list layout (e.g., in the Pages screen) and verify the styles.