### PR TITLE
Trash the Note Replies

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -296,17 +296,29 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 		}
 	};
 
+	// Recursively delete a comment and all its replies.
+	const deleteCommentAndReplies = async ( comment ) => {
+		// First, delete all child replies recursively.
+		if (
+			comment.reply &&
+			Array.isArray( comment.reply ) &&
+			comment.reply.length > 0
+		) {
+			for ( const reply of comment.reply ) {
+				await deleteCommentAndReplies( reply );
+			}
+		}
+
+		// Then delete the comment itself.
+		await deleteEntityRecord( 'root', 'comment', comment.id, undefined, {
+			throwOnError: true,
+		} );
+	};
+
 	const onDelete = async ( comment ) => {
 		try {
-			await deleteEntityRecord(
-				'root',
-				'comment',
-				comment.id,
-				undefined,
-				{
-					throwOnError: true,
-				}
-			);
+			// Delete the comment and all its replies recursively.
+			await deleteCommentAndReplies( comment );
 
 			if ( ! comment.parent ) {
 				const clientId = getSelectedBlockClientId();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72862

This PR fixes a bug where deleting a parent note did not delete its child replies. The deletion confirmation dialog promised to delete all replies, but only the parent note was actually deleted from the database, leaving orphaned replies.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously, when a user deleted a note that had replies, the confirmation dialog stated: "Are you sure you want to delete this note? This will also delete all of this note's replies." However, the implementation only deleted the parent note itself. Child replies remained in the database (they only disappeared from the UI because their parent relationship was lost).

This created data integrity issues and a mismatch between what the UI promised and what actually happened.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix adds a new recursive helper function `deleteCommentAndReplies` that:

1. Checks if the comment has any replies in its `reply` array
2. Recursively deletes each reply (and their nested replies) before deleting the parent
3. Handles deeply nested reply structures

The `onDelete` function now calls this helper instead of directly deleting only the single comment. This ensures that when a parent note is deleted, all its replies (including nested ones) are properly removed from the database.

The recursive approach handles any depth of nesting:
- Parent Note → Reply 1 → Nested Reply → Deeply Nested Reply
- All children are deleted before their parent

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a post or page in the editor.
2. Insert a block (e.g., a Heading block).
3. Add a note to the block by clicking the "Add note" button or using the Notes panel.
4. Add at least one reply to the note.
5. Optionally, add nested replies (replies to replies) to test deeper nesting.
6. Click the delete button (three dots menu → Delete) on the parent note.
7. Confirm the deletion when prompted.
8. **Verify**: Check the database (e.g., `wp_comments` table) or refresh the page - both the parent note and all child replies should be completely removed, not just marked as trashed.


## Video


https://github.com/user-attachments/assets/3edfe197-7ae5-49fa-be8f-a0bfa9180b12


