### PR TITLE
Fix: Make fit text work with the interativity API.

### DIFF
--- a/backport-changelog/6.9/10455.md
+++ b/backport-changelog/6.9/10455.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10455
+
+* https://github.com/WordPress/gutenberg/pull/72923

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -252,9 +252,11 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
-					$processor->set_attribute( 'data-wp-interactive', 'core/fit-text' );
+					$processor->set_attribute( 'data-wp-interactive', true );
 				}
-				$processor->set_attribute( 'data-wp-init', 'callbacks.init' );
+				$processor->set_attribute( 'data-wp-context---core-fit-text', 'core/fit-text::{"fontSize":""}' );
+				$processor->set_attribute( 'data-wp-init---core-fit-text', 'core/fit-text::callbacks.init' );
+				$processor->set_attribute( 'data-wp-style--font-size', 'core/fit-text::context.fontSize' );
 				$block_content = $processor->get_updated_html();
 			}
 		}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -246,6 +246,20 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
 function gutenberg_render_typography_support( $block_content, $block ) {
 	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
+
+		// Add Interactivity API directives for fit text to work with client-side navigation.
+		if ( ! empty( $block_content ) ) {
+			$processor = new WP_HTML_Tag_Processor( $block_content );
+			if ( $processor->next_tag() ) {
+				// Add data-wp-interactive directive if not already present.
+				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
+					$processor->set_attribute( 'data-wp-interactive', 'core/fit-text' );
+				}
+				// Add data-wp-init directive to initialize fit text.
+				$processor->set_attribute( 'data-wp-init', 'callbacks.init' );
+				$block_content = $processor->get_updated_html();
+			}
+		}
 	}
 
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -251,11 +251,9 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 		if ( ! empty( $block_content ) ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
-				// Add data-wp-interactive directive if not already present.
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
 					$processor->set_attribute( 'data-wp-interactive', 'core/fit-text' );
 				}
-				// Add data-wp-init directive to initialize fit text.
 				$processor->set_attribute( 'data-wp-init', 'callbacks.init' );
 				$block_content = $processor->get_updated_html();
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51966,6 +51966,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/interactivity": "file:../interactivity",
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51967,6 +51967,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interactivity": "file:../interactivity",
+				"@wordpress/interactivity-router": "file:../interactivity-router",
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51967,7 +51967,6 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interactivity": "file:../interactivity",
-				"@wordpress/interactivity-router": "file:../interactivity-router",
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -75,6 +75,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/interactivity": "file:../interactivity",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -76,7 +76,6 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interactivity": "file:../interactivity",
-		"@wordpress/interactivity-router": "file:../interactivity-router",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -76,6 +76,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interactivity": "file:../interactivity",
+		"@wordpress/interactivity-router": "file:../interactivity-router",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -90,11 +90,15 @@ function useFitText( { fitText, name, clientId } ) {
 
 		const blockSelector = `#block-${ clientId }`;
 
-		const applyStylesFn = ( css ) => {
-			styleElement.textContent = css;
+		const applyFontSize = ( fontSize ) => {
+			if ( fontSize === 0 ) {
+				styleElement.textContent = '';
+			} else {
+				styleElement.textContent = `${ blockSelector } { font-size: ${ fontSize }px !important; }`;
+			}
 		};
 
-		optimizeFitText( blockElement, blockSelector, applyStylesFn );
+		optimizeFitText( blockElement, applyFontSize );
 	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
 
 	useEffect( () => {

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -7,66 +7,37 @@
 /**
  * WordPress dependencies
  */
-import { store, getElement } from '@wordpress/interactivity';
+import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
  * Internal dependencies
  */
 import { optimizeFitText } from './fit-text-utils';
 
-/**
- * Initialize fit text functionality for a single element.
- * Uses inline styles for better performance and automatic cleanup.
- *
- * @param {HTMLElement} element Element with fit text enabled.
- * @return {ResizeObserver|null} The ResizeObserver instance, or null if not created.
- */
-function initializeFitText( element ) {
-	const applyFitText = () => {
-		// Apply font size directly to the element via inline style attribute.
-		// The callback receives font size in pixels from optimizeFitText.
-		const applyFontSize = ( fontSize ) => {
-			if ( fontSize === 0 ) {
-				element.style.fontSize = '';
-			} else {
-				element.style.fontSize = `${ fontSize }px`;
-			}
-		};
-
-		// Use the shared utility function with inline style callback.
-		optimizeFitText( element, applyFontSize );
-	};
-
-	// Initial sizing
-	applyFitText();
-
-	// Watch for parent container resize
-	if ( window.ResizeObserver && element.parentElement ) {
-		const resizeObserver = new window.ResizeObserver( applyFitText );
-		resizeObserver.observe( element.parentElement );
-		return resizeObserver;
-	}
-
-	return null;
-}
-
 // Initialize via Interactivity API for client-side navigation
 store( 'core/fit-text', {
 	callbacks: {
 		init() {
+			const context = getContext();
 			const { ref } = getElement();
-			if ( ! ref || ! ref.classList.contains( 'has-fit-text' ) ) {
-				return;
+
+			// Initial fit text optimization.
+			context.fontSize = optimizeFitText( ref );
+
+			// Starts ResizeObserver to handle dynamic resizing.
+			if ( window.ResizeObserver && ref.parentElement ) {
+				const resizeObserver = new window.ResizeObserver( () => {
+					context.fontSize = optimizeFitText( ref );
+				} );
+				resizeObserver.observe( ref.parentElement );
+
+				// Return cleanup function to be called when element is removed.
+				return () => {
+					if ( resizeObserver ) {
+						resizeObserver.disconnect();
+					}
+				};
 			}
-
-			const observer = initializeFitText( ref );
-
-			// Return cleanup function to be called when element is removed.
-			return () => {
-				if ( observer ) {
-					observer.disconnect();
-				}
-			};
 		},
 	},
 } );

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -101,7 +101,6 @@ store( 'core/fit-text', {
 					observer.disconnect();
 				}
 
-				// Remove the associated style element
 				const styleId = `fit-text-${ elementId }`;
 				const styleElement = document.getElementById( styleId );
 				if ( styleElement ) {

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -1,7 +1,13 @@
 /**
  * Frontend fit text functionality.
  * Automatically detects and initializes fit text on blocks with the has-fit-text class.
+ * Supports both initial page load and Interactivity API client-side navigation.
  */
+
+/**
+ * WordPress dependencies
+ */
+import { store, getElement, useInit } from '@wordpress/interactivity';
 
 /**
  * Internal dependencies
@@ -47,6 +53,7 @@ function getElementIdentifier( element ) {
  * Initialize fit text functionality for a single element.
  *
  * @param {HTMLElement} element Element with fit text enabled.
+ * @return {ResizeObserver|null} The ResizeObserver instance, or null if not created.
  */
 function initializeFitText( element ) {
 	const elementId = getElementIdentifier( element );
@@ -70,15 +77,20 @@ function initializeFitText( element ) {
 	if ( window.ResizeObserver && element.parentElement ) {
 		const resizeObserver = new window.ResizeObserver( applyFitText );
 		resizeObserver.observe( element.parentElement );
+		return resizeObserver;
 	}
+
+	return null;
 }
 
-/**
- * Initialize fit text on all elements with the has-fit-text class.
- */
-function initializeAllFitText() {
-	const elements = document.querySelectorAll( '.has-fit-text' );
-	elements.forEach( initializeFitText );
-}
-
-window.addEventListener( 'load', initializeAllFitText );
+// Initialize via Interactivity API for client-side navigation
+store( 'core/fit-text', {
+	callbacks: {
+		init() {
+			const { ref } = getElement();
+			if ( ref && ref.classList.contains( 'has-fit-text' ) ) {
+				initializeFitText( ref );
+			}
+		},
+	},
+} );

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -15,59 +15,28 @@ import { store, getElement } from '@wordpress/interactivity';
 import { optimizeFitText } from './fit-text-utils';
 
 /**
- * Counter for generating unique element IDs.
- */
-let idCounter = 0;
-
-/**
- * Get or create a unique style element for a fit text element.
- *
- * @param {string} elementId Unique identifier for the element.
- * @return {HTMLElement} Style element.
- */
-function getOrCreateStyleElement( elementId ) {
-	const styleId = `fit-text-${ elementId }`;
-	let styleElement = document.getElementById( styleId );
-	if ( ! styleElement ) {
-		styleElement = document.createElement( 'style' );
-		styleElement.id = styleId;
-		document.head.appendChild( styleElement );
-	}
-	return styleElement;
-}
-
-/**
- * Generate a unique identifier for a fit text element.
- *
- * @param {HTMLElement} element The element to identify.
- * @return {string} Unique identifier.
- */
-function getElementIdentifier( element ) {
-	if ( ! element.dataset.fitTextId ) {
-		element.dataset.fitTextId = `fit-text-${ ++idCounter }`;
-	}
-	return element.dataset.fitTextId;
-}
-
-/**
  * Initialize fit text functionality for a single element.
+ * Uses inline styles for better performance and automatic cleanup.
  *
  * @param {HTMLElement} element Element with fit text enabled.
  * @return {ResizeObserver|null} The ResizeObserver instance, or null if not created.
  */
 function initializeFitText( element ) {
-	const elementId = getElementIdentifier( element );
-
 	const applyFitText = () => {
-		const styleElement = getOrCreateStyleElement( elementId );
-		const elementSelector = `[data-fit-text-id=\"${ elementId }\"]`;
-
-		// Style management callback
-		const applyStylesFn = ( css ) => {
-			styleElement.textContent = css;
+		// Apply font size directly to the element via inline style attribute.
+		// The callback receives font size in pixels from optimizeFitText.
+		const applyFontSize = ( fontSize ) => {
+			if ( fontSize === 0 ) {
+				// Clear: reset font-size
+				element.style.fontSize = '';
+			} else {
+				// Apply font size directly as inline style
+				element.style.fontSize = `${ fontSize }px`;
+			}
 		};
 
-		optimizeFitText( element, elementSelector, applyStylesFn );
+		// Use the shared utility function with inline style callback.
+		optimizeFitText( element, applyFontSize );
 	};
 
 	// Initial sizing
@@ -92,19 +61,13 @@ store( 'core/fit-text', {
 				return;
 			}
 
-			const elementId = getElementIdentifier( ref );
 			const observer = initializeFitText( ref );
 
 			// Return cleanup function to be called when element is removed.
+			// No need to remove style elements since we're using inline styles.
 			return () => {
 				if ( observer ) {
 					observer.disconnect();
-				}
-
-				const styleId = `fit-text-${ elementId }`;
-				const styleElement = document.getElementById( styleId );
-				if ( styleElement ) {
-					styleElement.remove();
 				}
 			};
 		},

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -27,10 +27,8 @@ function initializeFitText( element ) {
 		// The callback receives font size in pixels from optimizeFitText.
 		const applyFontSize = ( fontSize ) => {
 			if ( fontSize === 0 ) {
-				// Clear: reset font-size
 				element.style.fontSize = '';
 			} else {
-				// Apply font size directly as inline style
 				element.style.fontSize = `${ fontSize }px`;
 			}
 		};
@@ -64,7 +62,6 @@ store( 'core/fit-text', {
 			const observer = initializeFitText( ref );
 
 			// Return cleanup function to be called when element is removed.
-			// No need to remove style elements since we're using inline styles.
 			return () => {
 				if ( observer ) {
 					observer.disconnect();

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getElement, useInit } from '@wordpress/interactivity';
+import { store, getElement } from '@wordpress/interactivity';
 
 /**
  * Internal dependencies
@@ -88,9 +88,26 @@ store( 'core/fit-text', {
 	callbacks: {
 		init() {
 			const { ref } = getElement();
-			if ( ref && ref.classList.contains( 'has-fit-text' ) ) {
-				initializeFitText( ref );
+			if ( ! ref || ! ref.classList.contains( 'has-fit-text' ) ) {
+				return;
 			}
+
+			const elementId = getElementIdentifier( ref );
+			const observer = initializeFitText( ref );
+
+			// Return cleanup function to be called when element is removed.
+			return () => {
+				if ( observer ) {
+					observer.disconnect();
+				}
+
+				// Remove the associated style element
+				const styleId = `fit-text-${ elementId }`;
+				const styleElement = document.getElementById( styleId );
+				if ( styleElement ) {
+					styleElement.remove();
+				}
+			};
 		},
 	},
 } );

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -21,13 +21,21 @@ store( 'core/fit-text', {
 			const context = getContext();
 			const { ref } = getElement();
 
+			const applyFontSize = ( fontSize ) => {
+				if ( fontSize === 0 ) {
+					ref.style.fontSize = '';
+				} else {
+					ref.style.fontSize = `${ fontSize }px`;
+				}
+			};
+
 			// Initial fit text optimization.
-			context.fontSize = optimizeFitText( ref );
+			context.fontSize = optimizeFitText( ref, applyFontSize );
 
 			// Starts ResizeObserver to handle dynamic resizing.
 			if ( window.ResizeObserver && ref.parentElement ) {
 				const resizeObserver = new window.ResizeObserver( () => {
-					context.fontSize = optimizeFitText( ref );
+					context.fontSize = optimizeFitText( ref, applyFontSize );
 				} );
 				resizeObserver.observe( ref.parentElement );
 

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -1,16 +1,20 @@
 /**
  * Shared utility functions for fit text functionality.
- * Uses callback-based approach for maximum code reuse between editor and frontend.
  */
 
 /**
- * Find optimal font size using simple binary search between 5-600px.
+ * Finds optimal font size using simple binary search between 5-600px.
  *
- * @param {HTMLElement} textElement   The text element
- * @param {Function}    applyFontSize Function that receives font size in pixels
- * @return {number} Optimal font size
+ * @param {HTMLElement} textElement The text element.
+ * @return {number}                 Optimal font size.
  */
-function findOptimalFontSize( textElement, applyFontSize ) {
+export function optimizeFitText( textElement ) {
+	if ( ! textElement ) {
+		return 0;
+	}
+
+	textElement.style.fontSize = '';
+
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
@@ -19,7 +23,7 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
-		applyFontSize( midSize );
+		textElement.style.fontSize = midSize + 'px';
 
 		const fitsWidth = textElement.scrollWidth <= textElement.clientWidth;
 		const fitsHeight =
@@ -31,27 +35,9 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 			minSize = midSize + 1;
 		} else {
 			maxSize = midSize - 1;
+			textElement.style.fontSize = midSize - 1 + 'px';
 		}
 	}
 
-	return bestSize;
-}
-
-/**
- * Complete fit text optimization for a single text element.
- * Handles the full flow using callbacks for font size application.
- *
- * @param {HTMLElement} textElement   The text element (paragraph, heading, etc.)
- * @param {Function}    applyFontSize Function that receives font size in pixels (0 to clear, >0 to apply)
- */
-export function optimizeFitText( textElement, applyFontSize ) {
-	if ( ! textElement ) {
-		return;
-	}
-
-	applyFontSize( 0 );
-
-	const optimalSize = findOptimalFontSize( textElement, applyFontSize );
-
-	applyFontSize( optimalSize );
+	return bestSize + 'px';
 }

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -4,25 +4,13 @@
  */
 
 /**
- * Generate CSS rule for single text element.
- *
- * @param {string} elementSelector CSS selector for the text element
- * @param {number} fontSize        Font size in pixels
- * @return {string} CSS rule string
- */
-function generateCSSRule( elementSelector, fontSize ) {
-	return `${ elementSelector } { font-size: ${ fontSize }px !important; }`;
-}
-
-/**
  * Find optimal font size using simple binary search between 5-600px.
  *
- * @param {HTMLElement} textElement     The text element
- * @param {string}      elementSelector CSS selector for the text element
- * @param {Function}    applyStylesFn   Function to apply test styles
+ * @param {HTMLElement} textElement   The text element
+ * @param {Function}    applyFontSize Function that receives font size in pixels
  * @return {number} Optimal font size
  */
-function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
+function findOptimalFontSize( textElement, applyFontSize ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
@@ -31,7 +19,7 @@ function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
 
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
-		applyStylesFn( generateCSSRule( elementSelector, midSize ) );
+		applyFontSize( midSize );
 
 		const fitsWidth = textElement.scrollWidth <= textElement.clientWidth;
 		const fitsHeight =
@@ -51,25 +39,19 @@ function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
 
 /**
  * Complete fit text optimization for a single text element.
- * Handles the full flow using callbacks for style management.
+ * Handles the full flow using callbacks for font size application.
  *
- * @param {HTMLElement} textElement     The text element (paragraph, heading, etc.)
- * @param {string}      elementSelector CSS selector for the text element
- * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
+ * @param {HTMLElement} textElement   The text element (paragraph, heading, etc.)
+ * @param {Function}    applyFontSize Function that receives font size in pixels (0 to clear, >0 to apply)
  */
-export function optimizeFitText( textElement, elementSelector, applyStylesFn ) {
+export function optimizeFitText( textElement, applyFontSize ) {
 	if ( ! textElement ) {
 		return;
 	}
 
-	applyStylesFn( '' );
+	applyFontSize( 0 );
 
-	const optimalSize = findOptimalFontSize(
-		textElement,
-		elementSelector,
-		applyStylesFn
-	);
+	const optimalSize = findOptimalFontSize( textElement, applyFontSize );
 
-	const cssRule = generateCSSRule( elementSelector, optimalSize );
-	applyStylesFn( cssRule );
+	applyFontSize( optimalSize );
 }

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -1,20 +1,16 @@
 /**
  * Shared utility functions for fit text functionality.
+ * Uses callback-based approach for maximum code reuse between editor and frontend.
  */
 
 /**
- * Finds optimal font size using simple binary search between 5-600px.
+ * Find optimal font size using simple binary search between 5-600px.
  *
- * @param {HTMLElement} textElement The text element.
- * @return {number}                 Optimal font size.
+ * @param {HTMLElement} textElement   The text element
+ * @param {Function}    applyFontSize Function that receives font size in pixels
+ * @return {number} Optimal font size
  */
-export function optimizeFitText( textElement ) {
-	if ( ! textElement ) {
-		return 0;
-	}
-
-	textElement.style.fontSize = '';
-
+function findOptimalFontSize( textElement, applyFontSize ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
@@ -23,7 +19,7 @@ export function optimizeFitText( textElement ) {
 
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
-		textElement.style.fontSize = midSize + 'px';
+		applyFontSize( midSize );
 
 		const fitsWidth = textElement.scrollWidth <= textElement.clientWidth;
 		const fitsHeight =
@@ -35,9 +31,28 @@ export function optimizeFitText( textElement ) {
 			minSize = midSize + 1;
 		} else {
 			maxSize = midSize - 1;
-			textElement.style.fontSize = midSize - 1 + 'px';
 		}
 	}
 
-	return bestSize + 'px';
+	return bestSize;
+}
+
+/**
+ * Complete fit text optimization for a single text element.
+ * Handles the full flow using callbacks for font size application.
+ *
+ * @param {HTMLElement} textElement   The text element (paragraph, heading, etc.)
+ * @param {Function}    applyFontSize Function that receives font size in pixels (0 to clear, >0 to apply)
+ */
+export function optimizeFitText( textElement, applyFontSize ) {
+	if ( ! textElement ) {
+		return;
+	}
+
+	applyFontSize( 0 );
+
+	const optimalSize = findOptimalFontSize( textElement, applyFontSize );
+
+	applyFontSize( optimalSize );
+	return optimalSize;
 }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -22,6 +22,7 @@
 		{ "path": "../html-entities" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../interactivity" },
 		{ "path": "../is-shallow-equal" },
 		{ "path": "../keycodes" },
 		{ "path": "../notices" },


### PR DESCRIPTION
Alternative to: https://github.com/WordPress/gutenberg/pull/72797

Fit text did not work after navigating to a page using the Interactivity API router. When users navigated to a post via client-side navigation (e.g., in a Query block with pagination), fit text blocks would not recalculate their font sizes, appearing either too large or too small.

This occurred because the fit text initialization only ran on the `window.load` event, which doesn't fire during client-side navigation.

This PR refactors fit text front end to be an interactivity api first implementation, using an interactivity api init event instead of a window load event.


cc: @luisherranz 

### Changes

1. **Updated `fit-text-frontend.js`**:
   - Added Interactivity API store with `init` callback.
   - Callback uses `data-wp-init` directive to initialize fit text on element mount.
   - Returns cleanup function to disconnect ResizeObserver and remove style elements when elements are removed.

2. **Updated `typography.php`**:
   - Automatically injects `data-wp-interactive="core/fit-text"` directive on blocks with fit text enabled.
   - Adds `data-wp-init="callbacks.init"` to trigger initialization.
   - Uses `WP_HTML_Tag_Processor` to safely modify block HTML.

3. **Updated `package.json`**:
   - Added `@wordpress/interactivity` dependency to `@wordpress/block-editor`


## Testing Instructions
1.  Enable the "Interactivity API: Full-page client-side navigation" experiment.
2.  Add a new post with fit-text, load the blog page, and see that the post with fit-text works well.
3.  Navigate to that post (e.g., click the post title) and verify fit-text still looks as expected (on trunk, it does not work).
