### PR TITLE
Update Gutenberg Version for WordPress 6.9

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,10 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 20.5-21.9          | 6.9               |
+| 19.4-20.4          | 6.8.3             |
+| 19.4-20.4          | 6.8.2             |
+| 19.4-20.4          | 6.8.1             | 
 | 19.4-20.4          | 6.8               |
 | 18.6-19.3          | 6.7.2             |
 | 18.6-19.3          | 6.7.1             |


### PR DESCRIPTION

## What?
With WordPress 6.9 about to be released, the page listing [WordPress version and Gutenberg plugins version](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) needs to be updated, too.

[The code is located here](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/versions-in-wordpress.md)



## Why?
For accuracy and inform questions from users and developers

## How?
Just updated the markdown table
[The code is located here](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/versions-in-wordpress.md)
Also added rows for the point releases 6.8.x

## Testing Instructions
Documentation only
