### PR TITLE
i18n: Use _x() for Template Activation labels

### DIFF
--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -156,13 +156,13 @@ export const activeField = {
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
 		const activeLabel = item._isCustom
-			? __( 'Active when used' )
-			: __( 'Active' );
+			? _x( 'Active when used', 'template' )
+			: _x( 'Active', 'template' );
 		const activeIntent = item._isCustom ? 'info' : 'success';
 		const isActive = item._isActive;
 		return (
 			<Badge intent={ isActive ? activeIntent : 'default' }>
-				{ isActive ? activeLabel : __( 'Inactive' ) }
+				{ isActive ? activeLabel : _x( 'Inactive', 'template' ) }
 			</Badge>
 		);
 	},


### PR DESCRIPTION
## What?

Follow-up of #72713, per @tyxla's [feedback](https://github.com/WordPress/gutenberg/pull/72713#discussion_r2480877200)

Uses i18n's `_x()` function instead of `__()` to pass translation context to the following labels used in the Template Editor's items' Status field:

- _Active when used_
- _Active_
- _Inactive_

## Why?

Avoid ambiguities, mitigate locale-specific grammatical agreement issues, etc.
