### PR TITLE
DataViews: Add insert left/right in table column header

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -30,6 +30,7 @@
 - DataForm: add new details layout. [#72355](https://github.com/WordPress/gutenberg/pull/72355)
 - DatViews list layout: remove link variant from primary actions's button. [#72920](https://github.com/WordPress/gutenberg/pull/72920)
 - DataForm: simplify form normalization. [#72848](https://github.com/WordPress/gutenberg/pull/72848)
+- DataViews: Add insert left/right in table column header. [#72929](https://github.com/WordPress/gutenberg/pull/72929)
 - DataViewsPicker: Add With Modal story. [#72913](https://github.com/WordPress/gutenberg/pull/72913)
 - DataForm: make the card layout borderless. [#72514](https://github.com/WordPress/gutenberg/pull/72514)
 - DataViews: Simplify the view config properties section. [#73064](https://github.com/WordPress/gutenberg/pull/73064)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Simplify field normalization and types. [#73387](https://github.com/WordPress/gutenberg/pull/73387)
 - DataViews table layout: make checkboxes permanently visible when bulk actions are available. [#73245](https://github.com/WordPress/gutenberg/pull/73245)
+- DataViews: Add insert left/right in table column header. [#72929](https://github.com/WordPress/gutenberg/pull/72929)
 - DataViews: Make sticky elements (table headers, footer, actions column) inherit background colors from parent container. This allows DataViews instances to seamlessly adapt to containers with custom background colors. [#73240](https://github.com/WordPress/gutenberg/pull/73240)
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - DataViews: add support for activity layout. [#72780](https://github.com/WordPress/gutenberg/pull/72780)
@@ -30,7 +31,6 @@
 - DataForm: add new details layout. [#72355](https://github.com/WordPress/gutenberg/pull/72355)
 - DatViews list layout: remove link variant from primary actions's button. [#72920](https://github.com/WordPress/gutenberg/pull/72920)
 - DataForm: simplify form normalization. [#72848](https://github.com/WordPress/gutenberg/pull/72848)
-- DataViews: Add insert left/right in table column header. [#72929](https://github.com/WordPress/gutenberg/pull/72929)
 - DataViewsPicker: Add With Modal story. [#72913](https://github.com/WordPress/gutenberg/pull/72913)
 - DataForm: make the card layout borderless. [#72514](https://github.com/WordPress/gutenberg/pull/72514)
 - DataViews: Simplify the view config properties section. [#73064](https://github.com/WordPress/gutenberg/pull/73064)

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -18,6 +18,7 @@ import { check } from '@wordpress/icons';
  */
 import type { NormalizedField } from '../../types';
 import DataViewsContext from '../dataviews-context';
+import getHideableFields from '../../utils/get-hideable-fields';
 
 function FieldItem( {
 	field,
@@ -53,19 +54,8 @@ export function PropertiesSection( {
 } ) {
 	const { view, fields, onChangeView } = useContext( DataViewsContext );
 
-	const togglableFields = [
-		view?.titleField,
-		view?.mediaField,
-		view?.descriptionField,
-	].filter( Boolean );
-
 	// Get all regular fields (non-locked) in their original order from fields prop
-	const regularFields = fields.filter(
-		( f ) =>
-			! togglableFields.includes( f.id ) &&
-			f.type !== 'media' &&
-			f.enableHiding !== false
-	);
+	const regularFields = getHideableFields( view, fields );
 
 	if ( ! regularFields?.length ) {
 		return null;

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -28,7 +28,7 @@ import type {
 	Operator,
 } from '../../types';
 import DataViewsContext from '../../components/dataviews-context';
-import getHiddenFields from '../../utils/get-hidden-fields';
+import getHideableFields from '../../utils/get-hideable-fields';
 
 const { Menu } = unlock( componentsPrivateApis );
 
@@ -103,7 +103,9 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		return header;
 	}
 
-	const hiddenFields = getHiddenFields( view, fields );
+	const hiddenFields = getHideableFields( view, fields ).filter(
+		( f ) => ! visibleFieldIds.includes( f.id )
+	);
 
 	return (
 		<Menu>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -7,7 +7,14 @@ import type { ReactNode, Ref, PropsWithoutRef, RefAttributes } from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
+import {
+	arrowLeft,
+	arrowRight,
+	chevronRight,
+	chevronLeft,
+	unseen,
+	funnel,
+} from '@wordpress/icons';
 import {
 	Button,
 	Icon,
@@ -102,6 +109,20 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		return header;
 	}
 
+	// Calculate hidden fields that can be inserted.
+	const togglableFields = [
+		view?.titleField,
+		view?.mediaField,
+		view?.descriptionField,
+	].filter( Boolean );
+	const hiddenFields = fields.filter(
+		( f ) =>
+			! visibleFieldIds.includes( f.id ) &&
+			! togglableFields.includes( f.id ) &&
+			f.type !== 'media' &&
+			f.enableHiding !== false
+	);
+
 	return (
 		<Menu>
 			<Menu.TriggerButton
@@ -192,82 +213,177 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							</Menu.Item>
 						</Menu.Group>
 					) }
-					{ ( canMove || isHidable ) && field && (
-						<Menu.Group>
-							{ canMove && (
-								<Menu.Item
-									prefix={ <Icon icon={ arrowLeft } /> }
-									disabled={ index < 1 }
-									onClick={ () => {
-										onChangeView( {
-											...view,
-											fields: [
-												...( visibleFieldIds.slice(
-													0,
-													index - 1
-												) ?? [] ),
-												fieldId,
-												visibleFieldIds[ index - 1 ],
-												...visibleFieldIds.slice(
-													index + 1
+					{ ( canMove || isHidable || !! hiddenFields.length ) &&
+						field && (
+							<Menu.Group>
+								{ canMove && (
+									<Menu.Item
+										prefix={ <Icon icon={ chevronLeft } /> }
+										disabled={ index < 1 }
+										onClick={ () => {
+											onChangeView( {
+												...view,
+												fields: [
+													...( visibleFieldIds.slice(
+														0,
+														index - 1
+													) ?? [] ),
+													fieldId,
+													visibleFieldIds[
+														index - 1
+													],
+													...visibleFieldIds.slice(
+														index + 1
+													),
+												],
+											} );
+										} }
+									>
+										<Menu.ItemLabel>
+											{ __( 'Move left' ) }
+										</Menu.ItemLabel>
+									</Menu.Item>
+								) }
+								{ canMove && (
+									<Menu.Item
+										prefix={
+											<Icon icon={ chevronRight } />
+										}
+										disabled={
+											index >= visibleFieldIds.length - 1
+										}
+										onClick={ () => {
+											onChangeView( {
+												...view,
+												fields: [
+													...( visibleFieldIds.slice(
+														0,
+														index
+													) ?? [] ),
+													visibleFieldIds[
+														index + 1
+													],
+													fieldId,
+													...visibleFieldIds.slice(
+														index + 2
+													),
+												],
+											} );
+										} }
+									>
+										<Menu.ItemLabel>
+											{ __( 'Move right' ) }
+										</Menu.ItemLabel>
+									</Menu.Item>
+								) }
+								{ canMove && !! hiddenFields.length && (
+									<Menu>
+										<Menu.SubmenuTriggerItem
+											prefix={
+												<Icon icon={ arrowLeft } />
+											}
+										>
+											<Menu.ItemLabel>
+												{ __( 'Insert left' ) }
+											</Menu.ItemLabel>
+										</Menu.SubmenuTriggerItem>
+										<Menu.Popover>
+											{ hiddenFields.map(
+												( hiddenField ) => (
+													<Menu.Item
+														key={ hiddenField.id }
+														onClick={ () => {
+															onChangeView( {
+																...view,
+																fields: [
+																	...visibleFieldIds.slice(
+																		0,
+																		index
+																	),
+																	hiddenField.id,
+																	...visibleFieldIds.slice(
+																		index
+																	),
+																],
+															} );
+														} }
+													>
+														<Menu.ItemLabel>
+															{
+																hiddenField.label
+															}
+														</Menu.ItemLabel>
+													</Menu.Item>
+												)
+											) }
+										</Menu.Popover>
+									</Menu>
+								) }
+								{ !! hiddenFields.length && (
+									<Menu>
+										<Menu.SubmenuTriggerItem
+											prefix={
+												<Icon icon={ arrowRight } />
+											}
+										>
+											<Menu.ItemLabel>
+												{ __( 'Insert right' ) }
+											</Menu.ItemLabel>
+										</Menu.SubmenuTriggerItem>
+										<Menu.Popover>
+											{ hiddenFields.map(
+												( hiddenField ) => (
+													<Menu.Item
+														key={ hiddenField.id }
+														onClick={ () => {
+															onChangeView( {
+																...view,
+																fields: [
+																	...visibleFieldIds.slice(
+																		0,
+																		index +
+																			1
+																	),
+																	hiddenField.id,
+																	...visibleFieldIds.slice(
+																		index +
+																			1
+																	),
+																],
+															} );
+														} }
+													>
+														<Menu.ItemLabel>
+															{
+																hiddenField.label
+															}
+														</Menu.ItemLabel>
+													</Menu.Item>
+												)
+											) }
+										</Menu.Popover>
+									</Menu>
+								) }
+								{ isHidable && field && (
+									<Menu.Item
+										prefix={ <Icon icon={ unseen } /> }
+										onClick={ () => {
+											onHide( field );
+											onChangeView( {
+												...view,
+												fields: visibleFieldIds.filter(
+													( id ) => id !== fieldId
 												),
-											],
-										} );
-									} }
-								>
-									<Menu.ItemLabel>
-										{ __( 'Move left' ) }
-									</Menu.ItemLabel>
-								</Menu.Item>
-							) }
-							{ canMove && (
-								<Menu.Item
-									prefix={ <Icon icon={ arrowRight } /> }
-									disabled={
-										index >= visibleFieldIds.length - 1
-									}
-									onClick={ () => {
-										onChangeView( {
-											...view,
-											fields: [
-												...( visibleFieldIds.slice(
-													0,
-													index
-												) ?? [] ),
-												visibleFieldIds[ index + 1 ],
-												fieldId,
-												...visibleFieldIds.slice(
-													index + 2
-												),
-											],
-										} );
-									} }
-								>
-									<Menu.ItemLabel>
-										{ __( 'Move right' ) }
-									</Menu.ItemLabel>
-								</Menu.Item>
-							) }
-							{ isHidable && field && (
-								<Menu.Item
-									prefix={ <Icon icon={ unseen } /> }
-									onClick={ () => {
-										onHide( field );
-										onChangeView( {
-											...view,
-											fields: visibleFieldIds.filter(
-												( id ) => id !== fieldId
-											),
-										} );
-									} }
-								>
-									<Menu.ItemLabel>
-										{ __( 'Hide column' ) }
-									</Menu.ItemLabel>
-								</Menu.Item>
-							) }
-						</Menu.Group>
-					) }
+											} );
+										} }
+									>
+										<Menu.ItemLabel>
+											{ __( 'Hide column' ) }
+										</Menu.ItemLabel>
+									</Menu.Item>
+								) }
+							</Menu.Group>
+						) }
 				</WithMenuSeparators>
 			</Menu.Popover>
 		</Menu>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -7,14 +7,7 @@ import type { ReactNode, Ref, PropsWithoutRef, RefAttributes } from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	arrowLeft,
-	arrowRight,
-	chevronRight,
-	chevronLeft,
-	unseen,
-	funnel,
-} from '@wordpress/icons';
+import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
 import {
 	Button,
 	Icon,
@@ -218,7 +211,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							<Menu.Group>
 								{ canMove && (
 									<Menu.Item
-										prefix={ <Icon icon={ chevronLeft } /> }
+										prefix={ <Icon icon={ arrowLeft } /> }
 										disabled={ index < 1 }
 										onClick={ () => {
 											onChangeView( {
@@ -246,9 +239,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								) }
 								{ canMove && (
 									<Menu.Item
-										prefix={
-											<Icon icon={ chevronRight } />
-										}
+										prefix={ <Icon icon={ arrowRight } /> }
 										disabled={
 											index >= visibleFieldIds.length - 1
 										}
@@ -278,11 +269,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								) }
 								{ canMove && !! hiddenFields.length && (
 									<Menu>
-										<Menu.SubmenuTriggerItem
-											prefix={
-												<Icon icon={ arrowLeft } />
-											}
-										>
+										<Menu.SubmenuTriggerItem>
 											<Menu.ItemLabel>
 												{ __( 'Insert left' ) }
 											</Menu.ItemLabel>
@@ -321,11 +308,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								) }
 								{ !! hiddenFields.length && (
 									<Menu>
-										<Menu.SubmenuTriggerItem
-											prefix={
-												<Icon icon={ arrowRight } />
-											}
-										>
+										<Menu.SubmenuTriggerItem>
 											<Menu.ItemLabel>
 												{ __( 'Insert right' ) }
 											</Menu.ItemLabel>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -40,6 +40,8 @@ interface HeaderMenuProps< Item > {
 	onHide: ( field: NormalizedField< Item > ) => void;
 	setOpenedFilter: ( fieldId: string ) => void;
 	canMove?: boolean;
+	canInsertLeft?: boolean;
+	canInsertRight?: boolean;
 }
 
 function WithMenuSeparators( { children }: { children: ReactNode } ) {
@@ -62,6 +64,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		onHide,
 		setOpenedFilter,
 		canMove = true,
+		canInsertLeft = true,
+		canInsertRight = true,
 	}: HeaderMenuProps< Item >,
 	ref: Ref< HTMLButtonElement >
 ) {
@@ -106,6 +110,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	const hiddenFields = getHideableFields( view, fields ).filter(
 		( f ) => ! visibleFieldIds.includes( f.id )
 	);
+	const canInsert =
+		( canInsertLeft || canInsertRight ) && !! hiddenFields.length;
 
 	return (
 		<Menu>
@@ -197,167 +203,152 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							</Menu.Item>
 						</Menu.Group>
 					) }
-					{ ( canMove || isHidable || !! hiddenFields.length ) &&
-						field && (
-							<Menu.Group>
-								{ canMove && (
-									<Menu.Item
-										prefix={ <Icon icon={ arrowLeft } /> }
-										disabled={ index < 1 }
-										onClick={ () => {
-											onChangeView( {
-												...view,
-												fields: [
-													...( visibleFieldIds.slice(
-														0,
-														index - 1
-													) ?? [] ),
-													fieldId,
-													visibleFieldIds[
-														index - 1
-													],
-													...visibleFieldIds.slice(
-														index + 1
-													),
-												],
-											} );
-										} }
-									>
-										<Menu.ItemLabel>
-											{ __( 'Move left' ) }
-										</Menu.ItemLabel>
-									</Menu.Item>
-								) }
-								{ canMove && (
-									<Menu.Item
-										prefix={ <Icon icon={ arrowRight } /> }
-										disabled={
-											index >= visibleFieldIds.length - 1
-										}
-										onClick={ () => {
-											onChangeView( {
-												...view,
-												fields: [
-													...( visibleFieldIds.slice(
-														0,
-														index
-													) ?? [] ),
-													visibleFieldIds[
-														index + 1
-													],
-													fieldId,
-													...visibleFieldIds.slice(
-														index + 2
-													),
-												],
-											} );
-										} }
-									>
-										<Menu.ItemLabel>
-											{ __( 'Move right' ) }
-										</Menu.ItemLabel>
-									</Menu.Item>
-								) }
-								{ canMove && !! hiddenFields.length && (
-									<Menu>
-										<Menu.SubmenuTriggerItem>
-											<Menu.ItemLabel>
-												{ __( 'Insert left' ) }
-											</Menu.ItemLabel>
-										</Menu.SubmenuTriggerItem>
-										<Menu.Popover>
-											{ hiddenFields.map(
-												( hiddenField ) => (
-													<Menu.Item
-														key={ hiddenField.id }
-														onClick={ () => {
-															onChangeView( {
-																...view,
-																fields: [
-																	...visibleFieldIds.slice(
-																		0,
-																		index
-																	),
-																	hiddenField.id,
-																	...visibleFieldIds.slice(
-																		index
-																	),
-																],
-															} );
-														} }
-													>
-														<Menu.ItemLabel>
-															{
-																hiddenField.label
-															}
-														</Menu.ItemLabel>
-													</Menu.Item>
-												)
-											) }
-										</Menu.Popover>
-									</Menu>
-								) }
-								{ !! hiddenFields.length && (
-									<Menu>
-										<Menu.SubmenuTriggerItem>
-											<Menu.ItemLabel>
-												{ __( 'Insert right' ) }
-											</Menu.ItemLabel>
-										</Menu.SubmenuTriggerItem>
-										<Menu.Popover>
-											{ hiddenFields.map(
-												( hiddenField ) => (
-													<Menu.Item
-														key={ hiddenField.id }
-														onClick={ () => {
-															onChangeView( {
-																...view,
-																fields: [
-																	...visibleFieldIds.slice(
-																		0,
-																		index +
-																			1
-																	),
-																	hiddenField.id,
-																	...visibleFieldIds.slice(
-																		index +
-																			1
-																	),
-																],
-															} );
-														} }
-													>
-														<Menu.ItemLabel>
-															{
-																hiddenField.label
-															}
-														</Menu.ItemLabel>
-													</Menu.Item>
-												)
-											) }
-										</Menu.Popover>
-									</Menu>
-								) }
-								{ isHidable && field && (
-									<Menu.Item
-										prefix={ <Icon icon={ unseen } /> }
-										onClick={ () => {
-											onHide( field );
-											onChangeView( {
-												...view,
-												fields: visibleFieldIds.filter(
-													( id ) => id !== fieldId
+					{ ( canMove || isHidable || canInsert ) && field && (
+						<Menu.Group>
+							{ canMove && (
+								<Menu.Item
+									prefix={ <Icon icon={ arrowLeft } /> }
+									disabled={ index < 1 }
+									onClick={ () => {
+										onChangeView( {
+											...view,
+											fields: [
+												...( visibleFieldIds.slice(
+													0,
+													index - 1
+												) ?? [] ),
+												fieldId,
+												visibleFieldIds[ index - 1 ],
+												...visibleFieldIds.slice(
+													index + 1
 												),
-											} );
-										} }
-									>
+											],
+										} );
+									} }
+								>
+									<Menu.ItemLabel>
+										{ __( 'Move left' ) }
+									</Menu.ItemLabel>
+								</Menu.Item>
+							) }
+							{ canMove && (
+								<Menu.Item
+									prefix={ <Icon icon={ arrowRight } /> }
+									disabled={
+										index >= visibleFieldIds.length - 1
+									}
+									onClick={ () => {
+										onChangeView( {
+											...view,
+											fields: [
+												...( visibleFieldIds.slice(
+													0,
+													index
+												) ?? [] ),
+												visibleFieldIds[ index + 1 ],
+												fieldId,
+												...visibleFieldIds.slice(
+													index + 2
+												),
+											],
+										} );
+									} }
+								>
+									<Menu.ItemLabel>
+										{ __( 'Move right' ) }
+									</Menu.ItemLabel>
+								</Menu.Item>
+							) }
+							{ canInsertLeft && (
+								<Menu>
+									<Menu.SubmenuTriggerItem>
 										<Menu.ItemLabel>
-											{ __( 'Hide column' ) }
+											{ __( 'Insert left' ) }
 										</Menu.ItemLabel>
-									</Menu.Item>
-								) }
-							</Menu.Group>
-						) }
+									</Menu.SubmenuTriggerItem>
+									<Menu.Popover>
+										{ hiddenFields.map( ( hiddenField ) => (
+											<Menu.Item
+												key={ hiddenField.id }
+												onClick={ () => {
+													onChangeView( {
+														...view,
+														fields: [
+															...visibleFieldIds.slice(
+																0,
+																index
+															),
+															hiddenField.id,
+															...visibleFieldIds.slice(
+																index
+															),
+														],
+													} );
+												} }
+											>
+												<Menu.ItemLabel>
+													{ hiddenField.label }
+												</Menu.ItemLabel>
+											</Menu.Item>
+										) ) }
+									</Menu.Popover>
+								</Menu>
+							) }
+							{ canInsertRight && (
+								<Menu>
+									<Menu.SubmenuTriggerItem>
+										<Menu.ItemLabel>
+											{ __( 'Insert right' ) }
+										</Menu.ItemLabel>
+									</Menu.SubmenuTriggerItem>
+									<Menu.Popover>
+										{ hiddenFields.map( ( hiddenField ) => (
+											<Menu.Item
+												key={ hiddenField.id }
+												onClick={ () => {
+													onChangeView( {
+														...view,
+														fields: [
+															...visibleFieldIds.slice(
+																0,
+																index + 1
+															),
+															hiddenField.id,
+															...visibleFieldIds.slice(
+																index + 1
+															),
+														],
+													} );
+												} }
+											>
+												<Menu.ItemLabel>
+													{ hiddenField.label }
+												</Menu.ItemLabel>
+											</Menu.Item>
+										) ) }
+									</Menu.Popover>
+								</Menu>
+							) }
+							{ isHidable && field && (
+								<Menu.Item
+									prefix={ <Icon icon={ unseen } /> }
+									onClick={ () => {
+										onHide( field );
+										onChangeView( {
+											...view,
+											fields: visibleFieldIds.filter(
+												( id ) => id !== fieldId
+											),
+										} );
+									} }
+								>
+									<Menu.ItemLabel>
+										{ __( 'Hide column' ) }
+									</Menu.ItemLabel>
+								</Menu.Item>
+							) }
+						</Menu.Group>
+					) }
 				</WithMenuSeparators>
 			</Menu.Popover>
 		</Menu>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -259,7 +259,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 									</Menu.ItemLabel>
 								</Menu.Item>
 							) }
-							{ canInsertLeft && (
+							{ canInsertLeft && !! hiddenFields.length && (
 								<Menu>
 									<Menu.SubmenuTriggerItem>
 										<Menu.ItemLabel>
@@ -294,7 +294,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 									</Menu.Popover>
 								</Menu>
 							) }
-							{ canInsertRight && (
+							{ canInsertRight && !! hiddenFields.length && (
 								<Menu>
 									<Menu.SubmenuTriggerItem>
 										<Menu.ItemLabel>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -28,6 +28,7 @@ import type {
 	Operator,
 } from '../../types';
 import DataViewsContext from '../../components/dataviews-context';
+import getHiddenFields from '../../utils/get-hidden-fields';
 
 const { Menu } = unlock( componentsPrivateApis );
 
@@ -102,19 +103,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		return header;
 	}
 
-	// Calculate hidden fields that can be inserted.
-	const togglableFields = [
-		view?.titleField,
-		view?.mediaField,
-		view?.descriptionField,
-	].filter( Boolean );
-	const hiddenFields = fields.filter(
-		( f ) =>
-			! visibleFieldIds.includes( f.id ) &&
-			! togglableFields.includes( f.id ) &&
-			f.type !== 'media' &&
-			f.enableHiding !== false
-	);
+	const hiddenFields = getHiddenFields( view, fields );
 
 	return (
 		<Menu>

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -458,6 +458,10 @@ function ViewTable< Item >( {
 										onHide={ onHide }
 										setOpenedFilter={ setOpenedFilter }
 										canMove={ false }
+										canInsertLeft={ false }
+										canInsertRight={
+											view.layout?.enableMoving ?? true
+										}
 									/>
 								) }
 							</th>
@@ -466,6 +470,8 @@ function ViewTable< Item >( {
 							// Explicit picks the supported styles.
 							const { width, maxWidth, minWidth, align } =
 								view.layout?.styles?.[ column ] ?? {};
+							const canInsertOrMove =
+								view.layout?.enableMoving ?? true;
 							return (
 								<th
 									key={ column }
@@ -491,9 +497,9 @@ function ViewTable< Item >( {
 										onChangeView={ onChangeView }
 										onHide={ onHide }
 										setOpenedFilter={ setOpenedFilter }
-										canMove={
-											view.layout?.enableMoving ?? true
-										}
+										canMove={ canInsertOrMove }
+										canInsertLeft={ canInsertOrMove }
+										canInsertRight={ canInsertOrMove }
 									/>
 								</th>
 							);

--- a/packages/dataviews/src/utils/get-hidden-fields.ts
+++ b/packages/dataviews/src/utils/get-hidden-fields.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField, View } from '../types';
+
+export default function getHiddenFields< Item >(
+	view: View,
+	fields: NormalizedField< Item >[]
+): NormalizedField< Item >[] {
+	const visibleFieldIds = view.fields || [];
+	const togglableFields = [
+		view?.titleField,
+		view?.mediaField,
+		view?.descriptionField,
+	].filter( Boolean );
+	return fields.filter(
+		( f ) =>
+			! visibleFieldIds.includes( f.id ) &&
+			! togglableFields.includes( f.id ) &&
+			f.type !== 'media' &&
+			f.enableHiding !== false
+	);
+}

--- a/packages/dataviews/src/utils/get-hideable-fields.ts
+++ b/packages/dataviews/src/utils/get-hideable-fields.ts
@@ -3,11 +3,10 @@
  */
 import type { NormalizedField, View } from '../types';
 
-export default function getHiddenFields< Item >(
+export default function getHideableFields< Item >(
 	view: View,
 	fields: NormalizedField< Item >[]
 ): NormalizedField< Item >[] {
-	const visibleFieldIds = view.fields || [];
 	const togglableFields = [
 		view?.titleField,
 		view?.mediaField,
@@ -15,7 +14,6 @@ export default function getHiddenFields< Item >(
 	].filter( Boolean );
 	return fields.filter(
 		( f ) =>
-			! visibleFieldIds.includes( f.id ) &&
 			! togglableFields.includes( f.id ) &&
 			f.type !== 'media' &&
 			f.enableHiding !== false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/72844

This PR adds two menu items in `table` layout that enables users to insert left or right one of the hidden fields.

### Notes
1. I've updated the icons per the mock up [here](https://github.com/WordPress/gutenberg/issues/72844#issuecomment-3468885541) and that this PR doesn't implement any right-click implementation, as it might not be [necessary](https://github.com/WordPress/gutenberg/issues/72844#issuecomment-3480429606).
2. For reviews [hide the whitespace](https://github.com/WordPress/gutenberg/pull/72929/files?diff=split&w=1).




## Testing Instructions
1. Either in site editor or storybook, in a `table` DataViews click the column header and play around with the new menu items (insert left / insert right)
3. Observe that everything works as expected.


## Screenshots or screencast <!-- if applicable -->
<img width="786" height="556" alt="Screenshot 2025-11-06 at 5 52 41 PM" src="https://github.com/user-attachments/assets/5dc0c15d-9efd-4884-bf3d-bee7731d5198" />

