### PR TITLE
Math: Remove HTML support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -495,6 +495,7 @@ Display mathematical notation using LaTeX. ([Source](https://github.com/WordPres
 
 -	**Name:** core/math
 -	**Category:** text
+-	**Supports:** ~~html~~
 -	**Attributes:** latex, mathML
 
 ## Media & Text

--- a/packages/block-library/src/math/block.json
+++ b/packages/block-library/src/math/block.json
@@ -17,5 +17,8 @@
 			"source": "html",
 			"selector": "math"
 		}
+	},
+	"supports": {
+		"html": false
 	}
 }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -13,7 +13,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,12 +22,7 @@ import { unlock } from '../lock-unlock';
 
 const { Badge } = unlock( componentsPrivateApis );
 
-export default function MathEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	clientId,
-} ) {
+export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 	const { latex } = attributes;
 	const [ blockRef, setBlockRef ] = useState();
 	const [ error, setError ] = useState( null );
@@ -35,17 +30,6 @@ export default function MathEdit( {
 	const initialLatex = useRef( attributes.latex );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-
-	// Check if block is in HTML editing mode
-	const { isEditingAsHTML } = useSelect(
-		( select ) => {
-			const { getBlockMode } = select( blockEditorStore );
-			return {
-				isEditingAsHTML: getBlockMode( clientId ) === 'html',
-			};
-		},
-		[ clientId ]
-	);
 
 	useEffect( () => {
 		import( '@wordpress/latex-to-mathml' ).then( ( module ) => {
@@ -83,7 +67,7 @@ export default function MathEdit( {
 			) : (
 				'\u200B'
 			) }
-			{ isSelected && ! isEditingAsHTML && (
+			{ isSelected && (
 				<Popover
 					placement="bottom-start"
 					offset={ 8 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Resolves: https://github.com/WordPress/gutenberg/issues/72899

This PR disables HTML support  and reverts https://github.com/WordPress/gutenberg/pull/72902 with a different approach to the issue.


## Testing Instructions
1. Math block should work as before with HTML support disabled (not an option in block tools menu)

