### PR TITLE
Tests: Ensure block support tests are resilient to equivalent HTML changes

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -193,6 +193,8 @@ jobs:
                       wordpress: 'previous major version'
                     - php: '8.1'
                       wordpress: 'previous major version'
+                    - php: '8.2'
+                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -186,8 +186,6 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -186,6 +186,8 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -193,8 +193,6 @@ jobs:
                       wordpress: 'previous major version'
                     - php: '8.1'
                       wordpress: 'previous major version'
-                    - php: '8.2'
-                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -212,6 +212,8 @@ jobs:
                       wordpress: 'previous major version'
                     - php: '8.1'
                       wordpress: 'previous major version'
+                    - php: '8.2'
+                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -212,8 +212,6 @@ jobs:
                       wordpress: 'previous major version'
                     - php: '8.1'
                       wordpress: 'previous major version'
-                    - php: '8.2'
-                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -203,8 +203,6 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '7.3'
                       wordpress: 'previous major version'

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -123,34 +123,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 */
 	public function data_background_block_support() {
 		return array(
-			'demonstrate resilience to character reference encoding' => array(
-				'theme_name'          => 'block-theme-child-with-fluid-typography',
-				'block_name'          => 'test/background-rules-are-output',
-				'background_settings' => array(
-					'backgroundImage' => true,
-				),
-				'background_style'    => array(
-					'backgroundImage' => array(
-						'url' => 'https://example.com/image.jpg',
-					),
-				),
-				'expected_wrapper'    => '<div class=\'has-background\' style="background-image:url(\'https://example.com/image.jpg&apos;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div>Content</div>',
-			),
-			'demonstrate resilience to character reference encoding (2)' => array(
-				'theme_name'          => 'block-theme-child-with-fluid-typography',
-				'block_name'          => 'test/background-rules-are-output',
-				'background_settings' => array(
-					'backgroundImage' => true,
-				),
-				'background_style'    => array(
-					'backgroundImage' => array(
-						'url' => 'https://example.com/image.jpg',
-					),
-				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#00000039;https://example.com/image.jpg&#x27;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div>Content</div>',
-			),
 			'background image style is applied'      => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -134,7 +134,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is applied when backgroundImage is a string' => array(
@@ -146,7 +146,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(
@@ -163,7 +163,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					'backgroundSize'       => 'contain',
 					'backgroundAttachment' => 'fixed',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(\'https://example.com/image.jpg\');background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -177,7 +177,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
@@ -191,7 +191,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background gradient style is applied'   => array(
@@ -243,7 +243,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					),
 					'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background gradient with hsl colors and image combined' => array(
@@ -259,7 +259,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					),
 					'gradient'        => 'linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%)',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%), url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%), url(\'https://example.com/image.jpg\');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -123,6 +123,34 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 */
 	public function data_background_block_support() {
 		return array(
+			'demonstrate resilience to character reference encoding' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+				),
+				'expected_wrapper'    => '<div class=\'has-background\' style="background-image:url(\'https://example.com/image.jpg&apos;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'demonstrate resilience to character reference encoding (2)' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#00000039;https://example.com/image.jpg&#x27;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is applied'      => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -64,12 +64,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 		return $this->theme_root;
 	}
 
-	private function get_apostrophe_entity() {
-		// WP 6.9+ has get_block_bindings_supported_attributes() and uses &apos;
-		// WP 6.8 and earlier use &#039;
-		return function_exists( 'get_block_bindings_supported_attributes' ) ? '&apos;' : '&#039;';
-	}
-
 	/**
 	 * Tests that background image block support works as expected.
 	 *
@@ -127,10 +121,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_background_block_support() {
-		// Get the appropriate apostrophe encoding based on WordPress version.
-		// function_exists() works in data providers, unlike get_bloginfo().
-		$apos = $this->get_apostrophe_entity();
-
 		return array(
 			'background image style is applied'      => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
@@ -143,7 +133,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is applied when backgroundImage is a string' => array(
@@ -155,7 +145,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(
@@ -172,7 +162,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					'backgroundSize'       => 'contain',
 					'backgroundAttachment' => 'fixed',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -186,7 +176,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
@@ -200,7 +190,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background gradient style is applied'   => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -108,9 +108,10 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 
 		$actual = gutenberg_render_background_support( $wrapper, $block );
 
-		$this->assertEquals(
+		$this->assertEqualHTML(
 			$expected_wrapper,
 			$actual,
+			'<body>',
 			'Background block wrapper markup should be correct'
 		);
 	}

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -271,7 +271,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					),
 					'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background gradient with hsl colors and image combined' => array(
@@ -287,7 +287,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					),
 					'gradient'        => 'linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%)',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%), url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -123,6 +123,34 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 */
 	public function data_background_block_support() {
 		return array(
+			'demonstrate resilience to character reference encoding' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+				),
+				'expected_wrapper'    => '<div class=\'has-background\' style="background-image:url(\'https://example.com/image.jpg&apos;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'demonstrate resilience to character reference encoding (2)' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#00000039;https://example.com/image.jpg&#x27;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is applied' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -64,12 +64,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 		return $this->theme_root;
 	}
 
-	private function get_apostrophe_entity() {
-		// WP 6.9+ has get_block_bindings_supported_attributes() and uses &apos;
-		// WP 6.8 and earlier use &#039;
-		return function_exists( 'get_block_bindings_supported_attributes' ) ? '&apos;' : '&#039;';
-	}
-
 	/**
 	 * Tests that background image block support works as expected.
 	 *
@@ -127,10 +121,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_background_block_support() {
-		// Get the appropriate apostrophe encoding based on WordPress version.
-		// function_exists() works in data providers, unlike get_bloginfo().
-		$apos = $this->get_apostrophe_entity();
-
 		return array(
 			'background image style is applied' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
@@ -143,7 +133,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is applied when backgroundImage is a string' => array(
@@ -155,7 +145,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(
@@ -172,7 +162,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					'backgroundSize'       => 'contain',
 					'backgroundAttachment' => 'fixed',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -186,7 +176,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
@@ -200,7 +190,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(


### PR DESCRIPTION
## What?

Follow-up to #72236.

Updates background block support PHP tests to compare generated wrapper markup with `assertEqualHTML()` instead of byte-for-byte string equality. Also enables the PHP unit test workflow to run against the previous major WordPress version on PRs.

## Why?

Equivalent HTML can serialize with different character references across WordPress versions, for example `&#039;` vs `&apos;`. These differences should not fail tests when the resulting HTML is semantically equivalent.

## How?

- Replaces `assertEquals()` with `assertEqualHTML()` for HTML semantic equality comparison instead of string equality.

## Testing Instructions

CI workflow should be sufficient. This is a testing change.



## Use of AI Tools

OpenAI Codex was used to help rebase the branch, resolve conflicts, run local checks, and draft this PR description. The original changes were authored without the use of AI.