### PR TITLE
Routing: Add static and lazy routes support to the boot package

### DIFF
--- a/lib/experimental/boot/boot.php
+++ b/lib/experimental/boot/boot.php
@@ -52,7 +52,7 @@ function gutenberg_boot_admin_page() {
 		wp_add_inline_script(
 			'gutenberg-boot-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.init(%s));',
+				'import("@wordpress/boot").then(mod => mod.init({menuItems: %s}));',
 				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);

--- a/packages/boot/src/components/app/index.tsx
+++ b/packages/boot/src/components/app/index.tsx
@@ -2,24 +2,34 @@
  * WordPress dependencies
  */
 import { createRoot, StrictMode } from '@wordpress/element';
-import { dispatch } from '@wordpress/data';
+import { dispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Router from './router';
-import { STORE_NAME } from '../../store';
-import type { MenuItem } from '../../store/types';
+import { store } from '../../store';
+import type { MenuItem, Route } from '../../store/types';
 
 function App() {
-	return <Router />;
+	const routes = useSelect( ( select ) => select( store ).getRoutes(), [] );
+
+	return <Router routes={ routes } />;
 }
 
-export async function init( menuItems: MenuItem[] ) {
-	// Register menu items
-	menuItems.forEach( ( menuItem ) => {
-		// @ts-ignore
-		dispatch( STORE_NAME ).registerMenuItem( menuItem.id, menuItem );
+export async function init( {
+	menuItems,
+	routes,
+}: {
+	menuItems?: MenuItem[];
+	routes?: Route[];
+} ) {
+	( menuItems ?? [] ).forEach( ( menuItem ) => {
+		dispatch( store ).registerMenuItem( menuItem.id, menuItem );
+	} );
+
+	( routes ?? [] ).forEach( ( route ) => {
+		dispatch( store ).registerRoute( route );
 	} );
 
 	// Render the app

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -7,43 +7,142 @@ import {
 	createRoute,
 	RouterProvider,
 	createBrowserHistory,
+	type AnyRoute,
 } from '@tanstack/react-router';
 import { parseHref } from '@tanstack/history';
+import type { ComponentType } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { lazy, Suspense, useMemo } from '@wordpress/element';
+import { Page } from '@wordpress/admin-ui';
 
 /**
  * Internal dependencies
  */
 import Root from '../root';
-import Home from '../home';
+import type { Route, RouteLoaderContext } from '../../store/types';
+import * as homeRoute from '../home';
 
 // Not found component
 function NotFoundComponent() {
 	return (
 		<div className="boot-layout__stage">
-			<h1>{ __( 'Route not found' ) }</h1>
+			<Page title={ __( 'Route not found' ) } hasPadding>
+				{ __( "The page you're looking for does not exist" ) }
+			</Page>
 		</div>
 	);
 }
 
-// Create root route
-const rootRoute = createRootRoute( {
-	component: Root,
-} );
+function RouteComponent( {
+	stage: Stage,
+	inspector: Inspector,
+}: {
+	stage?: ComponentType;
+	inspector?: ComponentType;
+} ) {
+	return (
+		<>
+			{ Stage && (
+				<div className="boot-layout__stage">
+					<Suspense fallback={ <div>Loading...</div> }>
+						<Stage />
+					</Suspense>
+				</div>
+			) }
+			{ Inspector && (
+				<div className="boot-layout__inspector">
+					<Suspense fallback={ <div>Loading...</div> }>
+						<Inspector />
+					</Suspense>
+				</div>
+			) }
+		</>
+	);
+}
 
-// Create home route
-const homeRoute = createRoute( {
-	getParentRoute: () => rootRoute,
-	path: '/',
-	component: Home,
-} );
+/**
+ * Creates a TanStack route from a Route definition.
+ *
+ * @param route       Route configuration
+ * @param parentRoute Parent route.
+ * @return Tanstack Route.
+ */
+function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
+	if ( ! route.content && ! route.content_module ) {
+		throw new Error( 'Route must have content or content_module property' );
+	}
 
-// Create route tree
-const routeTree = rootRoute.addChildren( [ homeRoute ] );
+	// Create lazy components for stage and inspector surfaces
+	const SurfacesModule = route.content
+		? () => <RouteComponent { ...route.content } />
+		: lazy( async () => {
+				const module = await import( route.content_module as string );
+				// Return a component that renders the surfaces
+				return {
+					default: () => (
+						<RouteComponent
+							stage={ module.stage }
+							inspector={ module.inspector }
+						/>
+					),
+				};
+		  } );
+
+	return createRoute( {
+		getParentRoute: () => parentRoute,
+		path: route.path,
+		beforeLoad: route.beforeLoad
+			? async ( opts: any ) => {
+					const context: RouteLoaderContext = {
+						params: opts.params || {},
+						search: opts.search || {},
+					};
+					await route.beforeLoad?.( context );
+			  }
+			: undefined,
+		loader: route.loader
+			? async ( opts: any ) => {
+					const context: RouteLoaderContext = {
+						params: opts.params || {},
+						search: opts.search || {},
+					};
+					return await route.loader?.( context );
+			  }
+			: undefined,
+		component: SurfacesModule,
+	} );
+}
+
+/**
+ * Creates a route tree from route definitions.
+ *
+ * @param routes Routes definition.
+ * @return Router tree.
+ */
+function createRouteTree( routes: Route[] ) {
+	const rootRoute = createRootRoute( {
+		component: Root,
+		context: () => ( {} ),
+	} );
+
+	// Create home route using the route system
+	const homeRouteDefinition: Route = {
+		path: '/',
+		content: homeRoute,
+	};
+
+	// Create routes from definitions including home
+	const allRoutes = [ homeRouteDefinition, ...routes ];
+	const dynamicRoutes = allRoutes.map( ( route ) =>
+		createRouteFromDefinition( route, rootRoute )
+	);
+
+	return rootRoute.addChildren( dynamicRoutes );
+}
 
 // Create custom history that parses ?p= query parameter
 function createPathHistory() {
@@ -62,15 +161,22 @@ function createPathHistory() {
 	} );
 }
 
-const history = createPathHistory();
+interface RouterProps {
+	routes: Route[];
+}
 
-// Create router
-const router = createRouter( {
-	history,
-	routeTree,
-	defaultNotFoundComponent: NotFoundComponent,
-} );
+export default function Router( { routes }: RouterProps ) {
+	// Create router with dynamic routes
+	const router = useMemo( () => {
+		const history = createPathHistory();
+		const routeTree = createRouteTree( routes );
 
-export default function Router() {
+		return createRouter( {
+			history,
+			routeTree,
+			defaultNotFoundComponent: NotFoundComponent,
+		} );
+	}, [ routes ] );
+
 	return <RouterProvider router={ router } />;
 }

--- a/packages/boot/src/components/home/index.tsx
+++ b/packages/boot/src/components/home/index.tsx
@@ -4,10 +4,22 @@
 import { __ } from '@wordpress/i18n';
 import { Page } from '@wordpress/admin-ui';
 
-export default function Home() {
+function Stage() {
 	return (
 		<Page title={ __( 'Hello World' ) } hasPadding>
 			<p>{ __( 'Welcome to the minimal boot package!' ) }</p>
+			<p>{ __( 'This is the main route surface' ) }</p>
 		</Page>
 	);
 }
+
+function Inspector() {
+	return (
+		<Page title={ __( 'Inspector' ) } hasPadding>
+			<p>{ __( 'This is the inspector panel' ) }</p>
+		</Page>
+	);
+}
+
+export const stage = Stage;
+export const inspector = Inspector;

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -25,19 +25,15 @@ export default function Root() {
 			<ThemeProvider color={ { bg: '#1e1e1e', primary: '#3858e9' } }>
 				<div className="boot-layout">
 					<CommandMenu />
-					<div className="boot-layout__content">
-						<div className="boot-layout__sidebar-region">
-							<div className="boot-layout__sidebar">
-								<Sidebar />
-							</div>
-						</div>
-						<div className="boot-layout__stage">
-							<ThemeProvider
-								color={ { bg: '#ffffff', primary: '#3858e9' } }
-							>
-								<Outlet />
-							</ThemeProvider>
-						</div>
+					<div className="boot-layout__sidebar">
+						<Sidebar />
+					</div>
+					<div className="boot-layout__surfaces">
+						<ThemeProvider
+							color={ { bg: '#ffffff', primary: '#3858e9' } }
+						>
+							<Outlet />
+						</ThemeProvider>
 					</div>
 				</div>
 			</ThemeProvider>

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -2,37 +2,40 @@
 
 .boot-layout {
 	height: 100%;
+	width: 100%;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	isolation: isolate;
 	background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
 }
 
-.boot-layout__content {
-	height: 100%;
-	flex-grow: 1;
-	display: flex;
-}
-
-.boot-layout__sidebar-region {
-	flex-shrink: 0;
-	width: 240px;
-}
-
 .boot-layout__sidebar {
 	height: 100%;
+	flex-shrink: 0;
+	width: 240px;
 	position: relative;
 	overflow: hidden;
 }
 
-.boot-layout__stage {
+.boot-layout__surfaces {
+	display: flex;
+	flex-grow: 1;
+	margin: variables.$grid-unit-10;
+	gap: variables.$grid-unit-10;
+}
+
+.boot-layout__stage,
+.boot-layout__inspector {
 	flex: 1;
 	overflow-y: auto;
 	background: var(--wpds-color-bg-surface-neutral, #fff);
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
-	margin: variables.$grid-unit-10;
 	border-radius: 8px;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+}
+
+.boot-layout__inspector {
+	max-width: 400px;
 }

--- a/packages/boot/src/store/actions.ts
+++ b/packages/boot/src/store/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { MenuItem } from './types';
+import type { MenuItem, Route } from './types';
 
 export function registerMenuItem( id: string, menuItem: MenuItem ) {
 	return {
@@ -11,4 +11,13 @@ export function registerMenuItem( id: string, menuItem: MenuItem ) {
 	};
 }
 
-export type Action = ReturnType< typeof registerMenuItem >;
+export function registerRoute( route: Route ) {
+	return {
+		type: 'REGISTER_ROUTE' as const,
+		route,
+	};
+}
+
+export type Action =
+	| ReturnType< typeof registerMenuItem >
+	| ReturnType< typeof registerRoute >;

--- a/packages/boot/src/store/reducer.ts
+++ b/packages/boot/src/store/reducer.ts
@@ -6,6 +6,7 @@ import type { State } from './types';
 
 const initialState: State = {
 	menuItems: {},
+	routes: [],
 };
 
 export function reducer( state: State = initialState, action: Action ): State {
@@ -17,6 +18,12 @@ export function reducer( state: State = initialState, action: Action ): State {
 					...state.menuItems,
 					[ action.id ]: action.menuItem,
 				},
+			};
+
+		case 'REGISTER_ROUTE':
+			return {
+				...state,
+				routes: [ ...state.routes, action.route ],
 			};
 	}
 

--- a/packages/boot/src/store/selectors.ts
+++ b/packages/boot/src/store/selectors.ts
@@ -6,3 +6,7 @@ import type { State } from './types';
 export function getMenuItems( state: State ) {
 	return Object.values( state.menuItems );
 }
+
+export function getRoutes( state: State ) {
+	return state.routes;
+}

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactNode } from 'react';
+import type { ReactNode, ComponentType } from 'react';
 
 /**
  * Icon type supporting multiple formats:
@@ -21,6 +21,59 @@ export interface MenuItem {
 	parent_type?: 'drilldown' | 'dropdown';
 }
 
+/**
+ * Route surfaces exported from content_module.
+ * Stage is required, inspector is optional.
+ */
+export interface RouteSurfaces {
+	stage?: ComponentType;
+	inspector?: ComponentType;
+}
+
+/**
+ * Route loader context containing params and search.
+ */
+export interface RouteLoaderContext {
+	params: Record< string, string >;
+	search: Record< string, unknown >;
+}
+
+/**
+ * Route configuration interface.
+ * All routes must specify a content_module that exports surfaces.
+ */
+export interface Route {
+	/**
+	 * Route path (e.g., "/post-edit/$postId")
+	 */
+	path: string;
+
+	/**
+	 * Hook executed before the route loads.
+	 * Can throw redirect() or notFound() to prevent navigation.
+	 */
+	beforeLoad?: ( context: RouteLoaderContext ) => void | Promise< void >;
+
+	/**
+	 * Async data preloading function.
+	 * The returned data is available to route components.
+	 */
+	loader?: ( context: RouteLoaderContext ) => Promise< unknown >;
+
+	/**
+	 * Module path for lazy loading the route's surfaces.
+	 * The module must export: RouteSurfaces
+	 * This enables code splitting for better performance.
+	 */
+	content_module?: string;
+
+	/**
+	 * If the route is not lazy loaded, it can define a static "content" property.
+	 */
+	content?: RouteSurfaces;
+}
+
 export interface State {
 	menuItems: Record< string, MenuItem >;
+	routes: Route[];
 }


### PR DESCRIPTION
Related #70862 

## What?

Adds routes support to the @wordpress/boot package with surface-based rendering (stage and inspector areas).

## Why?

Enables the boot package to support dynamic route registration with lifecycle hooks and code splitting. Routes can define content for different UI surfaces (main stage area and optional inspector sidebar).

## How?

 - Updated init() to accept routes and menus
 - Converted Home to a static route. 

  Testing Instructions

You can access the demo route `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2F`

Or you can add a small testing route

 - Create a test route:

```
  import { init } from '@wordpress/boot';

  init({
    menuItems: [],
    routes: [{
      path: '/test',
      content: {
        stage: () => <div>Main content</div>,
        inspector: () => <div>Sidebar</div>
      }
    }]
  });
```

  - Navigate to ?p=/test and verify both surfaces render correctly

### What's next

As a next step, I would like to update the build too to support a "routes" folder with some conventions, that way folks don't have to hook anything, there routes will get automatically registered. 