### PR TITLE
Make accordion items inner blocks inherit styling attributes from last accordion item

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -32,6 +32,17 @@ const ACCORDION_BLOCK_NAME = 'core/accordion-item';
 const ACCORDION_HEADING_BLOCK_NAME = 'core/accordion-heading';
 const ACCORDION_BLOCK = {
 	name: ACCORDION_BLOCK_NAME,
+	attributesToCopy: [
+		'backgroundColor',
+		'border',
+		'className',
+		'fontFamily',
+		'fontSize',
+		'gradient',
+		'shadow',
+		'style',
+		'textColor',
+	],
 };
 
 export default function Edit( {

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -26,10 +26,11 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { name as ACCORDION_HEADING_BLOCK_NAME } from '../accordion-heading';
+import { name as ACCORDION_PANEL_BLOCK_NAME } from '../accordion-panel';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ACCORDION_BLOCK_NAME = 'core/accordion-item';
-const ACCORDION_HEADING_BLOCK_NAME = 'core/accordion-heading';
 const ACCORDION_BLOCK = {
 	name: ACCORDION_BLOCK_NAME,
 	attributesToCopy: [
@@ -58,7 +59,7 @@ export default function Edit( {
 	isSelected: isSingleSelected,
 } ) {
 	const registry = useRegistry();
-	const { getBlockOrder } = useSelect( blockEditorStore );
+	const { getBlockOrder, getBlock } = useSelect( blockEditorStore );
 	const blockProps = useBlockProps( {
 		role: 'group',
 	} );
@@ -76,13 +77,70 @@ export default function Edit( {
 	} );
 
 	const addAccordionItemBlock = () => {
-		// When adding, set the header's level to current headingLevel
-		const newAccordionItem = createBlock( ACCORDION_BLOCK_NAME, {}, [
-			createBlock( ACCORDION_HEADING_BLOCK_NAME, {
-				level: headingLevel,
-			} ),
-			createBlock( 'core/accordion-panel', {} ),
-		] );
+		const innerBlockClientIds = getBlockOrder( clientId );
+		const lastAccordionItemId =
+			innerBlockClientIds[ innerBlockClientIds.length - 1 ];
+
+		const accordionItemAttributes = {};
+		const accordionHeadingAttributes = { level: headingLevel };
+		const accordionPanelAttributes = {};
+
+		if ( lastAccordionItemId ) {
+			const lastAccordionItem = getBlock( lastAccordionItemId );
+
+			const attributesToCopy = [
+				'backgroundColor',
+				'border',
+				'className',
+				'fontFamily',
+				'fontSize',
+				'gradient',
+				'shadow',
+				'style',
+				'textColor',
+			];
+
+			if ( lastAccordionItem?.innerBlocks?.length ) {
+				const accordionHeading = lastAccordionItem.innerBlocks.find(
+					( block ) => block.name === ACCORDION_HEADING_BLOCK_NAME
+				);
+				const accordionPanel = lastAccordionItem.innerBlocks.find(
+					( block ) => block.name === ACCORDION_PANEL_BLOCK_NAME
+				);
+
+				attributesToCopy.forEach( ( key ) => {
+					if ( lastAccordionItem.attributes[ key ] ) {
+						accordionItemAttributes[ key ] =
+							lastAccordionItem.attributes[ key ];
+					}
+
+					if ( accordionHeading.attributes[ key ] ) {
+						accordionHeadingAttributes[ key ] =
+							accordionHeading.attributes[ key ];
+					}
+
+					if ( accordionPanel.attributes[ key ] ) {
+						accordionPanelAttributes[ key ] =
+							accordionPanel.attributes[ key ];
+					}
+				} );
+			}
+		}
+
+		const newAccordionItem = createBlock(
+			ACCORDION_BLOCK_NAME,
+			accordionItemAttributes,
+			[
+				createBlock(
+					ACCORDION_HEADING_BLOCK_NAME,
+					accordionHeadingAttributes
+				),
+				createBlock(
+					ACCORDION_PANEL_BLOCK_NAME,
+					accordionPanelAttributes
+				),
+			]
+		);
 		insertBlock( newAccordionItem, undefined, clientId );
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72579

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
