### PR TITLE
Testing: Enable no-unused-disable ESLint Comments plugin rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@ build-types
 build-wp
 node_modules
 packages/block-serialization-spec-parser/parser.js
+packages/icons/src/library/*.tsx
 packages/react-native-editor/bundle
 vendor
 !.*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,7 @@ module.exports = {
 		],
 		'@wordpress/no-unsafe-wp-apis': 'off',
 		'@wordpress/data-no-store-string-literals': 'error',
+		'eslint-comments/no-unused-disable': 'error',
 		'import/default': 'error',
 		'import/named': 'error',
 		'no-restricted-imports': [

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -430,7 +430,6 @@ async function fetchCommit( sha ) {
 	} );
 }
 
-// eslint-disable-next-line no-unused-vars
 async function getPullRequestDataForCommit( commitSha ) {
 	const pullRequests = await octokitRequest(
 		'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',

--- a/packages/autop/src/index.ts
+++ b/packages/autop/src/index.ts
@@ -2,7 +2,6 @@
  * The regular expression for an HTML element.
  */
 const htmlSplitRegex: RegExp = ( () => {
-	/* eslint-disable no-multi-spaces */
 	const comments =
 		'!' + // Start of comment, after the <.
 		'(?:' + // Unroll the loop: Consume everything until --> is found.
@@ -43,7 +42,6 @@ const htmlSplitRegex: RegExp = ( () => {
 		')';
 
 	return new RegExp( regex );
-	/* eslint-enable no-multi-spaces */
 } )();
 
 /**

--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -21,8 +21,6 @@ import { store as blockDirectoryStore } from '../../store';
 
 const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 	const { originalName } = props.attributes;
-	// Disable reason: This is a valid component, but it's mistaken for a callback.
-
 	const { block, hasPermission } = useSelect(
 		( select ) => {
 			const { getDownloadableBlocks } = select( blockDirectoryStore );

--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -22,7 +22,7 @@ import { store as blockDirectoryStore } from '../../store';
 const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 	const { originalName } = props.attributes;
 	// Disable reason: This is a valid component, but it's mistaken for a callback.
-	// eslint-disable-next-line react-hooks/rules-of-hooks
+
 	const { block, hasPermission } = useSelect(
 		( select ) => {
 			const { getDownloadableBlocks } = select( blockDirectoryStore );

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -217,7 +217,6 @@ function BlockPopoverInbetween( {
 		return null;
 	}
 
-	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	// While ideally it would be enough to capture the
 	// bubbling focus event from the Inserter, due to the
 	// characteristics of click focusing of `button`s in
@@ -253,7 +252,6 @@ function BlockPopoverInbetween( {
 			</div>
 		</Popover>
 	);
-	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 }
 
 export default BlockPopoverInbetween;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -344,7 +344,7 @@ function Iframe( {
 					createPortal(
 						// We want to prevent React events from bubbling through the iframe
 						// we bubble these manually.
-						/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
+
 						<body
 							ref={ bodyRef }
 							className={ clsx(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -342,9 +342,6 @@ function Iframe( {
 			>
 				{ iframeDocument &&
 					createPortal(
-						// We want to prevent React events from bubbling through the iframe
-						// we bubble these manually.
-
 						<body
 							ref={ bodyRef }
 							className={ clsx(

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -49,13 +49,11 @@ import deprecated from '@wordpress/deprecated';
  *                                    providing a custom `settings` prop.
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Custom settings values associated with a link.
  *
  * @typedef {{[setting:string]:any}} WPLinkControlSettingsValue
  */
-/* eslint-enable */
 
 /**
  * Custom settings values associated with a link.

--- a/packages/block-editor/src/components/list-view/expander.js
+++ b/packages/block-editor/src/components/list-view/expander.js
@@ -14,7 +14,7 @@ export default function ListViewExpander( { onClick } ) {
 		// We've mimicked this by adding an icon with aria-hidden set to true to hide this from the accessibility tree.
 		// For the current tree grid implementation, please do not try to make this a button.
 		//
-		// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+
 		<span
 			className="block-editor-list-view__expander"
 			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }

--- a/packages/block-editor/src/components/list-view/expander.js
+++ b/packages/block-editor/src/components/list-view/expander.js
@@ -13,8 +13,6 @@ export default function ListViewExpander( { onClick } ) {
 		//
 		// We've mimicked this by adding an icon with aria-hidden set to true to hide this from the accessibility tree.
 		// For the current tree grid implementation, please do not try to make this a button.
-		//
-
 		<span
 			className="block-editor-list-view__expander"
 			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -257,7 +257,6 @@ const MediaReplaceFlow = ( {
 							: children }
 					</NavigableMenu>
 					{ onSelectURL && (
-						// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
 						<form className="block-editor-media-flow__url-input">
 							<span className="block-editor-media-replace-flow__image-url-label">
 								{ __( 'Current media URL:' ) }

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -415,7 +415,7 @@ export function RichTextWrapper(
 				} );
 
 				// Allows us to ask for this information when we get a report.
-				// eslint-disable-next-line no-console
+
 				window.console.log( 'Received items:\n\n', files );
 
 				if ( onReplace && isEmpty( value ) ) {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -414,8 +414,6 @@ export function RichTextWrapper(
 					preserveWhiteSpace,
 				} );
 
-				// Allows us to ask for this information when we get a report.
-
 				window.console.log( 'Received items:\n\n', files );
 
 				if ( onReplace && isEmpty( value ) ) {

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -181,8 +181,6 @@ export default {
 		}
 
 		if ( rules.length ) {
-			// Reason to disable: the extra line breaks added by prettier mess with the unit tests.
-
 			output = `${ appendSelectors( selector ) } { ${ rules.join(
 				'; '
 			) }; }`;

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -182,7 +182,7 @@ export default {
 
 		if ( rules.length ) {
 			// Reason to disable: the extra line breaks added by prettier mess with the unit tests.
-			// eslint-disable-next-line prettier/prettier
+
 			output = `${ appendSelectors( selector ) } { ${ rules.join(
 				'; '
 			) }; }`;

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -104,7 +104,6 @@ export const validateBlocksToTemplate =
  * @property {WPBlockSelection} end   The selection end.
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Returns an action object used in signalling that selection state should be
  * reset to the specified selection.
@@ -120,7 +119,6 @@ export function resetSelection(
 	selectionEnd,
 	initialPosition
 ) {
-	/* eslint-enable jsdoc/valid-types */
 	return {
 		type: 'RESET_SELECTION',
 		selectionStart,
@@ -194,7 +192,6 @@ export function updateBlock( clientId, updates ) {
 	};
 }
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Returns an action object used in signalling that the block with the
  * specified client ID has been selected, optionally accepting a position
@@ -208,7 +205,6 @@ export function updateBlock( clientId, updates ) {
  * @return {Object} Action object.
  */
 export function selectBlock( clientId, initialPosition = 0 ) {
-	/* eslint-enable jsdoc/valid-types */
 	return {
 		type: 'SELECT_BLOCK',
 		initialPosition,
@@ -355,7 +351,6 @@ export function toggleSelection( isSelectionEnabled = true ) {
 	};
 }
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Action that replaces given blocks with one or more replacement blocks.
  *
@@ -370,7 +365,6 @@ export function toggleSelection( isSelectionEnabled = true ) {
 export const replaceBlocks =
 	( clientIds, blocks, indexToSelect, initialPosition = 0, meta ) =>
 	( { select, dispatch, registry } ) => {
-		/* eslint-enable jsdoc/valid-types */
 		clientIds = castArray( clientIds );
 		blocks = castArray( blocks );
 		const rootClientId = select.getBlockRootClientId( clientIds[ 0 ] );
@@ -540,7 +534,6 @@ export function insertBlock(
 	);
 }
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Action that inserts an array of blocks, optionally at a specific index respective a root block list.
  *
@@ -566,7 +559,6 @@ export const insertBlocks =
 		meta
 	) =>
 	( { select, dispatch } ) => {
-		/* eslint-enable jsdoc/valid-types */
 		if ( initialPosition !== null && typeof initialPosition === 'object' ) {
 			meta = initialPosition;
 			initialPosition = 0;
@@ -1400,7 +1392,6 @@ export function removeBlock( clientId, selectPrevious ) {
 	return removeBlocks( [ clientId ], selectPrevious );
 }
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Returns an action object used in signalling that the inner blocks with the
  * specified client ID should be replaced.
@@ -1417,7 +1408,6 @@ export function replaceInnerBlocks(
 	updateSelection = false,
 	initialPosition = 0
 ) {
-	/* eslint-enable jsdoc/valid-types */
 	return {
 		type: 'REPLACE_INNER_BLOCKS',
 		rootClientId,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -788,7 +788,6 @@ export function getNextBlockClientId( state, startClientId ) {
 	return getAdjacentBlockClientId( state, startClientId, 1 );
 }
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Returns the initial caret position for the selected block.
  * This position is to used to position the caret properly when the selected block changes.
@@ -799,7 +798,6 @@ export function getNextBlockClientId( state, startClientId ) {
  * @return {0|-1|null} Initial position.
  */
 export function getSelectedBlocksInitialCaretPosition( state ) {
-	/* eslint-enable jsdoc/valid-types */
 	return state.initialPosition;
 }
 

--- a/packages/block-library/src/comment-author-name/edit.js
+++ b/packages/block-library/src/comment-author-name/edit.js
@@ -56,7 +56,7 @@ export default function Edit( {
 			const { getEntityRecord } = select( coreStore );
 
 			const comment = getEntityRecord( 'root', 'comment', commentId );
-			const authorName = comment?.author_name; // eslint-disable-line camelcase
+			const authorName = comment?.author_name;
 
 			if ( comment && ! authorName ) {
 				const user = getEntityRecord( 'root', 'user', comment.author );

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -182,7 +182,6 @@ const CommentTemplatePreview = ( {
 			tabIndex={ 0 }
 			role="button"
 			style={ style }
-			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 			onClick={ handleOnClick }
 			onKeyPress={ handleOnClick }
 		/>

--- a/packages/block-library/src/form/view.js
+++ b/packages/block-library/src/form/view.js
@@ -7,8 +7,6 @@ try {
 	);
 } catch {}
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable no-undef */
 document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 	// Bail If the form settings not provided or the form is not using the mailto: action.
 	if (

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -56,7 +56,7 @@ export function getHrefAndDestination( image, destination ) {
 	switch ( destination ) {
 		case DEPRECATED_LINK_DESTINATION_MEDIA:
 			return {
-				href: image?.source_url || image?.url, // eslint-disable-line camelcase
+				href: image?.source_url || image?.url,
 				linkDestination: LINK_DESTINATION_MEDIA,
 			};
 		case DEPRECATED_LINK_DESTINATION_ATTACHMENT:
@@ -66,7 +66,7 @@ export function getHrefAndDestination( image, destination ) {
 			};
 		case LINK_DESTINATION_MEDIA:
 			return {
-				href: image?.source_url || image?.url, // eslint-disable-line camelcase
+				href: image?.source_url || image?.url,
 				linkDestination: LINK_DESTINATION_MEDIA,
 			};
 		case LINK_DESTINATION_ATTACHMENT:

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -40,7 +40,7 @@ export function getHrefAndDestination(
 		case LINK_DESTINATION_MEDIA_WP_CORE:
 		case LINK_DESTINATION_MEDIA:
 			return {
-				href: image?.source_url || image?.url, // eslint-disable-line camelcase
+				href: image?.source_url || image?.url,
 				linkDestination: IMAGE_LINK_DESTINATION_MEDIA,
 				lightbox: lightboxSetting?.enabled
 					? { ...attributes?.lightbox, enabled: false }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -911,9 +911,6 @@ export default function Image( {
 				<Spinner />
 			</Placeholder>
 		) : (
-			// Disable reason: Image itself is not meant to be interactive, but
-			// should direct focus to block.
-
 			<>
 				<img
 					src={ temporaryURL || url }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -913,7 +913,7 @@ export default function Image( {
 		) : (
 			// Disable reason: Image itself is not meant to be interactive, but
 			// should direct focus to block.
-			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+
 			<>
 				<img
 					src={ temporaryURL || url }
@@ -940,7 +940,6 @@ export default function Image( {
 				/>
 				{ temporaryURL && <Spinner /> }
 			</>
-			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 		);
 
 	if ( canEditImage && isEditingImage ) {

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -58,7 +58,6 @@ const applyWidthConstraints = ( width ) =>
 	);
 
 function getImageSourceUrlBySizeSlug( image, slug ) {
-	// eslint-disable-next-line camelcase
 	return image?.media_details?.sizes?.[ slug ]?.source_url;
 }
 
@@ -105,7 +104,6 @@ function attributesFromMedia( {
 			// Try the "large" size URL, falling back to the "full" size URL below.
 			src =
 				media.sizes?.large?.url ||
-				// eslint-disable-next-line camelcase
 				media.media_details?.sizes?.large?.source_url;
 		}
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -391,9 +391,8 @@ export default function NavigationSubmenuEdit( {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
+				{  }
 				<ParentElement className="wp-block-navigation-item__content">
-					{ /* eslint-enable */ }
 					<RichText
 						ref={ ref }
 						identifier="label"

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -391,7 +391,6 @@ export default function NavigationSubmenuEdit( {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{  }
 				<ParentElement className="wp-block-navigation-item__content">
 					<RichText
 						ref={ ref }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -133,9 +133,6 @@ const SiteLogo = ( {
 	);
 
 	let imgWrapper = img;
-
-	// Disable reason: Image itself is not meant to be interactive, but
-	// should direct focus to block.
 	if ( isLink ) {
 		imgWrapper = (
 			<a

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -138,7 +138,6 @@ const SiteLogo = ( {
 	// should direct focus to block.
 	if ( isLink ) {
 		imgWrapper = (
-			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 			<a
 				href={ siteUrl }
 				className="custom-logo-link"
@@ -148,7 +147,6 @@ const SiteLogo = ( {
 			>
 				{ img }
 			</a>
-			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 		);
 	}
 

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -25,7 +25,6 @@ function getLatestHeadings( select, clientId ) {
 	// declaring @wordpress/editor as a dependency, we must access its
 	// store by string. When the store is not available, editorSelectors
 	// will be null, and the block's saved markup will lack permalinks.
-
 	const permalink = select( 'core/editor' ).getPermalink() ?? null;
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -25,7 +25,7 @@ function getLatestHeadings( select, clientId ) {
 	// declaring @wordpress/editor as a dependency, we must access its
 	// store by string. When the store is not available, editorSelectors
 	// will be null, and the block's saved markup will lack permalinks.
-	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+
 	const permalink = select( 'core/editor' ).getPermalink() ?? null;
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -903,7 +903,6 @@ export const registerBlockBindingsSource = ( source ) => {
 
 	// Check the `getFieldsList` property is correct.
 	if ( getFieldsList && typeof getFieldsList !== 'function' ) {
-		// eslint-disable-next-line no-console
 		warning( 'Block bindings source getFieldsList must be a function.' );
 		return;
 	}

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/forbid-elements */
-
 /**
  * WordPress dependencies
  */
@@ -1755,5 +1753,3 @@ describe( 'blocks', () => {
 		} );
 	} );
 } );
-
-/* eslint-enable react/forbid-elements */

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -532,7 +532,6 @@ describe( 'Button', () => {
 			render(
 				<Button
 					// @ts-expect-error - a button should not have `href`
-
 					href="https://wordpress.org/"
 					disabled
 					accessibleWhenDisabled

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -532,7 +532,7 @@ describe( 'Button', () => {
 			render(
 				<Button
 					// @ts-expect-error - a button should not have `href`
-					// eslint-disable-next-line no-restricted-syntax
+
 					href="https://wordpress.org/"
 					disabled
 					accessibleWhenDisabled

--- a/packages/components/src/composite/legacy/index.tsx
+++ b/packages/components/src/composite/legacy/index.tsx
@@ -238,7 +238,7 @@ export function useCompositeState(
 		loop: focusLoop = false,
 		wrap: focusWrap = false,
 		shift: focusShift = false,
-		// eslint-disable-next-line camelcase
+
 		unstable_virtual: virtualFocus,
 	} = legacyStateOptions;
 

--- a/packages/components/src/composite/legacy/index.tsx
+++ b/packages/components/src/composite/legacy/index.tsx
@@ -238,7 +238,6 @@ export function useCompositeState(
 		loop: focusLoop = false,
 		wrap: focusWrap = false,
 		shift: focusShift = false,
-
 		unstable_virtual: virtualFocus,
 	} = legacyStateOptions;
 

--- a/packages/components/src/context/use-context-system.js
+++ b/packages/components/src/context/use-context-system.js
@@ -33,14 +33,12 @@ export function useContextSystem( props, namespace ) {
 
 	const contextProps = contextSystemProps?.[ namespace ] || {};
 
-	/* eslint-disable jsdoc/no-undefined-types */
 	/** @type {ConnectedProps<P>} */
 	// @ts-ignore We fill in the missing properties below
 	const finalComponentProps = {
 		...getConnectedNamespace(),
 		...getNamespace( namespace ),
 	};
-	/* eslint-enable jsdoc/no-undefined-types */
 
 	const { _overrides: overrideProps, ...otherContextProps } = contextProps;
 

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -47,7 +47,7 @@ describe( 'NumberControl', () => {
 			);
 
 			expect(
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				// eslint-disable-next-line testing-library/no-node-access
 				withoutClassName.querySelector( '.components-number-control' )
 			).not.toHaveClass( 'hello' );
 

--- a/packages/components/src/progress-bar/test/index.tsx
+++ b/packages/components/src/progress-bar/test/index.tsx
@@ -37,7 +37,7 @@ describe( 'ProgressBar', () => {
 		 * We're intentionally not using an accessible selector, because
 		 * the track is an intentionally non-interactive presentation element.
 		 */
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		// eslint-disable-next-line testing-library/no-node-access
 		const indicator = container.firstChild?.firstChild;
 
 		expect( indicator ).toHaveStyle( {
@@ -55,7 +55,7 @@ describe( 'ProgressBar', () => {
 		 * We're intentionally not using an accessible selector, because
 		 * the track is an intentionally non-interactive presentation element.
 		 */
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		// eslint-disable-next-line testing-library/no-node-access
 		const indicator = container.firstChild?.firstChild;
 
 		expect( indicator ).toHaveStyle( {

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -72,7 +72,6 @@ function UnforwardedSelectControl< V extends string >(
 	const id = useUniqueId( idProp );
 	const helpId = help ? `${ id }__help` : undefined;
 
-	// Disable reason: A select with an onchange throws a warning.
 	if ( ! options?.length && ! children ) {
 		return null;
 	}

--- a/packages/components/src/utils/hooks/use-controlled-state.js
+++ b/packages/components/src/utils/hooks/use-controlled-state.js
@@ -68,7 +68,6 @@ function useControlledState( currentState, options = defaultOptions ) {
 		fallback
 	);
 
-	/* eslint-disable jsdoc/no-undefined-types */
 	/** @type {(nextState: T) => void} */
 	const setState = useCallback(
 		( nextState ) => {
@@ -78,7 +77,6 @@ function useControlledState( currentState, options = defaultOptions ) {
 		},
 		[ hasCurrentState ]
 	);
-	/* eslint-enable jsdoc/no-undefined-types */
 
 	return [ state, setState ];
 }

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/valid-types */
 /**
  * Determines if a value is null or undefined.
  *
@@ -10,9 +9,7 @@
 export function isValueDefined( value ) {
 	return value !== undefined && value !== null;
 }
-/* eslint-enable jsdoc/valid-types */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Determines if a value is empty, null, or undefined.
  *
@@ -24,7 +21,6 @@ export function isValueEmpty( value ) {
 
 	return ! isValueDefined( value ) || isEmptyString;
 }
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Get the first defined/non-null value from an array.

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -15,7 +15,6 @@ import Listener from './listener';
  */
 const listener = new Listener();
 
-/* eslint-disable jsdoc/no-undefined-types */
 /**
  * Higher-order component creator which, given an object of DOM event types and
  * values corresponding to a callback function name on the component, will
@@ -69,7 +68,6 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 						/** @type {keyof GlobalEventHandlersEventMap} */ (
 							event.type
 						)
-						/* eslint-enable jsdoc/no-undefined-types */
 					];
 				if ( typeof this.wrappedRef[ handler ] === 'function' ) {
 					this.wrappedRef[ handler ]( event );

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -9,7 +9,6 @@ import Clipboard from 'clipboard';
 import { useRef, useEffect, useState } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
-/* eslint-disable jsdoc/no-undefined-types */
 /**
  * Copies the text to the clipboard when the element is clicked.
  *
@@ -24,7 +23,6 @@ import deprecated from '@wordpress/deprecated';
  *                   timeout.
  */
 export default function useCopyOnClick( ref, text, timeout = 4000 ) {
-	/* eslint-enable jsdoc/no-undefined-types */
 	deprecated( 'wp.compose.useCopyOnClick', {
 		since: '5.8',
 		alternative: 'wp.compose.useCopyToClipboard',

--- a/packages/compose/src/hooks/use-focus-outside/index.native.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.native.js
@@ -15,8 +15,6 @@ const INPUT_BUTTON_TYPES = [ 'button', 'submit' ];
  * @typedef {HTMLButtonElement | HTMLLinkElement | HTMLInputElement} FocusNormalizedButton
  */
 
-// Disable reason: Rule doesn't support predicate return types.
-
 /**
  * Returns true if the given element is a button element subject to focus
  * normalization, or false otherwise.

--- a/packages/compose/src/hooks/use-focus-outside/index.native.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.native.js
@@ -16,7 +16,7 @@ const INPUT_BUTTON_TYPES = [ 'button', 'submit' ];
  */
 
 // Disable reason: Rule doesn't support predicate return types.
-/* eslint-disable jsdoc/valid-types */
+
 /**
  * Returns true if the given element is a button element subject to focus
  * normalization, or false otherwise.
@@ -41,7 +41,6 @@ function isFocusNormalizedButton( eventTarget ) {
 
 	return false;
 }
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {import('react').SyntheticEvent} SyntheticEvent

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -21,7 +21,6 @@ import { isAppleOS } from '@wordpress/keycodes';
  * @property {import('react').RefObject<HTMLElement>} [target]     React reference to the DOM element used to catch the keyboard event.
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Attach a keyboard shortcut handler.
  *
@@ -32,7 +31,6 @@ import { isAppleOS } from '@wordpress/keycodes';
  * @param {WPKeyboardShortcutConfig}                                              options   Shortcut options.
  */
 function useKeyboardShortcut(
-	/* eslint-enable jsdoc/valid-types */
 	shortcuts,
 	callback,
 	{
@@ -89,11 +87,8 @@ function useKeyboardShortcut(
 			mousetrap[ bindFn ](
 				shortcut,
 				(
-					/* eslint-disable jsdoc/valid-types */
 					/** @type {[e: import('mousetrap').ExtendedKeyboardEvent, combo: string]} */ ...args
-				) =>
-					/* eslint-enable jsdoc/valid-types */
-					currentCallbackRef.current( ...args ),
+				) => currentCallbackRef.current( ...args ),
 				eventName
 			);
 		} );

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -3,12 +3,10 @@
  */
 import { useRef, useCallback, useLayoutEffect } from '@wordpress/element';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @template T
  * @typedef {T extends import('react').Ref<infer R> ? R : never} TypeFromRef
  */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @template T
@@ -19,10 +17,8 @@ function assignRef( ref, value ) {
 	if ( typeof ref === 'function' ) {
 		ref( value );
 	} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
-		/* eslint-disable jsdoc/no-undefined-types */
 		/** @type {import('react').MutableRefObject<T>} */ ( ref ).current =
 			value;
-		/* eslint-enable jsdoc/no-undefined-types */
 	}
 }
 
@@ -73,9 +69,8 @@ export default function useMergeRefs( refs ) {
 	const element = useRef();
 	const isAttachedRef = useRef( false );
 	const didElementChangeRef = useRef( false );
-	/* eslint-disable jsdoc/no-undefined-types */
+
 	/** @type {import('react').MutableRefObject<TRef[]>} */
-	/* eslint-enable jsdoc/no-undefined-types */
 	const previousRefsRef = useRef( [] );
 	const currentRefsRef = useRef( refs );
 

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -69,7 +69,6 @@ export default function useMergeRefs( refs ) {
 	const element = useRef();
 	const isAttachedRef = useRef( false );
 	const didElementChangeRef = useRef( false );
-
 	/** @type {import('react').MutableRefObject<TRef[]>} */
 	const previousRefsRef = useRef( [] );
 	const currentRefsRef = useRef( refs );

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -4,13 +4,11 @@
 // See https://babeljs.io/docs/en/babel-types.
 const { types: babelTypes } = require( '@babel/core' );
 
-/* eslint-disable jsdoc/valid-types */
 /** @typedef {ReturnType<import('comment-parser').parse>[0]} CommentBlock */
 /** @typedef {CommentBlock['tags'][0]} CommentTag */
 /** @typedef {babelTypes.TSType} TypeAnnotation */
 /** @typedef {babelTypes.TSCallSignatureDeclaration | babelTypes.TSFunctionType | babelTypes.TSConstructSignatureDeclaration} ExtendedTypeAnnotation */
 /** @typedef {import('@babel/core').Node} ASTNode */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @param {ExtendedTypeAnnotation} typeAnnotation

--- a/packages/dom/src/dom/clean-node-list.js
+++ b/packages/dom/src/dom/clean-node-list.js
@@ -10,7 +10,6 @@ import isElement from './is-element';
 
 const noop = () => {};
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef SchemaItem
  * @property {string[]}                            [attributes] Attributes.
@@ -22,7 +21,6 @@ const noop = () => {};
  */
 
 /** @typedef {{ [tag: string]: SchemaItem }} Schema */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Given a schema, unwraps or removes nodes, attributes and classes on a node

--- a/packages/dom/src/dom/get-computed-style.js
+++ b/packages/dom/src/dom/get-computed-style.js
@@ -3,13 +3,11 @@
  */
 import { assertIsDefined } from '../utils/assert-is-defined';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @param {Element} element
  * @return {ReturnType<Window['getComputedStyle']>} The computed style for the element.
  */
 export default function getComputedStyle( element ) {
-	/* eslint-enable jsdoc/valid-types */
 	assertIsDefined(
 		element.ownerDocument.defaultView,
 		'element.ownerDocument.defaultView'

--- a/packages/dom/src/dom/is-element.js
+++ b/packages/dom/src/dom/is-element.js
@@ -1,9 +1,7 @@
-/* eslint-disable jsdoc/valid-types */
 /**
  * @param {Node | null | undefined} node
  * @return {node is Element} True if node is an Element node
  */
 export default function isElement( node ) {
-	/* eslint-enable jsdoc/valid-types */
 	return !! node && node.nodeType === node.ELEMENT_NODE;
 }

--- a/packages/dom/src/dom/is-html-input-element.js
+++ b/packages/dom/src/dom/is-html-input-element.js
@@ -1,9 +1,7 @@
-/* eslint-disable jsdoc/valid-types */
 /**
  * @param {Node} node
  * @return {node is HTMLInputElement} Whether the node is an HTMLInputElement.
  */
 export default function isHTMLInputElement( node ) {
-	/* eslint-enable jsdoc/valid-types */
 	return node?.nodeName === 'INPUT';
 }

--- a/packages/dom/src/dom/is-input-or-text-area.js
+++ b/packages/dom/src/dom/is-input-or-text-area.js
@@ -1,9 +1,7 @@
-/* eslint-disable jsdoc/valid-types */
 /**
  * @param {Element} element
  * @return {element is HTMLInputElement | HTMLTextAreaElement} Whether the element is an input or textarea
  */
 export default function isInputOrTextArea( element ) {
-	/* eslint-enable jsdoc/valid-types */
 	return element.tagName === 'INPUT' || element.tagName === 'TEXTAREA';
 }

--- a/packages/dom/src/dom/is-number-input.js
+++ b/packages/dom/src/dom/is-number-input.js
@@ -8,7 +8,6 @@ import deprecated from '@wordpress/deprecated';
  */
 import isHTMLInputElement from './is-html-input-element';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Check whether the given element is an input field of type number.
  *
@@ -21,7 +20,6 @@ export default function isNumberInput( node ) {
 		since: '6.1',
 		version: '6.5',
 	} );
-	/* eslint-enable jsdoc/valid-types */
 	return (
 		isHTMLInputElement( node ) &&
 		node.type === 'number' &&

--- a/packages/dom/src/dom/is-text-field.js
+++ b/packages/dom/src/dom/is-text-field.js
@@ -3,7 +3,6 @@
  */
 import isHTMLInputElement from './is-html-input-element';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Check whether the given element is a text field, where text field is defined
  * by the ability to select within the input, or that it is contenteditable.
@@ -14,7 +13,6 @@ import isHTMLInputElement from './is-html-input-element';
  * @return {node is HTMLElement} True if the element is an text field, false if not.
  */
 export default function isTextField( node ) {
-	/* eslint-enable jsdoc/valid-types */
 	const nonTextInputs = [
 		'button',
 		'checkbox',

--- a/packages/e2e-test-utils/src/delete-theme.js
+++ b/packages/e2e-test-utils/src/delete-theme.js
@@ -40,7 +40,6 @@ export async function deleteTheme(
 	await page.waitForSelector( 'body:not(.modal-open)' );
 
 	// Wait for the theme to be removed from the page.
-
 	await page.waitForFunction(
 		( themeSlug ) =>
 			! document.querySelector( `[data-slug="${ themeSlug }"]` ),

--- a/packages/e2e-test-utils/src/delete-theme.js
+++ b/packages/e2e-test-utils/src/delete-theme.js
@@ -40,7 +40,7 @@ export async function deleteTheme(
 	await page.waitForSelector( 'body:not(.modal-open)' );
 
 	// Wait for the theme to be removed from the page.
-	// eslint-disable-next-line no-restricted-syntax
+
 	await page.waitForFunction(
 		( themeSlug ) =>
 			! document.querySelector( `[data-slug="${ themeSlug }"]` ),

--- a/packages/edit-site/src/utils/is-template-revertable.js
+++ b/packages/edit-site/src/utils/is-template-revertable.js
@@ -13,10 +13,9 @@ export default function isTemplateRevertable( template ) {
 	if ( ! template ) {
 		return false;
 	}
-	/* eslint-disable camelcase */
+
 	return (
 		template?.source === TEMPLATE_ORIGINS.custom &&
 		( Boolean( template?.plugin ) || template?.has_theme_file )
 	);
-	/* eslint-enable camelcase */
 }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1870,8 +1870,6 @@ export const getPostTypeLabel = createRegistrySelector(
 	( select ) => ( state ) => {
 		const currentPostType = getCurrentPostType( state );
 		const postType = select( coreStore ).getPostType( currentPostType );
-		// Disable reason: Post type labels object is shaped like this.
-
 		return postType?.labels?.singular_name;
 	}
 );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1871,7 +1871,7 @@ export const getPostTypeLabel = createRegistrySelector(
 		const currentPostType = getCurrentPostType( state );
 		const postType = select( coreStore ).getPostType( currentPostType );
 		// Disable reason: Post type labels object is shaped like this.
-		// eslint-disable-next-line camelcase
+
 		return postType?.labels?.singular_name;
 	}
 );

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -76,7 +76,6 @@ const withSpinner =
 					spinner.fail(
 						typeof error === 'string' ? error : error.message
 					);
-					// Disable reason: Using console.error() means we get a stack trace.
 					console.error( error );
 					process.exit( 1 );
 				} else {

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -1,5 +1,5 @@
 'use strict';
-/* eslint-disable jest/no-conditional-expect */
+
 /**
  * External dependencies
  */
@@ -201,4 +201,3 @@ describe( 'Config Integration', () => {
 		expect( config ).toMatchSnapshot();
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/env/lib/config/test/get-cache-directory.js
+++ b/packages/env/lib/config/test/get-cache-directory.js
@@ -1,5 +1,5 @@
 'use strict';
-/* eslint-disable jest/no-conditional-expect */
+
 /**
  * External dependencies
  */
@@ -54,4 +54,3 @@ describe( 'getCacheDirectory', () => {
 		expect( parsed ).toEqual( '/home/test/wp-env' );
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
@@ -226,7 +226,6 @@ function FontCollection( { slug }: { slug: string } ) {
 					} )
 				);
 			}
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch ( error ) {
 			// If any of the fonts fail to download,
 			// show an error notice and stop the request from being sent.

--- a/packages/global-styles-ui/src/font-library-modal/google-fonts-confirm-dialog.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/google-fonts-confirm-dialog.tsx
@@ -13,7 +13,6 @@ import {
 
 function GoogleFontsConfirmDialog(): JSX.Element {
 	const handleConfirm = (): void => {
-		// eslint-disable-next-line no-undef
 		window.localStorage.setItem(
 			'wp-font-library-google-fonts-permission',
 			'true'

--- a/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
@@ -3,7 +3,7 @@
  */
 // The font library modal is pre-existent in Gutenberg
 // It needs to be refactored to move all the API calls to core-data.
-// eslint-disable-next-line no-restricted-imports
+
 import apiFetch from '@wordpress/api-fetch';
 
 /**

--- a/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-// The font library modal is pre-existent in Gutenberg
-// It needs to be refactored to move all the API calls to core-data.
-
 import apiFetch from '@wordpress/api-fetch';
 
 /**

--- a/packages/global-styles-ui/src/font-library-modal/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/upload-fonts.tsx
@@ -132,7 +132,6 @@ function UploadFonts() {
 			const buffer = await readFileAsArrayBuffer( file );
 			await font.fromDataBuffer( buffer, 'font' );
 			return true;
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch ( error ) {
 			return false;
 		}

--- a/packages/global-styles-ui/src/font-library-modal/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/index.ts
@@ -106,7 +106,6 @@ export async function loadFontFaceInBrowser(
 
 	if ( typeof source === 'string' ) {
 		dataSource = `url(${ source })`;
-		// eslint-disable-next-line no-undef
 	} else if ( source instanceof File ) {
 		dataSource = await source.arrayBuffer();
 	} else {
@@ -209,7 +208,6 @@ export function getDisplaySrcFromFontFace(
 export function makeFontFamilyFormData( fontFamily: FontFamily ): FormData {
 	const formData = new FormData();
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { fontFace, category, ...familyWithValidParameters } = fontFamily;
 	const fontFamilySettings = {
 		...familyWithValidParameters,

--- a/packages/i18n/src/test/default-i18n.ts
+++ b/packages/i18n/src/test/default-i18n.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @wordpress/i18n-text-domain, @wordpress/i18n-translator-comments */
-
 /**
  * WordPress dependencies
  */
@@ -42,5 +40,3 @@ describe( 'i18n filters', () => {
 		expect( _nx( 'hello', 'hellos', 2, 'context' ) ).toBe( 'goodbyes' );
 	} );
 } );
-
-/* eslint-enable @wordpress/i18n-text-domain, @wordpress/i18n-translator-comments */

--- a/packages/icons/lib/generate-library.js
+++ b/packages/icons/lib/generate-library.js
@@ -189,8 +189,7 @@ function svgToTsx( svgContent ) {
 		.map( ( line ) => '\t' + line )
 		.join( '\n' );
 
-	return `/* eslint-disable prettier/prettier */
-/**
+	return `/**
  * WordPress dependencies
  */
 import { ${ Array.from( usedPrimitives )
@@ -200,7 +199,6 @@ import { ${ Array.from( usedPrimitives )
 export default (
 ${ jsxContent }
 );
-/* eslint-enable */
 `;
 }
 

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -459,7 +459,6 @@ export default () => {
 				let start;
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 					if ( globalThis.SCRIPT_DEBUG ) {
-						// eslint-disable-next-line no-unused-vars
 						start = performance.now();
 					}
 				}
@@ -513,7 +512,6 @@ export default () => {
 						performance.measure(
 							`interactivity api init ${ entry.namespace }`,
 							{
-								// eslint-disable-next-line no-undef
 								start,
 								end: performance.now(),
 								detail: {
@@ -575,7 +573,6 @@ export default () => {
 							performance.measure(
 								`interactivity api on ${ entry.namespace }`,
 								{
-									// eslint-disable-next-line no-undef
 									start,
 									end: performance.now(),
 									detail: {

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -1,6 +1,4 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
-/* eslint-disable @typescript-eslint/no-shadow */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
  * External dependencies

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -1,5 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
-
 /**
  * External dependencies
  */

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -152,7 +152,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 
 		// First modal should no longer be presented.
 		const replaceButtons = await editorPage.driver.$$( '~Replace' );
-		// eslint-disable-next-line jest/no-conditional-expect
+
 		expect( replaceButtons.length ).toBe( 0 );
 
 		// Select different media.

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -152,7 +152,6 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 
 		// First modal should no longer be presented.
 		const replaceButtons = await editorPage.driver.$$( '~Replace' );
-
 		expect( replaceButtons.length ).toBe( 0 );
 
 		// Select different media.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const childProcess = require( 'child_process' );
-// eslint-disable-next-line import/no-extraneous-dependencies, import/named
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { remote, Key } from 'webdriverio';
 
 const crypto = require( 'crypto' );

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -45,7 +45,7 @@ function deleteRecordingFile( filePath ) {
 
 let allPassed = true;
 
-// eslint-disable-next-line jest/no-jasmine-globals, no-undef
+// eslint-disable-next-line no-undef
 jasmine.getEnv().addReporter( {
 	specStarted: ( { testPath, id } ) => {
 		if ( ! isMacOSEnvironment() ) {

--- a/packages/react-native-editor/sass-transformer.js
+++ b/packages/react-native-editor/sass-transformer.js
@@ -39,7 +39,7 @@ const path = require( 'path' );
 const sass = require( 'sass' );
 // eslint-disable-next-line import/no-extraneous-dependencies
 const css2rn = require( 'css-to-react-native-transform' ).default;
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 const upstreamTransformer = require( '@react-native/metro-babel-transformer' );
 
 // TODO: need to find a way to pass the include paths and the default asset files via some config.

--- a/packages/react-native-editor/sass-transformer.js
+++ b/packages/react-native-editor/sass-transformer.js
@@ -39,7 +39,6 @@ const path = require( 'path' );
 const sass = require( 'sass' );
 // eslint-disable-next-line import/no-extraneous-dependencies
 const css2rn = require( 'css-to-react-native-transform' ).default;
-
 const upstreamTransformer = require( '@react-native/metro-babel-transformer' );
 
 // TODO: need to find a way to pass the include paths and the default asset files via some config.

--- a/packages/react-native-editor/sass-transformer.js
+++ b/packages/react-native-editor/sass-transformer.js
@@ -39,6 +39,7 @@ const path = require( 'path' );
 const sass = require( 'sass' );
 // eslint-disable-next-line import/no-extraneous-dependencies
 const css2rn = require( 'css-to-react-native-transform' ).default;
+// eslint-disable-next-line import/no-extraneous-dependencies
 const upstreamTransformer = require( '@react-native/metro-babel-transformer' );
 
 // TODO: need to find a way to pass the include paths and the default asset files via some config.

--- a/packages/sync/src/providers/y-webrtc/y-webrtc.js
+++ b/packages/sync/src/providers/y-webrtc/y-webrtc.js
@@ -19,7 +19,7 @@ import * as buffer from 'lib0/buffer';
 import * as math from 'lib0/math';
 import { createMutex } from 'lib0/mutex';
 
-import * as Y from 'yjs'; // eslint-disable-line
+import * as Y from 'yjs';
 import Peer from 'simple-peer/simplepeer.min.js';
 
 import * as syncProtocol from 'y-protocols/sync';

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -13,7 +13,6 @@ import {
 	type PlainColorObject,
 	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
 	// checking is redundant in TypeScript files.
-	// eslint-disable-next-line import/no-unresolved
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -11,8 +11,6 @@ import {
 	OKLCH,
 	sRGB,
 	type PlainColorObject,
-	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-	// checking is redundant in TypeScript files.
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/index.ts
+++ b/packages/theme/src/color-ramps/index.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { get, OKLCH, parse, serialize } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/index.ts
+++ b/packages/theme/src/color-ramps/index.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { get, OKLCH, parse, serialize } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -9,7 +9,6 @@ import {
 	type ColorTypes,
 	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
 	// checking is redundant in TypeScript files.
-	// eslint-disable-next-line import/no-unresolved
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -7,8 +7,6 @@ import {
 	contrastWCAG21,
 	sRGB,
 	type ColorTypes,
-	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-	// checking is redundant in TypeScript files.
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/constants.ts
+++ b/packages/theme/src/color-ramps/lib/constants.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { to, OKLCH } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/constants.ts
+++ b/packages/theme/src/color-ramps/lib/constants.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { to, OKLCH } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
+++ b/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { get, OKLCH, type ColorTypes } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
+++ b/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { get, OKLCH, type ColorTypes } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -9,8 +9,6 @@ import {
 	set,
 	type ColorTypes,
 	type PlainColorObject,
-	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-	// checking is redundant in TypeScript files.
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -11,7 +11,6 @@ import {
 	type PlainColorObject,
 	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
 	// checking is redundant in TypeScript files.
-	// eslint-disable-next-line import/no-unresolved
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/register-color-spaces.ts
+++ b/packages/theme/src/color-ramps/lib/register-color-spaces.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { ColorSpace, OKLCH, P3, sRGB, HSL } from 'colorjs.io/fn';
 
 // Ensures that all color spaces used in color ramps are registered globally, a

--- a/packages/theme/src/color-ramps/lib/register-color-spaces.ts
+++ b/packages/theme/src/color-ramps/lib/register-color-spaces.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { ColorSpace, OKLCH, P3, sRGB, HSL } from 'colorjs.io/fn';
 
 // Ensures that all color spaces used in color ramps are registered globally, a

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -11,7 +11,6 @@ import {
 	type ColorObject,
 	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
 	// checking is redundant in TypeScript files.
-	// eslint-disable-next-line import/no-unresolved
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -9,8 +9,6 @@ import {
 	sRGB,
 	type ColorTypes,
 	type ColorObject,
-	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-	// checking is redundant in TypeScript files.
 } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/utils.ts
+++ b/packages/theme/src/color-ramps/lib/utils.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { toGamut, to, P3, OKLCH, type ColorTypes } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/lib/utils.ts
+++ b/packages/theme/src/color-ramps/lib/utils.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { toGamut, to, P3, OKLCH, type ColorTypes } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -3,7 +3,7 @@
  */
 // Disable reason: ESLint resolver can't handle `exports`. Import resolver
 // checking is redundant in TypeScript files.
-// eslint-disable-next-line import/no-unresolved
+
 import { parse, to, serialize, sRGB } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-// checking is redundant in TypeScript files.
-
 import { parse, to, serialize, sRGB } from 'colorjs.io/fn';
 
 /**

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -10,8 +10,6 @@ import {
 	sRGB,
 	HSL,
 	type ColorTypes,
-	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
-	// checking is redundant in TypeScript files.
 } from 'colorjs.io/fn';
 import memoize from 'memize';
 

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -12,7 +12,6 @@ import {
 	type ColorTypes,
 	// Disable reason: ESLint resolver can't handle `exports`. Import resolver
 	// checking is redundant in TypeScript files.
-	// eslint-disable-next-line import/no-unresolved
 } from 'colorjs.io/fn';
 import memoize from 'memize';
 

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -152,8 +152,6 @@ test.describe( 'Block Toolbar', () => {
 		page,
 		pageUtils,
 	} ) => {
-		/* eslint-disable playwright/expect-expect */
-		/* eslint-disable playwright/no-wait-for-timeout */
 		// Set the fixed toolbar
 		await editor.setIsFixedToolbar( true );
 		// Insert a block with a lot of tool buttons
@@ -184,8 +182,6 @@ test.describe( 'Block Toolbar', () => {
 		// Test cleanup
 		await editor.setIsFixedToolbar( false );
 		await pageUtils.setBrowserViewport( 'large' );
-		/* eslint-enable playwright/expect-expect */
-		/* eslint-enable playwright/no-wait-for-timeout */
 	} );
 
 	test( 'Tab order of the block toolbar aligns with visual order', async ( {

--- a/test/performance/specs/front-end-block-theme.spec.js
+++ b/test/performance/specs/front-end-block-theme.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-disable playwright/expect-expect */
 
 /**
  * WordPress dependencies
@@ -64,4 +64,4 @@ test.describe( 'Front End Performance', () => {
 	}
 } );
 
-/* eslint-enable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-enable playwright/expect-expect */

--- a/test/performance/specs/front-end-classic-theme.spec.js
+++ b/test/performance/specs/front-end-classic-theme.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-disable playwright/expect-expect */
 
 /**
  * WordPress dependencies
@@ -63,4 +63,4 @@ test.describe( 'Front End Performance', () => {
 	}
 } );
 
-/* eslint-enable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-enable playwright/expect-expect */

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-disable playwright/expect-expect */
 
 /**
  * WordPress dependencies
@@ -717,4 +717,4 @@ test.describe( 'Post Editor Performance', () => {
 	} );
 } );
 
-/* eslint-enable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-enable playwright/expect-expect */

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -306,7 +306,6 @@ test.describe( 'Site Editor Performance', () => {
 				 * If there is a Replace template button (old UI), click it, otherwise, click the "transform into" button.
 				 * Once the performance tests are updated to compare compatible versions this code can be removed.
 				 */
-
 				const isActionsButtonVisible = await page
 					.locator(
 						'.edit-site-template-card__actions button[aria-label="Actions"]'

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-disable playwright/expect-expect */
 
 /**
  * WordPress dependencies
@@ -306,7 +306,7 @@ test.describe( 'Site Editor Performance', () => {
 				 * If there is a Replace template button (old UI), click it, otherwise, click the "transform into" button.
 				 * Once the performance tests are updated to compare compatible versions this code can be removed.
 				 */
-				// eslint-disable-next-line no-restricted-syntax
+
 				const isActionsButtonVisible = await page
 					.locator(
 						'.edit-site-template-card__actions button[aria-label="Actions"]'
@@ -454,4 +454,4 @@ test.describe( 'Site Editor Performance', () => {
 	} );
 } );
 
-/* eslint-enable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-enable playwright/expect-expect */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates project ESLint configuration to enable [`eslint-comments/no-unused-disable`](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html).

## Why?

Unused disables are ineffective and misleading technical debt.

We already have ESLint rules around best practices for ESLint comments, so this is a reasonable rule to enable.

## How?

Enables the rule. We already have the plugin, but it's not part of [the "recommended" preset](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/).

## Testing Instructions

`npm run lint:js` should pass.