### PR TITLE
wp-build: Update package detection to ignore empty folders

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { readFile, writeFile, copyFile, mkdir } from 'fs/promises';
-import { readdirSync } from 'fs';
 import path from 'path';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
@@ -58,9 +57,11 @@ const TEST_FILE_PATTERNS = [
  * @return {string[]} Array of package names.
  */
 function getAllPackages() {
-	return readdirSync( PACKAGES_DIR, { withFileTypes: true } )
-		.filter( ( dirent ) => dirent.isDirectory() )
-		.map( ( dirent ) => dirent.name );
+	return glob
+		.sync( path.join( PACKAGES_DIR, '*', 'package.json' ) )
+		.map( ( packageJsonPath ) =>
+			path.basename( path.dirname( packageJsonPath ) )
+		);
 }
 
 const PACKAGES = getAllPackages();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates the build script to ignore package folders which don't contain a `package.json`.

## Why?

When changing from a branch which introduces a new package to `trunk`, the package folder is not removed from the local filesystem, only the files within it. This causes `npm run build` to fail because it detects the folder, but cannot read the `package.json`:

```
❌ Build failed: Error: ENOENT: no such file or directory, open '/gutenberg/packages/foo/package.json'
```

## How?

Updates the package logic to only detect folders which contain a `package.json` file.

## Testing Instructions

Verify that adding an empty folder in `packages/` does not cause the build to fail as it does on `trunk`:

```
mkdir packages/foo
npm run build
```

Observe that the number of packages built is the same between trunk and this branch.