### PR TITLE
Theme: Fix Windows build using cross-env for environment variables

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -60,7 +60,7 @@
 	},
 	"scripts": {
 		"build:default-ramps": "node --import=esbuild-esm-loader/register bin/generate-default-ramps/index.ts",
-		"build:tokens": "node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && NODE_OPTIONS=--import=esbuild-esm-loader/register tz build --config terrazzo.config.ts",
+		"build:tokens": "node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && cross-env NODE_OPTIONS=--import=esbuild-esm-loader/register tz build --config terrazzo.config.ts",
 		"build": "npm run build:tokens && npm run build:default-ramps",
 		"postbuild": "prettier --write tokens/color.json src/prebuilt src/color-ramps/lib/default-ramps.ts docs"
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes an issue where the theme package can't be built on Windows.

Example: https://github.com/WordPress/wordpress-develop/actions/runs/19047308051/job/54400032675

Related Slack discussion: https://wordpress.slack.com/archives/C02RQBWTW/p1762200484307419

Error:

```
📦 Building workspaces...
'NODE_OPTIONS' is not recognized as an internal or external command,
operable program or batch file.

[...]

❌ Build failed: Command failed: npm run --if-present --workspaces --silent build
Error: Process completed with exit code 1.
```

## Why?

- Ensure Windows developers can run the build script
- Fix `wordpress-develop` build

## How?

Uses [`cross-env` package](https://www.npmjs.com/package/cross-env) to define environment variables. We use the package elsewhere in the project for the same purpose.

## Testing Instructions

Ensure that the build script finishes successfully, with no errors or local changes to your working branch:

```
npm run --workspace=@wordpress/theme build
```

Ideally you'd also test this on a Windows machine if you have one available.