### PR TITLE
Testing: Test across OS and Node.js version for commits to trunk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have `core.autocrlf` set.
-* text=auto
+* text=auto eol=lf
 
 # Windows bat files in mobile/android.
 *.bat -text

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -39,8 +39,8 @@ jobs:
                       node: '24'
                     - event: 'pull_request'
                       os: 'macos-15'
-                    # - event: 'pull_request'
-                    #   os: 'windows-2025'
+                    - event: 'pull_request'
+                      os: 'windows-2025'
 
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
     check:
-        name: All (Node.js ${{ matrix.node }} on ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }})
+        name: All${{ (matrix.node != '20' || matrix.os != 'ubuntu-24.04') && format(' (Node.js {0} on {1})', matrix.node, contains(matrix.os, 'macos-') && 'MacOS' || contains(matrix.os, 'windows-') && 'Windows' || 'Linux') || '' }}
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -39,8 +39,8 @@ jobs:
                       node: '24'
                     - event: 'pull_request'
                       os: 'macos-15'
-                    - event: 'pull_request'
-                      os: 'windows-2025'
+                    # - event: 'pull_request'
+                    #   os: 'windows-2025'
 
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -21,11 +21,26 @@ permissions: {}
 
 jobs:
     check:
-        name: All
-        runs-on: 'ubuntu-24.04'
+        name: All (Node.js ${{ matrix.node }} on ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }})
+        runs-on: ${{ matrix.os }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        strategy:
+            matrix:
+                event: ['${{ github.event_name }}']
+                node: ['20', '22', '24']
+                os: ['macos-15', 'ubuntu-24.04', 'windows-2025']
+                exclude:
+                    # On PRs: Only test Node 20 on Ubuntu
+                    - event: 'pull_request'
+                      node: '22'
+                    - event: 'pull_request'
+                      node: '24'
+                    - event: 'pull_request'
+                      os: 'macos-15'
+                    - event: 'pull_request'
+                      os: 'windows-2025'
 
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -36,9 +51,7 @@ jobs:
             - name: Use desired version of Node.js
               uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version-file: '.nvmrc'
-                  check-latest: true
-                  cache: npm
+                  node-version: ${{ matrix.node }}
 
             - name: Npm install
               # A "full" install is executed, since `npm ci` does not always exit

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,7 @@
 // Useful for editor integrations.
 module.exports = {
 	...require( '@wordpress/prettier-config' ),
+	endOfLine: 'lf',
 	overrides: [
 		{
 			files: [ 'changelog.txt' ],

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,7 +2,6 @@
 // Useful for editor integrations.
 module.exports = {
 	...require( '@wordpress/prettier-config' ),
-	endOfLine: 'lf',
 	overrides: [
 		{
 			files: [ 'changelog.txt' ],

--- a/bin/check-licenses.mjs
+++ b/bin/check-licenses.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { spawnSync } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ const ignored = [ '@ampproject/remapping', 'webpack' ];
 
 /** @type {ReadonlyArray<PackageInfo>} */
 const workspacePackages = JSON.parse(
-	spawnSync(
+	spawn.sync(
 		'npm',
 		[
 			'query',
@@ -42,7 +42,7 @@ const workspacePackages = JSON.parse(
 const packageNames = workspacePackages.map( ( { name } ) => name );
 
 const dependenciesToProcess = JSON.parse(
-	spawnSync(
+	spawn.sync(
 		'npm',
 		[
 			'ls',

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
 				"copy-webpack-plugin": "10.2.0",
 				"core-js-builder": "3.39.0",
 				"cross-env": "7.0.3",
+				"cross-spawn": "^7.0.6",
 				"css-loader": "6.2.0",
 				"deep-freeze": "0.0.1",
 				"equivalent-key-map": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
 		"copy-webpack-plugin": "10.2.0",
 		"core-js-builder": "3.39.0",
 		"cross-env": "7.0.3",
+		"cross-spawn": "^7.0.6",
 		"css-loader": "6.2.0",
 		"deep-freeze": "0.0.1",
 		"equivalent-key-map": "0.2.2",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates the "Static Checks" GitHub Actions workflow to run across multiple versions of Node.js and multiple operating systems for commits to trunk.

## Why?

Lately there's been a few incidents where non-Windows-compatible code has been merged to `trunk`, and only later discovered to be incompatible when `wordpress-develop` builds start to fail.

Examples:

- #72960
- #72605 
- #72944

Additionally, testing across different versions of Node.js ensures that we're better prepared for future updates.

Related: #71091

## How?

Adds a matrix configuration similar to what we have for other builds, ensuring a combination of testing across:

OS:
- `macos-15`
- `ubuntu-14.04`
- `windows-2025`

Node.js versions:
- `20`
- `22`
- `24`

Consistent with #72506, these workflows only run on `trunk` for any combination of the above other than `ubuntu-14.04` + `20`. This should at least provide a faster feedback loop than currently waiting for builds to fail in `wordpress-develop`.

## Testing Instructions

A demonstration commit causing Windows to be included in the strategy should hopefully show an expected failure.