### PR TITLE
Routes build tooling: Fix watching, css and min buildling

### DIFF
--- a/packages/wp-build/templates/routes.php.template
+++ b/packages/wp-build/templates/routes.php.template
@@ -24,7 +24,7 @@ if ( ! function_exists( '{{NAMESPACE}}_register_routes' ) ) {
 
 		foreach ( $routes as $route ) {
 			// Register content module
-			$content_asset_path = $routes_dir . '/' . $route['name'] . '/content.asset.php';
+			$content_asset_path = $routes_dir . '/' . $route['name'] . '/content.min.asset.php';
 			$content_asset      = file_exists( $content_asset_path ) ? require $content_asset_path : array();
 			$content_handle     = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
 
@@ -39,7 +39,7 @@ if ( ! function_exists( '{{NAMESPACE}}_register_routes' ) ) {
 
 			// Register route module if it exists
 			if ( isset( $route['has_route'] ) && $route['has_route'] ) {
-				$route_asset_path = $routes_dir . '/' . $route['name'] . '/route.asset.php';
+				$route_asset_path = $routes_dir . '/' . $route['name'] . '/route.min.asset.php';
 				$route_asset      = file_exists( $route_asset_path ) ? require $route_asset_path : array();
 				$route_handle     = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/route';
 


### PR DESCRIPTION
Related #70862 

## What?

Improves the routes build system to match package/module patterns and fix several issues.

## Why?

  Routes had several inconsistencies and bugs:
  - Watch mode didn't detect file changes
  - Only built non-minified files (SCRIPT_DEBUG didn't work)
  - Missing CSS bundling support
  - Hardcoded namespace filtering broke non-@wordpress packages

##  How?

  - Watch mode: Fixed route watcher (similar to packages)
  - Minification: Build both .min.js and .js versions for SCRIPT_DEBUG support
  - Asset files: Updated PHP template to use .min.asset.php (matching modules/scripts)
  - CSS support: Added sass plugins to content module for CSS modules/SCSS
  - Dependency tracking: Removed @wordpress/* namespace filter - now works with any monorepo namespace
  - Build cleanup: Removed unnecessary babel plugin (esbuild handles TS/JSX natively), created shared styleBundlingPlugins config

 ## Testing Instructions

  1. Create/modify a route file in routes/home/stage.tsx
  2. With npm run dev, verify file changes trigger rebuilds
  3. Check build/routes/home/ contains both .js and .min.js files
  4. Verify SCRIPT_DEBUG switches between minified/non-minified versions
  5. Import CSS modules in route components - verify they work
