### PR TITLE
Notes: Disable "Add note" button in Distraction free mode

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-menu-item.js
+++ b/packages/editor/src/components/collab-sidebar/comment-menu-item.js
@@ -18,7 +18,7 @@ import { unlock } from '../../lock-unlock';
 
 const { CommentIconSlotFill } = unlock( blockEditorPrivateApis );
 
-const AddCommentMenuItem = ( { clientId, onClick } ) => {
+const AddCommentMenuItem = ( { clientId, onClick, isDistractionFree } ) => {
 	const block = useSelect(
 		( select ) => {
 			return select( blockEditorStore ).getBlock( clientId );
@@ -33,31 +33,36 @@ const AddCommentMenuItem = ( { clientId, onClick } ) => {
 		return null;
 	}
 
-	const isFreeformBlock = block?.name === 'core/freeform';
+	const isDisabled = isDistractionFree || block?.name === 'core/freeform';
+
+	let infoText;
+
+	if ( isDistractionFree ) {
+		infoText = __( 'Notes are disabled in distraction free mode.' );
+	} else if ( block?.name === 'core/freeform' ) {
+		infoText = __( 'Convert to blocks to add notes.' );
+	}
 
 	return (
 		<MenuItem
 			icon={ commentIcon }
 			onClick={ onClick }
 			aria-haspopup="dialog"
-			disabled={ isFreeformBlock }
-			info={
-				isFreeformBlock
-					? __( 'Convert to blocks to add notes.' )
-					: undefined
-			}
+			disabled={ isDisabled }
+			info={ infoText }
 		>
 			{ __( 'Add note' ) }
 		</MenuItem>
 	);
 };
 
-const AddCommentMenuItemFill = ( { onClick } ) => {
+const AddCommentMenuItemFill = ( { onClick, isDistractionFree } ) => {
 	return (
 		<CommentIconSlotFill.Fill>
 			{ ( { clientId, onClose } ) => (
 				<AddCommentMenuItem
 					clientId={ clientId }
+					isDistractionFree={ isDistractionFree }
 					onClick={ () => {
 						onClick();
 						onClose();

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -208,22 +208,17 @@ function NotesSidebar( { postId, mode } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const { postId, mode, editorMode, isDistractionFree } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getRenderingMode, getEditorMode } =
-				select( editorStore );
-			const { getSettings } = select( blockEditorStore );
-			return {
-				postId: getCurrentPostId(),
-				mode: getRenderingMode(),
-				editorMode: getEditorMode(),
-				isDistractionFree: getSettings().isDistractionFree,
-			};
-		},
-		[]
-	);
+	const { postId, mode, editorMode } = useSelect( ( select ) => {
+		const { getCurrentPostId, getRenderingMode, getEditorMode } =
+			select( editorStore );
+		return {
+			postId: getCurrentPostId(),
+			mode: getRenderingMode(),
+			editorMode: getEditorMode(),
+		};
+	}, [] );
 
-	if ( ! postId || typeof postId !== 'number' || isDistractionFree ) {
+	if ( ! postId || typeof postId !== 'number' ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -87,17 +87,24 @@ function NotesSidebar( { postId, mode } ) {
 
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
-	const { clientId, blockCommentId } = useSelect( ( select ) => {
-		const { getBlockAttributes, getSelectedBlockClientId } =
-			select( blockEditorStore );
-		const _clientId = getSelectedBlockClientId();
-		return {
-			clientId: _clientId,
-			blockCommentId: _clientId
-				? getBlockAttributes( _clientId )?.metadata?.noteId
-				: null,
-		};
-	}, [] );
+	const { clientId, blockCommentId, isDistractionFree } = useSelect(
+		( select ) => {
+			const {
+				getBlockAttributes,
+				getSelectedBlockClientId,
+				getSettings,
+			} = select( blockEditorStore );
+			const _clientId = getSelectedBlockClientId();
+			return {
+				clientId: _clientId,
+				blockCommentId: _clientId
+					? getBlockAttributes( _clientId )?.metadata?.noteId
+					: null,
+				isDistractionFree: getSettings().isDistractionFree,
+			};
+		},
+		[]
+	);
 
 	const {
 		resultComments,
@@ -148,6 +155,10 @@ function NotesSidebar( { postId, mode } ) {
 			! blockCommentId ? 'textarea' : undefined
 		);
 		toggleBlockSpotlight( clientId, true );
+	}
+
+	if ( isDistractionFree ) {
+		return <AddCommentMenuItem isDistractionFree />;
 	}
 
 	return (


### PR DESCRIPTION
Fixes #72945

## What? Why?

In #72945, we have completely disabled the Notes feature in DFM mode. As a more friendly approach, this pull request displays a disabled "Add note" button with help text to indicate why the Notes feature is disabled.

## How?

In DFM mode, only the "Add note" button in the toolbar drop-down menu is visually restored. The following three buttons remain hidden:

- The "View Notes" button in the toolbar,
- The "All notes" button in the header,
- The "All notes" button in the header options menu.

## Testing Instructions

- Enable DFM mode.
- Select a block and open the Options dropdown button.
- Confirm that the disabled "Add note" button with help text is displayed.

## Screenshots or screencast <!-- if applicable -->

<img width="629" height="305" alt="image" src="https://github.com/user-attachments/assets/b3c05014-6e54-4bf8-83b0-58a73d9977a2" />
