### PR TITLE
Accordion: allow font style inheritance from button to inner text blocks

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -7,6 +7,7 @@
 	text-transform: inherit;
 	text-decoration: inherit;
 	word-spacing: inherit;
+	font-style: inherit;
 	background: none;
 	border: none;
 	color: inherit;


### PR DESCRIPTION

## What?

Ensures rich text child elements inherit font style from the `button.wp-block-accordion-heading__toggle`



## Why?

They don't. It looks like an oversight?

## How?

Adding `font-style: inherit;`

## Testing Instructions

1. Insert an Accordion block
2. For the Accordion Heading/Panel blocks apply an italic font style (under Typography > Appearance)
3. Check that it's applied in the editor.
4. Check the front end for good measure.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/3edeb6de-2ba3-46ec-97a2-0e484a0c9b77



### After

https://github.com/user-attachments/assets/47f60d89-65b9-48c4-842e-f9f9e7cfb8a1



