### PR TITLE
Build v2: Fix build failure on Windows

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -65,7 +65,7 @@ const TEST_FILE_PATTERNS = [
  */
 function getAllPackages() {
 	return glob
-		.sync( path.join( PACKAGES_DIR, '*', 'package.json' ) )
+		.sync( normalizePath( path.join( PACKAGES_DIR, '*', 'package.json' ) ) )
 		.map( ( packageJsonPath ) =>
 			path.basename( path.dirname( packageJsonPath ) )
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes the Gutenberg build CI failures occurring in the `wordpress-develop` repository.

Example of a failed CI: https://github.com/WordPress/wordpress-develop/actions/runs/19058795688/job/54435503272

## Why? How?

The `getAllPackages()` function retrieves all packages using a regular expression pattern. However, on Windows, the path separator is a backslash, and the `glob` method will not work correctly as is.

This is a common problem, and it can be solved by using `normalizePath`.


## Testing Instructions

On a Windows host OS, check out this branch and run `npm run build`. The build should succeed.