### PR TITLE
Editor: Fix template panel check and restore duplicate action

### DIFF
--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -53,14 +53,17 @@ export default function PostTemplatePanel() {
 		return canCreateTemplates;
 	}, [] );
 
-	const canViewTemplates = useSelect( ( select ) => {
-		return (
-			select( coreStore ).canUser( 'read', {
-				kind: 'postType',
-				name: 'wp_template',
-			} ) ?? false
-		);
-	}, [] );
+	const canViewTemplates = useSelect(
+		( select ) => {
+			return isVisible
+				? select( coreStore ).canUser( 'read', {
+						kind: 'postType',
+						name: 'wp_template',
+				  } )
+				: false;
+		},
+		[ isVisible ]
+	);
 
 	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
 		return <ClassicThemeControl />;


### PR DESCRIPTION
## What?
Band-aid fix for issue described in #72798.

PR avoids checking users read permission for templates if the `PostTemplatePanel` shoundn't be visible.

## Why?
* There's no need to perform this check, if template panel isn't rendered.
* Temporarely avoids conflicts described in #72798.

## Testing Instructions
1. Go to `/wp-admin/site-editor.php?p=%2F&canvas=edit.`
2. Check the actions in the document panel (ellipsis menu).
3. Check that duplicate action is present.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="284" height="572" alt="CleanShot 2025-11-04 at 13 29 08" src="https://github.com/user-attachments/assets/4b809381-dab1-4790-a62e-5ebaaa230fd3" />
