### PR TITLE
Notes: Fix sidebar opening logic

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -137,7 +137,7 @@ function NotesSidebar( { postId, mode } ) {
 
 		if ( currentThread?.status === 'approved' ) {
 			enableComplementaryArea( 'core', collabHistorySidebarName );
-		} else if ( ! activeNotesArea ) {
+		} else if ( ! activeNotesArea || ! showAllNotesSidebar ) {
 			enableComplementaryArea(
 				'core',
 				showFloatingSidebar


### PR DESCRIPTION
## What?
Closes #72872.

Fixes a minor issue that was overlooked when changing the pinned sidebar logic. Allows re-opening floating sidebar, after the pinned sidebar gets "closed" by removing last note.

## Why?
We're forcing the hiding of the pinned sidebar, but the state in store remains the same, which results in an incorrect `activeNotesArea` value.

I'm making a simple condition fix here, but in the future, we could replace `useEnableFloatingSidebar` with a more general sidebar manager.

## Testing Instructions
1. Create a post.
2. Add a block and note for it.
3. Switch to the pinned sidebar.
4. Delete the note.
5. Try adding new one.
6. Confirm that 

### Testing Instructions for Keyboard
Same.
