### PR TITLE
Disable TinyMCE: Bump `needsClassicBlock` further down

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -16,7 +16,7 @@ function gutenberg_declare_classic_block_necessary() {
 	}
 	echo '<script type="text/javascript">window.wp.needsClassicBlock = true;</script>';
 }
-add_action( 'admin_footer', 'gutenberg_declare_classic_block_necessary' );
+add_action( 'admin_print_footer_scripts', 'gutenberg_declare_classic_block_necessary', 20 );
 
 // If user has already requested TinyMCE, we're ending the experiment.
 if ( ! empty( $_GET['requiresTinymce'] ) || gutenberg_post_being_edited_requires_classic_block() ) {


### PR DESCRIPTION
## What?

Fixes a bug with the "Disable TinyMCE" experiment, where the `needsClassicBlock` global var is defined too early. 

## Why?
Just fixing a bug.

## How?
We're moving it to `admin_print_footer_scripts` and adding a priority to bump it even further down.

## Testing Instructions
* Go to Gutenberg > Experiments
* Enable the "Blocks: disable TinyMCE and Classic block" experiment
* Start a new post that has some raw HTML in the content, like this: `<div class="notice">You can include <em>raw HTML</em> here.</div>`.
* Save the post and reload the post page.
* Verify you no longer see the error. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<img width="600" height="33" alt="Screenshot 2025-11-04 at 14 24 14" src="https://github.com/user-attachments/assets/d7436b29-b0ae-4d7d-812b-7e62de0ebd5e" />
