### PR TITLE
Disable TinyMCE: Handle old core/freeform syntax in editor

### DIFF
--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -59,7 +59,11 @@ export default function MissingEdit( { attributes, clientId } ) {
 		</Button>
 	);
 
-	if ( hasContent && ! hasFreeformBlock && ! originalName ) {
+	if (
+		hasContent &&
+		! hasFreeformBlock &&
+		( ! originalName || originalName === 'core/freeform' )
+	) {
 		if ( hasHTMLBlock ) {
 			messageHTML = __(
 				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely. Alternatively, you can refresh the page to use the Classic block.'


### PR DESCRIPTION
## What?
Fixes handling of the old `core/freeform` block syntax by the missing block logic.

## Why?
This is part of the experiment to disable TinyMCE loading by default, while still making it load where necessary.

## How?
In addition to handling raw code blocks in the editor as freeform blocks, we're now also handling explicit `wp:core/freeform` ones. 

You'll also need the fix from #72966, otherwise you'll be getting some errors when attemtping to load a post that has a classic block.

## Testing Instructions
* Go to Gutenberg > Experiments
* Enable the "Blocks: disable TinyMCE and Classic block" experiment
* Start a new post.
* Go to the code editor.
* Insert a `core/freeform` block as shown on the video.
* Go back to visual mode
* Verify it's recognized properly as a "Classic" block. 
* Try also with only `<div class="notice">You can include <em>raw HTML</em> here.</div>` without the `core/freeform` wrapper and verify it continues to recognize it as a "Classic" block.

Here's the block markup I'm testing with in the video:

```
<!-- wp:core/freeform -->
<p>This content is inside a Classic (freeform) block.</p>
<div class="notice">You can include <em>raw HTML</em> here.</div>
<!-- /wp:core/freeform -->
```

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Before:




https://github.com/user-attachments/assets/fc0c3495-226b-486c-bd2f-dcba7ee1086b


After:

https://github.com/user-attachments/assets/8af3df03-07f5-416d-941b-177a39135d49


