### PR TITLE
Notes: Don't hide floating sidebar while adding the note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -48,12 +48,16 @@ export function AddComment( {
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 
 	const unselectThread = () => {
-		setShowCommentBoard( false );
+		setShowCommentBoard( 'closed' );
 		blockElement?.focus();
 		toggleBlockSpotlight( clientId, false );
 	};
 
-	if ( ! showCommentBoard || ! clientId || undefined !== blockCommentId ) {
+	if (
+		showCommentBoard !== 'open' ||
+		! clientId ||
+		undefined !== blockCommentId
+	) {
 		return null;
 	}
 
@@ -81,7 +85,7 @@ export function AddComment( {
 					return;
 				}
 				toggleBlockSpotlight( clientId, false );
-				setShowCommentBoard( false );
+				setShowCommentBoard( 'closed' );
 			} }
 		>
 			<HStack alignment="left" spacing="3">
@@ -91,7 +95,7 @@ export function AddComment( {
 				onSubmit={ async ( inputComment ) => {
 					const { id } = await onSubmit( { content: inputComment } );
 					focusCommentThread( id, commentSidebarRef.current );
-					setShowCommentBoard( false );
+					setShowCommentBoard( 'creating' );
 				} }
 				onCancel={ unselectThread }
 				reflowComments={ reflowComments }

--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -28,8 +28,8 @@ const { useBlockElement } = unlock( blockEditorPrivateApis );
 
 export function AddComment( {
 	onSubmit,
-	showCommentBoard,
-	setShowCommentBoard,
+	newNoteFormState,
+	setNewNoteFormState,
 	commentSidebarRef,
 	reflowComments = noop,
 	isFloating = false,
@@ -48,13 +48,13 @@ export function AddComment( {
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 
 	const unselectThread = () => {
-		setShowCommentBoard( 'closed' );
+		setNewNoteFormState( 'closed' );
 		blockElement?.focus();
 		toggleBlockSpotlight( clientId, false );
 	};
 
 	if (
-		showCommentBoard !== 'open' ||
+		newNoteFormState !== 'open' ||
 		! clientId ||
 		undefined !== blockCommentId
 	) {
@@ -85,7 +85,7 @@ export function AddComment( {
 					return;
 				}
 				toggleBlockSpotlight( clientId, false );
-				setShowCommentBoard( 'closed' );
+				setNewNoteFormState( 'closed' );
 			} }
 		>
 			<HStack alignment="left" spacing="3">
@@ -95,7 +95,7 @@ export function AddComment( {
 				onSubmit={ async ( inputComment ) => {
 					const { id } = await onSubmit( { content: inputComment } );
 					focusCommentThread( id, commentSidebarRef.current );
-					setShowCommentBoard( 'creating' );
+					setNewNoteFormState( 'creating' );
 				} }
 				onCancel={ unselectThread }
 				reflowComments={ reflowComments }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -53,8 +53,8 @@ export function Comments( {
 	onEditComment,
 	onAddReply,
 	onCommentDelete,
-	showCommentBoard,
-	setShowCommentBoard,
+	newNoteFormState,
+	setNewNoteFormState,
 	commentSidebarRef,
 	reflowComments,
 	isFloating = false,
@@ -92,7 +92,7 @@ export function Comments( {
 		// component instead of a regular comment thread.
 		if (
 			isFloating &&
-			showCommentBoard === 'open' &&
+			newNoteFormState === 'open' &&
 			undefined === blockCommentId
 		) {
 			// Insert the new note entry at the correct location for its blockId.
@@ -120,7 +120,7 @@ export function Comments( {
 	}, [
 		noteThreads,
 		isFloating,
-		showCommentBoard,
+		newNoteFormState,
 		blockCommentId,
 		selectedBlockClientId,
 		orderedBlockIds,
@@ -148,7 +148,7 @@ export function Comments( {
 			focusCommentThread( prevThread.id, commentSidebarRef.current );
 		} else {
 			setSelectedThread( null );
-			setShowCommentBoard( 'closed' );
+			setNewNoteFormState( 'closed' );
 			// Move focus to the related block.
 			relatedBlockElement?.focus();
 		}
@@ -157,9 +157,9 @@ export function Comments( {
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
 		// Fallback to 'new-note-thread' when showing the comment board for a new note.
-		const fallback = showCommentBoard === 'open' ? 'new-note-thread' : null;
+		const fallback = newNoteFormState === 'open' ? 'new-note-thread' : null;
 		setSelectedThread( blockCommentId ?? fallback );
-	}, [ blockCommentId, showCommentBoard ] );
+	}, [ blockCommentId, newNoteFormState ] );
 
 	const setBlockRef = useCallback( ( id, blockRef ) => {
 		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: blockRef } ) );
@@ -320,12 +320,12 @@ export function Comments( {
 	return (
 		<>
 			{ ! isFloating &&
-				showCommentBoard === 'open' &&
+				newNoteFormState === 'open' &&
 				undefined === blockCommentId && (
 					<AddComment
 						onSubmit={ onAddReply }
-						showCommentBoard={ showCommentBoard }
-						setShowCommentBoard={ setShowCommentBoard }
+						newNoteFormState={ newNoteFormState }
+						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
 					/>
 				) }
@@ -338,7 +338,7 @@ export function Comments( {
 					onEditComment={ onEditComment }
 					isSelected={ selectedThread === thread.id }
 					setSelectedThread={ setSelectedThread }
-					setShowCommentBoard={ setShowCommentBoard }
+					setNewNoteFormState={ setNewNoteFormState }
 					commentSidebarRef={ commentSidebarRef }
 					reflowComments={ reflowComments }
 					isFloating={ isFloating }
@@ -347,7 +347,7 @@ export function Comments( {
 					setBlockRef={ setBlockRef }
 					selectedThread={ selectedThread }
 					commentLastUpdated={ commentLastUpdated }
-					showCommentBoard={ showCommentBoard }
+					newNoteFormState={ newNoteFormState }
 				/>
 			) ) }
 		</>
@@ -360,7 +360,7 @@ function Thread( {
 	onAddReply,
 	onCommentDelete,
 	isSelected,
-	setShowCommentBoard,
+	setNewNoteFormState,
 	commentSidebarRef,
 	reflowComments,
 	isFloating,
@@ -370,7 +370,7 @@ function Thread( {
 	setSelectedThread,
 	selectedThread,
 	commentLastUpdated,
-	showCommentBoard,
+	newNoteFormState,
 } ) {
 	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
@@ -398,7 +398,7 @@ function Thread( {
 	};
 
 	const handleCommentSelect = () => {
-		setShowCommentBoard( 'closed' );
+		setNewNoteFormState( 'closed' );
 		setSelectedThread( thread.id );
 		if ( !! thread.blockClientId ) {
 			// Pass `null` as the second parameter to prevent focusing the block.
@@ -409,7 +409,7 @@ function Thread( {
 
 	const unselectThread = () => {
 		setSelectedThread( null );
-		setShowCommentBoard( 'closed' );
+		setNewNoteFormState( 'closed' );
 		toggleBlockSpotlight( thread.blockClientId, false );
 	};
 
@@ -437,14 +437,14 @@ function Thread( {
 
 	if (
 		thread.id === 'new-note-thread' &&
-		showCommentBoard === 'open' &&
+		newNoteFormState === 'open' &&
 		isFloating
 	) {
 		return (
 			<AddComment
 				onSubmit={ onAddReply }
-				showCommentBoard={ showCommentBoard }
-				setShowCommentBoard={ setShowCommentBoard }
+				newNoteFormState={ newNoteFormState }
+				setNewNoteFormState={ setNewNoteFormState }
 				commentSidebarRef={ commentSidebarRef }
 				reflowComments={ reflowComments }
 				isFloating={ isFloating }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -90,7 +90,11 @@ export function Comments( {
 		// add a "new note" entry to the threads. This special thread type
 		// gets sorted and floated like regular threads, but shows an AddComment
 		// component instead of a regular comment thread.
-		if ( isFloating && showCommentBoard && undefined === blockCommentId ) {
+		if (
+			isFloating &&
+			showCommentBoard === 'open' &&
+			undefined === blockCommentId
+		) {
 			// Insert the new note entry at the correct location for its blockId.
 			const newNoteThread = {
 				id: 'new-note-thread',
@@ -144,7 +148,7 @@ export function Comments( {
 			focusCommentThread( prevThread.id, commentSidebarRef.current );
 		} else {
 			setSelectedThread( null );
-			setShowCommentBoard( false );
+			setShowCommentBoard( 'closed' );
 			// Move focus to the related block.
 			relatedBlockElement?.focus();
 		}
@@ -153,7 +157,7 @@ export function Comments( {
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
 		// Fallback to 'new-note-thread' when showing the comment board for a new note.
-		const fallback = showCommentBoard ? 'new-note-thread' : null;
+		const fallback = showCommentBoard === 'open' ? 'new-note-thread' : null;
 		setSelectedThread( blockCommentId ?? fallback );
 	}, [ blockCommentId, showCommentBoard ] );
 
@@ -316,7 +320,7 @@ export function Comments( {
 	return (
 		<>
 			{ ! isFloating &&
-				showCommentBoard &&
+				showCommentBoard === 'open' &&
 				undefined === blockCommentId && (
 					<AddComment
 						onSubmit={ onAddReply }
@@ -394,7 +398,7 @@ function Thread( {
 	};
 
 	const handleCommentSelect = () => {
-		setShowCommentBoard( false );
+		setShowCommentBoard( 'closed' );
 		setSelectedThread( thread.id );
 		if ( !! thread.blockClientId ) {
 			// Pass `null` as the second parameter to prevent focusing the block.
@@ -405,7 +409,7 @@ function Thread( {
 
 	const unselectThread = () => {
 		setSelectedThread( null );
-		setShowCommentBoard( false );
+		setShowCommentBoard( 'closed' );
 		toggleBlockSpotlight( thread.blockClientId, false );
 	};
 
@@ -431,7 +435,11 @@ function Thread( {
 				commentExcerpt
 		  );
 
-	if ( 'new-note-thread' === thread.id && showCommentBoard && isFloating ) {
+	if (
+		thread.id === 'new-note-thread' &&
+		showCommentBoard === 'open' &&
+		isFloating
+	) {
 		return (
 			<AddComment
 				onSubmit={ onAddReply }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -34,8 +34,8 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
 
 function NotesSidebarContent( {
-	showCommentBoard,
-	setShowCommentBoard,
+	newNoteFormState,
+	setNewNoteFormState,
 	styles,
 	comments,
 	commentSidebarRef,
@@ -69,8 +69,8 @@ function NotesSidebarContent( {
 				onEditComment={ onEdit }
 				onAddReply={ onCreate }
 				onCommentDelete={ onDelete }
-				showCommentBoard={ showCommentBoard }
-				setShowCommentBoard={ setShowCommentBoard }
+				newNoteFormState={ newNoteFormState }
+				setNewNoteFormState={ setNewNoteFormState }
 				commentSidebarRef={ commentSidebarRef }
 				reflowComments={ reflowComments }
 				commentLastUpdated={ commentLastUpdated }
@@ -82,7 +82,7 @@ function NotesSidebarContent( {
 
 function NotesSidebar( { postId, mode } ) {
 	// Enum: 'closed' | 'creating' | 'open'
-	const [ showCommentBoard, setShowCommentBoard ] = useState( 'closed' );
+	const [ newNoteFormState, setNewNoteFormState ] = useState( 'closed' );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
@@ -119,7 +119,7 @@ function NotesSidebar( { postId, mode } ) {
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
 			( unresolvedSortedThreads.length > 0 ||
-				showCommentBoard !== 'closed' )
+				newNoteFormState !== 'closed' )
 	);
 
 	// Get the global styles to set the background color of the sidebar.
@@ -154,7 +154,7 @@ function NotesSidebar( { postId, mode } ) {
 			return;
 		}
 
-		setShowCommentBoard( ! blockCommentId ? 'open' : 'closed' );
+		setNewNoteFormState( ! blockCommentId ? 'open' : 'closed' );
 		focusCommentThread(
 			blockCommentId,
 			commentSidebarRef.current,
@@ -192,8 +192,8 @@ function NotesSidebar( { postId, mode } ) {
 				>
 					<NotesSidebarContent
 						comments={ resultComments }
-						showCommentBoard={ showCommentBoard }
-						setShowCommentBoard={ setShowCommentBoard }
+						newNoteFormState={ newNoteFormState }
+						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
 						reflowComments={ reflowComments }
 						commentLastUpdated={ commentLastUpdated }
@@ -211,8 +211,8 @@ function NotesSidebar( { postId, mode } ) {
 				>
 					<NotesSidebarContent
 						comments={ unresolvedSortedThreads }
-						showCommentBoard={ showCommentBoard }
-						setShowCommentBoard={ setShowCommentBoard }
+						newNoteFormState={ newNoteFormState }
+						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
 						reflowComments={ reflowComments }
 						commentLastUpdated={ commentLastUpdated }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -81,7 +81,8 @@ function NotesSidebarContent( {
 }
 
 function NotesSidebar( { postId, mode } ) {
-	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
+	// Enum: 'closed' | 'creating' | 'open'
+	const [ showCommentBoard, setShowCommentBoard ] = useState( 'closed' );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
@@ -117,7 +118,8 @@ function NotesSidebar( { postId, mode } ) {
 	} = useBlockComments( postId );
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
-			( unresolvedSortedThreads.length > 0 || showCommentBoard )
+			( unresolvedSortedThreads.length > 0 ||
+				showCommentBoard !== 'closed' )
 	);
 
 	// Get the global styles to set the background color of the sidebar.
@@ -152,7 +154,7 @@ function NotesSidebar( { postId, mode } ) {
 			return;
 		}
 
-		setShowCommentBoard( ! blockCommentId );
+		setShowCommentBoard( ! blockCommentId ? 'open' : 'closed' );
 		focusCommentThread(
 			blockCommentId,
 			commentSidebarRef.current,

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -99,15 +99,11 @@ export function getCommentExcerpt( text, excerptLength = 10 ) {
  * @typedef {import('@wordpress/element').RefObject} RefObject
  *
  * @param {string}       commentId          The ID of the comment thread to focus.
- * @param {?HTMLElement} threadContainer    The container element to search within.
+ * @param {?HTMLElement} container          The container element to search within.
  * @param {string}       additionalSelector The additional selector to focus on.
  */
-export function focusCommentThread(
-	commentId,
-	threadContainer,
-	additionalSelector
-) {
-	if ( ! threadContainer ) {
+export function focusCommentThread( commentId, container, additionalSelector ) {
+	if ( ! container ) {
 		return;
 	}
 
@@ -120,11 +116,6 @@ export function focusCommentThread(
 		: threadSelector;
 
 	return new Promise( ( resolve ) => {
-		// Watch the sidebar skeleton in case the sidebar disappears and re-appears.
-		const container = threadContainer.closest(
-			'.interface-interface-skeleton__sidebar'
-		);
-
 		if ( container.querySelector( selector ) ) {
 			return resolve( container.querySelector( selector ) );
 		}


### PR DESCRIPTION
## What?
Related https://github.com/WordPress/gutenberg/pull/72872#issuecomment-3483074518.

PR fixes an issue that occurs when floating sidebars are closed and reopened while adding the first note. The problem is more visible if working slow networks.

## How?
Switch `showCommentBoard` to use enum state instead of boolean.

## Testing Instructions
1. Create a post.
2. Add a block.
3. Try adding a new note for a block.
4. Confirm that sidebar space is preserved while new note is created.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Examples are with Network > Slow 4G.

**Before**

https://github.com/user-attachments/assets/b9bc3ecd-4bdd-459d-9c0b-ce557f6bc306

**After**

https://github.com/user-attachments/assets/fac43b91-997d-4c52-b078-55c015a17317


