### PR TITLE
Theme: Update precomputed color ramps script for Node.js v20.10 compatibility

### DIFF
--- a/packages/theme/bin/generate-default-ramps/index.ts
+++ b/packages/theme/bin/generate-default-ramps/index.ts
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Internal dependencies
@@ -12,6 +13,8 @@ import {
 	buildBgRamp,
 	buildAccentRamp,
 } from '../../src/color-ramps/index.ts';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
 const bgRamp = buildBgRamp( DEFAULT_SEED_COLORS.bg );
 const accentRamps = Object.fromEntries(
@@ -26,7 +29,7 @@ const accentRamps = Object.fromEntries(
 const ramps = { bg: bgRamp, ...accentRamps };
 
 const outputPath = join(
-	import.meta.dirname,
+	__dirname,
 	'../../src/color-ramps/lib/default-ramps.ts'
 );
 


### PR DESCRIPTION
## What?

Updates the script added in #72847 to ensure compatibility with Node.js v20.10.0, which is the current [minimum version supported](https://github.com/WordPress/gutenberg/blob/e8685b430ee908d75554f9dfa77307112807e532/package.json#L18) and [current version of Node.js used on WordPress build servers](https://make.wordpress.org/systems/2023/11/27/install-node-js-20-x-on-the-build-server/#comment-2188).

Follow-up to #72847

Related Slack discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1762245589360919

## Why?

So that developers running versions of Node.js which are claimed to be supported don't encounter errors when running these scripts.

## How?

Replaces `import.meta.dirname` with an equivalent implementation that is compatible with Node.js v20.10.0.

`import.meta.dirname` was [added in Node.js v20.11.0](https://nodejs.org/api/esm.html#importmetadirname).

## Testing Instructions

Verify the script runs successfully on Node.js v20.10.0 and produces no errors:

```
nvm install 20.10.0
nvm use 20.10.0
npm run --workspace @wordpress/theme build
```