### PR TITLE
Disable TinyMCE: Dequeue `mce-view`

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -44,7 +44,7 @@ function gutenberg_enqueue_tinymce_proxy() {
 add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_tinymce_proxy' );
 
 /**
- * Dequeue the `mce-view` script as it was only necessary for the Classic block
+ * Dequeue the `mce-view` script as it was only necessary for the Classic block.
  */
 function gutenberg_wp_enqueue_media() {
 	wp_dequeue_script( 'mce-view' );

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -44,6 +44,15 @@ function gutenberg_enqueue_tinymce_proxy() {
 add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_tinymce_proxy' );
 
 /**
+ * Dequeue the `mce-view` script as it was only necessary for the Classic block
+ */
+function gutenberg_wp_enqueue_media() {
+	wp_dequeue_script( 'mce-view' );
+}
+
+add_action( 'wp_enqueue_media', 'gutenberg_wp_enqueue_media' );
+
+/**
  * Example TinyMCE usage used for testing.
  * Uncomment line 8 in this file to enable.
  */


### PR DESCRIPTION
## What?
Dequeue `mce-view` when TinyMCE is disabled as part of the relevant experiment.

## Why?
There are additional scripts we can stop loading together with TinyMCE.

## How?
Dequeueing if the experiment is running and we don't need TinyMCE on this page.

## Testing Instructions
* Go to Gutenberg > Experiments
* Enable the "Blocks: disable TinyMCE and Classic block" experiment
* Start a new post.
* Go to the code editor.
* Verify the `mce-view` script doesn't load.
* Go to Code Editor.
* Insert `<div class="notice">You can include <em>raw HTML</em> here.</div>`.
* Save the post.
* Refresh the page.
* Verify `mce-view` is loaded as part of the TinyMCE scripts.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None