### PR TITLE
Block Bindings: Move computation of sources into dedicated `useSelect`

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -341,7 +341,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						select,
 						context,
 					} );
-					if ( items.length !== 0 ) {
+					if ( items?.length ) {
 						data[ sourceName ] = items;
 					}
 				}

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -38,7 +38,6 @@ import { store as blockEditorStore } from '../store';
 const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_ARRAY = [];
-const EMPTY_OBJECT = {};
 
 /**
  * Get the normalized attribute type for block bindings.
@@ -306,23 +305,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	const { bindableAttributes, canUpdateBlockBindings, contexts } = useSelect(
+	const { canUpdateBlockBindings, bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
-			const { getContextForSource } = unlock( select( blockStore ) );
-
-			const registeredSources = unlock(
-				select( blockStore )
-			).getAllBlockBindingsSources();
-
-			const _contexts = Object.entries( registeredSources ).reduce(
-				( acc, [ sourceName, source ] ) => ( {
-					...acc,
-					[ sourceName ]: getContextForSource( source, blockContext ),
-				} ),
-				EMPTY_OBJECT
-			);
 
 			return {
 				canUpdateBlockBindings:
@@ -332,10 +318,27 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					__experimentalBlockBindingsSupportedAttributes?.[
 						blockName
 					],
-				contexts: _contexts,
 			};
 		},
-		[ blockName, blockContext ]
+		[ blockName ]
+	);
+
+	const contexts = useSelect(
+		( select ) => {
+			const registeredSources = unlock(
+				select( blockStore )
+			).getAllBlockBindingsSources();
+			const _contexts = {};
+			Object.entries( registeredSources ).forEach(
+				( [ sourceName, source ] ) => {
+					_contexts[ sourceName ] = unlock(
+						select( blockStore )
+					).getContextForSource( source, blockContext );
+				}
+			);
+			return _contexts;
+		},
+		[ blockContext ]
 	);
 
 	const sources = useSelect(

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -85,7 +85,7 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 			{ Object.entries( sources ).map( ( [ sourceKey, data ] ) => {
 				// Only show sources that have compatible data for this specific attribute.
 				const sourceDataItems = data.filter(
-					( item ) => item?.type === attributeType
+					( item ) => item.type === attributeType
 				);
 
 				const noItemsAvailable =
@@ -110,7 +110,7 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 								{ sourceDataItems.map( ( item ) => {
 									const itemBindings = {
 										source: sourceKey,
-										args: item?.args || {
+										args: item.args || {
 											key: item.key,
 										},
 									};
@@ -164,7 +164,7 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 											}
 										>
 											<Menu.ItemLabel>
-												{ item?.label }
+												{ item.label }
 											</Menu.ItemLabel>
 											<Menu.ItemHelpText>
 												{ values[ attribute ] }

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -325,23 +325,29 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	const sources = useSelect(
 		( select ) => {
-			const { getAllBlockBindingsSources, getContextForSource } = unlock(
+			const { getAllBlockBindingsSources } = unlock(
 				select( blockStore )
 			);
 			const data = {};
 			Object.entries( getAllBlockBindingsSources() ).forEach(
 				( [ sourceName, source ] ) => {
-					if ( source.getFieldsList ) {
-						data[ sourceName ] = source.getFieldsList( {
-							select,
-							context: getContextForSource(
-								source,
-								blockContext
-							),
-						} );
-						if ( data[ sourceName ].length === 0 ) {
-							data[ sourceName ] = EMPTY_ARRAY;
+					if ( ! source.getFieldsList ) {
+						return;
+					}
+
+					const context = {};
+					if ( source?.usesContext?.length ) {
+						for ( const key of source.usesContext ) {
+							context[ key ] = blockContext[ key ];
 						}
+					}
+
+					data[ sourceName ] = source.getFieldsList( {
+						select,
+						context,
+					} );
+					if ( data[ sourceName ].length === 0 ) {
+						data[ sourceName ] = EMPTY_ARRAY;
 					}
 				}
 			);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -331,7 +331,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					}
 
 					const context = {};
-					if ( source?.usesContext?.length ) {
+					if ( source.usesContext?.length ) {
 						for ( const key of source.usesContext ) {
 							context[ key ] = blockContext[ key ];
 						}

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -194,8 +194,8 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 		// Check if there are any compatible sources for this attribute type.
 		const attributeType = getAttributeType( blockName, attribute );
 
-		const hasCompatibleSources = Object.values( sources ).some( ( _data ) =>
-			_data.some( ( item ) => item.type === attributeType )
+		const hasCompatibleSources = Object.values( sources ).some( ( items ) =>
+			items.some( ( item ) => item.type === attributeType )
 		);
 
 		if ( ! hasCompatibleSources ) {

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -37,8 +37,6 @@ import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
 
-const EMPTY_ARRAY = [];
-
 /**
  * Get the normalized attribute type for block bindings.
  * Converts 'rich-text' to 'string' since rich-text is stored as string.
@@ -86,7 +84,7 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, data ] ) => {
 				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = data?.filter(
+				const sourceDataItems = data.filter(
 					( item ) => item?.type === attributeType
 				);
 
@@ -197,7 +195,7 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 		const attributeType = getAttributeType( blockName, attribute );
 
 		const hasCompatibleSources = Object.values( sources ).some( ( _data ) =>
-			_data?.some( ( item ) => item?.type === attributeType )
+			_data.some( ( item ) => item.type === attributeType )
 		);
 
 		if ( ! hasCompatibleSources ) {
@@ -210,9 +208,6 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 		// If there's a binding but the source is not found, it's invalid.
 		isValid = false;
 		displayText = __( 'Source not registered' );
-		if ( Object.keys( sources ).length === 0 ) {
-			displayText = __( 'No sources available' );
-		}
 	} else {
 		displayText =
 			data?.find( ( item ) => fastDeepEqual( item.args, args ) )?.label ||
@@ -342,12 +337,12 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					}
 
-					data[ sourceName ] = source.getFieldsList( {
+					const items = source.getFieldsList( {
 						select,
 						context,
 					} );
-					if ( data[ sourceName ].length === 0 ) {
-						data[ sourceName ] = EMPTY_ARRAY;
+					if ( items.length !== 0 ) {
+						data[ sourceName ] = items;
 					}
 				}
 			);
@@ -363,10 +358,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	const { bindings } = metadata || {};
 
-	// Check if all sources have empty data arrays.
-	const hasCompatibleData = Object.values( sources ).some(
-		( data ) => data && data.length > 0
-	);
+	const hasCompatibleData = Object.keys( sources ).length > 0;
 
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
 	const readOnly = ! canUpdateBlockBindings || ! hasCompatibleData;
@@ -398,9 +390,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						const hasCompatibleDataForAttribute = Object.values(
 							sources
 						).some( ( data ) =>
-							data?.some(
-								( item ) => item?.type === attributeType
-							)
+							data.some( ( item ) => item.type === attributeType )
 						);
 
 						const isAttributeReadOnly =

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -33,6 +33,8 @@ import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
 
+const EMPTY_OBJECT = {};
+
 /**
  * Get the normalized attribute type for block bindings.
  * Converts 'rich-text' to 'string' since rich-text is stored as string.
@@ -301,6 +303,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
+			const _bindableAttributes =
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
+			if ( ! _bindableAttributes || _bindableAttributes.length === 0 ) {
+				return EMPTY_OBJECT;
+			}
 
 			return {
 				sources: unlock(
@@ -309,10 +316,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
-				bindableAttributes:
-					__experimentalBlockBindingsSupportedAttributes?.[
-						blockName
-					],
+				bindableAttributes: _bindableAttributes,
 			};
 		},
 		[ blockContext, blockName ]

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -7,7 +7,7 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getBlockBindingsSources, getBlockType } from '@wordpress/blocks';
+import { getBlockType, store as blockStore } from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -299,8 +299,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	// Still needs a fix regarding _sources scope.
-	const _sources = {};
 	const { sources, canUpdateBlockBindings, bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
@@ -311,48 +309,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				return EMPTY_OBJECT;
 			}
 
-			const registeredSources = getBlockBindingsSources();
-			Object.entries( registeredSources ).forEach(
-				( [
-					sourceName,
-					{ getFieldsList, usesContext, label, getValues },
-				] ) => {
-					// Populate context.
-					const context = {};
-					if ( usesContext?.length ) {
-						for ( const key of usesContext ) {
-							context[ key ] = blockContext[ key ];
-						}
-					}
-					if ( getFieldsList ) {
-						const fieldsListResult = getFieldsList( {
-							select,
-							context,
-						} );
-						_sources[ sourceName ] = {
-							data: fieldsListResult || [],
-							label,
-							getValues,
-						};
-					} else {
-						/*
-						 * Include sources without getFieldsList if they are already used in a binding.
-						 * This allows them to be displayed in read-only mode.
-						 */
-						_sources[ sourceName ] = {
-							data: [],
-							label,
-							getValues,
-						};
-					}
-				}
-			);
-
 			return {
-				sources:
-					Object.values( _sources ).length > 0
-						? _sources
-						: EMPTY_OBJECT,
+				sources: unlock(
+					select( blockStore )
+				).getBlockBindingsSourcesForBlock( blockName, blockContext ),
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -33,8 +33,6 @@ import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
 
-const EMPTY_OBJECT = {};
-
 /**
  * Get the normalized attribute type for block bindings.
  * Converts 'rich-text' to 'string' since rich-text is stored as string.
@@ -303,11 +301,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
-			const _bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-			if ( ! _bindableAttributes || _bindableAttributes.length === 0 ) {
-				return EMPTY_OBJECT;
-			}
 
 			return {
 				sources: unlock(
@@ -316,7 +309,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
-				bindableAttributes: _bindableAttributes,
+				bindableAttributes:
+					__experimentalBlockBindingsSupportedAttributes?.[
+						blockName
+					],
 			};
 		},
 		[ blockContext, blockName ]

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -7,7 +7,11 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getBlockType, store as blockStore } from '@wordpress/blocks';
+import {
+	getBlockBindingsSource,
+	getBlockType,
+	store as blockStore,
+} from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -33,6 +37,7 @@ import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
 
+const EMPTY_ARRAY = [];
 const EMPTY_OBJECT = {};
 
 /**
@@ -80,9 +85,9 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 	);
 	return (
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
-			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
+			{ Object.entries( sources ).map( ( [ sourceKey, data ] ) => {
 				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter(
+				const sourceDataItems = data?.filter(
 					( item ) => item?.type === attributeType
 				);
 
@@ -92,6 +97,8 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 				if ( noItemsAvailable ) {
 					return null;
 				}
+
+				const source = getBlockBindingsSource( sourceKey );
 
 				return (
 					<Menu
@@ -179,7 +186,8 @@ function BlockBindingsPanelMenuContent( { attribute, binding, sources } ) {
 
 function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	const { source: sourceName, args } = binding || {};
-	const source = sources?.[ sourceName ];
+	const data = sources?.[ sourceName ];
+	const source = getBlockBindingsSource( sourceName );
 
 	let displayText;
 	let isValid = true;
@@ -189,8 +197,8 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 		// Check if there are any compatible sources for this attribute type.
 		const attributeType = getAttributeType( blockName, attribute );
 
-		const hasCompatibleSources = Object.values( sources ).some( ( src ) =>
-			src.data?.some( ( item ) => item?.type === attributeType )
+		const hasCompatibleSources = Object.values( sources ).some( ( _data ) =>
+			_data?.some( ( item ) => item?.type === attributeType )
 		);
 
 		if ( ! hasCompatibleSources ) {
@@ -208,9 +216,8 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 		}
 	} else {
 		displayText =
-			source.data?.find( ( item ) => fastDeepEqual( item.args, args ) )
-				?.label ||
-			source.label ||
+			data?.find( ( item ) => fastDeepEqual( item.args, args ) )?.label ||
+			source?.label ||
 			sourceName;
 	}
 
@@ -299,7 +306,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	const { sources, canUpdateBlockBindings, bindableAttributes } = useSelect(
+	const { canUpdateBlockBindings, bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
@@ -310,17 +317,57 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			}
 
 			return {
-				sources: unlock(
-					select( blockStore )
-				).getBlockBindingsSourcesForBlock( blockName, blockContext ),
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
 				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName ]
+		[ blockName ]
 	);
+
+	const contexts = useSelect(
+		( select ) => {
+			const registeredSources = unlock(
+				select( blockStore )
+			).getAllBlockBindingsSources();
+			const _contexts = {};
+			Object.entries( registeredSources ).forEach(
+				( [ sourceName, source ] ) => {
+					_contexts[ sourceName ] = unlock(
+						select( blockStore )
+					).getContextForSource( source, blockContext );
+				}
+			);
+			return _contexts;
+		},
+		[ blockContext ]
+	);
+
+	const sources = useSelect(
+		( select ) => {
+			const registeredSources = unlock(
+				select( blockStore )
+			).getAllBlockBindingsSources();
+			const data = {};
+			Object.entries( registeredSources ).forEach(
+				( [ sourceName, source ] ) => {
+					if ( source.getFieldsList ) {
+						data[ sourceName ] = source.getFieldsList( {
+							select,
+							context: contexts[ sourceName ],
+						} );
+						if ( data[ sourceName ].length === 0 ) {
+							data[ sourceName ] = EMPTY_ARRAY;
+						}
+					}
+				}
+			);
+			return data;
+		},
+		[ contexts ]
+	);
+
 	// Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
@@ -330,7 +377,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Check if all sources have empty data arrays.
 	const hasCompatibleData = Object.values( sources ).some(
-		( source ) => source.data && source.data.length > 0
+		( data ) => data && data.length > 0
 	);
 
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
@@ -362,8 +409,8 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 						const hasCompatibleDataForAttribute = Object.values(
 							sources
-						).some( ( source ) =>
-							source.data?.some(
+						).some( ( data ) =>
+							data?.some(
 								( item ) => item?.type === attributeType
 							)
 						);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -38,6 +38,7 @@ import { store as blockEditorStore } from '../store';
 const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Get the normalized attribute type for block bindings.
@@ -305,10 +306,23 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	const { canUpdateBlockBindings, bindableAttributes } = useSelect(
+	const { bindableAttributes, canUpdateBlockBindings, contexts } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
+			const { getContextForSource } = unlock( select( blockStore ) );
+
+			const registeredSources = unlock(
+				select( blockStore )
+			).getAllBlockBindingsSources();
+
+			const _contexts = Object.entries( registeredSources ).reduce(
+				( acc, [ sourceName, source ] ) => ( {
+					...acc,
+					[ sourceName ]: getContextForSource( source, blockContext ),
+				} ),
+				EMPTY_OBJECT
+			);
 
 			return {
 				canUpdateBlockBindings:
@@ -318,27 +332,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					__experimentalBlockBindingsSupportedAttributes?.[
 						blockName
 					],
+				contexts: _contexts,
 			};
 		},
-		[ blockName ]
-	);
-
-	const contexts = useSelect(
-		( select ) => {
-			const registeredSources = unlock(
-				select( blockStore )
-			).getAllBlockBindingsSources();
-			const _contexts = {};
-			Object.entries( registeredSources ).forEach(
-				( [ sourceName, source ] ) => {
-					_contexts[ sourceName ] = unlock(
-						select( blockStore )
-					).getContextForSource( source, blockContext );
-				}
-			);
-			return _contexts;
-		},
-		[ blockContext ]
+		[ blockName, blockContext ]
 	);
 
 	const sources = useSelect(

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -323,37 +323,21 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		[ blockName ]
 	);
 
-	const contexts = useSelect(
+	const sources = useSelect(
 		( select ) => {
 			const { getAllBlockBindingsSources, getContextForSource } = unlock(
 				select( blockStore )
 			);
-			const _contexts = {};
-			Object.entries( getAllBlockBindingsSources() ).forEach(
-				( [ sourceName, source ] ) => {
-					_contexts[ sourceName ] = getContextForSource(
-						source,
-						blockContext
-					);
-				}
-			);
-			return _contexts;
-		},
-		[ blockContext ]
-	);
-
-	const sources = useSelect(
-		( select ) => {
-			const registeredSources = unlock(
-				select( blockStore )
-			).getAllBlockBindingsSources();
 			const data = {};
-			Object.entries( registeredSources ).forEach(
+			Object.entries( getAllBlockBindingsSources() ).forEach(
 				( [ sourceName, source ] ) => {
 					if ( source.getFieldsList ) {
 						data[ sourceName ] = source.getFieldsList( {
 							select,
-							context: contexts[ sourceName ],
+							context: getContextForSource(
+								source,
+								blockContext
+							),
 						} );
 						if ( data[ sourceName ].length === 0 ) {
 							data[ sourceName ] = EMPTY_ARRAY;
@@ -363,7 +347,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			);
 			return data;
 		},
-		[ contexts ]
+		[ blockContext ]
 	);
 
 	// Return early if there are no bindable attributes.

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -325,15 +325,16 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	const contexts = useSelect(
 		( select ) => {
-			const registeredSources = unlock(
+			const { getAllBlockBindingsSources, getContextForSource } = unlock(
 				select( blockStore )
-			).getAllBlockBindingsSources();
+			);
 			const _contexts = {};
-			Object.entries( registeredSources ).forEach(
+			Object.entries( getAllBlockBindingsSources() ).forEach(
 				( [ sourceName, source ] ) => {
-					_contexts[ sourceName ] = unlock(
-						select( blockStore )
-					).getContextForSource( source, blockContext );
+					_contexts[ sourceName ] = getContextForSource(
+						source,
+						blockContext
+					);
 				}
 			);
 			return _contexts;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -38,7 +38,6 @@ import { store as blockEditorStore } from '../store';
 const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_ARRAY = [];
-const EMPTY_OBJECT = {};
 
 /**
  * Get the normalized attribute type for block bindings.
@@ -310,17 +309,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
-			const _bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-			if ( ! _bindableAttributes || _bindableAttributes.length === 0 ) {
-				return EMPTY_OBJECT;
-			}
 
 			return {
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
-				bindableAttributes: _bindableAttributes,
+				bindableAttributes:
+					__experimentalBlockBindingsSupportedAttributes?.[
+						blockName
+					],
 			};
 		},
 		[ blockName ]

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -7,6 +7,8 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
+import { STORE_NAME } from './constants';
+import { unlock } from '../lock-unlock';
 import { getBlockType } from './selectors';
 import { getValueFromObjectPath } from './utils';
 import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '../api/constants';
@@ -211,16 +213,44 @@ export function getBlockBindingsSource( state, sourceName ) {
 	return state.blockBindingsSources[ sourceName ];
 }
 
+// Separate selector to compute context for source?
+
+export const getSourceFieldsList = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state, source, blockContext ) => {
+			const context = {};
+			if ( source?.usesContext?.length ) {
+				for ( const key of source.usesContext ) {
+					context[ key ] = blockContext[ key ];
+				}
+			}
+			return source.getFieldsList( { select, context } );
+		},
+		( state, source, blockContext ) => [ source, blockContext ]
+	)
+);
+
+export const getContextForSource = createSelector(
+	( state, source, blockContext ) => {
+		const context = {};
+		if ( source?.usesContext?.length ) {
+			for ( const key of source.usesContext ) {
+				context[ key ] = blockContext[ key ];
+			}
+		}
+		return context;
+	},
+	( state, source, blockContext ) => [ source, blockContext ]
+);
+
 export const getBlockBindingsSourcesForBlock = createRegistrySelector(
 	( select ) => ( state, blockName, blockContext ) => {
 		const registeredSources = getAllBlockBindingsSources( state );
 		const sources = {};
 
 		Object.entries( registeredSources ).forEach(
-			( [
-				sourceName,
-				{ getFieldsList, usesContext, label, getValues },
-			] ) => {
+			( [ sourceName, source ] ) => {
+				const { getFieldsList, usesContext, label, getValues } = source;
 				// Populate context.
 				const context = {};
 				if ( usesContext?.length ) {
@@ -229,10 +259,9 @@ export const getBlockBindingsSourcesForBlock = createRegistrySelector(
 					}
 				}
 				if ( getFieldsList ) {
-					const fieldsListResult = getFieldsList( {
-						select,
-						context,
-					} );
+					const fieldsListResult = unlock(
+						select( STORE_NAME )
+					).getSourceFieldsList( source, blockContext );
 					sources[ sourceName ] = {
 						data: fieldsListResult || [],
 						label,

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -1,14 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { createSelector, createRegistrySelector } from '@wordpress/data';
+import { createSelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
-import { unlock } from '../lock-unlock';
 import { getBlockType } from './selectors';
 import { getValueFromObjectPath } from './utils';
 import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '../api/constants';
@@ -213,23 +211,6 @@ export function getBlockBindingsSource( state, sourceName ) {
 	return state.blockBindingsSources[ sourceName ];
 }
 
-// Separate selector to compute context for source?
-
-export const getSourceFieldsList = createRegistrySelector( ( select ) =>
-	createSelector(
-		( state, source, blockContext ) => {
-			const context = {};
-			if ( source?.usesContext?.length ) {
-				for ( const key of source.usesContext ) {
-					context[ key ] = blockContext[ key ];
-				}
-			}
-			return source.getFieldsList( { select, context } );
-		},
-		( state, source, blockContext ) => [ source, blockContext ]
-	)
-);
-
 export const getContextForSource = createSelector(
 	( state, source, blockContext ) => {
 		const context = {};
@@ -241,47 +222,6 @@ export const getContextForSource = createSelector(
 		return context;
 	},
 	( state, source, blockContext ) => [ source, blockContext ]
-);
-
-export const getBlockBindingsSourcesForBlock = createRegistrySelector(
-	( select ) => ( state, blockName, blockContext ) => {
-		const registeredSources = getAllBlockBindingsSources( state );
-		const sources = {};
-
-		Object.entries( registeredSources ).forEach(
-			( [ sourceName, source ] ) => {
-				const { getFieldsList, usesContext, label, getValues } = source;
-				// Populate context.
-				const context = {};
-				if ( usesContext?.length ) {
-					for ( const key of usesContext ) {
-						context[ key ] = blockContext[ key ];
-					}
-				}
-				if ( getFieldsList ) {
-					const fieldsListResult = unlock(
-						select( STORE_NAME )
-					).getSourceFieldsList( source, blockContext );
-					sources[ sourceName ] = {
-						data: fieldsListResult || [],
-						label,
-						getValues,
-					};
-				} else {
-					/*
-					 * Include sources without getFieldsList if they are already used in a binding.
-					 * This allows them to be displayed in read-only mode.
-					 */
-					sources[ sourceName ] = {
-						data: [],
-						label,
-						getValues,
-					};
-				}
-			}
-		);
-		return sources;
-	}
 );
 
 /**

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createSelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -210,6 +210,54 @@ export function getAllBlockBindingsSources( state ) {
 export function getBlockBindingsSource( state, sourceName ) {
 	return state.blockBindingsSources[ sourceName ];
 }
+
+export const getBlockBindingsSourcesForBlock = createRegistrySelector(
+	( select ) =>
+		createSelector(
+			( state, blockName, blockContext ) => {
+				const registeredSources = getAllBlockBindingsSources( state );
+				const sources = {};
+
+				Object.entries( registeredSources ).forEach(
+					( [
+						sourceName,
+						{ getFieldsList, usesContext, label, getValues },
+					] ) => {
+						// Populate context.
+						const context = {};
+						if ( usesContext?.length ) {
+							for ( const key of usesContext ) {
+								context[ key ] = blockContext[ key ];
+							}
+						}
+						if ( getFieldsList ) {
+							const fieldsListResult = getFieldsList( {
+								select,
+								context,
+							} );
+							sources[ sourceName ] = {
+								data: fieldsListResult || [],
+								label,
+								getValues,
+							};
+						} else {
+							/*
+							 * Include sources without getFieldsList if they are already used in a binding.
+							 * This allows them to be displayed in read-only mode.
+							 */
+							sources[ sourceName ] = {
+								data: [],
+								label,
+								getValues,
+							};
+						}
+					}
+				);
+				return sources;
+			},
+			( state ) => [ getAllBlockBindingsSources( state ) ]
+		)
+);
 
 /**
  * Determines if any of the block type's attributes have

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -212,51 +212,47 @@ export function getBlockBindingsSource( state, sourceName ) {
 }
 
 export const getBlockBindingsSourcesForBlock = createRegistrySelector(
-	( select ) =>
-		createSelector(
-			( state, blockName, blockContext ) => {
-				const registeredSources = getAllBlockBindingsSources( state );
-				const sources = {};
+	( select ) => ( state, blockName, blockContext ) => {
+		const registeredSources = getAllBlockBindingsSources( state );
+		const sources = {};
 
-				Object.entries( registeredSources ).forEach(
-					( [
-						sourceName,
-						{ getFieldsList, usesContext, label, getValues },
-					] ) => {
-						// Populate context.
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
-						}
-						if ( getFieldsList ) {
-							const fieldsListResult = getFieldsList( {
-								select,
-								context,
-							} );
-							sources[ sourceName ] = {
-								data: fieldsListResult || [],
-								label,
-								getValues,
-							};
-						} else {
-							/*
-							 * Include sources without getFieldsList if they are already used in a binding.
-							 * This allows them to be displayed in read-only mode.
-							 */
-							sources[ sourceName ] = {
-								data: [],
-								label,
-								getValues,
-							};
-						}
+		Object.entries( registeredSources ).forEach(
+			( [
+				sourceName,
+				{ getFieldsList, usesContext, label, getValues },
+			] ) => {
+				// Populate context.
+				const context = {};
+				if ( usesContext?.length ) {
+					for ( const key of usesContext ) {
+						context[ key ] = blockContext[ key ];
 					}
-				);
-				return sources;
-			},
-			( state ) => [ getAllBlockBindingsSources( state ) ]
-		)
+				}
+				if ( getFieldsList ) {
+					const fieldsListResult = getFieldsList( {
+						select,
+						context,
+					} );
+					sources[ sourceName ] = {
+						data: fieldsListResult || [],
+						label,
+						getValues,
+					};
+				} else {
+					/*
+					 * Include sources without getFieldsList if they are already used in a binding.
+					 * This allows them to be displayed in read-only mode.
+					 */
+					sources[ sourceName ] = {
+						data: [],
+						label,
+						getValues,
+					};
+				}
+			}
+		);
+		return sources;
+	}
 );
 
 /**

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -211,19 +211,6 @@ export function getBlockBindingsSource( state, sourceName ) {
 	return state.blockBindingsSources[ sourceName ];
 }
 
-export const getContextForSource = createSelector(
-	( state, source, blockContext ) => {
-		const context = {};
-		if ( source?.usesContext?.length ) {
-			for ( const key of source.usesContext ) {
-				context[ key ] = blockContext[ key ];
-			}
-		}
-		return context;
-	},
-	( state, source, blockContext ) => [ source, blockContext ]
-);
-
 /**
  * Determines if any of the block type's attributes have
  * the content role attribute.

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -152,34 +152,24 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'movie_field',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitem', {
-						name: 'Post Meta',
-					} )
-					.click();
-				await page
-					.getByRole( 'menuitemcheckbox' )
-					.filter( { hasText: 'Movie field label' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'Movie field label'
 				);
@@ -188,34 +178,24 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'field_without_label_or_default',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitem', {
-						name: 'Post Meta',
-					} )
-					.click();
-				await page
-					.getByRole( 'menuitemcheckbox' )
-					.filter( { hasText: 'field_without_label_or_default' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'field_without_label_or_default'
 				);


### PR DESCRIPTION
## What?

There are a few hacks and workarounds in Block Bindings to make them work. One example is the definition of `const _sources` outside of the following `useSelect` statement: https://github.com/WordPress/gutenberg/blob/2b6c500e18aeea2a2c9adf13c29e261f30451f8f/packages/block-editor/src/hooks/block-bindings.js#L300-L305

This was done to avoid the following console warning:

```
The `useSelect` hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.

Non-equal value keys: sources
```

However, this papered over an underlying issue (through forced referential equality).

Additionally, e2e tests had workarounds to make them pass in CI:

https://github.com/WordPress/gutenberg/blob/2b6c500e18aeea2a2c9adf13c29e261f30451f8f/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js#L147-L155

https://github.com/WordPress/gutenberg/blob/2b6c500e18aeea2a2c9adf13c29e261f30451f8f/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js#L183-L191

However, those tests (and the five in the `Fields list dropdown` group) _never_ passed when run locally. In other words, the workaround papered over a race condition in CI (but couldn't prevent tests from failing locally).

See https://github.com/WordPress/gutenberg/pull/65604 for a longer discussion of this issue, and https://github.com/WordPress/gutenberg/pull/72367#issuecomment-3436898201 for the rationale behind the present approach.

See https://github.com/WordPress/gutenberg/pull/67885 and https://github.com/WordPress/gutenberg/pull/72109 for further previous attempts at fixing the underlying issue.

## Why?
To improve stability, remove hacks, and ensure that e2e tests actually guard against regressions.

## How?
By moving `sources` computation into a dedicated `useSelect`, and some general refactoring.

## Testing Instructions
See CI, but also try some smoke testing. (Refer to other Block Bindings related PRs for some ideas.)

Additionally, verify that all tests from the `post-meta.spec.js` are now passing when run locally.

```bash
npm run test:e2e -- test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
```

## Follow-up

In a future iteration, we could consider introducing more granular selectors, but that can be done separately from this bugfix:

- Add block attribute compatibility check inside selector (so that only sources and source items that are compatible with the block's attributes are returned).
- Add `getBlockBindingsSourcesForBlockAttribute( state, blockName, blockContext, blockAttribute )` selector.