### PR TITLE
Routing Infra: Explore adding a posts route to the boot package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build-types
 build-wp
 node_modules
 gutenberg.zip
+.content-entry.js
 coverage
 .phpunit.result.cache
 .reassure

--- a/lib/experimental/boot/boot.php
+++ b/lib/experimental/boot/boot.php
@@ -33,8 +33,7 @@ function gutenberg_boot_admin_page() {
 
 	// Register some default menu items for demonstration.
 	gutenberg_register_boot_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
-	gutenberg_register_boot_menu_item( 'about', __( 'About', 'gutenberg' ), '/', '' );
-	gutenberg_register_boot_menu_item( 'settings', __( 'Settings', 'gutenberg' ), '/', '' );
+	gutenberg_register_boot_menu_item( 'posts', __( 'Posts', 'gutenberg' ), '/types/post/list/all', '' );
 
 	// Get routes and menu items.
 	$menu_items = gutenberg_get_boot_menu_items();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17228,6 +17228,10 @@
 			"resolved": "packages/plugins",
 			"link": true
 		},
+		"node_modules/@wordpress/post-list": {
+			"resolved": "routes/post-list",
+			"link": true
+		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
 			"resolved": "packages/postcss-plugins-preset",
 			"link": true
@@ -52185,6 +52189,7 @@
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
+				"@wordpress/editor": "file:../editor",
 				"@wordpress/element": "file:../element",
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
@@ -54805,6 +54810,128 @@
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/i18n": "file:../../packages/i18n"
+			}
+		},
+		"routes/post-list": {
+			"name": "@wordpress/post-list",
+			"version": "1.0.0",
+			"dependencies": {
+				"@tanstack/react-router": ">=1.120.5 <1.121.0",
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/block-editor": "file:../../packages/block-editor",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/dom": "file:../../packages/dom",
+				"@wordpress/editor": "file:../../packages/editor",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/fields": "file:../../packages/fields",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/keycodes": "file:../../packages/keycodes",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/views": "file:../../packages/views",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3"
+			}
+		},
+		"routes/post-list/node_modules/@tanstack/history": {
+			"version": "1.120.17",
+			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.120.17.tgz",
+			"integrity": "sha512-k07LFI4Qo074IIaWzT/XjD0KlkGx2w1V3fnNtclKx0oAl8z4O9kCh6za+FPEIRe98xLgNFEiddDbJeAYGSlPtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post-list/node_modules/@tanstack/react-router": {
+			"version": "1.120.20",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.20.tgz",
+			"integrity": "sha512-+zNruUE9NsfGm9cHd22Xs7FRtBrBhDZe94pB69BEIjqjrEPZct6f5VhTV9WQ+bDZ6fRz8tUuxNFAgm/3Lm4AIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.120.17",
+				"@tanstack/react-store": "^0.7.0",
+				"@tanstack/router-core": "1.120.19",
+				"jsesc": "^3.1.0",
+				"tiny-invariant": "^1.3.3",
+				"tiny-warning": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			}
+		},
+		"routes/post-list/node_modules/@tanstack/react-store": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.7.tgz",
+			"integrity": "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/store": "0.7.7",
+				"use-sync-external-store": "^1.5.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"routes/post-list/node_modules/@tanstack/router-core": {
+			"version": "1.120.19",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.19.tgz",
+			"integrity": "sha512-5JUVgkxnIM3NxMwzKt0tfz2UopZVxwq6Kl7Rp33zlFJaPjpiRs46VuRjVeAvkpJd6samo1gcH1rWqmnPUmtGcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.120.17",
+				"@tanstack/store": "^0.7.0",
+				"tiny-invariant": "^1.3.3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post-list/node_modules/@tanstack/store": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.7.tgz",
+			"integrity": "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post-list/node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		}
 	}

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/boot/src/index.tsx
+++ b/packages/boot/src/index.tsx
@@ -3,3 +3,10 @@
  */
 import './style.scss';
 export { init } from './components/app';
+
+// Hacks
+// This ensures wp-editor is added as a dependency to the boot package.
+/**
+ * WordPress dependencies
+ */
+import '@wordpress/editor';

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -10,6 +10,7 @@
 		{ "path": "../compose" },
 		{ "path": "../core-data" },
 		{ "path": "../data" },
+		{ "path": "../editor" },
 		{ "path": "../element" },
 		{ "path": "../html-entities" },
 		{ "path": "../i18n" },

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -476,6 +476,14 @@ export const autosave =
 		}
 	};
 
+/**
+ * Save for preview.
+ *
+ * @param {Object}  options                     Options object.
+ * @param {boolean} options.forceIsAutosaveable Whether to force the post to be autosaveable.
+ *
+ * @return {Function} Thunk that saves for preview and returns the preview link.
+ */
 export const __unstableSaveForPreview =
 	( { forceIsAutosaveable } = {} ) =>
 	async ( { select, dispatch } ) => {

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -30,6 +30,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/preferences',
 	'@wordpress/reusable-blocks',
 	'@wordpress/router',
+	'@wordpress/routes',
 	'@wordpress/sync',
 	'@wordpress/theme',
 	'@wordpress/dataviews',

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1511,6 +1511,18 @@ async function watchMode() {
 		const routeWatcher = chokidar.watch( routeWatchPaths, {
 			persistent: true,
 			ignoreInitial: true,
+			ignored: ( filepath ) => {
+				const basename = path.basename( filepath );
+				// Ignore .content-entry.js temporary build files
+				if ( basename === '.content-entry.js' ) {
+					return true;
+				}
+				// Ignore node_modules directories and contents
+				if ( filepath.includes( 'node_modules' ) ) {
+					return true;
+				}
+				return false;
+			},
 			useFsEvents: true,
 			depth: 10,
 			awaitWriteFinish: {

--- a/routes/lock-unlock.ts
+++ b/routes/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/routes'
+	);

--- a/routes/post-list/package.json
+++ b/routes/post-list/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@wordpress/post-list",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/types/$type/list/$slug"
+	},
+	"dependencies": {
+		"@tanstack/react-router": ">=1.120.5 <1.121.0",
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/block-editor": "file:../../packages/block-editor",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/dom": "file:../../packages/dom",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/fields": "file:../../packages/fields",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/keycodes": "file:../../packages/keycodes",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/views": "file:../../packages/views",
+		"clsx": "^2.1.1",
+		"dequal": "^2.0.3"
+	}
+}

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -1,0 +1,372 @@
+/**
+ * External dependencies
+ */
+import {
+	useParams,
+	useNavigate,
+	useSearch,
+	Link,
+	useRouter,
+} from '@tanstack/react-router';
+
+/**
+ * WordPress dependencies
+ */
+import { useView } from '@wordpress/views';
+import { DataViews } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type { View, Action } from '@wordpress/dataviews';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useCallback } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import type { Post } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import {
+	getDefaultView,
+	DEFAULT_VIEWS,
+	DEFAULT_LAYOUTS,
+	default as viewToQuery,
+} from './view-utils';
+
+// Unlock WordPress private APIs
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+const { usePostActions, usePostFields } = unlock( editorPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function getItemId( item: Post ) {
+	return item.id.toString();
+}
+
+function getItemLevel( item: Post ) {
+	return ( item as { level?: number } ).level ?? 0;
+}
+
+function PostList() {
+	const router = useRouter();
+	const { type: postType, slug = 'all' } = useParams( {
+		from: '/types/$type/list/$slug',
+	} );
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/types/$type/list/$slug' } );
+	const postTypeObject = useSelect(
+		( select ) => select( coreStore ).getPostType( postType ),
+		[ postType ]
+	);
+
+	const labels = postTypeObject?.labels;
+	const canCreateRecord = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: postType,
+			} ),
+		[ postType ]
+	);
+
+	const defaultView: View = useMemo( () => {
+		return getDefaultView( postTypeObject, slug );
+	}, [ postTypeObject, slug ] );
+
+	// Callback to handle URL query parameter changes
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+
+	// Use the new view persistence hook
+	const { view, isModified, updateView, resetToDefault } = useView( {
+		kind: 'postType',
+		name: postType,
+		slug,
+		defaultView,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
+
+	const onReset = () => {
+		resetToDefault();
+		router.invalidate();
+	};
+	const onChangeView = ( newView: View ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			// The rendered surfaces depend on the view type,
+			// so we need to retrigger the router loader when switching the view type.
+			// try switching from list to table and vice versa.
+			router.invalidate();
+		}
+	};
+
+	const postTypeQuery = useMemo(
+		() => viewToQuery( view, postType ),
+		[ view, postType ]
+	);
+	const {
+		records: posts,
+		totalItems,
+		totalPages,
+		isResolving,
+	} = useEntityRecordsWithPermissions( 'postType', postType, postTypeQuery );
+
+	const allFields = usePostFields( {
+		postType,
+	} );
+
+	// Hide status column except in 'All' tab, and disable status filtering
+	const fields = useMemo( () => {
+		return allFields
+			.filter( ( field: { id: string } ) => {
+				// Hide status column in specific status tabs
+				if ( field.id === 'status' && slug !== 'all' ) {
+					return false;
+				}
+				return true;
+			} )
+			.map( ( field: { id: string; filterBy?: any } ) => {
+				// Disable status field filtering since we use tabs
+				if ( field.id === 'status' ) {
+					return { ...field, filterBy: false };
+				}
+				return field;
+			} );
+	}, [ allFields, slug ] );
+
+	// Helper function to clean up postIds from URL after deletion
+	const cleanupDeletedPostIdsFromUrl = useCallback(
+		( deletedItems: Post[] ) => {
+			const deletedIds = deletedItems.map( ( item: Post ) =>
+				item.id.toString()
+			);
+			const currentPostIds = searchParams.postIds || [];
+			const remainingPostIds = currentPostIds.filter(
+				( id: string ) => ! deletedIds.includes( id )
+			);
+
+			if ( remainingPostIds.length !== currentPostIds.length ) {
+				navigate( {
+					search: {
+						...searchParams,
+						postIds:
+							remainingPostIds.length > 0
+								? remainingPostIds
+								: undefined,
+					},
+				} );
+			} else {
+				// If no change in the url, the first item might have changed.
+				router.invalidate();
+			}
+		},
+		[ router, searchParams, navigate ]
+	);
+
+	const postTypeActions: Action< Post >[] = usePostActions( {
+		postType,
+		context: 'list',
+		onActionPerformed: ( actionId: string, items: Post[] ) => {
+			// Clean up URL when delete actions are performed
+			if (
+				actionId === 'move-to-trash' ||
+				actionId === 'permanently-delete'
+			) {
+				cleanupDeletedPostIdsFromUrl( items );
+			}
+		},
+	} );
+
+	const actions = useMemo( () => {
+		return [
+			...postTypeActions?.flatMap< Action< Post > >( ( action ) => {
+				switch ( action.id ) {
+					case 'permanently-delete':
+						return [
+							{
+								...action,
+								isEligible( item ) {
+									if ( item.type === 'attachment' ) {
+										return true;
+									}
+									return action.isEligible?.( item ) ?? false;
+								},
+							},
+						];
+
+					// Media can in some circumstances need a trash option, but
+					// we need to extend the REST API to support it. See
+					// https://github.com/WordPress/wordpress-develop/pull/9210.
+					// Once that is merged we should fix this.
+					case 'move-to-trash':
+						return [
+							{
+								...action,
+								isEligible( item ) {
+									if ( item.type === 'attachment' ) {
+										return false;
+									}
+									return action.isEligible?.( item ) ?? false;
+								},
+							},
+						];
+
+					// Skip revisions as the admin does not support it
+					case 'view-post-revisions':
+						return [];
+				}
+
+				return [ action ];
+			} ),
+		];
+	}, [ postTypeActions ] );
+
+	const handleTabChange = useCallback(
+		( status: string ) => {
+			navigate( {
+				to: `/types/${ postType }/list/${ status }`,
+			} );
+		},
+		[ navigate, postType ]
+	);
+
+	if ( ! postTypeObject ) {
+		return null;
+	}
+
+	const selection = searchParams.postIds ?? [];
+
+	// Auto-select first post in list view if none selected
+	if ( view.type === 'list' && selection.length === 0 && posts?.length > 0 ) {
+		selection.push( posts[ 0 ].id.toString() );
+	}
+
+	// Until list view supports multi selection, only keep the first item.
+	if ( view.type === 'list' ) {
+		selection.splice( 1 );
+	}
+
+	return (
+		<Page
+			title={ postTypeObject.labels?.name }
+			subTitle={ postTypeObject.labels?.description }
+			className={ `${ postTypeObject.name.toLowerCase() }-page` }
+			actions={
+				<>
+					{ isModified && (
+						<Button
+							variant="tertiary"
+							size="compact"
+							onClick={ onReset }
+						>
+							{ __( 'Reset view' ) }
+						</Button>
+					) }
+					{ labels?.add_new_item &&
+						canCreateRecord &&
+						postType !== 'attachment' && (
+							<Button
+								variant="primary"
+								onClick={ () => {
+									navigate( {
+										to: `/types/${ postType }/new`,
+									} );
+								} }
+								size="compact"
+							>
+								{ labels.add_new_item }
+							</Button>
+						) }
+				</>
+			}
+			hasPadding={ false }
+		>
+			{ DEFAULT_VIEWS.length > 1 && (
+				<div className="routes-post-list__tabs-wrapper">
+					<Tabs
+						onSelect={ handleTabChange }
+						selectedTabId={ slug ?? 'all' }
+					>
+						<Tabs.TabList>
+							{ DEFAULT_VIEWS.map(
+								( filter: { slug: string; label: string } ) => (
+									<Tabs.Tab
+										tabId={ filter.slug }
+										key={ filter.slug }
+									>
+										{ filter.label }
+									</Tabs.Tab>
+								)
+							) }
+						</Tabs.TabList>
+					</Tabs>
+				</div>
+			) }
+			<DataViews
+				data={ posts }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				isLoading={ isResolving }
+				paginationInfo={ {
+					totalItems,
+					totalPages,
+				} }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ getItemId }
+				getItemLevel={ getItemLevel }
+				selection={ selection }
+				onChangeSelection={ ( items: string[] ) => {
+					navigate( {
+						search: {
+							...searchParams,
+							postIds: items.length > 0 ? items : undefined,
+							edit:
+								items.length === 0
+									? undefined
+									: searchParams.edit,
+						},
+					} );
+				} }
+				renderItemLink={ ( { item, ...props }: { item: Post } ) => (
+					<Link
+						to={ `/types/${ postType }/edit/${ encodeURIComponent(
+							item.id
+						) }` }
+						{ ...props }
+						onClick={ ( event ) => {
+							// Temporary fix to prevent triggering
+							// onChangeSelection, which would override the URL.
+							event.stopPropagation();
+						} }
+					/>
+				) }
+			/>
+		</Page>
+	);
+}
+
+export const stage = PostList;

--- a/routes/post-list/style.scss
+++ b/routes/post-list/style.scss
@@ -1,0 +1,11 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/fields/build-style/style.css" as fields;
+
+.routes-post-list__tabs-wrapper {
+	border-bottom: 1px solid $gray-100;
+	padding: 0 $grid-unit-60;
+	@container (max-width: 430px) {
+		padding: 0 $grid-unit-30;
+	}
+}

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -1,0 +1,222 @@
+/**
+ * WordPress dependencies
+ */
+import { loadView } from '@wordpress/views';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import type { Type } from '@wordpress/core-data';
+import type { View } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW: View = {
+	type: 'table' as const,
+	sort: {
+		field: 'date',
+		direction: 'desc' as const,
+	},
+	fields: [ 'author', 'status', 'date' ],
+	titleField: 'title',
+	mediaField: 'featured_media',
+	descriptionField: 'excerpt',
+};
+
+export const DEFAULT_LAYOUTS = {
+	table: {},
+	grid: {},
+	list: {},
+};
+
+export const DEFAULT_VIEWS: {
+	slug: string;
+	label: string;
+	view: View;
+}[] = [
+	{
+		slug: 'all',
+		label: 'All',
+		view: {
+			...DEFAULT_VIEW,
+		},
+	},
+	{
+		slug: 'publish',
+		label: 'Published',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'status',
+					operator: 'is',
+					value: 'publish',
+				},
+			],
+		},
+	},
+	{
+		slug: 'draft',
+		label: 'Draft',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'status',
+					operator: 'is',
+					value: 'draft',
+				},
+			],
+		},
+	},
+	{
+		slug: 'pending',
+		label: 'Pending',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'status',
+					operator: 'is',
+					value: 'pending',
+				},
+			],
+		},
+	},
+	{
+		slug: 'private',
+		label: 'Private',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'status',
+					operator: 'is',
+					value: 'private',
+				},
+			],
+		},
+	},
+	{
+		slug: 'trash',
+		label: 'Trash',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'status',
+					operator: 'is',
+					value: 'trash',
+				},
+			],
+		},
+	},
+];
+
+export function getDefaultView(
+	postType: Type | undefined,
+	slug?: string
+): View {
+	// Find the view configuration by slug
+	const viewConfig = DEFAULT_VIEWS.find( ( v ) => v.slug === slug );
+
+	// Use the view from the config if found, otherwise use default
+	const baseView = viewConfig?.view || DEFAULT_VIEW;
+
+	return {
+		...baseView,
+		showLevels: postType?.hierarchical,
+	};
+}
+
+export async function ensureView(
+	type: string,
+	slug?: string,
+	search?: { page?: number; search?: string }
+) {
+	const postTypeObject = await resolveSelect( coreStore ).getPostType( type );
+	const defaultView = getDefaultView( postTypeObject, slug );
+	return loadView( {
+		kind: 'postType',
+		name: type,
+		slug: slug ?? 'all',
+		defaultView,
+		queryParams: search,
+	} );
+}
+
+export default function viewToQuery( view: View, postType: string ) {
+	const result: Record< string, any > = {};
+
+	// Pagination, sorting, search.
+	if ( undefined !== view.perPage ) {
+		result.per_page = view.perPage;
+	}
+
+	if ( undefined !== view.page ) {
+		result.page = view.page;
+	}
+
+	if ( ! [ undefined, '' ].includes( view.search ) ) {
+		result.search = view.search;
+	}
+
+	if ( undefined !== view.sort?.field ) {
+		let sortField = view.sort.field;
+
+		if ( sortField === 'attached_to' ) {
+			sortField = 'parent';
+		}
+
+		result.orderby = sortField;
+	}
+
+	if ( undefined !== view.sort?.direction ) {
+		result.order = view.sort.direction;
+	}
+
+	if ( view.showLevels ) {
+		result.orderby_hierarchy = true;
+	}
+
+	// Filters.
+	const status = view.filters?.find(
+		( filter ) => filter.field === 'status'
+	);
+	if ( status ) {
+		result.status = status.value;
+	} else if ( postType === 'attachment' ) {
+		result.status = 'inherit';
+	} else {
+		result.status = 'draft,future,pending,private,publish';
+	}
+
+	const author = view.filters?.find(
+		( filter ) => filter.field === 'author'
+	);
+	if ( author && author.operator === 'is' ) {
+		result.author = author.value;
+	} else if ( author && author.operator === 'isNot' ) {
+		result.author_exclude = author.value;
+	}
+
+	const commentStatus = view.filters?.find(
+		( filter ) => filter.field === 'comment_status'
+	);
+	if ( commentStatus && commentStatus.operator === 'is' ) {
+		result.comment_status = commentStatus.value;
+	} else if ( commentStatus && commentStatus.operator === 'isNot' ) {
+		result.comment_status_exclude = commentStatus.value;
+	}
+
+	const mediaType = view.filters?.find(
+		( filter ) => filter.field === 'media_type'
+	);
+
+	if ( mediaType ) {
+		result.media_type = mediaType.value;
+	}
+
+	// For attachments, we need to embed the parent (attached to) post to get its title.
+	if ( postType === 'attachment' ) {
+		result._embed = 'wp:attached-to';
+	}
+
+	return result;
+}


### PR DESCRIPTION
Related #70862 

## What?

- Adds a new post-list route to display and manage posts using DataViews. Explores navigation, tabs, routing...

## Why?

To provide a modern, DataViews-based interface for managing posts in the admin, similar to the existing experimental page in edit-site but as a standalone route.

 ## How?

  - Created new route at `/routes/post-list/`
  - Added Posts menu item in `lib/experimental/boot/boot.php`
  - Implemented status filtering via tabs (All, Published, Draft, Pending, Private, Trash)
  - Uses `@wordpress/views` for view persistence.
  - Uses `@wordpress/dataviews` for table/grid/list views.
  - Use `usePostActions` and `usePostFields` for fields and actions.

 ## Testing Instructions

 - Navigate to `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot`
 - Click "posts" and try the page.

## Next steps

 In the next steps, I'm going to explore the quick edit panel
 I'd also like to explore a lazy loaded editor canvas (to avoid impacting the performance of the admin).