### PR TITLE
Accordion block: Lock `core/accordion` iAPI store

### DIFF
--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -3,85 +3,89 @@
  */
 import { store, getContext, withSyncEvent } from '@wordpress/interactivity';
 
-store( 'core/accordion', {
-	state: {
-		get isOpen() {
-			const { id, accordionItems } = getContext();
-			const accordionItem = accordionItems.find(
-				( item ) => item.id === id
-			);
-			return accordionItem ? accordionItem.isOpen : false;
+store(
+	'core/accordion',
+	{
+		state: {
+			get isOpen() {
+				const { id, accordionItems } = getContext();
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
+				return accordionItem ? accordionItem.isOpen : false;
+			},
 		},
-	},
-	actions: {
-		toggle: () => {
-			const context = getContext();
-			const { id, autoclose, accordionItems } = context;
-			const accordionItem = accordionItems.find(
-				( item ) => item.id === id
-			);
+		actions: {
+			toggle: () => {
+				const context = getContext();
+				const { id, autoclose, accordionItems } = context;
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
 
-			if ( autoclose ) {
-				accordionItems.forEach( ( item ) => {
-					item.isOpen =
-						item.id === id ? ! accordionItem.isOpen : false;
+				if ( autoclose ) {
+					accordionItems.forEach( ( item ) => {
+						item.isOpen =
+							item.id === id ? ! accordionItem.isOpen : false;
+					} );
+				} else {
+					accordionItem.isOpen = ! accordionItem.isOpen;
+				}
+			},
+			handleKeyDown: withSyncEvent( ( event ) => {
+				if (
+					event.key !== 'ArrowUp' &&
+					event.key !== 'ArrowDown' &&
+					event.key !== 'Home' &&
+					event.key !== 'End'
+				) {
+					return;
+				}
+
+				event.preventDefault();
+				const context = getContext();
+				const { id, accordionItems } = context;
+				const currentIndex = accordionItems.findIndex(
+					( item ) => item.id === id
+				);
+
+				let nextIndex;
+
+				switch ( event.key ) {
+					case 'ArrowUp':
+						nextIndex = Math.max( 0, currentIndex - 1 );
+						break;
+					case 'ArrowDown':
+						nextIndex = Math.min(
+							currentIndex + 1,
+							accordionItems.length - 1
+						);
+						break;
+					case 'Home':
+						nextIndex = 0;
+						break;
+					case 'End':
+						nextIndex = accordionItems.length - 1;
+						break;
+				}
+
+				const nextId = accordionItems[ nextIndex ].id;
+				const nextButton = document.getElementById( nextId );
+				if ( nextButton ) {
+					nextButton.focus();
+				}
+			} ),
+		},
+		callbacks: {
+			initAccordionItems: () => {
+				const context = getContext();
+				const { id, openByDefault } = context;
+				context.accordionItems.push( {
+					id,
+					isOpen: openByDefault,
 				} );
-			} else {
-				accordionItem.isOpen = ! accordionItem.isOpen;
-			}
-		},
-		handleKeyDown: withSyncEvent( ( event ) => {
-			if (
-				event.key !== 'ArrowUp' &&
-				event.key !== 'ArrowDown' &&
-				event.key !== 'Home' &&
-				event.key !== 'End'
-			) {
-				return;
-			}
-
-			event.preventDefault();
-			const context = getContext();
-			const { id, accordionItems } = context;
-			const currentIndex = accordionItems.findIndex(
-				( item ) => item.id === id
-			);
-
-			let nextIndex;
-
-			switch ( event.key ) {
-				case 'ArrowUp':
-					nextIndex = Math.max( 0, currentIndex - 1 );
-					break;
-				case 'ArrowDown':
-					nextIndex = Math.min(
-						currentIndex + 1,
-						accordionItems.length - 1
-					);
-					break;
-				case 'Home':
-					nextIndex = 0;
-					break;
-				case 'End':
-					nextIndex = accordionItems.length - 1;
-					break;
-			}
-
-			const nextId = accordionItems[ nextIndex ].id;
-			const nextButton = document.getElementById( nextId );
-			if ( nextButton ) {
-				nextButton.focus();
-			}
-		} ),
-	},
-	callbacks: {
-		initAccordionItems: () => {
-			const context = getContext();
-			const { id, openByDefault } = context;
-			context.accordionItems.push( {
-				id,
-				isOpen: openByDefault,
-			} );
+			},
 		},
 	},
-} );
+	{ lock: true }
+);


### PR DESCRIPTION
## What?

Locks the`core/accordion` interactivity store used by the Accordion block.

## Why?

To avoid exposing internal data that shouldn't become a public API.

## How?

Simply by adding a `{ lock: true }` option to the store definition.

## Testing Instructions
1. In the site editor, create a post.
2. Add an Accordion block and add some content to it.
3. Visit the created post.
4. Open the developer tools.
5. In the console, import `store()` from the Interactivity API module.
   ```js
   const { store } = await import( '@wordpress/interactivity' );
   ```
6. Try to access the `core/accordion` store. It should throw an error.
    ```js
    store( 'core/accordion' ); // Uncaught Error: Cannot unlock a private store with an invalid lock code
    ```
7. Don't forget to test that the Accordion block keeps working as expected.
