### PR TITLE
Components: Change types export to declaration file

### DIFF
--- a/packages/boot/src/components/navigation/router-link-item.tsx
+++ b/packages/boot/src/components/navigation/router-link-item.tsx
@@ -9,11 +9,9 @@ import type { ForwardedRef } from 'react';
  */
 import { forwardRef } from '@wordpress/element';
 import { __experimentalItem as Item } from '@wordpress/components';
-import type { ItemProps } from '@wordpress/components/build-types/item-group/types';
-import type { WordPressComponentProps } from '@wordpress/components/build-types/context';
 
 function AnchorOnlyItem(
-	props: WordPressComponentProps< ItemProps, 'a' >,
+	props: React.ComponentProps< typeof Item >,
 	forwardedRef: ForwardedRef< HTMLAnchorElement >
 ) {
 	return <Item as="a" ref={ forwardedRef } { ...props } />;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## Unreleased
 
-
 ### Bug Fixes
 
--   Reexport all of the `build-types` folder from the `components` package entry point ([#72809](https://github.com/WordPress/gutenberg/pull/72809)).
 -   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,7 +26,7 @@
 	"module": "build-module/index.js",
 	"exports": {
 		".": {
-			"types": "./build-types",
+			"types": "./build-types/index.d.ts",
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates components package to point to type declaration file and avoid exposing full `build-types` path, revising existing usage to use `React.ComponentProps` to extract props of an exported component from `@wordpress/components`.

Follow-up to #72809
Alternative to #72831

## Why?

- As identified in #72978, this can cause issues with resolving package types
- The purpose of `exports` is to be intentionally explicit about exposed paths, where the current usage allows arbitrary subpath exports
- This is the [documented pattern](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#typescript) for getting components types

## How?

- Reverts change to `@wordpress/components` `types` introduced in #72809
- Updates existing usage of `build-types/` to use `React.ComponentProps`

## Testing Instructions

Build should pass.