### PR TITLE
Testing: Increase memory limit for macOS CI runner

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -23,6 +23,8 @@ jobs:
     check:
         name: All${{ (matrix.node != '20' || matrix.os != 'ubuntu-24.04') && format(' (Node.js {0} on {1})', matrix.node, contains(matrix.os, 'macos-') && 'MacOS' || contains(matrix.os, 'windows-') && 'Windows' || 'Linux') || '' }}
         runs-on: ${{ matrix.os }}
+        env:
+            NODE_OPTIONS: --max-old-space-size=4096
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -37,8 +37,8 @@ jobs:
                       node: '22'
                     - event: 'pull_request'
                       node: '24'
-                    - event: 'pull_request'
-                      os: 'macos-15'
+                    # - event: 'pull_request'
+                    #   os: 'macos-15'
                     - event: 'pull_request'
                       os: 'windows-2025'
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -39,8 +39,8 @@ jobs:
                       node: '22'
                     - event: 'pull_request'
                       node: '24'
-                    # - event: 'pull_request'
-                    #   os: 'macos-15'
+                    - event: 'pull_request'
+                      os: 'macos-15'
                     - event: 'pull_request'
                       os: 'windows-2025'
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates build environment to increase maximum memory size, to resolve build failures on trunk in macOS environments.

Example: https://github.com/WordPress/gutenberg/actions/runs/19078202144/job/54499466625

Follow-up to #72946

## Why?

Builds should pass.

## How?

Specifies `max-old-space-size` to 4MB to increase available memory.

## Testing Instructions

The branch changes include a temporary commit to run macOS build on this branch, which should pass with the changes. The temporary commit will be reverted before merge.