### PR TITLE
Change Accordion block toolbar label to spell “Add Accordion Item”

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -114,7 +114,7 @@ export default function Edit( {
 					</BlockControls>
 					<BlockControls group="other">
 						<ToolbarButton onClick={ addAccordionItemBlock }>
-							{ __( 'Add Accordion Item' ) }
+							{ __( 'Add item' ) }
 						</ToolbarButton>
 					</BlockControls>
 				</>

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -114,7 +114,7 @@ export default function Edit( {
 					</BlockControls>
 					<BlockControls group="other">
 						<ToolbarButton onClick={ addAccordionItemBlock }>
-							{ __( 'Add' ) }
+							{ __( 'Add Accordion Item' ) }
 						</ToolbarButton>
 					</BlockControls>
 				</>


### PR DESCRIPTION
## What?

The block toolbar button to add new Accordion Items within an Accordion block, only spells “Add”, which is highly ambiguous. This PR merely changes the label to spell out “Add Accordion Item” instead, which is in line with the label appearing in the inserter _and_ similar behavior in the Tabs block.

## Testing Instructions

1. Add an Accordion block.
2. Select it and verify that the toolbar button spells “Add Accordion Item”.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="651" height="154" alt="Screenshot 2025-11-04 at 13 27 50" src="https://github.com/user-attachments/assets/df29aa8f-81e3-46c9-b584-949e76d0d038" />| <img width="641" height="141" alt="Screenshot 2025-11-04 at 13 15 14" src="https://github.com/user-attachments/assets/e6316145-59e6-4511-9011-fb2f245361f0" /> |
