### PR TITLE
Revise block direct dragging to fix adjacent issues

### DIFF
--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -18,3 +18,10 @@
 		content: none !important;
 	}
 }
+
+// Images are draggable by default, so disable drag for them if not explicitly
+// set. This is done so that the block can capture the drag event instead.
+.wp-block img:not([draggable]),
+.wp-block svg:not([draggable]) {
+	-webkit-user-drag: none;
+}

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -18,10 +18,3 @@
 		content: none !important;
 	}
 }
-
-// Images are draggable by default, so disable drag for them if not explicitly
-// set. This is done so that the block can capture the drag event instead.
-.wp-block img:not([draggable]),
-.wp-block svg:not([draggable]) {
-	pointer-events: none;
-}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -90,7 +90,8 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 */
 			function onDragStart( event ) {
 				if (
-					node !== event.target ||
+					( node !== event.target &&
+						event.target.getAttribute( 'draggable' ) === 'true' ) ||
 					node.isContentEditable ||
 					node.ownerDocument.activeElement !== node ||
 					hasMultiSelection()

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -90,8 +90,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 */
 			function onDragStart( event ) {
 				if (
-					( node !== event.target &&
-						event.target.getAttribute( 'draggable' ) === 'true' ) ||
 					node.isContentEditable ||
 					node.ownerDocument.activeElement !== node ||
 					hasMultiSelection()

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -34,6 +34,14 @@ figure.wp-block-image:not(.wp-block) {
 		transform: translate(-50%, -50%);
 		margin: 0;
 	}
+
+	.components-resizable-box__container {
+		pointer-events: none;
+	}
+
+	.components-resizable-box__handle {
+		pointer-events: auto;
+	}
 }
 
 // Shown while image is being uploaded but cannot be previewed.


### PR DESCRIPTION
## What?
Closes #70425
Closes #72949

Tries minimally fixing the above issues.

## Why?

- It allows the image-specific browser context menu over images as previously on some blocks
- It fixes a regression on selecting rich text inline images and the ability to right click

## How?

- Uses `-webkit-user-drag: none` to disable dragging instead of `pointer-events: none` which lets the context menu be available for images and restores click selection of images in rich text. However, because that CSS property is unsupported in Firefox the next change ensures direct-dragging still works there.
- Removes the condition to not drag blocks if the `dragstart` target was not the block itself, which makes the CSS rule mentioned above extraneous except for a visual detail in Safari.

From my testing the CSS is **not necessary** for any browser because block dragging works no matter what the `dragstart` event target is. However, Safari, will display an file type icon alongside the cursor while dragging if the `dragstart` event target was an `<img>`*.

*It seems that can be worked around too if the `img` has `draggable="true"` but mentioning it only to note some trivia I learned while working on this.

## Testing Instructions
1. Try dragging all the blocks you can think of
2. Verify that works as expected
3. Open the context menu over image having blocks like Image or Featured Image
4. Verify the context menu is specific to an image

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f4dcd1f6-61ae-4d82-b4d9-a92fb1d3af99
