### PR TITLE
contentOnly patterns: mark patterns as contentOnly by adding metadata.patternName to the root block

### DIFF
--- a/backport-changelog/7.0/10248.md
+++ b/backport-changelog/7.0/10248.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10248
+
+* https://github.com/WordPress/gutenberg/pull/72988

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -50,6 +50,7 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 				// START CORE MODIFICATIONS //
 				//////////////////////////////
 				$blocks_to_insert = parse_blocks( trim( $pattern['content'] ) );
+
 				/*
 				* For single-root patterns, add the pattern name to make this a pattern instance in the editor.
 				* If the pattern has metadata, merge it with the existing metadata.

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Compatibility shims for block APIs for WordPress 7.0.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
+	/**
+	 * Replaces patterns in a block tree with their content.
+	 *
+	 * @since 6.6.0
+	 * @since 7.0.0 Adds metadata to attributes of single-pattern container blocks.
+	 *
+	 * @param array $blocks An array blocks.
+	 *
+	 * @return array An array of blocks with patterns replaced by their content.
+	 */
+	function gutenberg_resolve_pattern_blocks( $blocks ) {
+		static $inner_content;
+		// Keep track of seen references to avoid infinite loops.
+		static $seen_refs = array();
+		$i                = 0;
+		while ( $i < count( $blocks ) ) {
+			if ( 'core/pattern' === $blocks[ $i ]['blockName'] ) {
+				$attrs = $blocks[ $i ]['attrs'];
+
+				if ( empty( $attrs['slug'] ) ) {
+					++$i;
+					continue;
+				}
+
+				$slug = $attrs['slug'];
+
+				if ( isset( $seen_refs[ $slug ] ) ) {
+					// Skip recursive patterns.
+					array_splice( $blocks, $i, 1 );
+					continue;
+				}
+
+				$registry = WP_Block_Patterns_Registry::get_instance();
+				$pattern  = $registry->get_registered( $slug );
+
+				// Skip unknown patterns.
+				if ( ! $pattern ) {
+					++$i;
+					continue;
+				}
+				//////////////////////////////
+				// START CORE MODIFICATIONS //
+				//////////////////////////////
+				$blocks_to_insert = parse_blocks( trim( $pattern['content'] ) );
+				/*
+				* For single-root patterns, add the pattern name to make this a pattern instance in the editor.
+				* If the pattern has metadata, merge it with the existing metadata.
+				*/
+				if ( count( $blocks_to_insert ) === 1 ) {
+					$block_metadata = $blocks_to_insert[0]['attrs']['metadata'] ?? array();
+					$metadata       = array( 'patternName' => $slug );
+
+					foreach ( array(
+						'name'        => 'title',
+						'description' => 'description',
+						'categories'  => 'categories',
+					) as $key => $pattern_key ) {
+						$value = $pattern[ $pattern_key ] ?? $block_metadata[ $key ] ?? null;
+						if ( $value ) {
+							$metadata[ $key ] = 'categories' === $key && is_array( $value )
+								? array_map( 'sanitize_text_field', $value )
+								: sanitize_text_field( $value );
+						}
+					}
+
+					$blocks_to_insert[0]['attrs']['metadata'] = $metadata;
+				}
+				//////////////////////////////
+				// END CORE MODIFICATIONS //
+				//////////////////////////////
+
+				$seen_refs[ $slug ] = true;
+				$prev_inner_content = $inner_content;
+				$inner_content      = null;
+				$blocks_to_insert   = gutenberg_resolve_pattern_blocks( $blocks_to_insert );
+				$inner_content      = $prev_inner_content;
+				unset( $seen_refs[ $slug ] );
+				array_splice( $blocks, $i, 1, $blocks_to_insert );
+
+				// If we have inner content, we need to insert nulls in the
+				// inner content array, otherwise serialize_blocks will skip
+				// blocks.
+				if ( $inner_content ) {
+					$null_indices  = array_keys( $inner_content, null, true );
+					$content_index = $null_indices[ $i ];
+					$nulls         = array_fill( 0, count( $blocks_to_insert ), null );
+					array_splice( $inner_content, $content_index, 1, $nulls );
+				}
+
+				// Skip inserted blocks.
+				$i += count( $blocks_to_insert );
+			} else {
+				if ( ! empty( $blocks[ $i ]['innerBlocks'] ) ) {
+					$prev_inner_content           = $inner_content;
+					$inner_content                = $blocks[ $i ]['innerContent'];
+					$blocks[ $i ]['innerBlocks']  = gutenberg_resolve_pattern_blocks(
+						$blocks[ $i ]['innerBlocks']
+					);
+					$blocks[ $i ]['innerContent'] = $inner_content;
+					$inner_content                = $prev_inner_content;
+				}
+				++$i;
+			}
+		}
+		return $blocks;
+	}
+}

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -58,6 +58,13 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 					$block_metadata = $blocks_to_insert[0]['attrs']['metadata'] ?? array();
 					$metadata       = array( 'patternName' => $slug );
 
+					/*
+					* Merge pattern metadata with existing block metadata.
+					* Pattern metadata takes precedence, but existing block metadata
+					* is preserved as a fallback when the pattern doesn't define that field.
+					* Only the defined fields (name, description, categories) are merged;
+					* other metadata keys are not preserved.
+					*/
 					foreach ( array(
 						'name'        => 'title',
 						'description' => 'description',

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -55,30 +55,30 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 				* If the pattern has metadata, merge it with the existing metadata.
 				*/
 				if ( count( $blocks_to_insert ) === 1 ) {
-					$block_metadata = $blocks_to_insert[0]['attrs']['metadata'] ?? array();
-					$metadata       = array( 'patternName' => $slug );
+					$block_metadata                = $blocks_to_insert[0]['attrs']['metadata'] ?? array();
+					$block_metadata['patternName'] = $slug;
 
 					/*
 					* Merge pattern metadata with existing block metadata.
 					* Pattern metadata takes precedence, but existing block metadata
 					* is preserved as a fallback when the pattern doesn't define that field.
-					* Only the defined fields (name, description, categories) are merged;
-					* other metadata keys are not preserved.
+					* Only the defined fields (name, description, categories) are updated;
+					* other metadata keys are preserved.
 					*/
 					foreach ( array(
-						'name'        => 'title',
+						'name'        => 'title', // 'title' is the field in the pattern object 'name' is the field in the block metadata.
 						'description' => 'description',
 						'categories'  => 'categories',
 					) as $key => $pattern_key ) {
 						$value = $pattern[ $pattern_key ] ?? $block_metadata[ $key ] ?? null;
 						if ( $value ) {
-							$metadata[ $key ] = 'categories' === $key && is_array( $value )
+							$block_metadata[ $key ] = 'categories' === $key && is_array( $value )
 								? array_map( 'sanitize_text_field', $value )
 								: sanitize_text_field( $value );
 						}
 					}
 
-					$blocks_to_insert[0]['attrs']['metadata'] = $metadata;
+					$blocks_to_insert[0]['attrs']['metadata'] = $block_metadata;
 				}
 				//////////////////////////////
 				// END CORE MODIFICATIONS //

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WordPress 7.0 compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Retrieves a single unified template object using its id.
+ * Parses pattern blocks in the template content.
+ *
+ * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
+ * @param string                 $id             Template unique identifier (example: 'theme_slug//template_slug').
+ * @param string                 $template_type  Template type. Either 'wp_template' or 'wp_template_part'.
+ */
+function gutenberg_parse_pattern_blocks_in_block_template( $block_template, $id, $template_type ) {
+	if ( 'wp_template' !== $template_type ) {
+		return $block_template;
+	}
+
+	if ( ! empty( $block_template->content ) ) {
+		$blocks = parse_blocks( $block_template->content );
+		if ( ! empty( $blocks ) ) {
+			$blocks                  = gutenberg_resolve_pattern_blocks( $blocks );
+			$block_template->content = serialize_blocks( $blocks );
+		}
+	}
+	return $block_template;
+}
+
+add_filter( 'get_block_template', 'gutenberg_parse_pattern_blocks_in_block_template', 10, 3 );
+add_filter( 'get_block_file_template', 'gutenberg_parse_pattern_blocks_in_block_template', 10, 3 );
+
+/**
+ * Retrieves a list of unified template objects based on a query.
+ * Parses pattern blocks in the template content items.
+ *
+ * @param WP_Block_Template[] $query_result Array of found block templates.
+ * @param array               $query {
+ *     Arguments to retrieve templates. All arguments are optional.
+ *
+ *     @type string[] $slug__in  List of slugs to include.
+ *     @type int      $wp_id     Post ID of customized template.
+ *     @type string   $area      A 'wp_template_part_area' taxonomy value to filter by (for 'wp_template_part' template type only).
+ *     @type string   $post_type Post type to get the templates for.
+ * }
+ * @param string              $template_type wp_template or wp_template_part.
+ */
+function gutenberg_parse_pattern_blocks_in_block_templates( $query_result, $query, $template_type ) {
+	if ( 'wp_template' !== $template_type ) {
+		return $query_result;
+	}
+
+	if ( ! empty( $query_result ) ) {
+		foreach ( $query_result as $template ) {
+			$blocks = parse_blocks( $template->content );
+			if ( ! empty( $blocks ) ) {
+				$blocks            = gutenberg_resolve_pattern_blocks( $blocks );
+				$template->content = serialize_blocks( $blocks );
+			}
+		}
+	}
+	return $query_result;
+}
+
+add_filter( 'get_block_templates', 'gutenberg_parse_pattern_blocks_in_block_templates', 10, 3 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,6 +56,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.9/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php';
 
+	// WordPress 7.0 compat.
+	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
+
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';
@@ -94,6 +97,7 @@ require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
 
 // WordPress 7.0 compat.
 require __DIR__ . '/compat/wordpress-7.0/php-only-blocks.php';
+require __DIR__ . '/compat/wordpress-7.0/blocks.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
+++ b/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
@@ -118,7 +118,7 @@ class Gutenberg_Resolve_Pattern_Blocks_Test extends WP_UnitTestCase {
 			// Metadata is merged with existing metadata and existing metadata is preserved.
 			'existing metadata preserved'   => array(
 				'<!-- wp:pattern {"slug":"core/existing-metadata"} /-->',
-				'<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata","name":"Existing Metadata Pattern","description":"A existing metadata pattern.","categories":["cake"]}} -->Existing metadata content<!-- /wp:paragraph -->',
+				'<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata","description":"A existing metadata pattern.","categories":["cake"],"name":"Existing Metadata Pattern"}} -->Existing metadata content<!-- /wp:paragraph -->',
 			),
 		);
 	}

--- a/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
+++ b/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
@@ -65,6 +65,15 @@ class Gutenberg_Resolve_Pattern_Blocks_Test extends WP_UnitTestCase {
 				'content' => '<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata-should-not-overwrite","description":"A existing metadata pattern.","categories":["cake"]}} -->Existing metadata content<!-- /wp:paragraph -->',
 			)
 		);
+		register_block_pattern(
+			'core/with-custom-metadata',
+			array(
+				'title'       => 'Pattern With Custom Metadata',
+				'content'     => '<!-- wp:paragraph {"metadata":{"customKey":"customValue","anotherKey":123,"booleanKey":true}} -->Content with custom metadata<!-- /wp:paragraph -->',
+				'description' => 'A pattern with custom metadata keys.',
+				'categories'  => array( 'test' ),
+			)
+		);
 	}
 
 	public function tear_down() {
@@ -73,6 +82,7 @@ class Gutenberg_Resolve_Pattern_Blocks_Test extends WP_UnitTestCase {
 		unregister_block_pattern( 'core/with-attrs' );
 		unregister_block_pattern( 'core/nested-single' );
 		unregister_block_pattern( 'core/existing-metadata' );
+		unregister_block_pattern( 'core/with-custom-metadata' );
 		parent::tear_down();
 	}
 
@@ -119,6 +129,11 @@ class Gutenberg_Resolve_Pattern_Blocks_Test extends WP_UnitTestCase {
 			'existing metadata preserved'   => array(
 				'<!-- wp:pattern {"slug":"core/existing-metadata"} /-->',
 				'<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata","description":"A existing metadata pattern.","categories":["cake"],"name":"Existing Metadata Pattern"}} -->Existing metadata content<!-- /wp:paragraph -->',
+			),
+			// Custom metadata keys are preserved when resolving patterns.
+			'custom metadata preserved'     => array(
+				'<!-- wp:pattern {"slug":"core/with-custom-metadata"} /-->',
+				'<!-- wp:paragraph {"metadata":{"customKey":"customValue","anotherKey":123,"booleanKey":true,"patternName":"core/with-custom-metadata","name":"Pattern With Custom Metadata","description":"A pattern with custom metadata keys.","categories":["test"]}} -->Content with custom metadata<!-- /wp:paragraph -->',
 			),
 		);
 	}

--- a/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
+++ b/phpunit/blocks/gutenberg-resolve-pattern-blocks.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for the gutenberg_resolve_pattern_blocks function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Test the gutenberg_resolve_pattern_blocks function.
+ *
+ * @group blocks
+ * @covers ::gutenberg_resolve_pattern_blocks
+ */
+class Gutenberg_Resolve_Pattern_Blocks_Test extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		register_block_pattern(
+			'core/single-root',
+			array(
+				'title'       => 'Single Root Pattern',
+				'content'     => '<!-- wp:paragraph -->Single root content<!-- /wp:paragraph -->',
+				'description' => 'A single root pattern.',
+				'categories'  => array( 'text' ),
+			)
+		);
+		register_block_pattern(
+			'core/single-root-with-forbidden-chars-in-attrs',
+			array(
+				'title'       => 'Single Root Pattern<script>alert("XSS")</script>',
+				'content'     => '<!-- wp:paragraph -->Single root content<!-- /wp:paragraph -->',
+				'description' => 'A single root pattern.<script>alert("XSS")</script><img src=x onerror=alert(1)>',
+				'categories'  => array(
+					'text<script>alert("XSS")</script>',
+					'bad\'); DROP TABLE wp_posts;--',
+					'<img src=x onerror=alert(1)>',
+					"evil\x00null\nbyte",
+					'category with <strong>html</strong> tags',
+				),
+			)
+		);
+		register_block_pattern(
+			'core/with-attrs',
+			array(
+				'title'       => 'Pattern With Attrs',
+				'content'     => '<!-- wp:paragraph {"className":"custom-class"} -->Content<!-- /wp:paragraph -->',
+				'description' => 'A pattern with existing attributes.',
+			)
+		);
+		register_block_pattern(
+			'core/nested-single',
+			array(
+				'title'       => 'Nested Pattern',
+				'content'     => '<!-- wp:group --><!-- wp:paragraph -->Nested content<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/single-root"} /--><!-- /wp:group -->',
+				'description' => 'A nested single root pattern.',
+				'categories'  => array( 'featured' ),
+			)
+		);
+		register_block_pattern(
+			'core/existing-metadata',
+			array(
+				'title'   => 'Existing Metadata Pattern',
+				'content' => '<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata-should-not-overwrite","description":"A existing metadata pattern.","categories":["cake"]}} -->Existing metadata content<!-- /wp:paragraph -->',
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_block_pattern( 'core/single-root' );
+		unregister_block_pattern( 'core/single-root-with-forbidden-chars-in-attrs' );
+		unregister_block_pattern( 'core/with-attrs' );
+		unregister_block_pattern( 'core/nested-single' );
+		unregister_block_pattern( 'core/existing-metadata' );
+		parent::tear_down();
+	}
+
+
+	/**
+	 * @dataProvider data_should_resolve_pattern_blocks_as_expected
+	 *
+	 * @param string $blocks   A string representing blocks that need resolving.
+	 * @param string $expected Expected result.
+	 */
+	public function test_should_resolve_pattern_blocks_as_expected( $blocks, $expected ) {
+		$actual = gutenberg_resolve_pattern_blocks( parse_blocks( $blocks ) );
+		$this->assertSame( $expected, serialize_blocks( $actual ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_resolve_pattern_blocks_as_expected() {
+		return array(
+			// Resolves the single-root pattern and adds metadata.
+			'single-root pattern'           => array(
+				'<!-- wp:pattern {"slug":"core/single-root"} /-->',
+				'<!-- wp:paragraph {"metadata":{"patternName":"core/single-root","name":"Single Root Pattern","description":"A single root pattern.","categories":["text"]}} -->Single root content<!-- /wp:paragraph -->',
+			),
+			// Existing attributes are preserved when adding metadata.
+			'existing attributes preserved' => array(
+				'<!-- wp:pattern {"slug":"core/with-attrs"} /-->',
+				'<!-- wp:paragraph {"className":"custom-class","metadata":{"patternName":"core/with-attrs","name":"Pattern With Attrs","description":"A pattern with existing attributes."}} -->Content<!-- /wp:paragraph -->',
+			),
+			// Resolves the nested single-root pattern and adds metadata.
+			'nested single-root pattern'    => array(
+				'<!-- wp:pattern {"slug":"core/nested-single"} /-->',
+				'<!-- wp:group {"metadata":{"patternName":"core/nested-single","name":"Nested Pattern","description":"A nested single root pattern.","categories":["featured"]}} --><!-- wp:paragraph -->Nested content<!-- /wp:paragraph --><!-- wp:paragraph {"metadata":{"patternName":"core/single-root","name":"Single Root Pattern","description":"A single root pattern.","categories":["text"]}} -->Single root content<!-- /wp:paragraph --><!-- /wp:group -->',
+			),
+			// Sanitizes fields.
+			'sanitized pattern attrs'       => array(
+				'<!-- wp:pattern {"slug":"core/single-root-with-forbidden-chars-in-attrs"} /-->',
+				'<!-- wp:paragraph {"metadata":{"patternName":"core/single-root-with-forbidden-chars-in-attrs","name":"Single Root Pattern","description":"A single root pattern.","categories":["text","bad\'); DROP TABLE wp_posts;\u002d\u002d","","evil\u0000null byte","category with html tags"]}} -->Single root content<!-- /wp:paragraph -->',
+			),
+			// Metadata is merged with existing metadata and existing metadata is preserved.
+			'existing metadata preserved'   => array(
+				'<!-- wp:pattern {"slug":"core/existing-metadata"} /-->',
+				'<!-- wp:paragraph {"metadata":{"patternName":"core/existing-metadata","name":"Existing Metadata Pattern","description":"A existing metadata pattern.","categories":["cake"]}} -->Existing metadata content<!-- /wp:paragraph -->',
+			),
+		);
+	}
+}

--- a/phpunit/class-resolve-patterns-in-templates-test.php
+++ b/phpunit/class-resolve-patterns-in-templates-test.php
@@ -178,36 +178,33 @@ class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testca
 		// Verify pattern block is resolved.
 		$blocks = parse_blocks( $data['content']['raw'] );
 		$this->assertNotEmpty( $blocks );
+		$this->assertGreaterThanOrEqual( 3, count( $blocks ), 'Template should have at least 3 blocks after pattern resolution.' );
 
-		// Find the resolved paragraph block (should not be a pattern block).
-		$has_pattern_block    = false;
-		$has_resolved_content = false;
-		$has_metadata         = false;
+		// Block structure after resolution:
+		// blocks[0] = "Before pattern" paragraph
+		// blocks[1] = Resolved pattern content (single paragraph with metadata)
+		// blocks[2] = "After pattern" paragraph
+
+		// Verify the resolved pattern block (should be at index 1).
+		$resolved_block = $blocks[1];
+		$this->assertSame( 'core/paragraph', $resolved_block['blockName'], 'Resolved pattern should be a paragraph block.' );
+		$this->assertStringContainsString( 'Single root content', $resolved_block['innerHTML'] ?? '', 'Resolved pattern should contain expected content.' );
+
+		// Verify metadata is present on single-root pattern.
+		$this->assertArrayHasKey( 'metadata', $resolved_block['attrs'], 'Resolved pattern block should have metadata.' );
+		$metadata = $resolved_block['attrs']['metadata'];
+		$this->assertSame( 'test/single-root', $metadata['patternName'], 'Pattern name should match.' );
+		$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
+		$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
+		$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
+		$this->assertSame( 'Single Root Pattern', $metadata['name'], 'Pattern name should match.' );
+		$this->assertSame( 'A single root pattern.', $metadata['description'], 'Pattern description should match.' );
+		$this->assertSame( array( 'text' ), $metadata['categories'], 'Pattern categories should match.' );
+
+		// Verify no pattern blocks remain.
 		foreach ( $blocks as $block ) {
-			if ( 'core/pattern' === $block['blockName'] ) {
-				$has_pattern_block = true;
-			}
-			if ( 'core/paragraph' === $block['blockName'] && isset( $block['innerHTML'] ) && strpos( $block['innerHTML'], 'Single root content' ) !== false ) {
-				$has_resolved_content = true;
-				// Verify metadata is present on single-root pattern.
-				if ( isset( $block['attrs']['metadata'] ) ) {
-					$metadata = $block['attrs']['metadata'];
-					if ( isset( $metadata['patternName'] ) && 'test/single-root' === $metadata['patternName'] ) {
-						$has_metadata = true;
-						$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
-						$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
-						$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
-						$this->assertSame( 'Single Root Pattern', $metadata['name'], 'Pattern name should match.' );
-						$this->assertSame( 'A single root pattern.', $metadata['description'], 'Pattern description should match.' );
-						$this->assertSame( array( 'text' ), $metadata['categories'], 'Pattern categories should match.' );
-					}
-				}
-			}
+			$this->assertNotSame( 'core/pattern', $block['blockName'], 'Pattern block should be resolved and not present in the content.' );
 		}
-
-		$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved and not present in the content.' );
-		$this->assertTrue( $has_resolved_content, 'Pattern content should be resolved in the template.' );
-		$this->assertTrue( $has_metadata, 'Pattern metadata should be preserved in resolved blocks.' );
 
 		unregister_block_template( $template_name );
 	}
@@ -261,46 +258,43 @@ class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testca
 		$this->assertNotNull( $template_2, 'Template 2 should be found. Available template IDs: ' . implode( ', ', wp_list_pluck( $data, 'id' ) ) );
 
 		// Verify pattern blocks are resolved in template 1.
-		if ( $template_1 ) {
-			$blocks            = parse_blocks( $template_1['content']['raw'] );
-			$has_pattern_block = false;
-			$has_metadata      = false;
-			foreach ( $blocks as $block ) {
-				if ( 'core/pattern' === $block['blockName'] ) {
-					$has_pattern_block = true;
-					break;
-				}
-				// Verify metadata is present on single-root pattern.
-				if ( 'core/paragraph' === $block['blockName'] && isset( $block['attrs']['metadata'] ) ) {
-					$metadata = $block['attrs']['metadata'];
-					if ( isset( $metadata['patternName'] ) && 'test/single-root' === $metadata['patternName'] ) {
-						$has_metadata = true;
-						$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
-						$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
-						$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
-					}
-				}
-			}
-			$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved in template 1.' );
-			$this->assertTrue( $has_metadata, 'Pattern metadata should be preserved in template 1.' );
+		$blocks = parse_blocks( $template_1['content']['raw'] );
+		$this->assertNotEmpty( $blocks, 'Template 1 should have at least one block after pattern resolution.' );
+
+		// Block structure after resolution:
+		// blocks[0] = Resolved pattern content (single paragraph with metadata)
+
+		// Verify the resolved pattern block (should be at index 0).
+		$resolved_block = $blocks[0];
+		$this->assertSame( 'core/paragraph', $resolved_block['blockName'], 'Resolved pattern should be a paragraph block.' );
+
+		// Verify metadata is present on single-root pattern.
+		$this->assertArrayHasKey( 'metadata', $resolved_block['attrs'], 'Resolved pattern block should have metadata.' );
+		$metadata = $resolved_block['attrs']['metadata'];
+		$this->assertSame( 'test/single-root', $metadata['patternName'], 'Pattern name should match.' );
+		$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
+		$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
+		$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
+
+		// Verify no pattern blocks remain.
+		foreach ( $blocks as $block ) {
+			$this->assertNotSame( 'core/pattern', $block['blockName'], 'Pattern block should be resolved in template 1.' );
 		}
 
 		// Verify pattern blocks are resolved in template 2.
-		if ( $template_2 ) {
-			$blocks            = parse_blocks( $template_2['content']['raw'] );
-			$has_pattern_block = false;
-			$paragraph_count   = 0;
-			foreach ( $blocks as $block ) {
-				if ( 'core/pattern' === $block['blockName'] ) {
-					$has_pattern_block = true;
-				}
-				if ( 'core/paragraph' === $block['blockName'] ) {
-					++$paragraph_count;
-				}
+		$blocks            = parse_blocks( $template_2['content']['raw'] );
+		$has_pattern_block = false;
+		$paragraph_count   = 0;
+		foreach ( $blocks as $block ) {
+			if ( 'core/pattern' === $block['blockName'] ) {
+				$has_pattern_block = true;
 			}
-			$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved in template 2.' );
-			$this->assertGreaterThanOrEqual( 2, $paragraph_count, 'Template 2 should have resolved pattern content with multiple blocks.' );
+			if ( 'core/paragraph' === $block['blockName'] ) {
+				++$paragraph_count;
+			}
 		}
+		$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved in template 2.' );
+		$this->assertGreaterThanOrEqual( 2, $paragraph_count, 'Template 2 should have resolved pattern content with multiple blocks.' );
 
 		unregister_block_template( $template_name_1 );
 		unregister_block_template( $template_name_2 );

--- a/phpunit/class-resolve-patterns-in-templates-test.php
+++ b/phpunit/class-resolve-patterns-in-templates-test.php
@@ -246,9 +246,8 @@ class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testca
 		$this->assertIsArray( $data );
 
 		// Find our test templates by slug (REST API may normalize IDs to theme slug format).
-		$template_1    = null;
-		$template_2    = null;
-		$current_theme = get_stylesheet();
+		$template_1 = null;
+		$template_2 = null;
 		foreach ( $data as $template ) {
 			if ( isset( $template['slug'] ) && 'test-template-1' === $template['slug'] ) {
 				$template_1 = $template;

--- a/phpunit/class-resolve-patterns-in-templates-test.php
+++ b/phpunit/class-resolve-patterns-in-templates-test.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Tests for pattern block resolution in templates via REST API.
+ *
+ * @package gutenberg
+ *
+ * @group rest-api
+ * @covers ::gutenberg_parse_pattern_blocks_in_block_template
+ * @covers ::gutenberg_parse_pattern_blocks_in_block_templates
+ */
+class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register test patterns.
+		register_block_pattern(
+			'test/single-root',
+			array(
+				'title'       => 'Single Root Pattern',
+				'content'     => '<!-- wp:paragraph -->Single root content<!-- /wp:paragraph -->',
+				'description' => 'A single root pattern.',
+				'categories'  => array( 'text' ),
+			)
+		);
+
+		register_block_pattern(
+			'test/nested-pattern',
+			array(
+				'title'       => 'Nested Pattern',
+				'content'     => '<!-- wp:group --><!-- wp:paragraph -->Nested content<!-- /wp:paragraph --><!-- wp:pattern {"slug":"test/single-root"} /--><!-- /wp:group -->',
+				'description' => 'A nested pattern.',
+				'categories'  => array( 'featured' ),
+			)
+		);
+
+		register_block_pattern(
+			'test/multiple-blocks',
+			array(
+				'title'       => 'Multiple Blocks Pattern',
+				'content'     => '<!-- wp:paragraph -->First paragraph<!-- /wp:paragraph --><!-- wp:paragraph -->Second paragraph<!-- /wp:paragraph -->',
+				'description' => 'A pattern with multiple blocks.',
+			)
+		);
+
+		// Switch to a block theme for template support.
+		switch_theme( 'emptytheme' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		unregister_block_pattern( 'test/single-root' );
+		unregister_block_pattern( 'test/nested-pattern' );
+		unregister_block_pattern( 'test/multiple-blocks' );
+
+		// Clean up registered templates.
+		$templates = get_block_templates( array(), 'wp_template' );
+		foreach ( $templates as $template ) {
+			if ( isset( $template->wp_id ) && $template->wp_id ) {
+				wp_delete_post( $template->wp_id, true );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_register_routes() {
+		// We are testing filters, not controller routes.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {
+		// We are testing filters, not controller context.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {
+		// We are testing filters, not controller get_items().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {
+		// We are testing filters, not controller get_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {
+		// We are testing filters, not controller create_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {
+		// We are testing filters, not controller update_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {
+		// We are testing filters, not controller delete_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {
+		// We are testing filters, not controller prepare_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {
+		// We are testing filters, not controller schema.
+	}
+
+	/**
+	 * Test that pattern blocks are resolved when fetching a single template via REST API.
+	 */
+	public function test_get_template_resolves_pattern_blocks() {
+		wp_set_current_user( self::$admin_id );
+
+		// Register a template with a pattern block.
+		$template_name = 'test-plugin//test-template-with-pattern';
+		register_block_template(
+			$template_name,
+			array(
+				'title'   => 'Test Template With Pattern',
+				'content' => '<!-- wp:paragraph -->Before pattern<!-- /wp:paragraph --><!-- wp:pattern {"slug":"test/single-root"} /--><!-- wp:paragraph -->After pattern<!-- /wp:paragraph -->',
+			)
+		);
+
+		// Get template via REST API (use theme slug format for registered templates).
+		$current_theme = get_stylesheet();
+		$request       = new WP_REST_Request( 'GET', '/wp/v2/templates/' . $current_theme . '//test-template-with-pattern' );
+		$response      = rest_get_server()->dispatch( $request );
+		$data          = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'content', $data );
+
+		// Verify pattern block is resolved.
+		$blocks = parse_blocks( $data['content']['raw'] );
+		$this->assertNotEmpty( $blocks );
+
+		// Find the resolved paragraph block (should not be a pattern block).
+		$has_pattern_block    = false;
+		$has_resolved_content = false;
+		$has_metadata         = false;
+		foreach ( $blocks as $block ) {
+			if ( 'core/pattern' === $block['blockName'] ) {
+				$has_pattern_block = true;
+			}
+			if ( 'core/paragraph' === $block['blockName'] && isset( $block['innerHTML'] ) && strpos( $block['innerHTML'], 'Single root content' ) !== false ) {
+				$has_resolved_content = true;
+				// Verify metadata is present on single-root pattern.
+				if ( isset( $block['attrs']['metadata'] ) ) {
+					$metadata = $block['attrs']['metadata'];
+					if ( isset( $metadata['patternName'] ) && 'test/single-root' === $metadata['patternName'] ) {
+						$has_metadata = true;
+						$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
+						$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
+						$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
+						$this->assertSame( 'Single Root Pattern', $metadata['name'], 'Pattern name should match.' );
+						$this->assertSame( 'A single root pattern.', $metadata['description'], 'Pattern description should match.' );
+						$this->assertSame( array( 'text' ), $metadata['categories'], 'Pattern categories should match.' );
+					}
+				}
+			}
+		}
+
+		$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved and not present in the content.' );
+		$this->assertTrue( $has_resolved_content, 'Pattern content should be resolved in the template.' );
+		$this->assertTrue( $has_metadata, 'Pattern metadata should be preserved in resolved blocks.' );
+
+		unregister_block_template( $template_name );
+	}
+
+	/**
+	 * Test that pattern blocks are resolved when fetching multiple templates via REST API.
+	 */
+	public function test_get_templates_resolves_pattern_blocks() {
+		wp_set_current_user( self::$admin_id );
+
+		// Register templates with pattern blocks.
+		$template_name_1 = 'test-plugin//test-template-1';
+		register_block_template(
+			$template_name_1,
+			array(
+				'title'   => 'Test Template 1',
+				'content' => '<!-- wp:pattern {"slug":"test/single-root"} /-->',
+			)
+		);
+
+		$template_name_2 = 'test-plugin//test-template-2';
+		register_block_template(
+			$template_name_2,
+			array(
+				'title'   => 'Test Template 2',
+				'content' => '<!-- wp:pattern {"slug":"test/multiple-blocks"} /-->',
+			)
+		);
+
+		// Get templates via REST API.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+
+		// Find our test templates by slug (REST API may normalize IDs to theme slug format).
+		$template_1    = null;
+		$template_2    = null;
+		$current_theme = get_stylesheet();
+		foreach ( $data as $template ) {
+			if ( isset( $template['slug'] ) && 'test-template-1' === $template['slug'] ) {
+				$template_1 = $template;
+			}
+			if ( isset( $template['slug'] ) && 'test-template-2' === $template['slug'] ) {
+				$template_2 = $template;
+			}
+		}
+
+		$this->assertNotNull( $template_1, 'Template 1 should be found. Available template IDs: ' . implode( ', ', wp_list_pluck( $data, 'id' ) ) );
+		$this->assertNotNull( $template_2, 'Template 2 should be found. Available template IDs: ' . implode( ', ', wp_list_pluck( $data, 'id' ) ) );
+
+		// Verify pattern blocks are resolved in template 1.
+		if ( $template_1 ) {
+			$blocks            = parse_blocks( $template_1['content']['raw'] );
+			$has_pattern_block = false;
+			$has_metadata      = false;
+			foreach ( $blocks as $block ) {
+				if ( 'core/pattern' === $block['blockName'] ) {
+					$has_pattern_block = true;
+					break;
+				}
+				// Verify metadata is present on single-root pattern.
+				if ( 'core/paragraph' === $block['blockName'] && isset( $block['attrs']['metadata'] ) ) {
+					$metadata = $block['attrs']['metadata'];
+					if ( isset( $metadata['patternName'] ) && 'test/single-root' === $metadata['patternName'] ) {
+						$has_metadata = true;
+						$this->assertArrayHasKey( 'name', $metadata, 'Pattern name should be in metadata.' );
+						$this->assertArrayHasKey( 'description', $metadata, 'Pattern description should be in metadata.' );
+						$this->assertArrayHasKey( 'categories', $metadata, 'Pattern categories should be in metadata.' );
+					}
+				}
+			}
+			$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved in template 1.' );
+			$this->assertTrue( $has_metadata, 'Pattern metadata should be preserved in template 1.' );
+		}
+
+		// Verify pattern blocks are resolved in template 2.
+		if ( $template_2 ) {
+			$blocks            = parse_blocks( $template_2['content']['raw'] );
+			$has_pattern_block = false;
+			$paragraph_count   = 0;
+			foreach ( $blocks as $block ) {
+				if ( 'core/pattern' === $block['blockName'] ) {
+					$has_pattern_block = true;
+				}
+				if ( 'core/paragraph' === $block['blockName'] ) {
+					++$paragraph_count;
+				}
+			}
+			$this->assertFalse( $has_pattern_block, 'Pattern block should be resolved in template 2.' );
+			$this->assertGreaterThanOrEqual( 2, $paragraph_count, 'Template 2 should have resolved pattern content with multiple blocks.' );
+		}
+
+		unregister_block_template( $template_name_1 );
+		unregister_block_template( $template_name_2 );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Resolves https://github.com/WordPress/gutenberg/issues/71888

Backports the Core patch https://github.com/WordPress/wordpress-develop/pull/10248 to Gutenberg.

These changes ensure that patterns returned in registered theme templates have pattern metadata, so that themes that use patterns automatically opt into the [content only behaviour](https://github.com/WordPress/gutenberg/issues/71517).

Registered theme patterns are returned from the `/wp/v2/registered-templates` endpoint.

In Core this is done in [WP_REST_Registered_Templates_Controller](https://github.com/wordpress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-registered-templates-controller.php#L3)

In Gutenberg it's done using the `get_block_template*` filters.

### TODO

- [x] Give the same treatment to the [WP_REST_Block_Patterns_Controller](https://github.com/ramonjd/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php#L168) https://github.com/WordPress/gutenberg/pull/73375

## Why?

Content Only will be released in the plugin before Core (probably 7.0) so we need these changes so the content only feature can be properly tested.

## How?

Modifies the `resolve_pattern_blocks` function to include metadata for single-root patterns, allowing the pattern name and title to be stored in the block attributes. The metadata contains the `patternName` and `name` attributes.

This enables identification of patterns inside templates and allows for special treatment in the editor.

## Testing Instructions

Check out this PR and head over to `/wp-admin/admin.php?page=gutenberg-experiments` to enable the `contentOnly: Make patterns contentOnly by default upon insertion` experiment.

<img width="899" height="93" alt="Screenshot 2025-11-05 at 2 25 21 pm" src="https://github.com/user-attachments/assets/ebe7893a-7b8d-4a35-981d-3a3d9c56c5d2" />

I'm using TT4 to test.

Head over to `/wp-admin/site-editor.php?p=%2Ftemplate`

In the browser network console, you can check the response of `/wp/v2/registered-templates` to see if the template content contains pattern metadata (search for `metadata`)

Now edit the [All Archives template](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfour/templates/archive.html) (or any that contains a pattern).

In the list view, check that the [post 3 col pattern](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfour/patterns/posts-3-col.php) is in content only mode, that is, that it only displays text and other blocks (not containers and so on)



## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
| <img width="393" height="369" alt="Screenshot 2025-11-10 at 12 38 42 pm" src="https://github.com/user-attachments/assets/137b54f5-2986-4afb-a6c4-db4ec29d459c" />  | <img width="369" height="496" alt="Screenshot 2025-11-10 at 12 36 33 pm" src="https://github.com/user-attachments/assets/ee765bfa-0324-4194-8bed-19bed20fbd1b" /> |


