### PR TITLE
Notes: Add status divider when listing all notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -13,6 +13,7 @@ import {
 	useCallback,
 	useMemo,
 	useRef,
+	Fragment,
 } from '@wordpress/element';
 import {
 	__experimentalText as Text,
@@ -313,6 +314,13 @@ export function Comments( {
 		return null;
 	}
 
+	const lastUnresolvedIndex = ! isFloating
+		? threads.findLastIndex( ( thread ) => thread.status === 'hold' )
+		: -1;
+	const lastResolvedIndex = ! isFloating
+		? threads.findLastIndex( ( thread ) => thread.status === 'approved' )
+		: -1;
+
 	return (
 		<>
 			{ ! isFloating &&
@@ -325,26 +333,41 @@ export function Comments( {
 						commentSidebarRef={ commentSidebarRef }
 					/>
 				) }
-			{ threads.map( ( thread ) => (
-				<Thread
-					key={ thread.id }
-					thread={ thread }
-					onAddReply={ onAddReply }
-					onCommentDelete={ handleDelete }
-					onEditComment={ onEditComment }
-					isSelected={ selectedThread === thread.id }
-					setSelectedThread={ setSelectedThread }
-					setShowCommentBoard={ setShowCommentBoard }
-					commentSidebarRef={ commentSidebarRef }
-					reflowComments={ reflowComments }
-					isFloating={ isFloating }
-					calculatedOffset={ boardOffsets[ thread.id ] ?? 0 }
-					setHeights={ setHeights }
-					setBlockRef={ setBlockRef }
-					selectedThread={ selectedThread }
-					commentLastUpdated={ commentLastUpdated }
-					showCommentBoard={ showCommentBoard }
-				/>
+			{ threads.map( ( thread, index ) => (
+				<Fragment key={ thread.id }>
+					<Thread
+						thread={ thread }
+						onAddReply={ onAddReply }
+						onCommentDelete={ handleDelete }
+						onEditComment={ onEditComment }
+						isSelected={ selectedThread === thread.id }
+						setSelectedThread={ setSelectedThread }
+						setShowCommentBoard={ setShowCommentBoard }
+						commentSidebarRef={ commentSidebarRef }
+						reflowComments={ reflowComments }
+						isFloating={ isFloating }
+						calculatedOffset={ boardOffsets[ thread.id ] ?? 0 }
+						setHeights={ setHeights }
+						setBlockRef={ setBlockRef }
+						selectedThread={ selectedThread }
+						commentLastUpdated={ commentLastUpdated }
+						showCommentBoard={ showCommentBoard }
+					/>
+					{ ( index === lastUnresolvedIndex ||
+						index === lastResolvedIndex ) && (
+						<HStack
+							className="editor-collab-sidebar-panel__status-separator"
+							alignment="center"
+							justify="center"
+						>
+							<Text as="p" variant="muted">
+								{ index === lastUnresolvedIndex
+									? __( 'Resolved' )
+									: __( 'Deleted' ) }
+							</Text>
+						</HStack>
+					) }
+				</Fragment>
 			) ) }
 		</>
 	);

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -143,9 +143,13 @@ export function useBlockComments( postId ) {
 			);
 
 		// Append orphaned notes (whose related block was deleted or missing).
-		const orphanedComments = updatedResult.filter(
-			( thread ) => ! mappedIds.has( String( thread.id ) )
-		);
+		const orphanedComments = updatedResult
+			.filter( ( thread ) => ! mappedIds.has( String( thread.id ) ) )
+			.map( ( thread ) => ( {
+				...thread,
+				// This is an interim status for orphaned comments.
+				status: 'orphaned',
+			} ) );
 
 		const allSortedComments = [
 			...unresolvedSortedComments,

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -99,7 +99,8 @@
 	flex-shrink: 0;
 }
 
-.editor-collab-sidebar-panel__more-reply-separator {
+.editor-collab-sidebar-panel__more-reply-separator,
+.editor-collab-sidebar-panel__status-separator {
 	&::before,
 	&::after {
 		content: "";


### PR DESCRIPTION
## What?
Fixes #72752.

PR adds a visual divider for resolved and orphaned notes (whose related block was deleted or missing).

This is just a proof of concept. We should also consider the accessibility of similar dividers and how they fit into tree navigation - #72958.

## Why?

## How?

## Testing Instructions
1. Open a post with notes.
2. Resolve some notes.
3. Confirm divider is displayed.
4. Delete related block for a note.
5. Confirm another divider is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="280" height="951" alt="CleanShot 2025-11-05 at 10 12 41" src="https://github.com/user-attachments/assets/405c495a-521f-47b6-b4a8-dfd247b536db" />

