### PR TITLE
 Upgrade TypeScript to 5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,7 @@
 				"stylelint-plugin-logical-css": "^1.2.3",
 				"terser": "5.32.0",
 				"terser-webpack-plugin": "5.3.10",
-				"typescript": "5.7.2",
+				"typescript": "5.9.3",
 				"uuid": "9.0.1",
 				"wait-on": "8.0.1",
 				"webdriverio": "8.16.20",
@@ -47943,9 +47943,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
 		"stylelint-plugin-logical-css": "^1.2.3",
 		"terser": "5.32.0",
 		"terser-webpack-plugin": "5.3.10",
-		"typescript": "5.7.2",
+		"typescript": "5.9.3",
 		"uuid": "9.0.1",
 		"wait-on": "8.0.1",
 		"webdriverio": "8.16.20",

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -61,9 +61,13 @@ export default function useFixedWindowList(
 			return;
 		}
 		const scrollContainer = getScrollContainer( elementRef.current );
-		const measureWindow = (
-			/** @type {boolean | undefined} */ initRender
-		) => {
+		/**
+		 *  Measures and sets the window of items to render based on the scroll position
+		 *
+		 * @param {boolean} [initRender] Indicates if this is the initial render
+		 * @return {void}
+		 */
+		const measureWindow = ( initRender ) => {
 			if ( ! scrollContainer ) {
 				return;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- **Upgrade typescript to 5.9.3**
- **Fix type errors**

[TypeScript 5.9 was released in August 2025](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/), let's upgrade.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
CI build should be sufficient.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
