### PR TITLE
DataViews: Add `grid` keyboard navigation

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 - DataViews: Make sticky elements (table headers, footer, actions column) inherit background colors from parent container. This allows DataViews instances to seamlessly adapt to containers with custom background colors. [#73240](https://github.com/WordPress/gutenberg/pull/73240)
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - DataViews: add support for activity layout. [#72780](https://github.com/WordPress/gutenberg/pull/72780)
+- DataViews: Add grid keyboard navigation. [#72997](https://github.com/WordPress/gutenberg/pull/72997)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 - Documentation: improve Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Documentation: surface better the `type` property in the documentation. [#73349](https://github.com/WordPress/gutenberg/pull/73349)

--- a/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
@@ -353,11 +353,7 @@ export default function CompositeGrid< Item >( {
 	return (
 		<Composite
 			role={ isInfiniteScroll ? 'feed' : 'grid' }
-			className={ clsx(
-				'dataviews-view-grid',
-				'dataviews-view-grid__content',
-				className
-			) }
+			className={ clsx( 'dataviews-view-grid', className ) }
 			focusWrap
 			aria-busy={ isLoading }
 			aria-rowcount={ isInfiniteScroll ? undefined : totalRows }

--- a/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
@@ -1,0 +1,443 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import type { ComponentProps, ReactElement } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Flex,
+	FlexItem,
+	Tooltip,
+	Composite,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
+import { isAppleOS } from '@wordpress/keycodes';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import ItemActions from '../../components/dataviews-item-actions';
+import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import DataViewsContext from '../../components/dataviews-context';
+import {
+	useHasAPossibleBulkAction,
+	useSomeItemHasAPossibleBulkAction,
+} from '../../components/dataviews-bulk-actions';
+import type {
+	Action,
+	NormalizedField,
+	ViewGrid as ViewGridType,
+} from '../../types';
+import type { SetSelection } from '../../types/private';
+import { ItemClickWrapper } from '../utils/item-click-wrapper';
+const { Badge } = unlock( componentsPrivateApis );
+import { useGridColumns } from './preview-size-picker';
+
+function chunk< T >( array: T[], size: number ): T[][] {
+	const chunks: T[][] = [];
+	for ( let i = 0, j = array.length; i < j; i += size ) {
+		chunks.push( array.slice( i, i + size ) );
+	}
+	return chunks;
+}
+
+interface GridItemProps< Item > {
+	view: ViewGridType;
+	selection: string[];
+	onChangeSelection: SetSelection;
+	getItemId: ( item: Item ) => string;
+	onClickItem?: ( item: Item ) => void;
+	renderItemLink?: (
+		props: {
+			item: Item;
+		} & ComponentProps< 'a' >
+	) => ReactElement;
+	isItemClickable: ( item: Item ) => boolean;
+	item: Item;
+	actions: Action< Item >[];
+	titleField?: NormalizedField< Item >;
+	mediaField?: NormalizedField< Item >;
+	descriptionField?: NormalizedField< Item >;
+	regularFields: NormalizedField< Item >[];
+	badgeFields: NormalizedField< Item >[];
+	hasBulkActions: boolean;
+	config: {
+		sizes: string;
+	};
+}
+
+function GridItem< Item >( {
+	view,
+	selection,
+	onChangeSelection,
+	onClickItem,
+	isItemClickable,
+	renderItemLink,
+	getItemId,
+	item,
+	actions,
+	mediaField,
+	titleField,
+	descriptionField,
+	regularFields,
+	badgeFields,
+	hasBulkActions,
+	config,
+}: GridItemProps< Item > ) {
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
+	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
+	const id = getItemId( item );
+	const instanceId = useInstanceId( GridItem );
+	const isSelected = selection.includes( id );
+	const renderedMediaField = mediaField?.render ? (
+		<mediaField.render
+			item={ item }
+			field={ mediaField }
+			config={ config }
+		/>
+	) : null;
+	const renderedTitleField =
+		showTitle && titleField?.render ? (
+			<titleField.render item={ item } field={ titleField } />
+		) : null;
+	const shouldRenderMedia = showMedia && renderedMediaField;
+
+	let mediaA11yProps;
+	let titleA11yProps;
+	if ( isItemClickable( item ) && onClickItem ) {
+		if ( renderedTitleField ) {
+			mediaA11yProps = {
+				'aria-labelledby': `dataviews-view-grid__title-field-${ instanceId }`,
+			};
+			titleA11yProps = {
+				id: `dataviews-view-grid__title-field-${ instanceId }`,
+			};
+		} else {
+			mediaA11yProps = {
+				'aria-label': __( 'Navigate to item' ),
+			};
+		}
+	}
+	return (
+		<VStack
+			spacing={ 0 }
+			key={ id }
+			className={ clsx( 'dataviews-view-grid__card', {
+				'is-selected': hasBulkAction && isSelected,
+			} ) }
+			onClickCapture={ ( event ) => {
+				if ( isAppleOS() ? event.metaKey : event.ctrlKey ) {
+					event.stopPropagation();
+					event.preventDefault();
+					if ( ! hasBulkAction ) {
+						return;
+					}
+					onChangeSelection(
+						selection.includes( id )
+							? selection.filter( ( itemId ) => id !== itemId )
+							: [ ...selection, id ]
+					);
+				}
+			} }
+		>
+			{ shouldRenderMedia && (
+				<ItemClickWrapper
+					item={ item }
+					isItemClickable={ isItemClickable }
+					onClickItem={ onClickItem }
+					renderItemLink={ renderItemLink }
+					className="dataviews-view-grid__media"
+					{ ...mediaA11yProps }
+				>
+					{ renderedMediaField }
+				</ItemClickWrapper>
+			) }
+			{ hasBulkActions && shouldRenderMedia && (
+				<DataViewsSelectionCheckbox
+					item={ item }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					getItemId={ getItemId }
+					titleField={ titleField }
+					disabled={ ! hasBulkAction }
+				/>
+			) }
+			{ ! showTitle && shouldRenderMedia && !! actions?.length && (
+				<div className="dataviews-view-grid__media-actions">
+					<ItemActions item={ item } actions={ actions } isCompact />
+				</div>
+			) }
+			{ showTitle && (
+				<HStack
+					justify="space-between"
+					className="dataviews-view-grid__title-actions"
+				>
+					<ItemClickWrapper
+						item={ item }
+						isItemClickable={ isItemClickable }
+						onClickItem={ onClickItem }
+						renderItemLink={ renderItemLink }
+						className="dataviews-view-grid__title-field dataviews-title-field"
+						{ ...titleA11yProps }
+					>
+						{ renderedTitleField }
+					</ItemClickWrapper>
+					{ !! actions?.length && (
+						<ItemActions
+							item={ item }
+							actions={ actions }
+							isCompact
+						/>
+					) }
+				</HStack>
+			) }
+			<VStack spacing={ 1 }>
+				{ showDescription && descriptionField?.render && (
+					<descriptionField.render
+						item={ item }
+						field={ descriptionField }
+					/>
+				) }
+				{ !! badgeFields?.length && (
+					<HStack
+						className="dataviews-view-grid__badge-fields"
+						spacing={ 2 }
+						wrap
+						alignment="top"
+						justify="flex-start"
+					>
+						{ badgeFields.map( ( field ) => {
+							return (
+								<Badge
+									key={ field.id }
+									className="dataviews-view-grid__field-value"
+								>
+									<field.render
+										item={ item }
+										field={ field }
+									/>
+								</Badge>
+							);
+						} ) }
+					</HStack>
+				) }
+				{ !! regularFields?.length && (
+					<VStack
+						className="dataviews-view-grid__fields"
+						spacing={ 1 }
+					>
+						{ regularFields.map( ( field ) => {
+							return (
+								<Flex
+									className="dataviews-view-grid__field"
+									key={ field.id }
+									gap={ 1 }
+									justify="flex-start"
+									expanded
+									style={ { height: 'auto' } }
+									direction="row"
+								>
+									<>
+										<Tooltip text={ field.label }>
+											<FlexItem className="dataviews-view-grid__field-name">
+												{ field.header }
+											</FlexItem>
+										</Tooltip>
+										<FlexItem
+											className="dataviews-view-grid__field-value"
+											style={ { maxHeight: 'none' } }
+										>
+											<field.render
+												item={ item }
+												field={ field }
+											/>
+										</FlexItem>
+									</>
+								</Flex>
+							);
+						} ) }
+					</VStack>
+				) }
+			</VStack>
+		</VStack>
+	);
+}
+
+interface CompositeGridProps< Item > {
+	data: Item[];
+	isInfiniteScroll: boolean;
+	className?: string;
+	isLoading?: boolean;
+	view: ViewGridType;
+	fields: NormalizedField< Item >[];
+	selection: string[];
+	onChangeSelection: SetSelection;
+	onClickItem?: ( item: Item ) => void;
+	isItemClickable: ( item: Item ) => boolean;
+	renderItemLink?: (
+		props: {
+			item: Item;
+		} & ComponentProps< 'a' >
+	) => ReactElement;
+	getItemId: ( item: Item ) => string;
+	actions: Action< Item >[];
+}
+
+export default function CompositeGrid< Item >( {
+	data,
+	isInfiniteScroll,
+	className,
+	isLoading,
+	view,
+	fields,
+	selection,
+	onChangeSelection,
+	onClickItem,
+	isItemClickable,
+	renderItemLink,
+	getItemId,
+	actions,
+}: CompositeGridProps< Item > ) {
+	const { paginationInfo, resizeObserverRef } =
+		useContext( DataViewsContext );
+	const gridColumns = useGridColumns();
+	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
+	const titleField = fields.find(
+		( field ) => field.id === view?.titleField
+	);
+	const mediaField = fields.find(
+		( field ) => field.id === view?.mediaField
+	);
+	const descriptionField = fields.find(
+		( field ) => field.id === view?.descriptionField
+	);
+	const otherFields = view.fields ?? [];
+	const { regularFields, badgeFields } = otherFields.reduce(
+		(
+			accumulator: Record< string, NormalizedField< Item >[] >,
+			fieldId
+		) => {
+			const field = fields.find( ( f ) => f.id === fieldId );
+			if ( ! field ) {
+				return accumulator;
+			}
+			// If the field is a badge field, add it to the badgeFields array
+			// otherwise add it to the rest visibleFields array.
+			const key = view.layout?.badgeFields?.includes( fieldId )
+				? 'badgeFields'
+				: 'regularFields';
+			accumulator[ key ].push( field );
+			return accumulator;
+		},
+		{ regularFields: [], badgeFields: [] }
+	);
+
+	/*
+	 * This is the maximum width that an image can achieve in the grid. The reasoning is:
+	 * The biggest min image width available is 430px (see /dataviews-layouts/grid/preview-size-picker.tsx).
+	 * Because the grid is responsive, once there is room for another column, the images shrink to accommodate it.
+	 * So each image will never grow past 2*430px plus a little more to account for the gaps.
+	 */
+	const size = '900px';
+	const totalRows = Math.ceil( data.length / gridColumns );
+
+	return (
+		<Composite
+			role={ isInfiniteScroll ? 'feed' : 'grid' }
+			className={ clsx(
+				'dataviews-view-grid',
+				'dataviews-view-grid__content',
+				className
+			) }
+			focusWrap
+			aria-busy={ isLoading }
+			aria-rowcount={ isInfiniteScroll ? undefined : totalRows }
+			ref={ resizeObserverRef }
+		>
+			{ chunk( data, gridColumns ).map( ( row, i ) => (
+				<Composite.Row
+					key={ i }
+					render={
+						<div
+							role="row"
+							aria-rowindex={ i + 1 }
+							aria-label={ sprintf(
+								/* translators: %d: The row number in the grid */
+								__( 'Row %d' ),
+								i + 1
+							) }
+							className="dataviews-view-grid__row"
+							style={ {
+								gridTemplateColumns: `repeat( ${ gridColumns }, minmax(0, 1fr) )`,
+							} }
+						/>
+					}
+				>
+					{ row.map( ( item, indexInRow ) => {
+						const index = i * gridColumns + indexInRow;
+						return (
+							<Composite.Item
+								key={ getItemId( item ) }
+								render={
+									<div
+										id={ getItemId( item ) }
+										className="dataviews-view-grid__row__gridcell"
+										role={
+											isInfiniteScroll
+												? 'article'
+												: 'gridcell'
+										}
+										aria-setsize={
+											isInfiniteScroll
+												? paginationInfo.totalItems
+												: undefined
+										}
+										aria-posinset={
+											isInfiniteScroll
+												? index + 1
+												: undefined
+										}
+									>
+										<GridItem
+											view={ view }
+											selection={ selection }
+											onChangeSelection={
+												onChangeSelection
+											}
+											onClickItem={ onClickItem }
+											isItemClickable={ isItemClickable }
+											renderItemLink={ renderItemLink }
+											getItemId={ getItemId }
+											item={ item }
+											actions={ actions }
+											mediaField={ mediaField }
+											titleField={ titleField }
+											descriptionField={
+												descriptionField
+											}
+											regularFields={ regularFields }
+											badgeFields={ badgeFields }
+											hasBulkActions={ hasBulkActions }
+											config={ {
+												sizes: size,
+											} }
+										/>
+									</div>
+								}
+							/>
+						);
+					} ) }
+				</Composite.Row>
+			) ) }
+		</Composite>
+	);
+}

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -2,283 +2,19 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { ComponentProps, ReactElement } from 'react';
 
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Spinner,
-	Flex,
-	FlexItem,
-	Tooltip,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
-import { isAppleOS } from '@wordpress/keycodes';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
-import ItemActions from '../../components/dataviews-item-actions';
-import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
-import DataViewsContext from '../../components/dataviews-context';
-import {
-	useHasAPossibleBulkAction,
-	useSomeItemHasAPossibleBulkAction,
-} from '../../components/dataviews-bulk-actions';
-import type {
-	Action,
-	NormalizedField,
-	ViewGrid as ViewGridType,
-	ViewGridProps,
-} from '../../types';
-import type { SetSelection } from '../../types/private';
-import { ItemClickWrapper } from '../utils/item-click-wrapper';
-import { GridItems } from '../utils/grid-items';
-const { Badge } = unlock( componentsPrivateApis );
+import type { ViewGridProps } from '../../types';
 import getDataByGroup from '../utils/get-data-by-group';
-
-interface GridItemProps< Item > {
-	view: ViewGridType;
-	selection: string[];
-	onChangeSelection: SetSelection;
-	getItemId: ( item: Item ) => string;
-	onClickItem?: ( item: Item ) => void;
-	renderItemLink?: (
-		props: {
-			item: Item;
-		} & ComponentProps< 'a' >
-	) => ReactElement;
-	isItemClickable: ( item: Item ) => boolean;
-	item: Item;
-	actions: Action< Item >[];
-	titleField?: NormalizedField< Item >;
-	mediaField?: NormalizedField< Item >;
-	descriptionField?: NormalizedField< Item >;
-	regularFields: NormalizedField< Item >[];
-	badgeFields: NormalizedField< Item >[];
-	hasBulkActions: boolean;
-	config: {
-		sizes: string;
-	};
-	posinset?: number;
-}
-
-function GridItem< Item >( {
-	view,
-	selection,
-	onChangeSelection,
-	onClickItem,
-	isItemClickable,
-	renderItemLink,
-	getItemId,
-	item,
-	actions,
-	mediaField,
-	titleField,
-	descriptionField,
-	regularFields,
-	badgeFields,
-	hasBulkActions,
-	config,
-	posinset,
-}: GridItemProps< Item > ) {
-	const {
-		showTitle = true,
-		showMedia = true,
-		showDescription = true,
-		infiniteScrollEnabled,
-	} = view;
-	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
-	const id = getItemId( item );
-	const instanceId = useInstanceId( GridItem );
-	const isSelected = selection.includes( id );
-	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render
-			item={ item }
-			field={ mediaField }
-			config={ config }
-		/>
-	) : null;
-	const renderedTitleField =
-		showTitle && titleField?.render ? (
-			<titleField.render item={ item } field={ titleField } />
-		) : null;
-	const shouldRenderMedia = showMedia && renderedMediaField;
-
-	let mediaA11yProps;
-	let titleA11yProps;
-	if ( isItemClickable( item ) && onClickItem ) {
-		if ( renderedTitleField ) {
-			mediaA11yProps = {
-				'aria-labelledby': `dataviews-view-grid__title-field-${ instanceId }`,
-			};
-			titleA11yProps = {
-				id: `dataviews-view-grid__title-field-${ instanceId }`,
-			};
-		} else {
-			mediaA11yProps = {
-				'aria-label': __( 'Navigate to item' ),
-			};
-		}
-	}
-	const { paginationInfo } = useContext( DataViewsContext );
-
-	return (
-		<VStack
-			spacing={ 0 }
-			key={ id }
-			className={ clsx( 'dataviews-view-grid__card', {
-				'is-selected': hasBulkAction && isSelected,
-			} ) }
-			onClickCapture={ ( event ) => {
-				if ( isAppleOS() ? event.metaKey : event.ctrlKey ) {
-					event.stopPropagation();
-					event.preventDefault();
-					if ( ! hasBulkAction ) {
-						return;
-					}
-					onChangeSelection(
-						selection.includes( id )
-							? selection.filter( ( itemId ) => id !== itemId )
-							: [ ...selection, id ]
-					);
-				}
-			} }
-			role={ infiniteScrollEnabled ? 'article' : undefined }
-			aria-setsize={
-				infiniteScrollEnabled ? paginationInfo.totalItems : undefined
-			}
-			aria-posinset={ posinset }
-		>
-			{ shouldRenderMedia && (
-				<ItemClickWrapper
-					item={ item }
-					isItemClickable={ isItemClickable }
-					onClickItem={ onClickItem }
-					renderItemLink={ renderItemLink }
-					className="dataviews-view-grid__media"
-					{ ...mediaA11yProps }
-				>
-					{ renderedMediaField }
-				</ItemClickWrapper>
-			) }
-			{ hasBulkActions && shouldRenderMedia && (
-				<DataViewsSelectionCheckbox
-					item={ item }
-					selection={ selection }
-					onChangeSelection={ onChangeSelection }
-					getItemId={ getItemId }
-					titleField={ titleField }
-					disabled={ ! hasBulkAction }
-				/>
-			) }
-			{ ! showTitle && shouldRenderMedia && !! actions?.length && (
-				<div className="dataviews-view-grid__media-actions">
-					<ItemActions item={ item } actions={ actions } isCompact />
-				</div>
-			) }
-			{ showTitle && (
-				<HStack
-					justify="space-between"
-					className="dataviews-view-grid__title-actions"
-				>
-					<ItemClickWrapper
-						item={ item }
-						isItemClickable={ isItemClickable }
-						onClickItem={ onClickItem }
-						renderItemLink={ renderItemLink }
-						className="dataviews-view-grid__title-field dataviews-title-field"
-						{ ...titleA11yProps }
-					>
-						{ renderedTitleField }
-					</ItemClickWrapper>
-					{ !! actions?.length && (
-						<ItemActions
-							item={ item }
-							actions={ actions }
-							isCompact
-						/>
-					) }
-				</HStack>
-			) }
-			<VStack spacing={ 1 }>
-				{ showDescription && descriptionField?.render && (
-					<descriptionField.render
-						item={ item }
-						field={ descriptionField }
-					/>
-				) }
-				{ !! badgeFields?.length && (
-					<HStack
-						className="dataviews-view-grid__badge-fields"
-						spacing={ 2 }
-						wrap
-						alignment="top"
-						justify="flex-start"
-					>
-						{ badgeFields.map( ( field ) => {
-							return (
-								<Badge
-									key={ field.id }
-									className="dataviews-view-grid__field-value"
-								>
-									<field.render
-										item={ item }
-										field={ field }
-									/>
-								</Badge>
-							);
-						} ) }
-					</HStack>
-				) }
-				{ !! regularFields?.length && (
-					<VStack
-						className="dataviews-view-grid__fields"
-						spacing={ 1 }
-					>
-						{ regularFields.map( ( field ) => {
-							return (
-								<Flex
-									className="dataviews-view-grid__field"
-									key={ field.id }
-									gap={ 1 }
-									justify="flex-start"
-									expanded
-									style={ { height: 'auto' } }
-									direction="row"
-								>
-									<>
-										<Tooltip text={ field.label }>
-											<FlexItem className="dataviews-view-grid__field-name">
-												{ field.header }
-											</FlexItem>
-										</Tooltip>
-										<FlexItem
-											className="dataviews-view-grid__field-value"
-											style={ { maxHeight: 'none' } }
-										>
-											<field.render
-												item={ item }
-												field={ field }
-											/>
-										</FlexItem>
-									</>
-								</Flex>
-							);
-						} ) }
-					</VStack>
-				) }
-			</VStack>
-		</VStack>
-	);
-}
+import CompositeGrid from './composite-grid';
 
 function ViewGrid< Item >( {
 	actions,
@@ -295,53 +31,25 @@ function ViewGrid< Item >( {
 	className,
 	empty,
 }: ViewGridProps< Item > ) {
-	const { resizeObserverRef } = useContext( DataViewsContext );
-	const titleField = fields.find(
-		( field ) => field.id === view?.titleField
-	);
-	const mediaField = fields.find(
-		( field ) => field.id === view?.mediaField
-	);
-	const descriptionField = fields.find(
-		( field ) => field.id === view?.descriptionField
-	);
-	const otherFields = view.fields ?? [];
-	const { regularFields, badgeFields } = otherFields.reduce(
-		(
-			accumulator: Record< string, NormalizedField< Item >[] >,
-			fieldId
-		) => {
-			const field = fields.find( ( f ) => f.id === fieldId );
-			if ( ! field ) {
-				return accumulator;
-			}
-			// If the field is a badge field, add it to the badgeFields array
-			// otherwise add it to the rest visibleFields array.
-			const key = view.layout?.badgeFields?.includes( fieldId )
-				? 'badgeFields'
-				: 'regularFields';
-			accumulator[ key ].push( field );
-			return accumulator;
-		},
-		{ regularFields: [], badgeFields: [] }
-	);
 	const hasData = !! data?.length;
-	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
-	const usedPreviewSize = view.layout?.previewSize;
-	/*
-	 * This is the maximum width that an image can achieve in the grid. The reasoning is:
-	 * The biggest min image width available is 430px (see /dataviews-layouts/grid/preview-size-picker.tsx).
-	 * Because the grid is responsive, once there is room for another column, the images shrink to accommodate it.
-	 * So each image will never grow past 2*430px plus a little more to account for the gaps.
-	 */
-	const size = '900px';
-
 	const groupField = view.groupBy?.field
 		? fields.find( ( f ) => f.id === view.groupBy?.field )
 		: null;
 	const dataByGroup = groupField ? getDataByGroup( data, groupField ) : null;
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
-
+	const gridProps = {
+		className,
+		isLoading,
+		view,
+		fields,
+		selection,
+		onChangeSelection,
+		onClickItem,
+		isItemClickable,
+		renderItemLink,
+		getItemId,
+		actions,
+	};
 	return (
 		<>
 			{
@@ -359,99 +67,25 @@ function ViewGrid< Item >( {
 											groupName
 										) }
 									</h3>
-									<GridItems
-										className={ clsx(
-											'dataviews-view-grid',
-											className
-										) }
-										previewSize={ usedPreviewSize }
-										aria-busy={ isLoading }
-										ref={ resizeObserverRef }
-									>
-										{ groupItems.map( ( item ) => {
-											return (
-												<GridItem
-													key={ getItemId( item ) }
-													view={ view }
-													selection={ selection }
-													onChangeSelection={
-														onChangeSelection
-													}
-													onClickItem={ onClickItem }
-													isItemClickable={
-														isItemClickable
-													}
-													renderItemLink={
-														renderItemLink
-													}
-													getItemId={ getItemId }
-													item={ item }
-													actions={ actions }
-													mediaField={ mediaField }
-													titleField={ titleField }
-													descriptionField={
-														descriptionField
-													}
-													regularFields={
-														regularFields
-													}
-													badgeFields={ badgeFields }
-													hasBulkActions={
-														hasBulkActions
-													}
-													config={ {
-														sizes: size,
-													} }
-												/>
-											);
-										} ) }
-									</GridItems>
+									<CompositeGrid
+										{ ...gridProps }
+										data={ groupItems }
+										isInfiniteScroll={ false }
+									/>
 								</VStack>
 							)
 						) }
 					</VStack>
 				)
 			}
-
 			{
 				// Render a single grid with all data.
 				hasData && ! dataByGroup && (
-					<GridItems
-						className={ clsx( 'dataviews-view-grid', className ) }
-						previewSize={ usedPreviewSize }
-						aria-busy={ isLoading }
-						ref={ resizeObserverRef }
-						role={ isInfiniteScroll ? 'feed' : undefined }
-					>
-						{ data.map( ( item, index ) => {
-							return (
-								<GridItem
-									key={ getItemId( item ) }
-									view={ view }
-									selection={ selection }
-									onChangeSelection={ onChangeSelection }
-									onClickItem={ onClickItem }
-									isItemClickable={ isItemClickable }
-									renderItemLink={ renderItemLink }
-									getItemId={ getItemId }
-									item={ item }
-									actions={ actions }
-									mediaField={ mediaField }
-									titleField={ titleField }
-									descriptionField={ descriptionField }
-									regularFields={ regularFields }
-									badgeFields={ badgeFields }
-									hasBulkActions={ hasBulkActions }
-									config={ {
-										sizes: size,
-									} }
-									posinset={
-										isInfiniteScroll ? index + 1 : undefined
-									}
-								/>
-							);
-						} ) }
-					</GridItems>
+					<CompositeGrid
+						{ ...gridProps }
+						data={ data }
+						isInfiniteScroll={ !! isInfiniteScroll }
+					/>
 				)
 			}
 			{

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,6 +37,25 @@ const imageSizes = [
 		breakpoint: 588, // at minimum image width, 2 images display at this container size
 	},
 ];
+
+/**
+ * Calculate the number of grid columns based on container width and preview size.
+ * This matches how CSS grid auto-fill works: repeat(auto-fill, minmax(previewSize, 1fr)).
+ */
+export function useGridColumns() {
+	const context = useContext( DataViewsContext );
+	const view = context.view as ViewGrid;
+	return useMemo( () => {
+		const containerWidth = context.containerWidth;
+		const gap = 32; // This is the value of the grid gap in CSS.
+		// Default to the third smallest size if no preview size is set.
+		const previewSize = view.layout?.previewSize ?? 230;
+		const columns = Math.floor(
+			( containerWidth + gap ) / ( previewSize + gap )
+		);
+		return Math.max( 1, columns ); // Ensure at least 1 column.
+	}, [ context.containerWidth, view.layout?.previewSize ] );
+}
 
 export default function PreviewSizePicker() {
 	const context = useContext( DataViewsContext );

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -38,6 +38,9 @@ const imageSizes = [
 	},
 ];
 
+// Default preview size is the third smallest image size if no preview size is set.
+const DEFAULT_PREVIEW_SIZE = imageSizes[ 2 ].value;
+
 /**
  * Calculate the number of grid columns based on container width and preview size.
  * This matches how CSS grid auto-fill works: repeat(auto-fill, minmax(previewSize, 1fr)).
@@ -48,8 +51,7 @@ export function useGridColumns() {
 	return useMemo( () => {
 		const containerWidth = context.containerWidth;
 		const gap = 32; // This is the value of the grid gap in CSS.
-		// Default to the third smallest size if no preview size is set.
-		const previewSize = view.layout?.previewSize ?? 230;
+		const previewSize = view.layout?.previewSize ?? DEFAULT_PREVIEW_SIZE;
 		const columns = Math.floor(
 			( containerWidth + gap ) / ( previewSize + gap )
 		);
@@ -65,7 +67,7 @@ export default function PreviewSizePicker() {
 		return context.containerWidth >= size.breakpoint;
 	} );
 
-	const layoutPreviewSize = view.layout?.previewSize ?? 230; // Default to the third smallest size if no preview size is set.
+	const layoutPreviewSize = view.layout?.previewSize ?? DEFAULT_PREVIEW_SIZE;
 	// If the container has resized and the set preview size is no longer available,
 	// we reset it to the next smallest size, or the smallest available size.
 	const previewSizeToUse =

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -28,6 +28,7 @@
 			.dataviews-view-grid__row__gridcell {
 				outline: 0;
 				outline-style: solid;
+				border-radius: $radius-medium;
 
 				&[data-focus-visible] {
 					outline-color: var(--wp-admin-theme-color);

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -5,44 +5,42 @@
 @use "../utils/grid-items.scss" as *;
 
 .dataviews-view-grid {
-	&.dataviews-view-grid__content {
-		padding: 0 $grid-unit-60 $grid-unit-30;
-		display: flex;
-		flex-direction: column;
+	padding: 0 $grid-unit-60 $grid-unit-30;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-40;
+	container-type: inline-size;
+
+	@media not (prefers-reduced-motion) {
+		transition: padding ease-out 0.1s;
+	}
+
+	@container (max-width: 430px) {
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
+	}
+
+	.dataviews-view-grid__row {
+		display: grid;
 		gap: $grid-unit-40;
-		container-type: inline-size;
 
-		@media not (prefers-reduced-motion) {
-			transition: padding ease-out 0.1s;
-		}
+		.dataviews-view-grid__row__gridcell {
+			border-radius: $radius-medium;
+			position: relative;
 
-		@container (max-width: 430px) {
-			padding-left: $grid-unit-30;
-			padding-right: $grid-unit-30;
-		}
-
-		.dataviews-view-grid__row {
-			display: grid;
-			gap: $grid-unit-40;
-
-			.dataviews-view-grid__row__gridcell {
+			&[data-focus-visible]::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 				border-radius: $radius-medium;
-				position: relative;
+				pointer-events: none;
 
-				&[data-focus-visible]::after {
-					content: "";
-					position: absolute;
-					top: 0;
-					left: 0;
-					width: 100%;
-					height: 100%;
-					box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-					border-radius: $radius-medium;
-					pointer-events: none;
-
-					// Windows High Contrast mode will show this outline, but not the box-shadow.
-					outline: 2px solid transparent;
-				}
+				// Windows High Contrast mode will show this outline, but not the box-shadow.
+				outline: 2px solid transparent;
 			}
 		}
 	}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -39,6 +39,9 @@
 					box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 					border-radius: $radius-medium;
 					pointer-events: none;
+
+					// Windows High Contrast mode will show this outline, but not the box-shadow.
+					outline: 2px solid transparent;
 				}
 			}
 		}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -26,13 +26,19 @@
 			gap: $grid-unit-40;
 
 			.dataviews-view-grid__row__gridcell {
-				outline: 0;
-				outline-style: solid;
 				border-radius: $radius-medium;
+				position: relative;
 
-				&[data-focus-visible] {
-					outline-color: var(--wp-admin-theme-color);
-					outline-width: var(--wp-admin-border-width-focus);
+				&[data-focus-visible]::after {
+					content: "";
+					position: absolute;
+					top: 0;
+					left: 0;
+					width: 100%;
+					height: 100%;
+					box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+					border-radius: $radius-medium;
+					pointer-events: none;
 				}
 			}
 		}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -5,6 +5,38 @@
 @use "../utils/grid-items.scss" as *;
 
 .dataviews-view-grid {
+	&.dataviews-view-grid__content {
+		padding: 0 $grid-unit-60 $grid-unit-30;
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-40;
+		container-type: inline-size;
+
+		@media not (prefers-reduced-motion) {
+			transition: padding ease-out 0.1s;
+		}
+
+		@container (max-width: 430px) {
+			padding-left: $grid-unit-30;
+			padding-right: $grid-unit-30;
+		}
+
+		.dataviews-view-grid__row {
+			display: grid;
+			gap: $grid-unit-40;
+
+			.dataviews-view-grid__row__gridcell {
+				outline: 0;
+				outline-style: solid;
+
+				&[data-focus-visible] {
+					outline-color: var(--wp-admin-theme-color);
+					outline-width: var(--wp-admin-border-width-focus);
+				}
+			}
+		}
+	}
+
 	.dataviews-view-grid__card {
 		height: 100%;
 		justify-content: flex-start;

--- a/packages/dataviews/src/test/dataviews.tsx
+++ b/packages/dataviews/src/test/dataviews.tsx
@@ -539,6 +539,7 @@ describe( 'DataViews component', () => {
 			await user.click( viewOptionsButton );
 
 			await user.tab();
+			await user.tab();
 
 			expect(
 				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
@@ -582,6 +583,7 @@ describe( 'DataViews component', () => {
 			// instead of a direct .focus() so that effects have time to complete.
 			await user.click( viewOptionsButton );
 			await user.click( viewOptionsButton );
+			await user.tab();
 			await user.tab();
 
 			expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This PR revives this old one: https://github.com/WordPress/gutenberg/pull/68225 for adding keyboard navigation to DataViews `grid` layout. It applies the a11y feedback from the previous one, which seemed to be really close to landing.

I opened a new one, because code had changed significantly in the past year. 

### Notes
Should we have similar navigation to `DataViewsPicker`. Was there specific reasons for having a `listbox` even if it displays a grid? --cc @talldan @tellthemachines 



## Testing Instructions
1. DataViews in `grid` layout should be displayed and work exactly as before. This means the `auto` adjusting of columns and the `Preview size` under view options.
2. Test keyboard navigation by also using screen readers.
3. `Grouped by`  and `Infinite scroll` functionality should work well with the keyboard navigation.
4. You can also test in storybook `npm run storybook:dev`

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7934357a-3fab-4729-b09d-6d0f3a694db8

