### PR TITLE
Field API: add `format` to `date` field type

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
+- Field API: introduce the `displayFormat` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
+
 ## 10.3.0 (2025-11-12)
 
 ### Enhancements
 
-- Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - DataForm: add new details layout. [#72355](https://github.com/WordPress/gutenberg/pull/72355)
 - DatViews list layout: remove link variant from primary actions's button. [#72920](https://github.com/WordPress/gutenberg/pull/72920)
 - DataForm: simplify form normalization. [#72848](https://github.com/WordPress/gutenberg/pull/72848)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 - Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
-- Field API: introduce the `displayFormat` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
+- Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 
 ## 10.3.0 (2025-11-12)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1675,6 +1675,30 @@ Example:
 }
 ```
 
+### `displayFormat`
+
+Display format configuration for fields. Currently supported for date fields. This configuration affects how the field is displayed in the `render` method, the `Edit` control, and filter controls.
+
+-   Type: `object`.
+-   Optional.
+-   Properties:
+    -   `date`: The format string using PHP date format (e.g., 'F j, Y' for 'March 10, 2023'). Optional, defaults to WordPress date format settings.
+    -   `weekStartsOn`: Specifies the first day of the week for calendar controls. One of `'sunday'`, `'monday'`, `'tuesday'`, `'wednesday'`, `'thursday'`, `'friday'`, `'saturday'`. Optional, defaults to WordPress date format settings.
+
+Example:
+
+```js
+{
+	id: 'publishDate',
+	type: 'date',
+	label: 'Publish Date',
+	displayFormat: {
+		date: 'F j, Y',
+		weekStartsOn: 'monday',
+	},
+}
+```
+
 ## Form Field API
 
 ### `id`

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1682,8 +1682,8 @@ Display format configuration for fields. Currently supported for date fields. Th
 -   Type: `object`.
 -   Optional.
 -   Properties:
-    -   `date`: The format string using PHP date format (e.g., 'F j, Y' for 'March 10, 2023'). Optional, defaults to WordPress date format settings.
-    -   `weekStartsOn`: Specifies the first day of the week for calendar controls. One of `'sunday'`, `'monday'`, `'tuesday'`, `'wednesday'`, `'thursday'`, `'friday'`, `'saturday'`. Optional, defaults to WordPress date format settings.
+    -   `date`: The format string using PHP date format (e.g., 'F j, Y' for 'March 10, 2023'). Optional, defaults to WordPress "Date Format" setting.
+    -   `weekStartsOn`: Specifies the first day of the week for calendar controls. One of `'sunday'`, `'monday'`, `'tuesday'`, `'wednesday'`, `'thursday'`, `'friday'`, `'saturday'`. Optional, defaults to WordPress "Week Starts On" setting.
 
 Example:
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1675,7 +1675,7 @@ Example:
 }
 ```
 
-### `displayFormat`
+### `format`
 
 Display format configuration for fields. Currently supported for date fields. This configuration affects how the field is displayed in the `render` method, the `Edit` control, and filter controls.
 
@@ -1692,7 +1692,7 @@ Example:
 	id: 'publishDate',
 	type: 'date',
 	label: 'Publish Date',
-	displayFormat: {
+	format: {
 		date: 'F j, Y',
 		weekStartsOn: 'monday',
 	},

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -19,7 +19,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, createInterpolateElement } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getDate } from '@wordpress/date';
 
 const ENTER = 'Enter';
 const SPACE = ' ';
@@ -503,7 +503,7 @@ export default function Filter( {
 			try {
 				const dateValue = parseDateTime( label );
 				if ( dateValue !== null ) {
-					label = dateI18n( field.format.date, label );
+					label = dateI18n( field.format.date, getDate( label ) );
 				}
 			} catch ( e ) {
 				label = filterInView.value;

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -503,7 +503,7 @@ export default function Filter( {
 			try {
 				const dateValue = parseDateTime( label );
 				if ( dateValue !== null ) {
-					label = dateI18n( field.displayFormat.date, label );
+					label = dateI18n( field.format.date, label );
 				}
 			} catch ( e ) {
 				label = filterInView.value;

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -19,6 +19,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, createInterpolateElement } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
+import { dateI18n } from '@wordpress/date';
 
 const ENTER = 'Enter';
 const SPACE = ' ';
@@ -498,7 +499,16 @@ export default function Filter( {
 		const field = fields.find( ( f ) => f.id === filter.field );
 		let label = filterInView.value;
 
-		if ( field?.type === 'datetime' && typeof label === 'string' ) {
+		if ( field?.type === 'date' && typeof label === 'string' ) {
+			try {
+				const dateValue = parseDateTime( label );
+				if ( dateValue !== null ) {
+					label = dateI18n( field.format, label );
+				}
+			} catch ( e ) {
+				label = filterInView.value;
+			}
+		} else if ( field?.type === 'datetime' && typeof label === 'string' ) {
 			try {
 				const dateValue = parseDateTime( label );
 				if ( dateValue !== null ) {

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -503,7 +503,7 @@ export default function Filter( {
 			try {
 				const dateValue = parseDateTime( label );
 				if ( dateValue !== null ) {
-					label = dateI18n( field.format, label );
+					label = dateI18n( field.displayFormat.date, label );
 				}
 			} catch ( e ) {
 				label = filterInView.value;

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -3,7 +3,7 @@
  */
 import clsx from 'clsx';
 import {
-	format,
+	format as formatDateFns,
 	isValid as isValidDate,
 	subMonths,
 	subDays,
@@ -148,7 +148,9 @@ const formatDate = ( date?: Date | string ): string => {
 	if ( ! date ) {
 		return '';
 	}
-	return typeof date === 'string' ? date : format( date, 'yyyy-MM-dd' );
+	return typeof date === 'string'
+		? date
+		: formatDateFns( date, 'yyyy-MM-dd' );
 };
 
 function ValidatedDateControl< Item >( {
@@ -258,15 +260,14 @@ function CalendarDateControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, type, label, setValue, getValue, isValid, displayFormat } =
-		field;
+	const { id, type, label, setValue, getValue, isValid, format } = field;
 	const [ selectedPresetId, setSelectedPresetId ] = useState< string | null >(
 		null
 	);
 
 	let weekStartsOn;
 	if ( type === 'date' ) {
-		weekStartsOn = weekStartsOnToNumber( displayFormat.weekStartsOn );
+		weekStartsOn = weekStartsOnToNumber( format.weekStartsOn );
 	}
 
 	const fieldValue = getValue( { item: data } );
@@ -288,7 +289,7 @@ function CalendarDateControl< Item >( {
 	const onSelectDate = useCallback(
 		( newDate: Date | undefined | null ) => {
 			const dateValue = newDate
-				? format( newDate, 'yyyy-MM-dd' )
+				? formatDateFns( newDate, 'yyyy-MM-dd' )
 				: undefined;
 			onChangeCallback( dateValue );
 			setSelectedPresetId( null );
@@ -417,7 +418,7 @@ function CalendarDateRangeControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, type, label, getValue, setValue, displayFormat } = field;
+	const { id, type, label, getValue, setValue, format } = field;
 	let value: DateRange;
 	const fieldValue = getValue( { item: data } );
 	if (
@@ -430,7 +431,7 @@ function CalendarDateRangeControl< Item >( {
 
 	let weekStartsOn;
 	if ( type === 'date' ) {
-		weekStartsOn = weekStartsOnToNumber( displayFormat.weekStartsOn );
+		weekStartsOn = weekStartsOnToNumber( format.weekStartsOn );
 	}
 
 	const onChangeCallback = useCallback(

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -51,6 +51,7 @@ import type {
 	NormalizedField,
 } from '../types';
 import getCustomValidity from './utils/get-custom-validity';
+import { weekStartsOnToNumber } from '../utils/week-starts-on';
 
 const { DateCalendar, DateRangeCalendar } = unlock( componentsPrivateApis );
 
@@ -395,7 +396,9 @@ function CalendarDateControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezoneString || undefined }
-						weekStartsOn={ field.displayFormat.weekStartsOn }
+						weekStartsOn={ weekStartsOnToNumber(
+							field.displayFormat.weekStartsOn
+						) }
 					/>
 				</VStack>
 			</BaseControl>
@@ -608,7 +611,9 @@ function CalendarDateRangeControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezone.string || undefined }
-						weekStartsOn={ field.displayFormat.weekStartsOn }
+						weekStartsOn={ weekStartsOnToNumber(
+							field.displayFormat.weekStartsOn
+						) }
 					/>
 				</VStack>
 			</BaseControl>

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -3,7 +3,7 @@
  */
 import clsx from 'clsx';
 import {
-	format as formatDateFns,
+	format,
 	isValid as isValidDate,
 	subMonths,
 	subDays,
@@ -148,9 +148,7 @@ const formatDate = ( date?: Date | string ): string => {
 	if ( ! date ) {
 		return '';
 	}
-	return typeof date === 'string'
-		? date
-		: formatDateFns( date, 'yyyy-MM-dd' );
+	return typeof date === 'string' ? date : format( date, 'yyyy-MM-dd' );
 };
 
 function ValidatedDateControl< Item >( {
@@ -260,14 +258,22 @@ function CalendarDateControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, type, label, setValue, getValue, isValid, format } = field;
+	const {
+		id,
+		type,
+		label,
+		setValue,
+		getValue,
+		isValid,
+		format: fieldFormat,
+	} = field;
 	const [ selectedPresetId, setSelectedPresetId ] = useState< string | null >(
 		null
 	);
 
 	let weekStartsOn;
 	if ( type === 'date' ) {
-		weekStartsOn = weekStartsOnToNumber( format.weekStartsOn );
+		weekStartsOn = weekStartsOnToNumber( fieldFormat.weekStartsOn );
 	}
 
 	const fieldValue = getValue( { item: data } );
@@ -289,7 +295,7 @@ function CalendarDateControl< Item >( {
 	const onSelectDate = useCallback(
 		( newDate: Date | undefined | null ) => {
 			const dateValue = newDate
-				? formatDateFns( newDate, 'yyyy-MM-dd' )
+				? format( newDate, 'yyyy-MM-dd' )
 				: undefined;
 			onChangeCallback( dateValue );
 			setSelectedPresetId( null );
@@ -418,7 +424,7 @@ function CalendarDateRangeControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, type, label, getValue, setValue, format } = field;
+	const { id, type, label, getValue, setValue, format: fieldFormat } = field;
 	let value: DateRange;
 	const fieldValue = getValue( { item: data } );
 	if (
@@ -431,7 +437,7 @@ function CalendarDateRangeControl< Item >( {
 
 	let weekStartsOn;
 	if ( type === 'date' ) {
-		weekStartsOn = weekStartsOnToNumber( format.weekStartsOn );
+		weekStartsOn = weekStartsOnToNumber( fieldFormat.weekStartsOn );
 	}
 
 	const onChangeCallback = useCallback(

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -258,10 +258,16 @@ function CalendarDateControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, label, setValue, getValue, isValid } = field;
+	const { id, type, label, setValue, getValue, isValid, displayFormat } =
+		field;
 	const [ selectedPresetId, setSelectedPresetId ] = useState< string | null >(
 		null
 	);
+
+	let weekStartsOn;
+	if ( type === 'date' ) {
+		weekStartsOn = weekStartsOnToNumber( displayFormat.weekStartsOn );
+	}
 
 	const fieldValue = getValue( { item: data } );
 	const value = typeof fieldValue === 'string' ? fieldValue : undefined;
@@ -396,9 +402,7 @@ function CalendarDateControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezoneString || undefined }
-						weekStartsOn={ weekStartsOnToNumber(
-							field.displayFormat.weekStartsOn
-						) }
+						weekStartsOn={ weekStartsOn }
 					/>
 				</VStack>
 			</BaseControl>
@@ -413,7 +417,7 @@ function CalendarDateRangeControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, label, getValue, setValue } = field;
+	const { id, type, label, getValue, setValue, displayFormat } = field;
 	let value: DateRange;
 	const fieldValue = getValue( { item: data } );
 	if (
@@ -422,6 +426,11 @@ function CalendarDateRangeControl< Item >( {
 		fieldValue.every( ( date ) => typeof date === 'string' )
 	) {
 		value = fieldValue as DateRange;
+	}
+
+	let weekStartsOn;
+	if ( type === 'date' ) {
+		weekStartsOn = weekStartsOnToNumber( displayFormat.weekStartsOn );
 	}
 
 	const onChangeCallback = useCallback(
@@ -611,9 +620,7 @@ function CalendarDateRangeControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezone.string || undefined }
-						weekStartsOn={ weekStartsOnToNumber(
-							field.displayFormat.weekStartsOn
-						) }
+						weekStartsOn={ weekStartsOn }
 					/>
 				</VStack>
 			</BaseControl>

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -320,7 +320,6 @@ function CalendarDateControl< Item >( {
 
 	const {
 		timezone: { string: timezoneString },
-		l10n: { startOfWeek },
 	} = getSettings();
 
 	const displayLabel = isValid?.required
@@ -396,7 +395,7 @@ function CalendarDateControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezoneString || undefined }
-						weekStartsOn={ startOfWeek }
+						weekStartsOn={ field.displayFormat.weekStartsOn }
 					/>
 				</VStack>
 			</BaseControl>
@@ -521,7 +520,7 @@ function CalendarDateRangeControl< Item >( {
 		[ value, updateDateRange ]
 	);
 
-	const { timezone, l10n } = getSettings();
+	const { timezone } = getSettings();
 
 	const displayLabel = field.isValid?.required
 		? `${ label } (${ __( 'Required' ) })`
@@ -609,7 +608,7 @@ function CalendarDateRangeControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timezone.string || undefined }
-						weekStartsOn={ l10n.startOfWeek }
+						weekStartsOn={ field.displayFormat.weekStartsOn }
 					/>
 				</VStack>
 			</BaseControl>

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -48,6 +48,15 @@ export default {
 			return '';
 		}
 
+		// Not all fields have displayFormat, but date fields do.
+		//
+		// At runtime, this method will never be called for non-date fields.
+		// However, the type system does not know this, so we need to check it.
+		// There's an opportunity here to improve the type system.
+		if ( field.type !== 'date' ) {
+			return '';
+		}
+
 		return dateI18n( field.displayFormat.date, value );
 	},
 	enableSorting: true,

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -48,7 +48,7 @@ export default {
 			return '';
 		}
 
-		return dateI18n( field.format, value );
+		return dateI18n( field.displayFormat.date, value );
 	},
 	enableSorting: true,
 	filterBy: {

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -23,9 +23,6 @@ import {
 	OPERATOR_OVER,
 	OPERATOR_BETWEEN,
 } from '../constants';
-
-const getFormattedDate = ( dateToDisplay: string | null ) =>
-	dateI18n( getSettings().formats.date, getDate( dateToDisplay ) );
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	const timeA = new Date( a ).getTime();
@@ -51,7 +48,7 @@ export default {
 			return '';
 		}
 
-		return getFormattedDate( value );
+		return dateI18n( field.format, value );
 	},
 	enableSorting: true,
 	filterBy: {

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -48,7 +48,7 @@ export default {
 			return '';
 		}
 
-		// Not all fields have displayFormat, but date fields do.
+		// Not all fields have format, but date fields do.
 		//
 		// At runtime, this method will never be called for non-date fields.
 		// However, the type system does not know this, so we need to check it.
@@ -57,7 +57,7 @@ export default {
 			return '';
 		}
 
-		return dateI18n( field.displayFormat.date, value );
+		return dateI18n( field.format.date, value );
 	},
 	enableSorting: true,
 	filterBy: {

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getDate } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ export default {
 			return '';
 		}
 
-		return dateI18n( field.format.date, value );
+		return dateI18n( field.format.date, getDate( value ) );
 	},
 	enableSorting: true,
 	filterBy: {

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -832,14 +832,14 @@ export const DateComponent = ( {
 	type,
 	Edit,
 	asyncElements,
-	displayFormatDate,
-	displayFormatWeekStartsOn,
+	formatDate,
+	formatWeekStartsOn,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
-	displayFormatDate?: string;
-	displayFormatWeekStartsOn?:
+	formatDate?: string;
+	formatWeekStartsOn?:
 		| 'sunday'
 		| 'monday'
 		| 'tuesday'
@@ -853,11 +853,8 @@ export const DateComponent = ( {
 			fields
 				.filter( ( field ) => field.type === 'date' )
 				.map( ( field ) => {
-					if (
-						displayFormatDate ||
-						displayFormatWeekStartsOn !== undefined
-					) {
-						const displayFormat: {
+					if ( formatDate || formatWeekStartsOn !== undefined ) {
+						const format: {
 							date?: string;
 							weekStartsOn?:
 								| 'sunday'
@@ -868,21 +865,20 @@ export const DateComponent = ( {
 								| 'friday'
 								| 'saturday';
 						} = {};
-						if ( displayFormatDate ) {
-							displayFormat.date = displayFormatDate;
+						if ( formatDate ) {
+							format.date = formatDate;
 						}
-						if ( displayFormatWeekStartsOn !== undefined ) {
-							displayFormat.weekStartsOn =
-								displayFormatWeekStartsOn;
+						if ( formatWeekStartsOn !== undefined ) {
+							format.weekStartsOn = formatWeekStartsOn;
 						}
 						return {
 							...field,
-							displayFormat,
+							format,
 						};
 					}
 					return field;
 				} ),
-		[ displayFormatDate, displayFormatWeekStartsOn ]
+		[ formatDate, formatWeekStartsOn ]
 	);
 
 	return (
@@ -896,16 +892,16 @@ export const DateComponent = ( {
 };
 DateComponent.storyName = 'date';
 DateComponent.args = {
-	displayFormatDate: '',
-	displayFormatWeekStartsOn: undefined,
+	formatDate: '',
+	formatWeekStartsOn: undefined,
 };
 DateComponent.argTypes = {
-	displayFormatDate: {
+	formatDate: {
 		control: 'text',
 		description:
 			'Custom PHP date format string (e.g., "F j, Y" for "November 6, 2010"). Leave empty to use WordPress default.',
 	},
-	displayFormatWeekStartsOn: {
+	formatWeekStartsOn: {
 		control: 'select',
 		options: {
 			Default: undefined,

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -832,14 +832,19 @@ export const DateComponent = ( {
 	type,
 	Edit,
 	asyncElements,
+	format,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
+	format?: string;
 } ) => {
 	const dateFields = useMemo(
-		() => fields.filter( ( field ) => field.type === 'date' ),
-		[]
+		() =>
+			fields
+				.filter( ( field ) => field.type === 'date' )
+				.map( ( field ) => ( format ? { ...field, format } : field ) ),
+		[ format ]
 	);
 
 	return (
@@ -852,6 +857,16 @@ export const DateComponent = ( {
 	);
 };
 DateComponent.storyName = 'date';
+DateComponent.args = {
+	format: '',
+};
+DateComponent.argTypes = {
+	format: {
+		control: 'text',
+		description:
+			'Custom PHP date format string (e.g., "F j, Y" for "November 6, 2010"). Leave empty to use WordPress default.',
+	},
+};
 
 export const EmailComponent = ( {
 	type,

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -839,7 +839,14 @@ export const DateComponent = ( {
 	Edit: ControlTypes;
 	asyncElements: boolean;
 	displayFormatDate?: string;
-	displayFormatWeekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+	displayFormatWeekStartsOn?:
+		| 'sunday'
+		| 'monday'
+		| 'tuesday'
+		| 'wednesday'
+		| 'thursday'
+		| 'friday'
+		| 'saturday';
 } ) => {
 	const dateFields = useMemo(
 		() =>
@@ -852,7 +859,14 @@ export const DateComponent = ( {
 					) {
 						const displayFormat: {
 							date?: string;
-							weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+							weekStartsOn?:
+								| 'sunday'
+								| 'monday'
+								| 'tuesday'
+								| 'wednesday'
+								| 'thursday'
+								| 'friday'
+								| 'saturday';
 						} = {};
 						if ( displayFormatDate ) {
 							displayFormat.date = displayFormatDate;
@@ -895,13 +909,13 @@ DateComponent.argTypes = {
 		control: 'select',
 		options: {
 			Default: undefined,
-			Sunday: 0,
-			Monday: 1,
-			Tuesday: 2,
-			Wednesday: 3,
-			Thursday: 4,
-			Friday: 5,
-			Saturday: 6,
+			Sunday: 'sunday',
+			Monday: 'monday',
+			Tuesday: 'tuesday',
+			Wednesday: 'wednesday',
+			Thursday: 'thursday',
+			Friday: 'friday',
+			Saturday: 'saturday',
 		},
 		description:
 			'Day that the week starts on. Leave as Default to use WordPress default.',

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -832,19 +832,26 @@ export const DateComponent = ( {
 	type,
 	Edit,
 	asyncElements,
-	format,
+	displayFormatDate,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
-	format?: string;
+	displayFormatDate?: string;
 } ) => {
 	const dateFields = useMemo(
 		() =>
 			fields
 				.filter( ( field ) => field.type === 'date' )
-				.map( ( field ) => ( format ? { ...field, format } : field ) ),
-		[ format ]
+				.map( ( field ) =>
+					displayFormatDate
+						? {
+								...field,
+								displayFormat: { date: displayFormatDate },
+						  }
+						: field
+				),
+		[ displayFormatDate ]
 	);
 
 	return (
@@ -858,10 +865,10 @@ export const DateComponent = ( {
 };
 DateComponent.storyName = 'date';
 DateComponent.args = {
-	format: '',
+	displayFormatDate: '',
 };
 DateComponent.argTypes = {
-	format: {
+	displayFormatDate: {
 		control: 'text',
 		description:
 			'Custom PHP date format string (e.g., "F j, Y" for "November 6, 2010"). Leave empty to use WordPress default.',

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -833,25 +833,42 @@ export const DateComponent = ( {
 	Edit,
 	asyncElements,
 	displayFormatDate,
+	displayFormatWeekStartsOn,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
 	displayFormatDate?: string;
+	displayFormatWeekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 } ) => {
 	const dateFields = useMemo(
 		() =>
 			fields
 				.filter( ( field ) => field.type === 'date' )
-				.map( ( field ) =>
-					displayFormatDate
-						? {
-								...field,
-								displayFormat: { date: displayFormatDate },
-						  }
-						: field
-				),
-		[ displayFormatDate ]
+				.map( ( field ) => {
+					if (
+						displayFormatDate ||
+						displayFormatWeekStartsOn !== undefined
+					) {
+						const displayFormat: {
+							date?: string;
+							weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+						} = {};
+						if ( displayFormatDate ) {
+							displayFormat.date = displayFormatDate;
+						}
+						if ( displayFormatWeekStartsOn !== undefined ) {
+							displayFormat.weekStartsOn =
+								displayFormatWeekStartsOn;
+						}
+						return {
+							...field,
+							displayFormat,
+						};
+					}
+					return field;
+				} ),
+		[ displayFormatDate, displayFormatWeekStartsOn ]
 	);
 
 	return (
@@ -866,12 +883,28 @@ export const DateComponent = ( {
 DateComponent.storyName = 'date';
 DateComponent.args = {
 	displayFormatDate: '',
+	displayFormatWeekStartsOn: undefined,
 };
 DateComponent.argTypes = {
 	displayFormatDate: {
 		control: 'text',
 		description:
 			'Custom PHP date format string (e.g., "F j, Y" for "November 6, 2010"). Leave empty to use WordPress default.',
+	},
+	displayFormatWeekStartsOn: {
+		control: 'select',
+		options: {
+			Default: undefined,
+			Sunday: 0,
+			Monday: 1,
+			Tuesday: 2,
+			Wednesday: 3,
+			Thursday: 4,
+			Friday: 5,
+			Saturday: 6,
+		},
+		description:
+			'Day that the week starts on. Leave as Default to use WordPress default.',
 	},
 };
 

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -348,6 +348,12 @@ describe( 'normalizeFields: default getValue', () => {
 			expect( typeof normalizedFields[ 0 ].displayFormat.date ).toBe(
 				'string'
 			);
+			expect(
+				normalizedFields[ 0 ].displayFormat.weekStartsOn
+			).toBeDefined();
+			expect(
+				typeof normalizedFields[ 0 ].displayFormat.weekStartsOn
+			).toBe( 'number' );
 		} );
 
 		it( 'preserves custom format when provided', () => {
@@ -357,14 +363,18 @@ describe( 'normalizeFields: default getValue', () => {
 					type: 'date',
 					displayFormat: {
 						date: 'F j, Y',
+						weekStartsOn: 1,
 					},
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
 			expect( normalizedFields[ 0 ].displayFormat.date ).toBe( 'F j, Y' );
+			expect( normalizedFields[ 0 ].displayFormat.weekStartsOn ).toBe(
+				1
+			);
 		} );
 
-		it( 'always adds displayFormat.date for all field types', () => {
+		it( 'always adds displayFormat.date and displayFormat.weekStartsOn for all field types', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
@@ -378,6 +388,12 @@ describe( 'normalizeFields: default getValue', () => {
 			const normalizedFields = normalizeFields( fields );
 			expect( normalizedFields[ 0 ].displayFormat.date ).toBeDefined();
 			expect( normalizedFields[ 1 ].displayFormat.date ).toBeDefined();
+			expect(
+				normalizedFields[ 0 ].displayFormat.weekStartsOn
+			).toBeDefined();
+			expect(
+				normalizedFields[ 1 ].displayFormat.weekStartsOn
+			).toBeDefined();
 		} );
 	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -334,7 +334,7 @@ describe( 'normalizeFields: default getValue', () => {
 		} );
 	} );
 
-	describe( 'format normalization', () => {
+	describe( 'displayFormat normalization', () => {
 		it( 'applies default format when not provided for date fields', () => {
 			const fields: Field< {} >[] = [
 				{
@@ -343,8 +343,11 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format ).toBeDefined();
-			expect( typeof normalizedFields[ 0 ].format ).toBe( 'string' );
+			expect( normalizedFields[ 0 ].displayFormat ).toBeDefined();
+			expect( normalizedFields[ 0 ].displayFormat.date ).toBeDefined();
+			expect( typeof normalizedFields[ 0 ].displayFormat.date ).toBe(
+				'string'
+			);
 		} );
 
 		it( 'preserves custom format when provided', () => {
@@ -352,14 +355,16 @@ describe( 'normalizeFields: default getValue', () => {
 				{
 					id: 'publishDate',
 					type: 'date',
-					format: 'F j, Y',
+					displayFormat: {
+						date: 'F j, Y',
+					},
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format ).toBe( 'F j, Y' );
+			expect( normalizedFields[ 0 ].displayFormat.date ).toBe( 'F j, Y' );
 		} );
 
-		it( 'does not add format for non-date field types', () => {
+		it( 'always adds displayFormat.date for all field types', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
@@ -371,8 +376,8 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format ).toBeUndefined();
-			expect( normalizedFields[ 1 ].format ).toBeUndefined();
+			expect( normalizedFields[ 0 ].displayFormat.date ).toBeDefined();
+			expect( normalizedFields[ 1 ].displayFormat.date ).toBeDefined();
 		} );
 	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -353,7 +353,7 @@ describe( 'normalizeFields: default getValue', () => {
 			).toBeDefined();
 			expect(
 				typeof normalizedFields[ 0 ].displayFormat.weekStartsOn
-			).toBe( 'number' );
+			).toBe( 'string' );
 		} );
 
 		it( 'preserves custom format when provided', () => {
@@ -363,14 +363,14 @@ describe( 'normalizeFields: default getValue', () => {
 					type: 'date',
 					displayFormat: {
 						date: 'F j, Y',
-						weekStartsOn: 1,
+						weekStartsOn: 'monday',
 					},
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
 			expect( normalizedFields[ 0 ].displayFormat.date ).toBe( 'F j, Y' );
 			expect( normalizedFields[ 0 ].displayFormat.weekStartsOn ).toBe(
-				1
+				'monday'
 			);
 		} );
 

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -333,4 +333,46 @@ describe( 'normalizeFields: default getValue', () => {
 			} );
 		} );
 	} );
+
+	describe( 'format normalization', () => {
+		it( 'applies default format when not provided for date fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'publishDate',
+					type: 'date',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toBeDefined();
+			expect( typeof normalizedFields[ 0 ].format ).toBe( 'string' );
+		} );
+
+		it( 'preserves custom format when provided', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'publishDate',
+					type: 'date',
+					format: 'F j, Y',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toBe( 'F j, Y' );
+		} );
+
+		it( 'does not add format for non-date field types', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+				},
+				{
+					id: 'count',
+					type: 'integer',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toBeUndefined();
+			expect( normalizedFields[ 1 ].format ).toBeUndefined();
+		} );
+	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -334,7 +334,7 @@ describe( 'normalizeFields: default getValue', () => {
 		} );
 	} );
 
-	describe( 'displayFormat normalization', () => {
+	describe( 'format normalization', () => {
 		it( 'applies default format when not provided for date fields', () => {
 			const fields: Field< {} >[] = [
 				{
@@ -343,17 +343,13 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].displayFormat ).toBeDefined();
-			expect( normalizedFields[ 0 ].displayFormat.date ).toBeDefined();
-			expect( typeof normalizedFields[ 0 ].displayFormat.date ).toBe(
+			expect( normalizedFields[ 0 ].format ).toBeDefined();
+			expect( normalizedFields[ 0 ].format.date ).toBeDefined();
+			expect( typeof normalizedFields[ 0 ].format.date ).toBe( 'string' );
+			expect( normalizedFields[ 0 ].format.weekStartsOn ).toBeDefined();
+			expect( typeof normalizedFields[ 0 ].format.weekStartsOn ).toBe(
 				'string'
 			);
-			expect(
-				normalizedFields[ 0 ].displayFormat.weekStartsOn
-			).toBeDefined();
-			expect(
-				typeof normalizedFields[ 0 ].displayFormat.weekStartsOn
-			).toBe( 'string' );
 		} );
 
 		it( 'preserves custom format when provided', () => {
@@ -361,20 +357,20 @@ describe( 'normalizeFields: default getValue', () => {
 				{
 					id: 'publishDate',
 					type: 'date',
-					displayFormat: {
+					format: {
 						date: 'F j, Y',
 						weekStartsOn: 'monday',
 					},
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].displayFormat.date ).toBe( 'F j, Y' );
-			expect( normalizedFields[ 0 ].displayFormat.weekStartsOn ).toBe(
+			expect( normalizedFields[ 0 ].format.date ).toBe( 'F j, Y' );
+			expect( normalizedFields[ 0 ].format.weekStartsOn ).toBe(
 				'monday'
 			);
 		} );
 
-		it( 'adds empty displayFormat for non-date field types', () => {
+		it( 'adds empty format for non-date field types', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
@@ -386,8 +382,8 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].displayFormat ).toEqual( {} );
-			expect( normalizedFields[ 1 ].displayFormat ).toEqual( {} );
+			expect( normalizedFields[ 0 ].format ).toEqual( {} );
+			expect( normalizedFields[ 1 ].format ).toEqual( {} );
 		} );
 	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -374,7 +374,7 @@ describe( 'normalizeFields: default getValue', () => {
 			);
 		} );
 
-		it( 'always adds displayFormat.date and displayFormat.weekStartsOn for all field types', () => {
+		it( 'adds empty displayFormat for non-date field types', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
@@ -386,14 +386,8 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].displayFormat.date ).toBeDefined();
-			expect( normalizedFields[ 1 ].displayFormat.date ).toBeDefined();
-			expect(
-				normalizedFields[ 0 ].displayFormat.weekStartsOn
-			).toBeDefined();
-			expect(
-				normalizedFields[ 1 ].displayFormat.weekStartsOn
-			).toBeDefined();
+			expect( normalizedFields[ 0 ].displayFormat ).toEqual( {} );
+			expect( normalizedFields[ 1 ].displayFormat ).toEqual( {} );
 		} );
 	} );
 } );

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -319,13 +319,20 @@ export type Field< Item > = {
  * Format for date fields:
  *
  * - date: the format string (e.g., 'F j, Y' for WordPress default format like 'March 10, 2023')
- * - weekStartsOn: to specify the first day of the week (0 is Sunday).
+ * - weekStartsOn: to specify the first day of the week ('sunday', 'monday', etc.).
  *
  * If not provided, defaults to WordPress date format settings.
  */
 type DisplayFormatDate = {
 	date?: string;
-	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+	weekStartsOn?:
+		| 'sunday'
+		| 'monday'
+		| 'tuesday'
+		| 'wednesday'
+		| 'thursday'
+		| 'friday'
+		| 'saturday';
 };
 
 export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -308,6 +308,12 @@ export type Field< Item > = {
 	 * Used for editing operations to update field values.
 	 */
 	setValue?: ( args: { item: Item; value: any } ) => DeepPartial< Item >;
+
+	/**
+	 * Format string for fields of type date.
+	 * If not provided, defaults to WordPress date format settings.
+	 */
+	format?: string;
 };
 
 export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
@@ -324,6 +330,7 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
+	format: string;
 };
 
 /**

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -325,15 +325,17 @@ export type Field< Item > = {
  */
 type FormatDate = {
 	date?: string;
-	weekStartsOn?:
-		| 'sunday'
-		| 'monday'
-		| 'tuesday'
-		| 'wednesday'
-		| 'thursday'
-		| 'friday'
-		| 'saturday';
+	weekStartsOn?: DayString;
 };
+export type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type DayString =
+	| 'sunday'
+	| 'monday'
+	| 'tuesday'
+	| 'wednesday'
+	| 'thursday'
+	| 'friday'
+	| 'saturday';
 
 export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	label: string;

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -335,7 +335,7 @@ type FormatDate = {
 		| 'saturday';
 };
 
-type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
+export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	label: string;
 	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;
@@ -349,21 +349,8 @@ type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
+	format: {} | Required< FormatDate >;
 };
-
-export type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
-	type: 'date';
-	format: Required< FormatDate >;
-};
-
-export type NormalizedFieldGeneric< Item > = NormalizedFieldBase< Item > & {
-	type?: Exclude< FieldType, 'date' >;
-	format: {};
-};
-
-export type NormalizedField< Item > =
-	| NormalizedFieldDate< Item >
-	| NormalizedFieldGeneric< Item >;
 
 /**
  * A collection of dataview fields for a data type.

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -310,10 +310,13 @@ export type Field< Item > = {
 	setValue?: ( args: { item: Item; value: any } ) => DeepPartial< Item >;
 
 	/**
-	 * Format string for fields of type date.
+	 * Display format configuration for fields.
+	 * For date fields, contains a date property with the format string.
 	 * If not provided, defaults to WordPress date format settings.
 	 */
-	format?: string;
+	displayFormat?: {
+		date: string;
+	};
 };
 
 export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
@@ -330,7 +333,9 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
-	format: string;
+	displayFormat: {
+		date: string;
+	};
 };
 
 /**

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -311,12 +311,21 @@ export type Field< Item > = {
 
 	/**
 	 * Display format configuration for fields.
-	 * For date fields, contains a date property with the format string.
-	 * If not provided, defaults to WordPress date format settings.
 	 */
-	displayFormat?: {
-		date: string;
-	};
+	displayFormat?: DisplayFormatDate;
+};
+
+/**
+ * Format for date fields:
+ *
+ * - date: the format string (e.g., 'F j, Y' for WordPress default format like 'March 10, 2023')
+ * - weekStartsOn: to specify the first day of the week (0 is Sunday).
+ *
+ * If not provided, defaults to WordPress date format settings.
+ */
+type DisplayFormatDate = {
+	date?: string;
+	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 };
 
 export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
@@ -333,9 +342,7 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
-	displayFormat: {
-		date: string;
-	};
+	displayFormat: Required< DisplayFormatDate >;
 };
 
 /**

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -312,7 +312,7 @@ export type Field< Item > = {
 	/**
 	 * Display format configuration for fields.
 	 */
-	displayFormat?: DisplayFormatDate;
+	format?: FormatDate;
 };
 
 /**
@@ -323,7 +323,7 @@ export type Field< Item > = {
  *
  * If not provided, defaults to WordPress date format settings.
  */
-type DisplayFormatDate = {
+type FormatDate = {
 	date?: string;
 	weekStartsOn?:
 		| 'sunday'
@@ -353,12 +353,12 @@ type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
 
 export type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
 	type: 'date';
-	displayFormat: Required< DisplayFormatDate >;
+	format: Required< FormatDate >;
 };
 
 export type NormalizedFieldGeneric< Item > = NormalizedFieldBase< Item > & {
 	type?: Exclude< FieldType, 'date' >;
-	displayFormat: {};
+	format: {};
 };
 
 export type NormalizedField< Item > =

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -335,7 +335,7 @@ type DisplayFormatDate = {
 		| 'saturday';
 };
 
-export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
+type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
 	label: string;
 	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;
@@ -349,8 +349,21 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
+};
+
+export type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
+	type: 'date';
 	displayFormat: Required< DisplayFormatDate >;
 };
+
+export type NormalizedFieldGeneric< Item > = NormalizedFieldBase< Item > & {
+	type?: Exclude< FieldType, 'date' >;
+	displayFormat: {};
+};
+
+export type NormalizedField< Item > =
+	| NormalizedFieldDate< Item >
+	| NormalizedFieldGeneric< Item >;
 
 /**
  * A collection of dataview fields for a data type.

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -337,7 +337,7 @@ export type DayString =
 	| 'friday'
 	| 'saturday';
 
-export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
+type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
 	label: string;
 	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;
@@ -351,8 +351,21 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
-	format: {} | Required< FormatDate >;
 };
+
+type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
+	type: 'date';
+	format: Required< FormatDate >;
+};
+
+type NormalizedFieldGeneric< Item > = NormalizedFieldBase< Item > & {
+	type?: Exclude< FieldType, 'date' >;
+	format: {};
+};
+
+export type NormalizedField< Item > =
+	| NormalizedFieldGeneric< Item >
+	| NormalizedFieldDate< Item >;
 
 /**
  * A collection of dataview fields for a data type.

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -231,11 +231,15 @@ export default function normalizeFields< Item >(
 					typeof field.format.date === 'string'
 						? field.format.date
 						: getSettings().formats.date,
-				weekStartsOn: DAYS_OF_WEEK.includes(
-					field.format?.weekStartsOn as DayString
-				)
-					? field?.format?.weekStartsOn
-					: numberToWeekStartsOn( getSettings().l10n.startOfWeek ),
+				weekStartsOn:
+					field.format?.weekStartsOn !== undefined &&
+					DAYS_OF_WEEK.includes(
+						field.format?.weekStartsOn as DayString
+					)
+						? field.format.weekStartsOn
+						: numberToWeekStartsOn(
+								getSettings().l10n.startOfWeek
+						  ),
 			};
 
 			return {

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -189,24 +189,22 @@ export default function normalizeFields< Item >(
 
 		const filterBy = getFilterBy( field, fieldTypeDefinition );
 
-		let format = {};
-		if ( field.type === 'date' ) {
-			format = {
-				date:
-					field.format?.date !== undefined &&
-					typeof field.format.date === 'string'
-						? field.format.date
-						: getSettings().formats.date,
-				weekStartsOn: DAYS_OF_WEEK.includes(
-					field.format?.weekStartsOn as DayString
-				)
-					? field?.format?.weekStartsOn
-					: numberToWeekStartsOn( getSettings().l10n.startOfWeek ),
-			};
-		}
+		/**
+		 * NormalizedField is a discriminated union type: the shape of the format property
+		 * depends on the type property. For example, for the 'date' type, the format
+		 * contains date or weekStartsOn — which are not valid for other types.
+		 *
+		 * Being type and format interdependent, we need to write the code
+		 * in a way that TypeScript is able to statically infer the types.
+		 * That's why we have a return branch for every item in the union type.
+		 *
+		 * See a longer explanation with examples at
+		 * https://github.com/WordPress/gutenberg/pull/72999#discussion_r2523145453
+		 */
+		const { type, ...fieldWithoutType } = field;
 
-		return {
-			...field,
+		const baseField = {
+			...fieldWithoutType,
 			label: field.label || field.id,
 			header: field.header || field.label || field.id,
 			getValue,
@@ -223,7 +221,30 @@ export default function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
-			format,
+			format: {},
 		};
+
+		if ( field.type === 'date' ) {
+			const format = {
+				date:
+					field.format?.date !== undefined &&
+					typeof field.format.date === 'string'
+						? field.format.date
+						: getSettings().formats.date,
+				weekStartsOn: DAYS_OF_WEEK.includes(
+					field.format?.weekStartsOn as DayString
+				)
+					? field?.format?.weekStartsOn
+					: numberToWeekStartsOn( getSettings().l10n.startOfWeek ),
+			};
+
+			return {
+				...baseField,
+				type: 'date',
+				format,
+			};
+		}
+
+		return { ...baseField, type: field.type, format: {} };
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -188,15 +188,25 @@ export default function normalizeFields< Item >(
 
 		const filterBy = getFilterBy( field, fieldTypeDefinition );
 
-		// TypeScript is unable to figure out that we're returning the proper types
-		// (either NormalizedFieldDate or NormalizedFieldGeneric)
-		// when the type is part of the object spread below.
-		//
-		// Hence, why we remove it and add back it later.
-		const { type, ...fieldWithoutType } = field;
+		const format =
+			field.type === 'date'
+				? {
+						date:
+							field.format?.date !== undefined &&
+							typeof field.format.date === 'string'
+								? field.format.date
+								: getSettings().formats.date,
+						weekStartsOn:
+							field.format?.weekStartsOn !== undefined
+								? field.format.weekStartsOn
+								: numberToWeekStartsOn(
+										getSettings().l10n.startOfWeek
+								  ),
+				  }
+				: {};
 
-		const baseField = {
-			...fieldWithoutType,
+		return {
+			...field,
 			label: field.label || field.id,
 			header: field.header || field.label || field.id,
 			getValue,
@@ -213,32 +223,7 @@ export default function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
-		};
-
-		if ( field.type === 'date' ) {
-			return {
-				...baseField,
-				type: 'date' as const,
-				format: {
-					date:
-						field.format?.date !== undefined &&
-						typeof field.format.date === 'string'
-							? field.format.date
-							: getSettings().formats.date,
-					weekStartsOn:
-						field.format?.weekStartsOn !== undefined
-							? field.format.weekStartsOn
-							: numberToWeekStartsOn(
-									getSettings().l10n.startOfWeek
-							  ),
-				},
-			};
-		}
-
-		return {
-			...baseField,
-			type: field.type,
-			format: {},
+			format,
 		};
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -4,6 +4,11 @@
 import type { FunctionComponent } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { getSettings } from '@wordpress/date';
+
+/**
  * Internal dependencies
  */
 import getFieldTypeDefinition from '../field-types';
@@ -200,6 +205,12 @@ export default function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
+			format:
+				field.type === 'date' &&
+				field.format !== undefined &&
+				typeof field.format === 'string'
+					? field.format
+					: getSettings().formats.date,
 		};
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -13,6 +13,7 @@ import { getSettings } from '@wordpress/date';
  */
 import getFieldTypeDefinition from '../field-types';
 import type {
+	DayString,
 	DataViewRenderFieldProps,
 	Field,
 	FieldTypeDefinition,
@@ -26,7 +27,7 @@ import {
 	SINGLE_SELECTION_OPERATORS,
 } from '../constants';
 import hasElements from './has-elements';
-import { numberToWeekStartsOn } from './week-starts-on';
+import { numberToWeekStartsOn, DAYS_OF_WEEK } from './week-starts-on';
 
 const getValueFromId =
 	( id: string ) =>
@@ -188,22 +189,21 @@ export default function normalizeFields< Item >(
 
 		const filterBy = getFilterBy( field, fieldTypeDefinition );
 
-		const format =
-			field.type === 'date'
-				? {
-						date:
-							field.format?.date !== undefined &&
-							typeof field.format.date === 'string'
-								? field.format.date
-								: getSettings().formats.date,
-						weekStartsOn:
-							field.format?.weekStartsOn !== undefined
-								? field.format.weekStartsOn
-								: numberToWeekStartsOn(
-										getSettings().l10n.startOfWeek
-								  ),
-				  }
-				: {};
+		let format = {};
+		if ( field.type === 'date' ) {
+			format = {
+				date:
+					field.format?.date !== undefined &&
+					typeof field.format.date === 'string'
+						? field.format.date
+						: getSettings().formats.date,
+				weekStartsOn: DAYS_OF_WEEK.includes(
+					field.format?.weekStartsOn as DayString
+				)
+					? field?.format?.weekStartsOn
+					: numberToWeekStartsOn( getSettings().l10n.startOfWeek ),
+			};
+		}
 
 		return {
 			...field,

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -219,15 +219,15 @@ export default function normalizeFields< Item >(
 			return {
 				...baseField,
 				type: 'date' as const,
-				displayFormat: {
+				format: {
 					date:
-						field.displayFormat?.date !== undefined &&
-						typeof field.displayFormat.date === 'string'
-							? field.displayFormat.date
+						field.format?.date !== undefined &&
+						typeof field.format.date === 'string'
+							? field.format.date
 							: getSettings().formats.date,
 					weekStartsOn:
-						field.displayFormat?.weekStartsOn !== undefined
-							? field.displayFormat.weekStartsOn
+						field.format?.weekStartsOn !== undefined
+							? field.format.weekStartsOn
 							: numberToWeekStartsOn(
 									getSettings().l10n.startOfWeek
 							  ),
@@ -238,7 +238,7 @@ export default function normalizeFields< Item >(
 		return {
 			...baseField,
 			type: field.type,
-			displayFormat: {},
+			format: {},
 		};
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -188,8 +188,15 @@ export default function normalizeFields< Item >(
 
 		const filterBy = getFilterBy( field, fieldTypeDefinition );
 
-		return {
-			...field,
+		// TypeScript is unable to figure out that we're returning the proper types
+		// (either NormalizedFieldDate or NormalizedFieldGeneric)
+		// when the type is part of the object spread below.
+		//
+		// Hence, why we remove it and add back it later.
+		const { type, ...fieldWithoutType } = field;
+
+		const baseField = {
+			...fieldWithoutType,
 			label: field.label || field.id,
 			header: field.header || field.label || field.id,
 			getValue,
@@ -206,21 +213,32 @@ export default function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
-			displayFormat: {
-				date:
-					field.type === 'date' &&
-					field.displayFormat?.date !== undefined &&
-					typeof field.displayFormat.date === 'string'
-						? field.displayFormat.date
-						: getSettings().formats.date,
-				weekStartsOn:
-					field.type === 'date' &&
-					field.displayFormat?.weekStartsOn !== undefined
-						? field.displayFormat.weekStartsOn
-						: numberToWeekStartsOn(
-								getSettings().l10n.startOfWeek
-						  ),
-			},
+		};
+
+		if ( field.type === 'date' ) {
+			return {
+				...baseField,
+				type: 'date' as const,
+				displayFormat: {
+					date:
+						field.displayFormat?.date !== undefined &&
+						typeof field.displayFormat.date === 'string'
+							? field.displayFormat.date
+							: getSettings().formats.date,
+					weekStartsOn:
+						field.displayFormat?.weekStartsOn !== undefined
+							? field.displayFormat.weekStartsOn
+							: numberToWeekStartsOn(
+									getSettings().l10n.startOfWeek
+							  ),
+				},
+			};
+		}
+
+		return {
+			...baseField,
+			type: field.type,
+			displayFormat: {},
 		};
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -212,6 +212,11 @@ export default function normalizeFields< Item >(
 					typeof field.displayFormat.date === 'string'
 						? field.displayFormat.date
 						: getSettings().formats.date,
+				weekStartsOn:
+					field.type === 'date' &&
+					field.displayFormat?.weekStartsOn !== undefined
+						? field.displayFormat.weekStartsOn
+						: getSettings().l10n.startOfWeek,
 			},
 		};
 	} );

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -205,12 +205,14 @@ export default function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
-			format:
-				field.type === 'date' &&
-				field.format !== undefined &&
-				typeof field.format === 'string'
-					? field.format
-					: getSettings().formats.date,
+			displayFormat: {
+				date:
+					field.type === 'date' &&
+					field.displayFormat?.date !== undefined &&
+					typeof field.displayFormat.date === 'string'
+						? field.displayFormat.date
+						: getSettings().formats.date,
+			},
 		};
 	} );
 }

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -26,6 +26,7 @@ import {
 	SINGLE_SELECTION_OPERATORS,
 } from '../constants';
 import hasElements from './has-elements';
+import { numberToWeekStartsOn } from './week-starts-on';
 
 const getValueFromId =
 	( id: string ) =>
@@ -216,7 +217,9 @@ export default function normalizeFields< Item >(
 					field.type === 'date' &&
 					field.displayFormat?.weekStartsOn !== undefined
 						? field.displayFormat.weekStartsOn
-						: getSettings().l10n.startOfWeek,
+						: numberToWeekStartsOn(
+								getSettings().l10n.startOfWeek
+						  ),
 			},
 		};
 	} );

--- a/packages/dataviews/src/utils/week-starts-on.ts
+++ b/packages/dataviews/src/utils/week-starts-on.ts
@@ -1,13 +1,9 @@
-type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-type DayString =
-	| 'sunday'
-	| 'monday'
-	| 'tuesday'
-	| 'wednesday'
-	| 'thursday'
-	| 'friday'
-	| 'saturday';
-const days: DayString[] = [
+/**
+ * Internal dependencies
+ */
+import type { DayNumber, DayString } from '../types/field-api';
+
+export const DAYS_OF_WEEK: DayString[] = [
 	'sunday',
 	'monday',
 	'tuesday',
@@ -26,7 +22,7 @@ const DEFAULT_DAY_NUMBER = 0;
  * @return The corresponding number (0 for Sunday, 1 for Monday, etc.)
  */
 export function weekStartsOnToNumber( day: DayString ): DayNumber {
-	const index = days.indexOf( day );
+	const index = DAYS_OF_WEEK.indexOf( day );
 	if ( index === -1 ) {
 		return DEFAULT_DAY_NUMBER;
 	}
@@ -41,7 +37,7 @@ export function weekStartsOnToNumber( day: DayString ): DayNumber {
  * @return The corresponding day name ('sunday', 'monday', etc.)
  */
 export function numberToWeekStartsOn( day: DayNumber ): DayString {
-	const result = days[ day ];
+	const result = DAYS_OF_WEEK[ day ];
 	if ( result === undefined ) {
 		return DEFAULT_DAY_STRING;
 	}

--- a/packages/dataviews/src/utils/week-starts-on.ts
+++ b/packages/dataviews/src/utils/week-starts-on.ts
@@ -1,0 +1,57 @@
+/**
+ * Converts a weekStartsOn string to a number (0-6).
+ *
+ * @param day - The day name ('sunday', 'monday', etc.)
+ * @return The corresponding number (0 for Sunday, 1 for Monday, etc.)
+ */
+export function weekStartsOnToNumber(
+	day:
+		| 'sunday'
+		| 'monday'
+		| 'tuesday'
+		| 'wednesday'
+		| 'thursday'
+		| 'friday'
+		| 'saturday'
+): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+	const mapping = {
+		sunday: 0,
+		monday: 1,
+		tuesday: 2,
+		wednesday: 3,
+		thursday: 4,
+		friday: 5,
+		saturday: 6,
+	} as const;
+
+	return mapping[ day ];
+}
+
+/**
+ * Converts a weekStartsOn number (0-6) to a string.
+ *
+ * @param day - The day number (0 for Sunday, 1 for Monday, etc.)
+ * @return The corresponding day name ('sunday', 'monday', etc.)
+ */
+export function numberToWeekStartsOn(
+	day: 0 | 1 | 2 | 3 | 4 | 5 | 6
+):
+	| 'sunday'
+	| 'monday'
+	| 'tuesday'
+	| 'wednesday'
+	| 'thursday'
+	| 'friday'
+	| 'saturday' {
+	const mapping = {
+		0: 'sunday',
+		1: 'monday',
+		2: 'tuesday',
+		3: 'wednesday',
+		4: 'thursday',
+		5: 'friday',
+		6: 'saturday',
+	} as const;
+
+	return mapping[ day ];
+}

--- a/packages/dataviews/src/utils/week-starts-on.ts
+++ b/packages/dataviews/src/utils/week-starts-on.ts
@@ -1,30 +1,37 @@
+type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+type DayString =
+	| 'sunday'
+	| 'monday'
+	| 'tuesday'
+	| 'wednesday'
+	| 'thursday'
+	| 'friday'
+	| 'saturday';
+const days: DayString[] = [
+	'sunday',
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+];
+const DEFAULT_DAY_STRING = 'sunday';
+const DEFAULT_DAY_NUMBER = 0;
+
 /**
  * Converts a weekStartsOn string to a number (0-6).
  *
  * @param day - The day name ('sunday', 'monday', etc.)
  * @return The corresponding number (0 for Sunday, 1 for Monday, etc.)
  */
-export function weekStartsOnToNumber(
-	day:
-		| 'sunday'
-		| 'monday'
-		| 'tuesday'
-		| 'wednesday'
-		| 'thursday'
-		| 'friday'
-		| 'saturday'
-): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
-	const mapping = {
-		sunday: 0,
-		monday: 1,
-		tuesday: 2,
-		wednesday: 3,
-		thursday: 4,
-		friday: 5,
-		saturday: 6,
-	} as const;
+export function weekStartsOnToNumber( day: DayString ): DayNumber {
+	const index = days.indexOf( day );
+	if ( index === -1 ) {
+		return DEFAULT_DAY_NUMBER;
+	}
 
-	return mapping[ day ];
+	return index as DayNumber;
 }
 
 /**
@@ -33,25 +40,11 @@ export function weekStartsOnToNumber(
  * @param day - The day number (0 for Sunday, 1 for Monday, etc.)
  * @return The corresponding day name ('sunday', 'monday', etc.)
  */
-export function numberToWeekStartsOn(
-	day: 0 | 1 | 2 | 3 | 4 | 5 | 6
-):
-	| 'sunday'
-	| 'monday'
-	| 'tuesday'
-	| 'wednesday'
-	| 'thursday'
-	| 'friday'
-	| 'saturday' {
-	const mapping = {
-		0: 'sunday',
-		1: 'monday',
-		2: 'tuesday',
-		3: 'wednesday',
-		4: 'thursday',
-		5: 'friday',
-		6: 'saturday',
-	} as const;
+export function numberToWeekStartsOn( day: DayNumber ): DayString {
+	const result = days[ day ];
+	if ( result === undefined ) {
+		return DEFAULT_DAY_STRING;
+	}
 
-	return mapping[ day ];
+	return result;
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/73154

## What?

This PR explores introducing formats to the Field API, leveraging the existing [WordPress format for dates](https://wordpress.org/documentation/article/customize-date-and-time-format/#format-string-examples). A format defines how a field is visualized in a few places: render, filters, edit.

https://github.com/user-attachments/assets/408a13ea-c433-4557-afd3-413a74d09fb4

**This PR is in draft state and only implements a format for the `date` field type.**

## Why?

Data can be displayed in multiple formats depending on the situation. While field authors can already control how a field is displayed by using the `render` and `Edit` functions, the current approach has limits:

- We want the Field API to be serializable, and fields with `render` and `Edit` components are not.
- Formatting data in different ways is a basic need, specially for locale-sensible types such as `date` or `number`.
- Field authors cannot currently control how a filter value is displayed.

Related conversations and work:

- https://github.com/WordPress/gutenberg/pull/71797#discussion_r2370438700 @dinhtungdu 
- https://github.com/WordPress/gutenberg/pull/72756

## Questions

- There's an established date format in WordPress (docs, see "General > Settings"). In addition to date format, it also configures timezone or the starting day of the week. Is this good enough? Should we support this from the start? There's none for numbers that I could see. What's the prior art here?
- There are other places where we need formats, and there's been conversations about converging into a single structure. This requires evaluation.
  - https://github.com/WordPress/gutenberg/pull/72716 for block bindings / block types. cc @cbravobernal and @ockham for awareness
  - https://github.com/WordPress/gutenberg/pull/72792 for semantic roles in blocks. @ntsekouras 
  - The [REST API uses JSON Schema](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#format) and uses "formats" to classify "string" types into others (date, uri, etc.).

## How?

- Introduce a `format` prop to the Field API.
- Field normalization: if a `date` field doesn't provide a format, the WordPress default is used.
- The default `render` provided by the field type definition uses the format to display the date.
- The filter summary uses the format to display the date.
- Allow users to configure the format in the story for `date`.

## Testing Instructions

- Run the storybook locally (`npm run storybook:dev`).
- Go to the "DataViews > Field Types > date" story and interact with the formatting control.
