### PR TITLE
Block Bindings: Remove workaround that made e2e tests pass in CI

### DIFF
--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -144,34 +144,24 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'movie_field',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitem', {
-						name: 'Post Meta',
-					} )
-					.click();
-				await page
-					.getByRole( 'menuitemcheckbox' )
-					.filter( { hasText: 'Movie field label' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'Movie field label'
 				);
@@ -180,34 +170,24 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'field_without_label_or_default',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitem', {
-						name: 'Post Meta',
-					} )
-					.click();
-				await page
-					.getByRole( 'menuitemcheckbox' )
-					.filter( { hasText: 'field_without_label_or_default' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'field_without_label_or_default'
 				);


### PR DESCRIPTION
## What?
This is for demonstration purposes only, as a companion to https://github.com/WordPress/gutenberg/pull/72974.

## Why?
Some of the e2e tests in `test/e2e/specs/editor/various/block-bindings/post-meta.spec.js` are failing _when run locally_. This is consistently happening in `trunk`.

```
  7 failed
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:143:4 › Post Meta source › Movie CPT template › Attributes panel › should show the field label if it is defined 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:179:4 › Post Meta source › Movie CPT template › Attributes panel › should fall back to the field key if the field label is not defined 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:241:4 › Post Meta source › Movie CPT template › Fields list dropdown › should include movie fields in UI to connect attributes 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:249:4 › Post Meta source › Movie CPT template › Fields list dropdown › should include global fields in UI to connect attributes 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:257:4 › Post Meta source › Movie CPT template › Fields list dropdown › should not include protected fields 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:273:4 › Post Meta source › Movie CPT template › Fields list dropdown › should show the default value if it is defined 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:284:4 › Post Meta source › Movie CPT template › Fields list dropdown › should not show anything if the default value is not defined
```

They are, however, passing in CI. The reason for this seems to be the way that test blocks are manually created, and only then connected to a Block Bindings source (via the Attributes panel in the block inspector). (This gives WordPress enough time to load the Post Meta source, which the block is supposed to connect to.) That workaround is even documented in the code (see diff).

## How?
This PR removes the workaround for the first two test cases. The expected result is that they will now also fail in CI.

The remaining five test cases that are failing locally (but passing in CI) are all in the `Fields list dropdown` group of tests. There, the block is created in `test.beforeEach`, and individual tests then verify that items are present or absent in the sources dropdown in the Attributes panel. For this reason, we cannot simply replace the logic with directly inserting the already-connected block, as that's now what those tests are checking. In other words, we cannot make them fail in CI, even when they're failing locally.

## Testing Instructions

In `trunk`, verify that the tests mentioned in the "Why" section above are failing when run locally:

```
npm run test:e2e -- test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
```

Verify that the same is true on this branch.

In CI, verify that on this PR, the following two tests are now failing:

```
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:143:4 › Post Meta source › Movie CPT template › Attributes panel › should show the field label if it is defined 
    [chromium] › test/e2e/specs/editor/various/block-bindings/post-meta.spec.js:179:4 › Post Meta source › Movie CPT template › Attributes panel › should fall back to the field key if the field label is not defined 
```