### PR TITLE
Math: Fixing Edit as HTML feature and code editor sync (#72910)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -495,6 +495,7 @@ Display mathematical notation using LaTeX. ([Source](https://github.com/WordPres
 
 -	**Name:** core/math
 -	**Category:** text
+-	**Supports:** ~~html~~
 -	**Attributes:** latex, mathML
 
 ## Media & Text

--- a/packages/block-library/src/math/block.json
+++ b/packages/block-library/src/math/block.json
@@ -7,6 +7,9 @@
 	"description": "Display mathematical notation using LaTeX.",
 	"keywords": [ "equation", "formula", "latex", "mathematics" ],
 	"textdomain": "default",
+	"supports": {
+		"html": false
+	},
 	"attributes": {
 		"latex": {
 			"type": "string",

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -23,11 +23,11 @@ import { unlock } from '../lock-unlock';
 const { Badge } = unlock( componentsPrivateApis );
 
 export default function MathEdit( { attributes, setAttributes, isSelected } ) {
-	const { latex } = attributes;
+	const { latex, mathML } = attributes;
 	const [ blockRef, setBlockRef ] = useState();
 	const [ error, setError ] = useState( null );
 	const [ latexToMathML, setLatexToMathML ] = useState();
-	const initialLatex = useRef( attributes.latex );
+	const initialLatex = useRef( latex );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -56,13 +56,13 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 
 	return (
 		<div { ...blockProps }>
-			{ attributes.mathML ? (
+			{ mathML ? (
 				<math
 					// We can't spread block props on the math element because
 					// it only supports a limited amount of global attributes.
 					// For example, draggable will have no effect.
 					display="block"
-					dangerouslySetInnerHTML={ { __html: attributes.mathML } }
+					dangerouslySetInnerHTML={ { __html: mathML } }
 				/>
 			) : (
 				'\u200B'
@@ -88,9 +88,9 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setAttributes( { latex: newLatex } );
 										return;
 									}
-									let mathML = '';
+									let newMathML = '';
 									try {
-										mathML = latexToMathML( newLatex, {
+										newMathML = latexToMathML( newLatex, {
 											displayMode: true,
 										} );
 										setError( null );
@@ -98,7 +98,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setError( err.message );
 									}
 									setAttributes( {
-										mathML,
+										mathML: newMathML,
 										latex: newLatex,
 									} );
 								} }


### PR DESCRIPTION
This is the cherry pick from #72910

Original ticket: #72899

* Math: Fixing Edit as HTML feature and code editor sync
* fix: More syntactical uniformity
* fix: Add support indication for core/math block in documentation