### PR TITLE
Term Name: Add `levelOptions` attribute to control available heading levels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1039,7 +1039,7 @@ Displays the name of a taxonomy term. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/term-name
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, textAlign
+-	**Attributes:** isLink, level, levelOptions, textAlign
 
 ## Term Template
 

--- a/packages/block-library/src/term-name/block.json
+++ b/packages/block-library/src/term-name/block.json
@@ -19,6 +19,9 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"levelOptions": {
+			"type": "array"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/term-name/edit.js
+++ b/packages/block-library/src/term-name/edit.js
@@ -32,7 +32,7 @@ export default function TermNameEdit( {
 	setAttributes,
 	context: { termId, taxonomy },
 } ) {
-	const { textAlign, level = 0, isLink } = attributes;
+	const { textAlign, level = 0, isLink, levelOptions } = attributes;
 	const { term } = useTermName( termId, taxonomy );
 
 	const termName = term?.name
@@ -66,7 +66,7 @@ export default function TermNameEdit( {
 			<BlockControls group="block">
 				<HeadingLevelDropdown
 					value={ level }
-					options={ [ 0, 1, 2, 3, 4, 5, 6 ] }
+					options={ levelOptions }
 					onChange={ ( newLevel ) => {
 						setAttributes( { level: newLevel } );
 					} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related #63535

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Term Name can have its level changed.
Like other blocks, you can customize it by adding a level option to the attributes.

> Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc.

Quoting #64103

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `levelOptions` attribute to control available heading levels

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Please copy and paste the following code into your editor.
```html
<!-- wp:term-name {"level":3,"levelOptions":[3,4,5]} /-->
```
3. The number of available heading levels will be reduced.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="313" height="219" alt="term-name" src="https://github.com/user-attachments/assets/5326909b-02e4-455b-a0cd-416eac1df91e" />


