### PR TITLE
Notes: Fix selector for orderedBlockIds

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -68,15 +68,18 @@ export function Comments( {
 	const { setCanvasMinHeight } = unlock( useDispatch( editorStore ) );
 	const { blockCommentId, selectedBlockClientId, orderedBlockIds } =
 		useSelect( ( select ) => {
-			const { getBlockAttributes, getSelectedBlockClientId } =
-				select( blockEditorStore );
+			const {
+				getBlockAttributes,
+				getSelectedBlockClientId,
+				getClientIdsWithDescendants,
+			} = select( blockEditorStore );
 			const clientId = getSelectedBlockClientId();
 			return {
 				blockCommentId: clientId
 					? getBlockAttributes( clientId )?.metadata?.noteId
 					: null,
 				selectedBlockClientId: clientId,
-				orderedBlockIds: select( blockEditorStore ).getBlockOrder(),
+				orderedBlockIds: getClientIdsWithDescendants(),
 			};
 		}, [] );
 


### PR DESCRIPTION
## What?
Closes #72896.

PR fixes block cliend ID order used for floating notes and new form positions to handle nested blocks correctly. Replaces `getBlockOrder` with `getClientIdsWithDescendants`. The `getBlockOrder` method defaults to returning only top-level blocks for the root content or the specified block.

We're also using same selector in the `useBlockComments` hook.

## Testing Instructions
1. Create a post.
2. Add Group/Details/Quote block and nest couple of paragraphs in it.
3. Try adding note to the nested paragraph.
4. The "New note" form should be displayed correctly.
5. The new note should be created and positioned correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1170" height="751" alt="CleanShot 2025-11-05 at 16 29 45" src="https://github.com/user-attachments/assets/ff3b5bd5-2a62-407b-8cd2-6dc1a9f2b30f" />

