### PR TITLE
Testing: Sync lockfile changes from latest versions of npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54269,47 +54269,6 @@
 				"postcss": "^8.0.0"
 			}
 		},
-		"packages/postcss-plugins-preset/node_modules/autoprefixer": {
-			"version": "10.4.20",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"dependencies": {
-				"browserslist": "^4.23.3",
-				"caniuse-lite": "^1.0.30001646",
-				"fraction.js": "^4.3.7",
-				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.1",
-				"postcss-value-parser": "^4.2.0"
-			},
-			"bin": {
-				"autoprefixer": "bin/autoprefixer"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			},
-			"peerDependencies": {
-				"postcss": "^8.1.0"
-			}
-		},
-		"packages/postcss-plugins-preset/node_modules/postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-		},
 		"packages/postcss-themes": {
 			"name": "@wordpress/postcss-themes",
 			"version": "6.34.0",


### PR DESCRIPTION
## What?

Commits a change to `package-lock.json` which is currently causing builds to fail for Node.js v24 static analysis checks.

Example: https://github.com/WordPress/gutenberg/actions/runs/19095598129/job/54556333563

Slack discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1762332226667849

## Why?

So builds pass.

## How?

I installed the version of Node.js used in those tests (found the version under "Use desired version of Node.js" expander of [the run logs](https://github.com/WordPress/gutenberg/actions/runs/19095598129/job/54556333563)):

```
npm install -g npm@11.6.1
```

Then ran `npm install`.

Then repeated the process with npm 10.8.2 (the version used in Node.js v20 builds) to verify that the entry wasn't re-added.

A better fix will be exploring a solution to #72143, or at least ensuring CI is configured to use the same version of npm.

## Testing Instructions

Run `npm install` and confirm that there are no local changes to commit.

Verify that builds pass.