### PR TITLE
Notes: fix avatar image size in mobile layout

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -163,6 +163,7 @@
 	border-style: solid;
 	padding: var(--wp-admin-border-width-focus);
 	background: $white;
+	box-sizing: border-box;
 
 	&:first-child {
 		margin-left: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

|Before|After|
|-|-|
| <img width="395" height="302" alt="image" src="https://github.com/user-attachments/assets/dd5f5a0e-4378-4e73-992f-3c713a0e2883" /> | <img width="397" height="305" alt="image" src="https://github.com/user-attachments/assets/538ff2b2-bc2f-45c4-a192-41f68c059674" /> |

<!-- In a few words, what is the PR actually doing? -->

## Why?

In the desktop layout, the avatar fortunately inherited `box-sizing: border-box`, and was rendered at a size of 24px, including padding and borders. However, this doesn't seem to be the case in the mobile layout.

## Testing Instructions

- Narrow the width of your browser window.
- Insert a block and add a note on it
- Confirm the sidebar
