### PR TITLE
DataViews list layout: use regular button for primary action (#72920)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DatViews list layout: remove link variant from primary actions's button. [#72920](https://github.com/WordPress/gutenberg/pull/72920)
+
 ### Bug fixes
 
 - Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -109,7 +109,6 @@ function PrimaryActionGridCell< Item >( {
 						text={ label }
 						size="small"
 						onClick={ () => setIsModalOpen( true ) }
-						variant="link"
 					/>
 				}
 			>
@@ -134,7 +133,6 @@ function PrimaryActionGridCell< Item >( {
 						onClick={ () => {
 							primaryAction.callback( [ item ], { registry } );
 						} }
-						variant="link"
 					>
 						{ label }
 					</Button>


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/72920