### PR TITLE
Notes: Fix block toolbar display for show icon labels

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -168,3 +168,18 @@
 		margin-left: 0;
 	}
 }
+
+.show-icon-labels {
+	.comment-avatar-indicator {
+		width: auto;
+		// Hide the user avatars container when labels are set to display...
+		div {
+			display: none;
+		}
+		// ... and display labels.
+		&::after {
+			content: attr(aria-label);
+			font-size: $helptext-font-size;
+		}
+	}
+}


### PR DESCRIPTION
## What?

PR fixes block toolbar avatar indicator display for Notes when the "Show button text labels" preference is enabled. Now it matches the display of other buttons.

## Why?
The "Show button text labels" is a11y feature and new buttons should adhere to it.

## Testing Instructions
1. Open post or page with notes.
2. Go to Options > Preferences > Accessiblity.
3. Enabled "Show button text labels".
4. Select block with a note.
5. Confirm that "View Notes" text is displayed instead of avatars.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="624" height="304" alt="CleanShot 2025-11-05 at 17 44 03" src="https://github.com/user-attachments/assets/cf99fc94-7dc5-4465-8a47-ee1276453a96" />|<img width="658" height="281" alt="CleanShot 2025-11-05 at 17 36 49" src="https://github.com/user-attachments/assets/e4a1fd6c-170b-4e78-9fa5-eee32aafb6b7" />|

