### PR TITLE
Remove some modal subscriptions when inactive

### DIFF
--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -19,19 +19,14 @@ export default function InitPatternModal() {
 	const [ syncType, setSyncType ] = useState( undefined );
 	const [ title, setTitle ] = useState( '' );
 
-	const { postType, isNewPost } = useSelect( ( select ) => {
-		const { getEditedPostAttribute, isCleanNewPost } =
-			select( editorStore );
-		return {
-			postType: getEditedPostAttribute( 'type' ),
-			isNewPost: isCleanNewPost(),
-		};
-	}, [] );
-	const [ isModalOpen, setIsModalOpen ] = useState(
-		() => isNewPost && postType === 'wp_block'
+	const isNewPost = useSelect(
+		( select ) => select( editorStore ).isCleanNewPost(),
+		[]
 	);
 
-	if ( postType !== 'wp_block' || ! isNewPost ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( () => isNewPost );
+
+	if ( ! isNewPost ) {
 		return null;
 	}
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -676,7 +676,9 @@ function Layout( {
 						<EditPostKeyboardShortcuts />
 						<EditorKeyboardShortcutsRegister />
 						<BlockKeyboardShortcuts />
-						<InitPatternModal />
+						{ currentPostType === 'wp_block' && (
+							<InitPatternModal />
+						) }
 						<PluginArea onError={ onPluginAreaError } />
 						<PostEditorMoreMenu />
 						{ backButton }

--- a/packages/editor/src/components/pattern-duplicate-modal/index.js
+++ b/packages/editor/src/components/pattern-duplicate-modal/index.js
@@ -17,24 +17,32 @@ const { DuplicatePatternModal } = unlock( patternsPrivateApis );
 export const modalName = 'editor/pattern-duplicate';
 
 export default function PatternDuplicateModal() {
-	const { record, postType } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const _postType = getCurrentPostType();
-		return {
-			record: getEditedEntityRecord(
-				'postType',
-				_postType,
-				getCurrentPostId()
-			),
-			postType: _postType,
-		};
-	}, [] );
-	const { closeModal } = useDispatch( interfaceStore );
-
 	const isActive = useSelect( ( select ) =>
 		select( interfaceStore ).isModalActive( modalName )
 	);
+
+	const { record, postType } = useSelect(
+		( select ) => {
+			if ( ! isActive ) {
+				return {};
+			}
+
+			const { getCurrentPostType, getCurrentPostId } =
+				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const _postType = getCurrentPostType();
+			return {
+				record: getEditedEntityRecord(
+					'postType',
+					_postType,
+					getCurrentPostId()
+				),
+				postType: _postType,
+			};
+		},
+		[ isActive ]
+	);
+	const { closeModal } = useDispatch( interfaceStore );
 
 	if ( ! isActive || postType !== PATTERN_POST_TYPE ) {
 		return null;

--- a/packages/editor/src/components/pattern-rename-modal/index.js
+++ b/packages/editor/src/components/pattern-rename-modal/index.js
@@ -17,24 +17,33 @@ const { RenamePatternModal } = unlock( patternsPrivateApis );
 export const modalName = 'editor/pattern-rename';
 
 export default function PatternRenameModal() {
-	const { record, postType } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const _postType = getCurrentPostType();
-		return {
-			record: getEditedEntityRecord(
-				'postType',
-				_postType,
-				getCurrentPostId()
-			),
-			postType: _postType,
-		};
-	}, [] );
-	const { closeModal } = useDispatch( interfaceStore );
-
 	const isActive = useSelect( ( select ) =>
 		select( interfaceStore ).isModalActive( modalName )
 	);
+
+	const { record, postType } = useSelect(
+		( select ) => {
+			if ( ! isActive ) {
+				return {};
+			}
+
+			const { getCurrentPostType, getCurrentPostId } =
+				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const _postType = getCurrentPostType();
+			return {
+				record: getEditedEntityRecord(
+					'postType',
+					_postType,
+					getCurrentPostId()
+				),
+				postType: _postType,
+			};
+		},
+		[ isActive ]
+	);
+
+	const { closeModal } = useDispatch( interfaceStore );
 
 	if ( ! isActive || postType !== PATTERN_POST_TYPE ) {
 		return null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Removes subscriptions from modals that are not active, and cannot be active in their given scenario.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Minor perf. Reduce subscriptions if easy and sensible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Modals don't need to be subscribed to changes when inactive. They only need the information when they are open. Don't subscribe to the store if the modal isn't active or won't be rendered in that context.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Generated by Claude AI

  1. InitPatternModal (Create New Pattern)

  Test that the modal appears correctly:
  - Navigate to Patterns → Add New Pattern
  - The "Create pattern" modal should appear automatically for new patterns
  - Modal should allow you to:
    - Enter a pattern title
    - Choose sync type (Synced or Standard)
    - Click "Create" to initialize the pattern

  Test that the modal doesn't mount unnecessarily:
  - Create or edit a regular post (not a pattern)
  - The InitPatternModal should not be mounted at all (performance improvement)

  2. PatternRenameModal

  Test the rename functionality:
  - Navigate to Patterns and open an existing pattern for editing
  - Open the pattern settings (three dots menu in toolbar)
  - Click "Rename"
  - The rename modal should appear with the current pattern name
  - Change the pattern name and save
  - Verify the pattern name updates successfully
  - Close the modal without saving and verify changes are discarded

  3. PatternDuplicateModal

  Test the duplicate functionality:
  - Navigate to Patterns and open an existing pattern for editing
  - Open the pattern settings (three dots menu in toolbar)
  - Click "Duplicate"
  - The duplicate modal should appear
  - Enter a new name for the duplicated pattern
  - Click "Duplicate" to create the copy
  - Verify a new pattern is created with the specified name
  - Verify the new pattern contains the same blocks/content as the original

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
