### PR TITLE
Raw Handling: Fix grok markdown pasting issues

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -287,4 +287,33 @@ describe( 'pasteHandler', () => {
 		expect( result.name ).toEqual( 'core/video' );
 		expect( result.isValid ).toBeTruthy();
 	} );
+
+	it( 'can handle Grok markdown wrapped in a styled span', () => {
+		// Simulates pasting markdown from Grok, which wraps content in a styled span
+		const grokMarkdownHTML =
+			'<span style="font-family: system-ui, -apple-system, sans-serif; font-size: 14px;"># Heading\n\nThis is a paragraph with **bold text** and *italic text*.\n\n## Subheading\n\nAnother paragraph with a [link](https://example.com).</span>';
+
+		const result = pasteHandler( {
+			HTML: grokMarkdownHTML,
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		// Should convert markdown to proper blocks
+		expect( result.length ).toBeGreaterThan( 1 );
+
+		// First block should be a heading
+		expect( result[ 0 ].name ).toEqual( 'core/heading' );
+		expect( result[ 0 ].attributes.content ).toContain( 'Heading' );
+
+		// Should have converted markdown formatting
+		const hasFormattedContent = result.some(
+			( block ) =>
+				block.name === 'core/paragraph' &&
+				( block.attributes.content.includes( '<strong>' ) ||
+					block.attributes.content.includes( '<em>' ) )
+		);
+		expect( hasFormattedContent ).toBe( true );
+	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -287,33 +287,4 @@ describe( 'pasteHandler', () => {
 		expect( result.name ).toEqual( 'core/video' );
 		expect( result.isValid ).toBeTruthy();
 	} );
-
-	it( 'can handle Grok markdown wrapped in a styled span', () => {
-		// Simulates pasting markdown from Grok, which wraps content in a styled span
-		const grokMarkdownHTML =
-			'<span style="font-family: system-ui, -apple-system, sans-serif; font-size: 14px;"># Heading\n\nThis is a paragraph with **bold text** and *italic text*.\n\n## Subheading\n\nAnother paragraph with a [link](https://example.com).</span>';
-
-		const result = pasteHandler( {
-			HTML: grokMarkdownHTML,
-			mode: 'BLOCKS',
-		} );
-
-		expect( console ).toHaveLogged();
-
-		// Should convert markdown to proper blocks
-		expect( result.length ).toBeGreaterThan( 1 );
-
-		// First block should be a heading
-		expect( result[ 0 ].name ).toEqual( 'core/heading' );
-		expect( result[ 0 ].attributes.content ).toContain( 'Heading' );
-
-		// Should have converted markdown formatting
-		const hasFormattedContent = result.some(
-			( block ) =>
-				block.name === 'core/paragraph' &&
-				( block.attributes.content.includes( '<strong>' ) ||
-					block.attributes.content.includes( '<em>' ) )
-		);
-		expect( hasFormattedContent ).toBe( true );
-	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -33,20 +33,16 @@ describe( 'isPlain', () => {
 
 	it( 'should return true for single non-semantic wrapper elements with only text', () => {
 		expect( isPlain( '<span>test</span>' ) ).toBe( true );
-		expect( isPlain( '<div>test</div>' ) ).toBe( true );
-		expect( isPlain( '<p>test</p>' ) ).toBe( true );
 	} );
 
 	it( 'should return true for single wrapper with styled content but no semantic tags', () => {
 		expect( isPlain( '<span style="color: red;">test</span>' ) ).toBe(
 			true
 		);
-		expect( isPlain( '<div class="wrapper">test</div>' ) ).toBe( true );
 	} );
 
 	it( 'should return true for single wrapper with line breaks', () => {
 		expect( isPlain( '<span>test<br>test</span>' ) ).toBe( true );
-		expect( isPlain( '<div>test<br/>more<br />text</div>' ) ).toBe( true );
 	} );
 
 	it( 'should return false for wrapper with semantic child elements', () => {
@@ -57,7 +53,6 @@ describe( 'isPlain', () => {
 
 	it( 'should return false for multiple wrapper elements', () => {
 		expect( isPlain( '<span>test</span><span>test</span>' ) ).toBe( false );
-		expect( isPlain( '<div>test</div><div>test</div>' ) ).toBe( false );
 	} );
 
 	it( 'should return false for semantic wrapper elements', () => {

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -30,6 +30,41 @@ describe( 'isPlain', () => {
 		expect( isPlain( '<strong>test<br></strong>' ) ).toBe( false );
 		expect( isPlain( 'test<br-custom>test' ) ).toBe( false );
 	} );
+
+	it( 'should return true for single non-semantic wrapper elements with only text', () => {
+		expect( isPlain( '<span>test</span>' ) ).toBe( true );
+		expect( isPlain( '<div>test</div>' ) ).toBe( true );
+		expect( isPlain( '<p>test</p>' ) ).toBe( true );
+	} );
+
+	it( 'should return true for single wrapper with styled content but no semantic tags', () => {
+		expect( isPlain( '<span style="color: red;">test</span>' ) ).toBe(
+			true
+		);
+		expect( isPlain( '<div class="wrapper">test</div>' ) ).toBe( true );
+	} );
+
+	it( 'should return true for single wrapper with line breaks', () => {
+		expect( isPlain( '<span>test<br>test</span>' ) ).toBe( true );
+		expect( isPlain( '<div>test<br/>more<br />text</div>' ) ).toBe( true );
+	} );
+
+	it( 'should return false for wrapper with semantic child elements', () => {
+		expect( isPlain( '<div><strong>test</strong></div>' ) ).toBe( false );
+		expect( isPlain( '<span><em>test</em></span>' ) ).toBe( false );
+		expect( isPlain( '<p>Some <a href="#">link</a></p>' ) ).toBe( false );
+	} );
+
+	it( 'should return false for multiple wrapper elements', () => {
+		expect( isPlain( '<span>test</span><span>test</span>' ) ).toBe( false );
+		expect( isPlain( '<div>test</div><div>test</div>' ) ).toBe( false );
+	} );
+
+	it( 'should return false for semantic wrapper elements', () => {
+		expect( isPlain( '<h1>test</h1>' ) ).toBe( false );
+		expect( isPlain( '<ul><li>test</li></ul>' ) ).toBe( false );
+		expect( isPlain( '<article>test</article>' ) ).toBe( false );
+	} );
 } );
 
 describe( 'getBlockContentSchema', () => {

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -143,11 +143,14 @@ export function isPlain( HTML ) {
 
 	// Check if the wrapper contains only text nodes and <br> tags
 	// (no other semantic elements)
-	const hasSemanticChildren = Array.from(
-		wrapper.getElementsByTagName( '*' )
-	).some( ( el ) => el.tagName.toLowerCase() !== 'br' );
-
-	return ! hasSemanticChildren;
+	const descendants = element.getElementsByTagName( '*' );
+	for ( let i = 0; i < descendants.length; i++ ) {
+		if ( descendants.item( i ).tagName !== 'BR' ) {
+			return false;
+		}
+	}
+	
+	return true;
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -114,7 +114,7 @@ export function getBlockContentSchema( context ) {
 /**
  * Checks whether HTML can be considered plain text. That is, it does not contain
  * any elements that are not line breaks, or it only contains a single non-semantic
- * wrapper element (span/div/p) with no semantic child elements.
+ * wrapper element (span) with no semantic child elements.
  *
  * @param {string} HTML The HTML to check.
  *

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -113,14 +113,49 @@ export function getBlockContentSchema( context ) {
 
 /**
  * Checks whether HTML can be considered plain text. That is, it does not contain
- * any elements that are not line breaks.
+ * any elements that are not line breaks, or it only contains a single non-semantic
+ * wrapper element (span/div/p) with no semantic child elements.
  *
  * @param {string} HTML The HTML to check.
  *
  * @return {boolean} Whether the HTML can be considered plain text.
  */
 export function isPlain( HTML ) {
-	return ! /<(?!br[ />])/i.test( HTML );
+	// Existing check: no tags except <br>
+	if ( ! /<(?!br[ />])/i.test( HTML ) ) {
+		return true;
+	}
+
+	// New check: single wrapper element with no semantic children
+	try {
+		const doc = document.implementation.createHTMLDocument( '' );
+		doc.body.innerHTML = HTML;
+
+		// Check if there's exactly one top-level element
+		const childElements = Array.from( doc.body.children );
+		if ( childElements.length !== 1 ) {
+			return false;
+		}
+
+		const wrapper = childElements[ 0 ];
+		const tagName = wrapper.tagName.toLowerCase();
+
+		// Only consider non-semantic wrapper tags
+		if ( ! [ 'span', 'div', 'p' ].includes( tagName ) ) {
+			return false;
+		}
+
+		// Check if the wrapper contains only text nodes and <br> tags
+		// (no other semantic elements)
+		const hasSemanticChildren = Array.from(
+			wrapper.getElementsByTagName( '*' )
+		).some( ( el ) => el.tagName.toLowerCase() !== 'br' );
+
+		return ! hasSemanticChildren;
+	} catch ( e ) {
+		// If parsing fails, fall back to the original behavior
+		return false;
+	}
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -125,34 +125,29 @@ export function isPlain( HTML ) {
 		return true;
 	}
 
-	try {
-		const doc = document.implementation.createHTMLDocument( '' );
-		doc.body.innerHTML = HTML;
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = HTML;
 
-		// Check if there's exactly one top-level element
-		if ( doc.body.children.length !== 1 ) {
-			return false;
-		}
-
-		const wrapper = doc.body.children.item( 0 );
-		const tagName = wrapper.tagName.toLowerCase();
-
-		// Only consider non-semantic wrapper tags
-		if ( tagName !== 'span' ) {
-			return false;
-		}
-
-		// Check if the wrapper contains only text nodes and <br> tags
-		// (no other semantic elements)
-		const hasSemanticChildren = Array.from(
-			wrapper.getElementsByTagName( '*' )
-		).some( ( el ) => el.tagName.toLowerCase() !== 'br' );
-
-		return ! hasSemanticChildren;
-	} catch ( e ) {
-		// If parsing fails, fall back to the original behavior
+	// Check if there's exactly one top-level element
+	if ( doc.body.children.length !== 1 ) {
 		return false;
 	}
+
+	const wrapper = doc.body.children.item( 0 );
+	const tagName = wrapper.tagName.toLowerCase();
+
+	// Only consider non-semantic wrapper tags
+	if ( tagName !== 'span' ) {
+		return false;
+	}
+
+	// Check if the wrapper contains only text nodes and <br> tags
+	// (no other semantic elements)
+	const hasSemanticChildren = Array.from(
+		wrapper.getElementsByTagName( '*' )
+	).some( ( el ) => el.tagName.toLowerCase() !== 'br' );
+
+	return ! hasSemanticChildren;
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -132,12 +132,11 @@ export function isPlain( HTML ) {
 		doc.body.innerHTML = HTML;
 
 		// Check if there's exactly one top-level element
-		const childElements = Array.from( doc.body.children );
-		if ( childElements.length !== 1 ) {
+		if ( doc.body.children.length !== 1 ) {
 			return false;
 		}
 
-		const wrapper = childElements[ 0 ];
+		const wrapper = doc.body.children.item(0);
 		const tagName = wrapper.tagName.toLowerCase();
 
 		// Only consider non-semantic wrapper tags

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -128,28 +128,23 @@ export function isPlain( HTML ) {
 	const doc = document.implementation.createHTMLDocument( '' );
 	doc.body.innerHTML = HTML;
 
-	// Check if there's exactly one top-level element
 	if ( doc.body.children.length !== 1 ) {
 		return false;
 	}
 
 	const wrapper = doc.body.children.item( 0 );
-	const tagName = wrapper.tagName.toLowerCase();
 
-	// Only consider non-semantic wrapper tags
-	if ( tagName !== 'span' ) {
-		return false;
-	}
-
-	// Check if the wrapper contains only text nodes and <br> tags
-	// (no other semantic elements)
-	const descendants = element.getElementsByTagName( '*' );
+	const descendants = wrapper.getElementsByTagName( '*' );
 	for ( let i = 0; i < descendants.length; i++ ) {
 		if ( descendants.item( i ).tagName !== 'BR' ) {
 			return false;
 		}
 	}
-	
+
+	if ( wrapper.tagName !== 'SPAN' ) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -121,12 +121,10 @@ export function getBlockContentSchema( context ) {
  * @return {boolean} Whether the HTML can be considered plain text.
  */
 export function isPlain( HTML ) {
-	// Existing check: no tags except <br>
 	if ( ! /<(?!br[ />])/i.test( HTML ) ) {
 		return true;
 	}
 
-	// New check: single wrapper element with no semantic children
 	try {
 		const doc = document.implementation.createHTMLDocument( '' );
 		doc.body.innerHTML = HTML;
@@ -136,7 +134,7 @@ export function isPlain( HTML ) {
 			return false;
 		}
 
-		const wrapper = doc.body.children.item(0);
+		const wrapper = doc.body.children.item( 0 );
 		const tagName = wrapper.tagName.toLowerCase();
 
 		// Only consider non-semantic wrapper tags

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -141,7 +141,7 @@ export function isPlain( HTML ) {
 		const tagName = wrapper.tagName.toLowerCase();
 
 		// Only consider non-semantic wrapper tags
-		if ( ! [ 'span' ].includes( tagName ) ) {
+		if ( tagName !== 'span' ) {
 			return false;
 		}
 

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -141,7 +141,7 @@ export function isPlain( HTML ) {
 		const tagName = wrapper.tagName.toLowerCase();
 
 		// Only consider non-semantic wrapper tags
-		if ( ! [ 'span', 'div', 'p' ].includes( tagName ) ) {
+		if ( ! [ 'span' ].includes( tagName ) ) {
 			return false;
 		}
 

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -20,6 +20,8 @@ exports[`Blocks raw handling pasteHandler google-docs-table-with-rowspan 1`] = `
 
 exports[`Blocks raw handling pasteHandler google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br><br>"`;
 
+exports[`Blocks raw handling pasteHandler grok-markdown 1`] = `"Heading<br>This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.<br>Subheading<br>Another paragraph with a <a href="https://example.com">link</a>."`;
+
 exports[`Blocks raw handling pasteHandler gutenberg 1`] = `"Test"`;
 
 exports[`Blocks raw handling pasteHandler iframe-embed 1`] = `""`;

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -419,6 +419,7 @@ describe( 'Blocks raw handling', () => {
 			'one-image',
 			'two-images',
 			'markdown',
+			'grok-markdown',
 			'wordpress',
 			'gutenberg',
 			'shortcode-matching',

--- a/test/integration/fixtures/documents/grok-markdown-in.html
+++ b/test/integration/fixtures/documents/grok-markdown-in.html
@@ -1,0 +1,7 @@
+<span style="font-family: system-ui, -apple-system, sans-serif; font-size: 14px;"># Heading
+
+This is a paragraph with **bold text** and *italic text*.
+
+## Subheading
+
+Another paragraph with a [link](https://example.com).</span>

--- a/test/integration/fixtures/documents/grok-markdown-in.txt
+++ b/test/integration/fixtures/documents/grok-markdown-in.txt
@@ -1,0 +1,7 @@
+# Heading
+
+This is a paragraph with **bold text** and *italic text*.
+
+## Subheading
+
+Another paragraph with a [link](https://example.com).

--- a/test/integration/fixtures/documents/grok-markdown-out.html
+++ b/test/integration/fixtures/documents/grok-markdown-out.html
@@ -1,0 +1,15 @@
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Subheading</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Another paragraph with a <a href="https://example.com">link</a>.</p>
+<!-- /wp:paragraph -->

--- a/test/integration/fixtures/documents/grok-markdown-out.html
+++ b/test/integration/fixtures/documents/grok-markdown-out.html
@@ -1,13 +1,13 @@
-<!-- wp:heading -->
-<h2 class="wp-block-heading">Heading</h2>
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">Heading</h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p>This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Subheading</h3>
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Subheading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
 ## What?
Fixes markdown paste from Grok by expanding the `isPlain()` function to detect single non-semantic wrapper elements. I worked with @youknowriad and Claude on this :) 

 ## Why?
Closes #72468

When copying markdown from Grok using "copy markdown", the clipboard contains both plain text (with markdown syntax like `**bold**`, `### headers`) and HTML (a `<span>` wrapper with the same markdown text). Gutenberg was detecting the HTML wrapper and skipping markdown conversion, pasting the literal markdown syntax instead of converting it to blocks.

## How?
Expanded `isPlain()` in `packages/blocks/src/api/raw-handling/utils.js` to return `true` when:
- HTML contains only a single wrapper element (`span`)
- The wrapper has no semantic child elements (only text nodes and `<br>` tags)

This allows the markdown converter to run on the plain text content instead of using the HTML wrapper.

## Testing Instructions
  1. Go to Grok and generate some content with markdown formatting (headers, bold, lists, etc.)
  2. Click "copy markdown"
  3. Paste into the Gutenberg editor
  4. Verify that markdown converts to proper blocks (headings, paragraphs with bold text, lists)

### Before
Markdown syntax appears literally in paragraph blocks

### After
Markdown converts to proper block structure