### PR TITLE
 Fix: Fit text not working in site editor preview

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -3,7 +3,12 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useEffect, useCallback, useState } from '@wordpress/element';
+import {
+	useEffect,
+	useCallback,
+	useState,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -64,51 +69,47 @@ function useFitText( { fitText, name, clientId } ) {
 	const blockElement = useBlockElement( clientId );
 
 	// Fallback: Try to query the DOM directly when blockElement is null
-	// This is needed for preview mode where the ref might not be set up properly
+	// This is needed because in preview mode use useBlockElement always returns null
+	// that probably is an existing bug but the fix is not obvious so for now lets
+	// try this workaround on fit text only.
 	const [ fallbackElement, setFallbackElement ] = useState( null );
-
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! fitText || ! hasFitTextSupport || ! clientId ) {
 			return;
 		}
 
 		// If we already have blockElement from the ref system, use it
-		if ( blockElement && fallbackElement !== null ) {
+		if ( blockElement ) {
 			setFallbackElement( null );
 			return;
 		}
 
-		// Otherwise, try to query the DOM directly
+		// Otherwise, try to query the DOM directly to get the block element
 		// We need to check both the main document and the editor canvas iframe
-		const tryQueryElement = () => {
-			// Try main document first
-			let element = document.getElementById( `block-${ clientId }` );
+		let element = document.getElementById( `block-${ clientId }` );
 
-			// If not found, check the editor canvas iframe (for preview mode)
-			if ( ! element ) {
-				const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-				if ( iframe ) {
-					try {
-						const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-						if ( iframeDoc ) {
-							element = iframeDoc.getElementById( `block-${ clientId }` );
-						}
-					} catch ( e ) {
-						// Cross-origin iframe, skip
+		// If not found, check the editor canvas iframe
+		if ( ! element ) {
+			const iframe = document.querySelector(
+				'iframe[name="editor-canvas"]'
+			);
+			if ( iframe ) {
+				try {
+					const iframeDoc =
+						iframe.contentDocument ||
+						iframe.contentWindow?.document;
+					if ( iframeDoc ) {
+						element = iframeDoc.getElementById(
+							`block-${ clientId }`
+						);
 					}
-				}
+				} catch ( e ) {}
 			}
+		}
 
-			if ( element ) {
-				setFallbackElement( element );
-			} else {
-				// Element not found yet, retry on next frame
-				// requestAnimationFrame( tryQueryElement );
-			}
-		};
-
-		const timeoutId = setTimeout( tryQueryElement, 0 );
-		return () => clearTimeout( timeoutId );
+		if ( element ) {
+			setFallbackElement( element );
+		}
 	}, [ blockElement, clientId, fitText, hasFitTextSupport ] );
 
 	// Use whichever element is available
@@ -132,7 +133,8 @@ function useFitText( { fitText, name, clientId } ) {
 		}
 		// Get or create style element with unique ID
 		const styleId = `fit-text-${ clientId }`;
-		let styleElement = actualElement.ownerDocument.getElementById( styleId );
+		let styleElement =
+			actualElement.ownerDocument.getElementById( styleId );
 		if ( ! styleElement ) {
 			styleElement = actualElement.ownerDocument.createElement( 'style' );
 			styleElement.id = styleId;

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -66,10 +66,10 @@ function addAttributes( settings ) {
  */
 function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
-	const blockElement = useBlockElement( clientId );
+	const refBlockElement = useBlockElement( clientId );
 
-	// Fallback: Try to query the DOM directly when blockElement is null
-	// This is needed because in preview mode use useBlockElement always returns null
+	// Fallback: Try to query the DOM directly when refBlockElement is null
+	// This is needed because in preview mode useBlockElement always returns null
 	// that probably is an existing bug but the fix is not obvious so for now lets
 	// try this workaround on fit text only.
 	const [ fallbackElement, setFallbackElement ] = useState( null );
@@ -78,8 +78,8 @@ function useFitText( { fitText, name, clientId } ) {
 			return;
 		}
 
-		// If we already have blockElement from the ref system, use it
-		if ( blockElement ) {
+		// If we already have refBlockElement from the ref system, use it
+		if ( refBlockElement ) {
 			setFallbackElement( null );
 			return;
 		}
@@ -110,10 +110,10 @@ function useFitText( { fitText, name, clientId } ) {
 		if ( element ) {
 			setFallbackElement( element );
 		}
-	}, [ blockElement, clientId, fitText, hasFitTextSupport ] );
+	}, [ refBlockElement, clientId, fitText, hasFitTextSupport ] );
 
 	// Use whichever element is available
-	const actualElement = blockElement || fallbackElement;
+	const blockElement = refBlockElement || fallbackElement;
 
 	// Monitor block attribute changes
 	// Any attribute may change the available space.
@@ -128,17 +128,16 @@ function useFitText( { fitText, name, clientId } ) {
 	);
 
 	const applyFitText = useCallback( () => {
-		if ( ! actualElement || ! hasFitTextSupport || ! fitText ) {
+		if ( ! blockElement || ! hasFitTextSupport || ! fitText ) {
 			return;
 		}
 		// Get or create style element with unique ID
 		const styleId = `fit-text-${ clientId }`;
-		let styleElement =
-			actualElement.ownerDocument.getElementById( styleId );
+		let styleElement = blockElement.ownerDocument.getElementById( styleId );
 		if ( ! styleElement ) {
-			styleElement = actualElement.ownerDocument.createElement( 'style' );
+			styleElement = blockElement.ownerDocument.createElement( 'style' );
 			styleElement.id = styleId;
-			actualElement.ownerDocument.head.appendChild( styleElement );
+			blockElement.ownerDocument.head.appendChild( styleElement );
 		}
 
 		const blockSelector = `#block-${ clientId }`;
@@ -151,20 +150,20 @@ function useFitText( { fitText, name, clientId } ) {
 			}
 		};
 
-		optimizeFitText( actualElement, applyFontSize );
-	}, [ actualElement, clientId, hasFitTextSupport, fitText ] );
+		optimizeFitText( blockElement, applyFontSize );
+	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
 
 	useEffect( () => {
 		if (
 			! fitText ||
-			! actualElement ||
+			! blockElement ||
 			! clientId ||
 			! hasFitTextSupport
 		) {
 			return;
 		}
 		// Store current element value for cleanup
-		const currentElement = actualElement;
+		const currentElement = blockElement;
 		const previousVisibility = currentElement.style.visibility;
 
 		// Store IDs for cleanup
@@ -221,14 +220,14 @@ function useFitText( { fitText, name, clientId } ) {
 				styleElement.remove();
 			}
 		};
-	}, [ fitText, clientId, applyFitText, actualElement, hasFitTextSupport ] );
+	}, [ fitText, clientId, applyFitText, blockElement, hasFitTextSupport ] );
 
 	// Trigger fit text recalculation when content changes
 	useEffect( () => {
-		if ( fitText && actualElement && hasFitTextSupport ) {
+		if ( fitText && blockElement && hasFitTextSupport ) {
 			// Wait for next frame to ensure DOM has updated after content changes
 			const frameId = window.requestAnimationFrame( () => {
-				if ( actualElement ) {
+				if ( blockElement ) {
 					applyFitText();
 				}
 			} );
@@ -239,7 +238,7 @@ function useFitText( { fitText, name, clientId } ) {
 		blockAttributes,
 		fitText,
 		applyFitText,
-		actualElement,
+		blockElement,
 		hasFitTextSupport,
 	] );
 }

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -3,13 +3,14 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -62,6 +63,57 @@ function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
 
+	// Fallback: Try to query the DOM directly when blockElement is null
+	// This is needed for preview mode where the ref might not be set up properly
+	const [ fallbackElement, setFallbackElement ] = useState( null );
+
+	useEffect( () => {
+		if ( ! fitText || ! hasFitTextSupport || ! clientId ) {
+			return;
+		}
+
+		// If we already have blockElement from the ref system, use it
+		if ( blockElement && fallbackElement !== null ) {
+			setFallbackElement( null );
+			return;
+		}
+
+		// Otherwise, try to query the DOM directly
+		// We need to check both the main document and the editor canvas iframe
+		const tryQueryElement = () => {
+			// Try main document first
+			let element = document.getElementById( `block-${ clientId }` );
+
+			// If not found, check the editor canvas iframe (for preview mode)
+			if ( ! element ) {
+				const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+				if ( iframe ) {
+					try {
+						const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+						if ( iframeDoc ) {
+							element = iframeDoc.getElementById( `block-${ clientId }` );
+						}
+					} catch ( e ) {
+						// Cross-origin iframe, skip
+					}
+				}
+			}
+
+			if ( element ) {
+				setFallbackElement( element );
+			} else {
+				// Element not found yet, retry on next frame
+				// requestAnimationFrame( tryQueryElement );
+			}
+		};
+
+		const timeoutId = setTimeout( tryQueryElement, 0 );
+		return () => clearTimeout( timeoutId );
+	}, [ blockElement, clientId, fitText, hasFitTextSupport ] );
+
+	// Use whichever element is available
+	const actualElement = blockElement || fallbackElement;
+
 	// Monitor block attribute changes
 	// Any attribute may change the available space.
 	const blockAttributes = useSelect(
@@ -75,17 +127,16 @@ function useFitText( { fitText, name, clientId } ) {
 	);
 
 	const applyFitText = useCallback( () => {
-		if ( ! blockElement || ! hasFitTextSupport || ! fitText ) {
+		if ( ! actualElement || ! hasFitTextSupport || ! fitText ) {
 			return;
 		}
-
 		// Get or create style element with unique ID
 		const styleId = `fit-text-${ clientId }`;
-		let styleElement = blockElement.ownerDocument.getElementById( styleId );
+		let styleElement = actualElement.ownerDocument.getElementById( styleId );
 		if ( ! styleElement ) {
-			styleElement = blockElement.ownerDocument.createElement( 'style' );
+			styleElement = actualElement.ownerDocument.createElement( 'style' );
 			styleElement.id = styleId;
-			blockElement.ownerDocument.head.appendChild( styleElement );
+			actualElement.ownerDocument.head.appendChild( styleElement );
 		}
 
 		const blockSelector = `#block-${ clientId }`;
@@ -98,21 +149,20 @@ function useFitText( { fitText, name, clientId } ) {
 			}
 		};
 
-		optimizeFitText( blockElement, applyFontSize );
-	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
+		optimizeFitText( actualElement, applyFontSize );
+	}, [ actualElement, clientId, hasFitTextSupport, fitText ] );
 
 	useEffect( () => {
 		if (
 			! fitText ||
-			! blockElement ||
+			! actualElement ||
 			! clientId ||
 			! hasFitTextSupport
 		) {
 			return;
 		}
-
 		// Store current element value for cleanup
-		const currentElement = blockElement;
+		const currentElement = actualElement;
 		const previousVisibility = currentElement.style.visibility;
 
 		// Store IDs for cleanup
@@ -169,14 +219,14 @@ function useFitText( { fitText, name, clientId } ) {
 				styleElement.remove();
 			}
 		};
-	}, [ fitText, clientId, applyFitText, blockElement, hasFitTextSupport ] );
+	}, [ fitText, clientId, applyFitText, actualElement, hasFitTextSupport ] );
 
 	// Trigger fit text recalculation when content changes
 	useEffect( () => {
-		if ( fitText && blockElement && hasFitTextSupport ) {
+		if ( fitText && actualElement && hasFitTextSupport ) {
 			// Wait for next frame to ensure DOM has updated after content changes
 			const frameId = window.requestAnimationFrame( () => {
-				if ( blockElement ) {
+				if ( actualElement ) {
 					applyFitText();
 				}
 			} );
@@ -187,7 +237,7 @@ function useFitText( { fitText, name, clientId } ) {
 		blockAttributes,
 		fitText,
 		applyFitText,
-		blockElement,
+		actualElement,
 		hasFitTextSupport,
 	] );
 }


### PR DESCRIPTION

The fit text feature wasn't working in site editor preview mode because `useBlockElement()` returns `null` when blocks are rendered there I think that's a bug but I was not having luck finding a fix in a very short time frame for 6.9. So I added a fit text specific work around.

## Solution
`useFitText()` that queries the DOM directly when the ref-based `useBlockElement()` returns `null`. The fallback checks both the main document and the editor canvas iframe (`iframe[name="editor-canvas"]`) to find the block element.


cc: @jasmussen, @henriqueiamarino
## Testing

- Using the site editor add a fit text paragraph or heading on a template or page.
- Go to the preview by clicking on the w button verify fit text works (on trunk it does not)
- Resize the canvas and verify the text fits.

## Technical Details

The fix uses `useLayoutEffect` to query the DOM when `blockElement` is null:
1. First checks `document.getElementById()` in the main document
2. If not found, searches inside `iframe[name="editor-canvas"]`
3. Uses the found element as a fallback
4. All fit text logic uses `actualElement = blockElement || fallbackElement`

This ensures fit text works both in the normal editor (using refs) and in preview mode (using DOM queries).


## Screenshot

https://github.com/user-attachments/assets/36f73bce-7958-438a-b71a-20484dc5733e




