### PR TITLE
Fix: Fit text may not update when being grouped in a smaller container.

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -64,12 +64,17 @@ function useFitText( { fitText, name, clientId } ) {
 
 	// Monitor block attribute changes
 	// Any attribute may change the available space.
-	const blockAttributes = useSelect(
+	const { blockAttributes, parentId } = useSelect(
 		( select ) => {
 			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {
 				return;
 			}
-			return select( blockEditorStore ).getBlockAttributes( clientId );
+			return {
+				blockAttributes:
+					select( blockEditorStore ).getBlockAttributes( clientId ),
+				parentId:
+					select( blockEditorStore ).getBlockRootClientId( clientId ),
+			};
 		},
 		[ clientId, hasFitTextSupport, fitText ]
 	);
@@ -143,6 +148,7 @@ function useFitText( { fitText, name, clientId } ) {
 		if ( window.ResizeObserver && currentElement.parentElement ) {
 			resizeObserver = new window.ResizeObserver( applyFitText );
 			resizeObserver.observe( currentElement.parentElement );
+			resizeObserver.observe( currentElement );
 		}
 
 		// Cleanup function
@@ -169,7 +175,14 @@ function useFitText( { fitText, name, clientId } ) {
 				styleElement.remove();
 			}
 		};
-	}, [ fitText, clientId, applyFitText, blockElement, hasFitTextSupport ] );
+	}, [
+		fitText,
+		clientId,
+		parentId,
+		applyFitText,
+		blockElement,
+		hasFitTextSupport,
+	] );
 
 	// Trigger fit text recalculation when content changes
 	useEffect( () => {

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -11,6 +11,8 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
+const EMPTY_OBJECT = {};
+
 /**
  * Internal dependencies
  */
@@ -67,7 +69,7 @@ function useFitText( { fitText, name, clientId } ) {
 	const { blockAttributes, parentId } = useSelect(
 		( select ) => {
 			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {
-				return;
+				return EMPTY_OBJECT;
 			}
 			return {
 				blockAttributes:

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -64,8 +64,8 @@ function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
 
-	// Monitor block attribute changes
-	// Any attribute may change the available space.
+	// Monitor block attribute changes, and parent changes.
+	// Any attribute or parent change may change the available space.
 	const { blockAttributes, parentId } = useSelect(
 		( select ) => {
 			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {

--- a/packages/block-editor/src/utils/fit-text-frontend.js
+++ b/packages/block-editor/src/utils/fit-text-frontend.js
@@ -38,6 +38,7 @@ store( 'core/fit-text', {
 					context.fontSize = optimizeFitText( ref, applyFontSize );
 				} );
 				resizeObserver.observe( ref.parentElement );
+				resizeObserver.observe( ref );
 
 				// Return cleanup function to be called when element is removed.
 				return () => {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/72963

Currently there is a bug where when a fit text block is grouped inside a smaller container it may not update right away.
This PR fixes the issue by monitoring changes of the parent and observing its dimensions and not only the parent.

cc: @saarnilauri

## Testing Instructions
Add a fit text paragraph with some text.
Group it inside a group block.
Set the group content width to 50%, verify fit text fits.
Change the content width to 66% verify it continues to fit.
Verify things also look good on the front end.
