### PR TITLE
Real-time collaboration: Sync collections

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -338,6 +338,18 @@ export const deleteEntityRecord =
 				} );
 
 				await dispatch( removeItems( kind, name, recordId, true ) );
+
+				if (
+					window.__experimentalEnableSync &&
+					entityConfig.syncConfig
+				) {
+					if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+						const objectType = `${ kind }/${ name }`;
+						const objectId = recordId;
+
+						getSyncManager()?.unload( objectType, objectId );
+					}
+				}
 			} catch ( _error ) {
 				hasError = true;
 				error = _error;

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -16,8 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { getSyncManager } from './sync';
 import {
 	applyPostChangesToCRDTDoc,
-	defaultApplyChangesToCRDTDoc,
-	defaultGetChangesFromCRDTDoc,
+	defaultSyncConfig,
 	getPostChangesFromCRDTDoc,
 } from './utils/crdt';
 
@@ -211,7 +210,20 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/registered-templates',
 		key: 'id',
 	},
-];
+].map( ( entity ) => {
+	const syncEnabledRootEntities = new Set( [ 'comment' ] );
+
+	// Add using `if` statement to preserve tree-shaking based on IS_GUTENBERG_PLUGIN.
+	if (
+		syncEnabledRootEntities.has( entity.name ) &&
+		window.__experimentalEnableSync
+	) {
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			entity.syncConfig = defaultSyncConfig;
+		}
+	}
+	return entity;
+} );
 
 export const deprecatedEntities = {
 	root: {
@@ -393,7 +405,7 @@ async function loadTaxonomyEntities() {
 	} );
 	return Object.entries( taxonomies ?? {} ).map( ( [ name, taxonomy ] ) => {
 		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
-		return {
+		const entity = {
 			kind: 'taxonomy',
 			baseURL: `/${ namespace }/${ taxonomy.rest_base }`,
 			baseURLParams: { context: 'edit' },
@@ -402,6 +414,15 @@ async function loadTaxonomyEntities() {
 			getTitle: ( record ) => record?.name,
 			supportsPagination: true,
 		};
+
+		// Add using `if` statement to preserve tree-shaking based on IS_GUTENBERG_PLUGIN.
+		if ( window.__experimentalEnableSync ) {
+			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+				entity.syncConfig = defaultSyncConfig;
+			}
+		}
+
+		return entity;
 	} );
 }
 
@@ -420,15 +441,10 @@ async function loadSiteEntity() {
 		meta: {},
 	};
 
+	// Add using `if` statement to preserve tree-shaking based on IS_GUTENBERG_PLUGIN.
 	if ( window.__experimentalEnableSync ) {
 		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-			/**
-			 * @type {import('@wordpress/sync').SyncConfig}
-			 */
-			entity.syncConfig = {
-				applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
-				getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
-			};
+			entity.syncConfig = defaultSyncConfig;
 		}
 	}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -430,6 +430,30 @@ export const getEntityRecords =
 				};
 			}
 
+			if (
+				window.__experimentalEnableSync &&
+				entityConfig.syncConfig &&
+				-1 === query.per_page
+			) {
+				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+					const objectType = `${ kind }/${ name }`;
+					getSyncManager()?.loadCollection(
+						entityConfig.syncConfig,
+						objectType,
+						{
+							refetchRecords: async () => {
+								dispatch.receiveEntityRecords(
+									kind,
+									name,
+									await apiFetch( { path, parse: true } ),
+									query
+								);
+							},
+						}
+					);
+				}
+			}
+
 			// If we request fields but the result doesn't contain the fields,
 			// explicitly set these fields as "undefined"
 			// that way we consider the query "fulfilled".

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -8,7 +8,12 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  */
 // @ts-expect-error No exported types.
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
-import { type CRDTDoc, type ObjectData, Y } from '@wordpress/sync';
+import {
+	type CRDTDoc,
+	type ObjectData,
+	type SyncConfig,
+	Y,
+} from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -47,6 +52,7 @@ export type PostChanges = Partial< Post > & {
 export interface YPostRecord extends YMapRecord {
 	author: number;
 	blocks: YBlocks;
+	categories: number[];
 	comment_status: string;
 	date: string | null;
 	excerpt: string;
@@ -66,6 +72,7 @@ export interface YPostRecord extends YMapRecord {
 const allowedPostProperties = new Set< string >( [
 	'author',
 	'blocks',
+	'categories',
 	'comment_status',
 	'date',
 	'excerpt',
@@ -94,7 +101,7 @@ const disallowedPostMetaKeys = new Set< string >( [
  * @param {Partial< ObjectData >} changes
  * @return {void}
  */
-export function defaultApplyChangesToCRDTDoc(
+function defaultApplyChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: ObjectData
 ): void {
@@ -242,7 +249,7 @@ export function applyPostChangesToCRDTDoc(
 	} );
 }
 
-export function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
+function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
 	return getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
 }
 
@@ -381,6 +388,15 @@ export function getPostChangesFromCRDTDoc(
 
 	return changes;
 }
+
+/**
+ * This default sync config can be used for entities that are flat maps of
+ * primitive values and do not require custom logic to merge changes.
+ */
+export const defaultSyncConfig: SyncConfig = {
+	applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
+	getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
+};
 
 /**
  * Extract the raw string value from a property that may be a string or an object

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -16,6 +16,7 @@ import {
 import { createPersistedCRDTDoc, getPersistedCrdtDoc } from './persistence';
 import { getProviderCreators } from './providers';
 import type {
+	CollectionHandlers,
 	CRDTDoc,
 	EntityID,
 	ObjectID,
@@ -29,6 +30,13 @@ import type {
 import { createUndoManager } from './undo-manager';
 import { createYjsDoc } from './utils';
 import { Awareness } from 'y-protocols/awareness';
+
+interface CollectionState {
+	handlers: CollectionHandlers;
+	syncConfig: SyncConfig;
+	unload: () => void;
+	ydoc: CRDTDoc;
+}
 
 interface EntityState {
 	handlers: RecordHandlers;
@@ -45,6 +53,7 @@ interface EntityState {
  * and coordinates with the `core-data` store.
  */
 export function createSyncManager(): SyncManager {
+	const collectionStates: Map< ObjectType, CollectionState > = new Map();
 	const entityStates: Map< EntityID, EntityState > = new Map();
 	const undoManager = createUndoManager();
 
@@ -85,6 +94,7 @@ export function createSyncManager(): SyncManager {
 		const unload = (): void => {
 			providerResults.forEach( ( result ) => result.destroy() );
 			recordMap.unobserveDeep( onRecordUpdate );
+			recordMetaMap.unobserve( onRecordMetaUpdate );
 			ydoc.destroy();
 			entityStates.delete( entityId );
 		};
@@ -176,24 +186,102 @@ export function createSyncManager(): SyncManager {
 	}
 
 	/**
-	 * Unload an entity, stop syncing, and destroy its in-memory state.
+	 * Load a collection for syncing and manage its lifecycle.
+	 *
+	 * @param {SyncConfig}         syncConfig Sync configuration for the object type.
+	 * @param {ObjectType}         objectType Object type.
+	 * @param {CollectionHandlers} handlers   Handlers for updating the collection.
+	 */
+	async function loadCollection(
+		syncConfig: SyncConfig,
+		objectType: ObjectType,
+		handlers: CollectionHandlers
+	): Promise< void > {
+		const providerCreators: ProviderCreator[] = getProviderCreators();
+
+		if ( 0 === providerCreators.length ) {
+			return; // No provider creators, so syncing is effectively disabled.
+		}
+
+		if ( collectionStates.has( objectType ) ) {
+			return; // Already loaded.
+		}
+
+		const ydoc = createYjsDoc( { collection: true, objectType } );
+		const recordMetaMap = ydoc.getMap( RECORD_METADATA_KEY );
+		const now = Date.now();
+
+		// Clean up providers and in-memory state when the entity is unloaded.
+		const unload = (): void => {
+			providerResults.forEach( ( result ) => result.destroy() );
+			recordMetaMap.unobserve( onRecordMetaUpdate );
+			ydoc.destroy();
+			collectionStates.delete( objectType );
+		};
+
+		const onRecordMetaUpdate = (
+			event: Y.YMapEvent< unknown >,
+			transaction: Y.Transaction
+		) => {
+			if ( transaction.local ) {
+				return;
+			}
+
+			event.keysChanged.forEach( ( key ) => {
+				switch ( key ) {
+					case SAVED_AT_KEY:
+						const newValue = recordMetaMap.get( SAVED_AT_KEY );
+						if ( 'number' === typeof newValue && newValue > now ) {
+							// Another peer has saved the record. Refetch it so that we have
+							// a correct understanding of our own unsaved edits.
+							void handlers.refetchRecords().catch( () => {} );
+						}
+						break;
+				}
+			} );
+		};
+
+		const collectionState: CollectionState = {
+			handlers,
+			syncConfig,
+			unload,
+			ydoc,
+		};
+
+		collectionStates.set( objectType, collectionState );
+
+		// Create providers for the given entity and its Yjs document.
+		const providerResults = await Promise.all(
+			providerCreators.map( ( create ) => {
+				return create( objectType, null, ydoc );
+			} )
+		);
+
+		// Attach observers.
+		recordMetaMap.observe( onRecordMetaUpdate );
+	}
+
+	/**
+	 * Unload an entity, stop syncing, destroy its in-memory state, and trigger an
+	 * update of the collection.
 	 *
 	 * @param {ObjectType} objectType Object type to discard.
-	 * @param {ObjectID}   objectId   Object ID to discard.
+	 * @param {ObjectID}   objectId   Object ID to discard, or null for collections.
 	 */
 	function unloadEntity( objectType: ObjectType, objectId: ObjectID ): void {
 		entityStates.get( getEntityId( objectType, objectId ) )?.unload();
+		updateCRDTDoc( objectType, null, {}, origin, true /* isSave */ );
 	}
 
 	/**
 	 * Get the entity ID for the given object type and object ID.
 	 *
-	 * @param {ObjectType} objectType Object type.
-	 * @param {ObjectID}   objectId   Object ID.
+	 * @param {ObjectType}    objectType Object type.
+	 * @param {ObjectID|null} objectId   Object ID.
 	 */
 	function getEntityId(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID | null
 	): EntityID {
 		return `${ objectType }_${ objectId }`;
 	}
@@ -258,30 +346,39 @@ export function createSyncManager(): SyncManager {
 	 */
 	function updateCRDTDoc(
 		objectType: ObjectType,
-		objectId: ObjectID,
+		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
 		isSave: boolean = false
 	): void {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
+		const collectionState = collectionStates.get( objectType );
 
-		if ( ! entityState ) {
-			return;
+		if ( entityState ) {
+			const { syncConfig, ydoc } = entityState;
+			ydoc.transact( () => {
+				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+
+				if ( isSave ) {
+					// Mark the document as saved in the record metadata map.
+					const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
+					recordMeta.set( SAVED_AT_KEY, Date.now() );
+					recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
+				}
+			}, origin );
 		}
 
-		const { syncConfig, ydoc } = entityState;
-
-		ydoc.transact( () => {
-			syncConfig.applyChangesToCRDTDoc( ydoc, changes );
-
-			if ( isSave ) {
+		if ( collectionState && isSave ) {
+			const { ydoc } = collectionState;
+			ydoc.transact( () => {
 				// Mark the document as saved in the record metadata map.
 				const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
+
 				recordMeta.set( SAVED_AT_KEY, Date.now() );
 				recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
-			}
-		}, origin );
+			}, origin );
+		}
 	}
 
 	/**
@@ -345,6 +442,7 @@ export function createSyncManager(): SyncManager {
 	return {
 		createMeta: createEntityMeta,
 		load: loadEntity,
+		loadCollection,
 		undoManager,
 		unload: unloadEntity,
 		update: updateCRDTDoc,

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -11,7 +11,6 @@ import {
 	LOCAL_SYNC_MANAGER_ORIGIN,
 	CRDT_RECORD_METADATA_MAP_KEY as RECORD_METADATA_KEY,
 	CRDT_RECORD_METADATA_SAVED_AT_KEY as SAVED_AT_KEY,
-	CRDT_RECORD_METADATA_SAVED_BY_KEY as SAVED_BY_KEY,
 } from './config';
 import { createPersistedCRDTDoc, getPersistedCrdtDoc } from './persistence';
 import { getProviderCreators } from './providers';
@@ -28,7 +27,7 @@ import type {
 	SyncManager,
 } from './types';
 import { createUndoManager } from './undo-manager';
-import { createYjsDoc } from './utils';
+import { createYjsDoc, markEntityAsSaved } from './utils';
 import { Awareness } from 'y-protocols/awareness';
 
 interface CollectionState {
@@ -361,22 +360,14 @@ export function createSyncManager(): SyncManager {
 				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
 
 				if ( isSave ) {
-					// Mark the document as saved in the record metadata map.
-					const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
-					recordMeta.set( SAVED_AT_KEY, Date.now() );
-					recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
+					markEntityAsSaved( ydoc );
 				}
 			}, origin );
 		}
 
 		if ( collectionState && isSave ) {
-			const { ydoc } = collectionState;
-			ydoc.transact( () => {
-				// Mark the document as saved in the record metadata map.
-				const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
-
-				recordMeta.set( SAVED_AT_KEY, Date.now() );
-				recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
+			collectionState.ydoc.transact( () => {
+				markEntityAsSaved( collectionState.ydoc );
 			}, origin );
 		}
 	}

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -231,8 +231,8 @@ export function createSyncManager(): SyncManager {
 					case SAVED_AT_KEY:
 						const newValue = recordMetaMap.get( SAVED_AT_KEY );
 						if ( 'number' === typeof newValue && newValue > now ) {
-							// Another peer has saved the record. Refetch it so that we have
-							// a correct understanding of our own unsaved edits.
+							// Another peer has mutated the collection. Refetch it so that we
+							// obtain the updated records.
 							void handlers.refetchRecords().catch( () => {} );
 						}
 						break;

--- a/packages/sync/src/providers/indexeddb-provider.js
+++ b/packages/sync/src/providers/indexeddb-provider.js
@@ -13,14 +13,14 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 /**
  * Connect function to the IndexedDB persistence provider.
  *
- * @param {ObjectType} objectType The object type.
- * @param {ObjectID}   objectId   The object ID.
- * @param {CRDTDoc}    doc        The CRDT document.
+ * @param {ObjectType}    objectType The object type.
+ * @param {ObjectID|null} objectId   The object ID.
+ * @param {CRDTDoc}       doc        The CRDT document.
  *
  * @return {Promise< ProviderCreatorResult >} Promise that resolves when the connection is established.
  */
 export function createIndexedDbProvider( objectType, objectId, doc ) {
-	const roomName = `${ objectType }-${ objectId }`;
+	const roomName = objectId ? `${ objectType }-${ objectId }` : objectType;
 	const provider = new IndexeddbPersistence( roomName, doc );
 
 	return Promise.resolve( {

--- a/packages/sync/src/providers/webrtc-provider.js
+++ b/packages/sync/src/providers/webrtc-provider.js
@@ -24,10 +24,12 @@ import { WebrtcProviderWithHttpSignaling } from './webrtc-http-stream-signaling'
 export function createWebRTCProvider( { signaling, password } ) {
 	return function (
 		/** @type {ObjectType} */ objectType,
-		/** @type {ObjectID} */ objectId,
+		/** @type {ObjectID|null} */ objectId,
 		/** @type {CRDTDoc} */ doc
 	) {
-		const roomName = `${ objectType }-${ objectId }`;
+		const roomName = objectId
+			? `${ objectType }-${ objectId }`
+			: objectType;
 		const provider = new WebrtcProviderWithHttpSignaling( roomName, doc, {
 			signaling,
 			password,

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -55,10 +55,14 @@ export interface ProviderCreatorResult {
 
 export type ProviderCreator = (
 	objectType: ObjectType,
-	objectId: ObjectID,
+	objectId: ObjectID | null,
 	ydoc: Y.Doc,
 	awareness?: Awareness
 ) => Promise< ProviderCreatorResult >;
+
+export interface CollectionHandlers {
+	refetchRecords: () => Promise< void >;
+}
 
 export interface RecordHandlers {
 	editRecord: ( data: Partial< ObjectData > ) => void;
@@ -91,11 +95,16 @@ export interface SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	) => Promise< void >;
+	loadCollection: (
+		syncConfig: SyncConfig,
+		objectType: ObjectType,
+		handlers: CollectionHandlers
+	) => Promise< void >;
 	undoManager: SyncUndoManager;
 	unload: ( objectType: ObjectType, objectId: ObjectID ) => void;
 	update: (
 		objectType: ObjectType,
-		objectId: ObjectID,
+		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
 		isSave?: boolean

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -10,6 +10,9 @@ import * as buffer from 'lib0/buffer';
 import {
 	CRDT_DOC_META_PERSISTENCE_KEY,
 	CRDT_DOC_VERSION,
+	CRDT_RECORD_METADATA_MAP_KEY as RECORD_METADATA_KEY,
+	CRDT_RECORD_METADATA_SAVED_AT_KEY as SAVED_AT_KEY,
+	CRDT_RECORD_METADATA_SAVED_BY_KEY as SAVED_BY_KEY,
 	CRDT_STATE_MAP_KEY,
 	CRDT_STATE_VERSION_KEY,
 } from './config';
@@ -31,6 +34,18 @@ export function createYjsDoc( documentMeta: DocumentMeta = {} ): Y.Doc {
 	stateMap.set( CRDT_STATE_VERSION_KEY, CRDT_DOC_VERSION );
 
 	return ydoc;
+}
+
+/**
+ * Record that the entity was saved (persisted to the database) in the CRDT
+ * document record metadata.
+ *
+ * @param {CRDTDoc} ydoc CRDT document.
+ */
+export function markEntityAsSaved( ydoc: CRDTDoc ): void {
+	const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
+	recordMeta.set( SAVED_AT_KEY, Date.now() );
+	recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
 }
 
 export function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {


### PR DESCRIPTION
## What?

Allow collaborators to receive updates to entity collections in real-time. 

## Why?

We currently approach syncing entity-by-entity. In other words, we only sync entities that were loaded by ID (e.g., a post with ID `123`). We have no mechanism to sync changes to entity collections. Examples of entity collections in the block editor include:

- Block comments
- Categories and other taxonomies
- Patterns

Syncing entity collections is important if we want to capture entity creation and deletion within a collaborative editing session. It also allows us to capture edits to entities in the collection without specifically opening a connection for each entity.

## How?

To accomplish this, we extend the `SyncManager` to allow entity collections to be loaded. Collections are represented by a CRDT document, but we do not load entity records into it. Instead, we keep track of when the collection was last updated. This is used as a signal to trigger a refetch of the collection and keep the entire collection in sync among peers.

This is the same method we use when syncing a single entity to understand if the entity was saved by a collaborative peer.

This approach assumes that:

1. collections are resolved with `getEntityRecords()`.
2. entity creations and edits use `saveEntityRecord()`.
3. entity deletions use `deleteEntityRecord()`.

This is a common pattern and fits the examples noted above.

## Testing Instructions

1. Check out this PR.
2. Open a post in two browsers for collaborative editing.
3. Add, remove, and edit block comments. Add and remove categories. Create patterns.

### Testing Instructions for Keyboard

No UI changes in this PR.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/96ce5567-9ac2-4ce9-b56d-1f41d9c94324

