### PR TITLE
Fix adding blocks through media tab with experimental modal.

### DIFF
--- a/backport-changelog/6.9/10054.md
+++ b/backport-changelog/6.9/10054.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10054
+
+* https://github.com/WordPress/gutenberg/pull/73029

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller-6-9.php
@@ -32,7 +32,30 @@ class Gutenberg_REST_Attachments_Controller_6_9 extends WP_REST_Attachments_Cont
 	 * @return array Array of query arguments.
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
+		// Store array parameters that we'll handle separately.
+		$media_type_array = null;
+		$mime_type_array  = null;
+
+		if ( ! empty( $request['media_type'] ) && is_array( $request['media_type'] ) ) {
+			$media_type_array = $request['media_type'];
+			unset( $request['media_type'] );
+		}
+
+		if ( ! empty( $request['mime_type'] ) && is_array( $request['mime_type'] ) ) {
+			$mime_type_array = $request['mime_type'];
+			unset( $request['mime_type'] );
+		}
+
 		$query_args = parent::prepare_items_query( $prepared_args, $request );
+
+		// Restore the array parameters to the request.
+		if ( null !== $media_type_array ) {
+			$request['media_type'] = $media_type_array;
+		}
+
+		if ( null !== $mime_type_array ) {
+			$request['mime_type'] = $mime_type_array;
+		}
 
 		if ( empty( $query_args['post_status'] ) ) {
 			$query_args['post_status'] = 'inherit';
@@ -41,16 +64,16 @@ class Gutenberg_REST_Attachments_Controller_6_9 extends WP_REST_Attachments_Cont
 		$all_mime_types = array();
 		$media_types    = $this->get_media_types();
 
-		if ( ! empty( $request['media_type'] ) && is_array( $request['media_type'] ) ) {
-			foreach ( $request['media_type'] as $type ) {
+		if ( null !== $media_type_array ) {
+			foreach ( $media_type_array as $type ) {
 				if ( isset( $media_types[ $type ] ) ) {
 					$all_mime_types = array_merge( $all_mime_types, $media_types[ $type ] );
 				}
 			}
 		}
 
-		if ( ! empty( $request['mime_type'] ) && is_array( $request['mime_type'] ) ) {
-			foreach ( $request['mime_type'] as $mime_type ) {
+		if ( null !== $mime_type_array ) {
+			foreach ( $mime_type_array as $mime_type ) {
 				$parts = explode( '/', $mime_type );
 				if ( isset( $media_types[ $parts[0] ] ) && in_array( $mime_type, $media_types[ $parts[0] ], true ) ) {
 					$all_mime_types[] = $mime_type;

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Attachments_Controller_6_9 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Controller which provides REST endpoint for retrieving attachments.
+ * This overrides the core WP_REST_Attachments_Controller to provide
+ * support for filtering by multiple media types.
+ *
+ * @since 6.9.0
+ *
+ * @see WP_REST_Attachments_Controller
+ */
+class Gutenberg_REST_Attachments_Controller_6_9 extends WP_REST_Attachments_Controller {
+
+	/**
+	 * Determines the allowed query_vars for a get_items() response and
+	 * prepares for WP_Query.
+	 *
+	 * This overrides the parent method to add support for filtering by
+	 * multiple media types, which was added in WordPress 6.9.
+	 *
+	 * @since 4.7.0
+	 * @since 6.9.0 Added orderby_mime_type filter to add custom ordering.
+	 * @since 6.9.0 Extends the `media_type` and `mime_type` request arguments to support array values.
+	 *
+	 * @param array           $prepared_args Optional. Array of prepared arguments. Default empty array.
+	 * @param WP_REST_Request $request       Optional. Request to prepare items for.
+	 * @return array Array of query arguments.
+	 */
+	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
+		$query_args = parent::prepare_items_query( $prepared_args, $request );
+
+		if ( empty( $query_args['post_status'] ) ) {
+			$query_args['post_status'] = 'inherit';
+		}
+
+		$all_mime_types = array();
+		$media_types    = $this->get_media_types();
+
+		if ( ! empty( $request['media_type'] ) && is_array( $request['media_type'] ) ) {
+			foreach ( $request['media_type'] as $type ) {
+				if ( isset( $media_types[ $type ] ) ) {
+					$all_mime_types = array_merge( $all_mime_types, $media_types[ $type ] );
+				}
+			}
+		}
+
+		if ( ! empty( $request['mime_type'] ) && is_array( $request['mime_type'] ) ) {
+			foreach ( $request['mime_type'] as $mime_type ) {
+				$parts = explode( '/', $mime_type );
+				if ( isset( $media_types[ $parts[0] ] ) && in_array( $mime_type, $media_types[ $parts[0] ], true ) ) {
+					$all_mime_types[] = $mime_type;
+				}
+			}
+		}
+
+		if ( ! empty( $all_mime_types ) ) {
+			$query_args['post_mime_type'] = array_values( array_unique( $all_mime_types ) );
+		}
+
+		// Filter query clauses to include filenames.
+		if ( isset( $query_args['s'] ) ) {
+			add_filter( 'wp_allow_query_attachment_by_filename', '__return_true' );
+		}
+
+		return $query_args;
+	}
+
+	/**
+	 * Retrieves the query params for collections of attachments.
+	 *
+	 * @since 4.7.0
+	 * @since 6.9.0 Extends the `media_type` and `mime_type` request arguments to support array values.
+	 *
+	 * @return array Query parameters for the attachment collection as an array.
+	 */
+	public function get_collection_params() {
+		$params                            = parent::get_collection_params();
+		$params['status']['default']       = 'inherit';
+		$params['status']['items']['enum'] = array( 'inherit', 'private', 'trash' );
+		$media_types                       = array_keys( $this->get_media_types() );
+
+		$params['media_type'] = array(
+			'default'     => null,
+			'description' => __( 'Limit result set to attachments of a particular media type or media types.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+				'enum' => $media_types,
+			),
+		);
+
+		$params['mime_type'] = array(
+			'default'     => null,
+			'description' => __( 'Limit result set to attachments of a particular MIME type or MIME types.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+			),
+		);
+
+		return $params;
+	}
+}

--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -29,3 +29,22 @@ function gutenberg_rest_theme_export_link_rel( $response, $theme ) {
 	return $response;
 }
 add_filter( 'rest_prepare_theme', 'gutenberg_rest_theme_export_link_rel', 10, 2 );
+
+/**
+ * Overrides the REST controller for the attachment post type to add support
+ * for filtering by multiple media types.
+ *
+ * Only applies if the experimental media processing feature is not enabled,
+ * as that feature includes this functionality and more.
+ *
+ * @param array  $args      Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
+ * @return array Modified array of arguments.
+ */
+function gutenberg_override_attachments_rest_controller( $args, $post_type ) {
+	if ( 'attachment' === $post_type && ! gutenberg_is_experiment_enabled( 'gutenberg-media-processing' ) ) {
+		$args['rest_controller_class'] = 'Gutenberg_REST_Attachments_Controller_6_9';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_override_attachments_rest_controller', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -45,6 +45,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
+	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php';
 	require __DIR__ . '/compat/wordpress-6.9/template-activate.php';
 	require __DIR__ . '/compat/wordpress-6.9/block-bindings.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -45,7 +45,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
-	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller.php';
+	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller-6-9.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-static-templates-controller.php';
 	require __DIR__ . '/compat/wordpress-6.9/template-activate.php';
 	require __DIR__ . '/compat/wordpress-6.9/block-bindings.php';

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -77,7 +77,13 @@ function MediaTab( {
 			if ( ! media?.url ) {
 				return;
 			}
-			const [ block ] = getBlockAndPreviewFromMedia( media, media.type );
+			// When the experimental DataViews media modal is enabled,
+			// we need to extract the media type from mime_type (e.g., 'image/jpeg' -> 'image')
+			const mediaType =
+				window.__experimentalDataViewsMediaModal && media.mime_type
+					? media.mime_type.split( '/' )[ 0 ]
+					: media.type;
+			const [ block ] = getBlockAndPreviewFromMedia( media, mediaType );
 			onInsert( block );
 		},
 		[ onInsert ]

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -185,7 +185,7 @@ export function MediaUploadModal( {
 		if ( ! filters.media_type ) {
 			filters.media_type = allowedTypes.includes( '*' )
 				? undefined
-				: allowedTypes[ 0 ];
+				: allowedTypes;
 		}
 
 		return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Follow-up from #71944.

Fixes a bug in the media modal experiment where adding media from the media modal that opens in the media tab caused an error in the added block, because the block derives its type from the media type.

Also enables correct media types to display in the media tab modal.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the dataviews media modal experiment.
2. In a post, open the "Add" sidebar and go to the media tab. Click the "open media library" button at the bottom.
3. Try adding an image, an audio file and a video. All 3 should be added in their correct blocks.





https://github.com/user-attachments/assets/f8c41eac-b8aa-4599-ae19-b7681f659dbf


