### PR TITLE
Accordion Header, Panel: Add CSS for the default style

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,41 +1,15 @@
-@mixin accordion-inherit-style {
-	background-color: inherit;
-	border-color: inherit;
-	color: inherit;
-}
-
-// The .wp-block-accordion selector is needed to make this CSS stronger
-// than the default heading padding when background color is applied.
-// than the default button background, color and border styles.
-.wp-block-accordion .wp-block-accordion-heading {
+// In many classic themes, selectors like `.entry-content h1` are used,
+// potentially applying relatively high specificity (such as `0-1-1`) to
+// heading elements. To properly override those styles, use a selector
+// with a specificity of `0-2-0`.
+.wp-block-accordion-heading.wp-block-accordion-heading {
+	// Some themes may have an explicit width. Since it's unpredictable
+	// what CSS specificity should be used to override them, ensure 100%
+	// width using min-width instead.
+	min-width: 100%;
+	// Some classic themes apply default margins to heading elements,
+	// so those styles need to be reset.
 	margin: 0;
-	padding: 0;
-}
-
-.wp-block-accordion {
-	.wp-block {
-		&.wp-block-accordion-heading {
-			margin: 0;
-		}
-	}
-	.wp-block-accordion-item {
-		.wp-block-accordion-heading {
-			width: 100%;
-
-			&.has-text-color,
-			&.has-background {
-				.wp-block-accordion-heading__toggle {
-					text-decoration: none;
-					@include accordion-inherit-style;
-
-					&:hover,
-					&:focus {
-						@include accordion-inherit-style;
-					}
-				}
-			}
-		}
-	}
 }
 
 .wp-block-accordion-heading__toggle {
@@ -48,26 +22,45 @@
 	text-decoration: inherit;
 	word-spacing: inherit;
 	font-style: inherit;
-	background: none;
 	border: none;
-	color: inherit;
 	padding: var(--wp--preset--spacing--20, 1em) 0;
 	cursor: pointer;
 	overflow: hidden;
 	display: flex;
 	align-items: center;
 	text-align: inherit;
-	position: relative;
 	width: 100%;
+
+	// Some themes may apply colors to button elements with a particularly
+	// high CSS specificity. Since it's impossible to predict this specificity,
+	// we reset the colors using `!important`.
+	background-color: inherit !important;
+	color: inherit !important;
 
 	&:not(:focus-visible) {
 		outline: none;
 	}
 
-	&:hover {
-		.wp-block-accordion-heading__toggle-title {
-			text-decoration: underline;
-		}
+	&:hover,
+	&:focus {
+		// Some themes may apply styles when a button element is hovered
+		// over or focused. This is not intended for accordion toggle
+		// buttons, so we reset it here.
+		text-decoration: none;
+		background-color: inherit !important;
+		box-shadow: none;
+		color: inherit;
+		border: none;
+		padding: var(--wp--preset--spacing--20, 1em) 0;
+	}
+
+	&:focus-visible {
+		outline: auto;
+		outline-offset: 0;
+	}
+
+	&:hover .wp-block-accordion-heading__toggle-title {
+		text-decoration: underline;
 	}
 }
 

--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,3 +1,43 @@
+@mixin accordion-inherit-style {
+	background-color: inherit;
+	border-color: inherit;
+	color: inherit;
+}
+
+// The .wp-block-accordion selector is needed to make this CSS stronger
+// than the default heading padding when background color is applied.
+// than the default button background, color and border styles.
+.wp-block-accordion .wp-block-accordion-heading {
+	margin: 0;
+	padding: 0;
+}
+
+.wp-block-accordion {
+	.wp-block {
+		&.wp-block-accordion-heading {
+			margin: 0;
+		}
+	}
+	.wp-block-accordion-item {
+		.wp-block-accordion-heading {
+			width: 100%;
+
+			&.has-text-color,
+			&.has-background {
+				.wp-block-accordion-heading__toggle {
+					text-decoration: none;
+					@include accordion-inherit-style;
+
+					&:hover,
+					&:focus {
+						@include accordion-inherit-style;
+					}
+				}
+			}
+		}
+	}
+}
+
 .wp-block-accordion-heading__toggle {
 	font-family: inherit;
 	font-size: inherit;

--- a/packages/block-library/src/accordion-panel/style.scss
+++ b/packages/block-library/src/accordion-panel/style.scss
@@ -1,8 +1,20 @@
+.wp-block-accordion {
+	.wp-block {
+		&.wp-block-accordion-panel {
+			margin: 0;
+		}
+	}
+}
+
 .wp-block-accordion-panel {
 	// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
 	&[inert],
 	&[aria-hidden="true"] {
 		display: none;
 		margin-block-start: 0;
+	}
+
+	p {
+		margin: 0;
 	}
 }

--- a/packages/block-library/src/accordion-panel/style.scss
+++ b/packages/block-library/src/accordion-panel/style.scss
@@ -1,20 +1,13 @@
-.wp-block-accordion {
-	.wp-block {
-		&.wp-block-accordion-panel {
-			margin: 0;
-		}
-	}
-}
+// Some classic themes may use selectors like `.wp-block .wp-block`
+// and apply some kind of width to the blocks. To properly override
+// those styles, use a selector with a specificity of `0-2-0`.
+.wp-block-accordion-panel.wp-block-accordion-panel {
+	min-width: 100%;
 
-.wp-block-accordion-panel {
 	// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
 	&[inert],
 	&[aria-hidden="true"] {
 		display: none;
 		margin-block-start: 0;
-	}
-
-	p {
-		margin: 0;
 	}
 }


### PR DESCRIPTION
- Fixes https://github.com/WordPress/gutenberg/issues/71529
- Alternatives to https://github.com/WordPress/gutenberg/pull/72207

## What?

This pull request adds default styles to the accordion header and accordion panel.

## Why?

Many themes, especially classic themes, apply various CSS styles to heading and button elements. The Accordion Heading block is particularly susceptible to this because it consists of both heading and button elements. Therefore, an unnatural style may be applied to the accordion header in some cases.

## How?

I tested all the default classic themes and added CSS to ensure the following specifications are met.

- Accordion Heading:
  - Zero margin
  - Has 100% width
  - Accordion Heading Toggle:
    - Has default text color, no background color
    - No text decoration
    - Hover: 
      - Show text deloration
    - Focus with Keyboard:
      - Show default outline
- Accordion Panel:
  - Has 100% width

A completely different approach might be to leave it entirely up to the theme developer to decide which CSS to apply. However, this means that the default themes themselves would need to be modified.

## Testing Instructions

- Activate the default theme, especially the classic theme.
- Inset an Accordion block.
- Ensure that the above specifications are met.

## Screenshots or screencast <!-- if applicable -->

The following describes the behavior using the TT1 theme. It should work similarly with other default classic themes as well.

https://github.com/user-attachments/assets/56086428-cf71-4437-a40e-49d10dbc1264
