### PR TITLE
Border radius presets: support mixed values in the rangecontrol slider

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/test/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/test/utils.js
@@ -107,6 +107,96 @@ describe( 'getAllValue', () => {
 			expect( getAllValue( undefined ) ).toBe( undefined );
 		} );
 	} );
+
+	describe( 'when provided complex CSS values (clamp, min, max, calc)', () => {
+		it( 'should preserve clamp values when all corners have the same clamp value', () => {
+			const clampValue = 'clamp(1rem, 2vw, 3rem)';
+			const values = {
+				bottomLeft: clampValue,
+				bottomRight: clampValue,
+				topLeft: clampValue,
+				topRight: clampValue,
+			};
+			expect( getAllValue( values ) ).toBe( clampValue );
+		} );
+
+		it( 'should preserve min() values when all corners have the same min value', () => {
+			const minValue = 'min(10px, 5vw)';
+			const values = {
+				bottomLeft: minValue,
+				bottomRight: minValue,
+				topLeft: minValue,
+				topRight: minValue,
+			};
+			expect( getAllValue( values ) ).toBe( minValue );
+		} );
+
+		it( 'should preserve max() values when all corners have the same max value', () => {
+			const maxValue = 'max(20px, 10vw)';
+			const values = {
+				bottomLeft: maxValue,
+				bottomRight: maxValue,
+				topLeft: maxValue,
+				topRight: maxValue,
+			};
+			expect( getAllValue( values ) ).toBe( maxValue );
+		} );
+
+		it( 'should preserve calc() values when all corners have the same calc value', () => {
+			const calcValue = 'calc(100% - 20px)';
+			const values = {
+				bottomLeft: calcValue,
+				bottomRight: calcValue,
+				topLeft: calcValue,
+				topRight: calcValue,
+			};
+			expect( getAllValue( values ) ).toBe( calcValue );
+		} );
+
+		it( 'should return undefined when complex CSS values are mixed', () => {
+			const values = {
+				bottomLeft: 'clamp(1rem, 2vw, 3rem)',
+				bottomRight: 'clamp(1rem, 2vw, 3rem)',
+				topLeft: 'min(10px, 5vw)',
+				topRight: 'clamp(1rem, 2vw, 3rem)',
+			};
+			expect( getAllValue( values ) ).toBe( undefined );
+		} );
+
+		it( 'should return undefined when complex CSS values are mixed with simple values', () => {
+			const values = {
+				bottomLeft: 'clamp(1rem, 2vw, 3rem)',
+				bottomRight: 'clamp(1rem, 2vw, 3rem)',
+				topLeft: '2px',
+				topRight: 'clamp(1rem, 2vw, 3rem)',
+			};
+			expect( getAllValue( values ) ).toBe( undefined );
+		} );
+
+		it( 'should preserve string values that cannot be parsed at all (no numeric prefix)', () => {
+			// Values with no numeric prefix cannot be parsed, so they should be preserved
+			const unparseableValue = 'apples';
+			const values = {
+				bottomLeft: unparseableValue,
+				bottomRight: unparseableValue,
+				topLeft: unparseableValue,
+				topRight: unparseableValue,
+			};
+			expect( getAllValue( values ) ).toBe( unparseableValue );
+		} );
+
+		it( 'should parse numeric prefix from partially parseable values', () => {
+			// Values with numeric prefix get parsed, so "32apples" becomes "32"
+			const partiallyParseableValue = '32apples';
+			const values = {
+				bottomLeft: partiallyParseableValue,
+				bottomRight: partiallyParseableValue,
+				topLeft: partiallyParseableValue,
+				topRight: partiallyParseableValue,
+			};
+			expect( getAllValue( values ) ).toBe( '32' );
+		} );
+	} );
 } );
 
 describe( 'hasMixedValues', () => {

--- a/packages/block-editor/src/components/border-radius-control/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/utils.js
@@ -60,9 +60,14 @@ export function getAllValue( values = {} ) {
 		return values;
 	}
 
-	const parsedQuantitiesAndUnits = Object.values( values ).map( ( value ) =>
-		parseQuantityAndUnitFromRawValue( value )
-	);
+	const parsedQuantitiesAndUnits = Object.values( values ).map( ( value ) => {
+		const newValue = parseQuantityAndUnitFromRawValue( value );
+		if ( typeof value === 'string' && newValue[ 0 ] === undefined ) {
+			// Should we do some string testing here, like the font size picker's `isSimpleCssValue`?
+			return [ value, '' ];
+		}
+		return newValue;
+	} );
 
 	const allValues = parsedQuantitiesAndUnits.map(
 		( value ) => value[ 0 ] ?? ''

--- a/packages/block-editor/src/components/border-radius-control/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/utils.js
@@ -63,7 +63,6 @@ export function getAllValue( values = {} ) {
 	const parsedQuantitiesAndUnits = Object.values( values ).map( ( value ) => {
 		const newValue = parseQuantityAndUnitFromRawValue( value );
 		if ( typeof value === 'string' && newValue[ 0 ] === undefined ) {
-			// Should we do some string testing here, like the font size picker's `isSimpleCssValue`?
 			return [ value, '' ];
 		}
 		return newValue;


### PR DESCRIPTION


Fixes https://github.com/WordPress/gutenberg/issues/73018

## What?
Update the `getAllValue` function to handle complex CSS values and preserve unparseable strings. 

Added tests for clamp, min, max, and calc values, ensuring correct behavior with mixed and simple values.


## Why?

When `parseQuantityAndUnitFromRawValue` can't parse a clamp value like `"clamp(1rem, 2vw, 3rem)"`, it returns `[undefined, undefined]`.

Without the fix, that becomes `[undefined, undefined]`, and the clamp value is lost.

## How?

Check that the value is a string and is unparseable. Return the original value.

## Testing Instructions

Here is some test JSON to apply to your theme.

```json 
		"border": {
			"radiusSizes": [
				{
					"name": "Small",
					"slug": "small",
					"size": "2px"
				},
				{
					"name": "Medium",
					"slug": "medium",
					"size": "4px"
				},
				{
					"name": "ClampyMedium",
					"slug": "clampy-med",
					"size": "clamp(0.3125rem, 0.00391rem + 0.39063vw, 0.625rem)"
				},
				{
					"name": "ClampyLarge",
					"slug": "clampy-large",
					"size": "clamp(0.625rem, 0.00781rem + 0.78125vw, 1.25rem)"
				},
				{
					"name": "Full",
					"slug": "full",
					"size": "9999px"
				}
			]
		}
```

Head to the editor and try to apply these border radius presets to a Group or other block.

You should be able to apply all presents to all, or single corners.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a5f8478b-df30-4aa9-b33e-b695ed45523d



