### PR TITLE
DataViews Table - only output aria-label for media when item is clickable

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - useFormValidity: make it work with any level of nesting in the form. [#72588](https://github.com/WordPress/gutenberg/pull/72588)
 - Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)
+- Fix: Incorrect aria-label in table layout when items are not clickable. [#73034](https://github.com/WordPress/gutenberg/pull/73034)
 
 ## 10.2.0 (2025-10-29)
 

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -51,7 +51,7 @@ function ColumnPrimary< Item >( {
 					className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media"
 					aria-label={
 						isItemClickable( item ) &&
-						!! onClickItem &&
+						( !! onClickItem || !! renderItemLink ) &&
 						!! titleField
 							? titleField.getValue?.( { item } )
 							: undefined

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -16,7 +16,6 @@ import {
  */
 import type { NormalizedField } from '../../types';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
-import { sprintf, __ } from '@wordpress/i18n';
 
 function ColumnPrimary< Item >( {
 	item,
@@ -51,12 +50,10 @@ function ColumnPrimary< Item >( {
 					renderItemLink={ renderItemLink }
 					className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media"
 					aria-label={
-						titleField
-							? sprintf(
-									// translators: %s is the item title.
-									__( 'Click item: %s' ),
-									titleField.getValue?.( { item } )
-							  )
+						isItemClickable( item ) &&
+						!! onClickItem &&
+						!! titleField
+							? titleField.getValue?.( { item } )
 							: undefined
 					}
 				>

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -70,7 +70,10 @@ const defaultLayouts = {
 	[ LAYOUT_LIST ]: {},
 };
 
-export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
+export const Default = ( {
+	perPageSizes = [ 10, 25, 50, 100 ],
+	hasClickableItems = true,
+} ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'categories' ],
@@ -100,7 +103,7 @@ export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
 					{ ...props }
 				/>
 			) }
-			isItemClickable={ () => true }
+			isItemClickable={ () => hasClickableItems }
 			defaultLayouts={ defaultLayouts }
 			config={ { perPageSizes } }
 		/>
@@ -109,12 +112,17 @@ export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
 
 Default.args = {
 	perPageSizes: [ 10, 25, 50, 100 ],
+	hasClickableItems: true,
 };
 
 Default.argTypes = {
 	perPageSizes: {
 		control: 'object',
 		description: 'Array of available page sizes',
+	},
+	hasClickableItems: {
+		control: 'boolean',
+		description: 'Are the items clickable',
 	},
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a small issue with the DataViews table layout observed in https://github.com/WordPress/gutenberg/pull/72914#discussion_r2497817830.

When a table layout's item is not clickable, an aria-label saying "Click item" is still being rendered. This PR should fix the issue.

## How?
- Adds some extra checks for `isItemClickable( item )` and `onClickItem` | `renderItemLink`, to more closely match the logic that the grid layout has.
- Also removes the 'Click item' part of the text. I don't think this adds anything for a screenreader user, who will already know they can click the item because it's a button. The text would be more useful if it told the user what clicking the item will do, but that's up to the implementation.

## Testing Instructions
1. Checkout the branch and run `npm run storybook:dev` to open the storybook locally
2. Navigate to the DataViews story
3. From the controls at the bottom toggle off 'hasClickableItems'
4. Inspect the images and check that the wrapping element no longer has an aria label.

To reproduce the original bug you can also try checking out `trunk`, change this line to return false:
https://github.com/WordPress/gutenberg/blob/0e79f37e88ff5b82f5674c6e6b98039d6e96ae6c/packages/dataviews/src/stories/dataviews.story.tsx#L103

Then observe that the images in the table have a 'Click item' aria label on a non-interactive wrapping element.