### PR TITLE
Button: Revert disabled primary button state to its previous one

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Button`: Revert disabled primary button state to its previous one ([#73037](https://github.com/WordPress/gutenberg/pull/73037)).
 -   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -86,9 +86,9 @@
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: $components-color-foreground-inverted;
-			background: $components-color-gray-300;
-			border-color: $components-color-gray-300;
+			color: rgba($white, 0.4);
+			background: $components-color-accent;
+			border-color: $components-color-accent;
 			outline: none;
 
 			&:focus:enabled {


### PR DESCRIPTION
- Related to https://github.com/WordPress/gutenberg/issues/70674
- Closes https://github.com/WordPress/gutenberg/issues/72962

## What? Why?

We changed the color of the disabled primary button to make it less prominent. However, this resulted in a decrease in contrast ratio, and we received feedback that the button is difficult to see. After discussion and considering a future new design system, I think we should revert to the previous color design for now.

## Testing Instructions

- Open a new post and confirm the disabled primary "Publish" button
- You can also run `npm run storybook:e2e:dev` to confirm all button variations.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="470" height="175" alt="before-header" src="https://github.com/user-attachments/assets/92126d78-81bd-4d9f-a73a-e284a3edff52" />

<img width="738" height="474" alt="before" src="https://github.com/user-attachments/assets/19fd5eef-cca8-495c-a3b9-71a091368f30" />

### After

<img width="470" height="175" alt="after-header" src="https://github.com/user-attachments/assets/c264695f-68d6-4ded-b37f-7a9c0fcb6084" />

<img width="737" height="467" alt="after" src="https://github.com/user-attachments/assets/19d014c3-3f76-441b-afa5-ce27a3b58704" />
