### PR TITLE
Button: Revert disabled primary button state to its previous one (#73037)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `Badge`: Add max-width for text truncation ([#72653](https://github.com/WordPress/gutenberg/pull/72653)).
+-   `Button`: Revert disabled primary button state to its previous one ([#73037](https://github.com/WordPress/gutenberg/pull/73037)).
 
 ## 30.6.0 (2025-10-17)
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -85,9 +85,9 @@
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: $components-color-foreground-inverted;
-			background: $components-color-gray-300;
-			border-color: $components-color-gray-300;
+			color: rgba($white, 0.4);
+			background: $components-color-accent;
+			border-color: $components-color-accent;
 			outline: none;
 
 			&:focus:enabled {


### PR DESCRIPTION
## What?

Manually backports #73037 into the `wp/6.9` branch.

## Why?

This is a common automatic cherry-picking failure, caused by conflicts in the CHANGELOG file of the component package.