### PR TITLE
Notes position alignment in HTML

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -41,7 +41,7 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { focusCommentThread, getCommentExcerpt } from './utils';
-import { useFloatingThread, useBlockMode } from './hooks';
+import { useFloatingThread } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
 
@@ -69,22 +69,29 @@ export function Comments( {
 	const { selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
 	);
-	const { blockCommentId, selectedBlockClientId, orderedBlockIds } =
-		useSelect( ( select ) => {
-			const {
-				getBlockAttributes,
-				getSelectedBlockClientId,
-				getClientIdsWithDescendants,
-			} = select( blockEditorStore );
-			const clientId = getSelectedBlockClientId();
-			return {
-				blockCommentId: clientId
-					? getBlockAttributes( clientId )?.metadata?.noteId
-					: null,
-				selectedBlockClientId: clientId,
-				orderedBlockIds: getClientIdsWithDescendants(),
-			};
-		}, [] );
+
+	const {
+		blockCommentId,
+		selectedBlockClientId,
+		orderedBlockIds,
+		blockMode,
+	} = useSelect( ( select ) => {
+		const {
+			getBlockAttributes,
+			getSelectedBlockClientId,
+			getClientIdsWithDescendants,
+			getBlockMode,
+		} = select( blockEditorStore );
+		const clientId = getSelectedBlockClientId();
+		return {
+			blockCommentId: clientId
+				? getBlockAttributes( clientId )?.metadata?.noteId
+				: null,
+			selectedBlockClientId: clientId,
+			orderedBlockIds: getClientIdsWithDescendants(),
+			blockMode: clientId ? getBlockMode( clientId ) : null,
+		};
+	}, [] );
 
 	const relatedBlockElement = useBlockElement( selectedBlockClientId );
 
@@ -126,9 +133,6 @@ export function Comments( {
 		selectedBlockClientId,
 		orderedBlockIds,
 	] );
-
-	// Track mode change for the selected block to reflow offsets on "Edit as HTML"
-	const blockMode = useBlockMode( selectedBlockClientId );
 
 	const handleDelete = async ( comment ) => {
 		const currentIndex = threads.findIndex( ( t ) => t.id === comment.id );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -41,7 +41,7 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { focusCommentThread, getCommentExcerpt } from './utils';
-import { useFloatingThread } from './hooks';
+import { useFloatingThread, useBlockMode } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
 
@@ -126,6 +126,9 @@ export function Comments( {
 		selectedBlockClientId,
 		orderedBlockIds,
 	] );
+
+	// Track mode change for the selected block to reflow offsets on "Edit as HTML"
+	const blockMode = useBlockMode( selectedBlockClientId );
 
 	const handleDelete = async ( comment ) => {
 		const currentIndex = threads.findIndex( ( t ) => t.id === comment.id );
@@ -311,6 +314,7 @@ export function Comments( {
 		threads,
 		selectedThread,
 		setCanvasMinHeight,
+		blockMode,
 	] );
 
 	const handleThreadNavigation = ( event, thread, isSelected ) => {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -361,16 +361,6 @@ export function useEnableFloatingSidebar( enabled = false ) {
 	}, [ enabled, registry ] );
 }
 
-export function useBlockMode( blockClientId ) {
-	return useSelect(
-		( select ) =>
-			blockClientId
-				? select( blockEditorStore ).getBlockMode( blockClientId )
-				: null,
-		[ blockClientId ]
-	);
-}
-
 export function useFloatingThread( {
 	thread,
 	calculatedOffset,
@@ -382,7 +372,16 @@ export function useFloatingThread( {
 	const blockRef = useRef();
 	useBlockElementRef( thread.blockClientId, blockRef );
 
-	const blockMode = useBlockMode( thread.blockClientId );
+	const blockMode = useSelect(
+		( select ) => {
+			return thread.blockClientId
+				? select( blockEditorStore ).getBlockMode(
+						thread.blockClientId
+				  )
+				: null;
+		},
+		[ thread.blockClientId ]
+	);
 
 	const updateHeight = useCallback(
 		( id, newHeight ) => {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -361,6 +361,16 @@ export function useEnableFloatingSidebar( enabled = false ) {
 	}, [ enabled, registry ] );
 }
 
+export function useBlockMode( blockClientId ) {
+	return useSelect(
+		( select ) =>
+			blockClientId
+				? select( blockEditorStore ).getBlockMode( blockClientId )
+				: null,
+		[ blockClientId ]
+	);
+}
+
 export function useFloatingThread( {
 	thread,
 	calculatedOffset,
@@ -371,6 +381,8 @@ export function useFloatingThread( {
 } ) {
 	const blockRef = useRef();
 	useBlockElementRef( thread.blockClientId, blockRef );
+
+	const blockMode = useBlockMode( thread.blockClientId );
 
 	const updateHeight = useCallback(
 		( id, newHeight ) => {
@@ -400,7 +412,7 @@ export function useFloatingThread( {
 		if ( blockRef.current ) {
 			refs.setReference( blockRef.current );
 		}
-	}, [ blockRef, refs, commentLastUpdated ] );
+	}, [ blockRef, refs, commentLastUpdated, blockMode ] );
 
 	// Track thread heights.
 	useEffect( () => {


### PR DESCRIPTION
## What
Closes [#72836](https://github.com/WordPress/gutenberg/issues/72836)

Fixes the issue where note positions in the floating Notes panel become misaligned after switching a block between “Edit as HTML” and Visual modes. The change ensures that notes remain properly aligned with their corresponding blocks during and after editing mode transitions.

## Why?

When switching a block’s editing mode (Visual ↔ HTML), the notes sidebar incorrectly positions the affected notes at the top of the canvas until the page is refreshed.

This PR introduces a fix that reflows comment positions immediately after mode transitions, maintaining correct alignment without requiring a reload.

**Testing Instructions**

1. Open the Post Editor.
2. Add a few blocks (e.g., Paragraph, Heading) and create Notes on them.
3. Select any block and choose “Edit as HTML” from the block toolbar.
4. The Notes remain properly aligned with their respective blocks.
5. No notes jump or overlap in the floating sidebar.
6. Switch back to Visual mode.
7. Confirm that the notes remain correctly aligned without requiring a page refresh.

## Video

https://github.com/user-attachments/assets/294804e4-9ce9-48e0-9a3f-9bc69c209433

