### PR TITLE
Fix button text overflow in widget editor sidebar for long translations

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -32,6 +32,7 @@
 	padding: 6px 12px;
 	border-radius: $radius-small;
 	color: $components-color-foreground;
+	text-wrap: wrap;
 
 	&.is-next-40px-default-size {
 		height: $button-size-next-default-40px;


### PR DESCRIPTION
This PR adds `text-wrap: wrap;` to the `.components-button` class to prevent horizontal overflow of button text in the widget editor sidebar, especially for long translations like Italian.

Fixes #73048