### PR TITLE
Notes: Gracefully handle non-existing note metadata references

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -36,12 +36,10 @@ export function AddComment( {
 	y,
 	refs,
 } ) {
-	const { clientId, blockCommentId } = useSelect( ( select ) => {
-		const { getSelectedBlock } = select( blockEditorStore );
-		const selectedBlock = getSelectedBlock();
+	const { clientId } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( blockEditorStore );
 		return {
-			clientId: selectedBlock?.clientId,
-			blockCommentId: selectedBlock?.attributes?.metadata?.noteId,
+			clientId: getSelectedBlockClientId(),
 		};
 	}, [] );
 	const blockElement = useBlockElement( clientId );
@@ -53,11 +51,7 @@ export function AddComment( {
 		toggleBlockSpotlight( clientId, false );
 	};
 
-	if (
-		newNoteFormState !== 'open' ||
-		! clientId ||
-		undefined !== blockCommentId
-	) {
+	if ( newNoteFormState !== 'open' || ! clientId ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -7,7 +7,10 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
 
 /**
@@ -32,6 +35,8 @@ import {
 import { focusCommentThread } from './utils';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
+
+const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 function NotesSidebarContent( {
 	newNoteFormState,
@@ -85,30 +90,32 @@ function NotesSidebar( { postId, mode } ) {
 	const [ newNoteFormState, setNewNoteFormState ] = useState( 'closed' );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
+	const { toggleBlockSpotlight, updateBlockAttributes } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
 	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
-	const { clientId, blockCommentId, isDistractionFree } = useSelect(
-		( select ) => {
-			const {
-				getBlockAttributes,
-				getSelectedBlockClientId,
-				getSettings,
-			} = select( blockEditorStore );
-			const _clientId = getSelectedBlockClientId();
-			return {
-				clientId: _clientId,
-				blockCommentId: _clientId
-					? getBlockAttributes( _clientId )?.metadata?.noteId
-					: null,
-				isDistractionFree: getSettings().isDistractionFree,
-			};
-		},
-		[]
-	);
+	const {
+		clientId,
+		blockCommentId,
+		isDistractionFree,
+		getBlockAttributesSelector,
+	} = useSelect( ( select ) => {
+		const { getBlockAttributes, getSelectedBlockClientId, getSettings } =
+			select( blockEditorStore );
+		const _clientId = getSelectedBlockClientId();
+		return {
+			clientId: _clientId,
+			blockCommentId: _clientId
+				? getBlockAttributes( _clientId )?.metadata?.noteId
+				: null,
+			isDistractionFree: getSettings().isDistractionFree,
+			getBlockAttributesSelector: getBlockAttributes,
+		};
+	}, [] );
 
 	const {
 		resultComments,
@@ -148,18 +155,29 @@ function NotesSidebar( { postId, mode } ) {
 			);
 		}
 
+		// Remove non-existing note reference from the selected block.
+		if ( blockCommentId && ! currentThread ) {
+			const metadata = getBlockAttributesSelector( clientId )?.metadata;
+			updateBlockAttributes( clientId, {
+				metadata: cleanEmptyObject( {
+					...metadata,
+					noteId: undefined,
+				} ),
+			} );
+		}
+
 		const currentArea = await getActiveComplementaryArea( 'core' );
 		// Bail out if the current active area is not one of note sidebars.
 		if ( ! SIDEBARS.includes( currentArea ) ) {
 			return;
 		}
 
-		setNewNoteFormState( ! blockCommentId ? 'open' : 'closed' );
+		setNewNoteFormState( ! currentThread ? 'open' : 'closed' );
 		focusCommentThread(
-			blockCommentId,
+			currentThread?.id,
 			commentSidebarRef.current,
 			// Focus a comment thread when there's a selected block with a comment.
-			! blockCommentId ? 'textarea' : undefined
+			! currentThread ? 'textarea' : undefined
 		);
 		toggleBlockSpotlight( clientId, true );
 	}


### PR DESCRIPTION
## What?
Closes #73017.

A quick PoC for #73017. Requires more testing.

One possible issue I can imagine is that if the network is slow and notes aren't loading before the user clicks the "Add note" button, we might remove valid note metadata references.

## Why?

## How?

## Testing Instructions
1. Open a post or page.
2. Paste block with non-existing note reference.
3. Try adding note.
4. The new note form should be visible.

```html
<!-- wp:paragraph {"metadata":{"noteId":144444}} -->
<p>Testing an incorrect noteId medatadata</p>
<!-- /wp:paragraph -->
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
