### PR TITLE
Block Bindings: Add unit test coverage for `core/post-data` source

### DIFF
--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -16,7 +16,10 @@ describe( 'post-data bindings', () => {
 				select = ( store ) => {
 					if ( store === blockEditorStore ) {
 						return {
-							getBlockName: () => 'core/post-date',
+							getBlockName: ( clientId ) =>
+								clientId === '123abc456'
+									? 'core/post-date'
+									: undefined,
 							getBlockAttributes: () => ( {} ),
 						};
 					}

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -140,7 +140,7 @@ describe( 'post-data bindings', () => {
 							args: { field: 'link' },
 						},
 					},
-					clientId: 'client-1',
+					clientId: '123abc456',
 				} );
 
 				expect( values.url ).toBe( 'https://example.com/page' );

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -11,8 +11,9 @@ import postDataBindings from '../post-data';
 describe( 'post-data bindings', () => {
 	describe( 'getValues', () => {
 		describe( 'for regular blocks using block context', () => {
-			it( 'should return entity field values when they exist', () => {
-				const select = ( store ) => {
+			let select;
+			beforeAll( () => {
+				select = ( store ) => {
 					if ( store === blockEditorStore ) {
 						return {
 							getBlockName: () => 'core/post-date',
@@ -20,14 +21,20 @@ describe( 'post-data bindings', () => {
 						};
 					}
 					return {
-						getEditedEntityRecord: () => ( {
-							date: '2024-03-02 00:00:00',
-							modified: '2025-06-07 00:00:00',
-							link: 'https://example.com/post',
-						} ),
+						getEditedEntityRecord: ( kind, name, recordId ) =>
+							name === 'post' && recordId === 123
+								? {
+										date: '2024-03-02 00:00:00',
+										modified: '2025-06-07 00:00:00',
+										link: 'https://example.com/post',
+										unknown: 'Unknown field value',
+								  }
+								: {},
 					};
 				};
+			} );
 
+			it( 'should return entity field values when they exist', () => {
 				const values = postDataBindings.getValues( {
 					select,
 					context: { postId: 123, postType: 'post' },
@@ -56,21 +63,9 @@ describe( 'post-data bindings', () => {
 			} );
 
 			it( 'should fall back to field labels when entity value does not exist', () => {
-				const select = ( store ) => {
-					if ( store === blockEditorStore ) {
-						return {
-							getBlockName: () => 'core/post-date',
-							getBlockAttributes: () => ( {} ),
-						};
-					}
-					return {
-						getEditedEntityRecord: () => ( {} ),
-					};
-				};
-
 				const values = postDataBindings.getValues( {
 					select,
-					context: { postId: 123, postType: 'post' },
+					context: { postId: 456, postType: 'post' },
 					bindings: {
 						datetime: {
 							source: 'core/post-date',
@@ -85,7 +80,7 @@ describe( 'post-data bindings', () => {
 							args: { field: 'link' },
 						},
 					},
-					clientId: 'client-1',
+					clientId: '123abc456',
 				} );
 
 				expect( values ).toStrictEqual( {
@@ -96,30 +91,16 @@ describe( 'post-data bindings', () => {
 			} );
 
 			it( 'should return empty object for unknown fields', () => {
-				const select = ( store ) => {
-					if ( store === blockEditorStore ) {
-						return {
-							getBlockName: () => 'core/post-date',
-							getBlockAttributes: () => ( {} ),
-						};
-					}
-					return {
-						getEditedEntityRecord: () => ( {
-							title: 'Post Title',
-						} ),
-					};
-				};
-
 				const values = postDataBindings.getValues( {
 					select,
 					context: { postId: 123, postType: 'post' },
 					bindings: {
 						content: {
 							source: 'core/post-date',
-							args: { field: 'title' },
+							args: { field: 'unknown' },
 						},
 					},
-					clientId: 'client-1',
+					clientId: '123abc456',
 				} );
 
 				expect( values.content ).toEqual( {} );

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -144,7 +144,6 @@ describe( 'post-data bindings', () => {
 								return {};
 							}
 							return {
-								date: '2021-02-03',
 								link: 'https://example.com/page',
 							};
 						},
@@ -155,7 +154,10 @@ describe( 'post-data bindings', () => {
 					select,
 					context: { postId: 123, postType: 'post' },
 					bindings: {
-						url: { args: { field: 'link' } },
+						url: {
+							source: 'core/post-date',
+							args: { field: 'link' },
+						},
 					},
 					clientId: 'client-1',
 				} );

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -1,9 +1,204 @@
 /**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import postDataBindings from '../post-data';
 
 describe( 'post-data bindings', () => {
+	describe( 'getValues', () => {
+		describe( 'for regular blocks using context', () => {
+			it( 'should return entity field values when they exist', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/post-date',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: () => ( {
+							date: '2024-01-15',
+							modified: '2024-01-20',
+							link: 'https://example.com/post',
+						} ),
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 123, postType: 'post' },
+					bindings: {
+						content: { args: { field: 'date' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.content ).toBe( '2024-01-15' );
+			} );
+
+			it( 'should fall back to field label when entity value does not exist', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/post-date',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: () => ( {} ),
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 123, postType: 'post' },
+					bindings: {
+						content: { args: { field: 'date' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.content ).toBe( 'Post Date' );
+			} );
+
+			it( 'should handle multiple bindings', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/post-date',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: () => ( {
+							date: '2024-01-15',
+							modified: '2024-01-20',
+							link: 'https://example.com/post',
+						} ),
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 123, postType: 'post' },
+					bindings: {
+						date: { args: { field: 'date' } },
+						modified: { args: { field: 'modified' } },
+						link: { args: { field: 'link' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.date ).toBe( '2024-01-15' );
+				expect( values.modified ).toBe( '2024-01-20' );
+				expect( values.link ).toBe( 'https://example.com/post' );
+			} );
+
+			it( 'should return empty object for disallowed fields', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/post-date',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: () => ( {
+							title: 'Post Title',
+						} ),
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 123, postType: 'post' },
+					bindings: {
+						content: { args: { field: 'title' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.content ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'for navigation blocks using block attributes', () => {
+			it( 'should use block attributes instead of context for navigation-link', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/navigation-link',
+							getBlockAttributes: () => ( {
+								id: 456,
+								type: 'page',
+							} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: ( _kind, type, id ) => {
+							// Verify it's called with block attributes, not context
+							expect( id ).toBe( 456 );
+							expect( type ).toBe( 'page' );
+							return {
+								date: '2024-02-01',
+								link: 'https://example.com/page',
+							};
+						},
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 123, postType: 'post' },
+					bindings: {
+						url: { args: { field: 'link' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.url ).toBe( 'https://example.com/page' );
+			} );
+
+			it( 'should use block attributes instead of context for navigation-submenu', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/navigation-submenu',
+							getBlockAttributes: () => ( {
+								id: 789,
+								type: 'page',
+							} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: ( _kind, type, id ) => {
+							expect( id ).toBe( 789 );
+							expect( type ).toBe( 'page' );
+							return {
+								link: 'https://example.com/submenu',
+							};
+						},
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 999, postType: 'post' },
+					bindings: {
+						url: { args: { field: 'link' } },
+					},
+					clientId: 'client-1',
+				} );
+
+				expect( values.url ).toBe( 'https://example.com/submenu' );
+			} );
+		} );
+	} );
+
 	describe( 'getFieldsList', () => {
 		it( 'should return the list of available post data fields when selected block is core/post-date', () => {
 			const select = () => ( {

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import postDataBindings from '../post-data';
+
+describe( 'post-data bindings', () => {
+	describe( 'getFieldsList', () => {
+		it( 'should return the list of available post data fields when selected block is core/post-date', () => {
+			const select = () => ( {
+				getSelectedBlock: () => ( {
+					name: 'core/post-date',
+				} ),
+			} );
+
+			const fields = postDataBindings.getFieldsList( {
+				select,
+			} );
+
+			expect( fields ).toEqual( [
+				{
+					label: 'Post Date',
+					args: { field: 'date' },
+					type: 'string',
+				},
+				{
+					label: 'Post Modified Date',
+					args: { field: 'modified' },
+					type: 'string',
+				},
+				{
+					label: 'Post Link',
+					args: { field: 'link' },
+					type: 'string',
+				},
+			] );
+		} );
+
+		it( 'should return an empty array when selected block is not core/post-date', () => {
+			const select = () => ( {
+				getSelectedBlock: () => ( {
+					name: 'core/paragraph',
+				} ),
+			} );
+
+			const fields = postDataBindings.getFieldsList( {
+				select,
+			} );
+
+			expect( fields ).toEqual( [] );
+		} );
+	} );
+} );

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -10,7 +10,7 @@ import postDataBindings from '../post-data';
 
 describe( 'post-data bindings', () => {
 	describe( 'getValues', () => {
-		describe( 'for regular blocks using context', () => {
+		describe( 'for regular blocks using block context', () => {
 			it( 'should return entity field values when they exist', () => {
 				const select = ( store ) => {
 					if ( store === blockEditorStore ) {
@@ -21,8 +21,8 @@ describe( 'post-data bindings', () => {
 					}
 					return {
 						getEditedEntityRecord: () => ( {
-							date: '2024-01-15',
-							modified: '2024-01-20',
+							date: '2024-03-02 00:00:00',
+							modified: '2025-06-07 00:00:00',
 							link: 'https://example.com/post',
 						} ),
 					};
@@ -32,15 +32,30 @@ describe( 'post-data bindings', () => {
 					select,
 					context: { postId: 123, postType: 'post' },
 					bindings: {
-						content: { args: { field: 'date' } },
+						datetime: {
+							source: 'core/post-date',
+							args: { field: 'date' },
+						},
+						modified: {
+							source: 'core/post-date',
+							args: { field: 'modified' },
+						},
+						url: {
+							source: 'core/post-date',
+							args: { field: 'link' },
+						},
 					},
-					clientId: 'client-1',
+					clientId: '123abc456',
 				} );
 
-				expect( values.content ).toBe( '2024-01-15' );
+				expect( values ).toStrictEqual( {
+					datetime: '2024-03-02 00:00:00',
+					modified: '2025-06-07 00:00:00',
+					url: 'https://example.com/post',
+				} );
 			} );
 
-			it( 'should fall back to field label when entity value does not exist', () => {
+			it( 'should fall back to field labels when entity value does not exist', () => {
 				const select = ( store ) => {
 					if ( store === blockEditorStore ) {
 						return {
@@ -57,48 +72,30 @@ describe( 'post-data bindings', () => {
 					select,
 					context: { postId: 123, postType: 'post' },
 					bindings: {
-						content: { args: { field: 'date' } },
+						datetime: {
+							source: 'core/post-date',
+							args: { field: 'date' },
+						},
+						modified: {
+							source: 'core/post-date',
+							args: { field: 'modified' },
+						},
+						url: {
+							source: 'core/post-date',
+							args: { field: 'link' },
+						},
 					},
 					clientId: 'client-1',
 				} );
 
-				expect( values.content ).toBe( 'Post Date' );
-			} );
-
-			it( 'should handle multiple bindings', () => {
-				const select = ( store ) => {
-					if ( store === blockEditorStore ) {
-						return {
-							getBlockName: () => 'core/post-date',
-							getBlockAttributes: () => ( {} ),
-						};
-					}
-					return {
-						getEditedEntityRecord: () => ( {
-							date: '2024-01-15',
-							modified: '2024-01-20',
-							link: 'https://example.com/post',
-						} ),
-					};
-				};
-
-				const values = postDataBindings.getValues( {
-					select,
-					context: { postId: 123, postType: 'post' },
-					bindings: {
-						date: { args: { field: 'date' } },
-						modified: { args: { field: 'modified' } },
-						link: { args: { field: 'link' } },
-					},
-					clientId: 'client-1',
+				expect( values ).toStrictEqual( {
+					datetime: 'Post Date',
+					modified: 'Post Modified Date',
+					url: 'Post Link',
 				} );
-
-				expect( values.date ).toBe( '2024-01-15' );
-				expect( values.modified ).toBe( '2024-01-20' );
-				expect( values.link ).toBe( 'https://example.com/post' );
 			} );
 
-			it( 'should return empty object for disallowed fields', () => {
+			it( 'should return empty object for unknown fields', () => {
 				const select = ( store ) => {
 					if ( store === blockEditorStore ) {
 						return {
@@ -117,7 +114,10 @@ describe( 'post-data bindings', () => {
 					select,
 					context: { postId: 123, postType: 'post' },
 					bindings: {
-						content: { args: { field: 'title' } },
+						content: {
+							source: 'core/post-date',
+							args: { field: 'title' },
+						},
 					},
 					clientId: 'client-1',
 				} );
@@ -127,7 +127,7 @@ describe( 'post-data bindings', () => {
 		} );
 
 		describe( 'for navigation blocks using block attributes', () => {
-			it( 'should use block attributes instead of context for navigation-link', () => {
+			it( 'should use block attributes instead of context', () => {
 				const select = ( store ) => {
 					if ( store === blockEditorStore ) {
 						return {
@@ -140,11 +140,11 @@ describe( 'post-data bindings', () => {
 					}
 					return {
 						getEditedEntityRecord: ( _kind, type, id ) => {
-							// Verify it's called with block attributes, not context
-							expect( id ).toBe( 456 );
-							expect( type ).toBe( 'page' );
+							if ( type !== 'page' || id !== 456 ) {
+								return {};
+							}
 							return {
-								date: '2024-02-01',
+								date: '2021-02-03',
 								link: 'https://example.com/page',
 							};
 						},
@@ -162,45 +162,11 @@ describe( 'post-data bindings', () => {
 
 				expect( values.url ).toBe( 'https://example.com/page' );
 			} );
-
-			it( 'should use block attributes instead of context for navigation-submenu', () => {
-				const select = ( store ) => {
-					if ( store === blockEditorStore ) {
-						return {
-							getBlockName: () => 'core/navigation-submenu',
-							getBlockAttributes: () => ( {
-								id: 789,
-								type: 'page',
-							} ),
-						};
-					}
-					return {
-						getEditedEntityRecord: ( _kind, type, id ) => {
-							expect( id ).toBe( 789 );
-							expect( type ).toBe( 'page' );
-							return {
-								link: 'https://example.com/submenu',
-							};
-						},
-					};
-				};
-
-				const values = postDataBindings.getValues( {
-					select,
-					context: { postId: 999, postType: 'post' },
-					bindings: {
-						url: { args: { field: 'link' } },
-					},
-					clientId: 'client-1',
-				} );
-
-				expect( values.url ).toBe( 'https://example.com/submenu' );
-			} );
 		} );
 	} );
 
 	describe( 'getFieldsList', () => {
-		it( 'should return the list of available post data fields when selected block is core/post-date', () => {
+		it( 'should return the list of available post data fields when the Date block is selected', () => {
 			const select = () => ( {
 				getSelectedBlock: () => ( {
 					name: 'core/post-date',
@@ -230,7 +196,7 @@ describe( 'post-data bindings', () => {
 			] );
 		} );
 
-		it( 'should return an empty array when selected block is not core/post-date', () => {
+		it( 'should return an empty array when any other block than the Date block is selected', () => {
 			const select = () => ( {
 				getSelectedBlock: () => ( {
 					name: 'core/paragraph',


### PR DESCRIPTION
## What?
Add unit test coverage for the `core/post-data` block bindings source.

## Why?
We don't really have any test coverage for that source yet (other than a bit of indirect coverage through the Date block).

For reference, https://github.com/WordPress/gutenberg/pull/72799 added unit tests for the `core/post-meta` source.

## Testing Instructions
Verify that tests pass 🤷‍♂️ 