### PR TITLE
[Readd] Stretch text and strech heading variation

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -179,6 +179,7 @@ export default function TypographyPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
+	fitText = false,
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
@@ -448,7 +449,7 @@ export default function TypographyPanel( {
 					/>
 				</ToolsPanelItem>
 			) }
-			{ hasFontSizeEnabled && (
+			{ hasFontSizeEnabled && ! fitText && (
 				<ToolsPanelItem
 					label={ __( 'Size' ) }
 					hasValue={ hasFontSize }

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -208,73 +208,13 @@ function useFitText( { fitText, name, clientId } ) {
 }
 
 /**
- * Fit text control component for the typography panel.
+ * NOTE: This control has been disabled. FitText can only be used
+ * via block variations (Stretch Text / Stretch Heading).
+ * This is still included because an edit component is required-
  *
- * @param {Object}   props               Component props.
- * @param {string}   props.clientId      Block client ID.
- * @param {Function} props.setAttributes Function to set block attributes.
- * @param {string}   props.name          Block name.
- * @param {boolean}  props.fitText       Whether fit text is enabled.
- * @param {string}   props.fontSize      Font size slug.
- * @param {Object}   props.style         Block style object.
  */
-export function FitTextControl( {
-	clientId,
-	fitText = false,
-	setAttributes,
-	name,
-	fontSize,
-	style,
-} ) {
-	if ( ! hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY ) ) {
-		return null;
-	}
-	return (
-		<InspectorControls group="typography">
-			<ToolsPanelItem
-				hasValue={ () => fitText }
-				label={ __( 'Fit text' ) }
-				onDeselect={ () => setAttributes( { fitText: undefined } ) }
-				resetAllFilter={ () => ( { fitText: undefined } ) }
-				panelId={ clientId }
-			>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Fit text' ) }
-					checked={ fitText }
-					onChange={ () => {
-						const newFitText = ! fitText || undefined;
-						const updates = { fitText: newFitText };
-
-						// When enabling fit text, clear font size if it has a value
-						if ( newFitText ) {
-							if ( fontSize ) {
-								updates.fontSize = undefined;
-							}
-							if ( style?.typography?.fontSize ) {
-								updates.style = {
-									...style,
-									typography: {
-										...style?.typography,
-										fontSize: undefined,
-									},
-								};
-							}
-						}
-
-						setAttributes( updates );
-					} }
-					help={
-						fitText
-							? __( 'Text will resize to fit its container.' )
-							: __(
-									'The text will resize to fit its container, resetting other font size settings.'
-							  )
-					}
-				/>
-			</ToolsPanelItem>
-		</InspectorControls>
-	);
+export function FitTextControl() {
+	return null;
 }
 
 /**

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -5,11 +5,6 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { useEffect, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import {
-	ToggleControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
 
 const EMPTY_OBJECT = {};
 
@@ -19,7 +14,6 @@ const EMPTY_OBJECT = {};
 import { optimizeFitText } from '../utils/fit-text-utils';
 import { store as blockEditorStore } from '../store';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
-import InspectorControls from '../components/inspector-controls';
 
 export const FIT_TEXT_SUPPORT_KEY = 'typography.fitText';
 

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -202,16 +202,6 @@ function useFitText( { fitText, name, clientId } ) {
 }
 
 /**
- * NOTE: This control has been disabled. FitText can only be used
- * via block variations (Stretch Text / Stretch Heading).
- * This is still included because an edit component is required-
- *
- */
-export function FitTextControl() {
-	return null;
-}
-
-/**
  * Override props applied to the block element on save.
  *
  * @param {Object} props      Additional props applied to the block element.
@@ -272,7 +262,7 @@ const hasFitTextSupport = ( blockNameOrType ) => {
 export default {
 	useBlockProps,
 	addSaveProps,
-	attributeKeys: [ 'fitText', 'fontSize', 'style' ],
+	attributeKeys: [ 'fitText' ],
 	hasSupport: hasFitTextSupport,
-	edit: FitTextControl,
+	edit: () => null,
 };

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -92,11 +92,16 @@ function addSaveProps( props, blockNameOrType, attributes ) {
  */
 export function FontSizeEdit( props ) {
 	const {
-		attributes: { fontSize, style },
+		attributes: { fontSize, style, fitText },
 		setAttributes,
 	} = props;
+
 	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
 
+	// Hide font size UI when fitText is enabled
+	if ( fitText ) {
+		return null;
+	}
 	const onChange = ( value, selectedItem ) => {
 		// Use the selectedItem's slug if available, otherwise fall back to finding by value
 		const fontSizeSlug =
@@ -211,7 +216,7 @@ function useBlockProps( { name, fontSize, style } ) {
 export default {
 	useBlockProps,
 	addSaveProps,
-	attributeKeys: [ 'fontSize', 'style' ],
+	attributeKeys: [ 'fontSize', 'style', 'fitText' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, FONT_SIZE_SUPPORT_KEY );
 	},

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -144,16 +144,7 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	);
 
 	const onChange = ( newStyle ) => {
-		const newAttributes = styleToAttributes( newStyle );
-
-		// If setting a font size and fitText is currently enabled, disable it
-		const hasFontSize =
-			newAttributes.fontSize || newAttributes.style?.typography?.fontSize;
-		if ( hasFontSize && fitText ) {
-			newAttributes.fitText = undefined;
-		}
-
-		setAttributes( newAttributes );
+		setAttributes( styleToAttributes( newStyle ) );
 	};
 
 	if ( ! isEnabled ) {
@@ -173,6 +164,7 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 			value={ value }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
+			fitText={ fitText }
 		/>
 	);
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2293,7 +2293,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							.forEach( ( variation ) => {
 								if (
 									variation.id ===
-										'core/paragraph/stretchy-text' ||
+										'core/paragraph/stretchy-paragraph' ||
 									variation.id ===
 										'core/heading/stretchy-heading'
 								) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2293,9 +2293,9 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							.forEach( ( variation ) => {
 								if (
 									variation.id ===
-										'core/paragraph/stretch-text' ||
+										'core/paragraph/stretchy-text' ||
 									variation.id ===
-										'core/heading/stretch-heading'
+										'core/heading/stretchy-heading'
 								) {
 									stretchVariations.push( variation );
 								} else {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2288,13 +2288,20 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							state,
 							item
 						);
-						variations.map( variationMapper ).forEach( ( variation ) => {
-							if ( variation.id === 'core/paragraph/stretch-text' || variation.id === 'core/heading/stretch-heading' ) {
-								stretchVariations.push( variation );
-							} else {
-								accumulator.push( variation );
-							}
-						} );
+						variations
+							.map( variationMapper )
+							.forEach( ( variation ) => {
+								if (
+									variation.id ===
+										'core/paragraph/stretch-text' ||
+									variation.id ===
+										'core/heading/stretch-heading'
+								) {
+									stretchVariations.push( variation );
+								} else {
+									accumulator.push( variation );
+								}
+							} );
 					}
 					return accumulator;
 				},

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2274,6 +2274,8 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 					} ) );
 			}
 
+			// Collect stretch variations separately to add them at the end
+			const stretchVariations = [];
 			const items = blockTypeInserterItems.reduce(
 				( accumulator, item ) => {
 					const { variations = [] } = item;
@@ -2286,14 +2288,26 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							state,
 							item
 						);
-						accumulator.push(
-							...variations.map( variationMapper )
-						);
+						const mappedVariations = variations.map( variationMapper );
+						// Separate stretch variations from regular variations
+						mappedVariations.forEach( ( variation ) => {
+							if (
+								variation.id === 'core/paragraph/stretch-text' ||
+								variation.id === 'core/heading/stretch-heading'
+							) {
+								stretchVariations.push( variation );
+							} else {
+								accumulator.push( variation );
+							}
+						} );
 					}
 					return accumulator;
 				},
 				[]
 			);
+
+			// Add stretch variations at the end
+			items.push( ...stretchVariations );
 
 			// Ensure core blocks are prioritized in the returned results,
 			// because third party blocks can be registered earlier than

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2274,7 +2274,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 					} ) );
 			}
 
-			// Collect stretch variations separately to add them at the end
+			// Hardcode: Collect stretch variations separately to add at the end
 			const stretchVariations = [];
 			const items = blockTypeInserterItems.reduce(
 				( accumulator, item ) => {
@@ -2288,13 +2288,8 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							state,
 							item
 						);
-						const mappedVariations = variations.map( variationMapper );
-						// Separate stretch variations from regular variations
-						mappedVariations.forEach( ( variation ) => {
-							if (
-								variation.id === 'core/paragraph/stretch-text' ||
-								variation.id === 'core/heading/stretch-heading'
-							) {
+						variations.map( variationMapper ).forEach( ( variation ) => {
+							if ( variation.id === 'core/paragraph/stretch-text' || variation.id === 'core/heading/stretch-heading' ) {
 								stretchVariations.push( variation );
 							} else {
 								accumulator.push( variation );
@@ -2305,8 +2300,6 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 				},
 				[]
 			);
-
-			// Add stretch variations at the end
 			items.push( ...stretchVariations );
 
 			// Ensure core blocks are prioritized in the returned results,

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -65,6 +66,7 @@ export const settings = {
 	},
 	edit,
 	save,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -2,9 +2,20 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { justifyStretch } from '@wordpress/icons';
+import { justifyStretch, heading } from '@wordpress/icons';
 
 const variations = [
+	{
+		name: 'paragraph',
+		title: __( 'Heading' ),
+		description: __(
+			'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
+		),
+		isDefault: true,
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: { fitText: undefined },
+		icon: heading,
+	},
 	{
 		name: 'stretch-heading',
 		title: __( 'Stretch Heading' ),

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -3,20 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/primitives';
-import { heading } from '@wordpress/icons';
 
 const variations = [
-	{
-		name: 'heading',
-		title: __( 'Heading' ),
-		description: __(
-			'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
-		),
-		isDefault: true,
-		scope: [ 'block', 'inserter', 'transform' ],
-		attributes: { fitText: undefined },
-		icon: heading,
-	},
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
 	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
@@ -29,7 +17,7 @@ const variations = [
 			</SVG>
 		),
 		attributes: { fitText: true },
-		scope: [ 'inserter', 'transform' ],
+		scope: [ 'inserter' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
 	},
 ];

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -6,7 +6,7 @@ import { justifyStretch, heading } from '@wordpress/icons';
 
 const variations = [
 	{
-		name: 'paragraph',
+		name: 'heading',
 		title: __( 'Heading' ),
 		description: __(
 			'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
@@ -16,9 +16,11 @@ const variations = [
 		attributes: { fitText: undefined },
 		icon: heading,
 	},
+	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
+	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
-		name: 'stretch-heading',
-		title: __( 'Stretch Heading' ),
+		name: 'stretchy-heading',
+		title: __( 'Stretchy Heading' ),
 		description: __( 'Heading that resizes to fit its container.' ),
 		icon: justifyStretch,
 		attributes: { fitText: true },

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { justifyStretch, heading } from '@wordpress/icons';
+import { Path, SVG } from '@wordpress/primitives';
+import { heading } from '@wordpress/icons';
 
 const variations = [
 	{
@@ -22,7 +23,11 @@ const variations = [
 		name: 'stretchy-heading',
 		title: __( 'Stretchy Heading' ),
 		description: __( 'Heading that resizes to fit its container.' ),
-		icon: justifyStretch,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Path d="m3 18.6 6-4.7 6 4.7V5H3v13.6Zm16.2-9.8v1.5h2.2L17.7 14l1.1 1.1 3.7-3.7v2.2H24V8.8h-4.8Z" />
+			</SVG>
+		),
 		attributes: { fitText: true },
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { justifyStretch } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'stretch-heading',
+		title: __( 'Stretch Heading' ),
+		description: __( 'Heading that resizes to fit its container.' ),
+		icon: justifyStretch,
+		attributes: { fitText: true },
+		scope: [ 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -54,6 +55,7 @@ export const settings = {
 	},
 	edit,
 	save,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -6,17 +6,6 @@ import { Path, SVG } from '@wordpress/primitives';
 import { paragraph } from '@wordpress/icons';
 
 const variations = [
-	{
-		name: 'paragraph',
-		title: __( 'Paragraph' ),
-		description: __(
-			'Start with the basic building block of all narrative.'
-		),
-		isDefault: true,
-		scope: [ 'block', 'inserter', 'transform' ],
-		attributes: { fitText: undefined },
-		icon: paragraph,
-	},
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
 	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
@@ -31,7 +20,7 @@ const variations = [
 		attributes: {
 			fitText: true,
 		},
-		scope: [ 'inserter', 'transform' ],
+		scope: [ 'inserter' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
 	},
 ];

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/primitives';
-import { paragraph } from '@wordpress/icons';
 
 const variations = [
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -2,15 +2,28 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { justifyStretch } from '@wordpress/icons';
+import { justifyStretch, paragraph } from '@wordpress/icons';
 
 const variations = [
+	{
+		name: 'paragraph',
+		title: __( 'Paragraph' ),
+		description: __(
+			'Start with the basic building block of all narrative.'
+		),
+		isDefault: true,
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: { fitText: undefined },
+		icon: paragraph,
+	},
 	{
 		name: 'stretch-text',
 		title: __( 'Stretch Text' ),
 		description: __( 'Text that resizes to fit its container.' ),
 		icon: justifyStretch,
-		attributes: { fitText: true },
+		attributes: {
+			fitText: true,
+		},
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
 	},

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -20,9 +20,9 @@ const variations = [
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
 	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
-		name: 'stretchy-text',
-		title: __( 'Stretchy Text' ),
-		description: __( 'Text that resizes to fit its container.' ),
+		name: 'stretchy-paragraph',
+		title: __( 'Stretchy Paragraph' ),
+		description: __( 'Paragraph that resizes to fit its container.' ),
 		icon: (
 			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 				<Path d="M3 9c0 2.8 2.2 5 5 5v-.2V20h1.5V5.5H12V20h1.5V5.5h3V4H8C5.2 4 3 6.2 3 9Zm16.2-.2v1.5h2.2L17.7 14l1.1 1.1 3.7-3.7v2.2H24V8.8h-4.8Z" />

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -16,9 +16,11 @@ const variations = [
 		attributes: { fitText: undefined },
 		icon: paragraph,
 	},
+	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
+	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
-		name: 'stretch-text',
-		title: __( 'Stretch Text' ),
+		name: 'stretchy-text',
+		title: __( 'Stretchy Text' ),
 		description: __( 'Text that resizes to fit its container.' ),
 		icon: justifyStretch,
 		attributes: {

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { justifyStretch, paragraph } from '@wordpress/icons';
+import { textColor, paragraph } from '@wordpress/icons';
 
 const variations = [
 	{
@@ -22,7 +22,7 @@ const variations = [
 		name: 'stretchy-text',
 		title: __( 'Stretchy Text' ),
 		description: __( 'Text that resizes to fit its container.' ),
-		icon: justifyStretch,
+		icon: textColor,
 		attributes: {
 			fitText: true,
 		},

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { textColor, paragraph } from '@wordpress/icons';
+import { Path, SVG } from '@wordpress/primitives';
+import { paragraph } from '@wordpress/icons';
 
 const variations = [
 	{
@@ -22,7 +23,11 @@ const variations = [
 		name: 'stretchy-text',
 		title: __( 'Stretchy Text' ),
 		description: __( 'Text that resizes to fit its container.' ),
-		icon: textColor,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Path d="M3 9c0 2.8 2.2 5 5 5v-.2V20h1.5V5.5H12V20h1.5V5.5h3V4H8C5.2 4 3 6.2 3 9Zm16.2-.2v1.5h2.2L17.7 14l1.1 1.1 3.7-3.7v2.2H24V8.8h-4.8Z" />
+			</SVG>
+		),
 		attributes: {
 			fitText: true,
 		},

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { justifyStretch } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'stretch-text',
+		title: __( 'Stretch Text' ),
+		description: __( 'Text that resizes to fit its container.' ),
+		icon: justifyStretch,
+		attributes: { fitText: true },
+		scope: [ 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
+	},
+];
+
+export default variations;

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -123,6 +123,7 @@ test.describe( 'Details', () => {
 		await expect(
 			listView.getByRole( 'link', {
 				name: 'Paragraph',
+				exact: true,
 			} )
 		).toBeVisible();
 
@@ -131,6 +132,7 @@ test.describe( 'Details', () => {
 		await expect(
 			listView.getByRole( 'link', {
 				name: 'Paragraph',
+				exact: true,
 			} )
 		).toBeFocused();
 

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -9,17 +9,20 @@ test.describe( 'Fit Text', () => {
 	} );
 
 	test.describe( 'Editor functionality', () => {
-		test( 'should enable fit text on a heading block via Stretch Heading variation', async ( {
+		test( 'should enable fit text on a heading block via Stretchy Heading variation', async ( {
 			editor,
 			page,
 		} ) => {
-			// Insert Stretch Heading variation from block inserter
+			// Insert Stretchy Heading variation from block inserter
 			await page
 				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Text' } )
-				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
+				.getByRole( 'option', {
+					name: 'Stretchy Heading',
+					exact: true,
+				} )
 				.click();
 
 			// Wait for the block to be inserted and click into it to ensure focus
@@ -45,17 +48,17 @@ test.describe( 'Fit Text', () => {
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
 
-		test( 'should enable fit text on a paragraph block via Stretch Text variation', async ( {
+		test( 'should enable fit text on a paragraph block via Stretchy Text variation', async ( {
 			editor,
 			page,
 		} ) => {
-			// Insert Stretch Text variation from block inserter
+			// Insert Stretchy Text variation from block inserter
 			await page
 				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Text' } )
-				.getByRole( 'option', { name: 'Stretch Text', exact: true } )
+				.getByRole( 'option', { name: 'Stretchy Text', exact: true } )
 				.click();
 
 			// Wait for the block to be inserted and click into it to ensure focus
@@ -174,17 +177,20 @@ test.describe( 'Fit Text', () => {
 			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
 		} );
 
-		test( 'should not show font size UI for Stretch Text and Stretch Heading variations', async ( {
+		test( 'should not show font size UI for Stretchy Text and Stretchy Heading variations', async ( {
 			editor,
 			page,
 		} ) => {
-			// Insert Stretch Heading variation
+			// Insert Stretchy Heading variation
 			await page
 				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Text' } )
-				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
+				.getByRole( 'option', {
+					name: 'Stretchy Heading',
+					exact: true,
+				} )
 				.click();
 
 			// Wait for the block to be inserted and click into it to ensure focus
@@ -202,13 +208,13 @@ test.describe( 'Fit Text', () => {
 			const fontSizeButton = page.getByRole( 'button', {
 				name: 'Set custom size',
 			} );
-			await expect( fontSizeButton ).not.toBeVisible();
+			await expect( fontSizeButton ).toBeHidden();
 
 			// Verify no font size picker is present
 			const fontSizePicker = page.locator(
 				'[aria-label="Font size"], [aria-label="Size"]'
 			);
-			await expect( fontSizePicker ).not.toBeVisible();
+			await expect( fontSizePicker ).toBeHidden();
 		} );
 
 		test( 'should not load frontend script when editing a saved post with fit text', async ( {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -21,6 +21,14 @@ test.describe( 'Fit Text', () => {
 				.getByRole( 'listbox', { name: 'Text' } )
 				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
 				.click();
+
+			// Wait for the block to be inserted and click into it to ensure focus
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
+			await headingBlock.waitFor( { state: 'attached' } );
+			await headingBlock.click();
+
 			await page.keyboard.type( 'Test Heading' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -33,10 +41,6 @@ test.describe( 'Fit Text', () => {
 					},
 				},
 			] );
-
-			const headingBlock = editor.canvas.locator(
-				'[data-type="core/heading"]'
-			);
 
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
@@ -53,6 +57,14 @@ test.describe( 'Fit Text', () => {
 				.getByRole( 'listbox', { name: 'Text' } )
 				.getByRole( 'option', { name: 'Stretch Text', exact: true } )
 				.click();
+
+			// Wait for the block to be inserted and click into it to ensure focus
+			const paragraphBlock = editor.canvas.locator(
+				'[data-type="core/paragraph"]'
+			);
+			await paragraphBlock.waitFor( { state: 'attached' } );
+			await paragraphBlock.click();
+
 			await page.keyboard.type( 'Test paragraph with fit text enabled' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -64,10 +76,6 @@ test.describe( 'Fit Text', () => {
 					},
 				},
 			] );
-
-			const paragraphBlock = editor.canvas.locator(
-				'[data-type="core/paragraph"]'
-			);
 
 			await expect( paragraphBlock ).toHaveClass( /has-fit-text/ );
 		} );
@@ -178,6 +186,14 @@ test.describe( 'Fit Text', () => {
 				.getByRole( 'listbox', { name: 'Text' } )
 				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
 				.click();
+
+			// Wait for the block to be inserted and click into it to ensure focus
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
+			await headingBlock.waitFor( { state: 'attached' } );
+			await headingBlock.click();
+
 			await page.keyboard.type( 'Test Heading' );
 
 			await editor.openDocumentSettingsSidebar();

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -48,17 +48,20 @@ test.describe( 'Fit Text', () => {
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
 
-		test( 'should enable fit text on a paragraph block via Stretchy Text variation', async ( {
+		test( 'should enable fit text on a paragraph block via Stretchy Paragraph variation', async ( {
 			editor,
 			page,
 		} ) => {
-			// Insert Stretchy Text variation from block inserter
+			// Insert Stretchy Paragraph variation from block inserter
 			await page
 				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Text' } )
-				.getByRole( 'option', { name: 'Stretchy Text', exact: true } )
+				.getByRole( 'option', {
+					name: 'Stretchy Paragraph',
+					exact: true,
+				} )
 				.click();
 
 			// Wait for the block to be inserted and click into it to ensure focus
@@ -177,7 +180,7 @@ test.describe( 'Fit Text', () => {
 			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
 		} );
 
-		test( 'should not show font size UI for Stretchy Text and Stretchy Heading variations', async ( {
+		test( 'should not show font size UI for Stretchy Paragraph and Stretchy Heading variations', async ( {
 			editor,
 			page,
 		} ) => {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -9,35 +9,19 @@ test.describe( 'Fit Text', () => {
 	} );
 
 	test.describe( 'Editor functionality', () => {
-		test( 'should enable fit text on a heading block', async ( {
+		test( 'should enable fit text on a heading block via Stretch Heading variation', async ( {
 			editor,
 			page,
 		} ) => {
-			await editor.insertBlock( {
-				name: 'core/heading',
-				attributes: {
-					content: 'Test Heading',
-					level: 2,
-				},
-			} );
-
-			await editor.openDocumentSettingsSidebar();
-
-			// Enable Fit text control via Typography options menu
+			// Insert Stretch Heading variation from block inserter
 			await page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Typography options' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
-				.getByRole( 'menu', { name: 'Typography options' } )
-				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.getByRole( 'listbox', { name: 'Text' } )
+				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
 				.click();
-
-			const fitTextToggle = page.getByRole( 'checkbox', {
-				name: 'Fit text',
-			} );
-
-			await fitTextToggle.click();
+			await page.keyboard.type( 'Test Heading' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -57,59 +41,19 @@ test.describe( 'Fit Text', () => {
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
 
-		test( 'should disable fit text when toggled off', async ( {
+		test( 'should enable fit text on a paragraph block via Stretch Text variation', async ( {
 			editor,
 			page,
 		} ) => {
-			await editor.insertBlock( {
-				name: 'core/heading',
-				attributes: {
-					content: 'Test Heading',
-					level: 2,
-					fitText: true,
-				},
-			} );
-
-			await editor.openDocumentSettingsSidebar();
-
-			const fitTextToggle = page.getByRole( 'checkbox', {
-				name: 'Fit text',
-			} );
-
-			await fitTextToggle.click();
-
-			const blocks = await editor.getBlocks();
-			expect( blocks[ 0 ].attributes.fitText ).toBeUndefined();
-		} );
-
-		test( 'should enable fit text on a paragraph block', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: {
-					content: 'Test paragraph with fit text enabled',
-				},
-			} );
-
-			await editor.openDocumentSettingsSidebar();
-
-			// Enable Fit text control via Typography options menu
+			// Insert Stretch Text variation from block inserter
 			await page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Typography options' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
-				.getByRole( 'menu', { name: 'Typography options' } )
-				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.getByRole( 'listbox', { name: 'Text' } )
+				.getByRole( 'option', { name: 'Stretch Text', exact: true } )
 				.click();
-
-			const fitTextToggle = page.getByRole( 'checkbox', {
-				name: 'Fit text',
-			} );
-
-			await fitTextToggle.click();
+			await page.keyboard.type( 'Test paragraph with fit text enabled' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -222,87 +166,33 @@ test.describe( 'Fit Text', () => {
 			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
 		} );
 
-		test( 'should disable fit text when a font size is selected', async ( {
+		test( 'should not show font size UI for Stretch Text and Stretch Heading variations', async ( {
 			editor,
 			page,
 		} ) => {
-			await editor.insertBlock( {
-				name: 'core/heading',
-				attributes: {
-					content: 'Test Heading',
-					level: 2,
-					fitText: true,
-				},
-			} );
+			// Insert Stretch Heading variation
+			await page
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+				.click();
+			await page
+				.getByRole( 'listbox', { name: 'Text' } )
+				.getByRole( 'option', { name: 'Stretch Heading', exact: true } )
+				.click();
+			await page.keyboard.type( 'Test Heading' );
 
 			await editor.openDocumentSettingsSidebar();
 
-			// Set a custom font size
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
+			// Font size controls should not be visible
+			const fontSizeButton = page.getByRole( 'button', {
+				name: 'Set custom size',
+			} );
+			await expect( fontSizeButton ).not.toBeVisible();
+
+			// Verify no font size picker is present
+			const fontSizePicker = page.locator(
+				'[aria-label="Font size"], [aria-label="Size"]'
 			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
-			await page.keyboard.type( '24' );
-
-			// fitText should be cleared
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/heading',
-					attributes: expect.objectContaining( {
-						content: 'Test Heading',
-						level: 2,
-						style: {
-							typography: {
-								fontSize: '24px',
-							},
-						},
-					} ),
-				},
-			] );
-		} );
-
-		test( 'should clear font size when fit text is enabled', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/heading',
-				attributes: {
-					content: 'Test Heading',
-					level: 2,
-					fontSize: 'large',
-				},
-			} );
-
-			await editor.openDocumentSettingsSidebar();
-
-			// Enable Fit text control via Typography options menu
-			await page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Typography options' } )
-				.click();
-			await page
-				.getByRole( 'menu', { name: 'Typography options' } )
-				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
-				.click();
-
-			const fitTextToggle = page.getByRole( 'checkbox', {
-				name: 'Fit text',
-			} );
-
-			await fitTextToggle.click();
-
-			// fontSize should be cleared
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/heading',
-					attributes: expect.objectContaining( {
-						content: 'Test Heading',
-						level: 2,
-						fitText: true,
-					} ),
-				},
-			] );
+			await expect( fontSizePicker ).not.toBeVisible();
 		} );
 
 		test( 'should not load frontend script when editing a saved post with fit text', async ( {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -9,7 +9,7 @@ test.describe( 'Fit Text', () => {
 	} );
 
 	test.describe( 'Editor functionality', () => {
-		test( 'should enable fit text on a heading block via Stretchy Heading variation', async ( {
+		test( 'should enable stretchy text on a heading block via Stretchy Heading variation', async ( {
 			editor,
 			page,
 		} ) => {
@@ -48,7 +48,7 @@ test.describe( 'Fit Text', () => {
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
 
-		test( 'should enable fit text on a paragraph block via Stretchy Paragraph variation', async ( {
+		test( 'should enable stretchy text on a paragraph block via Stretchy Paragraph variation', async ( {
 			editor,
 			page,
 		} ) => {
@@ -132,7 +132,7 @@ test.describe( 'Fit Text', () => {
 			expect( newSize ).toBeLessThan( initialSize );
 		} );
 
-		test( 'should apply much larger font size with fit text compared to without fit text for a short text', async ( {
+		test( 'should apply much larger font size with stretchy text compared to without stretchy text for a short text', async ( {
 			editor,
 		} ) => {
 			// Insert two paragraphs with same content for comparison
@@ -268,7 +268,7 @@ test.describe( 'Fit Text', () => {
 	} );
 
 	test.describe( 'Frontend functionality', () => {
-		test( 'should render fit text correctly on the frontend', async ( {
+		test( 'should render stretchy text correctly on the frontend', async ( {
 			editor,
 			page,
 		} ) => {
@@ -377,7 +377,7 @@ test.describe( 'Fit Text', () => {
 			expect( newSize ).toBeLessThan( initialSize );
 		} );
 
-		test( 'should apply much larger font size with fit text compared to without fit text on frontend for a short text', async ( {
+		test( 'should apply much larger font size with stretchy text compared to without stretchy text on frontend for a short text', async ( {
 			editor,
 			page,
 		} ) => {

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1422,7 +1422,9 @@ test.describe( 'List (@firefox)', () => {
 		);
 
 		await page.getByRole( 'button', { name: 'List', exact: true } ).click();
-		await page.getByRole( 'menuitem', { name: 'Paragraph' } ).click();
+		await page
+			.getByRole( 'menuitem', { name: 'Paragraph', exact: true } )
+			.click();
 
 		expect( await editor.getEditedPostContent() )
 			.toBe( `<!-- wp:paragraph -->

--- a/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Allowed Blocks Filter', () => {
 		await searchbox.fill( 'Paragraph' );
 
 		await expect(
-			page.getByRole( 'option', { name: 'Paragraph' } )
+			page.getByRole( 'option', { name: 'Paragraph', exact: true } )
 		).toBeVisible();
 
 		// The gallery block is not available.

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Block variations', () => {
 			'Paragraph',
 			'Success Message',
 			'Warning Message',
-			'Stretch Text',
+			'Stretchy Text',
 		] );
 	} );
 

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Block variations', () => {
 			'Paragraph',
 			'Success Message',
 			'Warning Message',
-			'Stretchy Text',
+			'Stretchy Paragraph',
 		] );
 	} );
 

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -77,7 +77,12 @@ test.describe( 'Block variations', () => {
 			page
 				.getByRole( 'listbox', { name: 'Blocks' } )
 				.getByRole( 'option' )
-		).toHaveText( [ 'Paragraph', 'Success Message', 'Warning Message' ] );
+		).toHaveText( [
+			'Paragraph',
+			'Stretch Text',
+			'Success Message',
+			'Warning Message',
+		] );
 	} );
 
 	test( 'Insert the Success Message block variation', async ( {
@@ -88,7 +93,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.getByRole( 'option', { name: 'Heading' } ).click();
+		await page
+			.getByRole( 'option', { name: 'Heading', exact: true } )
+			.click();
 		await page.keyboard.type( '/Success Message' );
 		await page.getByRole( 'option', { name: 'Success Message' } ).click();
 
@@ -167,7 +174,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.getByRole( 'option', { name: 'Heading' } ).click();
+		await page
+			.getByRole( 'option', { name: 'Heading', exact: true } )
+			.click();
 		await page.keyboard.type( '/Success Message' );
 		await page.getByRole( 'option', { name: 'Success Message' } ).click();
 
@@ -203,7 +212,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.getByRole( 'option', { name: 'Heading' } ).click();
+		await page
+			.getByRole( 'option', { name: 'Heading', exact: true } )
+			.click();
 		await page.keyboard.type( '/Warning Message' );
 		await page.getByRole( 'option', { name: 'Warning Message' } ).click();
 

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -79,9 +79,9 @@ test.describe( 'Block variations', () => {
 				.getByRole( 'option' )
 		).toHaveText( [
 			'Paragraph',
-			'Stretch Text',
 			'Success Message',
 			'Warning Message',
+			'Stretch Text',
 		] );
 	} );
 

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -98,7 +98,7 @@ test.describe( 'Child Blocks', () => {
 		await expect( blockLibrary ).toBeVisible();
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
-			'Stretch Text',
+			'Stretchy Text',
 			'Child Blocks Child',
 			'Image',
 		] );

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -98,7 +98,7 @@ test.describe( 'Child Blocks', () => {
 		await expect( blockLibrary ).toBeVisible();
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
-			'Stretchy Text',
+			'Stretchy Paragraph',
 			'Child Blocks Child',
 			'Image',
 		] );

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -98,6 +98,7 @@ test.describe( 'Child Blocks', () => {
 		await expect( blockLibrary ).toBeVisible();
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
+			'Stretch Text',
 			'Child Blocks Child',
 			'Image',
 		] );

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -105,8 +105,8 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await expect( blockLibrary ).toBeVisible();
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
-			'Stretch Text',
 			'Heading',
+			'Stretch Text',
 			'Stretch Heading',
 			'Image',
 		] );
@@ -121,6 +121,9 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Allowed Blocks Dynamic' );
+		await expect(
+			page.getByRole( 'option', { name: /Allowed Blocks Dynamic/i } )
+		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
 
 		const blockAppender = editor.canvas.getByRole( 'button', {

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -105,7 +105,9 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await expect( blockLibrary ).toBeVisible();
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
+			'Stretch Text',
 			'Heading',
+			'Stretch Heading',
 			'Image',
 		] );
 	} );

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -106,8 +106,8 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
 			'Heading',
-			'Stretch Text',
-			'Stretch Heading',
+			'Stretchy Text',
+			'Stretchy Heading',
 			'Image',
 		] );
 	} );

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -106,7 +106,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await expect( blockLibrary.getByRole( 'option' ) ).toHaveText( [
 			'Paragraph',
 			'Heading',
-			'Stretchy Text',
+			'Stretchy Paragraph',
 			'Stretchy Heading',
 			'Image',
 		] );

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -352,8 +352,6 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menu', { name: 'Paragraph', exact: true } )
 					.getByRole( 'menuitem' )
 			).toHaveText( [
-				'Paragraph',
-				'Stretchy Paragraph',
 				'Heading',
 				'List',
 				'Quote',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -337,7 +337,7 @@ test.describe( 'Post-type locking', () => {
 
 			const blockSwitcher = page
 				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Paragraph' } );
+				.getByRole( 'button', { name: 'Paragraph', exact: true } );
 
 			// Verify the block switcher exists.
 			await expect( blockSwitcher ).toHaveAttribute(
@@ -349,7 +349,7 @@ test.describe( 'Post-type locking', () => {
 			await blockSwitcher.click();
 			await expect(
 				page
-					.getByRole( 'menu', { name: 'Paragraph' } )
+					.getByRole( 'menu', { name: 'Paragraph', exact: true } )
 					.getByRole( 'menuitem' )
 			).toHaveText( [
 				'Heading',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -352,6 +352,7 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menu', { name: 'Paragraph', exact: true } )
 					.getByRole( 'menuitem' )
 			).toHaveText( [
+				'Stretch Text',
 				'Heading',
 				'List',
 				'Quote',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -352,6 +352,7 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menu', { name: 'Paragraph', exact: true } )
 					.getByRole( 'menuitem' )
 			).toHaveText( [
+				'Paragraph',
 				'Stretch Text',
 				'Heading',
 				'List',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -353,7 +353,7 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menuitem' )
 			).toHaveText( [
 				'Paragraph',
-				'Stretchy Text',
+				'Stretchy Paragraph',
 				'Heading',
 				'List',
 				'Quote',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -353,7 +353,7 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menuitem' )
 			).toHaveText( [
 				'Paragraph',
-				'Stretch Text',
+				'Stretchy Text',
 				'Heading',
 				'List',
 				'Quote',

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -571,7 +571,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		// Get the assertive live region screen reader announcement.
 		await expect(
 			page.getByText(
-				'2 results found, use up and down arrow keys to navigate.'
+				'3 results found, use up and down arrow keys to navigate.'
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -53,7 +53,10 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Add a paragraph in the first column.
-		const paragraph = page.getByRole( 'option', { name: 'Paragraph' } );
+		const paragraph = page.getByRole( 'option', {
+			name: 'Paragraph',
+			exact: true,
+		} );
 		await expect( paragraph ).toBeVisible();
 		await paragraph.click();
 		await page.keyboard.type( 'First column' );
@@ -108,7 +111,10 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Add a paragraph in the first column.
-		const paragraph = page.getByRole( 'option', { name: 'Paragraph' } );
+		const paragraph = page.getByRole( 'option', {
+			name: 'Paragraph',
+			exact: true,
+		} );
 		await expect( paragraph ).toBeVisible();
 		await paragraph.click();
 		await page.keyboard.type( 'First column' );
@@ -204,7 +210,10 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Add some random blocks.
-		const paragraph = page.getByRole( 'option', { name: 'Paragraph' } );
+		const paragraph = page.getByRole( 'option', {
+			name: 'Paragraph',
+			exact: true,
+		} );
 		await expect( paragraph ).toBeVisible();
 		await paragraph.click();
 		await page.keyboard.type( 'just a paragraph' );

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -167,10 +167,6 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'You say goodbye' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '## Hello, hello' );
-		// Wait for the heading block to be created
-		await expect(
-			editor.canvas.getByRole( 'document', { name: 'Block: Heading' } )
-		).toBeVisible();
 
 		// Open list view and return to the first block.
 		await pageUtils.pressKeys( 'access+o' );
@@ -223,11 +219,6 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'just a paragraph' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/spacer' );
-		await expect(
-			page.getByRole( 'option', { name: 'Spacer', exact: true } )
-		).toBeVisible();
-		// Small delay to ensure autocomplete is fully ready
-		await page.waitForTimeout( 100 );
 		await page.keyboard.press( 'Enter' );
 
 		// Verify group block contents.

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -167,6 +167,10 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'You say goodbye' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '## Hello, hello' );
+		// Wait for the heading block to be created
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Heading' } )
+		).toBeVisible();
 
 		// Open list view and return to the first block.
 		await pageUtils.pressKeys( 'access+o' );
@@ -219,6 +223,11 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'just a paragraph' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/spacer' );
+		await expect(
+			page.getByRole( 'option', { name: 'Spacer', exact: true } )
+		).toBeVisible();
+		// Small delay to ensure autocomplete is fully ready
+		await page.waitForTimeout( 100 );
 		await page.keyboard.press( 'Enter' );
 
 		// Verify group block contents.

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -103,7 +103,7 @@ test.describe( 'Block Switcher', () => {
 		await pageUtils.pressKeys( 'alt+F10' );
 		const button = page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
-			.getByRole( 'button', { name: 'Paragraph' } );
+			.getByRole( 'button', { name: 'Paragraph', exact: true } );
 		await expect( button ).toBeEnabled();
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );

--- a/test/e2e/specs/editor/various/block-visibility.spec.js
+++ b/test/e2e/specs/editor/various/block-visibility.spec.js
@@ -96,7 +96,7 @@ test.describe( 'Block Visibility', () => {
 		await expect(
 			page
 				.getByRole( 'tabpanel', { name: 'Blocks' } )
-				.getByRole( 'option', { name: 'Heading' } ),
+				.getByRole( 'option', { name: 'Heading', exact: true } ),
 			'Heading block should be visible'
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -530,7 +530,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
-			.getByRole( 'option', { name: 'Heading' } )
+			.getByRole( 'option', { name: 'Heading', exact: true } )
 			.hover();
 
 		await expect( insertingBlocksUtils.indicator ).toBeVisible();
@@ -571,7 +571,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await page.getByRole( 'button', { name: 'Browse All' } ).click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
-			.getByRole( 'option', { name: 'Paragraph' } )
+			.getByRole( 'option', { name: 'Paragraph', exact: true } )
 			.click();
 		await editor.canvas
 			.getByRole( 'document', { name: 'Empty block' } )
@@ -673,7 +673,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
-			.getByRole( 'option', { name: 'Paragraph' } )
+			.getByRole( 'option', { name: 'Paragraph', exact: true } )
 			.hover();
 
 		await expect(

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -1163,7 +1163,7 @@ test.describe( 'List View', () => {
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
 		);
 		await listView
-			.getByRole( 'gridcell', { name: 'Paragraph' } )
+			.getByRole( 'gridcell', { name: 'Paragraph', exact: true } )
 			.getByRole( 'link' )
 			.focus();
 		await expect

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -140,7 +140,7 @@ test.describe( 'Block Toolbar', () => {
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block Tools' } )
-				.getByRole( 'button', { name: 'Paragraph' } )
+				.getByRole( 'button', { name: 'Paragraph', exact: true } )
 		).toBeFocused();
 	} );
 

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -162,6 +162,7 @@ test.describe( 'Widgets screen', () => {
 
 		const paragraphBlock = inlineQuickInserter.getByRole( 'option', {
 			name: 'Paragraph',
+			exact: true,
 		} );
 		await paragraphBlock.click();
 
@@ -214,7 +215,7 @@ test.describe( 'Widgets screen', () => {
 		await page.keyboard.type( 'Heading' );
 
 		await inlineQuickInserter
-			.getByRole( 'option', { name: 'Heading' } )
+			.getByRole( 'option', { name: 'Heading', exact: true } )
 			.click();
 
 		await expect(
@@ -708,7 +709,10 @@ class WidgetsScreen {
 			} )
 			.fill( blockName );
 
-		return blockLibrary.getByRole( 'option', { name: blockName } );
+		return blockLibrary.getByRole( 'option', {
+			name: blockName,
+			exact: true,
+		} );
 	};
 
 	saveWidgets = async () => {

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -492,12 +492,14 @@ test.describe( 'Post Editor Performance', () => {
 				.getByRole( 'button', {
 					name: 'Block Inserter',
 				} );
-			const paragraphBlockItem = page.locator(
-				'.block-editor-inserter__menu .editor-block-list-item-paragraph'
-			);
-			const headingBlockItem = page.locator(
-				'.block-editor-inserter__menu .editor-block-list-item-heading'
-			);
+			const paragraphBlockItem = page.getByRole( 'option', {
+				name: 'Paragraph',
+				exact: true,
+			} );
+			const headingBlockItem = page.getByRole( 'option', {
+				name: 'Heading',
+				exact: true,
+			} );
 
 			// Open Inserter.
 			await globalInserterToggle.click();


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/72948.

This PR is an alternative to X as instead of creating a new block it readds two variations "Stretch Text" and "Stretch Heading". It includes a mechanism of excepninally make this variations not appear right above there main blocks. It is a very small contained hardcoded change, we should find an API to do that in a good way in the future.

Fixes: https://github.com/WordPress/gutenberg/issues/72947


## Screenshot
<img width="330" height="1153" alt="Screenshot 2025-11-06 at 15 39 25" src="https://github.com/user-attachments/assets/5d783b6b-2cf6-42ec-b512-01b1c527aed6" />
<img width="277" height="867" alt="Screenshot 2025-11-06 at 16 20 28" src="https://github.com/user-attachments/assets/f03c05ba-f308-44b2-87ee-1000b68833df" />



## Testing Instructions
Verify both variations work well.
