### PR TITLE
Add specific classname to block toolbar icon

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -131,7 +131,12 @@ export default function BlockToolbarIcon( { clientIds, isSynced } ) {
 	// Used to hide the block icon when the showIconLabels preference is enabled, or to display the template title when it's a template.
 	const text = showBlockTitle && blockTitle ? blockTitle : undefined;
 
-	const BlockIconElement = <BlockIcon icon={ icon } />;
+	const BlockIconElement = (
+		<BlockIcon
+			className="block-editor-block-toolbar__block-icon"
+			icon={ icon }
+		/>
+	);
 
 	if ( variant === 'switcher' ) {
 		return (
@@ -159,7 +164,7 @@ export default function BlockToolbarIcon( { clientIds, isSynced } ) {
 	return (
 		<ToolbarButton
 			disabled
-			className="block-editor-block-toolbar__block-icon"
+			className="block-editor-block-toolbar__block-icon-button"
 			title={ label }
 			icon={ BlockIconElement }
 			text={ text }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -51,7 +51,7 @@
 	}
 
 	// Disabled block toolbar icon should have a fixed color.
-	.components-button.block-editor-block-toolbar__block-icon[aria-disabled="true"] {
+	.components-button.block-editor-block-toolbar__block-icon-button[aria-disabled="true"] {
 		color: $gray-900;
 
 		// Since it's not clickable, though, don't show a hover state.
@@ -62,7 +62,7 @@
 
 	&.is-synced,
 	&.is-connected {
-		.block-editor-block-icon {
+		.block-editor-block-toolbar__block-icon {
 			color: var(--wp-block-synced-color);
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73059

<!-- In a few words, what is the PR actually doing? -->
Makes parent block selector black instead of purple, as it can't be a synced block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix UX issue

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The wrapping button for the block toolbar icon has three different possible classnames and the icon itself had a generic classname by default when using the BlockIcon component. I added a className to the BlockIcon used by the BlockToolbarIcon so it could be targeted in all its instances and be unique from the parent selector. This allows us to target it with CSS more easily and keep styles targeted and tidy.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a synced pattern
- Add a group block
- Add a paragraph block inside the group
- In the sidebar inspector for that paragraph, go to Advanced
- Select the Enable Overrides button
- Add a name for the override
- Save
- Add this synced pattern to a post
- Select the paragraph block
- The group parent selector should be black, and the paragraph icon should be purple

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="653" height="581" alt="" src="https://github.com/user-attachments/assets/2ec4b517-ad28-4d3c-b442-f1f3c6352297" />|<img width="721" height="332" alt="" src="https://github.com/user-attachments/assets/942c68e8-b017-448b-affe-24a17f40f553" />|


