### PR TITLE
Notes: Gracefully handle non-existing note ID references (alt)

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -36,12 +36,10 @@ export function AddComment( {
 	y,
 	refs,
 } ) {
-	const { clientId, blockCommentId } = useSelect( ( select ) => {
-		const { getSelectedBlock } = select( blockEditorStore );
-		const selectedBlock = getSelectedBlock();
+	const { clientId } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( blockEditorStore );
 		return {
-			clientId: selectedBlock?.clientId,
-			blockCommentId: selectedBlock?.attributes?.metadata?.noteId,
+			clientId: getSelectedBlockClientId(),
 		};
 	}, [] );
 	const blockElement = useBlockElement( clientId );
@@ -53,11 +51,7 @@ export function AddComment( {
 		toggleBlockSpotlight( clientId, false );
 	};
 
-	if (
-		newNoteFormState !== 'open' ||
-		! clientId ||
-		undefined !== blockCommentId
-	) {
+	if ( newNoteFormState !== 'open' || ! clientId ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -93,11 +93,7 @@ export function Comments( {
 		// add a "new note" entry to the threads. This special thread type
 		// gets sorted and floated like regular threads, but shows an AddComment
 		// component instead of a regular comment thread.
-		if (
-			isFloating &&
-			newNoteFormState === 'open' &&
-			undefined === blockCommentId
-		) {
+		if ( isFloating && newNoteFormState === 'open' ) {
 			// Insert the new note entry at the correct location for its blockId.
 			const newNoteThread = {
 				id: 'new-note-thread',
@@ -124,7 +120,6 @@ export function Comments( {
 		noteThreads,
 		isFloating,
 		newNoteFormState,
-		blockCommentId,
 		selectedBlockClientId,
 		orderedBlockIds,
 	] );
@@ -160,8 +155,9 @@ export function Comments( {
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
 		// Fallback to 'new-note-thread' when showing the comment board for a new note.
-		const fallback = newNoteFormState === 'open' ? 'new-note-thread' : null;
-		setSelectedThread( blockCommentId ?? fallback );
+		setSelectedThread(
+			newNoteFormState === 'open' ? 'new-note-thread' : blockCommentId
+		);
 	}, [ blockCommentId, newNoteFormState ] );
 
 	const setBlockRef = useCallback( ( id, blockRef ) => {
@@ -322,16 +318,14 @@ export function Comments( {
 
 	return (
 		<>
-			{ ! isFloating &&
-				newNoteFormState === 'open' &&
-				undefined === blockCommentId && (
-					<AddComment
-						onSubmit={ onAddReply }
-						newNoteFormState={ newNoteFormState }
-						setNewNoteFormState={ setNewNoteFormState }
-						commentSidebarRef={ commentSidebarRef }
-					/>
-				) }
+			{ ! isFloating && newNoteFormState === 'open' && (
+				<AddComment
+					onSubmit={ onAddReply }
+					newNoteFormState={ newNoteFormState }
+					setNewNoteFormState={ setNewNoteFormState }
+					commentSidebarRef={ commentSidebarRef }
+				/>
+			) }
 			{ threads.map( ( thread ) => (
 				<Thread
 					key={ thread.id }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -154,12 +154,12 @@ function NotesSidebar( { postId, mode } ) {
 			return;
 		}
 
-		setNewNoteFormState( ! blockCommentId ? 'open' : 'closed' );
+		setNewNoteFormState( ! currentThread ? 'open' : 'closed' );
 		focusCommentThread(
-			blockCommentId,
+			currentThread?.id,
 			commentSidebarRef.current,
 			// Focus a comment thread when there's a selected block with a comment.
-			! blockCommentId ? 'textarea' : undefined
+			! currentThread ? 'textarea' : undefined
 		);
 		toggleBlockSpotlight( clientId, true );
 	}
@@ -170,7 +170,7 @@ function NotesSidebar( { postId, mode } ) {
 
 	return (
 		<>
-			{ blockCommentId && (
+			{ !! currentThread && (
 				<CommentAvatarIndicator
 					thread={ currentThread }
 					onClick={ openTheSidebar }


### PR DESCRIPTION
## What?
Closes #73017.
Alternative to #73050.

Allows adding new note to a block if associated `noteId` metadata doesn't exists or is invalid.

Note: Appriciate testing edge cases, I tried my best to do it, but we all forget something.

## Why?
Blocks and their attributes can be copied and pasted into different posts, where associated notes don't exist. This created a bug and prevented users from adding new notes to copied content.

## How?
Make `newNoteFormState === 'open'` only requirement and source of thruth to display the new note form.

## Testing Instructions
1. Open a post or page.
2. Paste block with non-existing note reference.
3. Try adding note.
4. The new note form should be visible.

```html
<!-- wp:paragraph {"metadata":{"noteId":144444}} -->
<p>Testing an incorrect noteId medatadata</p>
<!-- /wp:paragraph -->
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
