### PR TITLE
RichText: Don't forget ref passing in Preview mode

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -569,6 +569,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 		} = removeNativeProps( props );
 		return (
 			<Tag
+				ref={ ref }
 				{ ...contentProps }
 				dangerouslySetInnerHTML={ {
 					__html: valueToHTMLString( value, multiline ),


### PR DESCRIPTION
## What

Alternative to #73020
Bug introduced in #60544

Let RichText forward the ref that it receives to the element it returns, even when this element is the lightweight alternative returned when the block editor is in preview mode.

## Why?

Fixes any kind of bug arising from the fact that refs passed to RichText were ignored when the block editor is in preview mode. Particularly, `useBlockProps`, with its many merged refs, was systematically ignored.

This was revealed while debugging the bug that #73020 sought to fix: `useBlockElement` could never return elements because the ref callback of `useBlockElementRef` was never called.

## Testing Instructions
* Follow testing instructions in #73020: ensure everything works
* Test normally functioning preview contexts: nothing should change