### PR TITLE
Routing: Add a post edit route to the boot demo page

### DIFF
--- a/lib/experimental/boot/boot-routes.php
+++ b/lib/experimental/boot/boot-routes.php
@@ -16,17 +16,21 @@ $gutenberg_boot_routes = array();
 /**
  * Register a boot route.
  *
- * @param string $path           Route path (e.g., "/").
- * @param string $content_module Script module ID for route content (stage/inspector).
- * @param string $route_module   Optional script module ID for route lifecycle (beforeLoad/loader).
+ * @param string      $path           Route path (e.g., "/").
+ * @param string|null $content_module Optional script module ID for route content (stage/inspector).
+ * @param string|null $route_module   Optional script module ID for route lifecycle (beforeLoad/loader).
  */
-function gutenberg_register_boot_route( $path, $content_module, $route_module = null ) {
+function gutenberg_register_boot_route( $path, $content_module = null, $route_module = null ) {
 	global $gutenberg_boot_routes;
 
 	$route = array(
-		'path'           => $path,
-		'content_module' => $content_module,
+		'path' => $path,
 	);
+
+	// Only include content_module if it's not empty.
+	if ( ! empty( $content_module ) ) {
+		$route['content_module'] = $content_module;
+	}
 
 	// Only include route_module if it's not empty.
 	if ( ! empty( $route_module ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17505,6 +17505,10 @@
 			"resolved": "packages/plugins",
 			"link": true
 		},
+		"node_modules/@wordpress/post-edit": {
+			"resolved": "routes/post-edit",
+			"link": true
+		},
 		"node_modules/@wordpress/post-list": {
 			"resolved": "routes/post-list",
 			"link": true
@@ -55245,6 +55249,14 @@
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/i18n": "file:../../packages/i18n"
+			}
+		},
+		"routes/post-edit": {
+			"name": "@wordpress/post-edit",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data"
 			}
 		},
 		"routes/post-list": {

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -113,7 +113,7 @@ async function createRouteFromDefinition(
 		loader: async ( opts: any ) => {
 			const context: RouteLoaderContext = {
 				params: opts.params || {},
-				search: opts.search || {},
+				search: opts.deps || {},
 			};
 
 			// Call both loader and canvas functions if they exist
@@ -131,6 +131,7 @@ async function createRouteFromDefinition(
 				canvas: canvasData,
 			};
 		},
+		loaderDeps: ( opts: any ) => opts.search,
 		component: SurfacesModule,
 	} );
 }

--- a/packages/boot/src/components/canvas/back-button.scss
+++ b/packages/boot/src/components/canvas/back-button.scss
@@ -1,0 +1,62 @@
+@use "@wordpress/base-styles/variables";
+
+.boot-canvas-back-button {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: variables.$header-height;
+	width: variables.$header-height;
+	z-index: 100;
+}
+
+.boot-canvas-back-button__container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}
+
+.boot-canvas-back-button__link.components-button {
+	width: variables.$header-height;
+	height: variables.$header-height;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	text-decoration: none;
+	padding: 0;
+	border-radius: 0;
+
+	@media not (prefers-reduced-motion) {
+		transition: outline 0.1s ease-out;
+	}
+
+	&:focus:not(:active) {
+		outline:
+			var(--wpds-border-width-focus) solid
+			var(--wpds-color-stroke-focus-brand);
+		outline-offset: calc(-1 * var(--wpds-border-width-focus));
+	}
+}
+
+.boot-canvas-back-button__icon {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: variables.$header-height;
+	height: variables.$header-height;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: hsla(0, 0%, 80%);
+	pointer-events: none;
+
+	svg {
+		fill: currentColor;
+	}
+
+	&.has-site-icon {
+		background-color: hsla(0, 0%, 100%, 0.6);
+		-webkit-backdrop-filter: saturate(180%) blur(15px);
+		backdrop-filter: saturate(180%) blur(15px);
+	}
+}

--- a/packages/boot/src/components/canvas/back-button.tsx
+++ b/packages/boot/src/components/canvas/back-button.tsx
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Icon,
+	__unstableMotion as motion,
+} from '@wordpress/components';
+import { arrowUpLeft } from '@wordpress/icons';
+import { useReducedMotion } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SiteIcon from '../site-icon';
+import './back-button.scss';
+
+/**
+ * Overlay arrow animation that appears on hover.
+ * Matches next-admin implementation with clip-path.
+ */
+const toggleHomeIconVariants = {
+	edit: {
+		opacity: 0,
+		scale: 0.2,
+	},
+	hover: {
+		opacity: 1,
+		scale: 1,
+		clipPath: 'inset( 22% round 2px )',
+	},
+};
+
+/**
+ * Back button component that appears in full-screen canvas mode.
+ * Matches next-admin's SiteIconBackButton design.
+ *
+ * @param {Object} props        Component props
+ * @param {number} props.length Number of BackButton fills (from Slot)
+ * @return Back button with slide and hover animations
+ */
+export default function BootBackButton( { length }: { length: number } ) {
+	const disableMotion = useReducedMotion();
+
+	const handleBack = () => {
+		window.history.back();
+	};
+
+	// Only render if this is the only back button
+	if ( length > 1 ) {
+		return null;
+	}
+
+	const transition = {
+		duration: disableMotion ? 0 : 0.3,
+	};
+
+	return (
+		<motion.div
+			className="boot-canvas-back-button"
+			animate="edit"
+			initial="edit"
+			whileHover="hover"
+			whileTap="tap"
+			transition={ transition }
+		>
+			<Button
+				className="boot-canvas-back-button__link"
+				onClick={ handleBack }
+				aria-label={ __( 'Go back' ) }
+				__next40pxDefaultSize
+			>
+				<SiteIcon />
+			</Button>
+
+			{ /* Overlay arrow that appears on hover */ }
+			<motion.div
+				className="boot-canvas-back-button__icon"
+				variants={ toggleHomeIconVariants }
+			>
+				<Icon icon={ arrowUpLeft } />
+			</motion.div>
+		</motion.div>
+	);
+}

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -8,6 +8,7 @@ import { Spinner } from '@wordpress/components';
  * Internal dependencies
  */
 import type { CanvasData } from '../../store/types';
+import BootBackButton from './back-button';
 
 interface CanvasProps {
 	canvas: CanvasData;
@@ -52,12 +53,32 @@ export default function Canvas( { canvas }: CanvasProps ) {
 		);
 	}
 
+	// Conditionally set preview mode based on isPreview
+	const editorSettings = canvas.isPreview
+		? { isPreviewMode: true }
+		: { isPreviewMode: false };
+
+	// Render back button in full-screen mode (when not preview)
+	// Uses render prop pattern to receive fillProps from Slot
+	const backButton = ! canvas.isPreview
+		? ( { length }: { length: number } ) => (
+				<BootBackButton length={ length } />
+		  )
+		: undefined;
+
 	// Render the editor with canvas data
 	return (
-		<Editor
-			postType={ canvas.postType }
-			postId={ canvas.postId }
-			settings={ { isPreviewMode: true } }
-		/>
+		<div
+			style={ { height: '100%' } }
+			// @ts-expect-error inert untyped properly.
+			inert={ canvas.isPreview ? 'true' : undefined }
+		>
+			<Editor
+				postType={ canvas.postType }
+				postId={ canvas.postId }
+				settings={ editorSettings }
+				backButton={ backButton }
+			/>
+		</div>
 	);
 }

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -53,11 +53,6 @@ export default function Canvas( { canvas }: CanvasProps ) {
 		);
 	}
 
-	// Conditionally set preview mode based on isPreview
-	const editorSettings = canvas.isPreview
-		? { isPreviewMode: true }
-		: { isPreviewMode: false };
-
 	// Render back button in full-screen mode (when not preview)
 	// Uses render prop pattern to receive fillProps from Slot
 	const backButton = ! canvas.isPreview
@@ -76,7 +71,7 @@ export default function Canvas( { canvas }: CanvasProps ) {
 			<Editor
 				postType={ canvas.postType }
 				postId={ canvas.postId }
-				settings={ editorSettings }
+				settings={ { isPreviewMode: canvas.isPreview } }
 				backButton={ backButton }
 			/>
 		</div>

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -30,18 +30,24 @@ export default function Root() {
 		| CanvasData
 		| undefined;
 
+	// Hide sidebar in full-screen canvas mode
+	const isFullScreen = canvas && ! canvas.isPreview;
+
 	return (
 		<ThemeProvider isRoot color={ { bg: '#f8f8f8', primary: '#3858e9' } }>
 			<ThemeProvider color={ { bg: '#1e1e1e', primary: '#3858e9' } }>
 				<div
 					className={ clsx( 'boot-layout', {
 						'has-canvas': !! canvas,
+						'has-full-canvas': isFullScreen,
 					} ) }
 				>
 					<CommandMenu />
-					<div className="boot-layout__sidebar">
-						<Sidebar />
-					</div>
+					{ ! isFullScreen && (
+						<div className="boot-layout__sidebar">
+							<Sidebar />
+						</div>
+					) }
 					<div className="boot-layout__surfaces">
 						<ThemeProvider
 							color={ { bg: '#ffffff', primary: '#3858e9' } }

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -49,3 +49,28 @@
 	top: 0 !important;
 	left: 0 !important;
 }
+
+// Full-screen canvas mode
+.boot-layout.has-full-canvas .boot-layout__surfaces {
+	margin: 0;
+	gap: 0;
+}
+
+.boot-layout.has-full-canvas .boot-layout__stage,
+.boot-layout.has-full-canvas .boot-layout__inspector {
+	display: none;
+}
+
+.boot-layout.has-full-canvas .boot-layout__canvas {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	max-width: none;
+	margin: 0;
+	border-radius: 0;
+	border: none;
+	box-shadow: none;
+	overflow: hidden;
+}

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -44,6 +44,7 @@ export interface RouteLoaderContext {
 export interface CanvasData {
 	postType: string;
 	postId: string;
+	isPreview?: boolean;
 }
 
 /**

--- a/packages/lazy-editor/src/component.tsx
+++ b/packages/lazy-editor/src/component.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -15,24 +20,31 @@ import { useEditorSettings } from './hooks/use-editor-settings';
 import { useEditorAssets } from './hooks/use-editor-assets';
 import { unlock } from './lock-unlock';
 
-const { Editor: PrivateEditor } = unlock( editorPrivateApis );
+const { Editor: PrivateEditor, BackButton } = unlock( editorPrivateApis );
 
 interface EditorProps {
 	postType: string;
 	postId: string;
 	settings?: Record< string, any >;
+	backButton?: ReactNode;
 }
 
 /**
  * Lazy-loading editor component that handles asset loading and settings initialization.
  *
- * @param {Object} props          Component props
- * @param {string} props.postType The post type to edit
- * @param {string} props.postId   The post ID to edit
- * @param {Object} props.settings Optional extra settings to merge with editor settings
+ * @param {Object}    props            Component props
+ * @param {string}    props.postType   The post type to edit
+ * @param {string}    props.postId     The post ID to edit
+ * @param {Object}    props.settings   Optional extra settings to merge with editor settings
+ * @param {ReactNode} props.backButton Optional back button to render in editor header
  * @return The editor component with loading states
  */
-export function Editor( { postType, postId, settings }: EditorProps ) {
+export function Editor( {
+	postType,
+	postId,
+	settings,
+	backButton,
+}: EditorProps ) {
 	// Resolve template ID from post type/ID
 	const templateId = useSelect(
 		( select ) => {
@@ -91,6 +103,8 @@ export function Editor( { postType, postId, settings }: EditorProps ) {
 			templateId={ templateId }
 			settings={ finalSettings }
 			styles={ finalSettings.styles }
-		/>
+		>
+			{ backButton && <BackButton>{ backButton }</BackButton> }
+		</PrivateEditor>
 	);
 }

--- a/packages/wp-build/src/php-generator.mjs
+++ b/packages/wp-build/src/php-generator.mjs
@@ -107,6 +107,7 @@ export async function generateRoutesRegistry( rootDir, buildDir, prefix ) {
 			name: routeName,
 			path: routePath,
 			has_route: routeFiles.hasRoute,
+			has_content: routeFiles.hasStage || routeFiles.hasInspector,
 		};
 	} );
 
@@ -114,10 +115,12 @@ export async function generateRoutesRegistry( rootDir, buildDir, prefix ) {
 	const routeEntries = routes
 		.map( ( route ) => {
 			const hasRouteStr = route.has_route ? 'true' : 'false';
+			const hasContentStr = route.has_content ? 'true' : 'false';
 			return `\tarray(
-		'name'      => '${ route.name }',
-		'path'      => '${ route.path }',
-		'has_route' => ${ hasRouteStr },
+		'name'        => '${ route.name }',
+		'path'        => '${ route.path }',
+		'has_route'   => ${ hasRouteStr },
+		'has_content' => ${ hasContentStr },
 	)`;
 		} )
 		.join( ',\n' );

--- a/packages/wp-build/templates/routes.php.template
+++ b/packages/wp-build/templates/routes.php.template
@@ -23,17 +23,21 @@ if ( ! function_exists( '{{NAMESPACE}}_register_routes' ) ) {
 		$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
 		foreach ( $routes as $route ) {
-			// Register content module
-			$content_asset_path = $routes_dir . '/' . $route['name'] . '/content.min.asset.php';
-			$content_asset      = file_exists( $content_asset_path ) ? require $content_asset_path : array();
-			$content_handle     = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
+			$content_handle = null;
 
-			wp_register_script_module(
-				$content_handle,
-				$base_url . $route['name'] . '/content' . $extension,
-				$content_asset['module_dependencies'] ?? array(),
-				$content_asset['version'] ?? false
-			);
+			// Register content module if it exists
+			if ( isset( $route['has_content'] ) && $route['has_content'] ) {
+				$content_asset_path = $routes_dir . '/' . $route['name'] . '/content.min.asset.php';
+				$content_asset      = file_exists( $content_asset_path ) ? require $content_asset_path : array();
+				$content_handle     = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
+
+				wp_register_script_module(
+					$content_handle,
+					$base_url . $route['name'] . '/content' . $extension,
+					$content_asset['module_dependencies'] ?? array(),
+					$content_asset['version'] ?? false
+				);
+			}
 
 			$route_handle = null;
 

--- a/routes/post-edit/package.json
+++ b/routes/post-edit/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@wordpress/post-edit",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/types/$type/edit/$id"
+	},
+	"dependencies": {
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data"
+	}
+}

--- a/routes/post-edit/route.ts
+++ b/routes/post-edit/route.ts
@@ -1,0 +1,18 @@
+/**
+ * Route configuration for post edit.
+ */
+export const route = {
+	async canvas( context: {
+		params: {
+			type: string;
+			id: string;
+		};
+	} ) {
+		const { params } = context;
+
+		return {
+			postType: params.type,
+			postId: params.id,
+		};
+	},
+};

--- a/routes/post-list/route.ts
+++ b/routes/post-list/route.ts
@@ -21,7 +21,7 @@ export const route = {
 		search: {
 			page?: number;
 			search?: string;
-			postId?: string;
+			postIds?: string[];
 		};
 	} ) {
 		const { params, search } = context;
@@ -38,10 +38,11 @@ export const route = {
 		}
 
 		// Check if postId is provided in query params
-		if ( search.postId ) {
+		if ( search.postIds && search.postIds.length > 0 ) {
 			return {
 				postType: params.type,
-				postId: search.postId.toString(),
+				postId: search.postIds[ 0 ].toString(),
+				isPreview: true,
 			};
 		}
 
@@ -58,6 +59,7 @@ export const route = {
 			return {
 				postType: params.type,
 				postId: ( posts[ 0 ] as any ).id.toString(),
+				isPreview: true,
 			};
 		}
 


### PR DESCRIPTION
Related #70862 

## What

Implements canvas surface with two display modes (preview and full-screen) and adds a back button for navigation.

## Why?

Enables inline post previews in list views and full-screen editing experience matching next-admin's design patterns.

## How?

  - Canvas modes: Added isPreview to CanvasData type controlling layout (split-view vs full-screen) and editor settings (isPreviewMode)
  - Post routes: Created post-edit route for full-screen editing; updated post-list to use isPreview: true for split-view previews
  - Full-screen layout: When isPreview is false, hides sidebar and stage, expands canvas to full viewport
  - Back button: Ported next-admin's SiteIconBackButton using existing boot SiteIcon component with arrowUpLeft overlay, frosted glass hover effects, and window.history.back() navigation
  - Editor inert mode: Wraps editor in div with conditional inert attribute when in preview mode; explicitly sets isPreviewMode: false to fix state persistence when navigating between modes

## Testing Instructions

  1. Navigate to post list view `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Ftypes%2Fpost%2Flist%2Fall`
  2. Click post in list - canvas updates to show selected post