### PR TITLE
Update: Use a bigger max fit text font size.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -14,7 +14,7 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
-	let maxSize = 600;
+	let maxSize = 2400;
 	let bestSize = minSize;
 
 	while ( minSize <= maxSize ) {


### PR DESCRIPTION
Currently fit text is limiting the max size to 600px. According to feedback from @henriqueiamarino, @iamtakashi this may not be enough to have a fit effect on some cases, so this PR increases the max size to 2400px covering a much bigger set of possibilities without having a noticeable performance impact.


## Testing Instructions
Verify fit text still works.
Try Fit text with small text like "Fit" verify now the maximum font size is bigger than 600px.
