### PR TITLE
Border Panel: Decode values so that border radius presets are properly handled in global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -147,17 +147,21 @@ export default function BorderPanel( {
 	// Border radius.
 	const showBorderRadius = useHasBorderRadiusControl( settings );
 	const borderRadiusValues = useMemo( () => {
-		if ( typeof border?.radius !== 'object' ) {
-			return border?.radius;
+		if ( typeof inheritedValue?.border?.radius !== 'object' ) {
+			return decodeValue( inheritedValue?.border?.radius );
 		}
 
 		return {
-			topLeft: border?.radius?.topLeft,
-			topRight: border?.radius?.topRight,
-			bottomLeft: border?.radius?.bottomLeft,
-			bottomRight: border?.radius?.bottomRight,
+			topLeft: decodeValue( inheritedValue?.border?.radius?.topLeft ),
+			topRight: decodeValue( inheritedValue?.border?.radius?.topRight ),
+			bottomLeft: decodeValue(
+				inheritedValue?.border?.radius?.bottomLeft
+			),
+			bottomRight: decodeValue(
+				inheritedValue?.border?.radius?.bottomRight
+			),
 		};
-	}, [ border?.radius ] );
+	}, [ inheritedValue?.border?.radius, decodeValue ] );
 	const setBorderRadius = ( newBorderRadius ) =>
 		setBorder( { ...border, radius: newBorderRadius } );
 	const hasBorderRadius = () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Resolves an issue flagged in https://github.com/WordPress/gutenberg/pull/73033#issuecomment-3496494314 by @t-hamano

Fix the border panel in global styles so that the border radius UI correctly reflects any presets that are selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With border radius presets, when saving the changes in global styles, it's correctly _saved_ in the database, but the UI doesn't update correctly to reflect the selected values. Values can be either `var:` based or `var()` using the actual CSS variable. These values need to be decoded in order for the UI to correctly reflect the selected preset.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the border-panel to call `decodeValue` on the border radius values

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In your theme add the following under the `settings` section in your `theme.json` to add some border radius presets:

```json 
		"border": {
			"radiusSizes": [
				{
					"name": "Small",
					"slug": "small",
					"size": "2px"
				},
				{
					"name": "Medium",
					"slug": "medium",
					"size": "4px"
				},
				{
					"name": "ClampyMedium",
					"slug": "clampy-med",
					"size": "clamp(0.3125rem, 0.00391rem + 0.39063vw, 0.625rem)"
				},
				{
					"name": "ClampyLarge",
					"slug": "clampy-large",
					"size": "clamp(0.625rem, 0.00781rem + 0.78125vw, 1.25rem)"
				},
				{
					"name": "Full",
					"slug": "full",
					"size": "9999px"
				}
			]
		}
```

1. Open up the site editor
2. Go to a particular block in global styles (e.g. Heading) and give it a border
3. Then, give it a border radius, and try setting various corners to different preset values
4. Save the global styles
5. The UI should continue to reflect what you've selected
6. Reload the site editor and open up the block you changed. The UI should reflect what you selected.
7. In the editor itself, go to change the border at the individual block level within post content. It should work as on `trunk`.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5547bfcd-63f2-4113-969c-db59bfcbc4d8


