### PR TITLE
Fix: ToolsPanelItem: hasValue silently fails when it returns a non-boolean (e.g., undefined), causing the control to not render - #73069

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 -   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
+-   `ToolsPanelItem`: Update the custom hook `useToolsPanelItem` for `hasValue` prop to always be Boolean ([#73074](https://github.com/WordPress/gutenberg/pull/73074))
 
 ## 30.7.0 (2025-10-29)
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -54,7 +54,10 @@ export function useToolsPanelItem(
 
 	// hasValue is a new function on every render, so do not add it as a
 	// dependency to the useCallback hook! If needed, we should use a ref.
-	const hasValueCallback = useCallback( hasValue, [ panelId ] );
+	const hasValueCallback = useCallback(
+		() => Boolean( hasValue() ),
+		[ panelId ]
+	);
 	// resetAllFilter is a new function on every render, so do not add it as a
 	// dependency to the useCallback hook! If needed, we should use a ref.
 	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
@@ -122,7 +125,7 @@ export function useToolsPanelItem(
 	const wasMenuItemChecked = usePrevious( isMenuItemChecked );
 	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
 
-	const isValueSet = hasValue();
+	const isValueSet = Boolean( hasValue() );
 	// Notify the panel when an item's value has changed except for optional
 	// items without value because the item should not cause itself to hide.
 	useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73069

<!-- In a few words, what is the PR actually doing? -->

## Why?
- When passing an undefined value to `hasValue` prop in `ToolsPanelItem` component, the component was not being rendered and it does not reproduce any console erorr, so user/dev can know the exact issue. 

## How?
- The current approach, changes evaluate the value for `hasValue` prop to Boolean and does not rely on user passed input so that the component can render without any issue.
- Since if user/dev can pass `undefined` or any falsy or truthy value, the implementation intercepts and convert to actual Boolean True and False, such that it does not fails to render component.
- This approach does not need any console/log to show user about the issue because ultimately user supplied value and hasValue prop value should be Boolean.

## Testing Instructions
```js
<ToolsPanelItem
  hasValue={() => hoge || foo}
  /* ... */
>
  {/* control */}
</ToolsPanelItem>
```
Add the implementation for above component, you will notice that it would render component.

### Testing Instructions for Keyboard
- None.