### PR TITLE
Show Global Styles in editor only for users with the right caps

### DIFF
--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -49,6 +49,8 @@ function Editor( {
 				getResolutionError,
 				hasFinishedResolution,
 				getCurrentTheme,
+				__experimentalGetCurrentGlobalStylesId,
+				canUser,
 			} = select( coreStore );
 			const { getRenderingMode, getCurrentPostType } =
 				select( editorStore );
@@ -57,6 +59,14 @@ function Editor( {
 			const renderingMode = getRenderingMode();
 			const currentPostType = getCurrentPostType();
 			const _isBlockTheme = getCurrentTheme()?.is_block_theme;
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const userCanEditGlobalStyles = globalStylesId
+				? canUser( 'update', {
+						kind: 'root',
+						name: 'globalStyles',
+						id: globalStylesId,
+				  } )
+				: false;
 
 			return {
 				post: getEntityRecord( ...postArgs ),
@@ -76,6 +86,7 @@ function Editor( {
 				isBlockTheme: _isBlockTheme,
 				showGlobalStyles:
 					_isBlockTheme &&
+					userCanEditGlobalStyles &&
 					( currentPostType === 'wp_template' ||
 						renderingMode === 'template-locked' ),
 			};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73031

This PR shows the GS sidebar in post editor only for user with the proper caps.


## Testing Instructions
1. Log in with a non-admin user and edit a post
2. Click `show template` in post summary panel
3. Confirm that the GS sidebar is not displayed


