### PR TITLE
contentOnly: Add the "Done editing pattern" button to the document toolbar

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -56,8 +56,8 @@ export default function EditContents( { clientId } ) {
 				} }
 			>
 				{ editedContentOnlySection
-					? __( 'Lock design' )
-					: __( 'Unlock design' ) }
+					? __( 'Done editing pattern' )
+					: __( 'Edit pattern' ) }
 			</Button>
 		</VStack>
 	);

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -2,12 +2,13 @@
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMediaQuery, useViewportMatch } from '@wordpress/compose';
-import { __unstableMotion as motion } from '@wordpress/components';
+import { __unstableMotion as motion, Button } from '@wordpress/components';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,6 +65,7 @@ function Header( {
 		hasBlockSelection,
 		hasSectionRootClientId,
 		isStylesCanvasActive,
+		editedContentOnlySection,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -74,9 +76,11 @@ function Header( {
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
 		);
-		const { getBlockSelectionStart, getSectionRootClientId } = unlock(
-			select( blockEditorStore )
-		);
+		const {
+			getBlockSelectionStart,
+			getSectionRootClientId,
+			getEditedContentOnlySection,
+		} = unlock( select( blockEditorStore ) );
 
 		return {
 			postType: getCurrentPostType(),
@@ -89,8 +93,13 @@ function Header( {
 			isStylesCanvasActive:
 				!! getStylesPath()?.startsWith( '/revisions' ) ||
 				getShowStylebook(),
+			editedContentOnlySection: getEditedContentOnlySection(),
 		};
 	}, [] );
+
+	const { stopEditingContentOnlySection } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const canBeZoomedOut =
 		[ 'post', 'page', 'wp_template' ].includes( postType ) &&
@@ -149,7 +158,18 @@ function Header( {
 					variants={ toolbarVariations }
 					transition={ { type: 'tween' } }
 				>
-					<DocumentBar />
+					{ editedContentOnlySection ? (
+						<Button
+							className="editor-header__done-editing-button"
+							onClick={ stopEditingContentOnlySection }
+							variant="primary"
+							__next40pxDefaultSize
+						>
+							{ __( 'Done editing pattern' ) }
+						</Button>
+					) : (
+						<DocumentBar />
+					) }
 				</motion.div>
 			) }
 			<motion.div


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds the "Done editing pattern" button to the document toolbar.

## Why?
This makes the "Done" action more prominent.

There was a suggestion that this button should replace the one in the inspector controls. However I believe that users will expect to find the "Done" action in the same place as the "Edit pattern" button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Enable the content only editing experiment
2. Add a pattern to the page
3. Click the "Edit pattern" button in the inspector controls
4. Check that the document toolbar now contains a "Done editing pattern" button.


## Screenshots or screencast <!-- if applicable -->
<img width="1746" height="633" alt="Screenshot 2025-11-07 at 15 40 33" src="https://github.com/user-attachments/assets/dd8aecda-aa52-41a9-a50e-5f803aaeb8b0" />
<img width="1746" height="666" alt="Screenshot 2025-11-07 at 15 40 25" src="https://github.com/user-attachments/assets/692fd761-6f33-4f30-8365-134b90819ea6" />

