### PR TITLE
(no title supported) When title in Post Type is not supported

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -66,6 +66,7 @@ export default function DocumentBar( props ) {
 		onNavigateToPreviousEntityRecord,
 		isTemplatePreview,
 		stylesCanvasTitle,
+		postSupports,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
@@ -87,6 +88,7 @@ export default function DocumentBar( props ) {
 			_postType,
 			_postId
 		);
+		const _postTypeObject = getPostType( _postType );
 
 		const { default_template_types: templateTypes = [] } =
 			getCurrentTheme() ?? {};
@@ -95,7 +97,8 @@ export default function DocumentBar( props ) {
 			templateTypes,
 			template: _document,
 		} );
-		const _postTypeLabel = getPostType( _postType )?.labels?.singular_name;
+		const _postTypeLabel = _postTypeObject?.labels?.singular_name;
+		const _postSupports = _postTypeObject?.supports ?? null;
 
 		// Check if styles canvas is active and get its title
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -126,6 +129,7 @@ export default function DocumentBar( props ) {
 				getEditorSettings().onNavigateToPreviousEntityRecord,
 			isTemplatePreview: getRenderingMode() === 'template-locked',
 			stylesCanvasTitle: _stylesCanvasTitle,
+			postSupports: _postSupports,
 		};
 	}, [] );
 
@@ -139,6 +143,11 @@ export default function DocumentBar( props ) {
 	const icon = props.icon;
 
 	const pageTypeBadge = usePageTypeBadge( postId );
+	const isTitleSupported = postSupports?.title === true;
+	let displayedTitle = __( '(no title supported)' );
+	if ( isTitleSupported ) {
+		displayedTitle = title ? stripHTML( title ) : __( 'No title' );
+	}
 
 	const mountedRef = useRef( false );
 	useEffect( () => {
@@ -215,9 +224,7 @@ export default function DocumentBar( props ) {
 						{ icon && <BlockIcon icon={ icon } /> }
 						<Text size="body" as="h1">
 							<span className="editor-document-bar__post-title">
-								{ title
-									? stripHTML( title )
-									: __( 'No title' ) }
+								{ displayedTitle }
 							</span>
 							{ pageTypeBadge && (
 								<span className="editor-document-bar__post-type-label">


### PR DESCRIPTION
## What?
Closes #73090

Checking for title supports in the `DocumentBar` component in order to provide the predef `(no title supported)` as expected.

## Why?
We need to maintain consistency with Core #45516 which will be displaying this title `(no title supported)` when no titles are supported by the post type.

## How?
We fetch the supports from the given post type, and then we check if the title is supported or not. Conditionally we will select one title or another among the existing options.

## Testing Instructions
1. Create a new post type without adding `title` to supports
2. Ideally, use Core's [PR 9597](https://github.com/WordPress/wordpress-develop/pull/9597)
3. Create a new post from this new post type
4. In the Document Bar, we will see `(no title supported)`

## Screenshots or screencast 
|Before|After|
|-|-|
|<img width="625" height="290" alt="image" src="https://github.com/user-attachments/assets/b58730e5-7699-4c10-82cf-6df82cb80859" />|<img width="667" height="298" alt="image" src="https://github.com/user-attachments/assets/846af0ce-58ec-4750-9ea0-7f1dcb5664ba" />|
