### PR TITLE
Unused '@ts-expect-error' directive on npm build

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -9,8 +9,6 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  */
 import { RichTextData } from '@wordpress/rich-text';
 import { Y } from '@wordpress/sync';
-
-// @ts-expect-error No exported types.
 import { getBlockTypes } from '@wordpress/blocks';
 
 /**

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,7 +6,6 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 /**
  * WordPress dependencies
  */
-// @ts-expect-error No exported types.
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { type CRDTDoc, type ObjectData, Y } from '@wordpress/sync';
 


### PR DESCRIPTION
## What?
Closes #72881 
When doing `npm run build` or `npm run dev` errors are appearing relating to these two unused directives.

## Why?
It's impossible to build typescript without removing these.
It seems that `npm run clean:package-types` doesn't solve the problem.
And It doesn't appear to be triggered in all systems. This is my environment vars:

```
- WordPress: 6.9-beta3-61129-src
- PHP: 8.2.29
- Server: nginx/1.29.3
- Database: mysqli (Server: 8.4.7 / Client: mysqlnd 8.2.29)
- Browser: Chrome 142.0.0.0
- OS: Windows 10/11
- Theme: Twenty Twenty-Five 1.3
- MU Plugins: None activated
- Plugins:
  * Gutenberg 22.0.0
```

## How?
To solve this, we have to remove these two unused directives, 

## Testing Instructions
It's challenging to be reproducible, but according to yesterday's `Patch testing scrub` in #core-test, we found that users with WSL 2 (Ubuntu) and Windows, were reporting this problem. 

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="781" height="508" alt="image" src="https://github.com/user-attachments/assets/08bde546-11d6-4c7d-90eb-7b61383b3663" />|<img width="488" height="449" alt="image" src="https://github.com/user-attachments/assets/130983e9-2b5c-4c15-b7bc-556601994d31" />|
