### PR TITLE
Perf: Try pure function version of useBlockDisplayInformation and useBlockDisplayTitle

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -390,6 +390,23 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/font-sizes/README.md>
 
+### getBlockDisplayInformation
+
+Hook used to try to find a matching block variation and return the appropriate information for display reasons. In order to to try to find a match we need to things: 1. Block's client id to extract it's current attributes. 2. A block variation should have set `isActive` prop to a proper function.
+
+If for any reason a block variation match cannot be found, the returned information come from the Block Type. If no blockType is found with the provided clientId, returns null.
+
+_Parameters_
+
+-   _select_ `Object`: The select function from the WordPress data store.
+-   _options_ `Object`: Options object.
+-   _options.clientId_ `string`: Block's client id.
+-   _options.context_ `string`: Context in which the block is being displayed.
+
+_Returns_
+
+-   `?WPBlockDisplayInformation`: Block's display information, or `null` when the block or its type not found.
+
 ### getColorClassName
 
 Returns a class based on the context a color is being used and its slug.
@@ -939,17 +956,7 @@ Undocumented declaration.
 
 ### useBlockDisplayInformation
 
-Hook used to try to find a matching block variation and return the appropriate information for display reasons. In order to to try to find a match we need to things: 1. Block's client id to extract it's current attributes. 2. A block variation should have set `isActive` prop to a proper function.
-
-If for any reason a block variation match cannot be found, the returned information come from the Block Type. If no blockType is found with the provided clientId, returns null.
-
-_Parameters_
-
--   _clientId_ `string`: Block's client id.
-
-_Returns_
-
--   `?WPBlockDisplayInformation`: Block's display information, or `null` when the block or its type not found.
+Undocumented declaration.
 
 ### useBlockEditContext
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -18,7 +18,7 @@ import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockCard from '../block-card';
 import MultiSelectionInspector from '../multi-selection-inspector';
 import BlockVariationTransforms from '../block-variation-transforms';
-import useBlockDisplayInformation from '../use-block-display-information';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 import BlockStyles from '../block-styles';
 import { default as InspectorControls } from '../inspector-controls';
@@ -326,10 +326,17 @@ const BlockInspectorSingleBlock = ( {
 		window?.__experimentalContentOnlyPatternInsertion &&
 		editedContentOnlySection &&
 		editedContentOnlySection !== clientId;
-	const parentBlockInformation = useBlockDisplayInformation(
-		editedContentOnlySection
+	const { parentBlockInformation, blockInformation } = useSelect(
+		( select ) => ( {
+			parentBlockInformation: getBlockDisplayInformation( select, {
+				clientId: editedContentOnlySection,
+			} ),
+			blockInformation: getBlockDisplayInformation( select, {
+				clientId,
+			} ),
+		} ),
+		[ editedContentOnlySection, clientId ]
 	);
-	const blockInformation = useBlockDisplayInformation( clientId );
 	const isBlockSynced = blockInformation.isSynced;
 	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -326,31 +326,60 @@ const BlockInspectorSingleBlock = ( {
 		window?.__experimentalContentOnlyPatternInsertion &&
 		editedContentOnlySection &&
 		editedContentOnlySection !== clientId;
-	const { parentBlockInformation, blockInformation } = useSelect(
-		( select ) => ( {
-			parentBlockInformation: getBlockDisplayInformation( select, {
+	const {
+		parentTitle,
+		parentIcon,
+		parentDescription,
+		parentName,
+		parentIsSynced,
+		blockTitle,
+		blockIcon,
+		blockDescription,
+		blockCustomName,
+		isBlockSynced,
+	} = useSelect(
+		( select ) => {
+			const parentBlockInformation = getBlockDisplayInformation( select, {
 				clientId: editedContentOnlySection,
-			} ),
-			blockInformation: getBlockDisplayInformation( select, {
+			} );
+			const blockInformation = getBlockDisplayInformation( select, {
 				clientId,
-			} ),
-		} ),
+			} );
+
+			return {
+				parentTitle: parentBlockInformation?.title,
+				parentIcon: parentBlockInformation?.icon,
+				parentDescription: parentBlockInformation?.description,
+				parentName: parentBlockInformation?.name,
+				parentIsSynced: parentBlockInformation?.isSynced,
+				blockTitle: blockInformation?.title,
+				blockIcon: blockInformation?.icon,
+				blockDescription: blockInformation?.description,
+				blockCustomName: blockInformation?.name,
+				isBlockSynced: blockInformation?.isSynced,
+			};
+		},
 		[ editedContentOnlySection, clientId ]
 	);
-	const isBlockSynced = blockInformation.isSynced;
 	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
 
 	return (
 		<div className="block-editor-block-inspector">
 			{ hasParentChildBlockCards && (
 				<BlockCard
-					{ ...parentBlockInformation }
-					className={ parentBlockInformation.isSynced && 'is-synced' }
+					title={ parentTitle }
+					icon={ parentIcon }
+					description={ parentDescription }
+					name={ parentName }
+					className={ parentIsSynced && 'is-synced' }
 					parentClientId={ editedContentOnlySection }
 				/>
 			) }
 			<BlockCard
-				{ ...blockInformation }
+				title={ blockTitle }
+				icon={ blockIcon }
+				description={ blockDescription }
+				name={ blockCustomName }
 				allowParentNavigation
 				className={ isBlockSynced && 'is-synced' }
 				isChild={ hasParentChildBlockCards }

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -20,7 +20,7 @@ import { getBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import useBlockLock from './use-block-lock';
-import useBlockDisplayInformation from '../use-block-display-information';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
 // Entity based blocks which allow edit locking
@@ -43,7 +43,12 @@ function getTemplateLockValue( lock ) {
 export default function BlockLockModal( { clientId, onClose } ) {
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
-	const { allowsEditLocking, templateLock, hasTemplateLock } = useSelect(
+	const {
+		allowsEditLocking,
+		templateLock,
+		hasTemplateLock,
+		blockInformation,
+	} = useSelect(
 		( select ) => {
 			const { getBlockName, getBlockAttributes } =
 				select( blockEditorStore );
@@ -54,6 +59,9 @@ export default function BlockLockModal( { clientId, onClose } ) {
 				allowsEditLocking: ALLOWS_EDIT_LOCKING.includes( blockName ),
 				templateLock: getBlockAttributes( clientId )?.templateLock,
 				hasTemplateLock: !! blockType?.attributes?.templateLock,
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+				} ),
 			};
 		},
 		[ clientId ]
@@ -62,7 +70,6 @@ export default function BlockLockModal( { clientId, onClose } ) {
 		!! templateLock
 	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const blockInformation = useBlockDisplayInformation( clientId );
 
 	useEffect( () => {
 		setLock( {

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -43,29 +43,26 @@ function getTemplateLockValue( lock ) {
 export default function BlockLockModal( { clientId, onClose } ) {
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
-	const {
-		allowsEditLocking,
-		templateLock,
-		hasTemplateLock,
-		blockInformation,
-	} = useSelect(
-		( select ) => {
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
-			const blockName = getBlockName( clientId );
-			const blockType = getBlockType( blockName );
+	const { allowsEditLocking, templateLock, hasTemplateLock, title } =
+		useSelect(
+			( select ) => {
+				const { getBlockName, getBlockAttributes } =
+					select( blockEditorStore );
+				const blockName = getBlockName( clientId );
+				const blockType = getBlockType( blockName );
 
-			return {
-				allowsEditLocking: ALLOWS_EDIT_LOCKING.includes( blockName ),
-				templateLock: getBlockAttributes( clientId )?.templateLock,
-				hasTemplateLock: !! blockType?.attributes?.templateLock,
-				blockInformation: getBlockDisplayInformation( select, {
-					clientId,
-				} ),
-			};
-		},
-		[ clientId ]
-	);
+				return {
+					allowsEditLocking:
+						ALLOWS_EDIT_LOCKING.includes( blockName ),
+					templateLock: getBlockAttributes( clientId )?.templateLock,
+					hasTemplateLock: !! blockType?.attributes?.templateLock,
+					title: getBlockDisplayInformation( select, {
+						clientId,
+					} )?.title,
+				};
+			},
+			[ clientId ]
+		);
 	const [ applyTemplateLock, setApplyTemplateLock ] = useState(
 		!! templateLock
 	);
@@ -87,7 +84,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			title={ sprintf(
 				/* translators: %s: Name of the block. */
 				__( 'Lock %s' ),
-				blockInformation.title
+				title
 			) }
 			overlayClassName="block-editor-block-lock-modal"
 			onRequestClose={ onClose }

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -23,7 +23,7 @@ import { unlock } from '../../lock-unlock';
  */
 export default function BlockParentSelector() {
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const { parentClientId, blockInformation } = useSelect( ( select ) => {
+	const { parentClientId, title, icon } = useSelect( ( select ) => {
 		const {
 			getBlockParents,
 			getSelectedBlockClientId,
@@ -33,11 +33,13 @@ export default function BlockParentSelector() {
 		const parentSection = getParentSectionBlock( selectedBlockClientId );
 		const parents = getBlockParents( selectedBlockClientId );
 		const _parentClientId = parentSection ?? parents[ parents.length - 1 ];
+		const blockInformation = getBlockDisplayInformation( select, {
+			clientId: _parentClientId,
+		} );
 		return {
 			parentClientId: _parentClientId,
-			blockInformation: getBlockDisplayInformation( select, {
-				clientId: _parentClientId,
-			} ),
+			title: blockInformation?.title,
+			icon: blockInformation?.icon,
 		};
 	}, [] );
 
@@ -62,10 +64,10 @@ export default function BlockParentSelector() {
 				label={ sprintf(
 					/* translators: %s: Name of the block's parent. */
 					__( 'Select parent block: %s' ),
-					blockInformation?.title
+					title
 				) }
 				showTooltip
-				icon={ <BlockIcon icon={ blockInformation?.icon } /> }
+				icon={ <BlockIcon icon={ icon } /> }
 			/>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -9,7 +9,7 @@ import { useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useBlockDisplayInformation from '../use-block-display-information';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 import BlockIcon from '../block-icon';
 import { useShowHoveredOrFocusedGestures } from '../block-toolbar/utils';
 import { store as blockEditorStore } from '../../store';
@@ -23,7 +23,7 @@ import { unlock } from '../../lock-unlock';
  */
 export default function BlockParentSelector() {
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const { parentClientId } = useSelect( ( select ) => {
+	const { parentClientId, blockInformation } = useSelect( ( select ) => {
 		const {
 			getBlockParents,
 			getSelectedBlockClientId,
@@ -35,9 +35,11 @@ export default function BlockParentSelector() {
 		const _parentClientId = parentSection ?? parents[ parents.length - 1 ];
 		return {
 			parentClientId: _parentClientId,
+			blockInformation: getBlockDisplayInformation( select, {
+				clientId: _parentClientId,
+			} ),
 		};
 	}, [] );
-	const blockInformation = useBlockDisplayInformation( parentClientId );
 
 	// Allows highlighting the parent block outline when focusing or hovering
 	// the parent block selector within the child.

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -16,8 +16,8 @@ import {
  */
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
-import useBlockDisplayInformation from '../use-block-display-information';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { getBlockDisplayInformation } from '../use-block-display-information';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 	if ( ! clientIds.length ) {
@@ -37,12 +37,7 @@ export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 }
 
 function BlockQuickNavigationItem( { clientId, onSelect } ) {
-	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockTitle = useBlockDisplayTitle( {
-		clientId,
-		context: 'list-view',
-	} );
-	const { isSelected } = useSelect(
+	const { isSelected, blockInformation, blockTitle } = useSelect(
 		( select ) => {
 			const { isBlockSelected, hasSelectedInnerBlock } =
 				select( blockEditorStore );
@@ -51,6 +46,14 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+					context: 'list-view',
+				} ),
+				blockTitle: getBlockDisplayTitle( select, {
+					clientId,
+					context: 'list-view',
+				} ),
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -37,19 +37,21 @@ export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 }
 
 function BlockQuickNavigationItem( { clientId, onSelect } ) {
-	const { isSelected, blockInformation, blockTitle } = useSelect(
+	const { isSelected, icon, blockTitle } = useSelect(
 		( select ) => {
 			const { isBlockSelected, hasSelectedInnerBlock } =
 				select( blockEditorStore );
+
+			const blockInformation = getBlockDisplayInformation( select, {
+				clientId,
+				context: 'list-view',
+			} );
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
-				blockInformation: getBlockDisplayInformation( select, {
-					clientId,
-					context: 'list-view',
-				} ),
+				icon: blockInformation?.icon,
 				blockTitle: getBlockDisplayTitle( select, {
 					clientId,
 					context: 'list-view',
@@ -74,7 +76,7 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		>
 			<Flex>
 				<FlexItem>
-					<BlockIcon icon={ blockInformation?.icon } />
+					<BlockIcon icon={ icon } />
 				</FlexItem>
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ blockTitle }</Truncate>

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -17,19 +17,21 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { useBlockDisplayInformation } from '..';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 import isEmptyString from './is-empty-string';
 import { cleanEmptyObject } from '../../hooks/utils';
 
 export default function BlockRenameModal( { clientId, onClose } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState();
 
-	const blockInformation = useBlockDisplayInformation( clientId );
-	const { metadata } = useSelect(
+	const { blockInformation, metadata } = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = select( blockEditorStore );
 
 			return {
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+				} ),
 				metadata: getBlockAttributes( clientId )?.metadata,
 			};
 		},

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -24,14 +24,14 @@ import { cleanEmptyObject } from '../../hooks/utils';
 export default function BlockRenameModal( { clientId, onClose } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState();
 
-	const { blockInformation, metadata } = useSelect(
+	const { originalBlockName, metadata } = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = select( blockEditorStore );
 
 			return {
-				blockInformation: getBlockDisplayInformation( select, {
+				originalBlockName: getBlockDisplayInformation( select, {
 					clientId,
-				} ),
+				} )?.title,
 				metadata: getBlockAttributes( clientId )?.metadata,
 			};
 		},
@@ -40,7 +40,6 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const blockName = metadata?.name || '';
-	const originalBlockName = blockInformation?.title;
 	// Pattern Overrides is a WordPress-only feature but it also uses the Block Binding API.
 	// Ideally this should not be inside the block editor package, but we keep it here for simplicity.
 	const hasOverridesWarning =

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -26,14 +26,15 @@ export function getBlockDisplayTitle(
 
 	const attributes = getBlockAttributes( clientId );
 	const label = getBlockLabel( blockType, attributes, context );
+
+	let blockTitle;
 	// If the label is defined we prioritize it over a possible block variation title match.
 	if ( label !== blockType.title ) {
-		return label;
+		blockTitle = label;
+	} else {
+		const match = getActiveBlockVariation( blockName, attributes );
+		blockTitle = match?.title || blockType.title;
 	}
-
-	const match = getActiveBlockVariation( blockName, attributes );
-
-	const blockTitle = match?.title || blockType.title;
 
 	if ( ! blockTitle ) {
 		return null;

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -11,7 +11,47 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+export function getBlockDisplayTitle(
+	select,
+	{ clientId, context, maximumLength }
+) {
+	const { getBlockName, getBlockAttributes } = select( blockEditorStore );
+	const { getBlockType, getActiveBlockVariation } = select( blocksStore );
 
+	const blockName = getBlockName( clientId );
+	const blockType = getBlockType( blockName );
+	if ( ! blockType ) {
+		return null;
+	}
+
+	const attributes = getBlockAttributes( clientId );
+	const label = getBlockLabel( blockType, attributes, context );
+	// If the label is defined we prioritize it over a possible block variation title match.
+	if ( label !== blockType.title ) {
+		return label;
+	}
+
+	const match = getActiveBlockVariation( blockName, attributes );
+
+	const blockTitle = match?.title || blockType.title;
+
+	if ( ! blockTitle ) {
+		return null;
+	}
+
+	if (
+		maximumLength &&
+		maximumLength > 0 &&
+		blockTitle.length > maximumLength
+	) {
+		const omission = '...';
+		return (
+			blockTitle.slice( 0, maximumLength - omission.length ) + omission
+		);
+	}
+
+	return blockTitle;
+}
 /**
  * Returns the block's configured title as a string, or empty if the title
  * cannot be determined.
@@ -33,51 +73,18 @@ export default function useBlockDisplayTitle( {
 	maximumLength,
 	context,
 } ) {
-	const blockTitle = useSelect(
+	return useSelect(
 		( select ) => {
 			if ( ! clientId ) {
 				return null;
 			}
 
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
-			const { getBlockType, getActiveBlockVariation } =
-				select( blocksStore );
-
-			const blockName = getBlockName( clientId );
-			const blockType = getBlockType( blockName );
-			if ( ! blockType ) {
-				return null;
-			}
-
-			const attributes = getBlockAttributes( clientId );
-			const label = getBlockLabel( blockType, attributes, context );
-			// If the label is defined we prioritize it over a possible block variation title match.
-			if ( label !== blockType.title ) {
-				return label;
-			}
-
-			const match = getActiveBlockVariation( blockName, attributes );
-			// Label will fallback to the title if no label is defined for the current label context.
-			return match?.title || blockType.title;
+			return getBlockDisplayTitle( select, {
+				clientId,
+				context,
+				maximumLength,
+			} );
 		},
-		[ clientId, context ]
+		[ clientId, context, maximumLength ]
 	);
-
-	if ( ! blockTitle ) {
-		return null;
-	}
-
-	if (
-		maximumLength &&
-		maximumLength > 0 &&
-		blockTitle.length > maximumLength
-	) {
-		const omission = '...';
-		return (
-			blockTitle.slice( 0, maximumLength - omission.length ) + omission
-		);
-	}
-
-	return blockTitle;
 }

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -14,7 +14,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import BlockSwitcher from '../block-switcher';
 import BlockIcon from '../block-icon';
 import PatternOverridesDropdown from './pattern-overrides-dropdown';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import { store as blockEditorStore } from '../../store';
 import { hasPatternOverridesDefaultBinding } from '../../utils/block-bindings';
 import { unlock } from '../../lock-unlock';
@@ -103,7 +103,7 @@ function getBlockIcon( { select, clientIds } ) {
 }
 
 export default function BlockToolbarIcon( { clientIds, isSynced } ) {
-	const { icon, showIconLabels, variant } = useSelect(
+	const { icon, showIconLabels, variant, blockTitle } = useSelect(
 		( select ) => {
 			return {
 				icon: getBlockIcon( { select, clientIds } ),
@@ -115,15 +115,14 @@ export default function BlockToolbarIcon( { clientIds, isSynced } ) {
 					select,
 					clientIds,
 				} ),
+				blockTitle: getBlockDisplayTitle( select, {
+					clientId: clientIds?.[ 0 ],
+					maximumLength: 35,
+				} ),
 			};
 		},
 		[ clientIds ]
 	);
-
-	const blockTitle = useBlockDisplayTitle( {
-		clientId: clientIds?.[ 0 ],
-		maximumLength: 35,
-	} );
 
 	const isSingleBlock = clientIds.length === 1;
 	const showBlockTitle = isSingleBlock && isSynced && ! showIconLabels;

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
@@ -106,6 +106,7 @@ describe( 'BlockToolbarIcon', () => {
 				icon: paragraph,
 				showIconLabels: false,
 				variant: 'default',
+				blockTitle: 'Block Name',
 			} ) );
 
 			render( <BlockToolbarIcon { ...defaultProps } /> );
@@ -126,6 +127,7 @@ describe( 'BlockToolbarIcon', () => {
 				icon: paragraph,
 				showIconLabels: false,
 				variant: 'default',
+				blockTitle: 'Block Name',
 			} ) );
 
 			render(
@@ -150,6 +152,7 @@ describe( 'BlockToolbarIcon', () => {
 				icon: paragraph,
 				showIconLabels: false,
 				variant: 'default',
+				blockTitle: 'Block Name',
 			} ) );
 
 			render( <BlockToolbarIcon { ...defaultProps } /> );
@@ -163,6 +166,7 @@ describe( 'BlockToolbarIcon', () => {
 				icon: paragraph,
 				showIconLabels: false,
 				variant: 'default',
+				blockTitle: 'Block Name',
 			} ) );
 
 			render(

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -151,7 +151,10 @@ export {
 } from './typewriter';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
-export { default as useBlockDisplayInformation } from './use-block-display-information';
+export {
+	default as useBlockDisplayInformation,
+	getBlockDisplayInformation,
+} from './use-block-display-information';
 export { default as __unstableIframe } from './iframe';
 export {
 	RecursionProvider,

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -11,7 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import { useListViewContext } from './context';
 import Inserter from '../inserter';
 import AriaReferencedText from './aria-referenced-text';
@@ -22,33 +22,32 @@ export const Appender = forwardRef(
 		const { insertedBlock, setInsertedBlock } = useListViewContext();
 
 		const instanceId = useInstanceId( Appender );
-		const { directInsert, hideInserter } = useSelect(
-			( select ) => {
-				const { getBlockListSettings, getTemplateLock, isZoomOut } =
-					unlock( select( blockEditorStore ) );
+		const { directInsert, hideInserter, blockTitle, insertedBlockTitle } =
+			useSelect(
+				( select ) => {
+					const { getBlockListSettings, getTemplateLock, isZoomOut } =
+						unlock( select( blockEditorStore ) );
 
-				const settings = getBlockListSettings( clientId );
-				const directInsertValue = settings?.directInsert || false;
-				const hideInserterValue =
-					!! getTemplateLock( clientId ) || isZoomOut();
+					const settings = getBlockListSettings( clientId );
+					const directInsertValue = settings?.directInsert || false;
+					const hideInserterValue =
+						!! getTemplateLock( clientId ) || isZoomOut();
 
-				return {
-					directInsert: directInsertValue,
-					hideInserter: hideInserterValue,
-				};
-			},
-			[ clientId ]
-		);
-
-		const blockTitle = useBlockDisplayTitle( {
-			clientId,
-			context: 'list-view',
-		} );
-
-		const insertedBlockTitle = useBlockDisplayTitle( {
-			clientId: insertedBlock?.clientId,
-			context: 'list-view',
-		} );
+					return {
+						directInsert: directInsertValue,
+						hideInserter: hideInserterValue,
+						blockTitle: getBlockDisplayTitle( select, {
+							clientId,
+							context: 'list-view',
+						} ),
+						insertedBlockTitle: getBlockDisplayTitle( select, {
+							clientId: insertedBlock?.clientId,
+							context: 'list-view',
+						} ),
+					};
+				},
+				[ clientId, insertedBlock?.clientId ]
+			);
 
 		useEffect( () => {
 			if ( ! insertedBlockTitle?.length ) {

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -21,8 +21,8 @@ import { hasBlockSupport } from '@wordpress/blocks';
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
-import useBlockDisplayInformation from '../use-block-display-information';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { getBlockDisplayInformation } from '../use-block-display-information';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
@@ -49,34 +49,42 @@ function ListViewBlockSelectButton(
 	},
 	ref
 ) {
-	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockTitle = useBlockDisplayTitle( {
-		clientId,
-		context: 'list-view',
-	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { canToggleBlockVisibility, isBlockHidden, isContentOnly } =
-		useSelect(
-			( select ) => {
-				const { getBlockName } = select( blockEditorStore );
-				const { isBlockHidden: _isBlockHidden } = unlock(
-					select( blockEditorStore )
-				);
-				return {
-					canToggleBlockVisibility: hasBlockSupport(
-						getBlockName( clientId ),
-						'blockVisibility',
-						true
-					),
-					isBlockHidden: _isBlockHidden( clientId ),
-					isContentOnly:
-						select( blockEditorStore ).getBlockEditingMode(
-							clientId
-						) === 'contentOnly',
-				};
-			},
-			[ clientId ]
-		);
+	const {
+		canToggleBlockVisibility,
+		isBlockHidden,
+		isContentOnly,
+		blockInformation,
+		blockTitle,
+	} = useSelect(
+		( select ) => {
+			const { getBlockName } = select( blockEditorStore );
+			const { isBlockHidden: _isBlockHidden } = unlock(
+				select( blockEditorStore )
+			);
+			return {
+				canToggleBlockVisibility: hasBlockSupport(
+					getBlockName( clientId ),
+					'blockVisibility',
+					true
+				),
+				isBlockHidden: _isBlockHidden( clientId ),
+				isContentOnly:
+					select( blockEditorStore ).getBlockEditingMode(
+						clientId
+					) === 'contentOnly',
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+					context: 'list-view',
+				} ),
+				blockTitle: getBlockDisplayTitle( select, {
+					clientId,
+					context: 'list-view',
+				} ),
+			};
+		},
+		[ clientId ]
+	);
 	const shouldShowLockIcon = isLocked && ! isContentOnly;
 	const shouldShowBlockVisibilityIcon =
 		canToggleBlockVisibility && isBlockHidden;

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -22,7 +22,6 @@ import { hasBlockSupport } from '@wordpress/blocks';
  */
 import BlockIcon from '../block-icon';
 import { getBlockDisplayInformation } from '../use-block-display-information';
-import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
@@ -54,14 +53,21 @@ function ListViewBlockSelectButton(
 		canToggleBlockVisibility,
 		isBlockHidden,
 		isContentOnly,
-		blockInformation,
 		blockTitle,
+		anchor,
+		icon,
+		isSticky,
 	} = useSelect(
 		( select ) => {
 			const { getBlockName } = select( blockEditorStore );
 			const { isBlockHidden: _isBlockHidden } = unlock(
 				select( blockEditorStore )
 			);
+
+			const blockInformation = getBlockDisplayInformation( select, {
+				clientId,
+				context: 'list-view',
+			} );
 			return {
 				canToggleBlockVisibility: hasBlockSupport(
 					getBlockName( clientId ),
@@ -73,14 +79,10 @@ function ListViewBlockSelectButton(
 					select( blockEditorStore ).getBlockEditingMode(
 						clientId
 					) === 'contentOnly',
-				blockInformation: getBlockDisplayInformation( select, {
-					clientId,
-					context: 'list-view',
-				} ),
-				blockTitle: getBlockDisplayTitle( select, {
-					clientId,
-					context: 'list-view',
-				} ),
+				blockTitle: blockInformation?.title,
+				icon: blockInformation?.icon,
+				anchor: blockInformation?.anchor,
+				isSticky: blockInformation?.positionType === 'sticky',
 			};
 		},
 		[ clientId ]
@@ -88,7 +90,6 @@ function ListViewBlockSelectButton(
 	const shouldShowLockIcon = isLocked && ! isContentOnly;
 	const shouldShowBlockVisibilityIcon =
 		canToggleBlockVisibility && isBlockHidden;
-	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
@@ -130,11 +131,7 @@ function ListViewBlockSelectButton(
 			aria-expanded={ isExpanded }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
-			<BlockIcon
-				icon={ blockInformation?.icon }
-				showColors
-				context="list-view"
-			/>
+			<BlockIcon icon={ icon } showColors context="list-view" />
 			<HStack
 				alignment="center"
 				className="block-editor-list-view-block-select-button__label-wrapper"
@@ -144,10 +141,10 @@ function ListViewBlockSelectButton(
 				<span className="block-editor-list-view-block-select-button__title">
 					<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 				</span>
-				{ blockInformation?.anchor && (
+				{ anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor-wrapper">
 						<Badge className="block-editor-list-view-block-select-button__anchor">
-							{ blockInformation.anchor }
+							{ anchor }
 						</Badge>
 					</span>
 				) }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -22,6 +22,7 @@ import { hasBlockSupport } from '@wordpress/blocks';
  */
 import BlockIcon from '../block-icon';
 import { getBlockDisplayInformation } from '../use-block-display-information';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
@@ -79,7 +80,10 @@ function ListViewBlockSelectButton(
 					select( blockEditorStore ).getBlockEditingMode(
 						clientId
 					) === 'contentOnly',
-				blockTitle: blockInformation?.title,
+				blockTitle: getBlockDisplayTitle( select, {
+					clientId,
+					context: 'list-view',
+				} ),
 				icon: blockInformation?.icon,
 				anchor: blockInformation?.anchor,
 				isSticky: blockInformation?.positionType === 'sticky',

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -124,7 +124,8 @@ function ListViewBlock( {
 		blockName,
 		allowRightClickOverrides,
 		isBlockHidden,
-		blockInformation,
+		isSynced,
+		positionLabel,
 	} = useSelect(
 		( select ) => {
 			const { getBlock, getBlockName, getSettings } =
@@ -133,15 +134,18 @@ function ListViewBlock( {
 				select( blockEditorStore )
 			);
 
+			const blockInformation = getBlockDisplayInformation( select, {
+				clientId,
+			} );
+
 			return {
 				block: getBlock( clientId ),
 				blockName: getBlockName( clientId ),
 				allowRightClickOverrides:
 					getSettings().allowRightClickOverrides,
 				isBlockHidden: _isBlockHidden( clientId ),
-				blockInformation: getBlockDisplayInformation( select, {
-					clientId,
-				} ),
+				isSynced: blockInformation?.isSynced,
+				positionLabel: blockInformation?.positionLabel,
 			};
 		},
 		[ clientId ]
@@ -523,7 +527,7 @@ function ListViewBlock( {
 	);
 
 	const blockPropertiesDescription = getBlockPropertiesDescription(
-		blockInformation,
+		{ positionLabel },
 		isLocked
 	);
 
@@ -558,7 +562,7 @@ function ListViewBlock( {
 		'is-synced-branch': isSyncedBranch,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
-		'is-synced': blockInformation?.isSynced,
+		'is-synced': isSynced,
 		'is-draggable': canMove,
 		'is-displacement-normal': displacement === 'normal',
 		'is-displacement-up': displacement === 'up',

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -48,7 +48,7 @@ import {
 	focusListItem,
 } from './utils';
 import { store as blockEditorStore } from '../../store';
-import useBlockDisplayInformation from '../use-block-display-information';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
@@ -117,29 +117,35 @@ function ListViewBlock( {
 	} = useSelect( blockEditorStore );
 	const { getGroupingBlockName } = useSelect( blocksStore );
 
-	const blockInformation = useBlockDisplayInformation( clientId );
-
 	const pasteStyles = usePasteStyles();
 
-	const { block, blockName, allowRightClickOverrides, isBlockHidden } =
-		useSelect(
-			( select ) => {
-				const { getBlock, getBlockName, getSettings } =
-					select( blockEditorStore );
-				const { isBlockHidden: _isBlockHidden } = unlock(
-					select( blockEditorStore )
-				);
+	const {
+		block,
+		blockName,
+		allowRightClickOverrides,
+		isBlockHidden,
+		blockInformation,
+	} = useSelect(
+		( select ) => {
+			const { getBlock, getBlockName, getSettings } =
+				select( blockEditorStore );
+			const { isBlockHidden: _isBlockHidden } = unlock(
+				select( blockEditorStore )
+			);
 
-				return {
-					block: getBlock( clientId ),
-					blockName: getBlockName( clientId ),
-					allowRightClickOverrides:
-						getSettings().allowRightClickOverrides,
-					isBlockHidden: _isBlockHidden( clientId ),
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				block: getBlock( clientId ),
+				blockName: getBlockName( clientId ),
+				allowRightClickOverrides:
+					getSettings().allowRightClickOverrides,
+				isBlockHidden: _isBlockHidden( clientId ),
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+				} ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -101,15 +101,15 @@ function ListViewBranch( props ) {
 		showAppender: showAppenderProp = true,
 	} = props;
 
-	const { parentBlockInformation, canParentExpand } = useSelect(
+	const { isSynced, canParentExpand } = useSelect(
 		( select ) => {
 			if ( ! parentId ) {
-				return { parentBlockInformation: null, canParentExpand: true };
+				return { isSynced: null, canParentExpand: true };
 			}
 			return {
-				parentBlockInformation: getBlockDisplayInformation( select, {
+				isSynced: getBlockDisplayInformation( select, {
 					clientId: parentId,
-				} ),
+				} ).isSynced,
 				canParentExpand:
 					select( blockEditorStore ).canEditBlock( parentId ),
 			};
@@ -117,7 +117,7 @@ function ListViewBranch( props ) {
 		[ parentId ]
 	);
 
-	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
+	const syncedBranch = isSyncedBranch || !! isSynced;
 
 	const {
 		blockDropPosition,

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -16,7 +16,7 @@ import ListViewBlock from './block';
 import { useListViewContext } from './context';
 import { getDragDisplacementValues, isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
-import useBlockDisplayInformation from '../use-block-display-information';
+import { getBlockDisplayInformation } from '../use-block-display-information';
 
 /**
  * Given a block, returns the total number of blocks in that subtree. This is used to help determine
@@ -101,18 +101,23 @@ function ListViewBranch( props ) {
 		showAppender: showAppenderProp = true,
 	} = props;
 
-	const parentBlockInformation = useBlockDisplayInformation( parentId );
-	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
-
-	const canParentExpand = useSelect(
+	const { parentBlockInformation, canParentExpand } = useSelect(
 		( select ) => {
 			if ( ! parentId ) {
-				return true;
+				return { parentBlockInformation: null, canParentExpand: true };
 			}
-			return select( blockEditorStore ).canEditBlock( parentId );
+			return {
+				parentBlockInformation: getBlockDisplayInformation( select, {
+					clientId: parentId,
+				} ),
+				canParentExpand:
+					select( blockEditorStore ).canEditBlock( parentId ),
+			};
 		},
 		[ parentId ]
 	);
+
+	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
 
 	const {
 		blockDropPosition,

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -22,6 +22,7 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockIcon from '../block-icon';
 import { getBlockDisplayInformation } from '../use-block-display-information';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 
 export default function ListViewDropIndicatorPreview( {
@@ -37,7 +38,10 @@ export default function ListViewDropIndicatorPreview( {
 			} );
 
 			return {
-				blockTitle: blockInformation?.title,
+				blockTitle: getBlockDisplayTitle( select, {
+					clientId: draggedBlockClientId,
+					context: 'list-view',
+				} ),
 				blockIcon: blockInformation?.icon,
 			};
 		},

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -22,7 +22,6 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockIcon from '../block-icon';
 import { getBlockDisplayInformation } from '../use-block-display-information';
-import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 
 export default function ListViewDropIndicatorPreview( {
@@ -30,17 +29,18 @@ export default function ListViewDropIndicatorPreview( {
 	listViewRef,
 	blockDropTarget,
 } ) {
-	const { blockInformation, blockTitle } = useSelect(
-		( select ) => ( {
-			blockInformation: getBlockDisplayInformation( select, {
+	const { blockIcon, blockTitle } = useSelect(
+		( select ) => {
+			const blockInformation = getBlockDisplayInformation( select, {
 				clientId: draggedBlockClientId,
 				context: 'list-view',
-			} ),
-			blockTitle: getBlockDisplayTitle( select, {
-				clientId: draggedBlockClientId,
-				context: 'list-view',
-			} ),
-		} ),
+			} );
+
+			return {
+				blockTitle: blockInformation?.title,
+				blockIcon: blockInformation?.icon,
+			};
+		},
 		[ draggedBlockClientId ]
 	);
 
@@ -332,7 +332,7 @@ export default function ListViewDropIndicatorPreview( {
 					>
 						<ListViewExpander onClick={ () => {} } />
 						<BlockIcon
-							icon={ blockInformation?.icon }
+							icon={ blockIcon }
 							showColors
 							context="list-view"
 						/>

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -15,13 +15,14 @@ import {
 import { getScrollContainer } from '@wordpress/dom';
 import { useCallback, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
-import useBlockDisplayInformation from '../use-block-display-information';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { getBlockDisplayInformation } from '../use-block-display-information';
+import { getBlockDisplayTitle } from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 
 export default function ListViewDropIndicatorPreview( {
@@ -29,11 +30,19 @@ export default function ListViewDropIndicatorPreview( {
 	listViewRef,
 	blockDropTarget,
 } ) {
-	const blockInformation = useBlockDisplayInformation( draggedBlockClientId );
-	const blockTitle = useBlockDisplayTitle( {
-		clientId: draggedBlockClientId,
-		context: 'list-view',
-	} );
+	const { blockInformation, blockTitle } = useSelect(
+		( select ) => ( {
+			blockInformation: getBlockDisplayInformation( select, {
+				clientId: draggedBlockClientId,
+				context: 'list-view',
+			} ),
+			blockTitle: getBlockDisplayTitle( select, {
+				clientId: draggedBlockClientId,
+				context: 'list-view',
+			} ),
+		} ),
+		[ draggedBlockClientId ]
+	);
 
 	const { rootClientId, clientId, dropPosition } = blockDropTarget || {};
 

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -61,59 +61,63 @@ function getPositionTypeLabel( attributes ) {
  * the returned information come from the Block Type.
  * If no blockType is found with the provided clientId, returns null.
  *
- * @param {string} clientId Block's client id.
+ * @param {Object} select           The select function from the WordPress data store.
+ * @param {Object} options          Options object.
+ * @param {string} options.clientId Block's client id.
+ * @param {string} options.context  Context in which the block is being displayed.
  * @return {?WPBlockDisplayInformation} Block's display information, or `null` when the block or its type not found.
  */
+export function getBlockDisplayInformation( select, { clientId, context } ) {
+	const { getBlockName, getBlockAttributes } = select( blockEditorStore );
+	const { getBlockType, getActiveBlockVariation } = select( blocksStore );
+	const blockName = getBlockName( clientId );
+	const blockType = getBlockType( blockName );
+	if ( ! blockType ) {
+		return null;
+	}
+	const attributes = getBlockAttributes( clientId );
+	const match = getActiveBlockVariation( blockName, attributes );
+	const isSynced =
+		isReusableBlock( blockType ) || isTemplatePart( blockType );
+	const syncedTitle = isSynced
+		? getBlockLabel( blockType, attributes, context )
+		: undefined;
+	const title = syncedTitle || blockType.title;
+	const positionLabel = getPositionTypeLabel( attributes );
+	const blockTypeInfo = {
+		isSynced,
+		title,
+		icon: blockType.icon,
+		description: blockType.description,
+		anchor: attributes?.anchor,
+		positionLabel,
+		positionType: attributes?.style?.position?.type,
+		name: attributes?.metadata?.name,
+	};
+	if ( ! match ) {
+		return blockTypeInfo;
+	}
 
-export default function useBlockDisplayInformation( clientId ) {
+	return {
+		isSynced,
+		title: match.title || blockType.title,
+		icon: match.icon || blockType.icon,
+		description: match.description || blockType.description,
+		anchor: attributes?.anchor,
+		positionLabel,
+		positionType: attributes?.style?.position?.type,
+		name: attributes?.metadata?.name,
+	};
+}
+
+export default function useBlockDisplayInformation( clientId, context ) {
 	return useSelect(
 		( select ) => {
 			if ( ! clientId ) {
 				return null;
 			}
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
-			const { getBlockType, getActiveBlockVariation } =
-				select( blocksStore );
-			const blockName = getBlockName( clientId );
-			const blockType = getBlockType( blockName );
-			if ( ! blockType ) {
-				return null;
-			}
-			const attributes = getBlockAttributes( clientId );
-			const match = getActiveBlockVariation( blockName, attributes );
-			const isSynced =
-				isReusableBlock( blockType ) || isTemplatePart( blockType );
-			const syncedTitle = isSynced
-				? getBlockLabel( blockType, attributes )
-				: undefined;
-			const title = syncedTitle || blockType.title;
-			const positionLabel = getPositionTypeLabel( attributes );
-			const blockTypeInfo = {
-				isSynced,
-				title,
-				icon: blockType.icon,
-				description: blockType.description,
-				anchor: attributes?.anchor,
-				positionLabel,
-				positionType: attributes?.style?.position?.type,
-				name: attributes?.metadata?.name,
-			};
-			if ( ! match ) {
-				return blockTypeInfo;
-			}
-
-			return {
-				isSynced,
-				title: match.title || blockType.title,
-				icon: match.icon || blockType.icon,
-				description: match.description || blockType.description,
-				anchor: attributes?.anchor,
-				positionLabel,
-				positionType: attributes?.style?.position?.type,
-				name: attributes?.metadata?.name,
-			};
+			return getBlockDisplayInformation( select, { clientId, context } );
 		},
-		[ clientId ]
+		[ clientId, context ]
 	);
 }

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -18,7 +18,7 @@ import { useMemo, Platform } from '@wordpress/element';
  */
 import { useSettings } from '../components/use-settings';
 import InspectorControls from '../components/inspector-controls';
-import { getBlockDisplayInformation } from '../components/use-block-display-information';
+import { getBlockDisplayTitle } from '../components/block-title/use-block-display-title';
 import { cleanEmptyObject, useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 
@@ -202,13 +202,13 @@ export function PositionPanelPure( {
 	const allowSticky = hasStickyPositionSupport( blockName );
 	const value = style?.position?.type;
 
-	const { blockInformation } = useSelect(
+	const { blockTitle } = useSelect(
 		( select ) => {
 			const { getBlockParents } = select( blockEditorStore );
 			const parents = getBlockParents( clientId );
 			const firstParentClientId = parents[ parents.length - 1 ];
 			return {
-				blockInformation: getBlockDisplayInformation( select, {
+				blockTitle: getBlockDisplayTitle( select, {
 					clientId: firstParentClientId,
 				} ),
 			};
@@ -216,13 +216,13 @@ export function PositionPanelPure( {
 		[ clientId ]
 	);
 	const stickyHelpText =
-		allowSticky && value === STICKY_OPTION.value && blockInformation
+		allowSticky && value === STICKY_OPTION.value && blockTitle
 			? sprintf(
 					/* translators: %s: the name of the parent block. */
 					__(
 						'The block will stick to the scrollable area of the parent %s block.'
 					),
-					blockInformation.title
+					blockTitle
 			  )
 			: null;
 

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -18,7 +18,7 @@ import { useMemo, Platform } from '@wordpress/element';
  */
 import { useSettings } from '../components/use-settings';
 import InspectorControls from '../components/inspector-controls';
-import useBlockDisplayInformation from '../components/use-block-display-information';
+import { getBlockDisplayInformation } from '../components/use-block-display-information';
 import { cleanEmptyObject, useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 
@@ -202,16 +202,19 @@ export function PositionPanelPure( {
 	const allowSticky = hasStickyPositionSupport( blockName );
 	const value = style?.position?.type;
 
-	const { firstParentClientId } = useSelect(
+	const { blockInformation } = useSelect(
 		( select ) => {
 			const { getBlockParents } = select( blockEditorStore );
 			const parents = getBlockParents( clientId );
-			return { firstParentClientId: parents[ parents.length - 1 ] };
+			const firstParentClientId = parents[ parents.length - 1 ];
+			return {
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId: firstParentClientId,
+				} ),
+			};
 		},
 		[ clientId ]
 	);
-
-	const blockInformation = useBlockDisplayInformation( firstParentClientId );
 	const stickyHelpText =
 		allowSticky && value === STICKY_OPTION.value && blockInformation
 			? sprintf(

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -50,10 +50,10 @@ export default function PostTermsEdit( {
 	const blockEditingMode = useBlockEditingMode();
 	const showControls = blockEditingMode === 'default';
 
-	const { selectedTerm, blockInformation } = useSelect(
+	const { selectedTerm, blockTitle } = useSelect(
 		( select ) => {
 			if ( ! term ) {
-				return { selectedTerm: {}, blockInformation: null };
+				return { selectedTerm: {}, blockTitle: null };
 			}
 			const { getTaxonomy } = select( coreStore );
 			const taxonomy = getTaxonomy( term );
@@ -61,9 +61,9 @@ export default function PostTermsEdit( {
 				selectedTerm: taxonomy?.visibility?.publicly_queryable
 					? taxonomy
 					: {},
-				blockInformation: getBlockDisplayInformation( select, {
+				blockTitle: getBlockDisplayInformation( select, {
 					clientId,
-				} ),
+				} )?.title,
 			};
 		},
 		[ term, clientId ]
@@ -121,9 +121,7 @@ export default function PostTermsEdit( {
 						tagName="span"
 					/>
 				) }
-				{ ( ! hasPost || ! term ) && (
-					<span>{ blockInformation.title }</span>
-				) }
+				{ ( ! hasPost || ! term ) && <span>{ blockTitle }</span> }
 				{ hasPost &&
 					! isLoading &&
 					hasPostTerms &&

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -11,7 +11,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
-	useBlockDisplayInformation,
+	getBlockDisplayInformation,
 	RichText,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
@@ -50,23 +50,29 @@ export default function PostTermsEdit( {
 	const blockEditingMode = useBlockEditingMode();
 	const showControls = blockEditingMode === 'default';
 
-	const selectedTerm = useSelect(
+	const { selectedTerm, blockInformation } = useSelect(
 		( select ) => {
 			if ( ! term ) {
-				return {};
+				return { selectedTerm: {}, blockInformation: null };
 			}
 			const { getTaxonomy } = select( coreStore );
 			const taxonomy = getTaxonomy( term );
-			return taxonomy?.visibility?.publicly_queryable ? taxonomy : {};
+			return {
+				selectedTerm: taxonomy?.visibility?.publicly_queryable
+					? taxonomy
+					: {},
+				blockInformation: getBlockDisplayInformation( select, {
+					clientId,
+				} ),
+			};
 		},
-		[ term ]
+		[ term, clientId ]
 	);
 	const { postTerms, hasPostTerms, isLoading } = usePostTerms( {
 		postId,
 		term: selectedTerm,
 	} );
 	const hasPost = postId && postType;
-	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -29,6 +29,7 @@ export interface WPRawPerformanceResults {
 	typeWithoutInspector: number[];
 	typeWithTopToolbar: number[];
 	typeContainer: number[];
+	typeWithListViewOpen: number[];
 	focus: number[];
 	inserterOpen: number[];
 	inserterSearch: number[];
@@ -65,6 +66,7 @@ export interface WPPerformanceResults {
 	typeWithoutInspector?: PerformanceStats;
 	typeWithTopToolbar?: PerformanceStats;
 	typeContainer?: PerformanceStats;
+	typeWithListViewOpen?: PerformanceStats;
 	focus?: PerformanceStats;
 	inserterOpen?: PerformanceStats;
 	inserterSearch?: PerformanceStats;
@@ -103,6 +105,7 @@ export function curateResults(
 		typeWithoutInspector: stats( results.typeWithoutInspector ),
 		typeWithTopToolbar: stats( results.typeWithTopToolbar ),
 		typeContainer: stats( results.typeContainer ),
+		typeWithListViewOpen: stats( results.typeWithListViewOpen ),
 		focus: stats( results.focus ),
 		inserterOpen: stats( results.inserterOpen ),
 		inserterSearch: stats( results.inserterSearch ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -27,6 +27,7 @@ const results = {
 	typeContainer: [],
 	focus: [],
 	listViewOpen: [],
+	typeWithListViewOpen: [],
 	inserterOpen: [],
 	inserterHover: [],
 	inserterSearch: [],
@@ -352,6 +353,41 @@ test.describe( 'Post Editor Performance', () => {
 				await listViewToggle.click();
 				await perfUtils.expectExpandedState( listViewToggle, 'false' );
 			}
+		} );
+	} );
+
+	test.describe( 'Typing (with List View open)', () => {
+		let draftId = null;
+
+		test( 'Setup the test post', async ( { admin, perfUtils, editor } ) => {
+			await admin.createNewPost();
+			await perfUtils.loadBlocksForLargePost();
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( { admin, perfUtils, metrics, page } ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+
+			// Open List View
+			const listViewToggle = page.getByRole( 'button', {
+				name: 'Document Overview',
+			} );
+			await listViewToggle.click();
+			await perfUtils.expectExpandedState( listViewToggle, 'true' );
+
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraph = canvas.getByRole( 'document', {
+				name: /Empty block/i,
+			} );
+
+			await type( paragraph, metrics, 'typeWithListViewOpen' );
+
+			// Close List View
+			await listViewToggle.click();
+			await perfUtils.expectExpandedState( listViewToggle, 'false' );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Seeing if using a pure function version of these in components that already have a useSelect will help improve performance. The list view is especially heavy on this, so combining selectors there can have a compounding effect.

Also, adds a new performance test for typing with the list view open on a page with many blocks. This should stress test the system more. I'd like it to be obvious when there's a new useSelect added that is not performant.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Perf.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Extract the guts of the hooks and export those as a function as well. That way, if you have an existing useSelect, you don't have to add a new one in order to use the function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
