### PR TITLE
MathML block: fix lazy script loading

### DIFF
--- a/packages/latex-to-mathml/package.json
+++ b/packages/latex-to-mathml/package.json
@@ -34,7 +34,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"wpScript": true,
 	"wpScriptModuleExports": {
 		".": "./build-module/index.js",
 		"./loader": "./build-module/loader.js"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

There's a small issue with the MathML block/format: the LaTeX to MathML script is always loading, even if the block is not present. Riad correctly identified the issue: the package shouldn't have `wpScript` set to true in package.json.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The script should lazy load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check the network requests. The `latex-to-mathml/index.js` file should not be there on page load.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
