### PR TITLE
Math Block: Add inline editing and visual styling options

### DIFF
--- a/packages/block-library/src/math/block.json
+++ b/packages/block-library/src/math/block.json
@@ -8,7 +8,15 @@
 	"keywords": [ "equation", "formula", "latex", "mathematics" ],
 	"textdomain": "default",
 	"supports": {
-		"html": false
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"__experimentalDefaultControls": {
+				"text": true,
+				"background": true
+			}
+		}
 	},
 	"attributes": {
 		"latex": {
@@ -19,6 +27,25 @@
 			"type": "string",
 			"source": "html",
 			"selector": "math"
+		},
+		"fontSize": {
+			"type": "number",
+			"default": 16
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"border": {
+			"type": "object"
+		},
+		"borderRadius": {
+			"type": "string"
+		},
+		"padding": {
+			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -5,10 +5,16 @@ import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
+	InspectorControls,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import {
 	TextareaControl,
-	Popover,
+	PanelBody,
+	RangeControl,
+	__experimentalBorderControl as BorderControl,
+	__experimentalUnitControl as UnitControl,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -23,13 +29,25 @@ import { unlock } from '../lock-unlock';
 const { Badge } = unlock( componentsPrivateApis );
 
 export default function MathEdit( { attributes, setAttributes, isSelected } ) {
-	const { latex, mathML } = attributes;
-	const [ blockRef, setBlockRef ] = useState();
+	const {
+		latex,
+		mathML,
+		fontSize,
+		textColor,
+		backgroundColor,
+		border,
+		borderRadius,
+		padding,
+	} = attributes;
 	const [ error, setError ] = useState( null );
 	const [ latexToMathML, setLatexToMathML ] = useState();
+	const [ isEditing, setIsEditing ] = useState( ! latex );
 	const initialLatex = useRef( latex );
+	const textareaRef = useRef( null );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
+
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	useEffect( () => {
 		import( '@wordpress/latex-to-mathml' ).then( ( module ) => {
@@ -49,76 +67,203 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
+	// Enter edit mode when block is selected and empty
+	useEffect( () => {
+		if ( isSelected && ! latex ) {
+			setIsEditing( true );
+		}
+	}, [ isSelected, latex ] );
+
+	// Focus textarea when entering edit mode
+	useEffect( () => {
+		if ( isEditing && textareaRef.current ) {
+			textareaRef.current.focus();
+		}
+	}, [ isEditing ] );
+
+	const handleLatexChange = ( newLatex ) => {
+		if ( ! latexToMathML ) {
+			setAttributes( { latex: newLatex } );
+			return;
+		}
+		let newMathML = '';
+		try {
+			newMathML = latexToMathML( newLatex, {
+				displayMode: true,
+			} );
+			setError( null );
+		} catch ( err ) {
+			setError( err.message );
+		}
+		setAttributes( {
+			mathML: newMathML,
+			latex: newLatex,
+		} );
+	};
+
+	const handleBlur = () => {
+		// Only exit edit mode if there's content or if block is not selected
+		if ( latex || ! isSelected ) {
+			setIsEditing( false );
+		}
+	};
+
+	const handlePreviewClick = () => {
+		if ( isSelected ) {
+			setIsEditing( true );
+		}
+	};
+
+	// Build inline styles for the math container
+	const mathContainerStyle = {
+		fontSize: fontSize ? `${ fontSize }px` : undefined,
+		color: textColor,
+		backgroundColor,
+		borderWidth: border?.width,
+		borderStyle: border?.style || ( border?.width ? 'solid' : undefined ),
+		borderColor: border?.color,
+		borderRadius,
+		padding: padding || ( backgroundColor || border?.width ? '16px' : undefined ),
+		minHeight: '40px',
+		cursor: isSelected && ! isEditing ? 'text' : 'default',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+	};
+
 	const blockProps = useBlockProps( {
-		ref: setBlockRef,
-		position: 'relative',
+		className: isEditing ? 'is-editing' : '',
 	} );
 
 	return (
-		<div { ...blockProps }>
-			{ mathML ? (
-				<math
-					// We can't spread block props on the math element because
-					// it only supports a limited amount of global attributes.
-					// For example, draggable will have no effect.
-					display="block"
-					dangerouslySetInnerHTML={ { __html: mathML } }
-				/>
-			) : (
-				'\u200B'
-			) }
-			{ isSelected && (
-				<Popover
-					placement="bottom-start"
-					offset={ 8 }
-					anchor={ blockRef }
-					focusOnMount="firstContentElement"
-				>
-					<div style={ { padding: '4px', minWidth: '300px' } }>
-						<VStack spacing={ 1 }>
-							<TextareaControl
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								label={ __( 'LaTeX math syntax' ) }
-								hideLabelFromVision
-								value={ latex }
-								className="wp-block-math__textarea-control"
-								onChange={ ( newLatex ) => {
-									if ( ! latexToMathML ) {
-										setAttributes( { latex: newLatex } );
-										return;
-									}
-									let newMathML = '';
-									try {
-										newMathML = latexToMathML( newLatex, {
-											displayMode: true,
-										} );
-										setError( null );
-									} catch ( err ) {
-										setError( err.message );
-									}
-									setAttributes( {
-										mathML: newMathML,
-										latex: newLatex,
-									} );
-								} }
-								placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
-							/>
-							{ error && (
-								<>
-									<Badge
-										intent="error"
-										className="wp-block-math__error"
-									>
-										{ error }
-									</Badge>
-									<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
-								</>
-							) }
-						</VStack>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Appearance' ) } initialOpen>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Font size' ) }
+						value={ fontSize || 16 }
+						onChange={ ( value ) =>
+							setAttributes( { fontSize: value } )
+						}
+						min={ 12 }
+						max={ 120 }
+						step={ 1 }
+						help={ __( 'Adjust the size of the mathematical expression' ) }
+					/>
+					<UnitControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Padding' ) }
+						value={ padding || '0px' }
+						onChange={ ( value ) =>
+							setAttributes( { padding: value } )
+						}
+						units={ [
+							{ value: 'px', label: 'px' },
+							{ value: 'em', label: 'em' },
+							{ value: 'rem', label: 'rem' },
+						] }
+					/>
+					<div style={ { marginBottom: '16px' } }>
+						<BorderControl
+							__next40pxDefaultSize
+							label={ __( 'Border' ) }
+							value={ border }
+							onChange={ ( value ) =>
+								setAttributes( { border: value } )
+							}
+						/>
 					</div>
-				</Popover>
-			) }
-		</div>
+					<UnitControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Border radius' ) }
+						value={ borderRadius || '0px' }
+						onChange={ ( value ) =>
+							setAttributes( { borderRadius: value } )
+						}
+						units={ [
+							{ value: 'px', label: 'px' },
+							{ value: '%', label: '%' },
+							{ value: 'em', label: 'em' },
+						] }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<InspectorControls group="color">
+				<ColorGradientSettingsDropdown
+					__experimentalIsRenderedInSidebar
+					settings={ [
+						{
+							label: __( 'Text' ),
+							colorValue: textColor,
+							onColorChange: ( value ) =>
+								setAttributes( { textColor: value } ),
+						},
+						{
+							label: __( 'Background' ),
+							colorValue: backgroundColor,
+							onColorChange: ( value ) =>
+								setAttributes( { backgroundColor: value } ),
+						},
+					] }
+					panelId="math-color-settings"
+					{ ...colorGradientSettings }
+				/>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ isEditing ? (
+					<VStack spacing={ 1 }>
+						<TextareaControl
+							ref={ textareaRef }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'LaTeX math syntax' ) }
+							hideLabelFromVision
+							value={ latex }
+							className="wp-block-math__textarea-control"
+							onChange={ handleLatexChange }
+							onBlur={ handleBlur }
+							placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
+							rows={ 3 }
+						/>
+						{ error && (
+							<>
+								<Badge
+									intent="error"
+									className="wp-block-math__error"
+								>
+									{ error }
+								</Badge>
+								<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
+							</>
+						) }
+					</VStack>
+				) : (
+					<div
+						onClick={ handlePreviewClick }
+						role="button"
+						tabIndex={ 0 }
+						onKeyDown={ ( e ) => {
+							if ( e.key === 'Enter' || e.key === ' ' ) {
+								handlePreviewClick();
+							}
+						} }
+						style={ mathContainerStyle }
+					>
+						{ mathML ? (
+							<math
+								display="block"
+								dangerouslySetInnerHTML={ { __html: mathML } }
+							/>
+						) : (
+							'\u200B'
+						) }
+					</div>
+				) }
+			</div>
+		</>
 	);
 }

--- a/packages/block-library/src/math/save.js
+++ b/packages/block-library/src/math/save.js
@@ -4,16 +4,60 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { latex, mathML } = attributes;
+	const {
+		latex,
+		mathML,
+		fontSize,
+		textColor,
+		backgroundColor,
+		border,
+		borderRadius,
+		padding,
+	} = attributes;
 
 	if ( ! latex ) {
 		return null;
 	}
 
+	// Build inline styles for the math element
+	const mathStyle = {};
+
+	if ( fontSize ) {
+		mathStyle.fontSize = `${ fontSize }px`;
+	}
+	if ( textColor ) {
+		mathStyle.color = textColor;
+	}
+	if ( backgroundColor ) {
+		mathStyle.backgroundColor = backgroundColor;
+	}
+	if ( border?.width ) {
+		mathStyle.borderWidth = border.width;
+		mathStyle.borderStyle = border.style || 'solid';
+		if ( border.color ) {
+			mathStyle.borderColor = border.color;
+		}
+	}
+	if ( borderRadius ) {
+		mathStyle.borderRadius = borderRadius;
+	}
+	// Apply padding if explicitly set, or if there's a background/border
+	if ( padding ) {
+		mathStyle.padding = padding;
+	} else if ( backgroundColor || border?.width ) {
+		mathStyle.padding = '16px';
+	}
+
+	// Only apply styles if there are any to apply
+	const hasStyling = Object.keys( mathStyle ).length > 0;
+
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div { ...useBlockProps.save() }>
+		<div { ...blockProps }>
 			<math
 				display="block"
+				style={ hasStyling ? mathStyle : undefined }
 				dangerouslySetInnerHTML={ { __html: mathML } }
 			/>
 		</div>


### PR DESCRIPTION
## What?
Closes #73035 
Enhances the Math block with inline editing capabilities and comprehensive visual styling options.

## Why?
### Current Issues:
1. Math block editing happens in a popover, requiring extra clicks and breaking the inline editing flow
2. Limited styling options make it difficult to emphasize or style mathematical expressions for presentations, educational content, or design purposes

## How?
### Inline Editing:
- Removed popover interface for editing LaTeX
- LaTeX input now appears directly on the canvas when the block is selected
- Click on rendered math preview to enter edit mode
- Automatically converts to preview on blur
- Auto-focuses textarea for better UX

### Visual Styling Options:
Added comprehensive styling controls in the Inspector panel:
- **Font Size**: Range control (12-120px) for scaling mathematical expressions
- **Text Color**: Standard WordPress color picker
- **Background Color**: Standard WordPress color picker  
- **Border**: Width, style, and color controls
- **Border Radius**: Rounded corners with multiple units (px, %, em)
- **Padding**: Spacing control with multiple units (px, em, rem)

All styles are properly saved and rendered on the frontend.

## Testing Instructions
----------------------------------------------------------

### Styling:
1. Add a Math block with content (e.g., `x^2 + y^2 = r^2`)
2. Open the Appearance panel in the inspector
3. Adjust font size - math should scale accordingly
4. Add background color and verify padding is auto-applied
5. Add border and border radius
6. Change text color
7. Save the post and verify styles persist on frontend

## Screenshots/Screencast
https://github.com/user-attachments/assets/85ad5566-edc1-4c39-8fcb-ecf6a3f4f925


## Checklist
- [x] My code is tested and works locally
- [x] My code follows the WordPress coding standards

