### PR TITLE
Routing: Add post new and top level redirect route to the posts

### DIFF
--- a/lib/experimental/boot/boot.php
+++ b/lib/experimental/boot/boot.php
@@ -9,6 +9,7 @@
 require_once __DIR__ . '/boot-menu-items.php';
 require_once __DIR__ . '/boot-routes.php';
 require_once __DIR__ . '/preload.php';
+require_once __DIR__ . '/rest-api-overrides.php';
 
 /**
  * Initialize boot admin page.
@@ -33,7 +34,7 @@ function gutenberg_boot_admin_page() {
 
 	// Register some default menu items for demonstration.
 	gutenberg_register_boot_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
-	gutenberg_register_boot_menu_item( 'posts', __( 'Posts', 'gutenberg' ), '/types/post/list/all', '' );
+	gutenberg_register_boot_menu_item( 'posts', __( 'Posts', 'gutenberg' ), '/types/post', '' );
 
 	// Get routes and menu items.
 	$menu_items = gutenberg_get_boot_menu_items();

--- a/lib/experimental/boot/rest-api-overrides.php
+++ b/lib/experimental/boot/rest-api-overrides.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Boot package REST API overrides.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Allow auto-draft status in WordPress REST API for all post types.
+ *
+ * By default, WordPress REST API doesn't include 'auto-draft' in the
+ * allowed status values. This function adds it to the schema enum for
+ * all eligible post types.
+ */
+function gutenberg_boot_allow_auto_draft_in_rest_api() {
+	$auto_draft_filter = function ( $schema ) {
+		if ( isset( $schema['properties']['status']['enum'] ) ) {
+			$schema['properties']['status']['enum'][] = 'auto-draft';
+		}
+		return $schema;
+	};
+
+	// Get post types that should support auto-draft.
+	$post_types = get_post_types(
+		array(
+			'show_in_rest' => true,
+			'show_ui'      => true,
+		),
+		'objects'
+	);
+
+	foreach ( $post_types as $post_type ) {
+		$supports_editor   = post_type_supports( $post_type->name, 'editor' );
+		$supports_title    = post_type_supports( $post_type->name, 'title' );
+		$is_wp_core_system = strpos( $post_type->name, 'wp_' ) === 0;
+		$is_attachment     = 'attachment' === $post_type->name;
+
+		// Only add auto-draft to content post types:
+		// - Must support either editor or title (content editing capabilities).
+		// - Exclude WordPress core system types (wp_block, wp_navigation, etc.).
+		// - Exclude attachments (media files don't need auto-draft status).
+		$should_support_auto_draft = ( $supports_editor || $supports_title ) &&
+									! $is_wp_core_system &&
+									! $is_attachment;
+
+		if ( $should_support_auto_draft ) {
+			add_filter( "rest_{$post_type->name}_item_schema", $auto_draft_filter );
+		}
+	}
+}
+
+add_action( 'rest_api_init', 'gutenberg_boot_allow_auto_draft_in_rest_api' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17505,12 +17505,20 @@
 			"resolved": "packages/plugins",
 			"link": true
 		},
+		"node_modules/@wordpress/post": {
+			"resolved": "routes/post",
+			"link": true
+		},
 		"node_modules/@wordpress/post-edit": {
 			"resolved": "routes/post-edit",
 			"link": true
 		},
 		"node_modules/@wordpress/post-list": {
 			"resolved": "routes/post-list",
+			"link": true
+		},
+		"node_modules/@wordpress/post-new": {
+			"resolved": "routes/post-new",
 			"link": true
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
@@ -55251,6 +55259,13 @@
 				"@wordpress/i18n": "file:../../packages/i18n"
 			}
 		},
+		"routes/post": {
+			"name": "@wordpress/post",
+			"version": "1.0.0",
+			"dependencies": {
+				"@tanstack/react-router": ">=1.120.5 <1.121.0"
+			}
+		},
 		"routes/post-edit": {
 			"name": "@wordpress/post-edit",
 			"version": "1.0.0",
@@ -55370,6 +55385,110 @@
 			}
 		},
 		"routes/post-list/node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"routes/post-new": {
+			"name": "@wordpress/post-new",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data"
+			}
+		},
+		"routes/post/node_modules/@tanstack/history": {
+			"version": "1.120.17",
+			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.120.17.tgz",
+			"integrity": "sha512-k07LFI4Qo074IIaWzT/XjD0KlkGx2w1V3fnNtclKx0oAl8z4O9kCh6za+FPEIRe98xLgNFEiddDbJeAYGSlPtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post/node_modules/@tanstack/react-router": {
+			"version": "1.120.20",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.20.tgz",
+			"integrity": "sha512-+zNruUE9NsfGm9cHd22Xs7FRtBrBhDZe94pB69BEIjqjrEPZct6f5VhTV9WQ+bDZ6fRz8tUuxNFAgm/3Lm4AIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.120.17",
+				"@tanstack/react-store": "^0.7.0",
+				"@tanstack/router-core": "1.120.19",
+				"jsesc": "^3.1.0",
+				"tiny-invariant": "^1.3.3",
+				"tiny-warning": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			}
+		},
+		"routes/post/node_modules/@tanstack/react-store": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.7.tgz",
+			"integrity": "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/store": "0.7.7",
+				"use-sync-external-store": "^1.5.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"routes/post/node_modules/@tanstack/router-core": {
+			"version": "1.120.19",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.19.tgz",
+			"integrity": "sha512-5JUVgkxnIM3NxMwzKt0tfz2UopZVxwq6Kl7Rp33zlFJaPjpiRs46VuRjVeAvkpJd6samo1gcH1rWqmnPUmtGcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.120.17",
+				"@tanstack/store": "^0.7.0",
+				"tiny-invariant": "^1.3.3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post/node_modules/@tanstack/store": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.7.tgz",
+			"integrity": "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"routes/post/node_modules/jsesc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",

--- a/routes/post-new/package.json
+++ b/routes/post-new/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@wordpress/post-new",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/types/$type/new"
+	},
+	"dependencies": {
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data"
+	}
+}

--- a/routes/post-new/route.ts
+++ b/routes/post-new/route.ts
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Route configuration for creating a new post.
+ */
+export const route = {
+	async canvas( context: {
+		params: {
+			type: string;
+		};
+	} ) {
+		const { params } = context;
+
+		const newPost = await dispatch( coreStore ).saveEntityRecord(
+			'postType',
+			params.type,
+			{
+				title: 'Auto Draft',
+				content: '',
+				status: 'auto-draft',
+			}
+		);
+
+		return {
+			postType: params.type,
+			postId: String( newPost.id ),
+		};
+	},
+};

--- a/routes/post/package.json
+++ b/routes/post/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "@wordpress/post",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/types/$type"
+	},
+	"dependencies": {
+		"@tanstack/react-router": ">=1.120.5 <1.121.0"
+	}
+}

--- a/routes/post/route.ts
+++ b/routes/post/route.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { redirect } from '@tanstack/react-router';
+
+/**
+ * Route configuration for post redirect.
+ */
+export const route = {
+	beforeLoad: ( { params }: { params: { type: string } } ) => {
+		throw redirect( {
+			to: '/types/$type/list/$slug',
+			params: {
+				type: params.type,
+				slug: 'all',
+			},
+		} );
+	},
+};


### PR DESCRIPTION
Related #70862 

## What?

  Adds post and post-new routes to the boot package and adds REST API support for auto-draft post creation.

 ## Why?

The boot package needs dedicated is being iterated on for the "posts dataviews" experiment and these are requirements to reach the expected behavior (fix new post button, and fixes the active menu item)

## Testing Instructions

  1. Navigate to boot demo page `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2F`
  2. Click "Posts" menu item - should redirect to posts list
  3. Click "Add New" or navigate to /types/post/new - should create auto-draft and open editor

