### PR TITLE
Update synced pattern language from "Detach" to "Disconnect pattern"

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -103,7 +103,7 @@ function PatternsManageButton( { clientId } ) {
 						}
 					} }
 				>
-					{ __( 'Detach' ) }
+					{ __( 'Disconnect pattern' ) }
 				</MenuItem>
 			) }
 			<MenuItem href={ managePatternsUrl }>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -63,7 +63,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ __( 'Detach' ) }
+					{ __( 'Disconnect pattern' ) }
 				</MenuItem>
 			) }
 		</>

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -698,7 +698,7 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		// Check that the overrides remain.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -739,7 +739,7 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		// Check that the overrides remain.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -334,7 +334,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -369,7 +369,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -470,7 +470,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -173,7 +173,7 @@ test.describe( 'Template Part', () => {
 		);
 	} );
 
-	test( 'can disconnect blocks from a template part', async ( {
+	test( 'can detach blocks from a template part', async ( {
 		admin,
 		editor,
 	} ) => {
@@ -207,9 +207,9 @@ test.describe( 'Template Part', () => {
 		);
 		await expect( templatePartWithParagraph ).toBeVisible();
 
-		// Disconnect the paragraph from the header template part.
+		// Detach the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -173,7 +173,7 @@ test.describe( 'Template Part', () => {
 		);
 	} );
 
-	test( 'can detach blocks from a template part', async ( {
+	test( 'can disconnect blocks from a template part', async ( {
 		admin,
 		editor,
 	} ) => {
@@ -207,9 +207,9 @@ test.describe( 'Template Part', () => {
 		);
 		await expect( templatePartWithParagraph ).toBeVisible();
 
-		// Detach the paragraph from the header template part.
+		// Disconnect the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();


### PR DESCRIPTION
## Why?
The term "detach" was technically accurate but lacked clarity for both sighted and visually
impaired users. "Disconnect pattern" is more descriptive of the action being performed - breaking a pattern from the source. I think it's important to include "pattern" at the end here rather than just "Disconnect", especially when we already have a "Manage patterns" option. As is, it's not even clear what is being detached!

## How?
Changed the label text in:
- Pattern manage button component (`packages/patterns/src/components/patterns-manage-button.js`)
- Reusable blocks manage button component (`packages/reusable blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js`)
- Updated E2E test assertions in `test/e2e/specs/editor/various/patterns.spec.js`

## Testing Instructions
  1. Insert a synced pattern in the post or page editor
  2. Select the pattern block
  3. Click the block options menu (three vertical dots in the block toolbar)
  4. Verify the option now reads "Disconnect pattern" instead of "Detach"

## Testing Instructions for Keyboard
  1. Insert a synced pattern in the post or page editor
  2. With the pattern block selected, navigate to the block toolbar using `Shift+Alt+Z` or arrow
  keys
  3. Tab to the block options button (three dots) and press Enter
  4. Use arrow keys to navigate to and verify the option reads "Disconnect pattern"

##

Before:

<img width="634" height="624" alt="Screenshot 2025-11-07 at 10 17 33 PM" src="https://github.com/user-attachments/assets/cd00a0bc-6fc9-4fc5-beda-4317fd4a1713" />

After:

<img width="654" height="642" alt="Screenshot 2025-11-07 at 10 17 46 PM" src="https://github.com/user-attachments/assets/3dcac838-6424-41e9-9f87-5d3b8f3a5ca1" />
