### PR TITLE
NumberControl: Fix crash when min prop is string and step prop contains decimal

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 -   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
+-   `NumberControl`: Fix crash when min prop is string and step prop contains decimal ([#73107](https://github.com/WordPress/gutenberg/pull/73107)).
 
 ## 30.7.0 (2025-10-29)
 

--- a/packages/components/src/utils/math.js
+++ b/packages/components/src/utils/math.js
@@ -81,12 +81,12 @@ export function clamp( value, min, max ) {
  */
 export function ensureValidStep( value, min, step ) {
 	const baseValue = getNumber( value );
+	const minValue = getNumber( min );
 	const stepValue = getNumber( step );
 	const precision = Math.max( getPrecision( step ), getPrecision( min ) );
-	const realMin = Math.abs( min ) === Infinity ? 0 : min;
 	// If the step is not a factor of the minimum then the step must be
 	// offset by the minimum.
-	const tare = realMin % stepValue ? realMin : 0;
+	const tare = minValue % stepValue ? minValue : 0;
 	const rounded = Math.round( ( baseValue - tare ) / stepValue ) * stepValue;
 	const fromMin = rounded + tare;
 	return precision ? getNumber( fromMin.toFixed( precision ) ) : fromMin;


### PR DESCRIPTION
Follow-up to #34566

## What?

While testing my plugin with WordPress 6.9, I noticed that it was crashing due to the `NumberControl` component. This PR fixes the issue where the `NumberControl` component crashes under the following conditions:

- `min` prop is a string
- `step` prop contains decimal

The error message is as follows:

```
math.js:85 Uncaught TypeError: fromMin.toFixed is not a function
    at ensureValidStep (math.js:85:40)
    at constrainValue (index.tsx:73:15)
    at UnforwardedNumberControl (index.tsx:77:21)
    at renderWithHooks (react-dom.js?ver=18:15496:20)
    at updateForwardRef (react-dom.js?ver=18:19255:22)
    at beginWork (react-dom.js?ver=18:21685:18)
    at HTMLUnknownElement.callCallback (react-dom.js?ver=18:4151:16)
    at Object.invokeGuardedCallbackDev (react-dom.js?ver=18:4200:18)
    at invokeGuardedCallback (react-dom.js?ver=18:4264:33)
    at beginWork$1 (react-dom.js?ver=18:27500:9)
```

## Why?

The `min` prop is originally only supposed to accept a number, but until now, it was being converted to a number[within the `roundClamp` function](https://github.com/WordPress/gutenberg/pull/34566/files#diff-4cba7c09acfcc29531d286006f36a4f5ee7480234850b5aacc2a5d341a0e8547L93), so no problems occurred.

However, as a result of #34566, in some scenarios, the `fromMin` variable becomes a string instead of a number. Therefore, `fromMin.toFixed()` will fail.

## How?

Convert the `min` prop value to a number.

## Testing Instructions

> - `min` prop is a string
> - `step` prop contains decimal

Fortunately, Gutenberg does not have a component that matches these conditions, but please make the following changes to reproduce the problem:

```diff
diff --git a/packages/editor/src/components/posts-per-page/index.js b/packages/editor/src/components/posts-per-page/index.js
index 876644168a..0d212ffeec 100644
--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -89,7 +89,7 @@ export default function PostsPerPage() {
                                                        value={ postsPerPage }
                                                        size="__unstable-large"
                                                        spinControls="custom"
-                                                       step="1"
+                                                       step="0.1"
                                                        min="1"
                                                        onChange={ setPostsPerPage }
                                                        label={ __( 'Posts per page' ) }
```

- Open the site editor.
- Open the Blog Home template
- Click the "Posts per page" template
- Confirm that the component is correctly rendered. In the trunk branch, the crash occurs here.

