### PR TITLE
HTML Block: Add JS/CSS editing

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -6,6 +6,7 @@ import { useState } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockIcon,
+	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
@@ -13,6 +14,7 @@ import {
 	ToolbarGroup,
 	Placeholder,
 	Button,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { code } from '@wordpress/icons';
 
@@ -62,10 +64,25 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton onClick={ () => setIsModalOpen( true ) }>
-						{ __( 'Edit' ) }
+						{ __( 'Edit code' ) }
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
+			<InspectorControls>
+				<VStack
+					className="block-editor-block-inspector-edit-contents"
+					expanded
+				>
+					<Button
+						className="block-editor-block-inspector-edit-contents__button"
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ () => setIsModalOpen( true ) }
+					>
+						{ __( 'Edit code' ) }
+					</Button>
+				</VStack>
+			</InspectorControls>
 			<Preview content={ attributes.content } isSelected={ isSelected } />
 			<HTMLEditModal
 				isOpen={ isModalOpen }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,88 +2,77 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	BlockControls,
-	PlainText,
+	BlockIcon,
 	useBlockProps,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToolbarButton,
-	Disabled,
 	ToolbarGroup,
-	VisuallyHidden,
+	Placeholder,
+	Button,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
+import { code } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Preview from './preview';
+import HTMLEditModal from './modal';
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
-	const [ isPreview, setIsPreview ] = useState();
-	const isDisabled = useContext( Disabled.Context );
-
-	const instanceId = useInstanceId( HTMLEdit, 'html-edit-desc' );
-
-	const isPreviewMode = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings().isPreviewMode;
-	}, [] );
-
-	function switchToPreview() {
-		setIsPreview( true );
-	}
-
-	function switchToHTML() {
-		setIsPreview( false );
-	}
-
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const blockProps = useBlockProps( {
 		className: 'block-library-html__edit',
-		'aria-describedby': isPreview ? instanceId : undefined,
 	} );
+
+	// Show placeholder when content is empty
+	if ( ! attributes.content?.trim() ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ <BlockIcon icon={ code } /> }
+					label={ __( 'Custom HTML' ) }
+					instructions={ __(
+						'Add custom HTML code and preview how it looks.'
+					) }
+				>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ () => setIsModalOpen( true ) }
+					>
+						{ __( 'Edit HTML' ) }
+					</Button>
+				</Placeholder>
+				<HTMLEditModal
+					isOpen={ isModalOpen }
+					onRequestClose={ () => setIsModalOpen( false ) }
+					content={ attributes.content }
+					setAttributes={ setAttributes }
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div { ...blockProps }>
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton
-						isPressed={ ! isPreview }
-						onClick={ switchToHTML }
-					>
-						HTML
-					</ToolbarButton>
-					<ToolbarButton
-						isPressed={ isPreview }
-						onClick={ switchToPreview }
-					>
-						{ __( 'Preview' ) }
+					<ToolbarButton onClick={ () => setIsModalOpen( true ) }>
+						{ __( 'Edit' ) }
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			{ isPreview || isPreviewMode || isDisabled ? (
-				<>
-					<Preview
-						content={ attributes.content }
-						isSelected={ isSelected }
-					/>
-					<VisuallyHidden id={ instanceId }>
-						{ __(
-							'HTML preview is not yet fully accessible. Please switch screen reader to virtualized mode to navigate the below iFrame.'
-						) }
-					</VisuallyHidden>
-				</>
-			) : (
-				<PlainText
-					value={ attributes.content }
-					onChange={ ( content ) => setAttributes( { content } ) }
-					placeholder={ __( 'Write HTML…' ) }
-					aria-label={ __( 'HTML' ) }
-				/>
-			) }
+			<Preview content={ attributes.content } isSelected={ isSelected } />
+			<HTMLEditModal
+				isOpen={ isModalOpen }
+				onRequestClose={ () => setIsModalOpen( false ) }
+				content={ attributes.content }
+				setAttributes={ setAttributes }
+			/>
 		</div>
 	);
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -34,16 +34,42 @@
 
 .block-library-html__modal-tab {
 	height: 100%;
+
+	// Pre wrapper inherits wp-block-code styling from theme.json
+	pre.wp-block-code {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		margin: 0;
+		box-sizing: border-box;
+		border: 1px solid rgba(0, 0, 0, 0.2);
+		border-radius: 2px;
+	}
 }
 
 .block-library-html__modal-editor {
 	width: 100%;
-	@include editor-input-reset();
 	height: 100%;
+	flex: 1;
+	// Reset textarea styles to inherit from pre
+	border: none;
+	background: transparent;
+	padding: 0;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	color: inherit;
+	resize: none;
 	// HTML input is always LTR regardless of language.
 	/*rtl:ignore*/
 	direction: ltr;
 	overflow-x: auto;
+	box-sizing: border-box;
+
+	&:focus {
+		outline: none;
+		box-shadow: none;
+	}
 }
 
 .block-library-html__preview {

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -20,11 +20,15 @@
 		flex-direction: column;
 		padding: 0;
 	}
+
+	.components-modal__children-container {
+		height: 100%;
+	}
 }
 
 .block-library-html__modal-tabs {
-	min-height: 500px;
-	padding: 0 $grid-unit-40 $grid-unit-40;
+	height: 100%;
+	padding: $grid-unit-20 $grid-unit-40 $grid-unit-40;
 }
 
 .block-library-html__modal-tab {
@@ -38,4 +42,10 @@
 	// HTML input is always LTR regardless of language.
 	/*rtl:ignore*/
 	direction: ltr;
+	overflow-x: auto;
+}
+
+.block-library-html__modal-actions {
+	margin-top: $grid-unit-20;
+	padding: 0 $grid-unit-40 $grid-unit-40;
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -34,17 +34,14 @@
 
 .block-library-html__modal-tab {
 	height: 100%;
-
-	// Pre wrapper inherits wp-block-code styling from theme.json
-	pre.wp-block-code {
-		height: 100%;
-		display: flex;
-		flex-direction: column;
-		margin: 0;
-		box-sizing: border-box;
-		border: 1px solid rgba(0, 0, 0, 0.2);
-		border-radius: 2px;
-	}
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	box-sizing: border-box;
+	border: 1px solid $gray-200;
+	border-radius: 2px;
+	padding: $grid-unit-20;
+	font-family: $editor-html-font;
 }
 
 .block-library-html__modal-editor {

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -19,16 +19,17 @@
 		display: flex;
 		flex-direction: column;
 		padding: 0;
+		min-height: 70vh;
 	}
 
 	.components-modal__children-container {
 		height: 100%;
+		padding: $grid-unit-20;
 	}
 }
 
 .block-library-html__modal-tabs {
 	height: 100%;
-	padding: $grid-unit-20 $grid-unit-40 $grid-unit-40;
 }
 
 .block-library-html__modal-tab {
@@ -37,12 +38,19 @@
 
 .block-library-html__modal-editor {
 	width: 100%;
-	height: 100%;
 	@include editor-input-reset();
+	height: 100%;
 	// HTML input is always LTR regardless of language.
 	/*rtl:ignore*/
 	direction: ltr;
 	overflow-x: auto;
+}
+
+.block-library-html__preview {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: $grid-unit-60;
 }
 
 .block-library-html__modal-actions {

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,4 +1,6 @@
 @use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
 
 .block-library-html__edit {
 	.block-library-html__preview-overlay {
@@ -8,16 +10,32 @@
 		top: 0;
 		left: 0;
 	}
+}
 
-	// The editing view for the HTML block is equivalent to block UI.
-	// Therefore we increase specificity to avoid theme styles bleeding in.
-	.block-editor-plain-text {
-		display: block;
-		box-sizing: border-box;
-		max-height: 250px;
-		@include editor-input-reset();
-		// HTML input is always LTR regardless of language.
-		/*rtl:ignore*/
-		direction: ltr;
+// Modal styles
+.block-library-html__modal {
+	// Make modal content scrollable
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
 	}
+}
+
+.block-library-html__modal-tabs {
+	min-height: 500px;
+	padding: 0 $grid-unit-40 $grid-unit-40;
+}
+
+.block-library-html__modal-tab {
+	height: 100%;
+}
+
+.block-library-html__modal-editor {
+	width: 100%;
+	height: 100%;
+	@include editor-input-reset();
+	// HTML input is always LTR regardless of language.
+	/*rtl:ignore*/
+	direction: ltr;
 }

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	Modal,
+	privateApis as componentsPrivateApis,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { PlainText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import Preview from './preview';
+
+const { Tabs } = unlock( componentsPrivateApis );
+
+export default function HTMLEditModal( {
+	isOpen,
+	onRequestClose,
+	content,
+	setAttributes,
+} ) {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Edit HTML' ) }
+			onRequestClose={ onRequestClose }
+			className="block-library-html__modal"
+			size="large"
+		>
+			<Tabs orientation="vertical" defaultTabId="html">
+				<HStack
+					alignment="stretch"
+					justify="flex-start"
+					spacing={ 4 }
+					className="block-library-html__modal-tabs"
+				>
+					<div>
+						<Tabs.TabList>
+							<Tabs.Tab tabId="html">HTML</Tabs.Tab>
+							<Tabs.Tab tabId="preview">
+								{ __( 'Preview' ) }
+							</Tabs.Tab>
+						</Tabs.TabList>
+					</div>
+					<div style={ { flexGrow: 1 } }>
+						<Tabs.TabPanel
+							tabId="html"
+							focusable={ false }
+							className="block-library-html__modal-tab"
+						>
+							<PlainText
+								value={ content }
+								onChange={ ( newContent ) =>
+									setAttributes( { content: newContent } )
+								}
+								placeholder={ __( 'Write HTML…' ) }
+								aria-label={ __( 'HTML' ) }
+								className="block-library-html__modal-editor"
+							/>
+						</Tabs.TabPanel>
+						<Tabs.TabPanel
+							tabId="preview"
+							focusable={ false }
+							className="block-library-html__modal-tab"
+						>
+							<Preview content={ content } isSelected />
+						</Tabs.TabPanel>
+					</div>
+				</HStack>
+			</Tabs>
+		</Modal>
+	);
+}

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -9,8 +9,10 @@ import {
 	Flex,
 	privateApis as componentsPrivateApis,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { PlainText } from '@wordpress/block-editor';
+import { fullscreen, square } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -34,27 +36,24 @@ export default function HTMLEditModal( {
 	const [ editedJs, setEditedJs ] = useState( js );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const [ showUnsavedWarning, setShowUnsavedWarning ] = useState( false );
+	const [ isFullscreen, setIsFullscreen ] = useState( false );
 
 	if ( ! isOpen ) {
 		return null;
 	}
 
-	// Wrapper functions that mark content as dirty
 	const handleHtmlChange = ( value ) => {
 		setEditedHtml( value );
 		setIsDirty( true );
 	};
-
 	const handleCssChange = ( value ) => {
 		setEditedCss( value );
 		setIsDirty( true );
 	};
-
 	const handleJsChange = ( value ) => {
 		setEditedJs( value );
 		setIsDirty( true );
 	};
-
 	const handleUpdate = () => {
 		setAttributes( {
 			content: serializeContent( {
@@ -65,13 +64,10 @@ export default function HTMLEditModal( {
 		} );
 		setIsDirty( false );
 	};
-
 	const handleCancel = () => {
 		setIsDirty( false );
 		onRequestClose();
 	};
-
-	// Handle close request - check for unsaved changes
 	const handleRequestClose = () => {
 		if ( isDirty ) {
 			setShowUnsavedWarning( true );
@@ -79,22 +75,19 @@ export default function HTMLEditModal( {
 			onRequestClose();
 		}
 	};
-
-	// Handle discard confirmation
 	const handleDiscardChanges = () => {
 		setShowUnsavedWarning( false );
 		onRequestClose();
 	};
-
-	// Handle continue editing
 	const handleContinueEditing = () => {
 		setShowUnsavedWarning( false );
 	};
-
-	// Handle update and close
 	const handleUpdateAndClose = () => {
 		handleUpdate();
 		onRequestClose();
+	};
+	const toggleFullscreen = () => {
+		setIsFullscreen( ( prevState ) => ! prevState );
 	};
 
 	return (
@@ -107,89 +100,84 @@ export default function HTMLEditModal( {
 				isDismissible={ false }
 				shouldCloseOnClickOutside={ ! isDirty }
 				shouldCloseOnEsc={ ! isDirty }
-				isFullScreen
-				headerActions={
-					<>
-						<Button
-							__next40pxDefaultSize
-							variant="tertiary"
-							onClick={ handleCancel }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
-							onClick={ handleUpdate }
-						>
-							{ __( 'Save' ) }
-						</Button>
-					</>
-				}
+				isFullScreen={ isFullscreen }
+				__experimentalHideHeader
 			>
-				<Tabs orientation="vertical" defaultTabId="html">
-					<HStack
-						alignment="stretch"
-						justify="flex-start"
-						spacing={ 4 }
-						className="block-library-html__modal-tabs"
-					>
-						<div>
-							<Tabs.TabList>
-								<Tabs.Tab tabId="html">HTML</Tabs.Tab>
-								<Tabs.Tab tabId="css">CSS</Tabs.Tab>
-								<Tabs.Tab tabId="js">
-									{ __( 'JavaScript' ) }
-								</Tabs.Tab>
-								<Tabs.Tab tabId="preview">
-									{ __( 'Preview' ) }
-								</Tabs.Tab>
-							</Tabs.TabList>
-						</div>
-						<div style={ { flexGrow: 1 } }>
-							<Tabs.TabPanel
-								tabId="html"
-								focusable={ false }
-								className="block-library-html__modal-tab"
-							>
-								<PlainText
-									value={ editedHtml }
-									onChange={ handleHtmlChange }
-									placeholder={ __( 'Write HTML…' ) }
-									aria-label={ __( 'HTML' ) }
-									className="block-library-html__modal-editor"
+				<Tabs orientation="horizontal" defaultTabId="html">
+					<VStack spacing={ 4 } style={ { height: '100%' } }>
+						<HStack justify="space-between">
+							<div>
+								<Tabs.TabList>
+									<Tabs.Tab tabId="html">HTML</Tabs.Tab>
+									<Tabs.Tab tabId="css">CSS</Tabs.Tab>
+									<Tabs.Tab tabId="js">
+										{ __( 'JavaScript' ) }
+									</Tabs.Tab>
+								</Tabs.TabList>
+							</div>
+							<div>
+								<Button
+									__next40pxDefaultSize
+									icon={ isFullscreen ? square : fullscreen }
+									label={ __( 'Enable/disable fullscreen' ) }
+									onClick={ toggleFullscreen }
+									variant="tertiary"
 								/>
-							</Tabs.TabPanel>
-							<Tabs.TabPanel
-								tabId="css"
-								focusable={ false }
-								className="block-library-html__modal-tab"
-							>
-								<PlainText
-									value={ editedCss }
-									onChange={ handleCssChange }
-									placeholder={ __( 'Write CSS…' ) }
-									aria-label={ __( 'CSS' ) }
-									className="block-library-html__modal-editor"
-								/>
-							</Tabs.TabPanel>
-							<Tabs.TabPanel
-								tabId="js"
-								focusable={ false }
-								className="block-library-html__modal-tab"
-							>
-								<PlainText
-									value={ editedJs }
-									onChange={ handleJsChange }
-									placeholder={ __( 'Write JavaScript…' ) }
-									aria-label={ __( 'JavaScript' ) }
-									className="block-library-html__modal-editor"
-								/>
-							</Tabs.TabPanel>
-							<Tabs.TabPanel
-								tabId="preview"
-								focusable={ false }
-								className="block-library-html__modal-tab"
+							</div>
+						</HStack>
+						<HStack
+							alignment="stretch"
+							justify="flex-start"
+							spacing={ 4 }
+							className="block-library-html__modal-tabs"
+							style={ { flexGrow: 1 } }
+						>
+							<div style={ { flexGrow: 1 } }>
+								<Tabs.TabPanel
+									tabId="html"
+									focusable={ false }
+									className="block-library-html__modal-tab"
+								>
+									<PlainText
+										value={ editedHtml }
+										onChange={ handleHtmlChange }
+										placeholder={ __( 'Write HTML…' ) }
+										aria-label={ __( 'HTML' ) }
+										className="block-library-html__modal-editor"
+									/>
+								</Tabs.TabPanel>
+								<Tabs.TabPanel
+									tabId="css"
+									focusable={ false }
+									className="block-library-html__modal-tab"
+								>
+									<PlainText
+										value={ editedCss }
+										onChange={ handleCssChange }
+										placeholder={ __( 'Write CSS…' ) }
+										aria-label={ __( 'CSS' ) }
+										className="block-library-html__modal-editor"
+									/>
+								</Tabs.TabPanel>
+								<Tabs.TabPanel
+									tabId="js"
+									focusable={ false }
+									className="block-library-html__modal-tab"
+								>
+									<PlainText
+										value={ editedJs }
+										onChange={ handleJsChange }
+										placeholder={ __(
+											'Write JavaScript…'
+										) }
+										aria-label={ __( 'JavaScript' ) }
+										className="block-library-html__modal-editor"
+									/>
+								</Tabs.TabPanel>
+							</div>
+							<div
+								className="block-library-html__preview"
+								style={ { width: '50%' } }
 							>
 								<Preview
 									content={ serializeContent( {
@@ -197,11 +185,30 @@ export default function HTMLEditModal( {
 										css: editedCss,
 										js: editedJs,
 									} ) }
-									isSelected
 								/>
-							</Tabs.TabPanel>
-						</div>
-					</HStack>
+							</div>
+						</HStack>
+						<HStack
+							alignment="center"
+							justify="flex-end"
+							spacing={ 4 }
+						>
+							<Button
+								__next40pxDefaultSize
+								variant="tertiary"
+								onClick={ handleCancel }
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ handleUpdateAndClose }
+							>
+								{ __( 'Update' ) }
+							</Button>
+						</HStack>
+					</VStack>
 				</Tabs>
 			</Modal>
 
@@ -236,7 +243,7 @@ export default function HTMLEditModal( {
 							variant="primary"
 							onClick={ handleUpdateAndClose }
 						>
-							{ __( 'Save and close' ) }
+							{ __( 'Update and close' ) }
 						</Button>
 					</Flex>
 				</Modal>

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -173,30 +173,26 @@ export default function HTMLEditModal( {
 									focusable={ false }
 									className="block-library-html__modal-tab"
 								>
-									<pre className="wp-block-code">
-										<PlainText
-											value={ editedHtml }
-											onChange={ handleHtmlChange }
-											placeholder={ __( 'Write HTML…' ) }
-											aria-label={ __( 'HTML' ) }
-											className="block-library-html__modal-editor"
-										/>
-									</pre>
+									<PlainText
+										value={ editedHtml }
+										onChange={ handleHtmlChange }
+										placeholder={ __( 'Write HTML…' ) }
+										aria-label={ __( 'HTML' ) }
+										className="block-library-html__modal-editor"
+									/>
 								</Tabs.TabPanel>
 								<Tabs.TabPanel
 									tabId="css"
 									focusable={ false }
 									className="block-library-html__modal-tab"
 								>
-									<pre className="wp-block-code">
-										<PlainText
-											value={ editedCss }
-											onChange={ handleCssChange }
-											placeholder={ __( 'Write CSS…' ) }
-											aria-label={ __( 'CSS' ) }
-											className="block-library-html__modal-editor"
-										/>
-									</pre>
+									<PlainText
+										value={ editedCss }
+										onChange={ handleCssChange }
+										placeholder={ __( 'Write CSS…' ) }
+										aria-label={ __( 'CSS' ) }
+										className="block-library-html__modal-editor"
+									/>
 								</Tabs.TabPanel>
 								{ shouldShowJsTab && (
 									<Tabs.TabPanel
@@ -204,19 +200,15 @@ export default function HTMLEditModal( {
 										focusable={ false }
 										className="block-library-html__modal-tab"
 									>
-										<pre className="wp-block-code">
-											<PlainText
-												value={ editedJs }
-												onChange={ handleJsChange }
-												placeholder={ __(
-													'Write JavaScript…'
-												) }
-												aria-label={ __(
-													'JavaScript'
-												) }
-												className="block-library-html__modal-editor"
-											/>
-										</pre>
+										<PlainText
+											value={ editedJs }
+											onChange={ handleJsChange }
+											placeholder={ __(
+												'Write JavaScript…'
+											) }
+											aria-label={ __( 'JavaScript' ) }
+											className="block-library-html__modal-editor"
+										/>
 									</Tabs.TabPanel>
 								) }
 							</div>

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	Modal,
@@ -39,14 +39,32 @@ export default function HTMLEditModal( {
 	const [ showUnsavedWarning, setShowUnsavedWarning ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 
-	// Check if user has permission to save scripts
-	const canUserUseUnfilteredHTML = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings()
-			.__experimentalCanUserUseUnfilteredHTML;
-	}, [] );
+	// Check if user has permission to save scripts and get editor styles
+	const { canUserUseUnfilteredHTML, editorStyles } = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			return {
+				canUserUseUnfilteredHTML:
+					settings.__experimentalCanUserUseUnfilteredHTML,
+				editorStyles: settings.styles,
+			};
+		},
+		[]
+	);
 
 	// Show JS tab if user has permission OR if block contains JavaScript
 	const shouldShowJsTab = canUserUseUnfilteredHTML || js.trim() !== '';
+
+	// Combine all editor styles to inject into modal
+	const styleContent = useMemo( () => {
+		if ( ! editorStyles ) {
+			return '';
+		}
+		return editorStyles
+			.filter( ( style ) => style.css )
+			.map( ( style ) => style.css )
+			.join( '\n' );
+	}, [ editorStyles ] );
 
 	if ( ! isOpen ) {
 		return null;
@@ -113,6 +131,11 @@ export default function HTMLEditModal( {
 				isFullScreen={ isFullscreen }
 				__experimentalHideHeader
 			>
+				{ styleContent && (
+					<style
+						dangerouslySetInnerHTML={ { __html: styleContent } }
+					/>
+				) }
 				<Tabs orientation="horizontal" defaultTabId="html">
 					<VStack spacing={ 4 } style={ { height: '100%' } }>
 						<HStack justify="space-between">
@@ -150,26 +173,30 @@ export default function HTMLEditModal( {
 									focusable={ false }
 									className="block-library-html__modal-tab"
 								>
-									<PlainText
-										value={ editedHtml }
-										onChange={ handleHtmlChange }
-										placeholder={ __( 'Write HTML…' ) }
-										aria-label={ __( 'HTML' ) }
-										className="block-library-html__modal-editor"
-									/>
+									<pre className="wp-block-code">
+										<PlainText
+											value={ editedHtml }
+											onChange={ handleHtmlChange }
+											placeholder={ __( 'Write HTML…' ) }
+											aria-label={ __( 'HTML' ) }
+											className="block-library-html__modal-editor"
+										/>
+									</pre>
 								</Tabs.TabPanel>
 								<Tabs.TabPanel
 									tabId="css"
 									focusable={ false }
 									className="block-library-html__modal-tab"
 								>
-									<PlainText
-										value={ editedCss }
-										onChange={ handleCssChange }
-										placeholder={ __( 'Write CSS…' ) }
-										aria-label={ __( 'CSS' ) }
-										className="block-library-html__modal-editor"
-									/>
+									<pre className="wp-block-code">
+										<PlainText
+											value={ editedCss }
+											onChange={ handleCssChange }
+											placeholder={ __( 'Write CSS…' ) }
+											aria-label={ __( 'CSS' ) }
+											className="block-library-html__modal-editor"
+										/>
+									</pre>
 								</Tabs.TabPanel>
 								{ shouldShowJsTab && (
 									<Tabs.TabPanel
@@ -177,15 +204,19 @@ export default function HTMLEditModal( {
 										focusable={ false }
 										className="block-library-html__modal-tab"
 									>
-										<PlainText
-											value={ editedJs }
-											onChange={ handleJsChange }
-											placeholder={ __(
-												'Write JavaScript…'
-											) }
-											aria-label={ __( 'JavaScript' ) }
-											className="block-library-html__modal-editor"
-										/>
+										<pre className="wp-block-code">
+											<PlainText
+												value={ editedJs }
+												onChange={ handleJsChange }
+												placeholder={ __(
+													'Write JavaScript…'
+												) }
+												aria-label={ __(
+													'JavaScript'
+												) }
+												className="block-library-html__modal-editor"
+											/>
+										</pre>
 									</Tabs.TabPanel>
 								) }
 							</div>

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -2,8 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import {
 	Modal,
+	Button,
+	Flex,
 	privateApis as componentsPrivateApis,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
@@ -14,6 +17,7 @@ import { PlainText } from '@wordpress/block-editor';
  */
 import { unlock } from '../lock-unlock';
 import Preview from './preview';
+import { parseContent, serializeContent } from './utils';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -23,58 +27,220 @@ export default function HTMLEditModal( {
 	content,
 	setAttributes,
 } ) {
+	// Parse content into separate sections and use as initial state
+	const { html, css, js } = parseContent( content );
+	const [ editedHtml, setEditedHtml ] = useState( html );
+	const [ editedCss, setEditedCss ] = useState( css );
+	const [ editedJs, setEditedJs ] = useState( js );
+	const [ isDirty, setIsDirty ] = useState( false );
+	const [ showUnsavedWarning, setShowUnsavedWarning ] = useState( false );
+
 	if ( ! isOpen ) {
 		return null;
 	}
 
+	// Wrapper functions that mark content as dirty
+	const handleHtmlChange = ( value ) => {
+		setEditedHtml( value );
+		setIsDirty( true );
+	};
+
+	const handleCssChange = ( value ) => {
+		setEditedCss( value );
+		setIsDirty( true );
+	};
+
+	const handleJsChange = ( value ) => {
+		setEditedJs( value );
+		setIsDirty( true );
+	};
+
+	const handleUpdate = () => {
+		setAttributes( {
+			content: serializeContent( {
+				html: editedHtml,
+				css: editedCss,
+				js: editedJs,
+			} ),
+		} );
+		setIsDirty( false );
+	};
+
+	const handleCancel = () => {
+		setIsDirty( false );
+		onRequestClose();
+	};
+
+	// Handle close request - check for unsaved changes
+	const handleRequestClose = () => {
+		if ( isDirty ) {
+			setShowUnsavedWarning( true );
+		} else {
+			onRequestClose();
+		}
+	};
+
+	// Handle discard confirmation
+	const handleDiscardChanges = () => {
+		setShowUnsavedWarning( false );
+		onRequestClose();
+	};
+
+	// Handle continue editing
+	const handleContinueEditing = () => {
+		setShowUnsavedWarning( false );
+	};
+
+	// Handle update and close
+	const handleUpdateAndClose = () => {
+		handleUpdate();
+		onRequestClose();
+	};
+
 	return (
-		<Modal
-			title={ __( 'Edit HTML' ) }
-			onRequestClose={ onRequestClose }
-			className="block-library-html__modal"
-			size="large"
-		>
-			<Tabs orientation="vertical" defaultTabId="html">
-				<HStack
-					alignment="stretch"
-					justify="flex-start"
-					spacing={ 4 }
-					className="block-library-html__modal-tabs"
+		<>
+			<Modal
+				title={ __( 'Edit HTML' ) }
+				onRequestClose={ handleRequestClose }
+				className="block-library-html__modal"
+				size="large"
+				isDismissible={ false }
+				shouldCloseOnClickOutside={ ! isDirty }
+				shouldCloseOnEsc={ ! isDirty }
+				isFullScreen
+				headerActions={
+					<>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ handleCancel }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ handleUpdate }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</>
+				}
+			>
+				<Tabs orientation="vertical" defaultTabId="html">
+					<HStack
+						alignment="stretch"
+						justify="flex-start"
+						spacing={ 4 }
+						className="block-library-html__modal-tabs"
+					>
+						<div>
+							<Tabs.TabList>
+								<Tabs.Tab tabId="html">HTML</Tabs.Tab>
+								<Tabs.Tab tabId="css">CSS</Tabs.Tab>
+								<Tabs.Tab tabId="js">
+									{ __( 'JavaScript' ) }
+								</Tabs.Tab>
+								<Tabs.Tab tabId="preview">
+									{ __( 'Preview' ) }
+								</Tabs.Tab>
+							</Tabs.TabList>
+						</div>
+						<div style={ { flexGrow: 1 } }>
+							<Tabs.TabPanel
+								tabId="html"
+								focusable={ false }
+								className="block-library-html__modal-tab"
+							>
+								<PlainText
+									value={ editedHtml }
+									onChange={ handleHtmlChange }
+									placeholder={ __( 'Write HTML…' ) }
+									aria-label={ __( 'HTML' ) }
+									className="block-library-html__modal-editor"
+								/>
+							</Tabs.TabPanel>
+							<Tabs.TabPanel
+								tabId="css"
+								focusable={ false }
+								className="block-library-html__modal-tab"
+							>
+								<PlainText
+									value={ editedCss }
+									onChange={ handleCssChange }
+									placeholder={ __( 'Write CSS…' ) }
+									aria-label={ __( 'CSS' ) }
+									className="block-library-html__modal-editor"
+								/>
+							</Tabs.TabPanel>
+							<Tabs.TabPanel
+								tabId="js"
+								focusable={ false }
+								className="block-library-html__modal-tab"
+							>
+								<PlainText
+									value={ editedJs }
+									onChange={ handleJsChange }
+									placeholder={ __( 'Write JavaScript…' ) }
+									aria-label={ __( 'JavaScript' ) }
+									className="block-library-html__modal-editor"
+								/>
+							</Tabs.TabPanel>
+							<Tabs.TabPanel
+								tabId="preview"
+								focusable={ false }
+								className="block-library-html__modal-tab"
+							>
+								<Preview
+									content={ serializeContent( {
+										html: editedHtml,
+										css: editedCss,
+										js: editedJs,
+									} ) }
+									isSelected
+								/>
+							</Tabs.TabPanel>
+						</div>
+					</HStack>
+				</Tabs>
+			</Modal>
+
+			{ showUnsavedWarning && (
+				<Modal
+					title={ __( 'Unsaved changes' ) }
+					onRequestClose={ handleContinueEditing }
+					size="medium"
 				>
-					<div>
-						<Tabs.TabList>
-							<Tabs.Tab tabId="html">HTML</Tabs.Tab>
-							<Tabs.Tab tabId="preview">
-								{ __( 'Preview' ) }
-							</Tabs.Tab>
-						</Tabs.TabList>
-					</div>
-					<div style={ { flexGrow: 1 } }>
-						<Tabs.TabPanel
-							tabId="html"
-							focusable={ false }
-							className="block-library-html__modal-tab"
+					<p>
+						{ __(
+							'You have unsaved changes. What would you like to do?'
+						) }
+					</p>
+					<Flex direction="row" justify="flex-end" gap={ 2 }>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ handleDiscardChanges }
 						>
-							<PlainText
-								value={ content }
-								onChange={ ( newContent ) =>
-									setAttributes( { content: newContent } )
-								}
-								placeholder={ __( 'Write HTML…' ) }
-								aria-label={ __( 'HTML' ) }
-								className="block-library-html__modal-editor"
-							/>
-						</Tabs.TabPanel>
-						<Tabs.TabPanel
-							tabId="preview"
-							focusable={ false }
-							className="block-library-html__modal-tab"
+							{ __( 'Discard unsaved changes' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ handleContinueEditing }
 						>
-							<Preview content={ content } isSelected />
-						</Tabs.TabPanel>
-					</div>
-				</HStack>
-			</Tabs>
-		</Modal>
+							{ __( 'Continue editing' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ handleUpdateAndClose }
+						>
+							{ __( 'Save and close' ) }
+						</Button>
+					</Flex>
+				</Modal>
+			) }
+		</>
 	);
 }

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import {
 	Modal,
 	Button,
@@ -11,7 +12,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { PlainText } from '@wordpress/block-editor';
+import { PlainText, store as blockEditorStore } from '@wordpress/block-editor';
 import { fullscreen, square } from '@wordpress/icons';
 
 /**
@@ -37,6 +38,15 @@ export default function HTMLEditModal( {
 	const [ isDirty, setIsDirty ] = useState( false );
 	const [ showUnsavedWarning, setShowUnsavedWarning ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
+
+	// Check if user has permission to save scripts
+	const canUserUseUnfilteredHTML = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings()
+			.__experimentalCanUserUseUnfilteredHTML;
+	}, [] );
+
+	// Show JS tab if user has permission OR if block contains JavaScript
+	const shouldShowJsTab = canUserUseUnfilteredHTML || js.trim() !== '';
 
 	if ( ! isOpen ) {
 		return null;
@@ -110,9 +120,11 @@ export default function HTMLEditModal( {
 								<Tabs.TabList>
 									<Tabs.Tab tabId="html">HTML</Tabs.Tab>
 									<Tabs.Tab tabId="css">CSS</Tabs.Tab>
-									<Tabs.Tab tabId="js">
-										{ __( 'JavaScript' ) }
-									</Tabs.Tab>
+									{ shouldShowJsTab && (
+										<Tabs.Tab tabId="js">
+											{ __( 'JavaScript' ) }
+										</Tabs.Tab>
+									) }
 								</Tabs.TabList>
 							</div>
 							<div>
@@ -159,21 +171,23 @@ export default function HTMLEditModal( {
 										className="block-library-html__modal-editor"
 									/>
 								</Tabs.TabPanel>
-								<Tabs.TabPanel
-									tabId="js"
-									focusable={ false }
-									className="block-library-html__modal-tab"
-								>
-									<PlainText
-										value={ editedJs }
-										onChange={ handleJsChange }
-										placeholder={ __(
-											'Write JavaScript…'
-										) }
-										aria-label={ __( 'JavaScript' ) }
-										className="block-library-html__modal-editor"
-									/>
-								</Tabs.TabPanel>
+								{ shouldShowJsTab && (
+									<Tabs.TabPanel
+										tabId="js"
+										focusable={ false }
+										className="block-library-html__modal-tab"
+									>
+										<PlainText
+											value={ editedJs }
+											onChange={ handleJsChange }
+											placeholder={ __(
+												'Write JavaScript…'
+											) }
+											aria-label={ __( 'JavaScript' ) }
+											className="block-library-html__modal-editor"
+										/>
+									</Tabs.TabPanel>
+								) }
 							</div>
 							<div
 								className="block-library-html__preview"

--- a/packages/block-library/src/html/test/utils.js
+++ b/packages/block-library/src/html/test/utils.js
@@ -90,7 +90,7 @@ console.log("hello");
 <style data-wp-block-html="css">second</style>`;
 			const result = parseContent( content );
 			expect( result.css ).toBe( 'first' );
-			expect( result.html ).not.toContain( 'second' );
+			expect( result.html ).toContain( 'second' );
 		} );
 
 		it( 'should handle multiple marked script tags (takes first)', () => {
@@ -98,7 +98,7 @@ console.log("hello");
 <script data-wp-block-html="js">second</script>`;
 			const result = parseContent( content );
 			expect( result.js ).toBe( 'first' );
-			expect( result.html ).not.toContain( 'second' );
+			expect( result.html ).toContain( 'second' );
 		} );
 
 		it( 'should trim whitespace from extracted sections', () => {

--- a/packages/block-library/src/html/test/utils.js
+++ b/packages/block-library/src/html/test/utils.js
@@ -1,0 +1,234 @@
+/**
+ * Internal dependencies
+ */
+import { parseContent, serializeContent } from '../utils';
+
+describe( 'core/html', () => {
+	describe( 'parseContent()', () => {
+		it( 'should parse empty content', () => {
+			const result = parseContent( '' );
+			expect( result ).toEqual( { html: '', css: '', js: '' } );
+		} );
+
+		it( 'should parse whitespace-only content', () => {
+			const result = parseContent( '   \n\t  ' );
+			expect( result ).toEqual( { html: '', css: '', js: '' } );
+		} );
+
+		it( 'should parse HTML-only content', () => {
+			const content = '<p>Hello World</p>';
+			const result = parseContent( content );
+			expect( result ).toEqual( {
+				html: '<p>Hello World</p>',
+				css: '',
+				js: '',
+			} );
+		} );
+
+		it( 'should parse CSS-only content', () => {
+			const content =
+				'<style data-wp-block-html="css">body { color: red; }</style>';
+			const result = parseContent( content );
+			expect( result ).toEqual( {
+				html: '',
+				css: 'body { color: red; }',
+				js: '',
+			} );
+		} );
+
+		it( 'should parse JavaScript-only content', () => {
+			const content =
+				'<script data-wp-block-html="js">console.log("hello");</script>';
+			const result = parseContent( content );
+			expect( result ).toEqual( {
+				html: '',
+				css: '',
+				js: 'console.log("hello");',
+			} );
+		} );
+
+		it( 'should parse content with all three sections', () => {
+			const content = `<style data-wp-block-html="css">
+body { color: red; }
+</style>
+
+<script data-wp-block-html="js">
+console.log("hello");
+</script>
+
+<p>Hello World</p>`;
+			const result = parseContent( content );
+			expect( result.css ).toBe( 'body { color: red; }' );
+			expect( result.js ).toBe( 'console.log("hello");' );
+			expect( result.html ).toBe( '<p>Hello World</p>' );
+		} );
+
+		it( 'should ignore unmarked style tags', () => {
+			const content = `<style>body { color: blue; }</style>
+<style data-wp-block-html="css">body { color: red; }</style>
+<p>Test</p>`;
+			const result = parseContent( content );
+			expect( result.css ).toBe( 'body { color: red; }' );
+			expect( result.html ).toContain(
+				'<style>body { color: blue; }</style>'
+			);
+		} );
+
+		it( 'should ignore unmarked script tags', () => {
+			const content = `<script>alert("unmarked");</script>
+<script data-wp-block-html="js">console.log("marked");</script>
+<p>Test</p>`;
+			const result = parseContent( content );
+			expect( result.js ).toBe( 'console.log("marked");' );
+			expect( result.html ).toContain(
+				'<script>alert("unmarked");</script>'
+			);
+		} );
+
+		it( 'should handle multiple marked style tags (takes first)', () => {
+			const content = `<style data-wp-block-html="css">first</style>
+<style data-wp-block-html="css">second</style>`;
+			const result = parseContent( content );
+			expect( result.css ).toBe( 'first' );
+			expect( result.html ).not.toContain( 'second' );
+		} );
+
+		it( 'should handle multiple marked script tags (takes first)', () => {
+			const content = `<script data-wp-block-html="js">first</script>
+<script data-wp-block-html="js">second</script>`;
+			const result = parseContent( content );
+			expect( result.js ).toBe( 'first' );
+			expect( result.html ).not.toContain( 'second' );
+		} );
+
+		it( 'should trim whitespace from extracted sections', () => {
+			const content = `<style data-wp-block-html="css">
+
+  body { color: red; }
+
+</style>
+
+<script data-wp-block-html="js">
+
+  console.log("test");
+
+</script>
+
+  <p>Test</p>  `;
+			const result = parseContent( content );
+			expect( result.css ).toBe( 'body { color: red; }' );
+			expect( result.js ).toBe( 'console.log("test");' );
+			expect( result.html ).toBe( '<p>Test</p>' );
+		} );
+
+		it( 'should handle malformed HTML gracefully', () => {
+			const content = '<p>Unclosed tag<div>Test</p>';
+			const result = parseContent( content );
+			expect( result ).toHaveProperty( 'html' );
+			expect( result ).toHaveProperty( 'css' );
+			expect( result ).toHaveProperty( 'js' );
+		} );
+	} );
+
+	describe( 'serializeContent()', () => {
+		it( 'should serialize empty sections', () => {
+			const result = serializeContent( { html: '', css: '', js: '' } );
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'should serialize HTML-only', () => {
+			const result = serializeContent( {
+				html: '<p>Hello World</p>',
+				css: '',
+				js: '',
+			} );
+			expect( result ).toBe( '<p>Hello World</p>' );
+		} );
+
+		it( 'should serialize CSS-only', () => {
+			const result = serializeContent( {
+				html: '',
+				css: 'body { color: red; }',
+				js: '',
+			} );
+			expect( result ).toBe(
+				'<style data-wp-block-html="css">\nbody { color: red; }\n</style>'
+			);
+		} );
+
+		it( 'should serialize JavaScript-only', () => {
+			const result = serializeContent( {
+				html: '',
+				css: '',
+				js: 'console.log("test");',
+			} );
+			expect( result ).toBe(
+				'<script data-wp-block-html="js">\nconsole.log("test");\n</script>'
+			);
+		} );
+
+		it( 'should serialize all three sections in correct order', () => {
+			const result = serializeContent( {
+				html: '<p>Hello</p>',
+				css: 'body { color: red; }',
+				js: 'console.log("test");',
+			} );
+			expect( result ).toBe(
+				'<style data-wp-block-html="css">\nbody { color: red; }\n</style>\n\n<script data-wp-block-html="js">\nconsole.log("test");\n</script>\n\n<p>Hello</p>'
+			);
+		} );
+
+		it( 'should ignore whitespace-only sections', () => {
+			const result = serializeContent( {
+				html: '<p>Test</p>',
+				css: '   \n  ',
+				js: '\t\t',
+			} );
+			expect( result ).toBe( '<p>Test</p>' );
+		} );
+
+		it( 'should handle missing properties gracefully', () => {
+			const result = serializeContent( {} );
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'should handle undefined values', () => {
+			const result = serializeContent( {
+				html: undefined,
+				css: undefined,
+				js: undefined,
+			} );
+			expect( result ).toBe( '' );
+		} );
+	} );
+
+	describe( 'round-trip serialization', () => {
+		it( 'should maintain HTML-only content', () => {
+			const original = '<p>Hello World</p>';
+			const parsed = parseContent( original );
+			const serialized = serializeContent( parsed );
+			expect( serialized ).toBe( original );
+		} );
+
+		it( 'should maintain content with all sections', () => {
+			const original =
+				'<style data-wp-block-html="css">\nbody { color: red; }\n</style>\n\n<script data-wp-block-html="js">\nconsole.log("test");\n</script>\n\n<p>Hello</p>';
+			const parsed = parseContent( original );
+			const serialized = serializeContent( parsed );
+			expect( serialized ).toBe( original );
+		} );
+
+		it( 'should maintain complex HTML structures', () => {
+			const sections = {
+				html: '<div><h1>Title</h1><p>Paragraph</p></div>',
+				css: 'h1 { font-size: 2em; }',
+				js: 'document.addEventListener("load", () => {});',
+			};
+			const serialized = serializeContent( sections );
+			const parsed = parseContent( serialized );
+			expect( parsed.html ).toBe( sections.html );
+			expect( parsed.css ).toBe( sections.css );
+			expect( parsed.js ).toBe( sections.js );
+		} );
+	} );
+} );

--- a/packages/block-library/src/html/utils.js
+++ b/packages/block-library/src/html/utils.js
@@ -1,0 +1,75 @@
+/**
+ * Parses content string into separate HTML, CSS, and JS sections.
+ *
+ * Extracts CSS from <style data-wp-block-html="css"> tags and
+ * JavaScript from <script data-wp-block-html="js"> tags.
+ * Everything else is treated as HTML.
+ *
+ * @param {string} content - The combined content string
+ * @return {Object} Object with html, css, and js properties
+ */
+export function parseContent( content = '' ) {
+	if ( ! content || ! content.trim() ) {
+		return { html: '', css: '', js: '' };
+	}
+
+	// Create a temporary document to parse HTML safely
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = content;
+
+	// Extract CSS from marked style tag
+	const styleTag = doc.body.querySelector(
+		'style[data-wp-block-html="css"]'
+	);
+	const css = styleTag ? styleTag.textContent.trim() : '';
+	if ( styleTag ) {
+		styleTag.remove();
+	}
+
+	// Extract JS from marked script tag
+	const scriptTag = doc.body.querySelector(
+		'script[data-wp-block-html="js"]'
+	);
+	const js = scriptTag ? scriptTag.textContent.trim() : '';
+	if ( scriptTag ) {
+		scriptTag.remove();
+	}
+
+	// Everything else is HTML
+	const html = doc.body.innerHTML.trim();
+
+	return { html, css, js };
+}
+
+/**
+ * Serializes HTML, CSS, and JS into a single content string.
+ *
+ * Creates marked <style> and <script> tags for CSS and JS sections,
+ * then appends the HTML content.
+ *
+ * @param {Object} sections      Object with html, css, and js properties
+ * @param {string} sections.html HTML content
+ * @param {string} sections.css  CSS content
+ * @param {string} sections.js   JavaScript content
+ * @return {string} Combined content string
+ */
+export function serializeContent( { html = '', css = '', js = '' } ) {
+	const parts = [];
+
+	// Add CSS if present
+	if ( css.trim() ) {
+		parts.push( `<style data-wp-block-html="css">\n${ css }\n</style>` );
+	}
+
+	// Add JS if present
+	if ( js.trim() ) {
+		parts.push( `<script data-wp-block-html="js">\n${ js }\n</script>` );
+	}
+
+	// Add HTML
+	if ( html.trim() ) {
+		parts.push( html );
+	}
+
+	return parts.join( '\n\n' );
+}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,10 @@
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 -   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
 
+### Internal
+
+-   `Modal`: Add a classname to simplify full height content modal styling ([#73108](https://github.com/WordPress/gutenberg/pull/73108)).
+
 ## 30.7.0 (2025-10-29)
 
 ### Bug Fixes

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -365,6 +365,7 @@ function UnforwardedModal(
 									? focusOnMountRef
 									: null,
 							] ) }
+							className="components-modal__children-container"
 						>
 							{ children }
 						</div>

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -18,11 +18,19 @@ test.describe( 'HTML block', () => {
 			page.locator( 'role=option[name="Custom HTML"i][selected]' )
 		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Edit HTML' } )
+			.click();
+		await page.getByRole( 'dialog' ).getByRole( 'textbox' ).click();
 		await page.keyboard.type( '<p>Pythagorean theorem: ' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type(
 			'<var>a</var><sup>2</sup> + <var>b</var><sup>2</sup> = <var>c</var><sup>2</sup> </p>'
 		);
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
 		// Check the content.
 		const content = await editor.getEditedPostContent();
 		expect( content ).toBe(
@@ -43,11 +51,19 @@ test.describe( 'HTML block', () => {
 			page.locator( 'role=option[name="Custom HTML"i][selected]' )
 		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Edit HTML' } )
+			.click();
+		await page.getByRole( 'dialog' ).getByRole( 'textbox' ).click();
 		await page.keyboard.type( '1 < 2' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
 		await editor.publishPost();
 		await page.reload();
 		await expect(
-			editor.canvas.locator( '[data-type="core/html"] textarea' )
+			editor.canvas.locator( '[data-type="core/html"] iframe' )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/preformatted.spec.js
+++ b/test/e2e/specs/editor/blocks/preformatted.spec.js
@@ -10,9 +10,17 @@ test.describe( 'Preformatted', () => {
 
 	test( 'should preserve character newlines', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/html' } );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Edit HTML' } )
+			.click();
+		await page.getByRole( 'dialog' ).getByRole( 'textbox' ).click();
 		await page.keyboard.type( '<pre>1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2</pre>' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 

--- a/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
+++ b/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
@@ -17,10 +17,17 @@ test.describe( 'Compatibility with classic editor', () => {
 		editor,
 	} ) => {
 		await editor.insertBlock( { name: 'core/html' } );
-		await editor.canvas.locator( 'role=textbox[name="HTML"i]' ).focus();
+		await editor.canvas
+			.getByRole( 'button', { name: 'Edit HTML' } )
+			.click();
+		await page.getByRole( 'dialog' ).getByRole( 'textbox' ).click();
 		await page.keyboard.type( '<a>' );
 		await page.keyboard.type( 'Random Link' );
 		await page.keyboard.type( '</a> ' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
 		// Publish Post
 		const postId = await editor.publishPost();
 		// View Post

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -90,20 +90,6 @@ test.describe( 'Toolbar roving tabindex', () => {
 			'Table'
 		);
 
-		// ensures custom html block toolbar uses roving tabindex
-		await editor.insertBlock( { name: 'core/html' } );
-		await ToolbarRovingTabindexUtils.testBlockToolbarKeyboardNavigation(
-			'HTML',
-			'Custom HTML'
-		);
-		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup(
-			'Custom HTML'
-		);
-		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
-			'Block: Custom HTML',
-			'Custom HTML'
-		);
-
 		// ensures image block toolbar uses roving tabindex
 		// This also tests if shift + tab works as expected to move focus to the toolbar when the preceding block has a form element.
 		await editor.insertBlock( { name: 'core/image' } );

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -582,10 +582,13 @@ test.describe( 'Widgets Customizer', () => {
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
 		await widgetsCustomizerPage.addBlock( 'Custom HTML' );
-		const HTMLBlockTextarea = page.locator(
-			'role=document[name="Block: Custom HTML"i] >> role=textbox[name="HTML"i]'
-		);
-		await HTMLBlockTextarea.type( 'hello' );
+		await page.getByRole( 'button', { name: 'Edit HTML' } ).click();
+		await page.getByRole( 'dialog' ).getByRole( 'textbox' ).click();
+		await page.keyboard.type( 'hello' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
 
 		// Click Publish
 		await Promise.all( [
@@ -596,8 +599,13 @@ test.describe( 'Widgets Customizer', () => {
 		// reload
 		await widgetsCustomizerPage.visitCustomizerPage();
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
-
-		await expect( HTMLBlockTextarea ).toHaveText( 'hello' );
+		await page
+			.locator( 'role=document[name="Block: Custom HTML"i]' )
+			.click();
+		await page.getByRole( 'button', { name: 'Edit' } ).click();
+		await expect(
+			page.getByRole( 'dialog' ).getByRole( 'textbox' )
+		).toHaveText( 'hello' );
 	} );
 } );
 


### PR DESCRIPTION
closes #73106

## What?

Redesigns the HTML block editing experience with a modal-based editor featuring separate tabs for HTML, CSS, and JavaScript and move to a modal (more details on the issue).

  ## How?

  ### Modal-based editing with vertical tabs

  - Block now always displays in preview mode with placeholder on initial addition.
  - "Edit" button in toolbar opens a fullscreen modal editor
  - Modal features four vertical tabs: HTML, CSS, JavaScript, and Preview
  - Save/Cancel buttons to commit or discard changes

### Content parsing and serialization

To achieve the tabs separation, we parse/serialize style and script tab by using data attributes to separate the "controlled" style/JS from the uncontrolled ones.  

  ## Testing Instructions

  1. **Basic editing:** Insert HTML block, click "Edit HTML", add content in tabs, preview and save
  2. **CSS and JavaScript:** Add styles and scripts in respective tabs, verify they work in preview
  3. **Unsaved changes:** Make edits, try to close modal, verify confirmation dialog works
  4. **Backward compatibility:** Test existing HTML blocks still work correctly