### PR TITLE
Allow embeds to grow and shrink inside flex group blocks

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -22,6 +22,12 @@
 	min-height: 240px;
 }
 
+// Allow embeds to grow and shrink inside flex group blocks (Stack/Row), preventing collapse while fitting available space.
+.wp-block-group.is-layout-flex .wp-block-embed {
+	flex: 1 1 0%;
+	min-width: 0;
+}
+
 .wp-block-embed {
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 


### PR DESCRIPTION
Closes #65741

<img width="734" height="302" alt="image" src="https://github.com/user-attachments/assets/55cb4166-78e2-4e13-8ee2-24a41e1db321" />

Testing instructions:

- Create and connect an embed block.
- Transform it to Row/Stack. The block should remain visible.
- Duplicate the block. The two embeds should render at 50% each.