### PR TITLE
Featured image block: add focal point controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -702,7 +702,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -58,6 +58,9 @@
 		"useFirstImageFromPost": {
 			"type": "boolean",
 			"default": false
+		},
+		"focalPoint": {
+			"type": "object"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -16,6 +16,7 @@ import {
 	Spinner,
 	TextControl,
 	ExternalLink,
+	FocalPointPicker,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -35,6 +36,7 @@ import {
 	useMemo,
 	useEffect,
 	useState,
+	useRef,
 	createInterpolateElement,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -53,6 +55,11 @@ import { unlock } from '../lock-unlock';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const { ResolutionTool } = unlock( blockEditorPrivateApis );
 const DEFAULT_MEDIA_SIZE_SLUG = 'full';
+const DEFAULT_FOCAL_POINT = { x: 0.5, y: 0.5 };
+
+function mediaPosition( { x, y } = DEFAULT_FOCAL_POINT ) {
+	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
+}
 
 function FeaturedImageResolutionTool( { image, value, onChange } ) {
 	const { imageSizes } = useSelect( ( select ) => {
@@ -99,8 +106,10 @@ export default function PostFeaturedImageEdit( {
 		rel,
 		linkTarget,
 		useFirstImageFromPost,
+		focalPoint,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState();
+	const imageElement = useRef();
 
 	const [ storedFeaturedImage, setFeaturedImage ] = useEntityProp(
 		'postType',
@@ -209,6 +218,7 @@ export default function PostFeaturedImageEdit( {
 			linkTarget: '_self',
 			rel: '',
 			sizeSlug: undefined,
+			focalPoint: undefined,
 		} );
 		setFeaturedImage( 0 );
 	};
@@ -224,6 +234,14 @@ export default function PostFeaturedImageEdit( {
 	const onUploadError = ( message ) => {
 		createErrorNotice( message, { type: 'snackbar' } );
 		setTemporaryURL();
+	};
+
+	const imperativeFocalPointPreview = ( value ) => {
+		if ( ! imageElement.current ) {
+			return;
+		}
+		// eslint-disable-next-line react-compiler/react-compiler
+		imageElement.current.style.objectPosition = mediaPosition( value );
 	};
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -255,6 +273,7 @@ export default function PostFeaturedImageEdit( {
 								linkTarget: '_self',
 								rel: '',
 								sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
+								focalPoint: undefined,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
@@ -361,6 +380,28 @@ export default function PostFeaturedImageEdit( {
 								}
 							/>
 						) }
+						<ToolsPanelItem
+							label={ __( 'Focal point' ) }
+							isShownByDefault
+							hasValue={ () => !! focalPoint }
+							onDeselect={ () =>
+								setAttributes( { focalPoint: undefined } )
+							}
+						>
+							<FocalPointPicker
+								__nextHasNoMarginBottom
+								label={ __( 'Focal point' ) }
+								url={ mediaUrl }
+								value={ focalPoint }
+								onDragStart={ imperativeFocalPointPreview }
+								onDrag={ imperativeFocalPointPreview }
+								onChange={ ( newFocalPoint ) =>
+									setAttributes( {
+										focalPoint: newFocalPoint,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
 					</ToolsPanel>
 				</InspectorControls>
 			) }
@@ -407,6 +448,7 @@ export default function PostFeaturedImageEdit( {
 		height: aspectRatio ? '100%' : height,
 		width: !! aspectRatio && '100%',
 		objectFit: !! ( height || aspectRatio ) && scale,
+		objectPosition: focalPoint ? mediaPosition( focalPoint ) : undefined,
 	};
 
 	/**
@@ -449,6 +491,7 @@ export default function PostFeaturedImageEdit( {
 			) : (
 				<>
 					<img
+						ref={ imageElement }
 						className={ borderProps.className }
 						src={ temporaryURL || mediaUrl }
 						alt={

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -51,6 +51,10 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! empty( $attributes['scale'] ) ) {
 		$extra_styles .= "object-fit:{$attributes['scale']};";
 	}
+	if ( ! empty( $attributes['focalPoint'] ) ) {
+		$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
+		$extra_styles   .= "object-position:{$object_position};";
+	}
 	if ( ! empty( $attributes['style']['shadow'] ) ) {
 		$shadow_styles = wp_style_engine_get_styles( array( 'shadow' => $attributes['style']['shadow'] ) );
 


### PR DESCRIPTION
## What?

Adds focal point picker to the Featured Image block. This partially addresses https://github.com/WordPress/gutenberg/issues/20321 by adding it to this block. This impacts both the Site Editor controls where you get a grey box that you can drag around for the focal point and in the Post Editor if you add a featured image block and it's able to pull the featured image in. 

## Why?
Users want the ability to control which part of the featured image is visible when using object-fit (cover/contain), similar to the Cover block. You can currently set the Cover image to a featured image and [set focal controls as well so this helps close the loop](https://github.com/Automattic/wp-calypso/issues/100142). 

## How?
  - Added `focalPoint` attribute to block.json
  - Added FocalPointPicker UI control in Settings panel
  - Applied focal point using CSS `object-position`
  - Implemented live preview during drag (matches Cover block behavior)

  ## Testing Instructions in the block editor

1. Create a post and set a featured image
2. Insert the Featured Image block
3. Set a fixed height or aspect ratio on the block
4. Open Settings panel → Focal Point picker should appear
5. Drag the focal point indicator - image should update in real-time
6. Save and verify the focal point persists

  ## Testing Instructions in the site editor

1. Open the site editor
2. Select the featured image block
3. Set an aspect ratio
4. Change the focal point.
5. View a post with a featured image and confirm it works.

  ## Screenshots or screencast

https://github.com/user-attachments/assets/e6f307ec-6bdd-4714-9b6f-dd7673bf548d

