### PR TITLE
Image: add focal point controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -437,7 +437,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
--	**Attributes:** alt, aspectRatio, blob, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -89,6 +89,9 @@
 		"scale": {
 			"type": "string"
 		},
+		"focalPoint": {
+			"type": "object"
+		},
 		"sizeSlug": {
 			"type": "string"
 		},

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -473,8 +473,10 @@ export default function Image( {
 
 	const imperativeFocalPointPreview = ( value ) => {
 		if ( imageElement ) {
-			// eslint-disable-next-line react-compiler/react-compiler
-			imageElement.style.objectPosition = mediaPosition( value );
+			imageElement.style.setProperty(
+				'object-position',
+				mediaPosition( value )
+			);
 		}
 	};
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -605,7 +605,6 @@ export default function Image( {
 	const resetSettings = () => {
 		setAttributes( {
 			lightbox: undefined,
-			focalPoint: undefined,
 		} );
 		updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 	};
@@ -875,9 +874,36 @@ export default function Image( {
 					width: undefined,
 					height: undefined,
 					scale: undefined,
+					focalPoint: undefined,
 				} ) }
 			>
 				{ dimensionsControl }
+				{ aspectRatio && url && (
+					<ToolsPanelItem
+						label={ __( 'Focal point' ) }
+						isShownByDefault
+						hasValue={ () => !! focalPoint }
+						onDeselect={ () =>
+							setAttributes( {
+								focalPoint: undefined,
+							} )
+						}
+						panelId={ clientId }
+					>
+						<FocalPointPicker
+							label={ __( 'Focal point' ) }
+							url={ url }
+							value={ focalPoint }
+							onDragStart={ imperativeFocalPointPreview }
+							onDrag={ imperativeFocalPointPreview }
+							onChange={ ( newFocalPoint ) =>
+								setAttributes( {
+									focalPoint: newFocalPoint,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+				) }
 			</InspectorControls>
 			{ !! imageSizeOptions.length && (
 				<InspectorControls>
@@ -892,32 +918,6 @@ export default function Image( {
 							onChange={ updateImage }
 							options={ imageSizeOptions }
 						/>
-						{ aspectRatio && url && (
-							<ToolsPanelItem
-								label={ __( 'Focal point' ) }
-								isShownByDefault
-								hasValue={ () => !! focalPoint }
-								onDeselect={ () =>
-									setAttributes( {
-										focalPoint: undefined,
-									} )
-								}
-							>
-								<FocalPointPicker
-									__nextHasNoMarginBottom
-									label={ __( 'Focal point' ) }
-									url={ url }
-									value={ focalPoint }
-									onDragStart={ imperativeFocalPointPreview }
-									onDrag={ imperativeFocalPointPreview }
-									onChange={ ( newFocalPoint ) =>
-										setAttributes( {
-											focalPoint: newFocalPoint,
-										} )
-									}
-								/>
-							</ToolsPanelItem>
-						) }
 					</ToolsPanel>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -471,6 +471,13 @@ export default function Image( {
 		setAttributes( { alt: newAlt } );
 	}
 
+	const imperativeFocalPointPreview = ( value ) => {
+		if ( imageElement ) {
+			// eslint-disable-next-line react-compiler/react-compiler
+			imageElement.style.objectPosition = mediaPosition( value );
+		}
+	};
+
 	function updateImage( newSizeSlug ) {
 		const newUrl = image?.media_details?.sizes?.[ newSizeSlug ]?.source_url;
 		if ( ! newUrl ) {
@@ -885,7 +892,7 @@ export default function Image( {
 							onChange={ updateImage }
 							options={ imageSizeOptions }
 						/>
-						{ ( aspectRatio || scale ) && url && (
+						{ aspectRatio && url && (
 							<ToolsPanelItem
 								label={ __( 'Focal point' ) }
 								isShownByDefault
@@ -901,6 +908,8 @@ export default function Image( {
 									label={ __( 'Focal point' ) }
 									url={ url }
 									value={ focalPoint }
+									onDragStart={ imperativeFocalPointPreview }
+									onDrag={ imperativeFocalPointPreview }
 									onChange={ ( newFocalPoint ) =>
 										setAttributes( {
 											focalPoint: newFocalPoint,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -62,8 +62,7 @@ import {
 	SIZED_LAYOUTS,
 	DEFAULT_MEDIA_SIZE_SLUG,
 } from './constants';
-import { evalAspectRatio } from './utils';
-import { mediaPosition } from '../cover/shared';
+import { evalAspectRatio, mediaPosition } from './utils';
 
 const { DimensionsTool, ResolutionTool } = unlock( blockEditorPrivateApis );
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -879,7 +879,7 @@ export default function Image( {
 				} ) }
 			>
 				{ dimensionsControl }
-				{ aspectRatio && url && (
+				{ url && scale && (
 					<ToolsPanelItem
 						label={ __( 'Focal point' ) }
 						isShownByDefault

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -4,6 +4,7 @@
 import { isBlobURL } from '@wordpress/blob';
 import {
 	ExternalLink,
+	FocalPointPicker,
 	ResizableBox,
 	Spinner,
 	TextareaControl,
@@ -62,6 +63,7 @@ import {
 	DEFAULT_MEDIA_SIZE_SLUG,
 } from './constants';
 import { evalAspectRatio } from './utils';
+import { mediaPosition } from '../cover/shared';
 
 const { DimensionsTool, ResolutionTool } = unlock( blockEditorPrivateApis );
 
@@ -279,6 +281,7 @@ export default function Image( {
 		height,
 		aspectRatio,
 		scale,
+		focalPoint,
 		linkTarget,
 		sizeSlug,
 		lightbox,
@@ -595,6 +598,7 @@ export default function Image( {
 	const resetSettings = () => {
 		setAttributes( {
 			lightbox: undefined,
+			focalPoint: undefined,
 		} );
 		updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 	};
@@ -881,6 +885,30 @@ export default function Image( {
 							onChange={ updateImage }
 							options={ imageSizeOptions }
 						/>
+						{ ( aspectRatio || scale ) && url && (
+							<ToolsPanelItem
+								label={ __( 'Focal point' ) }
+								isShownByDefault
+								hasValue={ () => !! focalPoint }
+								onDeselect={ () =>
+									setAttributes( {
+										focalPoint: undefined,
+									} )
+								}
+							>
+								<FocalPointPicker
+									__nextHasNoMarginBottom
+									label={ __( 'Focal point' ) }
+									url={ url }
+									value={ focalPoint }
+									onChange={ ( newFocalPoint ) =>
+										setAttributes( {
+											focalPoint: newFocalPoint,
+										} )
+									}
+								/>
+							</ToolsPanelItem>
+						) }
 					</ToolsPanel>
 				</InspectorControls>
 			) }
@@ -965,6 +993,10 @@ export default function Image( {
 							  }
 							: { width, height } ),
 						objectFit: scale,
+						objectPosition:
+							focalPoint && scale
+								? mediaPosition( focalPoint )
+								: undefined,
 						...borderProps.style,
 						...shadowProps.style,
 					} }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -14,6 +14,11 @@ import {
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { mediaPosition } from '../cover/shared';
+
 export default function save( { attributes } ) {
 	const {
 		url,
@@ -27,6 +32,7 @@ export default function save( { attributes } ) {
 		height,
 		aspectRatio,
 		scale,
+		focalPoint,
 		id,
 		linkTarget,
 		sizeSlug,
@@ -64,6 +70,10 @@ export default function save( { attributes } ) {
 				...shadowProps.style,
 				aspectRatio,
 				objectFit: scale,
+				objectPosition:
+					focalPoint && scale
+						? mediaPosition( focalPoint )
+						: undefined,
 				width,
 				height,
 			} }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -17,7 +17,7 @@ import {
 /**
  * Internal dependencies
  */
-import { mediaPosition } from '../cover/shared';
+import { mediaPosition } from './utils';
 
 export default function save( { attributes } ) {
 	const {

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -93,3 +93,7 @@ export function isValidFileType( file ) {
 		( mediaType ) => file.type.indexOf( mediaType ) === 0
 	);
 }
+
+export function mediaPosition( { x, y } = { x: 0.5, y: 0.5 } ) {
+	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
+}


### PR DESCRIPTION
## What?

Closes #73112

Adds focal point controls to the Image block, consistent with the Cover block and Featured
  Image implementations.

## Why?

Now that the Image block has aspect ratio control, users need focal point controls to specify which part of an image displays within a constrained aspect ratio. Currently, users must switch to the Cover block for this functionality.

## How?

- Added focalPoint attribute (type: object) to the Image block schema
- Added FocalPointPicker component to the block's InspectorControls (shown only when aspect
  ratio or scale is set)
- Applied focal point via object-position CSS property in both editor and frontend
- Reused the mediaPosition helper from the Cover block for consistency

## Testing Instructions

  1. Open a post or page
  2. Insert an Image block and upload/select an image
  3. In the Settings sidebar → Dimensions, set an aspect ratio (e.g., "16:9") or adjust the
  height with a scale option
  4. A "Focal point" control should appear in the Settings panel
  5. Click and drag on the focal point picker to adjust which part of the image is visible
  6. Verify the image updates in real-time as you drag
  7. Save/publish and verify the focal point is applied on the frontend

## Testing Instructions for Keyboard

  1. Follow steps 1-3 above
  2. Tab to the "Focal point" control in the Settings panel
  3. Use arrow keys to adjust the focal point position
  4. Verify the image updates accordingly

