### PR TITLE
Distraction Free: Keep the header visible in template-locked mode

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -31,8 +31,8 @@ $regionOutlineRatio: 2;
 	// a more abstracted approach to make the navigable regions focus style work
 	// regardless of the CSS used on other components.
 
-	// Header top bar when Distraction free mode is on.
-	&.is-distraction-free .interface-interface-skeleton__header .edit-post-header,
+	// Header top bar when animated header is enabled.
+	&.has-animated-header .interface-interface-skeleton__header .edit-post-header,
 	.interface-interface-skeleton__sidebar .editor-layout__toggle-sidebar-panel,
 	.interface-interface-skeleton__actions .editor-layout__toggle-publish-panel,
 	.interface-interface-skeleton__actions .editor-layout__toggle-entities-saved-states-panel,

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -21,6 +21,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
+import { DESIGN_POST_TYPES } from '../../store/constants';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
 
@@ -36,6 +37,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		listViewToggleRef,
 		showIconLabels,
 		renderingMode,
+		postType,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -44,6 +46,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			getInserterSidebarToggleRef,
 			getListViewToggleRef,
 			getRenderingMode,
+			getCurrentPostType,
 		} = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
@@ -59,6 +62,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isVisualMode: getEditorMode() === 'visual',
 			renderingMode: getRenderingMode(),
+			postType: getCurrentPostType(),
 		};
 	}, [] );
 
@@ -96,8 +100,11 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+	const isDesignPostType = DESIGN_POST_TYPES.includes( postType );
 	const showInserter =
-		! isDistractionFree || renderingMode === 'template-locked';
+		! isDistractionFree ||
+		renderingMode === 'template-locked' ||
+		isDesignPostType;
 
 	return (
 		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -35,6 +35,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		inserterSidebarToggleRef,
 		listViewToggleRef,
 		showIconLabels,
+		renderingMode,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -42,6 +43,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			getEditorMode,
 			getInserterSidebarToggleRef,
 			getListViewToggleRef,
+			getRenderingMode,
 		} = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
@@ -56,6 +58,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isVisualMode: getEditorMode() === 'visual',
+			renderingMode: getRenderingMode(),
 		};
 	}, [] );
 
@@ -93,6 +96,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+	const showInserter =
+		! isDistractionFree || renderingMode === 'template-locked';
 
 	return (
 		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to
@@ -109,7 +114,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
-				{ ! isDistractionFree && (
+				{ showInserter && (
 					<ToolbarButton
 						ref={ inserterSidebarToggleRef }
 						className="editor-document-tools__inserter-toggle"

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -18,6 +18,7 @@ import { useState, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { DESIGN_POST_TYPES } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 import EditorNotices from '../editor-notices';
 import Header from '../header';
@@ -64,10 +65,15 @@ export default function EditorInterface( {
 		stylesPath,
 		showStylebook,
 		renderingMode,
+		postType,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
-		const { getEditorSettings, getPostTypeLabel, getRenderingMode } =
-			select( editorStore );
+		const {
+			getEditorSettings,
+			getPostTypeLabel,
+			getRenderingMode,
+			getCurrentPostType,
+		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
 		);
@@ -95,6 +101,7 @@ export default function EditorInterface( {
 			stylesPath: getStylesPath(),
 			showStylebook: getShowStylebook(),
 			renderingMode: getRenderingMode(),
+			postType: getCurrentPostType(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -118,8 +125,11 @@ export default function EditorInterface( {
 		[ entitiesSavedStatesCallback ]
 	);
 
+	const isDesignPostType = DESIGN_POST_TYPES.includes( postType );
 	const shouldAnimateHeader =
-		isDistractionFree && renderingMode !== 'template-locked';
+		isDistractionFree &&
+		renderingMode !== 'template-locked' &&
+		! isDesignPostType;
 	const noticesInHeader = isDistractionFree;
 
 	return (

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -63,9 +63,11 @@ export default function EditorInterface( {
 		documentLabel,
 		stylesPath,
 		showStylebook,
+		renderingMode,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
-		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
+		const { getEditorSettings, getPostTypeLabel, getRenderingMode } =
+			select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
 		);
@@ -92,6 +94,7 @@ export default function EditorInterface( {
 				postTypeLabel || _x( 'Document', 'noun, breadcrumb' ),
 			stylesPath: getStylesPath(),
 			showStylebook: getShowStylebook(),
+			renderingMode: getRenderingMode(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -115,9 +118,14 @@ export default function EditorInterface( {
 		[ entitiesSavedStatesCallback ]
 	);
 
+	const shouldAnimateHeader =
+		isDistractionFree && renderingMode !== 'template-locked';
+	const noticesInHeader = isDistractionFree;
+
 	return (
 		<InterfaceSkeleton
-			isDistractionFree={ isDistractionFree }
+			shouldAnimateHeader={ shouldAnimateHeader }
+			noticesInHeader={ noticesInHeader }
 			className={ clsx( 'editor-editor-interface', className, {
 				'is-entity-save-view-open': !! entitiesSavedStatesCallback,
 				'is-distraction-free': isDistractionFree && ! isPreviewMode,

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -28,6 +28,7 @@ import {
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
+	DESIGN_POST_TYPES,
 } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 
@@ -109,9 +110,12 @@ function Header( {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	// In template-locked mode, we don't show the toolbar, so treat it as if there's no fixed toolbar
+	const isDesignPostType = DESIGN_POST_TYPES.includes( postType );
+	// In template-locked mode or design post types, we don't show the toolbar
 	const showsFixedToolbar =
-		hasFixedToolbar && renderingMode !== 'template-locked';
+		hasFixedToolbar &&
+		renderingMode !== 'template-locked' &&
+		! isDesignPostType;
 
 	const hasCenter =
 		! isTooNarrowForDocumentBar &&

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -64,12 +64,14 @@ function Header( {
 		hasBlockSelection,
 		hasSectionRootClientId,
 		isStylesCanvasActive,
+		renderingMode,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
 			getEditorMode,
 			getCurrentPostType,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
+			getRenderingMode,
 		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
@@ -89,6 +91,7 @@ function Header( {
 			isStylesCanvasActive:
 				!! getStylesPath()?.startsWith( '/revisions' ) ||
 				getShowStylebook(),
+			renderingMode: getRenderingMode(),
 		};
 	}, [] );
 
@@ -106,10 +109,14 @@ function Header( {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
+	// In template-locked mode, we don't show the toolbar, so treat it as if there's no fixed toolbar
+	const showsFixedToolbar =
+		hasFixedToolbar && renderingMode !== 'template-locked';
+
 	const hasCenter =
 		! isTooNarrowForDocumentBar &&
-		( ! hasFixedToolbar ||
-			( hasFixedToolbar &&
+		( ! showsFixedToolbar ||
+			( showsFixedToolbar &&
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
 
@@ -136,7 +143,7 @@ function Header( {
 				<DocumentTools
 					disableBlockTools={ isStylesCanvasActive || isTextEditor }
 				/>
-				{ hasFixedToolbar && isLargeViewport && (
+				{ showsFixedToolbar && isLargeViewport && (
 					<CollapsibleBlockToolbar
 						isCollapsed={ isBlockToolsCollapsed }
 						onToggle={ setIsBlockToolsCollapsed }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -32,17 +32,17 @@ import {
 import { unlock } from '../../lock-unlock';
 
 const toolbarVariations = {
-	distractionFreeDisabled: { y: '-50px' },
-	distractionFreeHover: { y: 0 },
-	distractionFreeHidden: { y: '-50px' },
+	animatedDisabled: { y: '-50px' },
+	animatedHover: { y: 0 },
+	animatedHidden: { y: '-50px' },
 	visible: { y: 0 },
 	hidden: { y: 0 },
 };
 
 const backButtonVariations = {
-	distractionFreeDisabled: { x: '-100%' },
-	distractionFreeHover: { x: 0 },
-	distractionFreeHidden: { x: '-100%' },
+	animatedDisabled: { x: '-100%' },
+	animatedHover: { x: 0 },
+	animatedHidden: { x: '-100%' },
 	visible: { x: 0 },
 	hidden: { x: 0 },
 };

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -249,7 +249,6 @@
 		}
 
 		& > .editor-header__toolbar .editor-document-tools__document-overview-toggle,
-		& > .editor-header__settings > .editor-preview-dropdown,
 		& > .editor-header__settings > .interface-pinned-items,
 		& > .editor-header__settings > .editor-zoom-out-toggle {
 			display: none;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -242,20 +242,7 @@
 }
 
 .editor-editor-interface.is-distraction-free {
-	.interface-interface-skeleton__header {
-		border-bottom: none;
-	}
-
 	.editor-header {
-		background-color: $white;
-		width: 100%;
-
-		@include break-medium {
-			box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
-			position: absolute;
-		}
-
-
 		// hide some parts
 		& > .edit-post-header__settings > .edit-post-header__post-preview-button {
 			visibility: hidden;
@@ -267,17 +254,6 @@
 		& > .editor-header__settings > .editor-zoom-out-toggle {
 			display: none;
 		}
-
-	}
-
-	// We need ! important because we override inline styles
-	// set by the motion component.
-	.interface-interface-skeleton__header:focus-within {
-		opacity: 1 !important;
-		div {
-			transform: translateX(0) translateZ(0) !important;
-		}
-
 	}
 
 	.components-editor-notices__dismissible {

--- a/packages/editor/src/store/constants.ts
+++ b/packages/editor/src/store/constants.ts
@@ -30,3 +30,4 @@ export const GLOBAL_POST_TYPES = [
 	'wp_block',
 	'wp_navigation',
 ];
+export const DESIGN_POST_TYPES = GLOBAL_POST_TYPES;

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -43,7 +43,7 @@ function useHTMLClass( className ) {
 const headerVariants = {
 	hidden: { opacity: 1, marginTop: -60 },
 	visible: { opacity: 1, marginTop: 0 },
-	distractionFreeHover: {
+	animatedHover: {
 		opacity: 1,
 		marginTop: 0,
 		transition: {
@@ -52,11 +52,11 @@ const headerVariants = {
 			delayChildren: 0.2,
 		},
 	},
-	distractionFreeHidden: {
+	animatedHidden: {
 		opacity: 0,
 		marginTop: -60,
 	},
-	distractionFreeDisabled: {
+	animatedDisabled: {
 		opacity: 0,
 		marginTop: 0,
 		transition: {
@@ -69,7 +69,8 @@ const headerVariants = {
 
 function InterfaceSkeleton(
 	{
-		isDistractionFree,
+		shouldAnimateHeader,
+		noticesInHeader,
 		footer,
 		header,
 		editorNotices,
@@ -116,7 +117,8 @@ function InterfaceSkeleton(
 			className={ clsx(
 				className,
 				'interface-interface-skeleton',
-				!! footer && 'has-footer'
+				!! footer && 'has-footer',
+				shouldAnimateHeader && 'has-animated-header'
 			) }
 		>
 			<div className="interface-interface-skeleton__editor">
@@ -127,23 +129,23 @@ function InterfaceSkeleton(
 							className="interface-interface-skeleton__header"
 							aria-label={ mergedLabels.header }
 							initial={
-								isDistractionFree && ! isMobileViewport
-									? 'distractionFreeHidden'
+								shouldAnimateHeader && ! isMobileViewport
+									? 'animatedHidden'
 									: 'hidden'
 							}
 							whileHover={
-								isDistractionFree && ! isMobileViewport
-									? 'distractionFreeHover'
+								shouldAnimateHeader && ! isMobileViewport
+									? 'animatedHover'
 									: 'visible'
 							}
 							animate={
-								isDistractionFree && ! isMobileViewport
-									? 'distractionFreeDisabled'
+								shouldAnimateHeader && ! isMobileViewport
+									? 'animatedDisabled'
 									: 'visible'
 							}
 							exit={
-								isDistractionFree && ! isMobileViewport
-									? 'distractionFreeHidden'
+								shouldAnimateHeader && ! isMobileViewport
+									? 'animatedHidden'
 									: 'hidden'
 							}
 							variants={ headerVariants }
@@ -153,7 +155,7 @@ function InterfaceSkeleton(
 						</NavigableRegion>
 					) }
 				</AnimatePresence>
-				{ isDistractionFree && (
+				{ noticesInHeader && (
 					<div className="interface-interface-skeleton__header">
 						{ editorNotices }
 					</div>

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -152,6 +152,32 @@ html.interface-interface-skeleton__html-container {
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 }
 
+// Animated header styles
+.interface-interface-skeleton.has-animated-header {
+	.interface-interface-skeleton__header {
+		border-bottom: none;
+		box-shadow: none;
+	}
+
+	// Generic header content styles for animated state
+	.interface-interface-skeleton__header > * {
+		@include break-medium() {
+			box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133);
+			position: absolute;
+			background-color: $white;
+			width: 100%;
+		}
+	}
+
+	// Focus-within override for motion styles
+	.interface-interface-skeleton__header:focus-within {
+		opacity: 1 !important;
+		div {
+			transform: translateX(0) translateZ(0) !important;
+		}
+	}
+}
+
 .interface-interface-skeleton__footer {
 	height: auto; // Keep the height flexible.
 	flex-shrink: 0;


### PR DESCRIPTION
## What?

Refactors `InterfaceSkeleton` to use generic UI props instead of editor-specific concepts, and fixes header fading in template-locked mode.

## Why?

In template-locked mode, in distraction free, users should be able to select blocks in the top of the template to edit them.

## How?

 - Remove domain semantics from InterfaceSkeleton.
 - Keep header visible in distraction free and template locked mode.

## Testing
  - Verify distraction-free mode still works in post-only mode (header fades)
  - Verify header stays visible in template-locked mode (no fading)
  - Verify edit-widgets interface is unaffected