### PR TITLE
Add Upload button to experimental media modal and always allow multiple uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54196,6 +54196,7 @@
 				"@wordpress/dataviews": "file:../dataviews",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
+				"@wordpress/icons": "file:../icons",
 				"@wordpress/private-apis": "file:../private-apis"
 			},
 			"engines": {

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/dataviews": "file:../dataviews",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/icons": "file:../icons",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
 	"publishConfig": {

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -8,7 +8,8 @@ import {
 	store as coreStore,
 } from '@wordpress/core-data';
 import { resolveSelect } from '@wordpress/data';
-import { Modal, DropZone } from '@wordpress/components';
+import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
+import { upload as uploadIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -290,6 +291,23 @@ export function MediaUploadModal( {
 		onClose?.();
 	}, [ onClose ] );
 
+	// Use onUpload if provided, otherwise fall back to uploadMedia
+	const handleUpload = onUpload || uploadMedia;
+
+	const handleFileSelect = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const files = event.target.files;
+			if ( files && files.length > 0 ) {
+				const filesArray = Array.from( files );
+				handleUpload( {
+					allowedTypes,
+					filesList: filesArray,
+				} );
+			}
+		},
+		[ allowedTypes, handleUpload ]
+	);
+
 	const paginationInfo = useMemo(
 		() => ( {
 			totalItems,
@@ -305,12 +323,17 @@ export function MediaUploadModal( {
 		[]
 	);
 
+	// Build accept attribute from allowedTypes
+	const acceptTypes = useMemo( () => {
+		if ( allowedTypes.includes( '*' ) ) {
+			return undefined;
+		}
+		return allowedTypes.join( ',' );
+	}, [ allowedTypes ] );
+
 	if ( ! isOpen ) {
 		return null;
 	}
-
-	// Use onUpload if provided, otherwise fall back to uploadMedia
-	const handleUpload = onUpload || uploadMedia;
 
 	return (
 		<Modal
@@ -319,6 +342,23 @@ export function MediaUploadModal( {
 			isDismissible={ isDismissible }
 			className={ modalClass }
 			size="fill"
+			headerActions={
+				<FormFileUpload
+					accept={ acceptTypes }
+					multiple
+					onChange={ handleFileSelect }
+					__next40pxDefaultSize
+					render={ ( { openFileDialog } ) => (
+						<Button
+							onClick={ openFileDialog }
+							icon={ uploadIcon }
+							__next40pxDefaultSize
+						>
+							{ __( 'Upload media' ) }
+						</Button>
+					) }
+				/>
+			}
 		>
 			<DropZone
 				onFilesDrop={ ( files ) => {
@@ -341,7 +381,6 @@ export function MediaUploadModal( {
 						handleUpload( {
 							allowedTypes,
 							filesList: filteredFiles,
-							multiple,
 						} );
 					}
 				} }

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../dataviews" },
 		{ "path": "../element" },
 		{ "path": "../i18n" },
+		{ "path": "../icons" },
 		{ "path": "../private-apis" }
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Starts addressing #73085.

Adds an "upload media" button to the media modal, and also adjusts the Dropzone logic to always allow dropping multiple files regardless of the modal's `multiple` property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the dataviews media modal experiment;
2. Add an Image block to a post;
3. Click to open media library and check the upload button at top right works correctly.
4. Also check it's possible to drop multiple files into the modal.

<img width="1030" height="387" alt="Screenshot 2025-11-10 at 11 36 35 am" src="https://github.com/user-attachments/assets/78685a55-fdaa-464f-bac3-6a7b73abf71e" />
