### PR TITLE
DataViews: Try removing outer padding from the component and layouts

### DIFF
--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -7,7 +7,7 @@
 	bottom: 0;
 	left: 0;
 	background-color: $white;
-	padding: $grid-unit-15 $grid-unit-60;
+	padding-top: $grid-unit-15;
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
 
@@ -16,12 +16,6 @@
 	}
 
 	z-index: z-index(".dataviews-footer");
-}
-
-@container (max-width: 430px) {
-	.dataviews-footer {
-		padding: $grid-unit-15 $grid-unit-30;
-	}
 }
 
 @container (max-width: 560px) {

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -19,7 +19,7 @@
 .dataviews__view-actions,
 .dataviews-filters__container {
 	box-sizing: border-box;
-	padding: $grid-unit-20 $grid-unit-60;
+	padding-bottom: $grid-unit-20;
 	flex-shrink: 0;
 	position: sticky;
 	left: 0;
@@ -31,7 +31,6 @@
 
 .dataviews-no-results,
 .dataviews-loading {
-	padding: 0 $grid-unit-60;
 	flex-grow: 1;
 	display: flex;
 	align-items: center;
@@ -44,19 +43,6 @@
 
 .dataviews-loading-more {
 	text-align: center;
-}
-
-@container (max-width: 430px) {
-	.dataviews__view-actions,
-	.dataviews-filters__container {
-		padding: $grid-unit-15 $grid-unit-30;
-	}
-
-	.dataviews-no-results,
-	.dataviews-loading {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 }
 
 .dataviews-title-field {
@@ -104,32 +90,4 @@
 		color: var(--wp-admin-theme-color);
 	}
 	@include link-reset();
-}
-
-/**
- * Applying a consistent 24px padding when DataViews are placed within cards.
- */
-.components-card__body:has(> .dataviews-wrapper),
-.components-card__body:has(> .dataviews-picker-wrapper) {
-	padding: $grid-unit-10 0 0;
-	overflow: hidden; // Prevent cells with white backgrounds overflowing the card
-
-	.dataviews__view-actions,
-	.dataviews-filters__container,
-	.dataviews-footer,
-	.dataviews-view-grid,
-	.dataviews-loading,
-	.dataviews-no-results {
-		padding-inline: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:first-child,
-	.dataviews-view-table tr th:first-child {
-		padding-inline-start: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:last-child,
-	.dataviews-view-table tr th:last-child {
-		padding-inline-end: $grid-unit-30;
-	}
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -183,11 +183,6 @@
 	font-weight: $font-weight-medium;
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
-	padding: 0 $grid-unit-60;
+	padding: 0;
 	container-type: inline-size;
-
-	@container (max-width: 430px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -63,16 +63,10 @@
 
 		td:first-child,
 		th:first-child {
-			padding-left: $grid-unit-60;
-
+			// TODO: Should this be removed?
 			.dataviews-view-table-header-button {
 				margin-left: - #{$grid-unit-10};
 			}
-		}
-
-		td:last-child,
-		th:last-child {
-			padding-right: $grid-unit-60;
 		}
 
 		&:last-child {
@@ -250,18 +244,6 @@
 				padding-right: 0;
 			}
 		}
-	}
-}
-
-@container (max-width: 430px) {
-	.dataviews-view-table tr td:first-child,
-	.dataviews-view-table tr th:first-child {
-		padding-left: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:last-child,
-	.dataviews-view-table tr th:last-child {
-		padding-right: $grid-unit-30;
 	}
 }
 

--- a/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
@@ -6,16 +6,9 @@
 	gap: $grid-unit-40;
 	grid-template-rows: max-content;
 	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-	padding: 0 $grid-unit-60 $grid-unit-30;
+	padding-top: 0;
+	padding-bottom: $grid-unit-30;
 	container-type: inline-size;
-	/**
-		* Breakpoints were adjusted from media queries breakpoints to account for
-		* the sidebar width. This was done to match the existing styles we had.
-		*/
-	@container (max-width: 430px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -266,18 +266,16 @@ export const WithModal = ( {
 					isFullScreen={ false }
 					size="fill"
 				>
-					<div style={ { padding: '16px' } }>
-						<DataViewsPickerContent
-							perPageSizes={ perPageSizes }
-							isMultiselectable={ isMultiselectable }
-							isGrouped={ isGrouped }
-							infiniteScrollEnabled={ infiniteScrollEnabled }
-							actions={ modalActions }
-							selection={ selectedItems.map( ( item ) =>
-								String( item.id )
-							) }
-						/>
-					</div>
+					<DataViewsPickerContent
+						perPageSizes={ perPageSizes }
+						isMultiselectable={ isMultiselectable }
+						isGrouped={ isGrouped }
+						infiniteScrollEnabled={ infiniteScrollEnabled }
+						actions={ modalActions }
+						selection={ selectedItems.map( ( item ) =>
+							String( item.id )
+						) }
+					/>
 				</Modal>
 			) }
 		</>

--- a/packages/dataviews/src/stories/dataviews.style.css
+++ b/packages/dataviews/src/stories/dataviews.style.css
@@ -10,7 +10,7 @@
 
 .free-composition-heading,
 .free-composition-header {
-	padding: 16px 48px;
+	padding: 16px 12px;
 }
 
 .free-composition-heading {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -204,6 +204,7 @@ export default function DataviewsPatterns() {
 				className="edit-site-page-patterns-dataviews"
 				title={ title }
 				subTitle={ description }
+				hasPadding
 				actions={
 					<>
 						{ isModified && (

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -318,6 +318,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			hasPadding
 			actions={
 				<>
 					{ isModified && (

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -221,6 +221,7 @@ export default function PostList( { postType } ) {
 	return (
 		<Page
 			title={ labels?.name }
+			hasPadding
 			actions={
 				<>
 					{ isModified && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Possible fix for: #72336 and an alternative to #72989 (which looked at adding padding as a configurable prop to DataViews)

This PR explores the idea of removing padding from the DataViews component (outer padding that is — internal padding, like the top of the footer, or vertical padding around the grid items is preserved).

When reviewing, I'm very happy for feedback on the overall direction, not just the code changes. This would be a breaking change, so I think we'll want to be fairly careful when considering the change.

## Why?

As described in #72336, the existing padding in DataViews means that there is unexpected additional padding when using DataViews (or DataViewsPicker) in contexts where padding already exists, such as Modals.

The idea in this PR and discussed in the issue is to try out removing padding from DataViews itself, so that the consumer is responsible for handling padding.

This presents some challenges and drawbacks, which I'll describe below. But the positive is that (at least in theory) the styling of DataViews can be slightly simpler.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove padding rules
* In areas in Gutenberg where DataViews is used, add padding to the page instead.

## ⚠️ Drawbacks and issues

Removing padding from DataViews highlights some challenges and has its drawbacks, including that consumers will need to update their styling to support this change. Outstanding issues include:

* Because the wrapper sets `overflow: auto`, any buttons at the edge of the DataViews now have their focused outlines cut off. This is because there is no longer padding to give it clearance.
* The scrollbar of the DataViews is now flush with items within the list or grid, this is because there is no longer padding to give scrollbar clearance.
* List items no longer extend all the way horizontally, nor the footer, so horizontal borders don't sit flush against the sides of the container
* Hovered items no longer hover the background color of the row all the way to edge of the container

## Testing Instructions

* Test in Storybook by running `npm run dev:storybook` and try out each of the different DataViews and DataViewsPicker stories to see how it looks and feels
* To see how it looks in Gutenberg, open up the site editor, and go to Pages. Try toggling through the different layouts (table, list, grid) and see how it looks
* Also take a look at the Templates and Pages screens
* To see the issues with scrollbars more visibly, set your OS to show scrollbars "always" if you haven't already

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### 🐛  Issue: Scrollbar sits flush with the grid items:

<img width="3552" height="1704" alt="image" src="https://github.com/user-attachments/assets/3b0034d6-0a5a-4a38-b83b-c1da84832a6f" />

### 🐛 Issue: List items hover state no longer looks balanced + focus styles on filters / config buttons gets cut off:

<img width="687" height="597" alt="image" src="https://github.com/user-attachments/assets/c1c024da-f97b-454f-9903-2809a7c2433b" />

### 🐛 Issue: When displayed in a Card, items no longer extend full width, so each item feels less like "part" of the card:

<img width="960" height="584" alt="image" src="https://github.com/user-attachments/assets/ef6cb87c-8c22-4ccb-808d-5ee0b5242c5a" />

### Modal: Generally looks good, but the top padding on the footer is less than the default padding of the modal, so it looks unbalanced:

<img width="973" height="684" alt="image" src="https://github.com/user-attachments/assets/22985a9a-69ed-4ebc-8070-87501c5fcfa8" />


