### PR TITLE
DataViews: Regression in DataViews pagination, On next page it does not increment count, instead it's concatenation

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -106,7 +106,7 @@ export default function DataviewsPatterns() {
 		slug: categoryId,
 		defaultView: DEFAULT_VIEW,
 		queryParams: {
-			page: Number( query.pageNumber ?? 1 ),
+			page: query.pageNumber ?? 1,
 			search: query.search,
 		},
 		onChangeQueryParams: ( params ) => {

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -66,7 +66,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const { set } = useDispatch( preferencesStore );
 
 	const baseView: View = persistedView ?? defaultView;
-	const page = queryParams?.page ?? baseView.page ?? 1;
+	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
 	// Merge URL query parameters (page, search) into the view
@@ -84,7 +84,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 		( newView: View ) => {
 			// Extract URL params (page, search) from the new view
 			const urlParams: { page?: number; search?: string } = {
-				page: newView?.page,
+				page: Number( newView?.page ),
 				search: newView?.search,
 			};
 			const preferenceView = omit( newView, [ 'page', 'search' ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73129

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Fixes the DataViews pagination.
- Regression from - https://github.com/WordPress/gutenberg/commit/af3d47d5a26b14d2026a4cb771a6074afc2417e3

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the useView hook, to typecast the page to Number coming from query params.
- This is added because, when taking the page from queryParam it is coming as a string, hence on next page it concatenates instead of incrementation, while for previous page, `string` - `Number` typecast to a Number, hence prev page is working as expected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to editor -> pages
2. Navigate via pagiantion.
3. Pagination works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3fffd8ca-741b-4650-b7e0-604f41b54bc1

