### PR TITLE
DataViews: Fix pagination

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -106,7 +106,7 @@ export default function DataviewsPatterns() {
 		slug: categoryId,
 		defaultView: DEFAULT_VIEW,
 		queryParams: {
-			page: Number( query.pageNumber ?? 1 ),
+			page: query.pageNumber,
 			search: query.search,
 		},
 		onChangeQueryParams: ( params ) => {

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -66,7 +66,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const { set } = useDispatch( preferencesStore );
 
 	const baseView: View = persistedView ?? defaultView;
-	const page = queryParams?.page ?? baseView.page ?? 1;
+	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
 	// Merge URL query parameters (page, search) into the view


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73129

From the issue: 

> On DataViews, clicking next page after (page 2), it is working as concatenation instead of increment.

> Initially, the view.page in data-views pagination is number, but when on clicking next page, it changes the view.page type to string, which makes it to concatenate instead of addition.


## Testing Instructions
1. DataViews pagination in site editor (pages, templates, patterns) should work as expected by navigating to next and previous pages