### PR TITLE
Testing: Add e2e test for DataViews pagination

### DIFF
--- a/test/e2e/specs/site-editor/dataviews-pagination.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-pagination.spec.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'DataViews Pagination', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		// Create 11 pages to force pagination when perPage is set to 10.
+		await Promise.all(
+			Array( 11 )
+				.fill()
+				.map( ( _, i ) =>
+					requestUtils.createPage( {
+						title: `Test Page ${ i + 1 }`,
+						status: 'publish',
+					} )
+				)
+		);
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deleteAllPages();
+	} );
+
+	test.beforeEach( async ( { admin, page } ) => {
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+	} );
+
+	test( 'navigates forward, backward, and forward again correctly', async ( {
+		page,
+	} ) => {
+		// Open View options and set items per page to 10.
+		await page.getByRole( 'button', { name: 'View options' } ).click();
+		await page.getByRole( 'radio', { name: 10 } ).click();
+		await page.keyboard.press( 'Escape' ); // Close the View options panel.
+
+		await page
+			.getByRole( 'button', { name: 'Next page', exact: true } )
+			.click();
+		expect( new URL( page.url() ).searchParams.get( 'pageNumber' ) ).toBe(
+			'2'
+		);
+		await page
+			.getByRole( 'button', { name: 'Previous page', exact: true } )
+			.click();
+		expect( new URL( page.url() ).searchParams.get( 'pageNumber' ) ).toBe(
+			'1'
+		);
+		await page
+			.getByRole( 'button', { name: 'Next page', exact: true } )
+			.click();
+		expect( new URL( page.url() ).searchParams.get( 'pageNumber' ) ).toBe(
+			'2'
+		);
+	} );
+} );

--- a/test/e2e/specs/site-editor/dataviews-pagination.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-pagination.spec.js
@@ -7,15 +7,17 @@ test.describe( 'DataViews Pagination', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		// Create 11 pages to force pagination when perPage is set to 10.
-		await Promise.all(
+		await requestUtils.batchRest(
 			Array( 11 )
 				.fill()
-				.map( ( _, i ) =>
-					requestUtils.createPage( {
+				.map( ( _, i ) => ( {
+					method: 'POST',
+					path: '/wp/v2/pages',
+					body: {
 						title: `Test Page ${ i + 1 }`,
 						status: 'publish',
-					} )
-				)
+					},
+				} ) )
 		);
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/73132

A new e2e test for DataViews pagination.
