### PR TITLE
Notes: Add keyboard support for tree navigation

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -66,6 +66,9 @@ export function Comments( {
 	const [ blockRefs, setBlockRefs ] = useState( {} );
 
 	const { setCanvasMinHeight } = unlock( useDispatch( editorStore ) );
+	const { selectBlock, toggleBlockSpotlight } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	const { blockCommentId, selectedBlockClientId, orderedBlockIds } =
 		useSelect( ( select ) => {
 			const {
@@ -310,6 +313,99 @@ export function Comments( {
 		setCanvasMinHeight,
 	] );
 
+	const handleThreadNavigation = useCallback(
+		( event, thread, isSelected ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			// Expand thread.
+			if (
+				( event.key === 'Enter' || event.key === 'ArrowRight' ) &&
+				event.currentTarget === event.target &&
+				! isSelected
+			) {
+				setNewNoteFormState( 'closed' );
+				setSelectedThread( thread.id );
+				if ( !! thread.blockClientId ) {
+					// Pass `null` as the second parameter to prevent focusing the block.
+					selectBlock( thread.blockClientId, null );
+					toggleBlockSpotlight( thread.blockClientId, true );
+				}
+				return;
+			}
+
+			// Collapse thread.
+			if (
+				( ( event.key === 'Enter' || event.key === 'ArrowLeft' ) &&
+					event.currentTarget === event.target &&
+					isSelected ) ||
+				event.key === 'Escape'
+			) {
+				setSelectedThread( null );
+				setNewNoteFormState( 'closed' );
+				if ( thread.blockClientId ) {
+					toggleBlockSpotlight( thread.blockClientId, false );
+				}
+				focusCommentThread( thread.id, commentSidebarRef.current );
+				return;
+			}
+
+			const currentIndex = threads.findIndex(
+				( t ) => t.id === thread.id
+			);
+
+			// Move to the next thread.
+			if (
+				event.key === 'ArrowDown' &&
+				currentIndex < threads.length - 1 &&
+				event.currentTarget === event.target
+			) {
+				const nextThread = threads[ currentIndex + 1 ];
+				focusCommentThread( nextThread.id, commentSidebarRef.current );
+				return;
+			}
+
+			// Move to the previous thread.
+			if (
+				event.key === 'ArrowUp' &&
+				currentIndex > 0 &&
+				event.currentTarget === event.target
+			) {
+				const prevThread = threads[ currentIndex - 1 ];
+				focusCommentThread( prevThread.id, commentSidebarRef.current );
+			}
+
+			// Move to the first thread.
+			if (
+				event.key === 'Home' &&
+				event.currentTarget === event.target
+			) {
+				focusCommentThread(
+					threads[ 0 ].id,
+					commentSidebarRef.current
+				);
+				return;
+			}
+
+			// Move to the last thread.
+			if ( event.key === 'End' && event.currentTarget === event.target ) {
+				focusCommentThread(
+					threads[ threads.length - 1 ].id,
+					commentSidebarRef.current
+				);
+			}
+		},
+		[
+			threads,
+			setSelectedThread,
+			setNewNoteFormState,
+			commentSidebarRef,
+			selectBlock,
+			toggleBlockSpotlight,
+		]
+	);
+
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	// This should no longer happen since https://github.com/WordPress/gutenberg/pull/72872.
 	if ( ! hasThreads && ! isFloating ) {
@@ -345,6 +441,13 @@ export function Comments( {
 					selectedThread={ selectedThread }
 					commentLastUpdated={ commentLastUpdated }
 					newNoteFormState={ newNoteFormState }
+					onKeyDown={ ( event ) =>
+						handleThreadNavigation(
+							event,
+							thread,
+							selectedThread === thread.id
+						)
+					}
 				/>
 			) ) }
 		</>
@@ -368,6 +471,7 @@ function Thread( {
 	selectedThread,
 	commentLastUpdated,
 	newNoteFormState,
+	onKeyDown,
 } ) {
 	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
@@ -464,27 +568,7 @@ function Thread( {
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onMouseEnter }
 			onBlur={ onMouseLeave }
-			onKeyDown={ ( event ) => {
-				if ( event.defaultPrevented ) {
-					return;
-				}
-				// Expand or Collapse thread.
-				if (
-					event.key === 'Enter' &&
-					event.currentTarget === event.target
-				) {
-					if ( isSelected ) {
-						unselectThread();
-					} else {
-						handleCommentSelect();
-					}
-				}
-				// Collapse thread and focus the thread.
-				if ( event.key === 'Escape' ) {
-					unselectThread();
-					focusCommentThread( thread.id, commentSidebarRef.current );
-				}
-			} }
+			onKeyDown={ onKeyDown }
 			tabIndex={ 0 }
 			role="treeitem"
 			aria-label={ ariaLabel }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -319,12 +319,16 @@ export function Comments( {
 				return;
 			}
 
-			// Expand thread.
+			const currentIndex = threads.findIndex(
+				( t ) => t.id === thread.id
+			);
+
 			if (
 				( event.key === 'Enter' || event.key === 'ArrowRight' ) &&
 				event.currentTarget === event.target &&
 				! isSelected
 			) {
+				// Expand thread.
 				setNewNoteFormState( 'closed' );
 				setSelectedThread( thread.id );
 				if ( !! thread.blockClientId ) {
@@ -332,64 +336,49 @@ export function Comments( {
 					selectBlock( thread.blockClientId, null );
 					toggleBlockSpotlight( thread.blockClientId, true );
 				}
-				return;
-			}
-
-			// Collapse thread.
-			if (
+			} else if (
 				( ( event.key === 'Enter' || event.key === 'ArrowLeft' ) &&
 					event.currentTarget === event.target &&
 					isSelected ) ||
 				event.key === 'Escape'
 			) {
+				// Collapse thread.
 				setSelectedThread( null );
 				setNewNoteFormState( 'closed' );
 				if ( thread.blockClientId ) {
 					toggleBlockSpotlight( thread.blockClientId, false );
 				}
 				focusCommentThread( thread.id, commentSidebarRef.current );
-				return;
-			}
-
-			const currentIndex = threads.findIndex(
-				( t ) => t.id === thread.id
-			);
-
-			// Move to the next thread.
-			if (
+			} else if (
 				event.key === 'ArrowDown' &&
 				currentIndex < threads.length - 1 &&
 				event.currentTarget === event.target
 			) {
+				// Move to the next thread.
 				const nextThread = threads[ currentIndex + 1 ];
 				focusCommentThread( nextThread.id, commentSidebarRef.current );
-				return;
-			}
-
-			// Move to the previous thread.
-			if (
+			} else if (
 				event.key === 'ArrowUp' &&
 				currentIndex > 0 &&
 				event.currentTarget === event.target
 			) {
+				// Move to the previous thread.
 				const prevThread = threads[ currentIndex - 1 ];
 				focusCommentThread( prevThread.id, commentSidebarRef.current );
-			}
-
-			// Move to the first thread.
-			if (
+			} else if (
 				event.key === 'Home' &&
 				event.currentTarget === event.target
 			) {
+				// Move to the first thread.
 				focusCommentThread(
 					threads[ 0 ].id,
 					commentSidebarRef.current
 				);
-				return;
-			}
-
-			// Move to the last thread.
-			if ( event.key === 'End' && event.currentTarget === event.target ) {
+			} else if (
+				event.key === 'End' &&
+				event.currentTarget === event.target
+			) {
+				// Move to the last thread.
 				focusCommentThread(
 					threads[ threads.length - 1 ].id,
 					commentSidebarRef.current


### PR DESCRIPTION
Closes #72958

## What?

This PR adds the following keyboard navigation to improve the accessibility of Note

## How?

To navigate to the adjacent note, the first note, or the last note, information about all the notes is required. Therefore, I moved the keydown event from the `Thread` component to the upstream `Comments` component.

## Testing Instructions

- The right arrow should open the tree item (same as Enter currently does), and left arrow should close it when the parent node is focused.
- Up/Down arrows should navigate between individual tree items.
- Home should go to the first comment.
- End should go to the last comment.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/1a99a384-2701-48fb-b16b-0081859006eb

