### PR TITLE
Pages DataViews: Fix content preview field after global styles refactor

### DIFF
--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -34,7 +34,7 @@ const DEFAULT_POST_BASE = {
 	},
 	showLevels: true,
 	titleField: 'title',
-	mediaField: 'featured_media',
+	mediaField: 'content-preview',
 	fields: [ 'author', 'status' ],
 	...defaultLayouts.list,
 };

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -34,7 +34,7 @@ const DEFAULT_POST_BASE = {
 	},
 	showLevels: true,
 	titleField: 'title',
-	mediaField: 'content-preview',
+	mediaField: 'featured_media',
 	fields: [ 'author', 'status' ],
 	...defaultLayouts.list,
 };

--- a/packages/editor/src/components/global-styles/hooks.js
+++ b/packages/editor/src/components/global-styles/hooks.js
@@ -188,8 +188,8 @@ export function useGlobalStyles() {
 /**
  * Hook to get a style value from global styles
  *
- * @param {string} path      Style path (e.g., 'color.background')
- * @param {string} blockName Optional block name
+ * @param {string}  path      Style path (e.g., 'color.background')
+ * @param {string=} blockName Optional block name
  * @return {*} Style value
  */
 export function useStyle( path, blockName ) {
@@ -203,8 +203,8 @@ export function useStyle( path, blockName ) {
 /**
  * Hook to get a setting value from global styles
  *
- * @param {string} path      Setting path (e.g., 'spacing.blockGap')
- * @param {string} blockName Optional block name
+ * @param {string}  path      Setting path (e.g., 'spacing.blockGap')
+ * @param {string=} blockName Optional block name
  * @return {*} Setting value
  */
 export function useSetting( path, blockName ) {

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -6,8 +6,6 @@ import {
 	// @ts-ignore
 	BlockPreview,
 	// @ts-ignore
-	privateApis as blockEditorPrivateApis,
-	// @ts-ignore
 } from '@wordpress/block-editor';
 import type { BasePost } from '@wordpress/fields';
 import { useSelect } from '@wordpress/data';
@@ -17,11 +15,10 @@ import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { EditorProvider } from '../../../components/provider';
+import { useStyle } from '../../../components/global-styles';
 import { unlock } from '../../../lock-unlock';
 // @ts-ignore
 import { store as editorStore } from '../../../store';
-
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function PostPreviewContainer( {
 	template,
@@ -30,7 +27,7 @@ function PostPreviewContainer( {
 	template: any;
 	post: any;
 } ) {
-	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ backgroundColor = 'white' ] = useStyle( 'color.background' );
 	const [ postBlocks ] = useEntityBlockEditor( 'postType', post.type, {
 		id: post.id,
 	} );


### PR DESCRIPTION
closes #73139

## What?

Fix the content preview field on pages dataviews. useGlobalStyle hook has been removed and was still being used in a field.
