### PR TITLE
Math format: remove empty format on serialise

### DIFF
--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -42,16 +42,18 @@ function InlineUI( {
 
 	// Update the math object in real-time as the user types
 	const handleLatexChange = ( newLatex ) => {
-		let mathML;
+		let mathML = '';
 
 		setLatex( newLatex );
 
-		try {
-			mathML = latexToMathML( newLatex, { displayMode: false } );
-			setError( null );
-		} catch ( err ) {
-			setError( err.message );
-			return;
+		if ( newLatex ) {
+			try {
+				mathML = latexToMathML( newLatex, { displayMode: false } );
+				setError( null );
+			} catch ( err ) {
+				setError( err.message );
+				return;
+			}
 		}
 
 		const newReplacements = value.replacements.slice();

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -250,40 +250,41 @@ export function toTree( {
 					),
 				} );
 			} else if ( formatType?.contentEditable === false ) {
-				pointer = getParent( pointer );
-				// For non editable formats, render the stored inner HTML.
-				if ( isEditableTree ) {
-					const attrs = {
-						contenteditable: 'false',
-						'data-rich-text-bogus': true,
-					};
-					if ( start === i && end === i + 1 ) {
-						attrs[ 'data-rich-text-format-boundary' ] = true;
+				if ( innerHTML || isEditableTree ) {
+					pointer = getParent( pointer );
+					// For non editable formats, render the stored inner HTML.
+					if ( isEditableTree ) {
+						const attrs = {
+							contenteditable: 'false',
+							'data-rich-text-bogus': true,
+						};
+						if ( start === i && end === i + 1 ) {
+							attrs[ 'data-rich-text-format-boundary' ] = true;
+						}
+						pointer = append( pointer, {
+							type: 'span',
+							attributes: attrs,
+						} );
+						// Some browsers like Safari and Firefox have issues placing
+						// the caret after a non-editable element when it's at the
+						// end of the field, so help them a little by providing a
+						// text element. Similar to `insertPadding` above.
+						if ( isEditableTree && i + 1 === text.length ) {
+							append( getParent( pointer ), ZWNBSP );
+						}
 					}
-					pointer = append( pointer, {
-						type: 'span',
-						attributes: attrs,
-					} );
-					// Some browsers like Safari and Firefox have issues placing
-					// the caret after a non-editable element when it's at the
-					// end of the field, so help them a little by providing a
-					// text element. Similar to `insertPadding` above.
-					if ( isEditableTree && i + 1 === text.length ) {
-						append( getParent( pointer ), ZWNBSP );
+					pointer = append(
+						pointer,
+						fromFormat( {
+							...replacement,
+							isEditableTree,
+						} )
+					);
+					if ( innerHTML ) {
+						append( pointer, {
+							html: innerHTML,
+						} );
 					}
-				}
-				pointer = append(
-					pointer,
-					fromFormat( {
-						...replacement,
-						isEditableTree,
-					} )
-				);
-
-				if ( innerHTML ) {
-					append( pointer, {
-						html: innerHTML,
-					} );
 				}
 			} else {
 				pointer = append(

--- a/test/e2e/specs/editor/various/format-library/math.spec.js
+++ b/test/e2e/specs/editor/various/format-library/math.spec.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Format Library - Math', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should insert math format with LaTeX', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add a paragraph block
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+
+		// Type some text
+		await page.keyboard.type( 'equation: ' );
+
+		// Access Math format via More menu
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.getByRole( 'menuitem', { name: 'Math' } ).click();
+
+		// Type LaTeX in the popover input
+		const mathInput = page.locator(
+			'.block-editor-format-toolbar__math-input input'
+		);
+		await mathInput.fill( 'x^2' );
+
+		// Verify the block contains math element with data-latex attribute
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						'equation: <math data-latex="x^2"><semantics><msup><mi>x</mi><mn>2</mn></msup><annotation encoding="application/x-tex">x^2</annotation></semantics></math>',
+				},
+			},
+		] );
+
+		// Test arrow key navigation around math element
+		// Shift+Tab to move focus out of the input
+		await pageUtils.pressKeys( 'shift+Tab' );
+
+		// Arrow left to move cursor before the math element
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Type text before the math
+		await page.keyboard.type( 'a' );
+
+		// Verify text is before the math
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						'equation: a<math data-latex="x^2"><semantics><msup><mi>x</mi><mn>2</mn></msup><annotation encoding="application/x-tex">x^2</annotation></semantics></math>',
+				},
+			},
+		] );
+
+		// Arrow right to move cursor after the math element
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Type text after the math
+		await page.keyboard.type( 'b' );
+
+		// Verify text is after the math
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						'equation: a<math data-latex="x^2"><semantics><msup><mi>x</mi><mn>2</mn></msup><annotation encoding="application/x-tex">x^2</annotation></semantics></math>b',
+				},
+			},
+		] );
+
+		await pageUtils.pressKeys( 'ArrowLeft' );
+
+		// Test selecting and clearing math element
+		// Shift+ArrowLeft to select the math element (cursor is already after it)
+		await pageUtils.pressKeys( 'shift+ArrowLeft' );
+
+		// Shift+Tab to focus into the input
+		await page.keyboard.press( 'Tab' );
+
+		// Empty the content
+		await page.keyboard.press( 'Backspace' );
+
+		// Verify the math element is removed
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'equation: ab',
+				},
+			},
+		] );
+	} );
+} );

--- a/test/e2e/specs/editor/various/format-library/math.spec.js
+++ b/test/e2e/specs/editor/various/format-library/math.spec.js
@@ -13,26 +13,30 @@ test.describe( 'Format Library - Math', () => {
 		page,
 		pageUtils,
 	} ) => {
-		// Add a paragraph block
 		await editor.canvas
 			.getByRole( 'button', { name: 'Add default block' } )
 			.click();
 
-		// Type some text
 		await page.keyboard.type( 'equation: ' );
 
-		// Access Math format via More menu
 		await editor.clickBlockToolbarButton( 'More' );
 		await page.getByRole( 'menuitem', { name: 'Math' } ).click();
 
-		// Type LaTeX in the popover input
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'equation: ',
+				},
+			},
+		] );
+
 		const mathInput = page.locator(
 			'.block-editor-format-toolbar__math-input input'
 		);
 		await mathInput.fill( 'x^2' );
 
-		// Verify the block contains math element with data-latex attribute
-		await expect.poll( editor.getBlocks ).toMatchObject( [
+		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -42,18 +46,12 @@ test.describe( 'Format Library - Math', () => {
 			},
 		] );
 
-		// Test arrow key navigation around math element
-		// Shift+Tab to move focus out of the input
+		// Test typing before.
 		await pageUtils.pressKeys( 'shift+Tab' );
-
-		// Arrow left to move cursor before the math element
 		await page.keyboard.press( 'ArrowLeft' );
-
-		// Type text before the math
 		await page.keyboard.type( 'a' );
 
-		// Verify text is before the math
-		await expect.poll( editor.getBlocks ).toMatchObject( [
+		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -63,14 +61,11 @@ test.describe( 'Format Library - Math', () => {
 			},
 		] );
 
-		// Arrow right to move cursor after the math element
+		// Test typing after.
 		await page.keyboard.press( 'ArrowRight' );
-
-		// Type text after the math
 		await page.keyboard.type( 'b' );
 
-		// Verify text is after the math
-		await expect.poll( editor.getBlocks ).toMatchObject( [
+		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -80,19 +75,12 @@ test.describe( 'Format Library - Math', () => {
 			},
 		] );
 
+		// Test removing math element.
 		await pageUtils.pressKeys( 'ArrowLeft' );
-
-		// Test selecting and clearing math element
-		// Shift+ArrowLeft to select the math element (cursor is already after it)
 		await pageUtils.pressKeys( 'shift+ArrowLeft' );
-
-		// Shift+Tab to focus into the input
 		await page.keyboard.press( 'Tab' );
-
-		// Empty the content
 		await page.keyboard.press( 'Backspace' );
 
-		// Verify the math element is removed
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

When adding inline math in rich text, and you dismiss it or empty it later, it leaves an empty math element.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This should not happen, we should remove it on serialization. This is similar to how there's no bold until there's content to bold.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When an object in rich text is contenteditable and doesn't have content, don't serialize anything.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add inline math to rich text. Don't write anything in the input. Then check the code editor, there shouldn't be a math element.

Also adds e2e tests for the math format generally.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
