### PR TITLE
DataViews: show "is busy" animation on row actions

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -46,6 +46,7 @@ function ActionWithModal< Item >( {
 			setIsModalOpen( true );
 		},
 		items,
+		isBusy: false,
 	};
 	return (
 		<>

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -29,7 +29,7 @@ const { Menu, kebabCase } = unlock( componentsPrivateApis );
 export interface ActionTriggerProps< Item > {
 	action: Action< Item >;
 	onClick: MouseEventHandler;
-	isBusy?: boolean;
+	isBusy: boolean;
 	items: Item[];
 }
 
@@ -44,6 +44,8 @@ interface ActionsMenuGroupProps< Item > {
 	item: Item;
 	registry: ReturnType< typeof useRegistry >;
 	setActiveModalAction: ( action: ActionModalType< Item > | null ) => void;
+	actionInProgress: string | null;
+	setActionInProgress: ( actionId: string | null ) => void;
 }
 
 interface ItemActionsProps< Item > {
@@ -57,25 +59,31 @@ interface CompactItemActionsProps< Item > {
 	actions: Action< Item >[];
 	isSmall?: boolean;
 	registry: ReturnType< typeof useRegistry >;
+	actionInProgress: string | null;
+	setActionInProgress: ( actionId: string | null ) => void;
 }
 
 interface PrimaryActionsProps< Item > {
 	item: Item;
 	actions: Action< Item >[];
 	registry: ReturnType< typeof useRegistry >;
+	actionInProgress: string | null;
+	setActionInProgress: ( actionId: string | null ) => void;
 }
 
 function ButtonTrigger< Item >( {
 	action,
 	onClick,
 	items,
+	isBusy,
 }: ActionTriggerProps< Item > ) {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
 		<Button
-			disabled={ !! action.disabled }
 			accessibleWhenDisabled
+			disabled={ !! action.disabled || isBusy }
+			isBusy={ isBusy }
 			size="compact"
 			onClick={ onClick }
 		>
@@ -88,11 +96,12 @@ function MenuItemTrigger< Item >( {
 	action,
 	onClick,
 	items,
+	isBusy,
 }: ActionTriggerProps< Item > ) {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Menu.Item disabled={ action.disabled } onClick={ onClick }>
+		<Menu.Item disabled={ action.disabled || isBusy } onClick={ onClick }>
 			<Menu.ItemLabel>{ label }</Menu.ItemLabel>
 		</Menu.Item>
 	);
@@ -131,6 +140,8 @@ export function ActionsMenuGroup< Item >( {
 	item,
 	registry,
 	setActiveModalAction,
+	actionInProgress,
+	setActionInProgress,
 }: ActionsMenuGroupProps< Item > ) {
 	const { primaryActions, regularActions } = useMemo( () => {
 		return actions.reduce(
@@ -181,6 +192,9 @@ export default function ItemActions< Item >( {
 	isCompact,
 }: ItemActionsProps< Item > ) {
 	const registry = useRegistry();
+	const [ actionInProgress, setActionInProgress ] = useState< string | null >(
+		null
+	);
 	const { primaryActions, eligibleActions } = useMemo( () => {
 		// If an action is eligible for all items, doesn't need
 		// to provide the `isEligible` function.
@@ -203,6 +217,8 @@ export default function ItemActions< Item >( {
 				actions={ eligibleActions }
 				isSmall
 				registry={ registry }
+				actionInProgress={ actionInProgress }
+				setActionInProgress={ setActionInProgress }
 			/>
 		);
 	}
@@ -221,12 +237,16 @@ export default function ItemActions< Item >( {
 				item={ item }
 				actions={ primaryActions }
 				registry={ registry }
+				actionInProgress={ actionInProgress }
+				setActionInProgress={ setActionInProgress }
 			/>
 			{ primaryActions.length < eligibleActions.length && (
 				<CompactItemActions
 					item={ item }
 					actions={ eligibleActions }
 					registry={ registry }
+					actionInProgress={ actionInProgress }
+					setActionInProgress={ setActionInProgress }
 				/>
 			) }
 		</HStack>
@@ -238,6 +258,8 @@ function CompactItemActions< Item >( {
 	actions,
 	isSmall,
 	registry,
+	actionInProgress,
+	setActionInProgress,
 }: CompactItemActionsProps< Item > ) {
 	const [ activeModalAction, setActiveModalAction ] = useState(
 		null as ActionModalType< Item > | null
@@ -263,6 +285,8 @@ function CompactItemActions< Item >( {
 						item={ item }
 						registry={ registry }
 						setActiveModalAction={ setActiveModalAction }
+						actionInProgress={ actionInProgress }
+						setActionInProgress={ setActionInProgress }
 					/>
 				</Menu.Popover>
 			</Menu>
@@ -281,6 +305,8 @@ function PrimaryActions< Item >( {
 	item,
 	actions,
 	registry,
+	actionInProgress,
+	setActionInProgress,
 }: PrimaryActionsProps< Item > ) {
 	const [ activeModalAction, setActiveModalAction ] = useState( null as any );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -298,13 +324,16 @@ function PrimaryActions< Item >( {
 				<ButtonTrigger
 					key={ action.id }
 					action={ action }
-					onClick={ () => {
+					onClick={ async () => {
 						if ( 'RenderModal' in action ) {
 							setActiveModalAction( action );
 							return;
 						}
-						action.callback( [ item ], { registry } );
+						setActionInProgress( action.id );
+						await action.callback( [ item ], { registry } );
+						setActionInProgress( null );
 					} }
+					isBusy={ actionInProgress === action.id }
 					items={ [ item ] }
 				/>
 			) ) }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -171,6 +171,9 @@ function ListItem< Item >( {
 	const [ activeModalAction, setActiveModalAction ] = useState(
 		null as ActionModalType< Item > | null
 	);
+	const [ actionInProgress, setActionInProgress ] = useState< string | null >(
+		null
+	);
 	const handleHover: React.MouseEventHandler = ( { type } ) => {
 		const isHover = type === 'mouseenter';
 		setIsHovered( isHover );
@@ -259,6 +262,8 @@ function ListItem< Item >( {
 								item={ item }
 								registry={ registry }
 								setActiveModalAction={ setActiveModalAction }
+								actionInProgress={ actionInProgress }
+								setActionInProgress={ setActionInProgress }
 							/>
 						</Menu.Popover>
 					</Menu>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

When row-actions take a longer time, we don't show "is busy" animation like we do for multi-item actions:


https://github.com/user-attachments/assets/78ef69a2-5969-4bfb-a361-2b9429fd7ec1



<!-- In a few words, what is the PR actually doing? -->

### Before


https://github.com/user-attachments/assets/6d387b49-6a40-4c9d-b159-858e9b156710



### After

WIP


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
