### PR TITLE
Improve checkbox selection UX in dataviews table

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -121,25 +121,44 @@ export function BulkSelectionCheckbox< Item >( {
 			selectableItems.includes( item )
 	);
 	const areAllSelected = selectedItems.length === selectableItems.length;
+	const handleToggle = () => {
+		if ( areAllSelected ) {
+			onChangeSelection( [] );
+		} else {
+			onChangeSelection(
+				selectableItems.map( ( item ) => getItemId( item ) )
+			);
+		}
+	};
 	return (
-		<CheckboxControl
-			className="dataviews-view-table-selection-checkbox"
-			__nextHasNoMarginBottom
-			checked={ areAllSelected }
-			indeterminate={ ! areAllSelected && !! selectedItems.length }
-			onChange={ () => {
-				if ( areAllSelected ) {
-					onChangeSelection( [] );
-				} else {
-					onChangeSelection(
-						selectableItems.map( ( item ) => getItemId( item ) )
-					);
+		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+		<div
+			onClick={ ( event ) => {
+				// Prevent triggering if clicking directly on the checkbox
+				if (
+					event.target instanceof HTMLElement &&
+					( event.target.tagName === 'INPUT' ||
+						event.target.closest( 'input' ) )
+				) {
+					return;
 				}
+				// Stop propagation to prevent any parent handlers from interfering
+				event.stopPropagation();
+				handleToggle();
 			} }
-			aria-label={
-				areAllSelected ? __( 'Deselect all' ) : __( 'Select all' )
-			}
-		/>
+			style={ { cursor: 'pointer' } }
+		>
+			<CheckboxControl
+				className="dataviews-view-table-selection-checkbox"
+				__nextHasNoMarginBottom
+				checked={ areAllSelected }
+				indeterminate={ ! areAllSelected && !! selectedItems.length }
+				onChange={ handleToggle }
+				aria-label={
+					areAllSelected ? __( 'Deselect all' ) : __( 'Select all' )
+				}
+			/>
+		</div>
 	);
 }
 

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -196,7 +196,37 @@ function TableRow< Item >( {
 		>
 			{ hasBulkActions && (
 				<td className="dataviews-view-table__checkbox-column">
-					<div className="dataviews-view-table__cell-content-wrapper">
+					{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */ }
+					<div
+						className="dataviews-view-table__cell-content-wrapper"
+						onClick={ ( event ) => {
+							if ( ! hasPossibleBulkAction ) {
+								return;
+							}
+							// Prevent triggering if clicking directly on the checkbox
+							if (
+								event.target instanceof HTMLElement &&
+								( event.target.tagName === 'INPUT' ||
+									event.target.closest( 'input' ) )
+							) {
+								return;
+							}
+							// Stop propagation to prevent row click handler from interfering
+							event.stopPropagation();
+							onChangeSelection(
+								selection.includes( id )
+									? selection.filter(
+											( itemId ) => id !== itemId
+									  )
+									: [ ...selection, id ]
+							);
+						} }
+						style={ {
+							cursor: hasPossibleBulkAction
+								? 'pointer'
+								: 'default',
+						} }
+					>
 						<DataViewsSelectionCheckbox
 							item={ item }
 							selection={ selection }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -47,10 +47,24 @@
 
 		&.dataviews-view-table__checkbox-column {
 			padding-right: 0;
+			padding-left: 0;
 
 			.dataviews-view-table__cell-content-wrapper {
 				max-width: auto;
 				min-width: auto;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				padding: $grid-unit-15;
+				min-height: 100%;
+			}
+
+			> div {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				padding: $grid-unit-15;
+				min-height: 100%;
 			}
 		}
 	}


### PR DESCRIPTION
Refactored bulk selection checkbox logic to handle clicks on the entire cell, not just the checkbox, and prevent event propagation issues. Updated styles for better alignment and padding of checkbox columns. These changes enhance usability and consistency for bulk actions in dataviews tables.

## Screenrecording

Before:

https://github.com/user-attachments/assets/4476a21b-93b5-4ba6-9f23-164bb68e0619

After:

https://github.com/user-attachments/assets/cde4687e-ca6a-4c84-b531-5d90f0e6919d


## What?
This PR make the checkbox a bit more clickable by making the clickable area larger. 

## Why?
While using the dataview in the admin area some of the feedback that we got was that checkbox are sometimes hard to click on desktop since if you miss just by a little bit you loose your selection and have to start all over again. 

This PR take a bit of a different approach from the current classic table view (that exists in the old wp-admin UI) by providing not making the whole cell clickable but just the surrounding area. 

## How?
This is done by adding a new wrapping div that take care of the on click event and the event bubbeling. 

## Testing Instructions
Load this PR. 
CLick on the checkboxes inte dataview. Do they still work as you would expect. Are you able to click just outside the checkbox and still make the checkbox?

### Testing Instructions for Keyboard
Use the keyboard in the data view it works as you would expect. 
