### PR TITLE
iAPI Router:  Show warning message for missing `data-wp-interactive` in router regions

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -25,6 +25,7 @@ const {
 	routerRegions,
 	cloneElement,
 	navigationSignal,
+	warn,
 } = privateApis(
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
 );
@@ -190,6 +191,29 @@ const preparePage: PreparePage = async ( url, dom, { vdom } = {} ) => {
 
 	const regions = {};
 	const regionsToAttach = {};
+
+	if ( globalThis.SCRIPT_DEBUG ) {
+		// Warn about router regions without a `data-wp-interactive` directive.
+		const invalidRouterRegions = document.querySelectorAll(
+			'[data-wp-router-region]:not([data-wp-interactive])'
+		);
+
+		if ( invalidRouterRegions.length > 0 ) {
+			const ids = Array.from( invalidRouterRegions )
+				.map( ( region ) => {
+					const { id } = parseRegionAttribute( region );
+					return `"${ id }"`;
+				} )
+				.join( ', ' );
+
+			warn(
+				`Page "${ url }" contains the following router regions without a 'data-wp-interactive' attribute: ${ ids }.
+
+Elements with a 'data-wp-router-region' directive must also include a 'data-wp-interactive' attribute on the same element in order for these router regions to be updated correctly during navigation.`
+			);
+		}
+	}
+
 	dom.querySelectorAll( regionsSelector ).forEach( ( region ) => {
 		const { id, attachTo } = parseRegionAttribute( region );
 

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -18,7 +18,7 @@ import { directive } from './hooks';
 import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
-import { deepReadOnly, navigationSignal } from './utils';
+import { deepReadOnly, navigationSignal, warn } from './utils';
 
 export {
 	store,
@@ -65,6 +65,7 @@ export const privateApis = (
 			routerRegions,
 			deepReadOnly,
 			navigationSignal,
+			warn,
 		};
 	}
 


### PR DESCRIPTION
## What?

Displays a warning message if router regions are found without a `data-wp-interactive` attribute.

<!-- In a few words, what is the PR actually doing? -->

## Why?

As mentioned in https://github.com/WordPress/gutenberg/pull/71635#issuecomment-3313963231, router regions, even nested inside a `data-wp-interactive` element, require both `data-wp-router-region` and `data-wp-interactive` attributes to be in place. When `data-wp-interactive` is missing, no warning message is emitted, causing confusion to developers (see https://github.com/WordPress/gutenberg/issues/70883#issuecomment-3510794860).

## How?

This PR does two things:
- Exposes the `warn` util from the Interactivity API as a private API.
- Uses `warn` to display a warning message when `SCRIPT_DEBUG` is `true`.

## Testing Instructions

1. Go to the site editor.
2. Modify the homepage template and add the following HTML outside of the Query block.
   ```html
   <div data-wp-router-region="region-1">Region 1.</div>
   <div data-wp-router-region="region-2">Region 2.</div>
   ```
3. Ensure "Force page reload" is disabled in the Query block.
4. Visit the homepage.
5. Open the console.
6. Hover the "Next Page" link.
7. Ensure a warning similar to this one appears on the console:
   ```
   Page "/?query-1-page=2" contains the following router regions without a 'data-wp-interactive' attribute: "region-1", "region-2".
   
   Elements with a 'data-wp-router-region' directive must also include a 'data-wp-interactive' attribute on the same element in order for these router regions to be updated correctly during navigation.
   ```
