### PR TITLE
Add: Stretch text variations transforms

### DIFF
--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -3,8 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/primitives';
+import { heading } from '@wordpress/icons';
 
 const variations = [
+	{
+		name: 'heading',
+		title: __( 'Heading' ),
+		description: __(
+			'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
+		),
+		isDefault: true,
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: { fitText: undefined },
+		icon: heading,
+	},
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
 	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
@@ -17,7 +29,7 @@ const variations = [
 			</SVG>
 		),
 		attributes: { fitText: true },
-		scope: [ 'inserter' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
 	},
 ];

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -13,7 +13,7 @@ const variations = [
 			'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.'
 		),
 		isDefault: true,
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'inserter', 'transform' ],
 		attributes: { fitText: undefined },
 		icon: heading,
 	},

--- a/packages/block-library/src/paragraph/variations.js
+++ b/packages/block-library/src/paragraph/variations.js
@@ -3,8 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/primitives';
+import { paragraph } from '@wordpress/icons';
 
 const variations = [
+	{
+		name: 'paragraph',
+		title: __( 'Paragraph' ),
+		description: __(
+			'Start with the basic building block of all narrative.'
+		),
+		isDefault: true,
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: { fitText: undefined },
+		icon: paragraph,
+	},
 	// There is a hardcoded workaround in packages/block-editor/src/store/selectors.js
 	// to make Stretchy variations appear as the last of their sections in the inserter.
 	{
@@ -19,7 +31,7 @@ const variations = [
 		attributes: {
 			fitText: true,
 		},
-		scope: [ 'inserter' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => blockAttributes.fitText === true,
 	},
 ];

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -352,6 +352,8 @@ test.describe( 'Post-type locking', () => {
 					.getByRole( 'menu', { name: 'Paragraph', exact: true } )
 					.getByRole( 'menuitem' )
 			).toHaveText( [
+				'Paragraph',
+				'Stretchy Paragraph',
 				'Heading',
 				'List',
 				'Quote',


### PR DESCRIPTION
This PR readds the variations transforms for Stretchy Text variations which were tried at https://github.com/WordPress/gutenberg/pull/73056 but ended not being part of what was merged.

The downside is that they are prominient but @ellatrix raised an important point the version that is currently merged does not allow to transform any existing block into their stretchy versions. Adding the transforms solves that using the same approach that allows a group the be transformed in a grid.

## Screenshots 
<img width="313" height="265" alt="Screenshot 2025-11-10 at 20 55 55" src="https://github.com/user-attachments/assets/c8f50494-ff07-4b08-a181-4dc9b512643a" />
<img width="939" height="568" alt="Screenshot 2025-11-10 at 20 55 15" src="https://github.com/user-attachments/assets/2120475d-2512-49f8-a9b1-413086af3a31" />
<img width="281" height="567" alt="Screenshot 2025-11-10 at 20 55 07" src="https://github.com/user-attachments/assets/521dcd4d-5257-4823-8ce4-3b2d40cc5423" />


