### PR TITLE
Fix broken editor when passing attributes as undefined or null and add warning for block authors

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -257,23 +257,6 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		return;
 	}
 
-	// Warn if attributes is explicitly set to undefined or null in metadata or settings.
-	if (
-		( isObject( blockNameOrMetadata ) &&
-			'attributes' in blockNameOrMetadata &&
-			( blockNameOrMetadata.attributes === null ||
-				blockNameOrMetadata.attributes === undefined ) ) ||
-		( 'attributes' in settings &&
-			( settings.attributes === null ||
-				settings.attributes === undefined ) )
-	) {
-		warning(
-			'The block "' +
-				name +
-				'" must not register attributes as null or undefined. Use an empty object or exclude the attributes key.'
-		);
-	}
-
 	const { addBootstrappedBlockType, addUnprocessedBlockType } = unlock(
 		dispatch( blocksStore )
 	);

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -257,6 +257,23 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		return;
 	}
 
+	// Warn if attributes is explicitly set to undefined or null in metadata or settings.
+	if (
+		( isObject( blockNameOrMetadata ) &&
+			'attributes' in blockNameOrMetadata &&
+			( blockNameOrMetadata.attributes === null ||
+				blockNameOrMetadata.attributes === undefined ) ) ||
+		( 'attributes' in settings &&
+			( settings.attributes === null ||
+				settings.attributes === undefined ) )
+	) {
+		warning(
+			'The block "' +
+				name +
+				'" must not register attributes as null or undefined. Use an empty object or exclude the attributes key.'
+		);
+	}
+
 	const { addBootstrappedBlockType, addUnprocessedBlockType } = unlock(
 		dispatch( blocksStore )
 	);

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -304,6 +304,56 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should default to empty object when attributes is omitted and without warning', () => {
+			registerBlockType( 'core/test-block-omitted-attributes', {
+				title: 'block title',
+				category: 'text',
+				save: noop,
+			} );
+
+			// Verify no warning was shown (unlike when explicitly set to null/undefined)
+			expect( console ).not.toHaveWarned();
+
+			const blockType = getBlockType(
+				'core/test-block-omitted-attributes'
+			);
+			expect( blockType.attributes ).toEqual( {} );
+		} );
+
+		it( 'should warn and default to empty object when attributes is undefined', () => {
+			registerBlockType( 'core/test-block-undefined-attributes', {
+				title: 'block title',
+				category: 'text',
+				save: noop,
+				attributes: undefined,
+			} );
+
+			expect( console ).toHaveWarnedWith(
+				'The block "core/test-block-undefined-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
+			);
+
+			const blockType = getBlockType(
+				'core/test-block-undefined-attributes'
+			);
+			expect( blockType.attributes ).toEqual( {} );
+		} );
+
+		it( 'should warn and default to empty object when attributes is null', () => {
+			registerBlockType( 'core/test-block-null-attributes', {
+				title: 'block title',
+				category: 'text',
+				save: noop,
+				attributes: null,
+			} );
+
+			expect( console ).toHaveWarnedWith(
+				'The block "core/test-block-null-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
+			);
+
+			const blockType = getBlockType( 'core/test-block-null-attributes' );
+			expect( blockType.attributes ).toEqual( {} );
+		} );
+
 		it( 'should default to browser-initialized global attributes', () => {
 			const attributes = { ok: { type: 'boolean' } };
 			unstable__bootstrapServerSideBlockDefinitions( {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -320,39 +320,29 @@ describe( 'blocks', () => {
 			expect( blockType.attributes ).toEqual( {} );
 		} );
 
-		it( 'should warn and default to empty object when attributes is undefined', () => {
-			registerBlockType( 'core/test-block-undefined-attributes', {
-				title: 'block title',
-				category: 'text',
-				save: noop,
-				attributes: undefined,
-			} );
+		it.each( [
+			[ 'undefined', undefined ],
+			[ 'null', null ],
+		] )(
+			'should warn and default to empty object when attributes is %s',
+			( _label, value ) => {
+				registerBlockType( 'core/test-block-null-attributes', {
+					title: 'block title',
+					category: 'text',
+					save: noop,
+					attributes: value,
+				} );
 
-			expect( console ).toHaveWarnedWith(
-				'The block "core/test-block-undefined-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
-			);
+				expect( console ).toHaveWarnedWith(
+					'The block "core/test-block-null-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
+				);
 
-			const blockType = getBlockType(
-				'core/test-block-undefined-attributes'
-			);
-			expect( blockType.attributes ).toEqual( {} );
-		} );
-
-		it( 'should warn and default to empty object when attributes is null', () => {
-			registerBlockType( 'core/test-block-null-attributes', {
-				title: 'block title',
-				category: 'text',
-				save: noop,
-				attributes: null,
-			} );
-
-			expect( console ).toHaveWarnedWith(
-				'The block "core/test-block-null-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
-			);
-
-			const blockType = getBlockType( 'core/test-block-null-attributes' );
-			expect( blockType.attributes ).toEqual( {} );
-		} );
+				const blockType = getBlockType(
+					'core/test-block-null-attributes'
+				);
+				expect( blockType.attributes ).toEqual( {} );
+			}
+		);
 
 		it( 'should default to browser-initialized global attributes', () => {
 			const attributes = { ok: { type: 'boolean' } };

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -334,7 +334,7 @@ describe( 'blocks', () => {
 				} );
 
 				expect( console ).toHaveWarnedWith(
-					'The block "core/test-block-null-attributes" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
+					'The block "core/test-block-null-attributes" is registering attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key.'
 				);
 
 				const blockType = getBlockType(

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -103,14 +103,6 @@ export const processBlockType =
 			),
 		};
 
-		// Ensure attributes is always an object, never null or undefined.
-		if (
-			! blockType.attributes ||
-			typeof blockType.attributes !== 'object'
-		) {
-			blockType.attributes = {};
-		}
-
 		const settings = applyFilters(
 			'blocks.registerBlockType',
 			blockType,

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -103,11 +103,16 @@ export const processBlockType =
 			),
 		};
 
-		// Ensure attributes is always an object, never null or undefined.
+		// Temporary fix to allow block authors time to fix blocks that register attributes as null or undefined.
 		if (
 			! blockType.attributes ||
 			typeof blockType.attributes !== 'object'
 		) {
+			warning(
+				'The block "' +
+					name +
+					'" must not register attributes as null or undefined. Use an empty object (`attributes: {}`) or exclude the attributes key. In the next Gutenberg release, passing null or undefined for attributes will cause the block editor to crash.'
+			);
 			blockType.attributes = {};
 		}
 

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -103,6 +103,14 @@ export const processBlockType =
 			),
 		};
 
+		// Ensure attributes is always an object, never null or undefined.
+		if (
+			! blockType.attributes ||
+			typeof blockType.attributes !== 'object'
+		) {
+			blockType.attributes = {};
+		}
+
 		const settings = applyFilters(
 			'blocks.registerBlockType',
 			blockType,

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -111,7 +111,7 @@ export const processBlockType =
 			warning(
 				'The block "' +
 					name +
-					'" must not register attributes as null or undefined. Use an empty object (`attributes: {}`) or exclude the attributes key. In the next Gutenberg release, passing null or undefined for attributes will cause the block editor to crash.'
+					'" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
 			);
 			blockType.attributes = {};
 		}

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -103,7 +103,7 @@ export const processBlockType =
 			),
 		};
 
-		// Temporary fix to allow block authors time to fix blocks that register attributes as null or undefined.
+		// If the block is registering attributes as null or undefined, warn and default to empty object.
 		if (
 			! blockType.attributes ||
 			typeof blockType.attributes !== 'object'
@@ -111,7 +111,7 @@ export const processBlockType =
 			warning(
 				'The block "' +
 					name +
-					'" must not register attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key. In the next Gutenberg release, passing `null` or `undefined` for `attributes` will cause the block editor to crash.'
+					'" is registering attributes as `null` or `undefined`. Use an empty object (`attributes: {}`) or exclude the `attributes` key.'
 			);
 			blockType.attributes = {};
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/73135#issuecomment-3513307782

<!-- In a few words, what is the PR actually doing? -->
Add a warning if attributes is set incorrectly (undefined or null) when registering a block, and fixes it by setting the attributes as an empty object.

## History
https://github.com/WordPress/gutenberg/pull/71982 added color support checks to more blocks that did not typically hit the color styles editing path. As a result, it exposed a root architectural issue that allowed some blocks to not have `attributes` defined if the block was registered specifically with attributes as `undefined` or `null`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Block structure should be consistent, and having attributes: undefined can cause odd issues. Give a warning when this happens and fix it. This should not be necessary, as block authors should not be passing attributes: undefined, but in case they are, this gives them time to fix it instead of crashing the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In registerBlockType, if block attributes is passed as undefined or null, output a warning to the block author so they know what went wrong and fix it by setting attributes as an empty object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Activate latest public WooCommerce release
- Go to the site editor
- There will be warnings in the console for some blocks about passing undefined or null attributes

```
installHook.js:1 The block "woocommerce/add-to-cart-with-options-quantity-selector" must not register attributes as null or undefined. Use an empty object (`attributes: {}`) or exclude the attributes key. In the next Gutenberg release, passing null or undefined for attributes will cause the block editor to crash.
installHook.js:1 The block "woocommerce/add-to-cart-with-options-variation-selector" must not register attributes as null or undefined. Use an empty object (`attributes: {}`) or exclude the attributes key. In the next Gutenberg release, passing null or undefined for attributes will cause the block editor to crash.
installHook.js:1 The block "woocommerce/add-to-cart-with-options-variation-selector-attribute" must not register attributes as null or undefined. Use an empty object (`attributes: {}`) or exclude the attributes key. In the next Gutenberg release, passing null or undefined for attributes will cause the block editor to crash.
[...]
```

- Deactivate WooCommerce
- Warnings should disappear as there are no blocks passing attributes: undefined in Gutenberg

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1726" height="1019" alt="functioning bock editor with many console warnings about undefined attributes" src="https://github.com/user-attachments/assets/b08e7e68-1e41-45d0-8e09-8747cd4d4b01" />


|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

https://github.com/user-attachments/assets/9c36e2e5-b70d-43ec-96a6-49230aada393



