### PR TITLE
Try fixing full-screen modal height so contents can scroll

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,8 @@
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
 -   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
 -   `NumberControl`: Fix crash when min prop is string and step prop contains decimal ([#73107](https://github.com/WordPress/gutenberg/pull/73107)).
+-   `Modal`: Fix full-screen modal height to allow contents to scroll properly ([#73150](https://github.com/WordPress/gutenberg/pull/73150)).
+
 
 ### Internal
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -118,6 +118,7 @@
 		}
 		.components-modal__children-container {
 			height: 100%;
+			display: flow-root;
 		}
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -111,6 +111,9 @@
 		// When full screen, make sure the children container is full height.
 		.components-modal__content {
 			display: flex;
+			// If this container is scrollable, bottom padding won't apply so we use margin instead.
+			margin-bottom: $grid-unit-40;
+			padding-bottom: 0;
 		}
 		.components-modal__children-container {
 			flex: 1;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -111,6 +111,10 @@
 		// When full screen, set explicit heights so contents can be scrollable.
 		.components-modal__content {
 			height: calc(100% - #{$header-height + $grid-unit-10}); // Subtract header height
+
+			&.hide-header {
+				height: 100%;
+			}
 		}
 		.components-modal__children-container {
 			height: 100%;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -106,6 +106,16 @@
 	@include break-large() {
 		max-height: 70%;
 	}
+
+	&.is-full-screen {
+		// When full screen, set explicit heights so contents can be scrollable.
+		.components-modal__content {
+			height: calc(100% - 72px); // Subtract header height
+		}
+		.components-modal__children-container {
+			height: 100%;
+		}
+	}
 }
 
 @keyframes components-modal__appear-animation {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -114,9 +114,10 @@
 			// If this container is scrollable, bottom padding won't apply so we use margin instead.
 			margin-bottom: $grid-unit-40;
 			padding-bottom: 0;
-		}
-		.components-modal__children-container {
-			flex: 1;
+
+			> :last-child {
+				flex: 1;
+			}
 		}
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -110,7 +110,7 @@
 	&.is-full-screen {
 		// When full screen, set explicit heights so contents can be scrollable.
 		.components-modal__content {
-			height: calc(100% - 72px); // Subtract header height
+			height: calc(100% - #{$header-height + $grid-unit-10}); // Subtract header height
 		}
 		.components-modal__children-container {
 			height: 100%;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -108,17 +108,12 @@
 	}
 
 	&.is-full-screen {
-		// When full screen, set explicit heights so contents can be scrollable.
+		// When full screen, make sure the children container is full height.
 		.components-modal__content {
-			height: calc(100% - #{$header-height + $grid-unit-10}); // Subtract header height
-
-			&.hide-header {
-				height: 100%;
-			}
+			display: flex;
 		}
 		.components-modal__children-container {
-			height: 100%;
-			display: flow-root;
+			flex: 1;
 		}
 	}
 }

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -266,18 +266,16 @@ export const WithModal = ( {
 					isFullScreen={ false }
 					size="fill"
 				>
-					<div style={ { padding: '16px' } }>
-						<DataViewsPickerContent
-							perPageSizes={ perPageSizes }
-							isMultiselectable={ isMultiselectable }
-							isGrouped={ isGrouped }
-							infiniteScrollEnabled={ infiniteScrollEnabled }
-							actions={ modalActions }
-							selection={ selectedItems.map( ( item ) =>
-								String( item.id )
-							) }
-						/>
-					</div>
+					<DataViewsPickerContent
+						perPageSizes={ perPageSizes }
+						isMultiselectable={ isMultiselectable }
+						isGrouped={ isGrouped }
+						infiniteScrollEnabled={ infiniteScrollEnabled }
+						actions={ modalActions }
+						selection={ selectedItems.map( ( item ) =>
+							String( item.id )
+						) }
+					/>
 				</Modal>
 			) }
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Fixes #70611. 

I haven't thoroughly tested every single full-screen modal but this doesn't seem to break the ones I looked at. Imo it's preferable for the solution to not require adding props to control modal height, or the components using the modal to add custom styles. If we can get away with fixing modal so its children can control their height, that's the most straightforward path.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Test full screen modals to ensure they don't break: add a new page and check the modal with pattern suggestions; click "change template" in the page settings sidebar and check the modal that appears there.
2. Enable the dataviews media modal experiment.
3. Add an Image block to a page and click "media library" to show the modal. The media modal footer should stick to the bottom when scrolling.

<img width="984" height="768" alt="Screenshot 2025-11-11 at 3 39 42 pm" src="https://github.com/user-attachments/assets/3c3ae883-8bdc-4730-b894-75309ebcd078" />

With the sticky footer, the modal bottom padding makes it look a bit weird.