### PR TITLE
Fix: Admin color scheme is not applied to Command Palette

### DIFF
--- a/packages/commands/src/style.scss
+++ b/packages/commands/src/style.scss
@@ -1,2 +1,5 @@
 @use "@wordpress/base-styles/default-custom-properties" as *;
+@use "@wordpress/base-styles/mixins" as *;
 @use "./components/style.scss" as *;
+
+@include wordpress-admin-schemes();


### PR DESCRIPTION
Fixes #73039

## What?

This PR correctly applies the admin color theme to the Command Palette rendered in the dashboard.

## Why?

The editor includes the `wordpress-admin-schemes` mixin, but the dashboard does not.

This mixin is [planned to be replaced in the future with a stylesheet that has the `wp-admin-schemes` handle](https://github.com/WordPress/gutenberg/pull/69130), but for now, you need to explicitly include the mixin within each package.

## Testing Instructions

- Change the Admin Color Scheme.
- Launch the Command Palette.


## Screenshots or screencast <!-- if applicable -->

### Berfore

<img width="853" height="452" alt="image" src="https://github.com/user-attachments/assets/e629b836-047a-418a-bce3-1222c2e39420" />

### After

<img width="853" height="449" alt="image" src="https://github.com/user-attachments/assets/01b639fa-f42e-4ab1-9edd-7765c552ca7e" />
