### PR TITLE
E2E Tests: Auto-retry canvas block assertions

### DIFF
--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -342,14 +342,14 @@ test.describe( 'Columns', () => {
 
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [
-				columnsBlock,
-			] );
+			await expect
+				.poll( editor.getBlocks )
+				.toMatchObject( [ columnsBlock ] );
 
 			// Ensure focus is on the columns block.
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [] );
+			await expect.poll( editor.getBlocks ).toMatchObject( [] );
 		} );
 
 		test( 'should only select Columns on Backspace when non-empty', async ( {
@@ -365,17 +365,16 @@ test.describe( 'Columns', () => {
 
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [
-				columnsBlock,
-				paragraphBlock,
-			] );
+			await expect
+				.poll( editor.getBlocks )
+				.toMatchObject( [ columnsBlock, paragraphBlock ] );
 
 			// Ensure focus is on the columns block.
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [
-				paragraphBlock,
-			] );
+			await expect
+				.poll( editor.getBlocks )
+				.toMatchObject( [ paragraphBlock ] );
 		} );
 	} );
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1587,7 +1587,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/list',
 				innerBlocks: [

--- a/test/e2e/specs/editor/blocks/verse-code-preformatted.spec.js
+++ b/test/e2e/specs/editor/blocks/verse-code-preformatted.spec.js
@@ -21,7 +21,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'b' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [
+			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: blockName,
 					attributes: {
@@ -39,7 +39,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 			await page.keyboard.press( 'ArrowLeft' );
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( [
+			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: blockName,
 					attributes: {

--- a/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
+++ b/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
@@ -71,7 +71,7 @@ test.describe( 'Preventing Pattern Recursion (server)', () => {
 		await page.getByRole( 'option', { name: 'Evil recursive' } ).click();
 		// By simply checking the editor content, we know that the pattern
 		// endpoint did not crash.
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'Hello' },

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -531,7 +531,7 @@ test.describe( 'Copy/cut/paste', () => {
 			html: '<a href="https://wordpress.org/gutenberg">https://wordpress.org/gutenberg</a>',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -624,7 +624,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.type( 'a' );
 		await pageUtils.pressKeys( 'shift+ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -665,7 +665,7 @@ test.describe( 'Copy/cut/paste', () => {
 			html: 'https://wordpress.org/gutenberg',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -683,9 +683,9 @@ test.describe( 'Copy/cut/paste', () => {
 			html: 'https://www.youtube.com/watch?v=FcTLMTyD2DU',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
-			{ name: 'core/embed' },
-		] );
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/embed' } ] );
 	} );
 
 	test( 'should not link selection for non http(s) protocol', async ( {
@@ -704,7 +704,7 @@ test.describe( 'Copy/cut/paste', () => {
 			html: 'movie: b',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -741,7 +741,7 @@ test.describe( 'Copy/cut/paste', () => {
 
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -776,7 +776,7 @@ test.describe( 'Copy/cut/paste', () => {
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/heading',
 				attributes: {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -44,7 +44,7 @@ test.describe( 'Footnotes', () => {
 			return document.activeElement.id;
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'first paragraph' },
@@ -75,7 +75,7 @@ test.describe( 'Footnotes', () => {
 			return document.activeElement.id;
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -109,7 +109,7 @@ test.describe( 'Footnotes', () => {
 		await editor.showBlockToolbar();
 		await editor.clickBlockToolbarButton( 'Move down' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -141,7 +141,7 @@ test.describe( 'Footnotes', () => {
 		await editor.canvas.locator( `a[href="#${ id2 }-link"]` ).click();
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -169,7 +169,7 @@ test.describe( 'Footnotes', () => {
 		await editor.canvas.locator( `a[href="#${ id1 }-link"]` ).click();
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -204,7 +204,7 @@ test.describe( 'Footnotes', () => {
 			return document.activeElement.id;
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/list',
 				innerBlocks: [
@@ -245,7 +245,7 @@ test.describe( 'Footnotes', () => {
 			return document.activeElement.id;
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/table',
 				attributes: {

--- a/test/e2e/specs/editor/various/rich-text-deprecated-multiline.spec.js
+++ b/test/e2e/specs/editor/various/rich-text-deprecated-multiline.spec.js
@@ -51,7 +51,7 @@ test.describe( 'RichText deprecated multiline', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/rich-text-deprecated-multiline',
 				attributes: {
@@ -75,7 +75,7 @@ test.describe( 'RichText deprecated multiline', () => {
 		// Test selection after split.
 		await page.keyboard.type( '‸' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/rich-text-deprecated-multiline',
 				attributes: {
@@ -94,7 +94,7 @@ test.describe( 'RichText deprecated multiline', () => {
 		// Test selection after merge.
 		await page.keyboard.type( '‸' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/rich-text-deprecated-multiline',
 				attributes: {
@@ -114,7 +114,7 @@ test.describe( 'RichText deprecated multiline', () => {
 		// Test selection after merge.
 		await page.keyboard.type( '‸' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/rich-text-deprecated-multiline',
 				attributes: {

--- a/test/e2e/specs/editor/various/rich-text-deprecated-on-split.spec.js
+++ b/test/e2e/specs/editor/various/rich-text-deprecated-on-split.spec.js
@@ -57,7 +57,7 @@ test.describe( 'RichText deprecated onSplit', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/rich-text-deprecated-on-split',
 				attributes: {

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -22,7 +22,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await editor.clickBlockToolbarButton( 'Change level' );
 		await page.locator( 'role=menuitemradio[name="Heading 3"]' ).click();
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/heading',
 				attributes: { level: 3 },
@@ -42,7 +42,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong>test</strong>' },
@@ -64,7 +64,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '.' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'Some <strong>bold</strong>.' },
@@ -87,7 +87,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '.' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong><em>1</em></strong>.' },
@@ -132,7 +132,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await editor.clickBlockToolbarButton( 'Bold' );
 		await page.keyboard.type( '.' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'Some <strong>bold</strong>.' },
@@ -150,7 +150,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			.click();
 		await page.keyboard.type( 'A `backtick`' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'A <code>backtick</code>' },
@@ -159,9 +159,9 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 		await pageUtils.pressKeys( 'primary+z' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
-			{ name: 'core/paragraph' },
-		] );
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
 	} );
 
 	test( 'should undo backtick transform with backspace', async ( {
@@ -174,7 +174,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( '`a`' );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '`a`' },
@@ -194,7 +194,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [] );
+		await expect.poll( editor.getBlocks ).toMatchObject( [] );
 	} );
 
 	test( 'should not undo backtick transform with backspace after selection change', async ( {
@@ -212,7 +212,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [] );
+		await expect.poll( editor.getBlocks ).toMatchObject( [] );
 	} );
 
 	test( 'should not format text after code backtick', async ( {
@@ -224,7 +224,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			.click();
 		await page.keyboard.type( 'A `backtick` and more.' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'A <code>backtick</code> and more.' },
@@ -247,7 +247,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'shiftAlt+ArrowRight' );
 		await page.keyboard.type( '`' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'A <code>selection</code> test.' },
@@ -256,7 +256,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 		await pageUtils.pressKeys( 'primary+z' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'A `selection` test.' },
@@ -351,7 +351,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			window.unsubscribes.forEach( ( unsubscribe ) => unsubscribe() );
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1<strong>2</strong>34' },
@@ -383,7 +383,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// deleting the numbers.
 		await page.keyboard.type( '-' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong>1</strong>2-3' },
@@ -407,7 +407,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'End' );
 		await page.keyboard.type( '+' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '-<strong>12</strong>+' },
@@ -430,7 +430,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'primary+b' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1<strong>2</strong>' },
@@ -463,7 +463,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'primary+b' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1<strong>2</strong>' },
@@ -489,7 +489,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'a1' },
@@ -516,7 +516,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '123' },
@@ -543,7 +543,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'a1<strong>2</strong>3b' },
@@ -565,7 +565,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '2' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1<strong>2</strong>' },
@@ -593,7 +593,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong>132</strong>3' },
@@ -634,7 +634,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			},
 		};
 
-		expect( await editor.getBlocks() ).toMatchObject( [ result ] );
+		await expect.poll( editor.getBlocks ).toMatchObject( [ result ] );
 
 		// Dismiss color picker popover.
 		await page.keyboard.press( 'Escape' );
@@ -654,9 +654,9 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// Paste the colored text.
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject(
-			Array( 2 ).fill( result )
-		);
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( Array( 2 ).fill( result ) );
 	} );
 
 	test( 'should paste paragraph contents into list', async ( {
@@ -686,7 +686,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// Paste paragraph contents.
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1<br>2' },
@@ -734,7 +734,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// Paste paragraph contents.
 		await pageUtils.pressKeys( 'primary+v' );
 
-		expect( await editor.getBlocks() ).toMatchObject(
+		await expect.poll( editor.getBlocks ).toMatchObject(
 			Array( 2 ).fill( {
 				name: 'core/list',
 				innerBlocks: [
@@ -768,7 +768,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( '1' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1🍓' },
@@ -800,7 +800,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			);
 		} );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<code>a</code>' },
@@ -823,7 +823,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'primary+i' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong>1</strong><em>2</em>' },
@@ -839,7 +839,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 		await page.keyboard.type( '-' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '<strong>1</strong>-<em>2</em>' },

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -337,7 +337,7 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'primary+z' );
 
 		// Check the content.
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
@@ -542,14 +542,14 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 			await pageUtils.pressKeys( 'ArrowUp', { times: 3 } );
 			await page.keyboard.press( 'Delete' );
 
-			expect( await editor.getBlocks() ).toMatchObject( snap1 );
+			await expect.poll( editor.getBlocks ).toMatchObject( snap1 );
 
 			await page.keyboard.press( 'Delete' );
 			// Caret should be in the first block and at the proper position.
 			await page.keyboard.type( '-' );
 
 			// Check the content.
-			expect( await editor.getBlocks() ).toMatchObject( snap2 );
+			await expect.poll( editor.getBlocks ).toMatchObject( snap2 );
 		} );
 
 		test( 'on backspace', async ( { editor, page, pageUtils } ) => {
@@ -563,14 +563,14 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 			await pageUtils.pressKeys( 'ArrowLeft', { times: 6 } );
 			await page.keyboard.press( 'Backspace' );
 
-			expect( await editor.getBlocks() ).toMatchObject( snap1 );
+			await expect.poll( editor.getBlocks ).toMatchObject( snap1 );
 
 			await page.keyboard.press( 'Backspace' );
 			// Caret should be in the first block and at the proper position.
 			await page.keyboard.type( '-' );
 
 			// Check the content.
-			expect( await editor.getBlocks() ).toMatchObject( snap2 );
+			await expect.poll( editor.getBlocks ).toMatchObject( snap2 );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -68,7 +68,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await expect( activeElementLocator ).toBeFocused();
 		await expect( activeElementLocator ).toHaveText( 'First paragraph' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'First paragraph' },
@@ -165,7 +165,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'Before' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'FirstAfter' },
@@ -437,7 +437,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'Enter', { times: 10 } );
 
 		// Check that none of the paragraph blocks have <br> in them.
-		expect( await editor.getBlocks() ).toMatchObject(
+		await expect.poll( editor.getBlocks ).toMatchObject(
 			Array( 11 ).fill( {
 				name: 'core/paragraph',
 				attributes: { content: '' },
@@ -456,7 +456,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( '3' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1' },
@@ -489,7 +489,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( '2' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1' },
@@ -513,7 +513,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( '1' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1' },
@@ -541,7 +541,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.up( 'Shift' );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1' },
@@ -563,7 +563,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowUp' );
 
 		// Ensure setup is correct.
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '' },
@@ -576,7 +576,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '2' },
@@ -747,7 +747,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( '1' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '1' },


### PR DESCRIPTION
## What?
Related #73143.

PR replaces `expect( await editor.getBlocks() )` Playwright assertions with `await expect.poll( editor.getBlocks )`, this should reduce risk of flaky tests.

P.S. Hopefully, code editos will also provide better auto-completes, that match our best practices.

See: https://playwright.dev/docs/test-assertions#non-retrying-assertions.

## Testing Instructions
All CIs should be green.