### PR TITLE
Notes: Fix first note creation with pinned sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -381,9 +381,16 @@ export function Comments( {
 	};
 
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
-	// This should no longer happen since https://github.com/WordPress/gutenberg/pull/72872.
+	// A special case for `template-locked` mode - https://github.com/WordPress/gutenberg/pull/72646.
 	if ( ! hasThreads && ! isFloating ) {
-		return null;
+		return (
+			<AddComment
+				onSubmit={ onAddReply }
+				newNoteFormState={ newNoteFormState }
+				setNewNoteFormState={ setNewNoteFormState }
+				commentSidebarRef={ commentSidebarRef }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
## What?
Closes #73162.
This is a follow-up to #72872.

PR fixes the first note creation when post type is rendered with `template-locked` mode, where only pinned sidebar is displayed.

## Testing Instructions
- Open a post with no notes.
- Enable the "Show template" mode.
- A Notes button appears in the header. This is not the intended behavior.
- Insert a block and add a note.
- An empty archive sidebar opens, new note form is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1312" height="713" alt="CleanShot 2025-11-11 at 19 49 54" src="https://github.com/user-attachments/assets/50f2f9d0-5d67-445a-8147-1d6b3f03fd59" />

