### PR TITLE
ColorPicker: Support pasting whole color values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Enhancements
 
 -   `ConfirmDialog`: Add `isBusy` prop to component. ([#73041](https://github.com/WordPress/gutenberg/pull/73041)).
+-   `ColorPicker`: Support pasting whole color values. ([#73166](https://github.com/WordPress/gutenberg/pull/73166)).
 
 ## 30.7.0 (2025-10-29)
 

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -96,10 +96,10 @@ const UnconnectedColorPicker = (
 				return;
 			}
 
-			const detectedFormat = getFormat( pastedText );
-			if ( ! detectedFormat ) {
-				return;
-			}
+			// Apply all valid colors, even if the format isn't supported in
+			// the UI (e.g. names like "cyan" or, in the future color spaces
+			// like "lch" if we add the right colord plugins)
+			handleChange( parsedColor );
 
 			// This redundancy helps TypeScript and is safer than assertions
 			const supportedFormats: Record< string, ColorType | undefined > = {
@@ -108,11 +108,7 @@ const UnconnectedColorPicker = (
 				hsl: 'hsl',
 			};
 
-			// Apply all valid colors, even if the format isn't supported in
-			// the UI (e.g. names like "cyan" or, in the future color spaces
-			// like "lch" if we add the right colord plugins)
-			handleChange( parsedColor );
-
+			const detectedFormat = String( getFormat( pastedText ) );
 			const newColorType = supportedFormats[ detectedFormat ];
 			if ( newColorType ) {
 				setColorType( newColorType );

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -80,12 +80,9 @@ const UnconnectedColorPicker = (
 	 * ! Listener intended for the CAPTURE phase
 	 *
 	 * Capture paste events over the entire color picker, looking for clipboard
-	 * data that could be parsed as a color.
-	 *
-	 * - If so, set both the color and color type to match the paste.
-	 *
-	 * - If not, let the paste event propagate normally, so that individual
-	 *   input controls within the component have a chance to handle it.
+	 * data that could be parsed as a color. If not, let the paste event
+	 * propagate normally, so that individual input controls within the
+	 * component have a chance to handle it.
 	 */
 	const maybeHandlePaste = useCallback(
 		( event: ClipboardEvent ) => {
@@ -111,13 +108,15 @@ const UnconnectedColorPicker = (
 				hsl: 'hsl',
 			};
 
-			const newColorType = supportedFormats[ detectedFormat ];
-			if ( ! newColorType ) {
-				return;
-			}
-
-			setColorType( newColorType );
+			// Apply all valid colors, even if the format isn't supported in
+			// the UI (e.g. names like "cyan" or, in the future color spaces
+			// like "lch" if we add the right colord plugins)
 			handleChange( parsedColor );
+
+			const newColorType = supportedFormats[ detectedFormat ];
+			if ( newColorType ) {
+				setColorType( newColorType );
+			}
 
 			// Stop at capture phase; no bubbling
 			event.stopPropagation();

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import type { ForwardedRef } from 'react';
+import type { ClipboardEvent, ForwardedRef } from 'react';
 import type { Colord } from 'colord';
-import { colord, extend } from 'colord';
+import { colord, extend, getFormat } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 
 /**
@@ -76,8 +76,62 @@ const UnconnectedColorPicker = (
 		copyFormat || 'hex'
 	);
 
+	/*
+	 * ! Listener intended for the CAPTURE phase
+	 *
+	 * Capture paste events over the entire color picker, looking for clipboard
+	 * data that could be parsed as a color.
+	 *
+	 * - If so, set both the color and color type to match the paste.
+	 *
+	 * - If not, let the paste event propagate normally, so that individual
+	 *   input controls within the component have a chance to handle it.
+	 */
+	const maybeHandlePaste = useCallback(
+		( event: ClipboardEvent ) => {
+			const pastedText = event.clipboardData?.getData( 'text' )?.trim();
+			if ( ! pastedText ) {
+				return;
+			}
+
+			const parsedColor = colord( pastedText );
+			if ( ! parsedColor.isValid() ) {
+				return;
+			}
+
+			const detectedFormat = getFormat( pastedText );
+			if ( ! detectedFormat ) {
+				return;
+			}
+
+			// This redundancy helps TypeScript and is safer than assertions
+			const supportedFormats: Record< string, ColorType | undefined > = {
+				hex: 'hex',
+				rgb: 'rgb',
+				hsl: 'hsl',
+			};
+
+			const newColorType = supportedFormats[ detectedFormat ];
+			if ( ! newColorType ) {
+				return;
+			}
+
+			setColorType( newColorType );
+			handleChange( parsedColor );
+
+			// Stop at capture phase; no bubbling
+			event.stopPropagation();
+			event.preventDefault();
+		},
+		[ handleChange, setColorType ]
+	);
+
 	return (
-		<ColorfulWrapper ref={ forwardedRef } { ...divProps }>
+		<ColorfulWrapper
+			ref={ forwardedRef }
+			{ ...divProps }
+			onPasteCapture={ maybeHandlePaste }
+		>
 			<Picker
 				onChange={ handleChange }
 				color={ safeColordColor }


### PR DESCRIPTION
## What?

When the ColorPicker is open, let the user paste a colour value in any recognisable format. No particular input needs to have focus: pasting works anywhere in the picker. This works even if the format isn't supported by the UI (internal representation is hexadecimal).

* When possible, the UI switches to the corresponding format (hex, RGB, HSL).
* Recognisable formats are hexadecimal, RGB, HSL and colour names. Example inputs: `#123`, `rgb(100 200 30)`, `hsl(60, 20%, 80%)`, `cyan`


https://github.com/user-attachments/assets/908a745b-db4e-4de0-bcc0-182d96b8bb55


https://github.com/user-attachments/assets/3c2a3736-12ba-4dca-8e75-14916a1ab4d3



## Why?

* Pasting colors is cumbersome. Usually it requires that 1) they be converted to hex, 2) the instance of ColorPicker be switched to hex type, 3) so that finally a regular paste event can triggered in the text input. I expect it would deter many novice users using colours from a different application.
* I believe that letting the UI switch to the provided format is also convenient, on the assumption that the user will want to make adjustments in the same format.

## How?

* Attach a **capture-time** listener to the picker component to intercept paste events.
* If it succeeds in parsing the input as a colour, it will apply it .
    * If the input format is one of hex / RGB / HSL, switch to that type too.
* Else let the event propagate normally.
    * This should be enough to let the input controls inside the picker work normally (e.g. when a user pastes a single component of a colour).

## Testing instructions

- Paste and verify correct application of:
    - hex colors (e.g. #ff0000)
    - rgb colors (e.g. rgb(255, 0, 0))
    - hsl colors (e.g. hsl(0, 100%, 50%))
    - named colors (e.g. "red", "cyan")
- Paste invalid text and verify normal paste behaviour works in individual inputs
- Test paste functionality across different ColorPicker instances