### PR TITLE
Fix `setupEditor` edits not being applied when non-iterable edits are used

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -62,7 +62,7 @@ export const setupEditor =
 		}
 		if (
 			edits &&
-			Object.values( edits ).some(
+			Object.entries( edits ).some(
 				( [ key, edit ] ) =>
 					edit !== ( post[ key ]?.raw ?? post[ key ] )
 			)

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -63,7 +63,8 @@ export const setupEditor =
 		if (
 			edits &&
 			Object.values( edits ).some(
-				( key, edit ) => edit !== ( post[ key ]?.raw ?? post[ key ] )
+				( [ key, edit ] ) =>
+					edit !== ( post[ key ]?.raw ?? post[ key ] )
 			)
 		) {
 			dispatch.editPost( edits );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -63,8 +63,7 @@ export const setupEditor =
 		if (
 			edits &&
 			Object.values( edits ).some(
-				( [ key, edit ] ) =>
-					edit !== ( post[ key ]?.raw ?? post[ key ] )
+				( key, edit ) => edit !== ( post[ key ]?.raw ?? post[ key ] )
 			)
 		) {
 			dispatch.editPost( edits );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
No issue number, was easier just to create the PR <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There is a bug with the [setupEditor](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-editor/#setupeditor) dispatcher.  If you pass a non-iterable edit, JS encounters an error preventing the edits from being carried out.  

The issue comes from this line:
https://github.com/WordPress/gutenberg/blob/0473a545fade60a3dfce12da64004a3b59766569/packages/editor/src/store/actions.js#L66

The parameters of the callback should not be destructured from an array but taken as separate arguments.  [See the JS documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some#using_the_third_argument_of_callbackfn).


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
[Remove the square brackets](https://github.com/WordPress/gutenberg/blob/0473a545fade60a3dfce12da64004a3b59766569/packages/editor/src/store/actions.js#L66) as we should not be using array destructuring for the params.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Note that the bug only appears when you pass **only** non-iterable edits like `null` or numbers.  If you include any edits that are iterable, the bug may not appear.

1. Create a new draft post
2. Run 
```JS
  wp.data.dispatch('core/editor').setupEditor( wp.data.select('core/editor').getCurrentPost(), { author: 2 } )
```
3. There should be no JS error.
4. Check that the edit is applied by running:
```JS
  wp.data.select('core').getEditedEntityRecord('postType', 'post', wp.data.select('core/editor').getCurrentPostId())
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/46cc31d1-ea83-4739-bf07-36fc17c1b332



**After**

https://github.com/user-attachments/assets/8992084a-4a88-4e67-8ad2-5f7df2e8b84f


