### PR TITLE
Routing Single Page Mode: Fix fullscreen editor mode

### DIFF
--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -29,8 +29,6 @@ export default function Root() {
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
 		| CanvasData
 		| undefined;
-
-	// Hide sidebar in full-screen canvas mode
 	const isFullScreen = canvas && ! canvas.isPreview;
 
 	return (

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -32,6 +32,7 @@ export default function RootSinglePage() {
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
 		| CanvasData
 		| undefined;
+	const isFullScreen = canvas && ! canvas.isPreview;
 
 	return (
 		<ThemeProvider isRoot color={ { bg: '#f8f8f8', primary: '#3858e9' } }>
@@ -39,6 +40,7 @@ export default function RootSinglePage() {
 				<div
 					className={ clsx( 'boot-layout boot-layout--single-page', {
 						'has-canvas': !! canvas,
+						'has-full-canvas': isFullScreen,
 					} ) }
 				>
 					<CommandMenu />

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/theme/src/prebuilt/css/design-tokens.css" as *;
 @use "@wordpress/admin-ui/build-style/style.css" as *;
+@use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables";
 
 // Reset wp-admin layout styles when loaded inside wp-admin.
@@ -22,4 +23,23 @@ body:has(.boot-layout-container) {
 
 #wpfooter {
 	display: none;
+}
+
+body:has(.boot-layout.has-full-canvas) {
+	@include break-medium {
+		// Reset the html.wp-topbar padding.
+		// Because this uses negative margins, we have to compensate for the height.
+		margin-top: - variables.$admin-bar-height;
+		height: calc(100% + #{ variables.$admin-bar-height });
+
+		#adminmenumain,
+		#wpadminbar {
+			display: none;
+		}
+
+		#wpcontent,
+		#wpfooter {
+			margin-left: 0;
+		}
+	}
 }


### PR DESCRIPTION
## What?

Related #70862 

This PR fixes the full screen mode of the editor in "single mode" to match the behavior of the post/site editor (the wp-admin sidebar/topbar are hidden)

## Testing Instructions

 - Open the post list in the "single page mode": `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot-wp-admin&p=%2Ftypes%2Fpost%2Flist%2Fall`
 - Click any post
 - The editor should open in full screen hiding the sidebar/header of wp-admin.
