### PR TITLE
Boot Package: Add save panel and shortcut.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52703,6 +52703,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/lazy-editor": "file:../lazy-editor",
 				"@wordpress/primitives": "file:../primitives",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/lazy-editor": "file:../lazy-editor",
 		"@wordpress/primitives": "file:../primitives",

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -16,6 +16,7 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
  */
 import Sidebar from '../sidebar';
 import Canvas from '../canvas';
+import SavePanel from '../save-panel';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -23,7 +24,6 @@ import './style.scss';
 const { ThemeProvider } = unlock( themePrivateApis );
 
 export default function Root() {
-	// Get canvas data from the current route's loader
 	const matches = useMatches();
 	const currentMatch = matches[ matches.length - 1 ];
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
@@ -43,6 +43,7 @@ export default function Root() {
 					} ) }
 				>
 					<CommandMenu />
+					<SavePanel />
 					{ ! isFullScreen && (
 						<div className="boot-layout__sidebar">
 							<Sidebar />

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -15,6 +15,7 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
  * Internal dependencies
  */
 import Canvas from '../canvas';
+import SavePanel from '../save-panel';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -26,7 +27,6 @@ const { ThemeProvider } = unlock( themePrivateApis );
  * Used when rendering pages within wp-admin without taking over the full page.
  */
 export default function RootSinglePage() {
-	// Get canvas data from the current route's loader
 	const matches = useMatches();
 	const currentMatch = matches[ matches.length - 1 ];
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
@@ -42,6 +42,7 @@ export default function RootSinglePage() {
 					} ) }
 				>
 					<CommandMenu />
+					<SavePanel />
 					<div className="boot-layout__surfaces">
 						<ThemeProvider
 							color={ { bg: '#ffffff', primary: '#3858e9' } }

--- a/packages/boot/src/components/save-panel/index.tsx
+++ b/packages/boot/src/components/save-panel/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Modal } from '@wordpress/components';
+import { EntitiesSavedStates } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useSaveShortcut from './use-save-shortcut';
+
+export default function SavePanel() {
+	const [ isOpen, setIsOpen ] = useState< boolean >( false );
+	useSaveShortcut( {
+		openSavePanel: () => setIsOpen( true ),
+	} );
+	if ( ! isOpen ) {
+		return false;
+	}
+	return (
+		<Modal
+			className="edit-site-save-panel__modal"
+			onRequestClose={ () => setIsOpen( false ) }
+			title={ __( 'Review changes' ) }
+			size="small"
+		>
+			<EntitiesSavedStates
+				close={ () => setIsOpen( false ) }
+				variant="inline"
+			/>
+		</Modal>
+	);
+}

--- a/packages/boot/src/components/save-panel/use-save-shortcut.ts
+++ b/packages/boot/src/components/save-panel/use-save-shortcut.ts
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+	// @ts-expect-error - No types available yet.
+} from '@wordpress/keyboard-shortcuts';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
+const shortcutName = 'core/boot/save';
+
+/**
+ * Register the save keyboard shortcut in view mode.
+ *
+ * @param param0               Object containing the function to open the save panel.
+ * @param param0.openSavePanel Function to open the save panel.
+ */
+export default function useSaveShortcut( {
+	openSavePanel,
+}: {
+	openSavePanel: () => void;
+} ) {
+	const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
+		useSelect( coreStore );
+	const { hasNonPostEntityChanges, isPostSavingLocked } =
+		useSelect( editorStore );
+	const { savePost } = useDispatch( editorStore );
+	const { registerShortcut, unregisterShortcut } = useDispatch(
+		keyboardShortcutsStore
+	);
+	useEffect( () => {
+		registerShortcut( {
+			name: shortcutName,
+			category: 'global',
+			description: __( 'Save your changes.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 's',
+			},
+		} );
+		return () => {
+			unregisterShortcut( shortcutName );
+		};
+	}, [ registerShortcut, unregisterShortcut ] );
+
+	useShortcut( shortcutName, ( event: Event ) => {
+		event.preventDefault();
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		const hasDirtyEntities = !! dirtyEntityRecords.length;
+		const isSaving = dirtyEntityRecords.some( ( record ) =>
+			isSavingEntityRecord( record.kind, record.name, record.key )
+		);
+		if ( ! hasDirtyEntities || isSaving ) {
+			return;
+		}
+		if ( hasNonPostEntityChanges() ) {
+			openSavePanel();
+		} else if ( ! isPostSavingLocked() ) {
+			savePost();
+		}
+	} );
+}

--- a/packages/boot/src/index.tsx
+++ b/packages/boot/src/index.tsx
@@ -3,10 +3,3 @@
  */
 import './style.scss';
 export { init, initSinglePage } from './components/app';
-
-// Hacks
-// This ensures wp-editor is added as a dependency to the boot package.
-/**
- * WordPress dependencies
- */
-import '@wordpress/editor';

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -837,7 +837,7 @@ function Paste( { children } ) {
 _Parameters_
 
 -   _mapSelect_ `T`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
--   _deps_ `unknown[]`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
+-   _deps_ `unknown[]=`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -253,15 +253,15 @@ function _useMappingSelect( suspense, mapSelect, deps ) {
  * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
  * @template {MapSelect | StoreDescriptor<any>} T
- * @param {T}         mapSelect Function called on every state change. The returned value is
- *                              exposed to the component implementing this hook. The function
- *                              receives the `registry.select` method on the first argument
- *                              and the `registry` on the second argument.
- *                              When a store key is passed, all selectors for the store will be
- *                              returned. This is only meant for usage of these selectors in event
- *                              callbacks, not for data needed to create the element tree.
- * @param {unknown[]} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
- *                              invoked on every state change unless the dependencies change.
+ * @param {T}          mapSelect Function called on every state change. The returned value is
+ *                               exposed to the component implementing this hook. The function
+ *                               receives the `registry.select` method on the first argument
+ *                               and the `registry` on the second argument.
+ *                               When a store key is passed, all selectors for the store will be
+ *                               returned. This is only meant for usage of these selectors in event
+ *                               callbacks, not for data needed to create the element tree.
+ * @param {unknown[]=} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
+ *                               invoked on every state change unless the dependencies change.
  *
  * @example
  * ```js

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -401,7 +401,7 @@ _Parameters_
 
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
--   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
+-   _props.renderDialog_ `boolean=`: Whether to render the component with modal dialog behavior.
 -   _props.variant_ `string`: Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
 
 _Returns_

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -36,7 +36,7 @@ function identity( values ) {
  *
  * @param {Object}   props              The component props.
  * @param {Function} props.close        The function to close the dialog.
- * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
+ * @param {boolean=} props.renderDialog Whether to render the component with modal dialog behavior.
  * @param {string}   props.variant      Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
  *
  * @return {React.ReactNode} The rendered component.

--- a/packages/global-styles-ui/src/screen-block-list.tsx
+++ b/packages/global-styles-ui/src/screen-block-list.tsx
@@ -112,7 +112,6 @@ interface BlockListProps {
 function BlockList( { filterValue }: BlockListProps ) {
 	const sortedBlockTypes = useSortedBlockTypes();
 	const debouncedSpeak = useDebounce( speak, 500 );
-	// @ts-expect-error - useSelect supports single argument calls
 	const { isMatchingSearchTerm } = useSelect( blocksStore );
 
 	const filteredBlockTypes = ! filterValue


### PR DESCRIPTION
Related #70862 

## What?

This PR adds a save shortcut to the boot package to match edit-site's behavior.

## Testing Instructions

 - Open the post list in the "single page mode": `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot-wp-admin&p=%2Ftypes%2Fpost%2Flist%2Fall`
 - Click any post
 - Make a change and hit ctrl+S

