### PR TITLE
Fix a11y of descriptions and alerts for "Invalid" Nav Items

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -404,21 +404,6 @@ export default function NavigationLinkEdit( {
 		}
 	}
 
-	const missingText = getMissingText( type );
-
-	const getErrorText = useCallback( () => {
-		if ( isInvalid ) {
-			return __( 'Invalid' );
-		}
-		if ( isDraft ) {
-			return __( 'Draft' );
-		}
-		return null;
-	}, [ isInvalid, isDraft ] );
-
-	/* translators: Whether the navigation link is Invalid or a Draft. */
-	const errorText = getErrorText();
-
 	const instanceId = useInstanceId( NavigationLinkEdit );
 	const hasMissingEntity = hasUrlBinding && ! isBoundEntityAvailable;
 	const missingEntityDescriptionId = hasMissingEntity
@@ -477,6 +462,12 @@ export default function NavigationLinkEdit( {
 			isDraft ||
 			( hasUrlBinding && ! isBoundEntityAvailable ),
 	} );
+
+	const missingText = getMissingText( type );
+	/* translators: Whether the navigation link is Invalid or a Draft. */
+	const placeholderText = `(${
+		isInvalid ? __( 'Invalid' ) : __( 'Draft' )
+	})`;
 
 	return (
 		<>
@@ -576,8 +567,8 @@ export default function NavigationLinkEdit( {
 											// so they display without encoding.
 											// See `updateAttributes` for more details.
 											`${ decodeEntities( label ) } ${
-												errorText
-													? `(${ errorText })`
+												isInvalid || isDraft
+													? placeholderText
 													: ''
 											}`.trim()
 										}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -8,9 +8,13 @@ import clsx from 'clsx';
  */
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import {
+	ToolbarButton,
+	ToolbarGroup,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -22,17 +26,30 @@ import {
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useRef,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMergeRefs, usePrevious } from '@wordpress/compose';
+import { useMergeRefs, usePrevious, useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { getColors } from '../navigation/edit/utils';
-import { Controls, LinkUI, updateAttributes, useEntityBinding } from './shared';
+import {
+	Controls,
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
+	MissingEntityHelpText,
+	BindingHelpText,
+} from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
@@ -394,6 +411,60 @@ export default function NavigationLinkEdit( {
 		}
 	}
 
+	const missingText = getMissingText( type );
+
+	const getErrorText = useCallback( () => {
+		if ( isInvalid ) {
+			return __( 'Invalid' );
+		}
+		if ( isDraft ) {
+			return __( 'Draft' );
+		}
+		return null;
+	}, [ isInvalid, isDraft ] );
+
+	/* translators: Whether the navigation link is Invalid or a Draft. */
+	const errorText = getErrorText();
+
+	// Generate screen reader description for block states
+	const navigationLinkDescription = useMemo( () => {
+		if ( isBoundEntityAvailable ) {
+			return BindingHelpText( { type, kind } );
+		}
+
+		// Handle missing URL states (informational, not an error)
+		if ( hasUrlBinding && ! isBoundEntityAvailable ) {
+			return MissingEntityHelpText( { type, kind } );
+		}
+
+		if ( ! url && ! metadata?.bindings?.url ) {
+			return missingText;
+		}
+
+		// Generic error text for draft or invalid links
+		if ( isDraft || isInvalid ) {
+			return getErrorText();
+		}
+
+		return null;
+	}, [
+		type,
+		kind,
+		metadata?.bindings?.url,
+		missingText,
+		url,
+		isBoundEntityAvailable,
+		isInvalid,
+		isDraft,
+		getErrorText,
+		hasUrlBinding,
+	] );
+	const instanceId = useInstanceId( NavigationLinkEdit );
+	const navigationLinkDescriptionId = sprintf(
+		'navigation-link-edit-%d-desc',
+		instanceId
+	);
+
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, listItemRef ] ),
 		className: clsx( 'wp-block-navigation-item', {
@@ -407,6 +478,11 @@ export default function NavigationLinkEdit( {
 			[ getColorClassName( 'background-color', backgroundColor ) ]:
 				!! backgroundColor,
 		} ),
+		'aria-describedby': navigationLinkDescription
+			? navigationLinkDescriptionId
+			: undefined,
+		'aria-invalid':
+			isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ),
 		style: {
 			color: ! textColor && customTextColor,
 			backgroundColor: ! backgroundColor && customBackgroundColor,
@@ -445,12 +521,6 @@ export default function NavigationLinkEdit( {
 			( hasUrlBinding && ! isBoundEntityAvailable ),
 	} );
 
-	const missingText = getMissingText( type );
-	/* translators: Whether the navigation link is Invalid or a Draft. */
-	const placeholderText = `(${
-		isInvalid ? __( 'Invalid' ) : __( 'Draft' )
-	})`;
-
 	return (
 		<>
 			<BlockControls>
@@ -482,6 +552,11 @@ export default function NavigationLinkEdit( {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
+				{ navigationLinkDescription && (
+					<VisuallyHidden id={ navigationLinkDescriptionId }>
+						{ navigationLinkDescription }
+					</VisuallyHidden>
+				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
@@ -544,8 +619,8 @@ export default function NavigationLinkEdit( {
 											// so they display without encoding.
 											// See `updateAttributes` for more details.
 											`${ decodeEntities( label ) } ${
-												isInvalid || isDraft
-													? placeholderText
+												errorText
+													? `(${ errorText })`
 													: ''
 											}`.trim()
 										}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -26,13 +26,7 @@ import {
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import {
-	useState,
-	useEffect,
-	useRef,
-	useCallback,
-	useMemo,
-} from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
@@ -48,7 +42,6 @@ import {
 	updateAttributes,
 	useEntityBinding,
 	MissingEntityHelpText,
-	BindingHelpText,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -426,44 +419,11 @@ export default function NavigationLinkEdit( {
 	/* translators: Whether the navigation link is Invalid or a Draft. */
 	const errorText = getErrorText();
 
-	// Generate screen reader description for block states
-	const navigationLinkDescription = useMemo( () => {
-		if ( isBoundEntityAvailable ) {
-			return BindingHelpText( { type, kind } );
-		}
-
-		// Handle missing URL states (informational, not an error)
-		if ( hasUrlBinding && ! isBoundEntityAvailable ) {
-			return MissingEntityHelpText( { type, kind } );
-		}
-
-		if ( ! url && ! metadata?.bindings?.url ) {
-			return missingText;
-		}
-
-		// Generic error text for draft or invalid links
-		if ( isDraft || isInvalid ) {
-			return getErrorText();
-		}
-
-		return null;
-	}, [
-		type,
-		kind,
-		metadata?.bindings?.url,
-		missingText,
-		url,
-		isBoundEntityAvailable,
-		isInvalid,
-		isDraft,
-		getErrorText,
-		hasUrlBinding,
-	] );
 	const instanceId = useInstanceId( NavigationLinkEdit );
-	const navigationLinkDescriptionId = sprintf(
-		'navigation-link-edit-%d-desc',
-		instanceId
-	);
+	const hasMissingEntity = hasUrlBinding && ! isBoundEntityAvailable;
+	const missingEntityDescriptionId = hasMissingEntity
+		? sprintf( 'navigation-link-edit-%d-desc', instanceId )
+		: undefined;
 
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, listItemRef ] ),
@@ -478,11 +438,8 @@ export default function NavigationLinkEdit( {
 			[ getColorClassName( 'background-color', backgroundColor ) ]:
 				!! backgroundColor,
 		} ),
-		'aria-describedby': navigationLinkDescription
-			? navigationLinkDescriptionId
-			: undefined,
-		'aria-invalid':
-			isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ),
+		'aria-describedby': missingEntityDescriptionId,
+		'aria-invalid': hasMissingEntity,
 		style: {
 			color: ! textColor && customTextColor,
 			backgroundColor: ! backgroundColor && customBackgroundColor,
@@ -552,9 +509,9 @@ export default function NavigationLinkEdit( {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ navigationLinkDescription && (
-					<VisuallyHidden id={ navigationLinkDescriptionId }>
-						{ navigationLinkDescription }
+				{ hasMissingEntity && (
+					<VisuallyHidden id={ missingEntityDescriptionId }>
+						<MissingEntityHelpText type={ type } kind={ kind } />
 					</VisuallyHidden>
 				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -348,7 +348,7 @@ export function MissingEntityHelpText( { type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
 	return sprintf(
 		/* translators: %s is the entity type (e.g., "page", "post", "category") */
-		__( 'Synced %s is missing. Please edit or remove this link.' ),
+		__( 'Synced %s is missing. Please update or remove this link.' ),
 		entityType
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -356,9 +356,7 @@ function MissingEntityHelpText( { id, type, kind } ) {
 		>
 			{ sprintf(
 				/* translators: %s is the entity type (e.g., "page", "post", "category") */
-				__(
-					'Synced %s is missing. Please update or remove this link.'
-				),
+				__( 'Synced %s is missing. Please edit or remove this link.' ),
 				entityType
 			) }
 		</span>

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -348,12 +348,7 @@ function BindingHelpText( { type, kind } ) {
 function MissingEntityHelpText( { id, type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
 	return (
-		<span
-			id={ id }
-			className="navigation-link-control__error-text"
-			role="alert"
-			aria-live="polite"
-		>
+		<span id={ id } className="navigation-link-control__error-text">
 			{ sprintf(
 				/* translators: %s is the entity type (e.g., "page", "post", "category") */
 				__( 'Synced %s is missing. Please edit or remove this link.' ),

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -354,10 +354,9 @@ export function MissingEntityHelpText( { type, kind } ) {
 }
 
 function MissingEntityHelp( { id, type, kind } ) {
-	const helpText = MissingEntityHelpText( { type, kind } );
 	return (
 		<span id={ id } className="navigation-link-control__error-text">
-			{ helpText }
+			<MissingEntityHelpText type={ type } kind={ kind } />
 		</span>
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -221,7 +221,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 					} }
 					help={
 						hasUrlBinding && ! isBoundEntityAvailable ? (
-							<MissingEntityHelpText
+							<MissingEntityHelp
 								id={ helpTextId }
 								type={ attributes.type }
 								kind={ attributes.kind }
@@ -327,7 +327,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
  * @param {string} props.kind - The entity kind
  * @return {string} Help text for the bound URL
  */
-function BindingHelpText( { type, kind } ) {
+export function BindingHelpText( { type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
 	return sprintf(
 		/* translators: %s is the entity type (e.g., "page", "post", "category") */
@@ -340,20 +340,24 @@ function BindingHelpText( { type, kind } ) {
  * Component to display error help text for missing entity bindings.
  *
  * @param {Object} props      - Component props
- * @param {string} props.id   - ID for the help text element (for aria-describedby)
  * @param {string} props.type - The entity type
  * @param {string} props.kind - The entity kind
  * @return {JSX.Element} Error help text component
  */
-function MissingEntityHelpText( { id, type, kind } ) {
+export function MissingEntityHelpText( { type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
+	return sprintf(
+		/* translators: %s is the entity type (e.g., "page", "post", "category") */
+		__( 'Synced %s is missing. Please edit or remove this link.' ),
+		entityType
+	);
+}
+
+function MissingEntityHelp( { id, type, kind } ) {
+	const helpText = MissingEntityHelpText( { type, kind } );
 	return (
 		<span id={ id } className="navigation-link-control__error-text">
-			{ sprintf(
-				/* translators: %s is the entity type (e.g., "page", "post", "category") */
-				__( 'Synced %s is missing. Please edit or remove this link.' ),
-				entityType
-			) }
+			{ helpText }
 		</span>
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -5,7 +5,7 @@
  * to reduce code duplication and ensure consistent behavior.
  */
 
-export { Controls } from './controls';
+export { Controls, BindingHelpText, MissingEntityHelpText } from './controls';
 export { updateAttributes } from './update-attributes';
 export {
 	useEntityBinding,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1363,7 +1363,7 @@ test.describe( 'Navigation block', () => {
 				// Verify help text shows error message
 				await expect(
 					settingsControls.getByText(
-						'Synced page is missing. Please edit or remove this link.'
+						'Synced page is missing. Please update or remove this link.'
 					)
 				).toBeVisible();
 
@@ -1408,7 +1408,7 @@ test.describe( 'Navigation block', () => {
 				// Wait for error help text to disappear (state updates asynchronously)
 				await expect(
 					settingsControls.getByText(
-						'Synced page is missing. Please edit or remove this link.'
+						'Synced page is missing. Please update or remove this link.'
 					)
 				).toBeHidden();
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1363,7 +1363,7 @@ test.describe( 'Navigation block', () => {
 				// Verify help text shows error message
 				await expect(
 					settingsControls.getByText(
-						'Synced page is missing. Please update or remove this link.'
+						'Synced page is missing. Please edit or remove this link.'
 					)
 				).toBeVisible();
 
@@ -1408,7 +1408,7 @@ test.describe( 'Navigation block', () => {
 				// Wait for error help text to disappear (state updates asynchronously)
 				await expect(
 					settingsControls.getByText(
-						'Synced page is missing. Please update or remove this link.'
+						'Synced page is missing. Please edit or remove this link.'
 					)
 				).toBeHidden();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Follow up to https://github.com/WordPress/gutenberg/pull/73142 to fix accessible descriptions and alerts. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The original PR was a fix for 6.9, and this PR follows up to ensure the fix is accessible to by making the error states perceivable to non-sighted users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Add `aria-invalid` state to block level information so it's clear to screen reader users that the block needs attention.
2. If the page link is synced to a deleted page, add an `aria-describedby` with the same error message that appears in the inspector. This allows the error message for the invalid state to be close-by and perceivable to screen readers.
3. Removes the role=alert and aria-live=polite from the inspector error message, as this causes the error message to be incorrectly announced twice everytime the sidebar mounts


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Start a screen reader
- Navigate to an synced page link block with a deleted page
- The block should have aria-invalid and an aria-describedby with an ID that points to the correct error message
- The sidebar inspector error message should not have role=alert or aria-live=polite

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
