### PR TITLE
RichText: Begin to support hiding richtext controls while having keyboard shortcuts available

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -13,7 +13,14 @@ const DEFAULT_BLOCK_CONTEXT = {};
 
 export const usesContextKey = Symbol( 'usesContext' );
 
-function Edit( { onChange, onFocus, value, forwardedRef, settings } ) {
+function Edit( {
+	onChange,
+	onFocus,
+	value,
+	forwardedRef,
+	settings,
+	isVisible,
+} ) {
 	const {
 		name,
 		edit: EditFunction,
@@ -47,6 +54,7 @@ function Edit( { onChange, onFocus, value, forwardedRef, settings } ) {
 		<EditFunction
 			key={ name }
 			isActive={ isActive }
+			isVisible={ isVisible }
 			activeAttributes={ isActive ? activeFormat.attributes || {} : {} }
 			isObjectActive={ isObjectActive }
 			activeObjectAttributes={

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -27,7 +27,7 @@ export const bold = {
 	tagName: 'strong',
 	className: null,
 	[ essentialFormatKey ]: true,
-	edit( { isActive, value, onChange, onFocus } ) {
+	edit( { isActive, value, onChange, onFocus, isVisible = true } ) {
 		function onToggle() {
 			onChange( toggleFormat( value, { type: name, title } ) );
 		}
@@ -44,15 +44,17 @@ export const bold = {
 					character="b"
 					onUse={ onToggle }
 				/>
-				<RichTextToolbarButton
-					name="bold"
-					icon={ formatBold }
-					title={ title }
-					onClick={ onClick }
-					isActive={ isActive }
-					shortcutType="primary"
-					shortcutCharacter="b"
-				/>
+				{ isVisible && (
+					<RichTextToolbarButton
+						name="bold"
+						icon={ formatBold }
+						title={ title }
+						onClick={ onClick }
+						isActive={ isActive }
+						shortcutType="primary"
+						shortcutCharacter="b"
+					/>
+				) }
 				<__unstableRichTextInputEvent
 					inputType="formatBold"
 					onInput={ onToggle }

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -27,7 +27,7 @@ export const italic = {
 	tagName: 'em',
 	className: null,
 	[ essentialFormatKey ]: true,
-	edit( { isActive, value, onChange, onFocus } ) {
+	edit( { isActive, value, onChange, onFocus, isVisible = true } ) {
 		function onToggle() {
 			onChange( toggleFormat( value, { type: name, title } ) );
 		}
@@ -44,15 +44,17 @@ export const italic = {
 					character="i"
 					onUse={ onToggle }
 				/>
-				<RichTextToolbarButton
-					name="italic"
-					icon={ formatItalic }
-					title={ title }
-					onClick={ onClick }
-					isActive={ isActive }
-					shortcutType="primary"
-					shortcutCharacter="i"
-				/>
+				{ isVisible && (
+					<RichTextToolbarButton
+						name="italic"
+						icon={ formatItalic }
+						title={ title }
+						onClick={ onClick }
+						isActive={ isActive }
+						shortcutType="primary"
+						shortcutCharacter="i"
+					/>
+				) }
 				<__unstableRichTextInputEvent
 					inputType="formatItalic"
 					onInput={ onToggle }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -41,6 +41,7 @@ function Edit( {
 	onChange,
 	onFocus,
 	contentRef,
+	isVisible = true,
 } ) {
 	const [ addingLink, setAddingLink ] = useState( false );
 
@@ -190,19 +191,21 @@ function Edit( {
 				character="k"
 				onUse={ onRemoveFormat }
 			/>
-			<RichTextToolbarButton
-				name="link"
-				icon={ linkIcon }
-				title={ isActive ? __( 'Link' ) : title }
-				onClick={ ( event ) => {
-					addLink( event.currentTarget );
-				} }
-				isActive={ isActive || addingLink }
-				shortcutType="primary"
-				shortcutCharacter="k"
-				aria-haspopup="true"
-				aria-expanded={ addingLink }
-			/>
+			{ isVisible && (
+				<RichTextToolbarButton
+					name="link"
+					icon={ linkIcon }
+					title={ isActive ? __( 'Link' ) : title }
+					onClick={ ( event ) => {
+						addLink( event.currentTarget );
+					} }
+					isActive={ isActive || addingLink }
+					shortcutType="primary"
+					shortcutCharacter="k"
+					aria-haspopup="true"
+					aria-expanded={ addingLink }
+				/>
+			) }
 			{ addingLink && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of: https://github.com/WordPress/gutenberg/issues/73180 and split out from: https://github.com/WordPress/gutenberg/pull/71730

In the block editor's rich text `FormatEdit` component, and in some of the format library, allow support for setting `isVisible` to `false` to hide rich text controls while still allowing keyboard shortcuts to be available. Note: this PR doesn't _quite_ expose this as an API for `RichText` just yet, it's just one step in this direction.

This PR just looks at doing this for bold, italic, and link for now, but could be expanded in follow-ups to include other formats. Note that these formats are chosen for now as they're the prominent ones that appear in [the block toolbar](https://github.com/WordPress/gutenberg/blob/9ff25d74d1bce31d29b4f8739744110001ec226d/packages/block-editor/src/components/rich-text/format-toolbar/index.js#L25).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As described in #73180 and being explored in https://github.com/WordPress/gutenberg/pull/71730 there is a need for editable fields where rich text is previewed _and_ editable while not actually showing toolbar items. Common cases are bold, italic, and creating links.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the `FormatEdit` component to support passing down an `isVisible` prop to the edit components for formats
* In the bold, italic, and link formats, add an `isVisible` prop that defaults to `true`. When this is falsy, the toolbar control will be hidden, but keyboard shortcuts will still work

Note: this PR intentionally only addresses that above formats. In most cases, if folks want to hide formats they can simply exclude those formats. Whereas for bold, italic, and link, there is a common use case of wanting to allow keyboard shortcuts while hiding the visual controls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

With this PR, everything should behave exactly as on trunk. However to test this, you can pass `isVisible={ false }` in `RichText` here:

```diff
diff --git a/packages/block-editor/src/components/rich-text/index.js b/packages/block-editor/src/components/rich-text/index.js
index f0c6e75630..3adb2c501d 100644
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -432,6 +432,7 @@ export function RichTextWrapper(
 								onFocus={ onFocus }
 								formatTypes={ formatTypes }
 								forwardedRef={ anchorRef }
+								isVisible={ false }
 							/>
 						</Popover.__unstableSlotNameProvider>
 					</inputEventContext.Provider>
```

Then load up the post editor and go to edit a paragraph. You should be able to use keyboard shortcuts to set bold, italic, and links, but the buttons will not be displayed in the toolbar.

## Screenshots or screencast <!-- if applicable -->

### This is how it should look normally

<img width="450" alt="image" src="https://github.com/user-attachments/assets/21fb21cc-ad41-4cdb-b19b-e2fbbff98edb" />

### If you apply the above diff to hide controls

You should be able to select text and use keyboard shortcuts to apply formats:

<img width="313" height="111" alt="image" src="https://github.com/user-attachments/assets/b57d7910-eace-41bf-8d3c-24e0d5ed8e35" />


