### PR TITLE
DataForms: Update Email Control component to use envelope icon instead of a Symbol 

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,7 @@
 - DataViews: Simplify the view config properties section. [#73064](https://github.com/WordPress/gutenberg/pull/73064)
 - DataViews: Add a contextual menu to the table layout header. [#73104](https://github.com/WordPress/gutenberg/pull/73104)
 - DataViewsPicker: Add table layout support. [#72914](https://github.com/WordPress/gutenberg/pull/72914)
+- DataForm: use envelope icon instead of atSymbol for email control component. [#73184](https://github.com/WordPress/gutenberg/pull/73184)
 
 ### Bug fixes
 

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -5,7 +5,7 @@ import {
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
-import { atSymbol } from '@wordpress/icons';
+import { envelope } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ export default function Email< Item >( {
 				type: 'email',
 				prefix: (
 					<InputControlPrefixWrapper variant="icon">
-						<Icon icon={ atSymbol } />
+						<Icon icon={ envelope } />
 					</InputControlPrefixWrapper>
 				),
 			} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73094 

<!-- In a few words, what is the PR actually doing? -->

Updates the DataForm email control component to use an envelope icon instead of the `@` symbol icon, providing a more conventional and recognizable visual indicator for email input fields.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current implementation uses an `@` symbol (`atSymbol` icon) for email fields in DataForm, which is unconventional. The envelope icon is a more widely recognized and standard icon for representing email fields across user interfaces, improving user experience and interface consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Modified [`packages/dataviews/src/dataform-controls/email.tsx`](packages/dataviews/src/dataform-controls/email.tsx)
- Changed the icon import from `atSymbol` to `envelope` from `@wordpress/icons`
- Updated the `InputControlPrefixWrapper` to render the envelope icon instead of the @ symbol

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Confirm email control icon is updated in http://localhost:50240/?path=/story/dataviews-dataform--layout-regular

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A - This change only affects the visual icon display and does not modify keyboard interactions or accessibility features.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


|Before|After|
|-|-|
|![Before - @ symbol icon](https://github.com/user-attachments/assets/5ef21702-0d65-4198-af9f-fe89ee173504)|![After - envelope icon](https://github.com/user-attachments/assets/c056aba3-5e3a-4b08-a4f1-f4b8643cbfb4)|
