### PR TITLE
Update button label from "Add new note" to "Add new reply"

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -569,7 +569,7 @@ function Thread( {
 					);
 				} }
 			>
-				{ __( 'Add new note' ) }
+				{ __( 'Add new reply' ) }
 			</Button>
 			{ ! thread.blockClientId && (
 				<Text as="p" weight={ 500 } variant="muted">

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -676,7 +676,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Note: Test comment',
 				} );
 			const addNewCommentButton = thread.getByRole( 'button', {
-				name: 'Add new note',
+				name: 'Add new reply',
 			} );
 			await thread.focus();
 			await page.keyboard.press( 'Tab' );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -709,6 +709,7 @@ test.describe( 'Block Comments', () => {
 				} );
 			const replyButton = thread.getByRole( 'button', {
 				name: 'Reply',
+				exact: true,
 			} );
 			const backToBlockButton = thread.getByRole( 'button', {
 				name: 'Back to block',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73187

This PR updates the text label of the "Add new note" button to "Add new reply" for improved clarity and accessibility.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Previously, the label “Add new note” could be misinterpreted as an action to create a new note on a different block, rather than replying to the existing note thread.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Insert a block and add a note to it.
2. Focus on the note using the Tab key.
3. Press Tab again to focus the button.
4. Confirm that the button now reads “Add new reply” instead of “Add new note.”
5. Add a reply and ensure the behavior remains unchanged.
6. Run E2E tests to confirm all related tests pass successfully.

## Video 


https://github.com/user-attachments/assets/74b90e45-23df-4ac5-8a06-9f421ceed561


