### PR TITLE
Fix Navigation links to deleted entities to show as invalid for all entity types

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -92,18 +92,19 @@ const useIsDraggingWithin = ( elementRef ) => {
 };
 
 const useIsInvalidLink = ( kind, type, id, enabled ) => {
-	const isPostType =
-		kind === 'post-type' || type === 'post' || type === 'page';
+	const isPostType = kind === 'post-type';
+	const isTaxonomy = kind === 'taxonomy';
+	const isEntityLink = isPostType || isTaxonomy;
 	const hasId = Number.isInteger( id );
 	const blockEditingMode = useBlockEditingMode();
 
 	const { postStatus, isDeleted } = useSelect(
 		( select ) => {
-			if ( ! isPostType ) {
+			if ( ! isEntityLink ) {
 				return { postStatus: null, isDeleted: false };
 			}
 
-			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
+			// Fetching the entity status is an "expensive" operation. Especially for sites with large navigations.
 			// When the block is rendered in a template or other disabled contexts we can skip this check in order
 			// to avoid all these additional requests that don't really add any value in that mode.
 			if ( blockEditingMode === 'disabled' || ! enabled ) {
@@ -112,10 +113,20 @@ const useIsInvalidLink = ( kind, type, id, enabled ) => {
 
 			const { getEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const entityRecord = getEntityRecord( 'postType', type, id );
+
+			// Use the correct entity type based on kind.
+			// For taxonomies, map 'tag' to 'post_tag' as that's the actual taxonomy slug.
+			const entityType = isTaxonomy ? 'taxonomy' : 'postType';
+			const entityTypeOrSlug =
+				isTaxonomy && type === 'tag' ? 'post_tag' : type;
+			const entityRecord = getEntityRecord(
+				entityType,
+				entityTypeOrSlug,
+				id
+			);
 			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
-				'postType',
-				type,
+				entityType,
+				entityTypeOrSlug,
 				id,
 			] );
 
@@ -127,22 +138,22 @@ const useIsInvalidLink = ( kind, type, id, enabled ) => {
 				isDeleted: deleted,
 			};
 		},
-		[ isPostType, blockEditingMode, enabled, type, id ]
+		[ kind, isEntityLink, isTaxonomy, blockEditingMode, enabled, type, id ]
 	);
 
 	// Check Navigation Link validity if:
-	// 1. Link is 'post-type'.
+	// 1. Link is 'post-type' or 'taxonomy'.
 	// 2. It has an id.
 	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
 	// If those conditions are met, check if
-	// 1. The post status is trash (trashed).
-	// 2. The entity doesn't exist (deleted).
+	// 1. The entity doesn't exist (deleted).
+	// 2. For post types: The post status is trash (trashed).
 	// If either of those is true, invalidate.
 	const isInvalid =
-		isPostType &&
+		isEntityLink &&
 		hasId &&
-		( isDeleted || ( postStatus && 'trash' === postStatus ) );
-	const isDraft = 'draft' === postStatus;
+		( isDeleted || ( isPostType && postStatus && 'trash' === postStatus ) );
+	const isDraft = isPostType && 'draft' === postStatus;
 
 	return [ isInvalid, isDraft ];
 };


### PR DESCRIPTION
Fixes #73188

## What

Extends the "(Invalid)" suffix to all Navigation Link entity types. Previously, only Posts and Pages showed "(Invalid)" when deleted. The fix now ensures this works for:
- Taxonomies (categories, tags, custom taxonomies)
- Custom Post Types

This ensures consistent behavior across all navigation link types.

## Why

The `useIsInvalidLink` hook only validated built-in post types (posts and pages) for deletion. Other entity types (taxonomies and custom post types) were not checked, so deleted entities could appear valid. This change validates all entity types for existence, improving consistency and helping users identify broken navigation links.

## How

The `useIsInvalidLink` hook now:
- Uses the `kind` attribute to identify both post types and taxonomies (not just checking the `type` field)
- Fetches entity records using the correct entity type (`postType` for all post types, `taxonomy` for terms)
- Checks for deletion for all entity types (taxonomies, custom post types, and built-in post types)
- Handles the taxonomy slug mapping (e.g., `tag` → `post_tag`)
- Maintains existing post status validation (trash/draft) for post types only

The validation logic now treats all entity types consistently: if an entity doesn't exist (deleted), the navigation link is marked as invalid, regardless of whether it's a taxonomy, custom post type, or built-in post type.

## Testing Instructions

1. Add a Post "Tag" via WP Admin
2. In the Editor, add a Tag Navigation Link block and link to that Tag
3. Delete the Tag in WP Admin
4. Reload the Editor
5. Select the Navigation block
6. Verify that the Tag Link shows "(Invalid)" suffix
7. Repeat the above steps but for a Custom Post Type link

## Screenshots
<img width="1642" height="338" alt="Screen Shot 2025-11-12 at 08 38 08" src="https://github.com/user-attachments/assets/72676c7e-7437-4475-afe5-2a5da49f3ae6" />

