### PR TITLE
Routing: Extract route package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1956,6 +1956,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/route",
+		"slug": "packages-route",
+		"markdown_source": "../packages/route/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/router",
 		"slug": "packages-router",
 		"markdown_source": "../packages/router/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17593,6 +17593,10 @@
 			"resolved": "packages/rich-text",
 			"link": true
 		},
+		"node_modules/@wordpress/route": {
+			"resolved": "packages/route",
+			"link": true
+		},
 		"node_modules/@wordpress/router": {
 			"resolved": "packages/router",
 			"link": true
@@ -52690,8 +52694,6 @@
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@tanstack/history": "^1.133.28",
-				"@tanstack/react-router": "^1.120.5",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/commands": "file:../commands",
 				"@wordpress/components": "file:../components",
@@ -52707,6 +52709,7 @@
 				"@wordpress/lazy-editor": "file:../lazy-editor",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/route": "file:../route",
 				"@wordpress/theme": "file:../theme",
 				"@wordpress/url": "file:../url",
 				"clsx": "^2.1.1"
@@ -54714,6 +54717,23 @@
 				"react": "^18.0.0"
 			}
 		},
+		"packages/route": {
+			"name": "@wordpress/route",
+			"version": "0.1.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tanstack/history": "^1.133.28",
+				"@tanstack/react-router": "^1.120.5",
+				"@wordpress/private-apis": "file:../private-apis"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"packages/router": {
 			"name": "@wordpress/router",
 			"version": "1.34.0",
@@ -55288,7 +55308,7 @@
 			"name": "@wordpress/post",
 			"version": "1.0.0",
 			"dependencies": {
-				"@tanstack/react-router": ">=1.120.5 <1.121.0"
+				"@wordpress/route": "file:../../packages/route"
 			}
 		},
 		"routes/post-edit": {
@@ -55303,7 +55323,6 @@
 			"name": "@wordpress/post-list",
 			"version": "1.0.0",
 			"dependencies": {
-				"@tanstack/react-router": ">=1.120.5 <1.121.0",
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/block-editor": "file:../../packages/block-editor",
 				"@wordpress/components": "file:../../packages/components",
@@ -55320,105 +55339,10 @@
 				"@wordpress/keycodes": "file:../../packages/keycodes",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/views": "file:../../packages/views",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"
-			}
-		},
-		"routes/post-list/node_modules/@tanstack/history": {
-			"version": "1.120.17",
-			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.120.17.tgz",
-			"integrity": "sha512-k07LFI4Qo074IIaWzT/XjD0KlkGx2w1V3fnNtclKx0oAl8z4O9kCh6za+FPEIRe98xLgNFEiddDbJeAYGSlPtw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post-list/node_modules/@tanstack/react-router": {
-			"version": "1.120.20",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.20.tgz",
-			"integrity": "sha512-+zNruUE9NsfGm9cHd22Xs7FRtBrBhDZe94pB69BEIjqjrEPZct6f5VhTV9WQ+bDZ6fRz8tUuxNFAgm/3Lm4AIg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/history": "1.120.17",
-				"@tanstack/react-store": "^0.7.0",
-				"@tanstack/router-core": "1.120.19",
-				"jsesc": "^3.1.0",
-				"tiny-invariant": "^1.3.3",
-				"tiny-warning": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": ">=18.0.0 || >=19.0.0",
-				"react-dom": ">=18.0.0 || >=19.0.0"
-			}
-		},
-		"routes/post-list/node_modules/@tanstack/react-store": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.7.tgz",
-			"integrity": "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/store": "0.7.7",
-				"use-sync-external-store": "^1.5.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"routes/post-list/node_modules/@tanstack/router-core": {
-			"version": "1.120.19",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.19.tgz",
-			"integrity": "sha512-5JUVgkxnIM3NxMwzKt0tfz2UopZVxwq6Kl7Rp33zlFJaPjpiRs46VuRjVeAvkpJd6samo1gcH1rWqmnPUmtGcw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/history": "1.120.17",
-				"@tanstack/store": "^0.7.0",
-				"tiny-invariant": "^1.3.3"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post-list/node_modules/@tanstack/store": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.7.tgz",
-			"integrity": "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post-list/node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"routes/post-new": {
@@ -55427,102 +55351,6 @@
 			"dependencies": {
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data"
-			}
-		},
-		"routes/post/node_modules/@tanstack/history": {
-			"version": "1.120.17",
-			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.120.17.tgz",
-			"integrity": "sha512-k07LFI4Qo074IIaWzT/XjD0KlkGx2w1V3fnNtclKx0oAl8z4O9kCh6za+FPEIRe98xLgNFEiddDbJeAYGSlPtw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post/node_modules/@tanstack/react-router": {
-			"version": "1.120.20",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.20.tgz",
-			"integrity": "sha512-+zNruUE9NsfGm9cHd22Xs7FRtBrBhDZe94pB69BEIjqjrEPZct6f5VhTV9WQ+bDZ6fRz8tUuxNFAgm/3Lm4AIg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/history": "1.120.17",
-				"@tanstack/react-store": "^0.7.0",
-				"@tanstack/router-core": "1.120.19",
-				"jsesc": "^3.1.0",
-				"tiny-invariant": "^1.3.3",
-				"tiny-warning": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": ">=18.0.0 || >=19.0.0",
-				"react-dom": ">=18.0.0 || >=19.0.0"
-			}
-		},
-		"routes/post/node_modules/@tanstack/react-store": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.7.tgz",
-			"integrity": "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/store": "0.7.7",
-				"use-sync-external-store": "^1.5.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"routes/post/node_modules/@tanstack/router-core": {
-			"version": "1.120.19",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.19.tgz",
-			"integrity": "sha512-5JUVgkxnIM3NxMwzKt0tfz2UopZVxwq6Kl7Rp33zlFJaPjpiRs46VuRjVeAvkpJd6samo1gcH1rWqmnPUmtGcw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/history": "1.120.17",
-				"@tanstack/store": "^0.7.0",
-				"tiny-invariant": "^1.3.3"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post/node_modules/@tanstack/store": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.7.tgz",
-			"integrity": "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"routes/post/node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		}
 	}

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -34,8 +34,6 @@
 	"wpScriptModuleExports": "./build-module/index.js",
 	"types": "build-types",
 	"dependencies": {
-		"@tanstack/history": "^1.133.28",
-		"@tanstack/react-router": "^1.120.5",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/commands": "file:../commands",
 		"@wordpress/components": "file:../components",
@@ -51,6 +49,7 @@
 		"@wordpress/lazy-editor": "file:../lazy-editor",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/route": "file:../route",
 		"@wordpress/theme": "file:../theme",
 		"@wordpress/url": "file:../url",
 		"clsx": "^2.1.1"

--- a/packages/boot/src/components/navigation/router-link-item.tsx
+++ b/packages/boot/src/components/navigation/router-link-item.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createLink } from '@tanstack/react-router';
 import type { ForwardedRef } from 'react';
 
 /**
@@ -9,6 +8,14 @@ import type { ForwardedRef } from 'react';
  */
 import { forwardRef } from '@wordpress/element';
 import { __experimentalItem as Item } from '@wordpress/components';
+import { privateApis as routePrivateApis } from '@wordpress/route';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { createLink } = unlock( routePrivateApis );
 
 function AnchorOnlyItem(
 	props: React.ComponentProps< typeof Item >,

--- a/packages/boot/src/components/navigation/use-sidebar-parent.ts
+++ b/packages/boot/src/components/navigation/use-sidebar-parent.ts
@@ -1,13 +1,16 @@
 /**
- * External dependencies
- */
-import { useRouter, useMatches } from '@tanstack/react-router';
-
-/**
  * WordPress dependencies
  */
+import { privateApis as routePrivateApis } from '@wordpress/route';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useRouter, useMatches } = unlock( routePrivateApis );
 
 /**
  * Internal dependencies

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Outlet, useMatches } from '@tanstack/react-router';
 import clsx from 'clsx';
 
 /**
  * WordPress dependencies
  */
+import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
 import { privateApis as themePrivateApis } from '@wordpress/theme';
@@ -21,6 +21,7 @@ import type { CanvasData } from '../../store/types';
 import './style.scss';
 
 const { ThemeProvider } = unlock( themePrivateApis );
+const { useMatches, Outlet } = unlock( routePrivateApis );
 
 export default function Root() {
 	// Get canvas data from the current route's loader

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Outlet, useMatches } from '@tanstack/react-router';
 import clsx from 'clsx';
 
 /**
  * WordPress dependencies
  */
+import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
 import { privateApis as themePrivateApis } from '@wordpress/theme';
@@ -19,6 +19,7 @@ import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
 
+const { useMatches, Outlet } = unlock( routePrivateApis );
 const { ThemeProvider } = unlock( themePrivateApis );
 
 /**

--- a/packages/boot/src/components/site-icon-link/index.tsx
+++ b/packages/boot/src/components/site-icon-link/index.tsx
@@ -1,13 +1,16 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { Link, useCanGoBack, useRouter } from '@tanstack/react-router';
+import { Link, privateApis as routePrivateApis } from '@wordpress/route';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import SiteIcon from '../site-icon';
 import './style.scss';
+
+const { useCanGoBack, useRouter } = unlock( routePrivateApis );
 
 function SiteIconLink( {
 	to,

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -19,6 +19,7 @@
 		{ "path": "../lazy-editor" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
+		{ "path": "../route" },
 		{ "path": "../theme" },
 		{ "path": "../url" }
 	]

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -29,6 +29,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/patterns',
 	'@wordpress/preferences',
 	'@wordpress/reusable-blocks',
+	'@wordpress/route',
 	'@wordpress/router',
 	'@wordpress/routes',
 	'@wordpress/sync',

--- a/packages/route/README.md
+++ b/packages/route/README.md
@@ -1,0 +1,50 @@
+# Route
+
+Routing utilities for WordPress admin interfaces, providing a shared instance of TanStack Router.
+
+## Installation
+
+Install the module:
+
+```bash
+npm install @wordpress/route --save
+```
+
+## Usage
+
+This package provides a shared instance of TanStack Router to ensure consistent routing across WordPress admin interfaces.
+
+### Public API
+
+The following hooks and components are available for use in routes:
+
+```js
+import { Link, useNavigate, useParams, useRouter, useSearch } from '@wordpress/route';
+
+function MyRoute() {
+	const params = useParams();
+	const navigate = useNavigate();
+	const search = useSearch();
+
+	return (
+		<div>
+			<Link to="/other-route">Go to other route</Link>
+			<button onClick={() => navigate({ to: '/somewhere' })}>
+				Navigate
+			</button>
+		</div>
+	);
+}
+```
+
+### Private API
+
+The boot package uses private APIs for router setup. These should not be used by individual routes.
+
+## Contributing to this package
+
+This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose.
+
+To find out more about contributing to this package or Gutenberg as a whole, please read the [project's main contributor guide](https://github.com/WordPress/gutenberg/blob/HEAD/CONTRIBUTING.md).
+
+<br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/route/package.json
+++ b/packages/route/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@wordpress/route",
+	"version": "0.1.0",
+	"description": "Routing utilities for WordPress admin interfaces.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"routing"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/route/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/route"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"exports": {
+		".": {
+			"types": "./build-types/index.d.ts",
+			"import": "./build-module/index.js",
+			"default": "./build/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"react-native": "src/index",
+	"wpScriptModuleExports": "./build-module/index.js",
+	"types": "build-types",
+	"sideEffects": false,
+	"dependencies": {
+		"@tanstack/history": "^1.133.28",
+		"@tanstack/react-router": "^1.120.5",
+		"@wordpress/private-apis": "file:../private-apis"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/route/src/index.ts
+++ b/packages/route/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useRouter } from '@tanstack/react-router';
+export {
+	Link,
+	redirect,
+	useNavigate,
+	useParams,
+	useSearch,
+} from '@tanstack/react-router';
+export type {
+	AnyRoute,
+	LinkProps,
+	NavigateOptions,
+	RouteOptions,
+	RouterOptions,
+	ToOptions,
+	UseNavigateResult,
+} from '@tanstack/react-router';
+
+/**
+ * Internal dependencies
+ */
+export { privateApis } from './private-apis';
+
+/**
+ * Hook to invalidate the router cache and trigger a re-render.
+ * This is useful when you want to refetch data without changing the URL.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const invalidate = useInvalidate();
+ *
+ *   const handleRefresh = () => {
+ *     invalidate();
+ *   };
+ *
+ *   return <button onClick={handleRefresh}>Refresh</button>;
+ * }
+ * ```
+ *
+ * @return A function to invalidate the router.
+ */
+export function useInvalidate() {
+	const router = useRouter();
+	return () => router.invalidate();
+}

--- a/packages/route/src/lock-unlock.ts
+++ b/packages/route/src/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/route'
+	);

--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { parseHref } from '@tanstack/history';
+import {
+	createBrowserHistory,
+	createLink,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	Outlet,
+	redirect,
+	RouterProvider,
+	useCanGoBack,
+	useMatches,
+	useRouter,
+} from '@tanstack/react-router';
+
+/**
+ * Internal dependencies
+ */
+import { lock } from './lock-unlock';
+
+/**
+ * Private APIs for the boot package only.
+ * These are router setup and internal utilities that should not be used
+ * by individual routes.
+ */
+export const privateApis = {};
+
+// Lock the private APIs so only authorized modules can access them
+lock( privateApis, {
+	// Router creation and setup
+	createBrowserHistory,
+	createRouter,
+	createRootRoute,
+	createRoute,
+	Outlet,
+	RouterProvider,
+
+	// Internal routing utilities
+	redirect,
+	createLink,
+	useCanGoBack,
+	useMatches,
+	useRouter,
+
+	// History utilities
+	parseHref,
+} );

--- a/packages/route/tsconfig.json
+++ b/packages/route/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [
+		{
+			"path": "../private-apis"
+		}
+	],
+	"include": [ "src/**/*" ]
+}

--- a/routes/post-list/package.json
+++ b/routes/post-list/package.json
@@ -7,7 +7,6 @@
 		"page": "gutenberg-boot"
 	},
 	"dependencies": {
-		"@tanstack/react-router": ">=1.120.5 <1.121.0",
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
 		"@wordpress/block-editor": "file:../../packages/block-editor",
 		"@wordpress/components": "file:../../packages/components",
@@ -22,6 +21,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/keycodes": "file:../../packages/keycodes",
+		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/private-apis": "file:../../packages/private-apis",
 		"@wordpress/views": "file:../../packages/views",

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -1,17 +1,13 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import {
 	useParams,
 	useNavigate,
 	useSearch,
 	Link,
-	useRouter,
-} from '@tanstack/react-router';
-
-/**
- * WordPress dependencies
- */
+	useInvalidate,
+} from '@wordpress/route';
 import { useView } from '@wordpress/views';
 import { DataViews } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
@@ -60,7 +56,7 @@ function getItemLevel( item: Post ) {
 }
 
 function PostList() {
-	const router = useRouter();
+	const invalidate = useInvalidate();
 	const { type: postType, slug = 'all' } = useParams( {
 		from: '/types/$type/list/$slug',
 	} );
@@ -110,7 +106,7 @@ function PostList() {
 
 	const onReset = () => {
 		resetToDefault();
-		router.invalidate();
+		invalidate();
 	};
 	const onChangeView = ( newView: View ) => {
 		updateView( newView );
@@ -118,7 +114,7 @@ function PostList() {
 			// The rendered surfaces depend on the view type,
 			// so we need to retrigger the router loader when switching the view type.
 			// try switching from list to table and vice versa.
-			router.invalidate();
+			invalidate();
 		}
 	};
 
@@ -179,10 +175,10 @@ function PostList() {
 				} );
 			} else {
 				// If no change in the url, the first item might have changed.
-				router.invalidate();
+				invalidate();
 			}
 		},
-		[ router, searchParams, navigate ]
+		[ invalidate, searchParams, navigate ]
 	);
 
 	const postTypeActions: Action< Post >[] = usePostActions( {

--- a/routes/post/package.json
+++ b/routes/post/package.json
@@ -7,6 +7,6 @@
 		"page": "gutenberg-boot"
 	},
 	"dependencies": {
-		"@tanstack/react-router": ">=1.120.5 <1.121.0"
+		"@wordpress/route": "file:../../packages/route"
 	}
 }

--- a/routes/post/route.ts
+++ b/routes/post/route.ts
@@ -1,14 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+/**
  * Route configuration for post redirect.
  */
 export const route = {
-	beforeLoad: ( {
-		params,
-		redirect,
-	}: {
-		params: { type: string };
-		redirect: Function;
-	} ) => {
+	beforeLoad: ( { params }: { params: { type: string } } ) => {
 		throw redirect( {
 			throw: true,
 			to: '/types/$type/list/$slug',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,7 @@
 		{ "path": "packages/redux-routine" },
 		{ "path": "packages/report-flaky-tests" },
 		{ "path": "packages/rich-text" },
+		{ "path": "packages/route" },
 		{ "path": "packages/router" },
 		{ "path": "packages/shortcode" },
 		{ "path": "packages/style-engine" },


### PR DESCRIPTION
Related #70862 

## What?

I noticed that I can't bundle tanstack router twice in the app (once in boot and once in routes), this means that we need to share it as a module. But to avoid making the whole tanstack a public API for routes, I limited the number of public APIs to the tools that routes should be using to handle navigation... Setting up the router remains private which allows to update the router more easily later even if there are breaking changes in the library (or switch library).

## Testing Instructions

- No functional change
- You can load http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot 
- click posts and be redirected properly to the post list.