### PR TITLE
Patterns: Update pattern editing button labels 

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -56,8 +56,8 @@ export default function EditContents( { clientId } ) {
 				} }
 			>
 				{ editedContentOnlySection
-					? __( 'Lock design' )
-					: __( 'Unlock design' ) }
+					? __( 'Exit pattern' )
+					: __( 'Edit pattern' ) }
 			</Button>
 		</VStack>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the content-only section editing button labels from "Lock design" / "Unlock design" to "Exit pattern" / "Edit pattern" for improved clarity and consistency with pattern editing terminology.

Taken out of https://github.com/WordPress/gutenberg/pull/72574

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The previous labels "Lock/Unlock design" were ambiguous and had some overlap with other unrelated concepts. The new labels "Edit pattern" and "Exit pattern" are more descriptive and align better with the actual functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Text changes

  - Updated button label: "Unlock design" → "Edit pattern"
  - Updated button label: "Lock design" → "Exit pattern"

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
0. Enable the content only experiment
1. Open a post or page
2. Insert a pattern
3. Confirm the text changes.

## Screenshots or screencast <!-- if applicable -->
<img width="298" height="336" alt="Screenshot 2025-11-12 at 11 40 14" src="https://github.com/user-attachments/assets/70149801-7898-4920-9153-c39e34896a1a" />
<img width="291" height="348" alt="Screenshot 2025-11-12 at 11 40 08" src="https://github.com/user-attachments/assets/3e7c7ff5-3877-4e36-a46e-d7e52178ff16" />
