### PR TITLE
Real-time collaboration: Add CollaborationMode SlotFill for editor toolbar

### DIFF
--- a/packages/editor/src/components/collaboration-mode/index.tsx
+++ b/packages/editor/src/components/collaboration-mode/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'CollaborationMode' );
+
+/**
+ * Renders the SlotFill for collaboration mode.
+ */
+export const CollaborationMode = Fill;
+
+export { Slot };

--- a/packages/editor/src/components/collaboration-mode/index.tsx
+++ b/packages/editor/src/components/collaboration-mode/index.tsx
@@ -3,7 +3,7 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill, Slot } = createSlotFill( 'CollaborationMode' );
+const { Fill, Slot } = createSlotFill( Symbol( 'CollaborationMode' ) );
 
 /**
  * Renders the SlotFill for collaboration mode.

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -110,29 +110,31 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
-				<CollaborationModeSlot>
-					{ ( fills ) =>
-						fills?.length ? (
-							<div className="editor-document-tools__collaboration-mode">
-								{ fills }
-							</div>
-						) : null
-					}
-				</CollaborationModeSlot>
 				{ ! isDistractionFree && (
-					<ToolbarButton
-						ref={ inserterSidebarToggleRef }
-						className="editor-document-tools__inserter-toggle"
-						variant="primary"
-						isPressed={ isInserterOpened }
-						onMouseDown={ preventDefault }
-						onClick={ toggleInserter }
-						disabled={ disableBlockTools }
-						icon={ plus }
-						label={ showIconLabels ? shortLabel : longLabel }
-						showTooltip={ ! showIconLabels }
-						aria-expanded={ isInserterOpened }
-					/>
+					<>
+						<CollaborationModeSlot>
+							{ ( fills ) =>
+								fills?.length ? (
+									<div className="editor-document-tools__collaboration-mode">
+										{ fills }
+									</div>
+								) : null
+							}
+						</CollaborationModeSlot>
+						<ToolbarButton
+							ref={ inserterSidebarToggleRef }
+							className="editor-document-tools__inserter-toggle"
+							variant="primary"
+							isPressed={ isInserterOpened }
+							onMouseDown={ preventDefault }
+							onClick={ toggleInserter }
+							disabled={ disableBlockTools }
+							icon={ plus }
+							label={ showIconLabels ? shortLabel : longLabel }
+							showTooltip={ ! showIconLabels }
+							aria-expanded={ isInserterOpened }
+						/>
+					</>
 				) }
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -23,6 +23,7 @@ import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
+import { Slot as CollaborationModeSlot } from '../collaboration-mode';
 
 function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
@@ -109,6 +110,15 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
+				<CollaborationModeSlot>
+					{ ( fills ) =>
+						fills?.length ? (
+							<div className="editor-document-tools__collaboration-mode">
+								{ fills }
+							</div>
+						) : null
+					}
+				</CollaborationModeSlot>
 				{ ! isDistractionFree && (
 					<ToolbarButton
 						ref={ inserterSidebarToggleRef }

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -12,6 +12,7 @@ import EditorContentSlotFill from './components/editor-interface/content-slot-fi
 import BackButton from './components/header/back-button';
 import Editor from './components/editor';
 import { EditorPresence } from './components/editor-presence';
+import { CollaborationMode } from './components/collaboration-mode';
 import PluginPostExcerpt from './components/post-excerpt/plugin';
 import PostCardPanel from './components/post-card-panel';
 import PreferencesModal from './components/preferences-modal';
@@ -44,6 +45,7 @@ lock( privateApis, {
 	Editor,
 	EditorContentSlotFill,
 	EditorPresence,
+	CollaborationMode,
 	GlobalStylesProvider,
 	mergeBaseAndUserConfigs,
 	PluginPostExcerpt,


### PR DESCRIPTION
# Add CollaborationMode SlotFill for editor toolbar

## What?

Adds a new `CollaborationMode` SlotFill that lets plugins display collaboration mode indicators (like view/edit state) in the editor toolbar.

## Why?

For real-time collaboration, we need to show users their current mode - whether they can edit or are in view-only mode. This follows the same pattern as `EditorPresence`.

## How?

- Created `CollaborationMode` SlotFill component
- Added slot as first element in the left toolbar section
- Exported as a private API

## Testing Instructions

1. Open the editor and verify it loads without errors
2. Check that toolbar functions normally (no visual changes without a plugin using the slot)

To test with a plugin:

```jsx
const { CollaborationMode } = unlock( editorStore.privateApis );

<CollaborationMode>
    <div>Edit Mode</div>
</CollaborationMode>
```

The indicator should appear as the first item in the left toolbar.

## Screenshots or screencast

N/A - Infrastructure only, no visual changes without a Fill.
