### PR TITLE
Routing: Add styles page as a route

### DIFF
--- a/lib/experimental/pages/gutenberg-boot.php
+++ b/lib/experimental/pages/gutenberg-boot.php
@@ -26,5 +26,6 @@ add_action( 'admin_menu', 'gutenberg_register_boot_admin_page' );
 function gutenberg_boot_register_default_menu_items() {
 	register_gutenberg_boot_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
 	register_gutenberg_boot_menu_item( 'posts', __( 'Posts', 'gutenberg' ), '/types/post', '' );
+	register_gutenberg_boot_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 }
 add_action( 'gutenberg-boot_init', 'gutenberg_boot_register_default_menu_items', 5 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -46548,6 +46548,10 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/styles": {
+			"resolved": "routes/styles",
+			"link": true
+		},
 		"node_modules/stylis": {
 			"version": "4.0.13",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
@@ -55352,6 +55356,21 @@
 			"dependencies": {
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data"
+			}
+		},
+		"routes/styles": {
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/editor": "file:../../packages/editor",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/url": "file:../../packages/url"
 			}
 		}
 	}

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -100,21 +100,20 @@ async function createRouteFromDefinition(
 	parentRoute: AnyRoute
 ) {
 	// Create lazy components for stage, inspector, and canvas surfaces
-	const SurfacesModule = route.content_module
-		? lazy( async () => {
-				const module = await import( route.content_module! );
-				// Return a component that renders the surfaces
-				return {
-					default: () => (
-						<RouteComponent
-							stage={ module.stage }
-							inspector={ module.inspector }
-							canvas={ module.canvas }
-						/>
-					),
-				};
-		  } )
-		: () => null;
+	const SurfacesModule = lazy( async () => {
+		const module = route.content_module
+			? await import( route.content_module )
+			: {};
+		return {
+			default: () => (
+				<RouteComponent
+					stage={ module.stage }
+					inspector={ module.inspector }
+					canvas={ module.canvas }
+				/>
+			),
+		};
+	} );
 
 	// Load route module for lifecycle functions if specified
 	let routeConfig: {

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -18,8 +18,9 @@ import {
  * Internal dependencies
  */
 import Root from '../root';
-import type { Route, RouteLoaderContext } from '../../store/types';
+import type { CanvasData, Route, RouteLoaderContext } from '../../store/types';
 import { unlock } from '../../lock-unlock';
+import Canvas from '../canvas';
 
 const {
 	createRouter,
@@ -28,6 +29,7 @@ const {
 	RouterProvider,
 	createBrowserHistory,
 	parseHref,
+	useMatches,
 } = unlock( routePrivateApis );
 
 // Not found component
@@ -44,10 +46,20 @@ function NotFoundComponent() {
 function RouteComponent( {
 	stage: Stage,
 	inspector: Inspector,
+	canvas: CustomCanvas,
 }: {
 	stage?: ComponentType;
 	inspector?: ComponentType;
+	canvas?: ComponentType;
 } ) {
+	// Get canvas data from the current route's loader
+	const matches = useMatches();
+	const currentMatch = matches[ matches.length - 1 ];
+	const canvasData = ( currentMatch?.loaderData as any )?.canvas as
+		| CanvasData
+		| null
+		| undefined;
+
 	return (
 		<>
 			{ Stage && (
@@ -58,6 +70,18 @@ function RouteComponent( {
 			{ Inspector && (
 				<div className="boot-layout__inspector">
 					<Inspector />
+				</div>
+			) }
+			{ /* Render custom canvas when canvas() returns null */ }
+			{ canvasData === null && CustomCanvas && (
+				<div className="boot-layout__canvas">
+					<CustomCanvas />
+				</div>
+			) }
+			{ /* Render default canvas when canvas() returns CanvasData */ }
+			{ canvasData && (
+				<div className="boot-layout__canvas">
+					<Canvas canvas={ canvasData } />
 				</div>
 			) }
 		</>
@@ -75,7 +99,7 @@ async function createRouteFromDefinition(
 	route: Route,
 	parentRoute: AnyRoute
 ) {
-	// Create lazy components for stage and inspector surfaces
+	// Create lazy components for stage, inspector, and canvas surfaces
 	const SurfacesModule = route.content_module
 		? lazy( async () => {
 				const module = await import( route.content_module! );
@@ -85,6 +109,7 @@ async function createRouteFromDefinition(
 						<RouteComponent
 							stage={ module.stage }
 							inspector={ module.inspector }
+							canvas={ module.canvas }
 						/>
 					),
 				};

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -15,7 +15,6 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
  * Internal dependencies
  */
 import Sidebar from '../sidebar';
-import Canvas from '../canvas';
 import SavePanel from '../save-panel';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
@@ -29,6 +28,7 @@ export default function Root() {
 	const currentMatch = matches[ matches.length - 1 ];
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
 		| CanvasData
+		| null
 		| undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
 
@@ -37,7 +37,7 @@ export default function Root() {
 			<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
 				<div
 					className={ clsx( 'boot-layout', {
-						'has-canvas': !! canvas,
+						'has-canvas': !! canvas || canvas === null,
 						'has-full-canvas': isFullScreen,
 					} ) }
 				>
@@ -53,11 +53,6 @@ export default function Root() {
 							color={ { bg: '#ffffff', primary: '#3858e9' } }
 						>
 							<Outlet />
-							{ canvas && (
-								<div className="boot-layout__canvas">
-									<Canvas canvas={ canvas } />
-								</div>
-							) }
 						</ThemeProvider>
 					</div>
 				</div>

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -14,7 +14,6 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
 /**
  * Internal dependencies
  */
-import Canvas from '../canvas';
 import SavePanel from '../save-panel';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
@@ -32,6 +31,7 @@ export default function RootSinglePage() {
 	const currentMatch = matches[ matches.length - 1 ];
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
 		| CanvasData
+		| null
 		| undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
 
@@ -40,7 +40,7 @@ export default function RootSinglePage() {
 			<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
 				<div
 					className={ clsx( 'boot-layout boot-layout--single-page', {
-						'has-canvas': !! canvas,
+						'has-canvas': !! canvas || canvas === null,
 						'has-full-canvas': isFullScreen,
 					} ) }
 				>
@@ -51,11 +51,6 @@ export default function RootSinglePage() {
 							color={ { bg: '#ffffff', primary: '#3858e9' } }
 						>
 							<Outlet />
-							{ canvas && (
-								<div className="boot-layout__canvas">
-									<Canvas canvas={ canvas } />
-								</div>
-							) }
 						</ThemeProvider>
 					</div>
 				</div>

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -1,0 +1,121 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { _n, __, sprintf } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
+import { check } from '@wordpress/icons';
+import { EntitiesSavedStates } from '@wordpress/editor';
+import { Button, Modal, Tooltip } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import useSaveShortcut from '../save-panel/use-save-shortcut';
+
+export default function SaveButton() {
+	const [ isSaveViewOpen, setIsSaveViewOpened ] = useState( false );
+	const { isSaving, dirtyEntityRecordsCount } = useSelect( ( select ) => {
+		const { isSavingEntityRecord, __experimentalGetDirtyEntityRecords } =
+			select( coreStore );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		return {
+			isSaving: dirtyEntityRecords.some( ( record ) =>
+				isSavingEntityRecord( record.kind, record.name, record.key )
+			),
+			dirtyEntityRecordsCount: dirtyEntityRecords.length,
+		};
+	}, [] );
+	const [ showSavedState, setShowSavedState ] = useState( false );
+
+	useEffect( () => {
+		if ( isSaving ) {
+			// Proactively expect to show saved state. This is done once save
+			// starts to avoid race condition where setting it after would cause
+			// the button to be unmounted before state is updated.
+			setShowSavedState( true );
+		}
+	}, [ isSaving ] );
+
+	const hasChanges = dirtyEntityRecordsCount > 0;
+
+	// Handle save failure case: If we were showing saved state but saving
+	// failed, reset to show changes again.
+	useEffect( () => {
+		if ( ! isSaving && hasChanges ) {
+			setShowSavedState( false );
+		}
+	}, [ isSaving, hasChanges ] );
+
+	function hideSavedState() {
+		if ( showSavedState ) {
+			setShowSavedState( false );
+		}
+	}
+
+	const shouldShowButton = hasChanges || showSavedState;
+
+	useSaveShortcut( { openSavePanel: () => setIsSaveViewOpened( true ) } );
+
+	if ( ! shouldShowButton ) {
+		return null;
+	}
+
+	const isInSavedState = showSavedState && ! hasChanges;
+	const disabled = isSaving || isInSavedState;
+
+	const getLabel = () => {
+		if ( isInSavedState ) {
+			return __( 'Saved' );
+		}
+		return sprintf(
+			// translators: %d: number of unsaved changes (number).
+			_n(
+				'Review %d change…',
+				'Review %d changes…',
+				dirtyEntityRecordsCount
+			),
+			dirtyEntityRecordsCount
+		);
+	};
+	const label = getLabel();
+
+	return (
+		<>
+			<Tooltip
+				text={ hasChanges ? label : undefined }
+				shortcut={ displayShortcut.primary( 's' ) }
+			>
+				<Button
+					variant="primary"
+					size="compact"
+					onClick={ () => setIsSaveViewOpened( true ) }
+					onBlur={ hideSavedState }
+					disabled={ disabled }
+					accessibleWhenDisabled
+					isBusy={ isSaving }
+					aria-keyshortcuts={ rawShortcut.primary( 's' ) }
+					className="boot-save-button"
+					icon={ isInSavedState ? check : undefined }
+				>
+					{ label }
+				</Button>
+			</Tooltip>
+			{ isSaveViewOpen && (
+				<Modal
+					title={ __( 'Review changes' ) }
+					onRequestClose={ () => setIsSaveViewOpened( false ) }
+					size="small"
+				>
+					<EntitiesSavedStates
+						close={ () => setIsSaveViewOpened( false ) }
+						variant="inline"
+					/>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/boot/src/components/save-button/style.scss
+++ b/packages/boot/src/components/save-button/style.scss
@@ -1,0 +1,3 @@
+.boot-save-button {
+	width: 100%;
+}

--- a/packages/boot/src/components/sidebar/index.tsx
+++ b/packages/boot/src/components/sidebar/index.tsx
@@ -3,6 +3,7 @@
  */
 import SiteHub from '../site-hub';
 import Navigation from '../navigation';
+import SaveButton from '../save-button';
 import './style.scss';
 
 export default function Sidebar() {
@@ -11,6 +12,9 @@ export default function Sidebar() {
 			<SiteHub />
 			<div className="boot-sidebar__content">
 				<Navigation />
+			</div>
+			<div className="boot-sidebar__footer">
+				<SaveButton />
 			</div>
 		</div>
 	);

--- a/packages/boot/src/components/sidebar/style.scss
+++ b/packages/boot/src/components/sidebar/style.scss
@@ -13,3 +13,7 @@
 	contain: content;
 	position: relative;
 }
+
+.boot-sidebar__footer {
+	padding: variables.$grid-unit-20 variables.$grid-unit-10 variables.$grid-unit-10 variables.$grid-unit-20;
+}

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -58,8 +58,11 @@ export interface Route {
 	path: string;
 
 	/**
-	 * Module path for lazy loading the route's surfaces (stage, inspector).
-	 * The module must export: RouteSurfaces (stage and/or inspector components)
+	 * Module path for lazy loading the route's surfaces.
+	 * The module can export:
+	 * - stage?: Main content component (ComponentType)
+	 * - inspector?: Sidebar component (ComponentType)
+	 * - canvas?: Custom canvas component (ComponentType)
 	 * This enables code splitting for better performance.
 	 */
 	content_module?: string;
@@ -69,7 +72,10 @@ export interface Route {
 	 * The module should export a named export `route` containing:
 	 * - beforeLoad?: Pre-navigation hook (authentication, validation, redirects)
 	 * - loader?: Data preloading function
-	 * - canvas?: Function that returns canvas data for rendering an editor
+	 * - canvas?: Function that returns canvas data for rendering
+	 *   - Returns CanvasData to use default editor canvas
+	 *   - Returns null to use custom canvas component from content_module
+	 *   - Returns undefined to show no canvas
 	 */
 	route_module?: string;
 }

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -32,16 +32,15 @@ function useServerData() {
 		const editorSettings = getEditorSettings();
 
 		const canUserUploadMedia = canUser( 'create', {
-			kind: 'root',
-			name: 'media',
+			kind: 'postType',
+			name: 'attachement',
 		} );
 
 		return {
-			styles: editorSettings?.styles || [],
-			__unstableResolvedAssets:
-				editorSettings?.__unstableResolvedAssets || {},
-			colors: editorSettings?.colors || [],
-			gradients: editorSettings?.gradients || [],
+			styles: editorSettings?.styles,
+			__unstableResolvedAssets: editorSettings?.__unstableResolvedAssets,
+			colors: editorSettings?.colors,
+			gradients: editorSettings?.gradients,
 			__experimentalDiscussionSettings:
 				editorSettings?.__experimentalDiscussionSettings,
 			mediaUploadHandler: canUserUploadMedia ? uploadMedia : undefined,
@@ -64,10 +63,10 @@ function useServerData() {
 			settings: {
 				color: {
 					palette: {
-						theme: colors,
+						theme: colors ?? [],
 					},
 					gradients: {
-						theme: gradients,
+						theme: gradients ?? [],
 					},
 					duotone: {
 						theme: [],

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 export { Editor } from './component';
+export { useEditorAssets, loadEditorAssets } from './hooks/use-editor-assets';

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -295,7 +295,8 @@ routes/
     package.json    # Route configuration
     stage.tsx       # Main content component
     inspector.tsx   # Optional sidebar component
-    route.tsx       # Optional lifecycle hooks (beforeLoad, loader)
+    canvas.tsx      # Optional custom canvas component
+    route.tsx       # Optional lifecycle hooks (beforeLoad, loader, canvas)
 ```
 
 ### Route Configuration
@@ -325,6 +326,13 @@ export const stage = () => <div>Content</div>;
 export const inspector = () => <div>Inspector</div>;
 ```
 
+**canvas.tsx** - Custom canvas component (optional):
+```tsx
+export const canvas = () => <div>Custom Canvas</div>;
+```
+
+The canvas is a full-screen area typically used for editor previews. You can provide a custom canvas component that will be conditionally rendered based on the `canvas()` function's return value in `route.tsx`.
+
 **route.tsx** - Lifecycle hooks (optional):
 ```tsx
 export const route = {
@@ -333,14 +341,33 @@ export const route = {
 	},
 	loader: ({ params, search }) => {
 		// Data preloading
+	},
+	canvas: ({ params, search }) => {
+		// Return CanvasData to use default canvas (editor)
+		return {
+			postType: 'post',
+			postId: '123',
+			isPreview: true
+		};
+
+		// Return null to use custom canvas.tsx component
+		// return null;
+
+		// Return undefined to show no canvas
+		// return undefined;
 	}
 };
 ```
 
+The `canvas()` function controls which canvas is rendered:
+- Returns `CanvasData` object (`{ postType, postId, isPreview? }`) → Renders the default WordPress editor canvas
+- Returns `null` → Renders the custom canvas component from `canvas.tsx` (if provided)
+- Returns `undefined` or is omitted → No canvas is rendered
+
 ### Build Output
 
 The build system generates:
-- `build/routes/{route-name}/content.js` - Bundled stage/inspector components
+- `build/routes/{route-name}/content.js` - Bundled stage/inspector/canvas components
 - `build/routes/{route-name}/route.js` - Bundled lifecycle hooks (if present)
 - `build/routes/index.php` - Route registry data
 - `build/routes.php` - Route registration logic

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1273,8 +1273,8 @@ async function buildRoute( routeName ) {
 		}
 	}
 
-	// Build content.js if stage or inspector exists
-	if ( files.hasStage || files.hasInspector ) {
+	// Build content.js if stage, inspector, or canvas exists
+	if ( files.hasStage || files.hasInspector || files.hasCanvas ) {
 		// Create synthetic entry point
 		const syntheticEntry = generateContentEntryPoint( files );
 		const tempEntryPath = path.join( routeDir, '.content-entry.js' );

--- a/packages/wp-build/src/route-utils.mjs
+++ b/packages/wp-build/src/route-utils.mjs
@@ -66,6 +66,7 @@ export function getRouteMetadata( rootDir, routeName ) {
  * @property {boolean} hasRoute     Whether route file exists.
  * @property {boolean} hasStage     Whether stage file exists.
  * @property {boolean} hasInspector Whether inspector file exists.
+ * @property {boolean} hasCanvas    Whether canvas file exists.
  * @property {boolean} hasStyle     Whether style file exists.
  */
 
@@ -81,6 +82,7 @@ export function getRouteFiles( routeDirectory ) {
 		hasRoute: false,
 		hasStage: false,
 		hasInspector: false,
+		hasCanvas: false,
 		hasStyle: false,
 	};
 
@@ -96,6 +98,9 @@ export function getRouteFiles( routeDirectory ) {
 		if ( entries.includes( `inspector.${ ext }` ) ) {
 			files.hasInspector = true;
 		}
+		if ( entries.includes( `canvas.${ ext }` ) ) {
+			files.hasCanvas = true;
+		}
 	}
 
 	if ( entries.includes( 'route.scss' ) ) {
@@ -107,7 +112,7 @@ export function getRouteFiles( routeDirectory ) {
 
 /**
  * Generate a synthetic content entry point for a route.
- * This creates a module that imports and re-exports stage and inspector components.
+ * This creates a module that imports and re-exports stage, inspector, and canvas components.
  *
  * @param {RouteFiles} files Route files information.
  * @return {string} Generated entry point code.
@@ -123,7 +128,11 @@ export function generateContentEntryPoint( files ) {
 		lines.push( "export { inspector } from './inspector';" );
 	}
 
-	// If neither stage nor inspector exists, export empty object
+	if ( files.hasCanvas ) {
+		lines.push( "export { canvas } from './canvas';" );
+	}
+
+	// If no components exist, export empty object
 	if ( lines.length === 0 ) {
 		lines.push( 'export {};' );
 	}

--- a/routes/styles/canvas.tsx
+++ b/routes/styles/canvas.tsx
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useNavigate, useSearch } from '@wordpress/route';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useEditorAssets } from '@wordpress/lazy-editor';
+import { Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { StyleBookPreview } = unlock( editorPrivateApis );
+
+function Canvas() {
+	const { isReady: assetsReady } = useEditorAssets();
+	const navigate = useNavigate();
+	const search = useSearch( { strict: false } ) as any;
+
+	// Get section from URL query params
+	const section = ( search.section ?? '/' ) as string;
+
+	const onChangeSection = ( updatedSection: string ) => {
+		navigate( {
+			search: {
+				...search,
+				section: updatedSection,
+			},
+		} );
+	};
+
+	if ( ! assetsReady ) {
+		return (
+			<div
+				style={ {
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					height: '100%',
+				} }
+			>
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<StyleBookPreview path={ section } onPathChange={ onChangeSection } />
+	);
+}
+
+export const canvas = Canvas;

--- a/routes/styles/package.json
+++ b/routes/styles/package.json
@@ -1,0 +1,19 @@
+{
+	"route": {
+		"path": "/styles",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/url": "file:../../packages/url"
+	}
+}

--- a/routes/styles/route.ts
+++ b/routes/styles/route.ts
@@ -1,0 +1,9 @@
+/**
+ * Route configuration for styles.
+ */
+export const route = {
+	async canvas() {
+		// Always use the custom canvas (StyleBookPreview)
+		return null;
+	},
+};

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useNavigate, useSearch } from '@wordpress/route';
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { unlock } from '../lock-unlock';
+
+const { GlobalStylesUIWrapper, GlobalStylesActionMenu } =
+	unlock( editorPrivateApis );
+
+function Stage() {
+	const navigate = useNavigate();
+	const search = useSearch( { strict: false } ) as any;
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+
+	const section = ( search.section ?? '/' ) as string;
+
+	const onChangeSection = ( updatedSection: string ) => {
+		navigate( {
+			search: {
+				...search,
+				section: updatedSection,
+			},
+		} );
+	};
+
+	return (
+		<Page
+			actions={
+				! isMobileViewport ? (
+					<GlobalStylesActionMenu
+						hideWelcomeGuide
+						onChangePath={ onChangeSection }
+					/>
+				) : null
+			}
+			className="routes-styles__page"
+			title={ __( 'Styles' ) }
+		>
+			<GlobalStylesUIWrapper
+				path={ section }
+				onPathChange={ onChangeSection }
+			/>
+		</Page>
+	);
+}
+
+export const stage = Stage;

--- a/routes/styles/style.scss
+++ b/routes/styles/style.scss
@@ -1,0 +1,28 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.routes-styles__page {
+	.global-styles-ui-screen-root {
+		box-shadow: none;
+		& > div > hr {
+			display: none;
+		}
+	}
+	.global-styles-ui-sidebar__navigator-provider {
+		.components-tools-panel {
+			border-top: none;
+		}
+		overflow-y: auto;
+		padding-left: 0;
+		padding-right: 0;
+
+		.global-styles-ui-sidebar__navigator-screen {
+			padding-top: $grid-unit-15;
+			padding-left: $grid-unit-15;
+			padding-right: $grid-unit-15;
+			padding-bottom: $grid-unit-15;
+			outline: none;
+		}
+	}
+}
+


### PR DESCRIPTION
Related #70862

## What?

This PR starts bringing features and pages from the site editor to routes. This starts with the styles page. 
It also adds "custom canvas" support to the boot package to be able to render the stylebook in the canvas (as opposed to the regular default editor).

## Testing Instructions

 - You can test using this URL `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Fstyles%3Fsection%3D%252F`