### PR TITLE
Notes: Fix warning in comment content check

### DIFF
--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
@@ -568,6 +568,10 @@ class Gutenberg_REST_Comment_Controller_6_9 extends WP_REST_Comments_Controller 
 	 * @return bool True if the content is allowed, false otherwise.
 	 */
 	protected function check_is_comment_content_allowed( $prepared_comment ) {
+		if ( ! isset( $prepared_comment['comment_content'] ) ) {
+			return true;
+		}
+
 		$check = wp_parse_args(
 			$prepared_comment,
 			array(


### PR DESCRIPTION
## What?
Part of #73141.

PR tries to fix warning triggered by `check_is_comment_content_allowed` call inside the `::update_item` controller method. The warning is logged when the note is resolved or reopened.

This doesn't look like a new issue, it just more visible with Notes.

```
PHP Warning: Undefined array key "comment_content" in ~/gutenberg/wp-content/plugins/gutenberg/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php on line 604
```

## Why?
Users can sent partial data when updating a comment/note, this includes omitting the content. The `::update_item` should account for this.

* `::create_item` sets content value to [empty string](https://github.com/WordPress/wordpress-develop/blob/f99957fa1ecfe8c7707c9d930a700dddc6506cbf/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php#L646-L648) when it's not included in the request. We can't do this when updating the item.
* `::update_item` has [special check](https://github.com/WordPress/wordpress-develop/blob/f99957fa1ecfe8c7707c9d930a700dddc6506cbf/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php#L899-L910) for when only comment status is changed, that code path never runs. The `$prepared_args` always includes fallback values for user ID and agent. I would like to fix this separately, will create the trac ticket.


## Testing Instructions
1. Open post or page with notes.
2. Try resolving or reopning a note.
3. Confirm PHP warnings aren't logged.

### Testing Instructions for Keyboard
Same.