### PR TITLE
Patterns: Add edit section to the list view instead of Ungroup

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -37,8 +37,8 @@ export default function EditContents( { clientId } ) {
 				} }
 			>
 				{ editedContentOnlySection
-					? __( 'Exit pattern' )
-					: __( 'Edit pattern' ) }
+					? __( 'Exit section' )
+					: __( 'Edit section' ) }
 			</Button>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -2,40 +2,21 @@
  * WordPress dependencies
  */
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
+import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
 
 export default function EditContents( { clientId } ) {
-	const { editContentOnlySection, stopEditingContentOnlySection } = unlock(
-		useDispatch( blockEditorStore )
-	);
-	const { isWithinSection, isWithinEditedSection, editedContentOnlySection } =
-		useSelect(
-			( select ) => {
-				const {
-					isSectionBlock,
-					getParentSectionBlock,
-					getEditedContentOnlySection,
-					isWithinEditedContentOnlySection,
-				} = unlock( select( blockEditorStore ) );
-
-				return {
-					isWithinSection:
-						isSectionBlock( clientId ) ||
-						!! getParentSectionBlock( clientId ),
-					isWithinEditedSection:
-						isWithinEditedContentOnlySection( clientId ),
-					editedContentOnlySection: getEditedContentOnlySection(),
-				};
-			},
-			[ clientId ]
-		);
+	const {
+		isWithinSection,
+		isWithinEditedSection,
+		editedContentOnlySection,
+		editContentOnlySection,
+		stopEditingContentOnlySection,
+	} = useContentOnlySectionEdit( clientId );
 
 	if ( ! isWithinSection && ! isWithinEditedSection ) {
 		return null;

--- a/packages/block-editor/src/components/block-settings-menu-controls/edit-pattern-menu-item.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/edit-pattern-menu-item.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
+
+export function EditPatternMenuItem( { clientId, onClose } ) {
+	const {
+		isSectionBlock,
+		isEditingContentOnlySection,
+		editContentOnlySection,
+	} = useContentOnlySectionEdit( clientId );
+
+	// Only show when the experiment is enabled, the block is a section block,
+	// and we're not already editing it
+	if (
+		! window?.__experimentalContentOnlyPatternInsertion ||
+		! isSectionBlock ||
+		isEditingContentOnlySection
+	) {
+		return null;
+	}
+
+	return (
+		<MenuItem
+			onClick={ () => {
+				editContentOnlySection( clientId );
+				onClose();
+			} }
+		>
+			{ _x( 'Edit pattern', 'Editing a pattern block in the Editor' ) }
+		</MenuItem>
+	);
+}

--- a/packages/block-editor/src/components/block-settings-menu-controls/edit-section-menu-item.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/edit-section-menu-item.js
@@ -9,7 +9,7 @@ import { _x } from '@wordpress/i18n';
  */
 import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
 
-export function EditPatternMenuItem( { clientId, onClose } ) {
+export function EditSectionMenuItem( { clientId, onClose } ) {
 	const {
 		isSectionBlock,
 		isEditingContentOnlySection,
@@ -33,7 +33,7 @@ export function EditPatternMenuItem( { clientId, onClose } ) {
 				onClose();
 			} }
 		>
-			{ _x( 'Edit pattern', 'Editing a pattern block in the Editor' ) }
+			{ _x( 'Edit section', 'Editing a section in the Editor' ) }
 		</MenuItem>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -22,6 +22,8 @@ import BlockModeToggle from '../block-settings-menu/block-mode-toggle';
 import { ModifyContentOnlySectionMenuItem } from '../content-lock';
 import { BlockRenameControl, useBlockRename } from '../block-rename';
 import { BlockVisibilityMenuItem } from '../block-visibility';
+import { EditPatternMenuItem } from './edit-pattern-menu-item';
+import { unlock } from '../../lock-unlock';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
@@ -31,6 +33,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		selectedClientIds,
 		isContentOnly,
 		canToggleSelectedBlocksVisibility,
+		isSectionBlock,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -39,6 +42,9 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 				getSelectedBlockClientIds,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
+			const { isSectionBlock: _isSectionBlock } = unlock(
+				select( blockEditorStore )
+			);
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
 			return {
@@ -51,6 +57,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 				).every( ( block ) =>
 					hasBlockSupport( block.name, 'blockVisibility', true )
 				),
+				isSectionBlock:
+					ids.length === 1 ? _isSectionBlock( ids[ 0 ] ) : false,
 			};
 		},
 		[ clientIds ]
@@ -70,8 +78,17 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const convertToGroupButtonProps =
 		useConvertToGroupButtonProps( selectedClientIds );
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
+
+	// Don't show ungroup for section blocks when the experiment is enabled
+	// since we show "Unlock design" instead
+	const shouldShowUngroup =
+		isUngroupable &&
+		! (
+			isSectionBlock && window?.__experimentalContentOnlyPatternInsertion
+		);
+
 	const showConvertToGroupButton =
-		( isGroupable || isUngroupable ) && ! isContentOnly;
+		( isGroupable || shouldShowUngroup ) && ! isContentOnly;
 
 	return (
 		<Slot
@@ -95,6 +112,13 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 						{ showConvertToGroupButton && (
 							<ConvertToGroupButton
 								{ ...convertToGroupButtonProps }
+								isUngroupable={ shouldShowUngroup }
+								onClose={ fillProps?.onClose }
+							/>
+						) }
+						{ selectedClientIds.length === 1 && (
+							<EditPatternMenuItem
+								clientId={ selectedClientIds[ 0 ] }
 								onClose={ fillProps?.onClose }
 							/>
 						) }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -71,7 +71,6 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const convertToGroupButtonProps =
 		useConvertToGroupButtonProps( selectedClientIds );
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
-
 	const showConvertToGroupButton =
 		( isGroupable || isUngroupable ) && ! isContentOnly;
 

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -22,7 +22,7 @@ import BlockModeToggle from '../block-settings-menu/block-mode-toggle';
 import { ModifyContentOnlySectionMenuItem } from '../content-lock';
 import { BlockRenameControl, useBlockRename } from '../block-rename';
 import { BlockVisibilityMenuItem } from '../block-visibility';
-import { EditPatternMenuItem } from './edit-pattern-menu-item';
+import { EditSectionMenuItem } from './edit-section-menu-item';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
@@ -101,7 +101,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 							/>
 						) }
 						{ selectedClientIds.length === 1 && (
-							<EditPatternMenuItem
+							<EditSectionMenuItem
 								clientId={ selectedClientIds[ 0 ] }
 								onClose={ fillProps?.onClose }
 							/>

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -23,7 +23,6 @@ import { ModifyContentOnlySectionMenuItem } from '../content-lock';
 import { BlockRenameControl, useBlockRename } from '../block-rename';
 import { BlockVisibilityMenuItem } from '../block-visibility';
 import { EditPatternMenuItem } from './edit-pattern-menu-item';
-import { unlock } from '../../lock-unlock';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
@@ -33,7 +32,6 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		selectedClientIds,
 		isContentOnly,
 		canToggleSelectedBlocksVisibility,
-		isSectionBlock,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -42,9 +40,6 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 				getSelectedBlockClientIds,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
-			const { isSectionBlock: _isSectionBlock } = unlock(
-				select( blockEditorStore )
-			);
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
 			return {
@@ -57,8 +52,6 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 				).every( ( block ) =>
 					hasBlockSupport( block.name, 'blockVisibility', true )
 				),
-				isSectionBlock:
-					ids.length === 1 ? _isSectionBlock( ids[ 0 ] ) : false,
 			};
 		},
 		[ clientIds ]
@@ -79,16 +72,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		useConvertToGroupButtonProps( selectedClientIds );
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
 
-	// Don't show ungroup for section blocks when the experiment is enabled
-	// since we show "Unlock design" instead
-	const shouldShowUngroup =
-		isUngroupable &&
-		! (
-			isSectionBlock && window?.__experimentalContentOnlyPatternInsertion
-		);
-
 	const showConvertToGroupButton =
-		( isGroupable || shouldShowUngroup ) && ! isContentOnly;
+		( isGroupable || isUngroupable ) && ! isContentOnly;
 
 	return (
 		<Slot
@@ -112,7 +97,6 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 						{ showConvertToGroupButton && (
 							<ConvertToGroupButton
 								{ ...convertToGroupButtonProps }
-								isUngroupable={ shouldShowUngroup }
 								onClose={ fillProps?.onClose }
 							/>
 						) }

--- a/packages/block-editor/src/hooks/use-content-only-section-edit.js
+++ b/packages/block-editor/src/hooks/use-content-only-section-edit.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
+
+/**
+ * Hook that provides section block editing state and actions.
+ *
+ * @param {string} clientId Block client ID.
+ * @return {Object} Object containing section block state and actions.
+ */
+export default function useContentOnlySectionEdit( clientId ) {
+	const {
+		isSectionBlock,
+		isWithinSection,
+		isWithinEditedSection,
+		isEditingContentOnlySection,
+		editedContentOnlySection,
+	} = useSelect(
+		( select ) => {
+			const {
+				isSectionBlock: _isSectionBlock,
+				getParentSectionBlock,
+				getEditedContentOnlySection,
+				isWithinEditedContentOnlySection,
+			} = unlock( select( blockEditorStore ) );
+
+			const editedSection = getEditedContentOnlySection();
+
+			return {
+				isSectionBlock: _isSectionBlock( clientId ),
+				isWithinSection:
+					_isSectionBlock( clientId ) ||
+					!! getParentSectionBlock( clientId ),
+				isWithinEditedSection:
+					isWithinEditedContentOnlySection( clientId ),
+				isEditingContentOnlySection: editedSection === clientId,
+				editedContentOnlySection: editedSection,
+			};
+		},
+		[ clientId ]
+	);
+
+	const blockEditorActions = useDispatch( blockEditorStore );
+	const { editContentOnlySection, stopEditingContentOnlySection } =
+		unlock( blockEditorActions );
+
+	return {
+		isSectionBlock,
+		isWithinSection,
+		isWithinEditedSection,
+		isEditingContentOnlySection,
+		editedContentOnlySection,
+		editContentOnlySection,
+		stopEditingContentOnlySection,
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
From #72574

If a pattern is a section block then rather than offering an "Ungroup" option we should offer "Edit section". 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This connects block actions in the List View to the contentOnly editing work for patterns. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Creates a new hook to share the selectors between the new menu item and the "edit contents" button.

## Testing Instructions
0. Enable the `contentOnly` experiment
1. Add a pattern that can be a section block
2. Select the pattern in List View
3. Open the block actions
4. Check that "Ungroup" is replaced with "Edit section"


## Screenshots or screencast <!-- if applicable -->
<img width="580" height="523" alt="Screenshot 2025-11-13 at 10 10 31" src="https://github.com/user-attachments/assets/8871f0b6-5c9a-4983-947f-28f4079c0626" />

