### PR TITLE
Global Styles: Add text justify

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -619,7 +619,7 @@ export default function TypographyPanel( {
 						<div>
 							<Notice status="warning" isDismissible={ false }>
 								{ __(
-									'Justified text can reduce readability, especially for users with visual or cognitive impairments. For better accessibility and legibility, consider using left-aligned text instead.'
+									'Justified text can reduce readability. For better accessibility, use left-aligned text instead.'
 								) }
 							</Notice>
 						</div>

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -609,6 +609,7 @@ export default function TypographyPanel( {
 					<TextAlignmentControl
 						value={ textAlign }
 						onChange={ setTextAlign }
+						options={ [ 'left', 'center', 'right', 'justify' ] }
 						size="__unstable-large"
 						__nextHasNoMarginBottom
 					/>

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -6,6 +6,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useEffect } from '@wordpress/element';
@@ -613,6 +614,16 @@ export default function TypographyPanel( {
 						size="__unstable-large"
 						__nextHasNoMarginBottom
 					/>
+
+					{ textAlign === 'justify' && (
+						<div>
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Justified text can reduce readability, especially for users with visual or cognitive impairments. For better accessibility and legibility, consider using left-aligned text instead.'
+								) }
+							</Notice>
+						</div>
+					) }
 				</ToolsPanelItem>
 			) }
 		</Wrapper>


### PR DESCRIPTION
## What?

Closes #48202

Now that we migrated the paragraph block to the textAlign block support, we can enable justify at the global styles level. 

**Note** The justify icon looks a bit weird compared to the other alignments icons but we can fix it separately if needed.

## Testing Instructions

 - Search for "paragraph" block in global styles panel.
 - Enable Justify.
 - Write some paragraphs and notice the text is justified.
 - You can override the text alignment at the paragraph level.