### PR TITLE
Media & Text: Fix RTLCSS control directives appearing in production CSS

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -2,9 +2,9 @@
 
 .wp-block-media-text {
 	// This block's direction should not be manipulated by rtl, as the mediaPosition control does.
-	/*!rtl:begin:ignore*/
+	/*rtl:begin:ignore*/
 	direction: ltr;
-	/*!rtl:end:ignore*/
+	/*rtl:end:ignore*/
 	display: grid;
 	grid-template-columns: 50% 1fr;
 	grid-template-rows: auto;
@@ -39,35 +39,35 @@
 }
 
 .wp-block-media-text > .wp-block-media-text__media {
-	/*!rtl:begin:ignore*/
+	/*rtl:begin:ignore*/
 	grid-column: 1;
 	grid-row: 1;
-	/*!rtl:end:ignore*/
+	/*rtl:end:ignore*/
 	margin: 0;
 }
 
 .wp-block-media-text > .wp-block-media-text__content {
 	direction: ltr;
-	/*!rtl:begin:ignore*/
+	/*rtl:begin:ignore*/
 	grid-column: 2;
 	grid-row: 1;
-	/*!rtl:end:ignore*/
+	/*rtl:end:ignore*/
 	padding: 0 8% 0 8%;
 	word-break: break-word;
 }
 
 .wp-block-media-text.has-media-on-the-right > .wp-block-media-text__media {
-	/*!rtl:begin:ignore*/
+	/*rtl:begin:ignore*/
 	grid-column: 2;
 	grid-row: 1;
-	/*!rtl:end:ignore*/
+	/*rtl:end:ignore*/
 }
 
 .wp-block-media-text.has-media-on-the-right > .wp-block-media-text__content {
-	/*!rtl:begin:ignore*/
+	/*rtl:begin:ignore*/
 	grid-column: 1;
 	grid-row: 1;
-	/*!rtl:end:ignore*/
+	/*rtl:end:ignore*/
 }
 
 .wp-block-media-text__media a {


### PR DESCRIPTION
## What?
  Closes #73193

  Fixes RTLCSS control directive comments appearing in minified production CSS for the Media & Text block.

  ## Why?
  The `/*!` syntax preserves comments during minification. RTLCSS control directives like `/*!rtl:begin:ignore*/` should use `/*` instead so they are stripped during minification and don't appear in production CSS files shipped with WordPress Core.

  As reported in #73193, these directives are currently visible in WordPress 6.8.3's minified CSS at `wp-includes/blocks/media-text/style.min.css`.

  ## How?
  Changed all RTLCSS control directives in `packages/block-library/src/media-text/style.scss` from `/*!` to `/*`.

  ## Testing Instructions
  1. Checkout this branch
  2. Run `npm run build`
  3. Check `packages/block-library/build-style/media-text/style.css`
  4. Verify RTLCSS directives use `/*rtl:` instead of `/*!rtl:`
  5. The comments should not appear in minified production CSS