### PR TITLE
Patterns: Add pattern name to document toolbar when editing in spotlight

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -33,6 +33,7 @@ import usePageTypeBadge from '../../utils/pageTypeBadge';
 import { getTemplateInfo } from '../../utils/get-template-info';
 import { getStylesCanvasTitle } from '../styles-canvas';
 import { unlock } from '../../lock-unlock';
+import useEditedSectionDetails from './useEditedSectionDetails';
 
 /** @typedef {import("@wordpress/components").IconType} IconType */
 
@@ -61,38 +62,8 @@ export default function DocumentBar( props ) {
 		useDispatch( blockEditorStore )
 	);
 
-	// Check if a pattern block is unlocked and being edited
-	const unlockedPatternInfo = useSelect( ( select ) => {
-		const { getBlockAttributes, __experimentalGetParsedPattern } =
-			select( blockEditorStore );
-		const { getEditedContentOnlySection } = unlock(
-			select( blockEditorStore )
-		);
-
-		// Get the clientId of the unlocked pattern/section
-		const editedSectionId = getEditedContentOnlySection();
-		if ( ! editedSectionId ) {
-			return null;
-		}
-
-		const attributes = getBlockAttributes( editedSectionId );
-		const patternName = attributes?.metadata?.patternName;
-
-		if ( ! patternName ) {
-			return null;
-		}
-
-		// Get pattern details if available
-		const pattern =
-			typeof __experimentalGetParsedPattern === 'function'
-				? __experimentalGetParsedPattern( patternName )
-				: null;
-
-		return {
-			patternName,
-			patternTitle: pattern?.title || attributes?.metadata?.name,
-		};
-	}, [] );
+	// Get details about the currently edited content-only section
+	const unlockedPatternInfo = useEditedSectionDetails();
 
 	const {
 		postId,
@@ -273,7 +244,10 @@ export default function DocumentBar( props ) {
 							</span>
 							{ unlockedPatternInfo && (
 								<span className="editor-document-bar__post-type-label">
-									{ `· ${ __( 'Pattern' ) }` }
+									{ unlockedPatternInfo.type ===
+									'template-part'
+										? `· ${ __( 'Template Part' ) }`
+										: `· ${ __( 'Pattern' ) }` }
 								</span>
 							) }
 							{ ! unlockedPatternInfo && pageTypeBadge && (

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -14,7 +14,7 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
-import { BlockIcon } from '@wordpress/block-editor';
+import { BlockIcon, store as blockEditorStore } from '@wordpress/block-editor';
 import { chevronLeftSmall, chevronRightSmall, layout } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
@@ -56,6 +56,44 @@ const MotionButton = motion.create( Button );
  * @return {React.ReactNode} The rendered DocumentBar component.
  */
 export default function DocumentBar( props ) {
+	// Get action to lock the pattern design
+	const { stopEditingContentOnlySection } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
+	// Check if a pattern block is unlocked and being edited
+	const unlockedPatternInfo = useSelect( ( select ) => {
+		const { getBlockAttributes, __experimentalGetParsedPattern } =
+			select( blockEditorStore );
+		const { getEditedContentOnlySection } = unlock(
+			select( blockEditorStore )
+		);
+
+		// Get the clientId of the unlocked pattern/section
+		const editedSectionId = getEditedContentOnlySection();
+		if ( ! editedSectionId ) {
+			return null;
+		}
+
+		const attributes = getBlockAttributes( editedSectionId );
+		const patternName = attributes?.metadata?.patternName;
+
+		if ( ! patternName ) {
+			return null;
+		}
+
+		// Get pattern details if available
+		const pattern =
+			typeof __experimentalGetParsedPattern === 'function'
+				? __experimentalGetParsedPattern( patternName )
+				: null;
+
+		return {
+			patternName,
+			patternTitle: pattern?.title || attributes?.metadata?.name,
+		};
+	}, [] );
+
 	const {
 		postId,
 		postType,
@@ -133,10 +171,27 @@ export default function DocumentBar( props ) {
 	const isReducedMotion = useReducedMotion();
 
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
-	const hasBackButton = !! onNavigateToPreviousEntityRecord;
+	const hasBackButton =
+		!! onNavigateToPreviousEntityRecord || !! unlockedPatternInfo;
 	const entityTitle = isTemplate ? templateTitle : documentTitle;
-	const title = props.title || stylesCanvasTitle || entityTitle;
+
+	// Use pattern info if a pattern block is unlocked, otherwise use document/entity info
+	const title =
+		unlockedPatternInfo?.patternTitle ||
+		props.title ||
+		stylesCanvasTitle ||
+		entityTitle;
 	const icon = props.icon;
+
+	// Determine the back button action
+	const handleBackClick = ( event ) => {
+		event.stopPropagation();
+		if ( unlockedPatternInfo ) {
+			stopEditingContentOnlySection();
+		} else if ( onNavigateToPreviousEntityRecord ) {
+			onNavigateToPreviousEntityRecord();
+		}
+	};
 
 	const pageTypeBadge = usePageTypeBadge( postId );
 
@@ -156,10 +211,7 @@ export default function DocumentBar( props ) {
 					<MotionButton
 						className="editor-document-bar__back"
 						icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-						onClick={ ( event ) => {
-							event.stopPropagation();
-							onNavigateToPreviousEntityRecord();
-						} }
+						onClick={ handleBackClick }
 						size="compact"
 						initial={
 							mountedRef.current

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -271,12 +271,18 @@ export default function DocumentBar( props ) {
 									? stripHTML( title )
 									: __( 'No title' ) }
 							</span>
-							{ pageTypeBadge && (
+							{ unlockedPatternInfo && (
+								<span className="editor-document-bar__post-type-label">
+									{ `· ${ __( 'Pattern' ) }` }
+								</span>
+							) }
+							{ ! unlockedPatternInfo && pageTypeBadge && (
 								<span className="editor-document-bar__post-type-label">
 									{ `· ${ pageTypeBadge }` }
 								</span>
 							) }
-							{ postTypeLabel &&
+							{ ! unlockedPatternInfo &&
+								postTypeLabel &&
 								! props.title &&
 								! pageTypeBadge && (
 									<span className="editor-document-bar__post-type-label">

--- a/packages/editor/src/components/document-bar/useEditedSectionDetails.js
+++ b/packages/editor/src/components/document-bar/useEditedSectionDetails.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Hook to get details about the currently edited content-only section.
+ * Only returns information when the content only pattern insertion experiment is enabled.
+ *
+ * @return {Object|null} Object with patternName, patternTitle, and type, or null if no section is being edited or experiment is disabled.
+ */
+export default function useEditedSectionDetails() {
+	return useSelect( ( select ) => {
+		// Only run when the content only pattern insertion experiment is enabled
+		if ( ! window?.__experimentalContentOnlyPatternInsertion ) {
+			return null;
+		}
+
+		const {
+			getBlockAttributes,
+			getBlockName,
+			__experimentalGetParsedPattern,
+		} = select( blockEditorStore );
+		const { getEditedEntityRecord, getCurrentTheme } = select( coreStore );
+		const { getEditedContentOnlySection } = unlock(
+			select( blockEditorStore )
+		);
+
+		// Get the clientId of the unlocked pattern/section
+		const editedSectionId = getEditedContentOnlySection();
+		if ( ! editedSectionId ) {
+			return null;
+		}
+
+		const attributes = getBlockAttributes( editedSectionId );
+
+		// Handle unsynced patterns (contentOnly patterns with patternName)
+		const patternName = attributes?.metadata?.patternName;
+		if ( patternName ) {
+			// Get pattern details if available
+			const pattern =
+				typeof __experimentalGetParsedPattern === 'function'
+					? __experimentalGetParsedPattern( patternName )
+					: null;
+
+			return {
+				patternName,
+				patternTitle: pattern?.title || attributes?.metadata?.name,
+				type: 'pattern',
+			};
+		}
+
+		const blockName = getBlockName( editedSectionId );
+
+		// Handle synced patterns (core/block)
+		if ( blockName === 'core/block' && !! attributes?.ref ) {
+			const entity = getEditedEntityRecord(
+				'postType',
+				'wp_block',
+				attributes.ref
+			);
+			if ( entity?.title ) {
+				return {
+					patternName: attributes.ref,
+					patternTitle: decodeEntities( entity.title ),
+					type: 'synced-pattern',
+				};
+			}
+		}
+
+		// Handle template parts (core/template-part)
+		if ( blockName === 'core/template-part' && !! attributes?.slug ) {
+			const theme = attributes.theme || getCurrentTheme()?.stylesheet;
+			const templatePartId = theme
+				? `${ theme }//${ attributes.slug }`
+				: null;
+			if ( templatePartId ) {
+				const entity = getEditedEntityRecord(
+					'postType',
+					'wp_template_part',
+					templatePartId
+				);
+				if ( entity?.title ) {
+					return {
+						patternName: attributes.slug,
+						patternTitle: decodeEntities( entity.title ),
+						type: 'template-part',
+					};
+				}
+			}
+		}
+
+		return null;
+	}, [] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
When a contentOnly pattern is being editing in the canvas, we should show the pattern name and a back button in the document toolbar.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This tells the user that they are editing a pattern, and gives them a mechanism to finish editing.

Alternative to #73088

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the document toolbar to detect when a pattern is being edited.

## Testing Instructions
0. Enable the content only experiment
1. Add a contentOnly pattern to a page
2. Edit a pattern in the inspector by clicking "Edit section"
3. Notice that the document toolbar is updated and has a Back button
4. Check that the Back button finished the pattern edit.
5. Try the same with template parts and synched patterns


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/0bf7a6a7-d581-4f5d-946d-8f78d489e3c0

