### PR TITLE
Comments Count and Comments Link: Ensures that the preview is displayed correctly in the StyleBook.

### DIFF
--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -9,13 +9,11 @@ import clsx from 'clsx';
 import {
 	AlignmentControl,
 	BlockControls,
-	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { __ } from '@wordpress/i18n';
 
 export default function PostCommentsCountEdit( {
 	attributes,
@@ -57,14 +55,6 @@ export default function PostCommentsCountEdit( {
 			: undefined,
 	};
 
-	if ( ! postId ) {
-		return (
-			<div { ...blockProps }>
-				<p>0</p>
-			</div>
-		);
-	}
-
 	return (
 		<>
 			<BlockControls group="block">
@@ -76,13 +66,7 @@ export default function PostCommentsCountEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps } style={ blockStyles }>
-				{ hasPostAndComments ? (
-					commentsCount
-				) : (
-					<Warning>
-						{ __( 'Post Comments Count block: post not found.' ) }
-					</Warning>
-				) }
+				{ hasPostAndComments ? commentsCount : '0' }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -57,6 +57,14 @@ export default function PostCommentsCountEdit( {
 			: undefined,
 	};
 
+	if ( ! postId ) {
+		return (
+			<div { ...blockProps }>
+				<p>0</p>
+			</div>
+		);
+	}
+
 	return (
 		<>
 			<BlockControls group="block">

--- a/packages/block-library/src/post-comments-link/edit.js
+++ b/packages/block-library/src/post-comments-link/edit.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import {
 	AlignmentControl,
 	BlockControls,
-	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
@@ -59,31 +58,6 @@ function PostCommentsLinkEdit( { context, attributes, setAttributes } ) {
 		[ postType, postId ]
 	);
 
-	if ( ! postId ) {
-		return (
-			<div { ...blockProps }>
-				<a
-					href="#post-comments-link-pseudo-link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					{ __( 'No comments' ) }
-				</a>
-			</div>
-		);
-	}
-
-	if ( ! post ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Post Comments Link block: post not found.' ) }
-				</Warning>
-			</div>
-		);
-	}
-
-	const { link } = post;
-
 	let commentsText;
 	if ( commentsCount !== undefined ) {
 		const commentsNumber = parseInt( commentsCount );
@@ -111,17 +85,20 @@ function PostCommentsLinkEdit( { context, attributes, setAttributes } ) {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				{ link && commentsText !== undefined ? (
+				{ post?.link && commentsText !== undefined ? (
 					<a
-						href={ link + '#comments' }
+						href={ post?.link + '#comments' }
 						onClick={ ( event ) => event.preventDefault() }
 					>
 						{ commentsText }
 					</a>
 				) : (
-					<Warning>
-						{ __( 'Post Comments Link block: post not found.' ) }
-					</Warning>
+					<a
+						href="#post-comments-link-pseudo-link"
+						onClick={ ( event ) => event.preventDefault() }
+					>
+						{ __( 'No comments' ) }
+					</a>
 				) }
 			</div>
 		</>

--- a/packages/block-library/src/post-comments-link/edit.js
+++ b/packages/block-library/src/post-comments-link/edit.js
@@ -59,6 +59,19 @@ function PostCommentsLinkEdit( { context, attributes, setAttributes } ) {
 		[ postType, postId ]
 	);
 
+	if ( ! postId ) {
+		return (
+			<div { ...blockProps }>
+				<a
+					href="#post-comments-link-pseudo-link"
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ __( 'No comments' ) }
+				</a>
+			</div>
+		);
+	}
+
 	if ( ! post ) {
 		return (
 			<div { ...blockProps }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73179

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add fallback text to prevent the warning from being displayed when postId does not exist.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to your site editor.
2. Open the StyleBook.
3. You can see that the fallback text is displayed in Comments Count and Comments Link.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/57da41f5-3356-4241-9644-5b7f33d66109

### After

https://github.com/user-attachments/assets/635d7999-e3c5-4c3d-9061-250792783bba



