### PR TITLE
Content only + patterns: remove experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,9 +31,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-media-processing', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaProcessing = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
-	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -175,18 +175,6 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
-	add_settings_field(
-		'gutenberg-content-only-pattern-insertion',
-		__( 'contentOnly: Make patterns contentOnly by default upon insertion', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'When patterns are inserted, default to a simplified content only mode for editing pattern content.', 'gutenberg' ),
-			'id'    => 'gutenberg-content-only-pattern-insertion',
-		)
-	);
-
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -323,9 +323,7 @@ const BlockInspectorSingleBlock = ( {
 } ) => {
 	const hasMultipleTabs = availableTabs?.length > 1;
 	const hasParentChildBlockCards =
-		window?.__experimentalContentOnlyPatternInsertion &&
-		editedContentOnlySection &&
-		editedContentOnlySection !== clientId;
+		editedContentOnlySection && editedContentOnlySection !== clientId;
 	const parentBlockInformation = useBlockDisplayInformation(
 		editedContentOnlySection
 	);
@@ -349,9 +347,7 @@ const BlockInspectorSingleBlock = ( {
 				isChild={ hasParentChildBlockCards }
 				clientId={ clientId }
 			/>
-			{ window?.__experimentalContentOnlyPatternInsertion && (
-				<EditContents clientId={ clientId } />
-			) }
+			<EditContents clientId={ clientId } />
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ shouldShowTabs && (
 				<InspectorControlsTabs

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -57,11 +57,9 @@ function getBlockIconVariant( { select, clientIds } ) {
 
 	const isDefaultEditingMode =
 		getBlockEditingMode( clientIds[ 0 ] ) === 'default';
-	const _hideTransformsForSections =
-		window?.__experimentalContentOnlyPatternInsertion &&
-		isSectionInSelection;
+
 	const _showBlockSwitcher =
-		! _hideTransformsForSections &&
+		! isSectionInSelection &&
 		isDefaultEditingMode &&
 		( hasBlockStyles || canRemove ) &&
 		! hasTemplateLock;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -122,9 +122,7 @@ export function PrivateBlockToolbar( {
 
 		// The switch style button appears more prominently with the
 		// content only pattern experiment.
-		const _showSwitchSectionStyleButton =
-			window?.__experimentalContentOnlyPatternInsertion &&
-			( _isZoomOut || _isSectionBlock );
+		const _showSwitchSectionStyleButton = _isZoomOut || _isSectionBlock;
 
 		return {
 			blockClientId: selectedBlockClientId,

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -206,10 +206,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	const hideVariationsForSections =
-		window?.__experimentalContentOnlyPatternInsertion && isSection;
-
-	if ( ! variations?.length || isContentOnly || hideVariationsForSections ) {
+	if ( ! variations?.length || isContentOnly || isSection ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/content-lock/modify-content-lock-menu-item.js
+++ b/packages/block-editor/src/components/content-lock/modify-content-lock-menu-item.js
@@ -39,12 +39,9 @@ export function ModifyContentOnlySectionMenuItem( { clientId, onClose } ) {
 	const isContentLocked =
 		! isLockedByParent && templateLock === 'contentOnly';
 
-	// Hide the Modify button when the content only pattern insertion experiment is active.
+	// Hide the Modify button when the content only pattern insertion is active.
 	// This is replaced by an alternative UI in the experiment.
-	if (
-		window?.__experimentalContentOnlyPatternInsertion ||
-		( ! isContentLocked && ! isEditingContentOnlySection )
-	) {
+	if ( ! isContentLocked && ! isEditingContentOnlySection ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -78,14 +78,13 @@ const StylesTab = ( {
 					</PanelBody>
 				</div>
 			) }
-			{ isSectionBlock &&
-				window?.__experimentalContentOnlyPatternInsertion && (
-					<SectionBlockColorControls
-						blockName={ blockName }
-						clientId={ clientId }
-						contentClientIds={ contentClientIds }
-					/>
-				) }
+			{ isSectionBlock && (
+				<SectionBlockColorControls
+					blockName={ blockName }
+					clientId={ clientId }
+					contentClientIds={ contentClientIds }
+				/>
+			) }
 			{ ! isSectionBlock && (
 				<>
 					<InspectorControls.Slot

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -99,11 +99,7 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if (
-		hasBlockStyles ||
-		hasStyleFills ||
-		window?.__experimentalContentOnlyPatternInsertion
-	) {
+	if ( hasBlockStyles || hasStyleFills ) {
 		tabs.push( TAB_STYLES );
 	}
 

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -50,10 +50,7 @@ function ContentLockControlsPure( { clientId } ) {
 
 	// Hide the Done button when the content only pattern insertion experiment is active.
 	// This is replaced by an alternative UI in the experiment.
-	if (
-		window?.__experimentalContentOnlyPatternInsertion ||
-		( ! isContentLocked && ! isEditingContentOnlySection )
-	) {
+	if ( ! isContentLocked && ! isEditingContentOnlySection ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -527,10 +527,7 @@ export function isSectionBlock( state, clientId ) {
 
 	const attributes = getBlockAttributes( state, clientId );
 	const isTemplatePart = blockName === 'core/template-part';
-	if (
-		( attributes?.metadata?.patternName || isTemplatePart ) &&
-		!! window?.__experimentalContentOnlyPatternInsertion
-	) {
+	if ( attributes?.metadata?.patternName || isTemplatePart ) {
 		return true;
 	}
 	return false;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2294,20 +2294,16 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	);
 	// Use array.from for better back compat. Older versions of the iterator returned
 	// from `keys()` didn't have the `filter` method.
-	const unsyncedPatternClientIds =
-		!! window?.__experimentalContentOnlyPatternInsertion
-			? Array.from( state.blocks.attributes.keys() ).filter(
-					( clientId ) =>
-						state.blocks.attributes.get( clientId )?.metadata
-							?.patternName
-			  )
-			: [];
+	const unsyncedPatternClientIds = Array.from(
+		state.blocks.attributes.keys()
+	).filter(
+		( clientId ) =>
+			state.blocks.attributes.get( clientId )?.metadata?.patternName
+	);
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
-		...( window?.__experimentalContentOnlyPatternInsertion
-			? templatePartClientIds
-			: [] ),
+		...templatePartClientIds,
 	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {
@@ -2332,11 +2328,8 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 				return;
 			}
 
-			// For the content only pattern experiment, disable blocks that are outside of the edited section.
-			if ( window?.__experimentalContentOnlyPatternInsertion ) {
-				derivedBlockEditingModes.set( clientId, 'disabled' );
-				return;
-			}
+			// For the content only patterns, disable blocks that are outside of the edited section.
+			derivedBlockEditingModes.set( clientId, 'disabled' );
 		}
 
 		// If the block already has an explicit block editing mode set,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4312,15 +4312,6 @@ describe( 'state', () => {
 		// If/when the experiment is stabilized, this wrapping `describe` and
 		// `beforeAll`/`afterAll` can be removed, un-nesting the tests within.
 		describe( 'contentOnly patterns experiment', () => {
-			beforeAll( () => {
-				globalThis.window.__experimentalContentOnlyPatternInsertion = true;
-			} );
-
-			afterAll( () => {
-				delete globalThis.window
-					.__experimentalContentOnlyPatternInsertion;
-			} );
-
 			describe( 'unsynced patterns', () => {
 				let initialState;
 				beforeAll( () => {

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -83,7 +83,6 @@ export default function PatternConvertButton( {
 				);
 
 			const isUnsyncedPattern =
-				window?.__experimentalContentOnlyPatternInsertion &&
 				blocks.length === 1 &&
 				blocks?.[ 0 ]?.attributes?.metadata?.patternName;
 

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -30,7 +30,6 @@ function PatternsManageButton( { clientId } ) {
 			const block = getBlock( clientId );
 
 			const _isUnsyncedPattern =
-				window?.__experimentalContentOnlyPatternInsertion &&
 				!! block?.attributes?.metadata?.patternName;
 
 			const _isSyncedPattern =


### PR DESCRIPTION
Just a PR in case we decide to this soon.

Remove content-only pattern insertion experiment references from various components and settings

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
