### PR TITLE
Fix: Keep Guide close button visible on hover

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fixed an issue where the `Guide` component’s close button became invisible on hover when used on light backgrounds. The component's close button now relies on the default button hover effect, and the custom hover color is applied only within `welcome-guide` implementations to maintain consistency.
+
 ## 30.8.0 (2025-11-12)
 
 ### Bug Fixes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Fixed an issue where the `Guide` component’s close button became invisible on hover when used on light backgrounds. The component's close button now relies on the default button hover effect, and the custom hover color is applied only within `welcome-guide` implementations to maintain consistency.
+-   Fixed an issue where the `Guide` component’s close button became invisible on hover when used on light backgrounds. The component's close button now relies on the default button hover effect, and the custom hover color is applied only within `welcome-guide` implementations to maintain consistency. ([#73220](https://github.com/WordPress/gutenberg/pull/73220))
 
 ## 30.8.0 (2025-11-12)
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -34,7 +34,7 @@
 
 			&:hover {
 				svg {
-					fill: $white;
+					fill: currentColor;
 				}
 			}
 		}

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -31,12 +31,6 @@
 			align-self: flex-start;
 			margin: $grid-unit-10 $grid-unit-10 0 0;
 			position: static;
-
-			&:hover {
-				svg {
-					fill: currentColor;
-				}
-			}
 		}
 	}
 

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Adjusted `welcome-guide` styles to define the close-button hover state internally after refactoring in the shared `Guide` component.
+
 ## 8.35.0 (2025-11-12)
 
 ## 8.34.0 (2025-10-29)

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -34,6 +34,13 @@
 		margin: 0 4px;
 		vertical-align: text-top;
 	}
+	.components-button {
+		&:hover {
+			svg {
+				fill: $white;
+			}
+		}
+	}
 }
 
 .edit-template-welcome-guide {

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Updated `welcome-guide` styles to apply the close-button hover color locally, following changes to the shared `Guide` component.
+
 ## 6.35.0 (2025-11-12)
 
 ## 6.34.0 (2025-10-29)

--- a/packages/edit-site/src/components/welcome-guide/style.scss
+++ b/packages/edit-site/src/components/welcome-guide/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .edit-site-welcome-guide {
@@ -48,5 +49,12 @@
 	&__inserter-icon {
 		margin: 0 4px;
 		vertical-align: text-top;
+	}
+	.components-button {
+		&:hover {
+			svg {
+				fill: $white;
+			}
+		}
 	}
 }

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Updated the `welcome-guide` implementation to specify its own close-button hover color, matching previous behavior after changes in the `Guide` component.
+
 ## 6.35.0 (2025-11-12)
 
 ## 6.34.0 (2025-10-29)

--- a/packages/edit-widgets/src/components/welcome-guide/style.scss
+++ b/packages/edit-widgets/src/components/welcome-guide/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .edit-widgets-welcome-guide {
@@ -31,5 +32,12 @@
 	&__inserter-icon {
 		margin: 0 4px;
 		vertical-align: text-top;
+	}
+	.components-button {
+		&:hover {
+			svg {
+				fill: $white;
+			}
+		}
 	}
 }

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Applied the `welcome-guide` close-button hover color locally to maintain consistent styling after changes to the shared `Guide` component.
+
 ## 14.35.0 (2025-11-12)
 
 ## 14.34.0 (2025-10-29)

--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -116,4 +116,11 @@
 			vertical-align: bottom;
 		}
 	}
+	.components-button {
+		&:hover {
+			svg {
+				fill: $white;
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73219 

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR fixes an accessibility/visibility issue in the **Guide** component.

Currently, the close button becomes invisible on hover because it changes to white while the background is also white.


## How?
The Guide component is shared across several welcome-guide implementations
(edit-site, edit-post, editor, and edit-widgets). These use blue backgrounds,
which required a white hover color for the close button.

However, this hover style caused inconsistency in other contexts where Guide
is used on light backgrounds.

This change removes the hover style from Guide and applies it only in
welcome-guide components, keeping Guide generic and easier to reuse.


## Testing Instructions
1. Run `npm run storybook:dev`
2. Open the Guide component
3. Hover over the close button
4. The button should remain visible and turn blue.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="312" height="361" alt="image" src="https://github.com/user-attachments/assets/7739383b-e197-4984-aae7-5eb17bf34d72" />|<img width="316" height="367" alt="image" src="https://github.com/user-attachments/assets/a8ad6341-197a-4eaf-9321-710e88c22939" />|



https://github.com/user-attachments/assets/3e0192c0-09ee-4098-8395-8d95501323aa

