### PR TITLE
Content only block inspector controls: add block selection and keyboard navigation

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -367,7 +367,10 @@ const BlockInspectorSingleBlock = ( {
 					{ hasBlockStyles && (
 						<BlockStylesPanel clientId={ clientId } />
 					) }
-					<ContentTab contentClientIds={ contentClientIds } />
+					<ContentTab
+						rootClientId={ clientId }
+						contentClientIds={ contentClientIds }
+					/>
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots
 							blockName={ blockName }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -29,7 +29,6 @@ import PositionControls from '../inspector-controls-tabs/position-controls-panel
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
 import { useBorderPanelLabel } from '../../hooks/border';
 import ContentTab from '../inspector-controls-tabs/content-tab';
-
 import { unlock } from '../../lock-unlock';
 
 function BlockStylesPanel( { clientId } ) {

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,8 +5,10 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -14,7 +16,61 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
-function RichTextControl() {}
+function RichTextControl( { label, value, setValue } ) {
+	return (
+		<TextControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			label={ label }
+			value={ value ? stripHTML( value ) : '' }
+			onChange={ setValue }
+			autoComplete="off"
+		/>
+	);
+}
+
+function getControlForAttribute( attribute ) {
+	if ( attribute.control.type === 'RichText' ) {
+		return RichTextControl;
+	}
+}
+
+function getDefaultValue( attribute ) {
+	if ( attribute.default ) {
+		return attribute.default;
+	}
+
+	return undefined;
+}
+
+function BlockAttributeToolsPanelItem( {
+	attributeDefinition,
+	setValue,
+	value,
+} ) {
+	const Control = getControlForAttribute( attributeDefinition );
+
+	if ( ! Control ) {
+		return null;
+	}
+
+	const defaultValue = getDefaultValue( attributeDefinition );
+
+	return (
+		<ToolsPanelItem
+			label={ attributeDefinition.control.label }
+			hasValue={ () => value !== defaultValue }
+			onDeselect={ () => setValue( defaultValue ) }
+			isShownByDefault={ attributeDefinition.control.shownByDefault }
+		>
+			<Control
+				label={ attributeDefinition.control.label }
+				value={ value }
+				setValue={ setValue }
+			/>
+		</ToolsPanelItem>
+	);
+}
 
 function getContentAttributesWithControls( blockType ) {
 	return Object.keys( blockType?.attributes ?? {} )
@@ -28,24 +84,14 @@ function getContentAttributesWithControls( blockType ) {
 		} ) );
 }
 
-function getControlForAttribute( attribute ) {
-	if ( attribute.control.type === 'RichText' ) {
-		return RichTextControl;
-	}
-}
+function getResetAllValue( attributes ) {
+	const resetValue = {};
 
-function BlockAttributeControl( { attributeDefinition, setAttribute, value } ) {
-	const Control = getControlForAttribute( attributeDefinition );
+	attributes.each( ( attribute ) => {
+		resetValue[ attribute.key ] = getDefaultValue( attribute );
+	} );
 
-	if ( ! Control ) {
-		return null;
-	}
-
-	return (
-		<ToolsPanelItem>
-			<Control value={ value } setAttribute={ setAttribute } />
-		</ToolsPanelItem>
-	);
+	return resetValue;
 }
 
 function BlockControls( { clientId } ) {
@@ -75,16 +121,27 @@ function BlockControls( { clientId } ) {
 	} );
 
 	if ( ! contentAttributesWithControls?.length ) {
+		// TODO - we might still want to show a placeholder for blocks with no controls.
+		// for example, a way to select the block.
 		return null;
 	}
 
 	return (
-		<ToolsPanel label={ blockTitle } panelId={ clientId }>
+		<ToolsPanel
+			label={ blockTitle }
+			panelId={ clientId }
+			resetAll={ () => {
+				updateBlockAttributes(
+					clientId,
+					getResetAllValue( contentAttributesWithControls )
+				);
+			} }
+		>
 			{ contentAttributesWithControls?.each( ( attribute ) => (
-				<BlockAttributeControl
+				<BlockAttributeToolsPanelItem
 					clientId={ clientId }
 					attributeDefinition={ attribute }
-					setAttribute={ ( value ) =>
+					setValue={ ( value ) =>
 						updateBlockAttributes( clientId, {
 							[ attribute.key ]: value,
 						} )

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,6 +5,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalHStack as HStack,
 	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -14,7 +15,9 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import useBlockDisplayInformation from '../use-block-display-information';
 
 function RichTextControl( { label, value, setValue } ) {
 	return (
@@ -121,6 +124,7 @@ function BlockControls( { clientId } ) {
 		clientId,
 		context: 'list-view',
 	} );
+	const blockInformation = useBlockDisplayInformation( clientId );
 
 	if ( ! contentAttributesWithControls?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no controls.
@@ -130,7 +134,12 @@ function BlockControls( { clientId } ) {
 
 	return (
 		<ToolsPanel
-			label={ blockTitle }
+			label={
+				<HStack spacing={ 1 }>
+					<BlockIcon icon={ blockInformation?.icon } />
+					<div>{ blockTitle }</div>
+				</HStack>
+			}
 			panelId={ clientId }
 			resetAll={ () => {
 				updateBlockAttributes(

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -44,6 +44,7 @@ function getDefaultValue( attribute ) {
 }
 
 function BlockAttributeToolsPanelItem( {
+	clientId,
 	attributeDefinition,
 	setValue,
 	value,
@@ -58,6 +59,7 @@ function BlockAttributeToolsPanelItem( {
 
 	return (
 		<ToolsPanelItem
+			panelId={ clientId }
 			label={ attributeDefinition.control.label }
 			hasValue={ () => value !== defaultValue }
 			onDeselect={ () => setValue( defaultValue ) }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -87,7 +87,7 @@ function getContentAttributesWithControls( blockType ) {
 function getResetAllValue( attributes ) {
 	const resetValue = {};
 
-	attributes.each( ( attribute ) => {
+	attributes.forEach( ( attribute ) => {
 		resetValue[ attribute.key ] = getDefaultValue( attribute );
 	} );
 
@@ -137,8 +137,9 @@ function BlockControls( { clientId } ) {
 				);
 			} }
 		>
-			{ contentAttributesWithControls?.each( ( attribute ) => (
+			{ contentAttributesWithControls?.map( ( attribute ) => (
 				<BlockAttributeToolsPanelItem
+					key={ clientId }
 					clientId={ clientId }
 					attributeDefinition={ attribute }
 					setValue={ ( value ) =>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -1,0 +1,107 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
+
+function RichTextControl() {}
+
+function getContentAttributesWithControls( blockType ) {
+	return Object.keys( blockType?.attributes ?? {} )
+		.filter( ( attributeKey ) => {
+			const attribute = blockType.attributes[ attributeKey ];
+			return attribute?.role === 'content' && !! attribute.control;
+		} )
+		.map( ( attributeKey ) => ( {
+			key: attributeKey,
+			...blockType?.attributes[ attributeKey ],
+		} ) );
+}
+
+function getControlForAttribute( attribute ) {
+	if ( attribute.control.type === 'RichText' ) {
+		return RichTextControl;
+	}
+}
+
+function BlockAttributeControl( { attributeDefinition, setAttribute, value } ) {
+	const Control = getControlForAttribute( attributeDefinition );
+
+	if ( ! Control ) {
+		return null;
+	}
+
+	return (
+		<ToolsPanelItem>
+			<Control value={ value } setAttribute={ setAttribute } />
+		</ToolsPanelItem>
+	);
+}
+
+function BlockControls( { clientId } ) {
+	const { blockType, attributes } = useSelect(
+		( select ) => {
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
+			const { getBlockType } = select( blocksStore );
+
+			const blockName = getBlockName( clientId );
+
+			return {
+				blockType: getBlockType( blockName ),
+				attributes: getBlockAttributes( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const contentAttributesWithControls =
+		getContentAttributesWithControls( blockType );
+
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
+
+	if ( ! contentAttributesWithControls?.length ) {
+		return null;
+	}
+
+	return (
+		<ToolsPanel label={ blockTitle } panelId={ clientId }>
+			{ contentAttributesWithControls?.each( ( attribute ) => (
+				<BlockAttributeControl
+					clientId={ clientId }
+					attributeDefinition={ attribute }
+					setAttribute={ ( value ) =>
+						updateBlockAttributes( clientId, {
+							[ attribute.key ]: value,
+						} )
+					}
+					value={ attributes[ attribute.key ] }
+				/>
+			) ) }
+		</ToolsPanel>
+	);
+}
+
+export default function ContentOnlyControls( { clientIds } ) {
+	if ( ! clientIds.length ) {
+		return null;
+	}
+
+	return clientIds.map( ( clientId ) => (
+		<BlockControls key={ clientId } clientId={ clientId } />
+	) );
+}

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -195,9 +195,9 @@ export default function ContentOnlyControls( { rootClientId } ) {
 				const { getClientIdsOfDescendants, getBlockEditingMode } =
 					select( blockEditorStore );
 
-				// _nestedContentClientIds is for content blocks within the 'drilldown'.
+				// _nestedContentClientIds is for content blocks within 'drilldowns'.
 				// It's an object where the key is the parent clientId, and the element is
-				// an array of child clientIds.
+				// an array of child clientIds whose controls are shown within the drilldown.
 				const _nestedContentClientIds = {};
 
 				// _contentClientIds is the list of contentClientIds for blocks being
@@ -205,8 +205,8 @@ export default function ContentOnlyControls( { rootClientId } ) {
 				// but not the children of those blocks.
 				const _contentClientIds = [];
 
-				// An array of all nested client ids. Used to ensure nested clientIds don't end
-				// up in _contentClientIds, but not returned from the useSelect.
+				// An array of all nested client ids. Used for ensuring blocks within drilldowns
+				// don't appear at the root level.
 				let allNestedClientIds = [];
 
 				// A flattened list of all content clientIds to arrange into the

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -3,17 +3,10 @@
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import {
-	Button,
 	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalHStack as HStack,
-	__experimentalGrid as Grid,
-	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
-import { __ } from '@wordpress/i18n';
-import { lineSolid, update } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -22,224 +15,16 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import useBlockDisplayInformation from '../use-block-display-information';
-import MediaUpload from '../media-upload';
-import MediaUploadCheck from '../media-upload/check';
+
+// controls
+import RichText from './rich-text';
+import Media from './media';
+import Link from './link';
 
 const controls = {
-	RichText( {
-		clientId,
-		control,
-		blockType,
-		attributeValues,
-		updateAttributes,
-	} ) {
-		const valueKey = control.mapping.value;
-		const value = attributeValues[ valueKey ];
-		const defaultValue =
-			blockType.attributes[ valueKey ]?.defaultValue ?? undefined;
-
-		return (
-			<ToolsPanelItem
-				panelId={ clientId }
-				label={ control.label }
-				hasValue={ () => value !== defaultValue }
-				onDeselect={ () => {
-					updateAttributes( { [ valueKey ]: defaultValue } );
-				} }
-				isShownByDefault={ control.shownByDefault }
-			>
-				<TextControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ control.label }
-					value={ value ? stripHTML( value ) : '' }
-					onChange={ ( newValue ) => {
-						updateAttributes( { [ valueKey ]: newValue } );
-					} }
-					autoComplete="off"
-				/>
-			</ToolsPanelItem>
-		);
-	},
-	Media( {
-		clientId,
-		control,
-		blockType,
-		attributeValues,
-		updateAttributes,
-	} ) {
-		const idKey = control.mapping.id;
-		const srcKey = control.mapping.src;
-		const captionKey = control.mapping.caption;
-		const altKey = control.mapping.alt;
-
-		const src = attributeValues[ srcKey ];
-		const caption = attributeValues[ captionKey ];
-		const alt = attributeValues[ altKey ];
-
-		const idDefaultValue =
-			blockType.attributes[ idKey ]?.defaultValue ?? undefined;
-		const srcDefaultValue =
-			blockType.attributes[ srcKey ]?.defaultValue ?? undefined;
-		const captionDefaultValue =
-			blockType.attributes[ captionKey ]?.defaultValue ?? undefined;
-		const altDefaultValue =
-			blockType.attributes[ altKey ]?.defaultValue ?? undefined;
-
-		// TODO - pluralize.
-		let chooseItemLabel;
-		if ( control.args.allowedTypes.length === 1 ) {
-			const allowedType = control.args.allowedTypes[ 0 ];
-			if ( allowedType === 'image' ) {
-				chooseItemLabel = __( 'Choose image' );
-			} else if ( allowedType === 'video' ) {
-				chooseItemLabel = __( 'Choose video' );
-			} else if ( allowedType === 'application' ) {
-				chooseItemLabel = __( 'Choose file' );
-			} else {
-				chooseItemLabel = __( 'Choose media item' );
-			}
-		} else {
-			chooseItemLabel = __( 'Choose media item' );
-		}
-
-		return (
-			<MediaUploadCheck>
-				<ToolsPanelItem
-					panelId={ clientId }
-					label={ control.label }
-					hasValue={ () => !! src }
-					onDeselect={ () => {
-						updateAttributes( {
-							[ idKey ]: idDefaultValue,
-							[ srcKey ]: srcDefaultValue,
-							[ captionKey ]: captionDefaultValue,
-							[ altKey ]: altDefaultValue,
-						} );
-					} }
-					isShownByDefault={ control.shownByDefault }
-				>
-					<MediaUpload
-						onSelect={ ( selectedMedia ) => {
-							if ( selectedMedia.id && selectedMedia.url ) {
-								const optionalAttributes = {};
-
-								if ( ! caption && selectedMedia.caption ) {
-									optionalAttributes[ captionKey ] =
-										selectedMedia.caption;
-								}
-								if ( ! alt && selectedMedia.alt ) {
-									optionalAttributes[ altKey ] =
-										selectedMedia.alt;
-								}
-
-								updateAttributes( {
-									[ idKey ]: selectedMedia.id,
-									[ srcKey ]: selectedMedia.url,
-									...optionalAttributes,
-								} );
-							}
-						} }
-						allowedTypes={ control.args.allowedTypes }
-						multiple={ control.args.multiple }
-						render={ ( { open } ) => {
-							return (
-								<div
-									role="button"
-									tabIndex={ -1 }
-									onClick={ () => {
-										open();
-									} }
-									onKeyDown={ open }
-								>
-									<Grid
-										rowGap={ 0 }
-										columnGap={ 8 }
-										templateColumns="24px 1fr 24px"
-									>
-										{ src && (
-											<>
-												<img
-													className="block-editor-content-only-controls__media-preview"
-													alt=""
-													width={ 24 }
-													height={ 24 }
-													src={ src }
-												/>
-												<span className="block-editor-content-only-controls__media-title">
-													{
-														// TODO - use media title instead of src.
-														src
-													}
-												</span>
-											</>
-										) }
-										{ ! src && (
-											<>
-												<span
-													className="block-editor-content-only-controls__media-placeholder"
-													style={ {
-														width: '24px',
-														height: '24px',
-													} }
-												/>
-												<span className="block-editor-content-only-controls__media-title">
-													{ chooseItemLabel }
-												</span>
-											</>
-										) }
-										{ src && (
-											<>
-												<Button
-													size="small"
-													className="block-editor-content-only-controls__remove-button"
-													icon={ lineSolid }
-													onClick={ ( event ) => {
-														event.stopPropagation();
-														updateAttributes( {
-															[ idKey ]:
-																idDefaultValue,
-															[ srcKey ]:
-																srcDefaultValue,
-															[ captionKey ]:
-																captionDefaultValue,
-															[ altKey ]:
-																altDefaultValue,
-														} );
-													} }
-												/>
-											</>
-										) }
-									</Grid>
-								</div>
-							);
-						} }
-					/>
-				</ToolsPanelItem>
-			</MediaUploadCheck>
-		);
-	},
-	Link( {
-		clientId,
-		control,
-		blockType,
-		attributeValues,
-		updateAttributes,
-	} ) {
-		return (
-			<ToolsPanelItem
-				panelId={ clientId }
-				label={ control.label }
-				hasValue={ () => false } // TODO.
-				onDeselect={ () => {
-					// TODO.
-				} }
-				isShownByDefault={ control.shownByDefault }
-			>
-				Link
-			</ToolsPanelItem>
-		);
-	},
+	RichText,
+	Media,
+	Link,
 };
 
 function BlockAttributeToolsPanelItem( {

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -42,22 +42,59 @@ function BlockAttributeToolsPanelItem( {
 	attributeValues,
 } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { selectBlock, toggleBlockSpotlight } = unlock(
+		useDispatch( blockEditorStore )
+	);
+	const { isBlockSelected } = useSelect( blockEditorStore );
 	const ControlComponent = controls[ control.type ];
 
 	if ( ! ControlComponent ) {
 		return null;
 	}
 
-	return (
-		<ControlComponent
-			clientId={ clientId }
-			control={ control }
-			blockType={ blockType }
-			attributeValues={ attributeValues }
-			updateAttributes={ ( attributes ) =>
-				updateBlockAttributes( clientId, attributes )
+	const isSelected = isBlockSelected( clientId );
+
+	const handleClick = () => {
+		// Navigate to block without changing focus (keeps focus in sidebar)
+		// Pass `null` as second parameter to prevent focusing the block
+		if ( ! isSelected ) {
+			selectBlock( clientId, null );
+			toggleBlockSpotlight( clientId, true );
+		}
+		// Don't prevent propagation so clicks can reach child elements (like input fields)
+	};
+
+	const handleFocusCapture = ( event ) => {
+		// Navigate to block when child controls receive focus (keyboard navigation)
+		// Only trigger if focus is actually on a child element, not the wrapper itself
+		if ( event.target !== event.currentTarget ) {
+			// Pass `null` as second parameter to prevent focusing the block
+			if ( ! isSelected ) {
+				selectBlock( clientId, null );
+				toggleBlockSpotlight( clientId, true );
 			}
-		/>
+		}
+	};
+
+	return (
+		// Keyboard navigation is handled via onFocusCapture when child controls receive focus.
+		// The wrapper itself is not focusable (no tabIndex) to avoid extra tab stops.
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div
+			className="block-editor-content-only-controls__item-wrapper"
+			onClick={ handleClick }
+			onFocusCapture={ handleFocusCapture }
+		>
+			<ControlComponent
+				clientId={ clientId }
+				control={ control }
+				blockType={ blockType }
+				attributeValues={ attributeValues }
+				updateAttributes={ ( attributes ) =>
+					updateBlockAttributes( clientId, attributes )
+				}
+			/>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -61,7 +61,7 @@ function BlockAttributeToolsPanelItem( {
 	);
 }
 
-function BlockControls( { clientId } ) {
+function BlockFields( { clientId } ) {
 	const { attributes, blockType } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getBlockName } =
@@ -83,8 +83,8 @@ function BlockControls( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const popoverPlacementProps = useInspectorPopoverPlacement();
 
-	if ( ! blockType?.controls?.length ) {
-		// TODO - we might still want to show a placeholder for blocks with no controls.
+	if ( ! blockType?.fields?.length ) {
+		// TODO - we might still want to show a placeholder for blocks with no fields.
 		// for example, a way to select the block.
 		return null;
 	}
@@ -100,11 +100,11 @@ function BlockControls( { clientId } ) {
 			panelId={ clientId }
 			dropdownMenuProps={ popoverPlacementProps }
 		>
-			{ blockType?.controls?.map( ( control, index ) => (
+			{ blockType?.fields?.map( ( field, index ) => (
 				<BlockAttributeToolsPanelItem
 					key={ `${ clientId }/${ index }` }
 					clientId={ clientId }
-					control={ control }
+					control={ field }
 					blockType={ blockType }
 					attributeValues={ attributes }
 				/>
@@ -169,9 +169,7 @@ function ContentOnlyControlsScreen( {
 					</Navigator.BackButton>
 				</div>
 			) }
-			{ isRootContentBlock && (
-				<BlockControls clientId={ rootClientId } />
-			) }
+			{ isRootContentBlock && <BlockFields clientId={ rootClientId } /> }
 			{ contentClientIds.map( ( clientId ) => {
 				if ( parentClientIds?.[ clientId ] ) {
 					return (
@@ -182,7 +180,7 @@ function ContentOnlyControlsScreen( {
 					);
 				}
 
-				return <BlockControls key={ clientId } clientId={ clientId } />;
+				return <BlockFields key={ clientId } clientId={ clientId } />;
 			} ) }
 		</div>
 	);

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -54,6 +54,48 @@ const controls = {
 			</ToolsPanelItem>
 		);
 	},
+	Media( {
+		clientId,
+		control,
+		blockType,
+		attributeValues,
+		updateAttributes,
+	} ) {
+		return (
+			<ToolsPanelItem
+				panelId={ clientId }
+				label={ control.label }
+				hasValue={ () => false } // TODO.
+				onDeselect={ () => {
+					// TODO.
+				} }
+				isShownByDefault={ control.shownByDefault }
+			>
+				Media
+			</ToolsPanelItem>
+		);
+	},
+	Link( {
+		clientId,
+		control,
+		blockType,
+		attributeValues,
+		updateAttributes,
+	} ) {
+		return (
+			<ToolsPanelItem
+				panelId={ clientId }
+				label={ control.label }
+				hasValue={ () => true } // TODO.
+				onDeselect={ () => {
+					// TODO.
+				} }
+				isShownByDefault={ control.shownByDefault }
+			>
+				Link
+			</ToolsPanelItem>
+		);
+	},
 };
 
 function BlockAttributeToolsPanelItem( {

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -19,106 +19,83 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import useBlockDisplayInformation from '../use-block-display-information';
 
-function RichTextControl( { label, value, setValue } ) {
+const controls = {
+	RichText( {
+		clientId,
+		control,
+		blockType,
+		attributeValues,
+		updateAttributes,
+	} ) {
+		const valueKey = control.mapping.value;
+		const value = attributeValues[ valueKey ];
+		const defaultValue = blockType.attributes[ valueKey ]?.defaultValue;
+
+		return (
+			<ToolsPanelItem
+				panelId={ clientId }
+				label={ control.label }
+				hasValue={ () => value !== defaultValue }
+				onDeselect={ () => {
+					updateAttributes( { [ valueKey ]: defaultValue } );
+				} }
+				isShownByDefault={ control.shownByDefault }
+			>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ control.label }
+					value={ value ? stripHTML( value ) : '' }
+					onChange={ ( newValue ) => {
+						updateAttributes( { [ valueKey ]: newValue } );
+					} }
+					autoComplete="off"
+				/>
+			</ToolsPanelItem>
+		);
+	},
+};
+
+function BlockAttributeToolsPanelItem( {
+	clientId,
+	control,
+	blockType,
+	attributeValues,
+} ) {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const ControlComponent = controls[ control.type ];
+
+	if ( ! ControlComponent ) {
+		return null;
+	}
+
 	return (
-		<TextControl
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-			label={ label }
-			value={ value ? stripHTML( value ) : '' }
-			onChange={ setValue }
-			autoComplete="off"
+		<ControlComponent
+			clientId={ clientId }
+			control={ control }
+			blockType={ blockType }
+			attributeValues={ attributeValues }
+			updateAttributes={ ( attributes ) =>
+				updateBlockAttributes( clientId, attributes )
+			}
 		/>
 	);
 }
 
-function getControlForAttribute( attribute ) {
-	if ( attribute.control.type === 'RichText' ) {
-		return RichTextControl;
-	}
-}
-
-function getDefaultValue( attribute ) {
-	if ( attribute.default ) {
-		return attribute.default;
-	}
-
-	return undefined;
-}
-
-function BlockAttributeToolsPanelItem( {
-	clientId,
-	attributeDefinition,
-	setValue,
-	value,
-} ) {
-	const Control = getControlForAttribute( attributeDefinition );
-
-	if ( ! Control ) {
-		return null;
-	}
-
-	const defaultValue = getDefaultValue( attributeDefinition );
-
-	return (
-		<ToolsPanelItem
-			panelId={ clientId }
-			label={ attributeDefinition.control.label }
-			hasValue={ () => value !== defaultValue }
-			onDeselect={ () => setValue( defaultValue ) }
-			isShownByDefault={ attributeDefinition.control.shownByDefault }
-		>
-			<Control
-				label={ attributeDefinition.control.label }
-				value={ value }
-				setValue={ setValue }
-			/>
-		</ToolsPanelItem>
-	);
-}
-
-function getContentAttributesWithControls( blockType ) {
-	return Object.keys( blockType?.attributes ?? {} )
-		.filter( ( attributeKey ) => {
-			const attribute = blockType.attributes[ attributeKey ];
-			return attribute?.role === 'content' && !! attribute.control;
-		} )
-		.map( ( attributeKey ) => ( {
-			key: attributeKey,
-			...blockType?.attributes[ attributeKey ],
-		} ) );
-}
-
-function getResetAllValue( attributes ) {
-	const resetValue = {};
-
-	attributes.forEach( ( attribute ) => {
-		resetValue[ attribute.key ] = getDefaultValue( attribute );
-	} );
-
-	return resetValue;
-}
-
 function BlockControls( { clientId } ) {
-	const { blockType, attributes } = useSelect(
+	const { attributes, blockType } = useSelect(
 		( select ) => {
-			const { getBlockName, getBlockAttributes } =
+			const { getBlockAttributes, getBlockName } =
 				select( blockEditorStore );
 			const { getBlockType } = select( blocksStore );
-
 			const blockName = getBlockName( clientId );
-
 			return {
-				blockType: getBlockType( blockName ),
 				attributes: getBlockAttributes( clientId ),
+				blockType: getBlockType( blockName ),
 			};
 		},
 		[ clientId ]
 	);
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-
-	const contentAttributesWithControls =
-		getContentAttributesWithControls( blockType );
 
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -126,7 +103,7 @@ function BlockControls( { clientId } ) {
 	} );
 	const blockInformation = useBlockDisplayInformation( clientId );
 
-	if ( ! contentAttributesWithControls?.length ) {
+	if ( ! blockType?.controls?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no controls.
 		// for example, a way to select the block.
 		return null;
@@ -141,24 +118,14 @@ function BlockControls( { clientId } ) {
 				</HStack>
 			}
 			panelId={ clientId }
-			resetAll={ () => {
-				updateBlockAttributes(
-					clientId,
-					getResetAllValue( contentAttributesWithControls )
-				);
-			} }
 		>
-			{ contentAttributesWithControls?.map( ( attribute ) => (
+			{ blockType?.controls?.map( ( control, index ) => (
 				<BlockAttributeToolsPanelItem
-					key={ clientId }
+					key={ `${ clientId }/${ index }` }
 					clientId={ clientId }
-					attributeDefinition={ attribute }
-					setValue={ ( value ) =>
-						updateBlockAttributes( clientId, {
-							[ attribute.key ]: value,
-						} )
-					}
-					value={ attributes[ attribute.key ] }
+					control={ control }
+					blockType={ blockType }
+					attributeValues={ attributes }
 				/>
 			) ) }
 		</ToolsPanel>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -226,7 +226,10 @@ export default function ContentOnlyControls( { rootClientId } ) {
 				);
 
 				// If there's more than one child block, use a drilldown.
-				if ( childClientIds.length > 1 ) {
+				if (
+					childClientIds.length > 1 &&
+					! allNestedClientIds.includes( clientId )
+				) {
 					_nestedContentClientIds[ clientId ] = childClientIds;
 					allNestedClientIds = [
 						allNestedClientIds,

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
@@ -106,12 +107,32 @@ function BlockControls( { clientId } ) {
 	);
 }
 
-export default function ContentOnlyControls( { clientIds } ) {
-	if ( ! clientIds.length ) {
+export default function ContentOnlyControls( {
+	rootClientId,
+	contentClientIds,
+} ) {
+	const isRootContentBlock = useSelect(
+		( select ) => {
+			const { getBlockName } = select( blockEditorStore );
+			const blockName = getBlockName( rootClientId );
+			const { hasContentRoleAttribute } = unlock( select( blocksStore ) );
+			return hasContentRoleAttribute( blockName );
+		},
+		[ rootClientId ]
+	);
+
+	if ( ! isRootContentBlock && ! contentClientIds.length ) {
 		return null;
 	}
 
-	return clientIds.map( ( clientId ) => (
-		<BlockControls key={ clientId } clientId={ clientId } />
-	) );
+	return (
+		<>
+			{ isRootContentBlock && (
+				<BlockControls clientId={ rootClientId } />
+			) }
+			{ contentClientIds.map( ( clientId ) => (
+				<BlockControls key={ clientId } clientId={ clientId } />
+			) ) }
+		</>
+	);
 }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -242,6 +242,21 @@ export default function ContentOnlyControls( { rootClientId } ) {
 				}
 			}
 
+			// Avoid showing only one drilldown block at the root.
+			if (
+				_contentClientIds.length === 1 &&
+				Object.keys( _nestedContentClientIds ).length === 1
+			) {
+				const onlyParentClientId = Object.keys(
+					_nestedContentClientIds
+				)[ 0 ];
+				return {
+					contentClientIds:
+						_nestedContentClientIds[ onlyParentClientId ],
+					nestedContentClientIds: {},
+				};
+			}
+
 			return {
 				nestedContentClientIds: _nestedContentClientIds,
 				contentClientIds: _contentClientIds,

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -189,87 +189,90 @@ function ContentOnlyControlsScreen( {
 }
 
 export default function ContentOnlyControls( { rootClientId } ) {
-	const { nestedContentClientIds, contentClientIds } = useSelect(
-		( select ) => {
-			const { getClientIdsOfDescendants, getBlockEditingMode } =
-				select( blockEditorStore );
+	const { updatedRootClientId, nestedContentClientIds, contentClientIds } =
+		useSelect(
+			( select ) => {
+				const { getClientIdsOfDescendants, getBlockEditingMode } =
+					select( blockEditorStore );
 
-			// _nestedContentClientIds is for content blocks within the 'drilldown'.
-			// It's an object where the key is the parent clientId, and the element is
-			// an array of child clientIds.
-			const _nestedContentClientIds = {};
+				// _nestedContentClientIds is for content blocks within the 'drilldown'.
+				// It's an object where the key is the parent clientId, and the element is
+				// an array of child clientIds.
+				const _nestedContentClientIds = {};
 
-			// _contentClientIds is the list of contentClientIds for blocks being
-			// shown at the root level. Includes parent blocks that might have a drilldown,
-			// but not the children of those blocks.
-			const _contentClientIds = [];
+				// _contentClientIds is the list of contentClientIds for blocks being
+				// shown at the root level. Includes parent blocks that might have a drilldown,
+				// but not the children of those blocks.
+				const _contentClientIds = [];
 
-			// An array of all nested client ids. Used to ensure nested clientIds don't end
-			// up in _contentClientIds, but not returned from the useSelect.
-			let allNestedClientIds = [];
+				// An array of all nested client ids. Used to ensure nested clientIds don't end
+				// up in _contentClientIds, but not returned from the useSelect.
+				let allNestedClientIds = [];
 
-			// A flattened list of all content clientIds to arrange into the
-			// groups above.
-			const allContentClientIds = getClientIdsOfDescendants(
-				rootClientId
-			).filter(
-				( clientId ) =>
-					getBlockEditingMode( clientId ) === 'contentOnly'
-			);
-
-			for ( const clientId of allContentClientIds ) {
-				const childClientIds = getClientIdsOfDescendants(
-					clientId
+				// A flattened list of all content clientIds to arrange into the
+				// groups above.
+				const allContentClientIds = getClientIdsOfDescendants(
+					rootClientId
 				).filter(
-					( childClientId ) =>
-						getBlockEditingMode( childClientId ) === 'contentOnly'
+					( clientId ) =>
+						getBlockEditingMode( clientId ) === 'contentOnly'
 				);
 
-				// If there's more than one child block, use a drilldown.
+				for ( const clientId of allContentClientIds ) {
+					const childClientIds = getClientIdsOfDescendants(
+						clientId
+					).filter(
+						( childClientId ) =>
+							getBlockEditingMode( childClientId ) ===
+							'contentOnly'
+					);
+
+					// If there's more than one child block, use a drilldown.
+					if (
+						childClientIds.length > 1 &&
+						! allNestedClientIds.includes( clientId )
+					) {
+						_nestedContentClientIds[ clientId ] = childClientIds;
+						allNestedClientIds = [
+							allNestedClientIds,
+							...childClientIds,
+						];
+					}
+
+					if ( ! allNestedClientIds.includes( clientId ) ) {
+						_contentClientIds.push( clientId );
+					}
+				}
+
+				// Avoid showing only one drilldown block at the root.
 				if (
-					childClientIds.length > 1 &&
-					! allNestedClientIds.includes( clientId )
+					_contentClientIds.length === 1 &&
+					Object.keys( _nestedContentClientIds ).length === 1
 				) {
-					_nestedContentClientIds[ clientId ] = childClientIds;
-					allNestedClientIds = [
-						allNestedClientIds,
-						...childClientIds,
-					];
+					const onlyParentClientId = Object.keys(
+						_nestedContentClientIds
+					)[ 0 ];
+					return {
+						updatedRootClientId: onlyParentClientId,
+						contentClientIds:
+							_nestedContentClientIds[ onlyParentClientId ],
+						nestedContentClientIds: {},
+					};
 				}
 
-				if ( ! allNestedClientIds.includes( clientId ) ) {
-					_contentClientIds.push( clientId );
-				}
-			}
-
-			// Avoid showing only one drilldown block at the root.
-			if (
-				_contentClientIds.length === 1 &&
-				Object.keys( _nestedContentClientIds ).length === 1
-			) {
-				const onlyParentClientId = Object.keys(
-					_nestedContentClientIds
-				)[ 0 ];
 				return {
-					contentClientIds:
-						_nestedContentClientIds[ onlyParentClientId ],
-					nestedContentClientIds: {},
+					nestedContentClientIds: _nestedContentClientIds,
+					contentClientIds: _contentClientIds,
 				};
-			}
-
-			return {
-				nestedContentClientIds: _nestedContentClientIds,
-				contentClientIds: _contentClientIds,
-			};
-		},
-		[ rootClientId ]
-	);
+			},
+			[ rootClientId ]
+		);
 
 	return (
 		<Navigator initialPath="/">
 			<Navigator.Screen path="/">
 				<ContentOnlyControlsScreen
-					rootClientId={ rootClientId }
+					rootClientId={ updatedRootClientId ?? rootClientId }
 					contentClientIds={ contentClientIds }
 					parentClientIds={ nestedContentClientIds }
 				/>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -158,7 +158,7 @@ function ContentOnlyControlsScreen( {
 	}
 
 	return (
-		<div className="block-editor-content-only-controls__screen">
+		<>
 			{ isNested && (
 				<div className="block-editor-content-only-controls__button-panel">
 					<Navigator.BackButton className="block-editor-content-only-controls__back-button">
@@ -182,7 +182,7 @@ function ContentOnlyControlsScreen( {
 
 				return <BlockFields key={ clientId } clientId={ clientId } />;
 			} ) }
-		</div>
+		</>
 	);
 }
 
@@ -268,7 +268,10 @@ export default function ContentOnlyControls( { rootClientId } ) {
 
 	return (
 		<Navigator initialPath="/">
-			<Navigator.Screen path="/">
+			<Navigator.Screen
+				path="/"
+				className="block-editor-content-only-controls__screen"
+			>
 				<ContentOnlyControlsScreen
 					rootClientId={ updatedRootClientId ?? rootClientId }
 					contentClientIds={ contentClientIds }
@@ -276,7 +279,11 @@ export default function ContentOnlyControls( { rootClientId } ) {
 				/>
 			</Navigator.Screen>
 			{ Object.keys( nestedContentClientIds ).map( ( clientId ) => (
-				<Navigator.Screen key={ clientId } path={ `/${ clientId }` }>
+				<Navigator.Screen
+					key={ clientId }
+					path={ `/${ clientId }` }
+					className="block-editor-content-only-controls__screen"
+				>
 					<ContentOnlyControlsScreen
 						isNested
 						rootClientId={ clientId }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -15,7 +15,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import useBlockDisplayInformation from '../use-block-display-information';
-import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
+import { useInspectorPopoverPlacement } from './use-inspector-popover-placement';
 
 // controls
 import RichText from './rich-text';
@@ -74,7 +74,7 @@ function BlockControls( { clientId } ) {
 		context: 'list-view',
 	} );
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const popoverPlacementProps = useInspectorPopoverPlacement();
 
 	if ( ! blockType?.controls?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no controls.
@@ -91,7 +91,7 @@ function BlockControls( { clientId } ) {
 				</HStack>
 			}
 			panelId={ clientId }
-			dropdownMenuProps={ dropdownMenuProps }
+			dropdownMenuProps={ popoverPlacementProps }
 		>
 			{ blockType?.controls?.map( ( control, index ) => (
 				<BlockAttributeToolsPanelItem

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,9 +5,12 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalHStack as HStack,
+	Icon,
 	Navigator,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { arrowLeft, arrowRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -117,12 +120,20 @@ function DrillDownButton( { clientId } ) {
 	} );
 	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
-		<Navigator.Button path={ `/${ clientId }` } variant="primary">
-			<HStack spacing={ 1 }>
-				<BlockIcon icon={ blockInformation?.icon } />
-				<div>{ blockTitle }</div>
-			</HStack>
-		</Navigator.Button>
+		<div className="block-editor-content-only-controls__button-panel">
+			<Navigator.Button
+				path={ `/${ clientId }` }
+				className="block-editor-content-only-controls__drill-down-button"
+			>
+				<HStack expanded justify="space-between">
+					<HStack justify="flex-start" spacing={ 1 }>
+						<BlockIcon icon={ blockInformation?.icon } />
+						<div>{ blockTitle }</div>
+					</HStack>
+					<Icon icon={ arrowRight } />
+				</HStack>
+			</Navigator.Button>
+		</div>
 	);
 }
 
@@ -130,6 +141,7 @@ function ContentOnlyControlsScreen( {
 	rootClientId,
 	contentClientIds,
 	parentClientIds,
+	isNested,
 } ) {
 	const isRootContentBlock = useSelect(
 		( select ) => {
@@ -146,7 +158,17 @@ function ContentOnlyControlsScreen( {
 	}
 
 	return (
-		<>
+		<div className="block-editor-content-only-controls__screen">
+			{ isNested && (
+				<div className="block-editor-content-only-controls__button-panel">
+					<Navigator.BackButton className="block-editor-content-only-controls__back-button">
+						<HStack expanded spacing={ 1 } justify="flex-start">
+							<Icon icon={ arrowLeft } />
+							<div>{ __( 'Back' ) }</div>
+						</HStack>
+					</Navigator.BackButton>
+				</div>
+			) }
 			{ isRootContentBlock && (
 				<BlockControls clientId={ rootClientId } />
 			) }
@@ -162,7 +184,7 @@ function ContentOnlyControlsScreen( {
 
 				return <BlockControls key={ clientId } clientId={ clientId } />;
 			} ) }
-		</>
+		</div>
 	);
 }
 
@@ -237,6 +259,7 @@ export default function ContentOnlyControls( { rootClientId } ) {
 			{ Object.keys( nestedContentClientIds ).map( ( clientId ) => (
 				<Navigator.Screen key={ clientId } path={ `/${ clientId }` }>
 					<ContentOnlyControlsScreen
+						isNested
 						rootClientId={ clientId }
 						contentClientIds={ nestedContentClientIds[ clientId ] }
 					/>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -19,11 +19,13 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { useInspectorPopoverPlacement } from './use-inspector-popover-placement';
 
 // controls
+import PlainText from './plain-text';
 import RichText from './rich-text';
 import Media from './media';
 import Link from './link';
 
 const controls = {
+	PlainText,
 	RichText,
 	Media,
 	Link,

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -15,6 +15,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import useBlockDisplayInformation from '../use-block-display-information';
+import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
 
 // controls
 import RichText from './rich-text';
@@ -73,6 +74,7 @@ function BlockControls( { clientId } ) {
 		context: 'list-view',
 	} );
 	const blockInformation = useBlockDisplayInformation( clientId );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( ! blockType?.controls?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no controls.
@@ -89,6 +91,7 @@ function BlockControls( { clientId } ) {
 				</HStack>
 			}
 			panelId={ clientId }
+			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ blockType?.controls?.map( ( control, index ) => (
 				<BlockAttributeToolsPanelItem

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -45,14 +45,11 @@ function BlockAttributeToolsPanelItem( {
 	const { selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
 	);
-	const { isBlockSelected } = useSelect( blockEditorStore );
+	const isSelected = useSelect(
+		( select ) => select( blockEditorStore ).isBlockSelected( clientId ),
+		[ clientId ]
+	);
 	const ControlComponent = controls[ control.type ];
-
-	if ( ! ControlComponent ) {
-		return null;
-	}
-
-	const isSelected = isBlockSelected( clientId );
 
 	const handleClick = () => {
 		// Navigate to block without changing focus (keeps focus in sidebar)
@@ -137,15 +134,17 @@ function BlockFields( { clientId } ) {
 			panelId={ clientId }
 			dropdownMenuProps={ popoverPlacementProps }
 		>
-			{ blockType?.fields?.map( ( field, index ) => (
-				<BlockAttributeToolsPanelItem
-					key={ `${ clientId }/${ index }` }
-					clientId={ clientId }
-					control={ field }
-					blockType={ blockType }
-					attributeValues={ attributes }
-				/>
-			) ) }
+			{ blockType?.fields
+				?.filter( ( field ) => controls[ field.type ] )
+				.map( ( field, index ) => (
+					<BlockAttributeToolsPanelItem
+						key={ `${ clientId }/${ index }` }
+						clientId={ clientId }
+						control={ field }
+						blockType={ blockType }
+						attributeValues={ attributes }
+					/>
+				) ) }
 		</ToolsPanel>
 	);
 }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,6 +5,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalHStack as HStack,
+	Navigator,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -109,9 +110,26 @@ function BlockControls( { clientId } ) {
 	);
 }
 
-export default function ContentOnlyControls( {
+function DrillDownButton( { clientId } ) {
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
+	const blockInformation = useBlockDisplayInformation( clientId );
+	return (
+		<Navigator.Button path={ `/${ clientId }` } variant="primary">
+			<HStack spacing={ 1 }>
+				<BlockIcon icon={ blockInformation?.icon } />
+				<div>{ blockTitle }</div>
+			</HStack>
+		</Navigator.Button>
+	);
+}
+
+function ContentOnlyControlsScreen( {
 	rootClientId,
 	contentClientIds,
+	parentClientIds,
 } ) {
 	const isRootContentBlock = useSelect(
 		( select ) => {
@@ -132,9 +150,98 @@ export default function ContentOnlyControls( {
 			{ isRootContentBlock && (
 				<BlockControls clientId={ rootClientId } />
 			) }
-			{ contentClientIds.map( ( clientId ) => (
-				<BlockControls key={ clientId } clientId={ clientId } />
-			) ) }
+			{ contentClientIds.map( ( clientId ) => {
+				if ( parentClientIds?.[ clientId ] ) {
+					return (
+						<DrillDownButton
+							key={ clientId }
+							clientId={ clientId }
+						/>
+					);
+				}
+
+				return <BlockControls key={ clientId } clientId={ clientId } />;
+			} ) }
 		</>
+	);
+}
+
+export default function ContentOnlyControls( { rootClientId } ) {
+	const { nestedContentClientIds, contentClientIds } = useSelect(
+		( select ) => {
+			const { getClientIdsOfDescendants, getBlockEditingMode } =
+				select( blockEditorStore );
+
+			// _nestedContentClientIds is for content blocks within the 'drilldown'.
+			// It's an object where the key is the parent clientId, and the element is
+			// an array of child clientIds.
+			const _nestedContentClientIds = {};
+
+			// _contentClientIds is the list of contentClientIds for blocks being
+			// shown at the root level. Includes parent blocks that might have a drilldown,
+			// but not the children of those blocks.
+			const _contentClientIds = [];
+
+			// An array of all nested client ids. Used to ensure nested clientIds don't end
+			// up in _contentClientIds, but not returned from the useSelect.
+			let allNestedClientIds = [];
+
+			// A flattened list of all content clientIds to arrange into the
+			// groups above.
+			const allContentClientIds = getClientIdsOfDescendants(
+				rootClientId
+			).filter(
+				( clientId ) =>
+					getBlockEditingMode( clientId ) === 'contentOnly'
+			);
+
+			for ( const clientId of allContentClientIds ) {
+				const childClientIds = getClientIdsOfDescendants(
+					clientId
+				).filter(
+					( childClientId ) =>
+						getBlockEditingMode( childClientId ) === 'contentOnly'
+				);
+
+				// If there's more than one child block, use a drilldown.
+				if ( childClientIds.length > 1 ) {
+					_nestedContentClientIds[ clientId ] = childClientIds;
+					allNestedClientIds = [
+						allNestedClientIds,
+						...childClientIds,
+					];
+				}
+
+				if ( ! allNestedClientIds.includes( clientId ) ) {
+					_contentClientIds.push( clientId );
+				}
+			}
+
+			return {
+				nestedContentClientIds: _nestedContentClientIds,
+				contentClientIds: _contentClientIds,
+			};
+		},
+		[ rootClientId ]
+	);
+
+	return (
+		<Navigator initialPath="/">
+			<Navigator.Screen path="/">
+				<ContentOnlyControlsScreen
+					rootClientId={ rootClientId }
+					contentClientIds={ contentClientIds }
+					parentClientIds={ nestedContentClientIds }
+				/>
+			</Navigator.Screen>
+			{ Object.keys( nestedContentClientIds ).map( ( clientId ) => (
+				<Navigator.Screen key={ clientId } path={ `/${ clientId }` }>
+					<ContentOnlyControlsScreen
+						rootClientId={ clientId }
+						contentClientIds={ nestedContentClientIds[ clientId ] }
+					/>
+				</Navigator.Screen>
+			) ) }
+		</Navigator>
 	);
 }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -3,13 +3,17 @@
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import {
+	Button,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalHStack as HStack,
+	__experimentalGrid as Grid,
 	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { __ } from '@wordpress/i18n';
+import { lineSolid, update } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,6 +22,8 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import useBlockDisplayInformation from '../use-block-display-information';
+import MediaUpload from '../media-upload';
+import MediaUploadCheck from '../media-upload/check';
 
 const controls = {
 	RichText( {
@@ -29,7 +35,8 @@ const controls = {
 	} ) {
 		const valueKey = control.mapping.value;
 		const value = attributeValues[ valueKey ];
-		const defaultValue = blockType.attributes[ valueKey ]?.defaultValue;
+		const defaultValue =
+			blockType.attributes[ valueKey ]?.defaultValue ?? undefined;
 
 		return (
 			<ToolsPanelItem
@@ -61,18 +68,155 @@ const controls = {
 		attributeValues,
 		updateAttributes,
 	} ) {
+		const idKey = control.mapping.id;
+		const srcKey = control.mapping.src;
+		const captionKey = control.mapping.caption;
+		const altKey = control.mapping.alt;
+
+		const src = attributeValues[ srcKey ];
+		const caption = attributeValues[ captionKey ];
+		const alt = attributeValues[ altKey ];
+
+		const idDefaultValue =
+			blockType.attributes[ idKey ]?.defaultValue ?? undefined;
+		const srcDefaultValue =
+			blockType.attributes[ srcKey ]?.defaultValue ?? undefined;
+		const captionDefaultValue =
+			blockType.attributes[ captionKey ]?.defaultValue ?? undefined;
+		const altDefaultValue =
+			blockType.attributes[ altKey ]?.defaultValue ?? undefined;
+
+		// TODO - pluralize.
+		let chooseItemLabel;
+		if ( control.args.allowedTypes.length === 1 ) {
+			const allowedType = control.args.allowedTypes[ 0 ];
+			if ( allowedType === 'image' ) {
+				chooseItemLabel = __( 'Choose image' );
+			} else if ( allowedType === 'video' ) {
+				chooseItemLabel = __( 'Choose video' );
+			} else if ( allowedType === 'application' ) {
+				chooseItemLabel = __( 'Choose file' );
+			} else {
+				chooseItemLabel = __( 'Choose media item' );
+			}
+		} else {
+			chooseItemLabel = __( 'Choose media item' );
+		}
+
 		return (
-			<ToolsPanelItem
-				panelId={ clientId }
-				label={ control.label }
-				hasValue={ () => false } // TODO.
-				onDeselect={ () => {
-					// TODO.
-				} }
-				isShownByDefault={ control.shownByDefault }
-			>
-				Media
-			</ToolsPanelItem>
+			<MediaUploadCheck>
+				<ToolsPanelItem
+					panelId={ clientId }
+					label={ control.label }
+					hasValue={ () => !! src }
+					onDeselect={ () => {
+						updateAttributes( {
+							[ idKey ]: idDefaultValue,
+							[ srcKey ]: srcDefaultValue,
+							[ captionKey ]: captionDefaultValue,
+							[ altKey ]: altDefaultValue,
+						} );
+					} }
+					isShownByDefault={ control.shownByDefault }
+				>
+					<MediaUpload
+						onSelect={ ( selectedMedia ) => {
+							if ( selectedMedia.id && selectedMedia.url ) {
+								const optionalAttributes = {};
+
+								if ( ! caption && selectedMedia.caption ) {
+									optionalAttributes[ captionKey ] =
+										selectedMedia.caption;
+								}
+								if ( ! alt && selectedMedia.alt ) {
+									optionalAttributes[ altKey ] =
+										selectedMedia.alt;
+								}
+
+								updateAttributes( {
+									[ idKey ]: selectedMedia.id,
+									[ srcKey ]: selectedMedia.url,
+									...optionalAttributes,
+								} );
+							}
+						} }
+						allowedTypes={ control.args.allowedTypes }
+						multiple={ control.args.multiple }
+						render={ ( { open } ) => {
+							return (
+								<div
+									role="button"
+									tabIndex={ -1 }
+									onClick={ () => {
+										open();
+									} }
+									onKeyDown={ open }
+								>
+									<Grid
+										rowGap={ 0 }
+										columnGap={ 8 }
+										templateColumns="24px 1fr 24px"
+									>
+										{ src && (
+											<>
+												<img
+													className="block-editor-content-only-controls__media-preview"
+													alt=""
+													width={ 24 }
+													height={ 24 }
+													src={ src }
+												/>
+												<span className="block-editor-content-only-controls__media-title">
+													{
+														// TODO - use media title instead of src.
+														src
+													}
+												</span>
+											</>
+										) }
+										{ ! src && (
+											<>
+												<span
+													className="block-editor-content-only-controls__media-placeholder"
+													style={ {
+														width: '24px',
+														height: '24px',
+													} }
+												/>
+												<span className="block-editor-content-only-controls__media-title">
+													{ chooseItemLabel }
+												</span>
+											</>
+										) }
+										{ src && (
+											<>
+												<Button
+													size="small"
+													className="block-editor-content-only-controls__remove-button"
+													icon={ lineSolid }
+													onClick={ ( event ) => {
+														event.stopPropagation();
+														updateAttributes( {
+															[ idKey ]:
+																idDefaultValue,
+															[ srcKey ]:
+																srcDefaultValue,
+															[ captionKey ]:
+																captionDefaultValue,
+															[ altKey ]:
+																altDefaultValue,
+														} );
+													} }
+												/>
+											</>
+										) }
+									</Grid>
+								</div>
+							);
+						} }
+					/>
+				</ToolsPanelItem>
+			</MediaUploadCheck>
 		);
 	},
 	Link( {
@@ -86,7 +230,7 @@ const controls = {
 			<ToolsPanelItem
 				panelId={ clientId }
 				label={ control.label }
-				hasValue={ () => true } // TODO.
+				hasValue={ () => false } // TODO.
 				onDeselect={ () => {
 					// TODO.
 				} }

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -125,7 +125,6 @@ export default function Link( {
 		>
 			<Button
 				__next40pxDefaultSize
-				variant="secondary"
 				className="block-editor-content-only-controls__link"
 				onClick={ () => {
 					setIsLinkControlOpen( true );

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
+
+export default function Link( {
+	clientId,
+	control,
+	blockType,
+	attributeValues,
+	updateAttributes,
+} ) {
+	return (
+		<ToolsPanelItem
+			panelId={ clientId }
+			label={ control.label }
+			hasValue={ () => false } // TODO.
+			onDeselect={ () => {
+				// TODO.
+			} }
+			isShownByDefault={ control.shownByDefault }
+		>
+			Link
+		</ToolsPanelItem>
+	);
+}

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -11,6 +11,7 @@ import {
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { lineSolid, link } from '@wordpress/icons';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
 
 /**
@@ -130,7 +131,13 @@ export default function Link( {
 					onClick={ () => {
 						setIsLinkControlOpen( true );
 					} }
-					onKeyDown={ () => setIsLinkControlOpen( true ) }
+					onKeyDown={ ( event ) => {
+						const { keyCode } = event;
+
+						if ( keyCode === ENTER || keyCode === SPACE ) {
+							setIsLinkControlOpen( true );
+						}
+					} }
 				>
 					<Grid
 						rowGap={ 0 }

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	Icon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
@@ -10,7 +11,6 @@ import {
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { link } from '@wordpress/icons';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
 
 /**
@@ -123,50 +123,42 @@ export default function Link( {
 			} }
 			isShownByDefault={ control.shownByDefault }
 		>
-			<div className="block-editor-content-only-controls__media">
-				<div
-					role="button"
-					tabIndex={ 0 }
-					onClick={ () => {
-						setIsLinkControlOpen( true );
-					} }
-					onKeyDown={ ( event ) => {
-						const { keyCode } = event;
-
-						if ( keyCode === ENTER || keyCode === SPACE ) {
-							setIsLinkControlOpen( true );
-						}
-					} }
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				className="block-editor-content-only-controls__link"
+				onClick={ () => {
+					setIsLinkControlOpen( true );
+				} }
+			>
+				<Grid
+					rowGap={ 0 }
+					columnGap={ 8 }
+					templateColumns="24px 1fr"
+					className="block-editor-content-only-controls__link-row"
 				>
-					<Grid
-						rowGap={ 0 }
-						columnGap={ 8 }
-						templateColumns="24px 1fr"
-						className="block-editor-content-only-controls__media-row"
-					>
-						{ href && (
-							<>
-								<Icon icon={ link } size={ 24 } />
-								<span className="block-editor-content-only-controls__media-title">
-									{ href }
-								</span>
-							</>
-						) }
-						{ ! href && (
-							<>
-								<Icon
-									icon={ link }
-									size={ 24 }
-									style={ { opacity: 0.3 } }
-								/>
-								<span className="block-editor-content-only-controls__media-title">
-									{ __( 'Link' ) }
-								</span>
-							</>
-						) }
-					</Grid>
-				</div>
-			</div>
+					{ href && (
+						<>
+							<Icon icon={ link } size={ 24 } />
+							<span className="block-editor-content-only-controls__link-title">
+								{ href }
+							</span>
+						</>
+					) }
+					{ ! href && (
+						<>
+							<Icon
+								icon={ link }
+								size={ 24 }
+								style={ { opacity: 0.3 } }
+							/>
+							<span className="block-editor-content-only-controls__link-title">
+								{ __( 'Link' ) }
+							</span>
+						</>
+					) }
+				</Grid>
+			</Button>
 			{ isLinkControlOpen && (
 				<Popover
 					onClose={ () => {

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	Icon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
@@ -10,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { lineSolid, link } from '@wordpress/icons';
+import { link } from '@wordpress/icons';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
 
@@ -127,7 +126,7 @@ export default function Link( {
 			<div className="block-editor-content-only-controls__media">
 				<div
 					role="button"
-					tabIndex={ -1 }
+					tabIndex={ 0 }
 					onClick={ () => {
 						setIsLinkControlOpen( true );
 					} }
@@ -142,7 +141,7 @@ export default function Link( {
 					<Grid
 						rowGap={ 0 }
 						columnGap={ 8 }
-						templateColumns="24px 1fr 24px"
+						templateColumns="24px 1fr"
 						className="block-editor-content-only-controls__media-row"
 					>
 						{ href && (
@@ -163,25 +162,6 @@ export default function Link( {
 								<span className="block-editor-content-only-controls__media-title">
 									{ __( 'Link' ) }
 								</span>
-							</>
-						) }
-						{ href && (
-							<>
-								<Button
-									size="small"
-									className="block-editor-content-only-controls__remove-button"
-									icon={ lineSolid }
-									onClick={ ( event ) => {
-										event.stopPropagation();
-										updateAttributes( {
-											[ hrefKey ]: hrefDefaultValue,
-											[ relKey ]: relDefaultValue,
-											[ targetKey ]: targetDefaultValue,
-											[ destinationKey ]:
-												destinationDefaultValue,
-										} );
-									} }
-								/>
 							</>
 						) }
 					</Grid>

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -1,7 +1,72 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
+import {
+	Button,
+	Icon,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalGrid as Grid,
+	Popover,
+} from '@wordpress/components';
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { lineSolid, link } from '@wordpress/icons';
+import { prependHTTP } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import LinkControl from '../../link-control';
+import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement';
+
+export const NEW_TAB_REL = 'noreferrer noopener';
+export const NEW_TAB_TARGET = '_blank';
+export const NOFOLLOW_REL = 'nofollow';
+
+/**
+ * Updates the link attributes.
+ *
+ * @param {Object}  attributes               The current block attributes.
+ * @param {string}  attributes.rel           The current link rel attribute.
+ * @param {string}  attributes.url           The current link url.
+ * @param {boolean} attributes.opensInNewTab Whether the link should open in a new window.
+ * @param {boolean} attributes.nofollow      Whether the link should be marked as nofollow.
+ */
+export function getUpdatedLinkAttributes( {
+	rel = '',
+	url = '',
+	opensInNewTab,
+	nofollow,
+} ) {
+	let newLinkTarget;
+	// Since `rel` is editable attribute, we need to check for existing values and proceed accordingly.
+	let updatedRel = rel;
+
+	if ( opensInNewTab ) {
+		newLinkTarget = NEW_TAB_TARGET;
+		updatedRel = updatedRel?.includes( NEW_TAB_REL )
+			? updatedRel
+			: updatedRel + ` ${ NEW_TAB_REL }`;
+	} else {
+		const relRegex = new RegExp( `\\b${ NEW_TAB_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	if ( nofollow ) {
+		updatedRel = updatedRel?.includes( NOFOLLOW_REL )
+			? updatedRel
+			: ( updatedRel + ` ${ NOFOLLOW_REL }` ).trim();
+	} else {
+		const relRegex = new RegExp( `\\b${ NOFOLLOW_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	return {
+		url: prependHTTP( url ),
+		linkTarget: newLinkTarget,
+		rel: updatedRel || undefined,
+	};
+}
 
 export default function Link( {
 	clientId,
@@ -10,17 +75,143 @@ export default function Link( {
 	attributeValues,
 	updateAttributes,
 } ) {
+	const [ isLinkControlOpen, setIsLinkControlOpen ] = useState( false );
+	const { popoverProps } = useInspectorPopoverPlacement( {
+		isControl: true,
+	} );
+	const hrefKey = control.mapping.href;
+	const relKey = control.mapping.rel;
+	const targetKey = control.mapping.target;
+	const destinationKey = control.mapping.destination;
+
+	const href = attributeValues[ hrefKey ];
+	const rel = attributeValues[ relKey ];
+	const target = attributeValues[ targetKey ];
+	const destination = attributeValues[ destinationKey ];
+
+	const hrefDefaultValue =
+		blockType.attributes[ href ]?.defaultValue ?? undefined;
+	const relDefaultValue =
+		blockType.attributes[ rel ]?.defaultValue ?? undefined;
+	const targetDefaultValue =
+		blockType.attributes[ target ]?.defaultValue ?? undefined;
+	const destinationDefaultValue =
+		blockType.attributes[ destination ]?.defaultValue ?? undefined;
+
+	const opensInNewTab = target === NEW_TAB_TARGET;
+	const nofollow = rel === NOFOLLOW_REL;
+
+	// Memoize link value to avoid overriding the LinkControl's internal state.
+	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
+	const linkValue = useMemo(
+		() => ( { url: href, opensInNewTab, nofollow } ),
+		[ href, opensInNewTab, nofollow ]
+	);
+
 	return (
 		<ToolsPanelItem
 			panelId={ clientId }
 			label={ control.label }
-			hasValue={ () => false } // TODO.
+			hasValue={ () => !! href }
 			onDeselect={ () => {
-				// TODO.
+				updateAttributes( {
+					[ hrefKey ]: hrefDefaultValue,
+					[ relKey ]: relDefaultValue,
+					[ targetKey ]: targetDefaultValue,
+					[ destinationKey ]: destinationDefaultValue,
+				} );
 			} }
 			isShownByDefault={ control.shownByDefault }
 		>
-			Link
+			<div className="block-editor-content-only-controls__media">
+				<div
+					role="button"
+					tabIndex={ -1 }
+					onClick={ () => {
+						setIsLinkControlOpen( true );
+					} }
+					onKeyDown={ () => setIsLinkControlOpen( true ) }
+				>
+					<Grid
+						rowGap={ 0 }
+						columnGap={ 8 }
+						templateColumns="24px 1fr 24px"
+						className="block-editor-content-only-controls__media-row"
+					>
+						{ href && (
+							<>
+								<Icon icon={ link } size={ 24 } />
+								<span className="block-editor-content-only-controls__media-title">
+									{ href }
+								</span>
+							</>
+						) }
+						{ ! href && (
+							<>
+								<Icon
+									icon={ link }
+									size={ 24 }
+									style={ { opacity: 0.3 } }
+								/>
+								<span className="block-editor-content-only-controls__media-title">
+									{ __( 'Link' ) }
+								</span>
+							</>
+						) }
+						{ href && (
+							<>
+								<Button
+									size="small"
+									className="block-editor-content-only-controls__remove-button"
+									icon={ lineSolid }
+									onClick={ ( event ) => {
+										event.stopPropagation();
+										updateAttributes( {
+											[ hrefKey ]: hrefDefaultValue,
+											[ relKey ]: relDefaultValue,
+											[ targetKey ]: targetDefaultValue,
+											[ destinationKey ]:
+												destinationDefaultValue,
+										} );
+									} }
+								/>
+							</>
+						) }
+					</Grid>
+				</div>
+			</div>
+			{ isLinkControlOpen && (
+				<Popover
+					onClose={ () => {
+						setIsLinkControlOpen( false );
+					} }
+					{ ...( popoverProps ?? {} ) }
+				>
+					<LinkControl
+						value={ linkValue }
+						onChange={ ( newValues ) => {
+							const updatedAttrs = getUpdatedLinkAttributes( {
+								rel,
+								...newValues,
+							} );
+
+							updateAttributes( {
+								[ hrefKey ]: updatedAttrs.url,
+								[ relKey ]: updatedAttrs.rel,
+								[ targetKey ]: updatedAttrs.linkTarget,
+							} );
+						} }
+						onRemove={ () => {
+							updateAttributes( {
+								[ hrefKey ]: hrefDefaultValue,
+								[ relKey ]: relDefaultValue,
+								[ targetKey ]: targetDefaultValue,
+								[ destinationKey ]: destinationDefaultValue,
+							} );
+						} }
+					/>
+				</Popover>
+			) }
 		</ToolsPanelItem>
 	);
 }

--- a/packages/block-editor/src/components/content-only-controls/link/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/link/styles.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
 .block-editor-content-only-controls__link {
 	width: 100%;
 	box-shadow: inset 0 0 0 $border-width $gray-400;

--- a/packages/block-editor/src/components/content-only-controls/link/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/link/styles.scss
@@ -1,5 +1,11 @@
 .block-editor-content-only-controls__link {
 	width: 100%;
+	box-shadow: inset 0 0 0 $border-width $gray-400;
+
+	&:focus:not(:disabled) {
+		// Allow smooth transition between focused and unfocused box-shadow states.
+		box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
 }
 
 .block-editor-content-only-controls__link-row {

--- a/packages/block-editor/src/components/content-only-controls/link/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/link/styles.scss
@@ -1,0 +1,14 @@
+.block-editor-content-only-controls__link {
+	width: 100%;
+}
+
+.block-editor-content-only-controls__link-row {
+	align-items: center;
+}
+
+.block-editor-content-only-controls__link-title {
+	width: 100%;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -40,21 +40,21 @@ export default function Media( {
 	const altDefaultValue =
 		blockType.attributes[ altKey ]?.defaultValue ?? undefined;
 
-	// TODO - pluralize.
+	// TODO - pluralize when multiple.
 	let chooseItemLabel;
 	if ( control.args.allowedTypes.length === 1 ) {
 		const allowedType = control.args.allowedTypes[ 0 ];
 		if ( allowedType === 'image' ) {
-			chooseItemLabel = __( 'Choose image' );
+			chooseItemLabel = __( 'Choose an image…' );
 		} else if ( allowedType === 'video' ) {
-			chooseItemLabel = __( 'Choose video' );
+			chooseItemLabel = __( 'Choose a video…' );
 		} else if ( allowedType === 'application' ) {
-			chooseItemLabel = __( 'Choose file' );
+			chooseItemLabel = __( 'Choose a file…' );
 		} else {
-			chooseItemLabel = __( 'Choose media item' );
+			chooseItemLabel = __( 'Choose a media item…' );
 		}
 	} else {
-		chooseItemLabel = __( 'Choose media item' );
+		chooseItemLabel = __( 'Choose a media item…' );
 	}
 
 	return (
@@ -98,73 +98,77 @@ export default function Media( {
 					multiple={ control.args.multiple }
 					render={ ( { open } ) => {
 						return (
-							<div
-								role="button"
-								tabIndex={ -1 }
-								onClick={ () => {
-									open();
-								} }
-								onKeyDown={ open }
-							>
-								<Grid
-									rowGap={ 0 }
-									columnGap={ 8 }
-									templateColumns="24px 1fr 24px"
+							<div className="block-editor-content-only-controls__media">
+								<div
+									role="button"
+									tabIndex={ -1 }
+									onClick={ () => {
+										open();
+									} }
+									onKeyDown={ open }
 								>
-									{ src && (
-										<>
-											<img
-												className="block-editor-content-only-controls__media-preview"
-												alt=""
-												width={ 24 }
-												height={ 24 }
-												src={ src }
-											/>
-											<span className="block-editor-content-only-controls__media-title">
-												{
-													// TODO - use media title instead of src.
-													src
-												}
-											</span>
-										</>
-									) }
-									{ ! src && (
-										<>
-											<span
-												className="block-editor-content-only-controls__media-placeholder"
-												style={ {
-													width: '24px',
-													height: '24px',
-												} }
-											/>
-											<span className="block-editor-content-only-controls__media-title">
-												{ chooseItemLabel }
-											</span>
-										</>
-									) }
-									{ src && (
-										<>
-											<Button
-												size="small"
-												className="block-editor-content-only-controls__remove-button"
-												icon={ lineSolid }
-												onClick={ ( event ) => {
-													event.stopPropagation();
-													updateAttributes( {
-														[ idKey ]:
-															idDefaultValue,
-														[ srcKey ]:
-															srcDefaultValue,
-														[ captionKey ]:
-															captionDefaultValue,
-														[ altKey ]:
-															altDefaultValue,
-													} );
-												} }
-											/>
-										</>
-									) }
-								</Grid>
+									<Grid
+										rowGap={ 0 }
+										columnGap={ 8 }
+										templateColumns="24px 1fr 24px"
+										className="block-editor-content-only-controls__media-row"
+									>
+										{ src && (
+											<>
+												<img
+													className="block-editor-content-only-controls__media-thumbnail"
+													alt=""
+													width={ 24 }
+													height={ 24 }
+													src={ src }
+												/>
+												<span className="block-editor-content-only-controls__media-title">
+													{
+														// TODO - use media title instead of src.
+														// TODO - truncate to show filename when there's no title.
+														src
+													}
+												</span>
+											</>
+										) }
+										{ ! src && (
+											<>
+												<span
+													className="block-editor-content-only-controls__media-placeholder"
+													style={ {
+														width: '24px',
+														height: '24px',
+													} }
+												/>
+												<span className="block-editor-content-only-controls__media-title">
+													{ chooseItemLabel }
+												</span>
+											</>
+										) }
+										{ src && (
+											<>
+												<Button
+													size="small"
+													className="block-editor-content-only-controls__remove-button"
+													icon={ lineSolid }
+													onClick={ ( event ) => {
+														event.stopPropagation();
+														updateAttributes( {
+															[ idKey ]:
+																idDefaultValue,
+															[ srcKey ]:
+																srcDefaultValue,
+															[ captionKey ]:
+																captionDefaultValue,
+															[ altKey ]:
+																altDefaultValue,
+														} );
+													} }
+												/>
+											</>
+										) }
+									</Grid>
+								</div>
 							</div>
 						);
 					} }

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	Icon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
@@ -15,7 +16,6 @@ import {
 	media as mediaIcon,
 	video as videoIcon,
 } from '@wordpress/icons';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -232,63 +232,49 @@ export default function Media( {
 						}
 					} }
 					renderToggle={ ( buttonProps ) => (
-						<div className="block-editor-content-only-controls__media">
-							<div
-								role="button"
-								tabIndex={ 0 }
-								{ ...buttonProps }
-								onKeyDown={ ( event ) => {
-									const { keyCode } = event;
-
-									if (
-										keyCode === ENTER ||
-										keyCode === SPACE
-									) {
-										buttonProps.onClick();
-									}
-								} }
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							className="block-editor-content-only-controls__media"
+							{ ...buttonProps }
+						>
+							<Grid
+								rowGap={ 0 }
+								columnGap={ 8 }
+								templateColumns="24px 1fr"
+								className="block-editor-content-only-controls__media-row"
 							>
-								<Grid
-									rowGap={ 0 }
-									columnGap={ 8 }
-									templateColumns="24px 1fr"
-									className="block-editor-content-only-controls__media-row"
-								>
-									{ src && (
-										<>
-											<MediaThumbnail
-												attachment={ attachment }
-												control={ control }
-												attributeValues={
-													attributeValues
-												}
-											/>
-											<span className="block-editor-content-only-controls__media-title">
-												{
-													// TODO - truncate long titles or url smartly (e.g. show filename).
-													attachment?.title?.raw ??
-														src
-												}
-											</span>
-										</>
-									) }
-									{ ! src && (
-										<>
-											<span
-												className="block-editor-content-only-controls__media-placeholder"
-												style={ {
-													width: '24px',
-													height: '24px',
-												} }
-											/>
-											<span className="block-editor-content-only-controls__media-title">
-												{ chooseItemLabel }
-											</span>
-										</>
-									) }
-								</Grid>
-							</div>
-						</div>
+								{ src && (
+									<>
+										<MediaThumbnail
+											attachment={ attachment }
+											control={ control }
+											attributeValues={ attributeValues }
+										/>
+										<span className="block-editor-content-only-controls__media-title">
+											{
+												// TODO - truncate long titles or url smartly (e.g. show filename).
+												attachment?.title?.raw ?? src
+											}
+										</span>
+									</>
+								) }
+								{ ! src && (
+									<>
+										<span
+											className="block-editor-content-only-controls__media-placeholder"
+											style={ {
+												width: '24px',
+												height: '24px',
+											} }
+										/>
+										<span className="block-editor-content-only-controls__media-title">
+											{ chooseItemLabel }
+										</span>
+									</>
+								) }
+							</Grid>
+						</Button>
 					) }
 				/>
 			</ToolsPanelItem>

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -84,6 +84,7 @@ export default function Media( {
 	attributeValues,
 	updateAttributes,
 } ) {
+	const typeKey = control.mapping.type;
 	const idKey = control.mapping.id;
 	const srcKey = control.mapping.src;
 	const captionKey = control.mapping.caption;
@@ -138,6 +139,11 @@ export default function Media( {
 					onSelect={ ( selectedMedia ) => {
 						if ( selectedMedia.id && selectedMedia.url ) {
 							const optionalAttributes = {};
+
+							if ( typeKey && selectedMedia.type ) {
+								optionalAttributes[ typeKey ] =
+									selectedMedia.type;
+							}
 
 							if (
 								captionKey &&

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -6,6 +6,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -22,12 +23,30 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 import MediaReplaceFlow from '../../media-replace-flow';
 import MediaUploadCheck from '../../media-upload/check';
 import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement';
+import { getMediaSelectKey } from '../../../store/private-keys';
+import { store as blockEditorStore } from '../../../store';
 
-function MediaThumbnail( { control, attributeValues } ) {
+function MediaThumbnail( { control, attributeValues, attachment } ) {
 	const { allowedTypes, multiple } = control.args;
 	const mapping = control.mapping;
 	if ( multiple ) {
 		return 'todo multiple';
+	}
+
+	if ( attachment?.media_type === 'image' || attachment?.poster ) {
+		return (
+			<img
+				className="block-editor-content-only-controls__media-thumbnail"
+				alt=""
+				width={ 24 }
+				height={ 24 }
+				src={
+					attachment.media_type === 'image'
+						? attachment.source_url
+						: attachment.poster
+				}
+			/>
+		);
 	}
 
 	if ( allowedTypes.length === 1 ) {
@@ -101,6 +120,24 @@ export default function Media( {
 	const alt = attributeValues[ altKey ];
 	const useFeaturedImage = attributeValues[ featuredImageKey ];
 
+	const attachment = useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return;
+			}
+
+			const settings = select( blockEditorStore ).getSettings();
+			const getMedia = settings[ getMediaSelectKey ];
+
+			if ( ! getMedia ) {
+				return;
+			}
+
+			return getMedia( select, id );
+		},
+		[ id ]
+	);
+
 	// TODO - pluralize when multiple.
 	let chooseItemLabel;
 	if ( control.args.allowedTypes.length === 1 ) {
@@ -145,7 +182,7 @@ export default function Media( {
 					className="block-editor-content-only-controls__media-replace-flow"
 					allowedTypes={ control.args.allowedTypes }
 					mediaId={ id }
-					mediaURL={ srcKey }
+					mediaURL={ src }
 					multiple={ control.args.multiple }
 					popoverProps={ popoverProps }
 					onReset={ () => {
@@ -220,6 +257,7 @@ export default function Media( {
 									{ src && (
 										<>
 											<MediaThumbnail
+												attachment={ attachment }
 												control={ control }
 												attributeValues={
 													attributeValues
@@ -227,9 +265,9 @@ export default function Media( {
 											/>
 											<span className="block-editor-content-only-controls__media-title">
 												{
-													// TODO - use media title instead of src.
-													// TODO - truncate to show filename when there's no title.
-													src
+													// TODO - truncate long titles or url smartly (e.g. show filename).
+													attachment?.title?.raw ??
+														src
 												}
 											</span>
 										</>

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -234,7 +234,6 @@ export default function Media( {
 					renderToggle={ ( buttonProps ) => (
 						<Button
 							__next40pxDefaultSize
-							variant="secondary"
 							className="block-editor-content-only-controls__media"
 							{ ...buttonProps }
 						>

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -10,6 +10,7 @@ import {
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
+	audio as audioIcon,
 	image as imageIcon,
 	media as mediaIcon,
 	video as videoIcon,
@@ -60,8 +61,10 @@ function MediaThumbnail( { control, attributeValues } ) {
 		let icon;
 		if ( allowedTypes[ 0 ] === 'image' ) {
 			icon = imageIcon;
-		} else if ( allowedTypes[ 1 ] === 'video' ) {
+		} else if ( allowedTypes[ 0 ] === 'video' ) {
 			icon = videoIcon;
+		} else if ( allowedTypes[ 0 ] === 'audio' ) {
+			icon = audioIcon;
 		} else {
 			icon = mediaIcon;
 		}

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	Icon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
@@ -14,14 +13,15 @@ import {
 	image as imageIcon,
 	media as mediaIcon,
 	video as videoIcon,
-	lineSolid,
 } from '@wordpress/icons';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import MediaUpload from '../../media-upload';
+import MediaReplaceFlow from '../../media-replace-flow';
 import MediaUploadCheck from '../../media-upload/check';
+import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement';
 
 function MediaThumbnail( { control, attributeValues } ) {
 	const { allowedTypes, multiple } = control.args;
@@ -84,6 +84,9 @@ export default function Media( {
 	attributeValues,
 	updateAttributes,
 } ) {
+	const { popoverProps } = useInspectorPopoverPlacement( {
+		isControl: true,
+	} );
 	const typeKey = control.mapping.type;
 	const idKey = control.mapping.id;
 	const srcKey = control.mapping.src;
@@ -91,6 +94,7 @@ export default function Media( {
 	const altKey = control.mapping.alt;
 	const posterKey = control.mapping.poster;
 
+	const id = attributeValues[ idKey ];
 	const src = attributeValues[ srcKey ];
 	const caption = attributeValues[ captionKey ];
 	const alt = attributeValues[ altKey ];
@@ -135,7 +139,16 @@ export default function Media( {
 				} }
 				isShownByDefault={ control.shownByDefault }
 			>
-				<MediaUpload
+				<MediaReplaceFlow
+					className="block-editor-content-only-controls__media-replace-flow"
+					allowedTypes={ control.args.allowedTypes }
+					mediaId={ id }
+					mediaURL={ srcKey }
+					multiple={ control.args.multiple }
+					popoverProps={ popoverProps }
+					onReset={ () => {
+						updateAttributes( defaultValues );
+					} }
 					onSelect={ ( selectedMedia ) => {
 						if ( selectedMedia.id && selectedMedia.url ) {
 							const optionalAttributes = {};
@@ -169,76 +182,64 @@ export default function Media( {
 							} );
 						}
 					} }
-					allowedTypes={ control.args.allowedTypes }
-					multiple={ control.args.multiple }
-					render={ ( { open } ) => {
-						return (
-							<div className="block-editor-content-only-controls__media">
-								<div
-									role="button"
-									tabIndex={ -1 }
-									onClick={ () => {
-										open();
-									} }
-									onKeyDown={ open }
+					renderToggle={ ( buttonProps ) => (
+						<div className="block-editor-content-only-controls__media">
+							<div
+								role="button"
+								tabIndex={ -1 }
+								{ ...buttonProps }
+								onKeyDown={ ( event ) => {
+									const { keyCode } = event;
+
+									if (
+										keyCode === ENTER ||
+										keyCode === SPACE
+									) {
+										buttonProps.onClick();
+									}
+								} }
+							>
+								<Grid
+									rowGap={ 0 }
+									columnGap={ 8 }
+									templateColumns="24px 1fr"
+									className="block-editor-content-only-controls__media-row"
 								>
-									<Grid
-										rowGap={ 0 }
-										columnGap={ 8 }
-										templateColumns="24px 1fr 24px"
-										className="block-editor-content-only-controls__media-row"
-									>
-										{ src && (
-											<>
-												<MediaThumbnail
-													control={ control }
-													attributeValues={
-														attributeValues
-													}
-												/>
-												<span className="block-editor-content-only-controls__media-title">
-													{
-														// TODO - use media title instead of src.
-														// TODO - truncate to show filename when there's no title.
-														src
-													}
-												</span>
-											</>
-										) }
-										{ ! src && (
-											<>
-												<span
-													className="block-editor-content-only-controls__media-placeholder"
-													style={ {
-														width: '24px',
-														height: '24px',
-													} }
-												/>
-												<span className="block-editor-content-only-controls__media-title">
-													{ chooseItemLabel }
-												</span>
-											</>
-										) }
-										{ src && (
-											<>
-												<Button
-													size="small"
-													className="block-editor-content-only-controls__remove-button"
-													icon={ lineSolid }
-													onClick={ ( event ) => {
-														event.stopPropagation();
-														updateAttributes(
-															defaultValues
-														);
-													} }
-												/>
-											</>
-										) }
-									</Grid>
-								</div>
+									{ src && (
+										<>
+											<MediaThumbnail
+												control={ control }
+												attributeValues={
+													attributeValues
+												}
+											/>
+											<span className="block-editor-content-only-controls__media-title">
+												{
+													// TODO - use media title instead of src.
+													// TODO - truncate to show filename when there's no title.
+													src
+												}
+											</span>
+										</>
+									) }
+									{ ! src && (
+										<>
+											<span
+												className="block-editor-content-only-controls__media-placeholder"
+												style={ {
+													width: '24px',
+													height: '24px',
+												} }
+											/>
+											<span className="block-editor-content-only-controls__media-title">
+												{ chooseItemLabel }
+											</span>
+										</>
+									) }
+								</Grid>
 							</div>
-						);
-					} }
+						</div>
+					) }
 				/>
 			</ToolsPanelItem>
 		</MediaUploadCheck>

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -1,0 +1,175 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalGrid as Grid,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { lineSolid } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import MediaUpload from '../../media-upload';
+import MediaUploadCheck from '../../media-upload/check';
+
+export default function Media( {
+	clientId,
+	control,
+	blockType,
+	attributeValues,
+	updateAttributes,
+} ) {
+	const idKey = control.mapping.id;
+	const srcKey = control.mapping.src;
+	const captionKey = control.mapping.caption;
+	const altKey = control.mapping.alt;
+
+	const src = attributeValues[ srcKey ];
+	const caption = attributeValues[ captionKey ];
+	const alt = attributeValues[ altKey ];
+
+	const idDefaultValue =
+		blockType.attributes[ idKey ]?.defaultValue ?? undefined;
+	const srcDefaultValue =
+		blockType.attributes[ srcKey ]?.defaultValue ?? undefined;
+	const captionDefaultValue =
+		blockType.attributes[ captionKey ]?.defaultValue ?? undefined;
+	const altDefaultValue =
+		blockType.attributes[ altKey ]?.defaultValue ?? undefined;
+
+	// TODO - pluralize.
+	let chooseItemLabel;
+	if ( control.args.allowedTypes.length === 1 ) {
+		const allowedType = control.args.allowedTypes[ 0 ];
+		if ( allowedType === 'image' ) {
+			chooseItemLabel = __( 'Choose image' );
+		} else if ( allowedType === 'video' ) {
+			chooseItemLabel = __( 'Choose video' );
+		} else if ( allowedType === 'application' ) {
+			chooseItemLabel = __( 'Choose file' );
+		} else {
+			chooseItemLabel = __( 'Choose media item' );
+		}
+	} else {
+		chooseItemLabel = __( 'Choose media item' );
+	}
+
+	return (
+		<MediaUploadCheck>
+			<ToolsPanelItem
+				panelId={ clientId }
+				label={ control.label }
+				hasValue={ () => !! src }
+				onDeselect={ () => {
+					updateAttributes( {
+						[ idKey ]: idDefaultValue,
+						[ srcKey ]: srcDefaultValue,
+						[ captionKey ]: captionDefaultValue,
+						[ altKey ]: altDefaultValue,
+					} );
+				} }
+				isShownByDefault={ control.shownByDefault }
+			>
+				<MediaUpload
+					onSelect={ ( selectedMedia ) => {
+						if ( selectedMedia.id && selectedMedia.url ) {
+							const optionalAttributes = {};
+
+							if ( ! caption && selectedMedia.caption ) {
+								optionalAttributes[ captionKey ] =
+									selectedMedia.caption;
+							}
+							if ( ! alt && selectedMedia.alt ) {
+								optionalAttributes[ altKey ] =
+									selectedMedia.alt;
+							}
+
+							updateAttributes( {
+								[ idKey ]: selectedMedia.id,
+								[ srcKey ]: selectedMedia.url,
+								...optionalAttributes,
+							} );
+						}
+					} }
+					allowedTypes={ control.args.allowedTypes }
+					multiple={ control.args.multiple }
+					render={ ( { open } ) => {
+						return (
+							<div
+								role="button"
+								tabIndex={ -1 }
+								onClick={ () => {
+									open();
+								} }
+								onKeyDown={ open }
+							>
+								<Grid
+									rowGap={ 0 }
+									columnGap={ 8 }
+									templateColumns="24px 1fr 24px"
+								>
+									{ src && (
+										<>
+											<img
+												className="block-editor-content-only-controls__media-preview"
+												alt=""
+												width={ 24 }
+												height={ 24 }
+												src={ src }
+											/>
+											<span className="block-editor-content-only-controls__media-title">
+												{
+													// TODO - use media title instead of src.
+													src
+												}
+											</span>
+										</>
+									) }
+									{ ! src && (
+										<>
+											<span
+												className="block-editor-content-only-controls__media-placeholder"
+												style={ {
+													width: '24px',
+													height: '24px',
+												} }
+											/>
+											<span className="block-editor-content-only-controls__media-title">
+												{ chooseItemLabel }
+											</span>
+										</>
+									) }
+									{ src && (
+										<>
+											<Button
+												size="small"
+												className="block-editor-content-only-controls__remove-button"
+												icon={ lineSolid }
+												onClick={ ( event ) => {
+													event.stopPropagation();
+													updateAttributes( {
+														[ idKey ]:
+															idDefaultValue,
+														[ srcKey ]:
+															srcDefaultValue,
+														[ captionKey ]:
+															captionDefaultValue,
+														[ altKey ]:
+															altDefaultValue,
+													} );
+												} }
+											/>
+										</>
+									) }
+								</Grid>
+							</div>
+						);
+					} }
+				/>
+			</ToolsPanelItem>
+		</MediaUploadCheck>
+	);
+}

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -198,7 +198,7 @@ export default function Media( {
 						<div className="block-editor-content-only-controls__media">
 							<div
 								role="button"
-								tabIndex={ -1 }
+								tabIndex={ 0 }
 								{ ...buttonProps }
 								onKeyDown={ ( event ) => {
 									const { keyCode } = event;

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -254,7 +254,10 @@ export default function Media( {
 										<span className="block-editor-content-only-controls__media-title">
 											{
 												// TODO - truncate long titles or url smartly (e.g. show filename).
-												attachment?.title?.raw ?? src
+												attachment?.title?.raw &&
+												attachment?.title?.raw !== ''
+													? attachment?.title?.raw
+													: src
 											}
 										</span>
 									</>

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -93,11 +93,13 @@ export default function Media( {
 	const captionKey = control.mapping.caption;
 	const altKey = control.mapping.alt;
 	const posterKey = control.mapping.poster;
+	const featuredImageKey = control.mapping.featuredImage;
 
 	const id = attributeValues[ idKey ];
 	const src = attributeValues[ srcKey ];
 	const caption = attributeValues[ captionKey ];
 	const alt = attributeValues[ altKey ];
+	const useFeaturedImage = attributeValues[ featuredImageKey ];
 
 	// TODO - pluralize when multiple.
 	let chooseItemLabel;
@@ -149,6 +151,16 @@ export default function Media( {
 					onReset={ () => {
 						updateAttributes( defaultValues );
 					} }
+					useFeaturedImage={ !! useFeaturedImage }
+					onToggleFeaturedImage={
+						!! featuredImageKey &&
+						( () => {
+							updateAttributes( {
+								...defaultValues,
+								[ featuredImageKey ]: ! useFeaturedImage,
+							} );
+						} )
+					}
 					onSelect={ ( selectedMedia ) => {
 						if ( selectedMedia.id && selectedMedia.url ) {
 							const optionalAttributes = {};

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -3,17 +3,76 @@
  */
 import {
 	Button,
+	Icon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalGrid as Grid,
 } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { lineSolid } from '@wordpress/icons';
+import {
+	image as imageIcon,
+	media as mediaIcon,
+	video as videoIcon,
+	lineSolid,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import MediaUpload from '../../media-upload';
 import MediaUploadCheck from '../../media-upload/check';
+
+function MediaThumbnail( { control, attributeValues } ) {
+	const { allowedTypes, multiple } = control.args;
+	const mapping = control.mapping;
+	if ( multiple ) {
+		return 'todo multiple';
+	}
+
+	if ( allowedTypes.length === 1 ) {
+		let src;
+		if (
+			allowedTypes[ 0 ] === 'image' &&
+			mapping.src &&
+			attributeValues[ mapping.src ]
+		) {
+			src = attributeValues[ mapping.src ];
+		} else if (
+			allowedTypes[ 0 ] === 'video' &&
+			mapping.poster &&
+			attributeValues[ mapping.poster ]
+		) {
+			src = attributeValues[ mapping.poster ];
+		}
+
+		if ( src ) {
+			return (
+				<img
+					className="block-editor-content-only-controls__media-thumbnail"
+					alt=""
+					width={ 24 }
+					height={ 24 }
+					src={ src }
+				/>
+			);
+		}
+
+		let icon;
+		if ( allowedTypes[ 0 ] === 'image' ) {
+			icon = imageIcon;
+		} else if ( allowedTypes[ 1 ] === 'video' ) {
+			icon = videoIcon;
+		} else {
+			icon = mediaIcon;
+		}
+
+		if ( icon ) {
+			return <Icon icon={ icon } size={ 24 } />;
+		}
+	}
+
+	return <Icon icon={ mediaIcon } size={ 24 } />;
+}
 
 export default function Media( {
 	clientId,
@@ -26,19 +85,11 @@ export default function Media( {
 	const srcKey = control.mapping.src;
 	const captionKey = control.mapping.caption;
 	const altKey = control.mapping.alt;
+	const posterKey = control.mapping.poster;
 
 	const src = attributeValues[ srcKey ];
 	const caption = attributeValues[ captionKey ];
 	const alt = attributeValues[ altKey ];
-
-	const idDefaultValue =
-		blockType.attributes[ idKey ]?.defaultValue ?? undefined;
-	const srcDefaultValue =
-		blockType.attributes[ srcKey ]?.defaultValue ?? undefined;
-	const captionDefaultValue =
-		blockType.attributes[ captionKey ]?.defaultValue ?? undefined;
-	const altDefaultValue =
-		blockType.attributes[ altKey ]?.defaultValue ?? undefined;
 
 	// TODO - pluralize when multiple.
 	let chooseItemLabel;
@@ -57,6 +108,18 @@ export default function Media( {
 		chooseItemLabel = __( 'Choose a media item…' );
 	}
 
+	const defaultValues = useMemo( () => {
+		return Object.fromEntries(
+			Object.entries( control.mapping ).map( ( [ , attributeKey ] ) => {
+				return [
+					attributeKey,
+					blockType.attributes[ attributeKey ]?.defaultValue ??
+						undefined,
+				];
+			} )
+		);
+	}, [ blockType.attributes, control.mapping ] );
+
 	return (
 		<MediaUploadCheck>
 			<ToolsPanelItem
@@ -64,12 +127,7 @@ export default function Media( {
 				label={ control.label }
 				hasValue={ () => !! src }
 				onDeselect={ () => {
-					updateAttributes( {
-						[ idKey ]: idDefaultValue,
-						[ srcKey ]: srcDefaultValue,
-						[ captionKey ]: captionDefaultValue,
-						[ altKey ]: altDefaultValue,
-					} );
+					updateAttributes( defaultValues );
 				} }
 				isShownByDefault={ control.shownByDefault }
 			>
@@ -78,13 +136,21 @@ export default function Media( {
 						if ( selectedMedia.id && selectedMedia.url ) {
 							const optionalAttributes = {};
 
-							if ( ! caption && selectedMedia.caption ) {
+							if (
+								captionKey &&
+								! caption &&
+								selectedMedia.caption
+							) {
 								optionalAttributes[ captionKey ] =
 									selectedMedia.caption;
 							}
-							if ( ! alt && selectedMedia.alt ) {
+							if ( altKey && ! alt && selectedMedia.alt ) {
 								optionalAttributes[ altKey ] =
 									selectedMedia.alt;
+							}
+							if ( posterKey && selectedMedia.poster ) {
+								optionalAttributes[ posterKey ] =
+									selectedMedia.poster;
 							}
 
 							updateAttributes( {
@@ -115,12 +181,11 @@ export default function Media( {
 									>
 										{ src && (
 											<>
-												<img
-													className="block-editor-content-only-controls__media-thumbnail"
-													alt=""
-													width={ 24 }
-													height={ 24 }
-													src={ src }
+												<MediaThumbnail
+													control={ control }
+													attributeValues={
+														attributeValues
+													}
 												/>
 												<span className="block-editor-content-only-controls__media-title">
 													{
@@ -153,16 +218,9 @@ export default function Media( {
 													icon={ lineSolid }
 													onClick={ ( event ) => {
 														event.stopPropagation();
-														updateAttributes( {
-															[ idKey ]:
-																idDefaultValue,
-															[ srcKey ]:
-																srcDefaultValue,
-															[ captionKey ]:
-																captionDefaultValue,
-															[ altKey ]:
-																altDefaultValue,
-														} );
+														updateAttributes(
+															defaultValues
+														);
 													} }
 												/>
 											</>

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -1,5 +1,11 @@
 .block-editor-content-only-controls__media {
 	width: 100%;
+	box-shadow: inset 0 0 0 $border-width $gray-400;
+
+	&:focus:not(:disabled) {
+		// Allow smooth transition between focused and unfocused box-shadow states.
+		box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
 }
 
 .block-editor-content-only-controls__media-replace-flow {

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -9,6 +9,11 @@
 	}
 }
 
+.block-editor-content-only-controls__media-replace-flow {
+	// Required, otherwise the width collapses.
+	display: block;
+}
+
 .block-editor-content-only-controls__media-row {
 	align-items: center;
 }

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -1,12 +1,5 @@
 .block-editor-content-only-controls__media {
-	border: $border-width solid $gray-600;
-	border-radius: $radius-small;
-	// Add important to prevent toolspanel from unsetting padding.
-	padding: 8px 12px !important;
-	cursor: pointer;
-	&:hover {
-		background-color: $gray-100;
-	}
+	width: 100%;
 }
 
 .block-editor-content-only-controls__media-replace-flow {
@@ -32,7 +25,6 @@
 
 .block-editor-content-only-controls__media-title {
 	width: 100%;
-	color: $gray-900;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -1,5 +1,5 @@
 .block-editor-content-only-controls__media {
-	border: $border-width solid $gray-300;
+	border: $border-width solid $gray-600;
 	border-radius: $radius-small;
 	// Add important to prevent toolspanel from unsetting padding.
 	padding: 8px 12px !important;

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -1,0 +1,41 @@
+.block-editor-content-only-controls__media {
+	border: $border-width solid $gray-300;
+	border-radius: $radius-small;
+	// Add important to prevent toolspanel from unsetting padding.
+	padding: 8px 12px !important;
+	cursor: pointer;
+	&:hover {
+		background-color: $gray-100;
+	}
+}
+
+.block-editor-content-only-controls__media-row {
+	align-items: center;
+}
+
+.block-editor-content-only-controls__media-placeholder {
+	width: 24px;
+	height: 24px;
+	border-radius: $radius-small;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	display: inline-block;
+	padding: 0;
+	background:
+		$white
+		linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+}
+
+.block-editor-content-only-controls__media-title {
+	width: 100%;
+	color: $gray-900;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+block-editor-content-only-controls__media-thumbnail {
+	width: 100%;
+	height: 100%;
+	border-radius: $radius-small;
+	align-self: center;
+}

--- a/packages/block-editor/src/components/content-only-controls/media/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/media/styles.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
 .block-editor-content-only-controls__media {
 	width: 100%;
 	box-shadow: inset 0 0 0 $border-width $gray-400;

--- a/packages/block-editor/src/components/content-only-controls/plain-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/plain-text/index.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
+} from '@wordpress/components';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+
+export default function RichText( {
+	clientId,
+	control,
+	blockType,
+	attributeValues,
+	updateAttributes,
+} ) {
+	const valueKey = control.mapping.value;
+	const value = attributeValues[ valueKey ];
+	const defaultValue =
+		blockType.attributes[ valueKey ]?.defaultValue ?? undefined;
+
+	return (
+		<ToolsPanelItem
+			panelId={ clientId }
+			label={ control.label }
+			hasValue={ () => {
+				return (
+					value !== defaultValue && stripHTML( value )?.length !== 0
+				);
+			} }
+			onDeselect={ () => {
+				updateAttributes( { [ valueKey ]: defaultValue } );
+			} }
+			isShownByDefault={ control.shownByDefault }
+		>
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ control.label }
+				value={ value ? stripHTML( value ) : '' }
+				onChange={ ( newValue ) => {
+					updateAttributes( { [ valueKey ]: newValue } );
+				} }
+				autoComplete="off"
+				hideLabelFromVision={ control.shownByDefault }
+			/>
+		</ToolsPanelItem>
+	);
+}

--- a/packages/block-editor/src/components/content-only-controls/plain-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/plain-text/index.js
@@ -7,7 +7,7 @@ import {
 } from '@wordpress/components';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
-export default function RichText( {
+export default function PlainText( {
 	clientId,
 	control,
 	blockType,

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -23,7 +23,11 @@ export default function RichText( {
 		<ToolsPanelItem
 			panelId={ clientId }
 			label={ control.label }
-			hasValue={ () => value !== defaultValue }
+			hasValue={ () => {
+				return (
+					value !== defaultValue && stripHTML( value )?.length !== 0
+				);
+			} }
 			onDeselect={ () => {
 				updateAttributes( { [ valueKey ]: defaultValue } );
 			} }
@@ -38,6 +42,7 @@ export default function RichText( {
 					updateAttributes( { [ valueKey ]: newValue } );
 				} }
 				autoComplete="off"
+				hideLabelFromVision={ control.shownByDefault }
 			/>
 		</ToolsPanelItem>
 	);

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -1,23 +1,74 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalToolsPanelItem as ToolsPanelItem,
-	TextControl,
-} from '@wordpress/components';
+import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
+import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { useState } from '@wordpress/element';
+import {
+	__unstableUseRichText as useRichText,
+	// removeFormat,
+} from '@wordpress/rich-text';
 
-export default function RichText( {
+/**
+ * Internal dependencies
+ */
+import { useFormatTypes } from '../rich-text';
+
+export default function RichTextControl( {
 	clientId,
 	control,
 	blockType,
 	attributeValues,
 	updateAttributes,
 } ) {
+	const instanceId = useInstanceId( RichTextControl );
+	const controlId = `block-editor-content-only-controls__rich-text-${ instanceId }`;
 	const valueKey = control.mapping.value;
-	const value = attributeValues[ valueKey ];
+	const attrValue = attributeValues[ valueKey ];
 	const defaultValue =
 		blockType.attributes[ valueKey ]?.defaultValue ?? undefined;
+	const [ selection, setSelection ] = useState( {
+		start: undefined,
+		end: undefined,
+	} );
+
+	// const {
+	// 	formatTypes,
+	// 	prepareHandlers,
+	// 	valueHandlers,
+	// 	changeHandlers,
+	// 	dependencies,
+	// } = useFormatTypes( {
+	// 	clientId,
+	// 	identifier,
+	// 	allowedFormats: adjustedAllowedFormats,
+	// 	withoutInteractiveFormatting,
+	// 	disableNoneEssentialFormatting: isContentOnlyWriteMode,
+	// } );
+
+	const { value, ref: richTextRef } = useRichText( {
+		value: attrValue,
+		onChange( html, { __unstableFormats, __unstableText } ) {
+			updateAttributes( { [ valueKey ]: html } );
+			// Object.values( changeHandlers ).forEach( ( changeHandler ) => {
+			// 	changeHandler( __unstableFormats, __unstableText );
+			// } );
+		},
+		selectionStart: selection.start,
+		selectionEnd: selection.end,
+		onSelectionChange: ( start, end ) => setSelection( { start, end } ),
+		// placeholder: bindingsPlaceholder || placeholder,
+		// __unstableIsSelected: isSelected,
+		// __unstableDisableFormats: disableFormats,
+		// preserveWhiteSpace,
+		// __unstableDependencies: dependencies,
+		// __unstableAfterParse: addEditorOnlyFormats,
+		// __unstableBeforeSerialize: removeEditorOnlyFormats,
+		// __unstableAddInvisibleFormats: addInvisibleFormats,
+	} );
+
+	const hasVisibleLabel = ! control.shownByDefault;
 
 	return (
 		<ToolsPanelItem
@@ -28,21 +79,21 @@ export default function RichText( {
 					value !== defaultValue && stripHTML( value )?.length !== 0
 				);
 			} }
-			onDeselect={ () => {
-				updateAttributes( { [ valueKey ]: defaultValue } );
-			} }
+			onDeselect={ () => {} }
 			isShownByDefault={ control.shownByDefault }
 		>
-			<TextControl
-				__nextHasNoMarginBottom
-				__next40pxDefaultSize
-				label={ control.label }
-				value={ value ? stripHTML( value ) : '' }
-				onChange={ ( newValue ) => {
-					updateAttributes( { [ valueKey ]: newValue } );
-				} }
-				autoComplete="off"
-				hideLabelFromVision={ control.shownByDefault }
+			{ hasVisibleLabel && (
+				<label htmlFor={ controlId }>{ control.label }</label>
+			) }
+			<div
+				tagName="div"
+				role="textbox"
+				id={ hasVisibleLabel ? controlId : undefined }
+				className="block-editor-content-only-controls__rich-text"
+				aria-label={ hasVisibleLabel ? undefined : control.label }
+				aria-multiline={ ! control.args?.disableLineBreaks }
+				ref={ useMergeRefs( [ richTextRef ] ) }
+				contentEditable
 			/>
 		</ToolsPanelItem>
 	);

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -152,6 +152,7 @@ export default function RichTextControl( {
 								onFocus={ onFocus }
 								formatTypes={ formatTypes }
 								forwardedRef={ anchorRef }
+								isVisible={ false }
 							/>
 						</div>
 					</inputEventContext.Provider>

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -161,7 +161,6 @@ export default function RichTextControl( {
 			<BaseControl __nextHasNoMarginBottom { ...baseControlProps }>
 				<div
 					className="block-editor-content-only-controls__rich-text"
-					tagName="div"
 					role="textbox"
 					aria-multiline={ ! control.args?.disableLineBreaks }
 					ref={ useMergeRefs( [
@@ -175,7 +174,6 @@ export default function RichTextControl( {
 							isSelected,
 							disableFormats: control.args?.disableFormats,
 							value,
-							tagName: 'div',
 							removeEditorOnlyFormats,
 							disableLineBreaks: control.args?.disableLineBreaks,
 							keyboardShortcuts,

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -1,8 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
-import { useInstanceId, useMergeRefs } from '@wordpress/compose';
+import {
+	BaseControl,
+	useBaseControlProps,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { useMergeRefs } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 import {
 	__unstableUseRichText as useRichText,
@@ -23,8 +27,6 @@ export default function RichTextControl( {
 	attributeValues,
 	updateAttributes,
 } ) {
-	const instanceId = useInstanceId( RichTextControl );
-	const controlId = `block-editor-content-only-controls__rich-text-${ instanceId }`;
 	const valueKey = control.mapping.value;
 	const attrValue = attributeValues[ valueKey ];
 	const defaultValue =
@@ -106,7 +108,10 @@ export default function RichTextControl( {
 		__unstableAddInvisibleFormats: addInvisibleFormats,
 	} );
 
-	const hasVisibleLabel = ! control.shownByDefault;
+	const { baseControlProps, controlProps } = useBaseControlProps( {
+		hideLabelFromVision: control.shownByDefault,
+		label: control.label,
+	} );
 
 	return (
 		<ToolsPanelItem
@@ -120,21 +125,19 @@ export default function RichTextControl( {
 			}
 			isShownByDefault={ control.shownByDefault }
 		>
-			{ hasVisibleLabel && (
-				<label htmlFor={ controlId }>{ control.label }</label>
-			) }
-			<div
-				tagName="div"
-				role="textbox"
-				id={ hasVisibleLabel ? controlId : undefined }
-				className="block-editor-content-only-controls__rich-text"
-				aria-label={ hasVisibleLabel ? undefined : control.label }
-				aria-multiline={ ! control.args?.disableLineBreaks }
-				ref={ useMergeRefs( [ richTextRef ] ) }
-				onFocus={ () => setIsSelected( true ) }
-				onBlur={ () => setIsSelected( false ) }
-				contentEditable
-			/>
+			<BaseControl __nextHasNoMarginBottom { ...baseControlProps }>
+				<div
+					className="block-editor-content-only-controls__rich-text"
+					tagName="div"
+					role="textbox"
+					aria-multiline={ ! control.args?.disableLineBreaks }
+					ref={ useMergeRefs( [ richTextRef ] ) }
+					onFocus={ () => setIsSelected( true ) }
+					onBlur={ () => setIsSelected( false ) }
+					contentEditable
+					{ ...controlProps }
+				/>
+			</BaseControl>
 		</ToolsPanelItem>
 	);
 }

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -174,6 +174,7 @@ export default function RichTextControl( {
 							isSelected,
 							disableFormats: control.args?.disableFormats,
 							value,
+							tagName: 'div',
 							removeEditorOnlyFormats,
 							disableLineBreaks: control.args?.disableLineBreaks,
 							keyboardShortcuts,

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -7,7 +7,8 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useMergeRefs } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useRegistry } from '@wordpress/data';
+import { useRef, useState } from '@wordpress/element';
 import {
 	__unstableUseRichText as useRichText,
 	isEmpty,
@@ -19,6 +20,9 @@ import {
  */
 import { useFormatTypes } from '../../rich-text/use-format-types';
 import { getAllowedFormats } from '../../rich-text/utils';
+import { useEventListeners } from '../../rich-text/event-listeners';
+import FormatEdit from '../../rich-text/format-edit';
+import { keyboardShortcutContext, inputEventContext } from '../../rich-text';
 
 export default function RichTextControl( {
 	clientId,
@@ -27,6 +31,7 @@ export default function RichTextControl( {
 	attributeValues,
 	updateAttributes,
 } ) {
+	const registry = useRegistry();
 	const valueKey = control.mapping.value;
 	const attrValue = attributeValues[ valueKey ];
 	const defaultValue =
@@ -36,6 +41,9 @@ export default function RichTextControl( {
 		end: undefined,
 	} );
 	const [ isSelected, setIsSelected ] = useState( false );
+	const anchorRef = useRef();
+	const inputEvents = useRef( new Set() );
+	const keyboardShortcuts = useRef( new Set() );
 
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats: control.args?.allowedFormats,
@@ -87,7 +95,16 @@ export default function RichTextControl( {
 		);
 	}
 
-	const { value, ref: richTextRef } = useRichText( {
+	function onFocus() {
+		anchorRef.current?.focus();
+	}
+
+	const {
+		value,
+		getValue,
+		onChange,
+		ref: richTextRef,
+	} = useRichText( {
 		value: attrValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
 			updateAttributes( { [ valueKey ]: html } );
@@ -125,13 +142,46 @@ export default function RichTextControl( {
 			}
 			isShownByDefault={ control.shownByDefault }
 		>
+			{ isSelected && (
+				<keyboardShortcutContext.Provider value={ keyboardShortcuts }>
+					<inputEventContext.Provider value={ inputEvents }>
+						<div>
+							<FormatEdit
+								value={ value }
+								onChange={ onChange }
+								onFocus={ onFocus }
+								formatTypes={ formatTypes }
+								forwardedRef={ anchorRef }
+							/>
+						</div>
+					</inputEventContext.Provider>
+				</keyboardShortcutContext.Provider>
+			) }
 			<BaseControl __nextHasNoMarginBottom { ...baseControlProps }>
 				<div
 					className="block-editor-content-only-controls__rich-text"
 					tagName="div"
 					role="textbox"
 					aria-multiline={ ! control.args?.disableLineBreaks }
-					ref={ useMergeRefs( [ richTextRef ] ) }
+					ref={ useMergeRefs( [
+						richTextRef,
+						useEventListeners( {
+							registry,
+							getValue,
+							onChange,
+							formatTypes,
+							selectionChange: setSelection,
+							isSelected,
+							disableFormats: control.args?.disableFormats,
+							value,
+							tagName: 'div',
+							removeEditorOnlyFormats,
+							disableLineBreaks: control.args?.disableLineBreaks,
+							keyboardShortcuts,
+							inputEvents,
+						} ),
+						anchorRef,
+					] ) }
 					onFocus={ () => setIsSelected( true ) }
 					onBlur={ () => setIsSelected( false ) }
 					contentEditable

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
+} from '@wordpress/components';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+
+export default function RichText( {
+	clientId,
+	control,
+	blockType,
+	attributeValues,
+	updateAttributes,
+} ) {
+	const valueKey = control.mapping.value;
+	const value = attributeValues[ valueKey ];
+	const defaultValue =
+		blockType.attributes[ valueKey ]?.defaultValue ?? undefined;
+
+	return (
+		<ToolsPanelItem
+			panelId={ clientId }
+			label={ control.label }
+			hasValue={ () => value !== defaultValue }
+			onDeselect={ () => {
+				updateAttributes( { [ valueKey ]: defaultValue } );
+			} }
+			isShownByDefault={ control.shownByDefault }
+		>
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ control.label }
+				value={ value ? stripHTML( value ) : '' }
+				onChange={ ( newValue ) => {
+					updateAttributes( { [ valueKey ]: newValue } );
+				} }
+				autoComplete="off"
+			/>
+		</ToolsPanelItem>
+	);
+}

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -3,17 +3,18 @@
  */
 import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
 import { useInstanceId, useMergeRefs } from '@wordpress/compose';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useState } from '@wordpress/element';
 import {
 	__unstableUseRichText as useRichText,
-	// removeFormat,
+	isEmpty,
+	removeFormat,
 } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
-import { useFormatTypes } from '../rich-text';
+import { useFormatTypes } from '../../rich-text/use-format-types';
+import { getAllowedFormats } from '../../rich-text/utils';
 
 export default function RichTextControl( {
 	clientId,
@@ -32,40 +33,77 @@ export default function RichTextControl( {
 		start: undefined,
 		end: undefined,
 	} );
+	const [ isSelected, setIsSelected ] = useState( false );
 
-	// const {
-	// 	formatTypes,
-	// 	prepareHandlers,
-	// 	valueHandlers,
-	// 	changeHandlers,
-	// 	dependencies,
-	// } = useFormatTypes( {
-	// 	clientId,
-	// 	identifier,
-	// 	allowedFormats: adjustedAllowedFormats,
-	// 	withoutInteractiveFormatting,
-	// 	disableNoneEssentialFormatting: isContentOnlyWriteMode,
-	// } );
+	const adjustedAllowedFormats = getAllowedFormats( {
+		allowedFormats: control.args?.allowedFormats,
+		disableFormats: control.args?.disableFormats,
+	} );
+
+	const {
+		formatTypes,
+		prepareHandlers,
+		valueHandlers,
+		changeHandlers,
+		dependencies,
+	} = useFormatTypes( {
+		clientId,
+		identifier: valueKey,
+		allowedFormats: adjustedAllowedFormats,
+		withoutInteractiveFormatting:
+			control.args?.withoutInteractiveFormatting,
+		disableNoneEssentialFormatting: true,
+	} );
+
+	function addEditorOnlyFormats( value ) {
+		return valueHandlers.reduce(
+			( accumulator, fn ) => fn( accumulator, value.text ),
+			value.formats
+		);
+	}
+
+	function removeEditorOnlyFormats( value ) {
+		formatTypes.forEach( ( formatType ) => {
+			// Remove formats created by prepareEditableTree, because they are editor only.
+			if ( formatType.__experimentalCreatePrepareEditableTree ) {
+				value = removeFormat(
+					value,
+					formatType.name,
+					0,
+					value.text.length
+				);
+			}
+		} );
+
+		return value.formats;
+	}
+
+	function addInvisibleFormats( value ) {
+		return prepareHandlers.reduce(
+			( accumulator, fn ) => fn( accumulator, value.text ),
+			value.formats
+		);
+	}
 
 	const { value, ref: richTextRef } = useRichText( {
 		value: attrValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
 			updateAttributes( { [ valueKey ]: html } );
-			// Object.values( changeHandlers ).forEach( ( changeHandler ) => {
-			// 	changeHandler( __unstableFormats, __unstableText );
-			// } );
+			Object.values( changeHandlers ).forEach( ( changeHandler ) => {
+				changeHandler( __unstableFormats, __unstableText );
+			} );
 		},
 		selectionStart: selection.start,
 		selectionEnd: selection.end,
 		onSelectionChange: ( start, end ) => setSelection( { start, end } ),
-		// placeholder: bindingsPlaceholder || placeholder,
-		// __unstableIsSelected: isSelected,
-		// __unstableDisableFormats: disableFormats,
-		// preserveWhiteSpace,
-		// __unstableDependencies: dependencies,
-		// __unstableAfterParse: addEditorOnlyFormats,
-		// __unstableBeforeSerialize: removeEditorOnlyFormats,
-		// __unstableAddInvisibleFormats: addInvisibleFormats,
+		__unstableIsSelected: isSelected,
+		preserveWhiteSpace: !! control.args?.preserveWhiteSpace,
+		placeholder: control.args?.placeholder,
+		__unstableDisableFormats: control.args?.disableFormats,
+		__unstableDependencies: dependencies,
+		__unstableAfterParse: addEditorOnlyFormats,
+		__unstableBeforeSerialize: removeEditorOnlyFormats,
+		__unstableAddInvisibleFormats: addInvisibleFormats,
 	} );
 
 	const hasVisibleLabel = ! control.shownByDefault;
@@ -75,11 +113,11 @@ export default function RichTextControl( {
 			panelId={ clientId }
 			label={ control.label }
 			hasValue={ () => {
-				return (
-					value !== defaultValue && stripHTML( value )?.length !== 0
-				);
+				return value?.text && ! isEmpty( value );
 			} }
-			onDeselect={ () => {} }
+			onDeselect={ () =>
+				updateAttributes( { [ valueKey ]: defaultValue } )
+			}
 			isShownByDefault={ control.shownByDefault }
 		>
 			{ hasVisibleLabel && (
@@ -93,6 +131,8 @@ export default function RichTextControl( {
 				aria-label={ hasVisibleLabel ? undefined : control.label }
 				aria-multiline={ ! control.args?.disableLineBreaks }
 				ref={ useMergeRefs( [ richTextRef ] ) }
+				onFocus={ () => setIsSelected( true ) }
+				onBlur={ () => setIsSelected( false ) }
 				contentEditable
 			/>
 		</ToolsPanelItem>

--- a/packages/block-editor/src/components/content-only-controls/rich-text/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/styles.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
 
 .block-editor-content-only-controls__rich-text {
 	width: 100%;

--- a/packages/block-editor/src/components/content-only-controls/rich-text/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/styles.scss
@@ -1,0 +1,21 @@
+
+.block-editor-content-only-controls__rich-text {
+	width: 100%;
+	// Override input style margin in WP forms.css.
+	margin: 0;
+	background: $white;
+	color: $gray-900;
+	@include input-control( var(--wp-admin-theme-color, #3858e9) );
+	border-color: $gray-600;
+
+	&::placeholder {
+		color: color-mix(in srgb, $gray-900, transparent 38%);
+	}
+
+	min-height: $grid-unit-50;
+
+	// Subtract 1px to account for the border, which isn't included on the element
+	// on newer components like InputControl, SelectControl, etc.
+	// These values should be shared with the `controlPaddingX` in ./utils/config-values.js
+	padding: $grid-unit-15;
+}

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -1,2 +1,3 @@
+@use "./link/styles.scss" as *;
 @use "./media/styles.scss" as *;
 @use "./rich-text/styles.scss" as *;

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -1,3 +1,24 @@
 @use "./link/styles.scss" as *;
 @use "./media/styles.scss" as *;
 @use "./rich-text/styles.scss" as *;
+
+.block-editor-content-only-controls__screen {
+	padding-top: $grid-unit-10;
+
+	// Add border for the entire content controls and remove the similar border
+	// for tools panel.
+	border-top: $border-width solid $gray-200;
+
+	.components-tools-panel {
+		border-top: none;
+	}
+}
+
+.block-editor-content-only-controls__button-panel {
+	padding: 4px;
+}
+
+.block-editor-content-only-controls__back-button,
+.block-editor-content-only-controls__drill-down-button {
+	width: 100%;
+}

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -1,1 +1,2 @@
 @use "./media/styles.scss" as *;
+@use "./rich-text/styles.scss" as *;

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -15,12 +15,14 @@
 
 		// Condense the tools panels more than normal.
 		padding-top: $grid-unit-10;
-		padding-bottom: $grid-unit-10;
 	}
 }
 
 .block-editor-content-only-controls__button-panel {
 	padding: 4px;
+
+	// Match heading font weights for the tools panels.
+	font-weight: 500 !important;
 }
 
 .block-editor-content-only-controls__back-button,

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -5,7 +5,9 @@
 @use "./rich-text/styles.scss" as *;
 
 .block-editor-content-only-controls__screen {
-	padding-top: $grid-unit-10;
+	&.components-navigator-screen {
+		padding: $grid-unit-10 0 0 0;
+	}
 
 	// Add border for the entire content controls and remove the similar border
 	// for tools panel.

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -9,8 +9,13 @@
 	// for tools panel.
 	border-top: $border-width solid $gray-200;
 
+
 	.components-tools-panel {
 		border-top: none;
+
+		// Condense the tools panels more than normal.
+		padding-top: $grid-unit-10;
+		padding-bottom: $grid-unit-10;
 	}
 }
 

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -33,3 +33,9 @@
 .block-editor-content-only-controls__drill-down-button {
 	width: 100%;
 }
+
+// So that the content-only controls receive the full width of the tools panel.
+.block-editor-content-only-controls__item-wrapper {
+	width: 100%;
+	grid-column: 1 / -1;
+}

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -1,0 +1,1 @@
+@use "./media/styles.scss" as *;

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
 @use "./link/styles.scss" as *;
 @use "./media/styles.scss" as *;
 @use "./rich-text/styles.scss" as *;

--- a/packages/block-editor/src/components/content-only-controls/use-inspector-popover-placement.js
+++ b/packages/block-editor/src/components/content-only-controls/use-inspector-popover-placement.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+
+export function useInspectorPopoverPlacement(
+	{ isControl } = { isControl: false }
+) {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: isControl ? 35 : 259,
+				},
+		  }
+		: {};
+}

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -24,10 +24,7 @@ const ContentTab = ( { rootClientId, contentClientIds } ) => {
 					</PanelBody>
 				) }
 				{ window?.__experimentalContentOnlyPatternInsertion && (
-					<ContentOnlyControls
-						rootClientId={ rootClientId }
-						contentClientIds={ contentClientIds }
-					/>
+					<ContentOnlyControls rootClientId={ rootClientId } />
 				) }
 			</>
 		</PanelBody>

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -16,18 +16,16 @@ const ContentTab = ( { rootClientId, contentClientIds } ) => {
 	}
 
 	return (
-		<PanelBody title={ __( 'Content' ) }>
-			<>
-				{ ! window?.__experimentalContentOnlyPatternInsertion && (
-					<PanelBody title={ __( 'Content' ) }>
-						<BlockQuickNavigation clientIds={ contentClientIds } />
-					</PanelBody>
-				) }
-				{ window?.__experimentalContentOnlyPatternInsertion && (
-					<ContentOnlyControls rootClientId={ rootClientId } />
-				) }
-			</>
-		</PanelBody>
+		<>
+			{ ! window?.__experimentalContentOnlyPatternInsertion && (
+				<PanelBody title={ __( 'Content' ) }>
+					<BlockQuickNavigation clientIds={ contentClientIds } />
+				</PanelBody>
+			) }
+			{ window?.__experimentalContentOnlyPatternInsertion && (
+				<ContentOnlyControls rootClientId={ rootClientId } />
+			) }
+		</>
 	);
 };
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockQuickNavigation from '../block-quick-navigation';
+import ContentOnlyControls from '../content-only-controls';
 
 const ContentTab = ( { contentClientIds } ) => {
 	if ( ! contentClientIds || contentClientIds.length === 0 ) {
@@ -16,7 +17,16 @@ const ContentTab = ( { contentClientIds } ) => {
 
 	return (
 		<PanelBody title={ __( 'Content' ) }>
-			<BlockQuickNavigation clientIds={ contentClientIds } />
+			<>
+				{ ! window?.__experimentalContentOnlyPatternInsertion && (
+					<PanelBody title={ __( 'Content' ) }>
+						<BlockQuickNavigation clientIds={ contentClientIds } />
+					</PanelBody>
+				) }
+				{ window?.__experimentalContentOnlyPatternInsertion && (
+					<ContentOnlyControls clientIds={ contentClientIds } />
+				) }
+			</>
 		</PanelBody>
 	);
 };

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import BlockQuickNavigation from '../block-quick-navigation';
 import ContentOnlyControls from '../content-only-controls';
 
-const ContentTab = ( { contentClientIds } ) => {
+const ContentTab = ( { rootClientId, contentClientIds } ) => {
 	if ( ! contentClientIds || contentClientIds.length === 0 ) {
 		return null;
 	}
@@ -24,7 +24,10 @@ const ContentTab = ( { contentClientIds } ) => {
 					</PanelBody>
 				) }
 				{ window?.__experimentalContentOnlyPatternInsertion && (
-					<ContentOnlyControls clientIds={ contentClientIds } />
+					<ContentOnlyControls
+						rootClientId={ rootClientId }
+						contentClientIds={ contentClientIds }
+					/>
 				) }
 			</>
 		</PanelBody>

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -109,7 +109,10 @@ export default function InspectorControlsTabs( {
 					/>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
-					<ContentTab contentClientIds={ contentClientIds } />
+					<ContentTab
+						rootClientId={ clientId }
+						contentClientIds={ contentClientIds }
+					/>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
 					<InspectorControls.Slot group="list" />

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -93,6 +93,7 @@ const MediaReplaceFlow = ( {
 	handleUpload = true,
 	popoverProps,
 	renderToggle,
+	className,
 } ) => {
 	const { getSettings } = useSelect( blockEditorStore );
 	const errorNoticeID = `block-editor/media-replace-flow/error-notice/${ ++uniqueId }`;
@@ -169,6 +170,7 @@ const MediaReplaceFlow = ( {
 	return (
 		<Dropdown
 			popoverProps={ popoverProps }
+			className={ className }
 			contentClassName="block-editor-media-replace-flow__options"
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				if ( renderToggle ) {

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -40,6 +40,7 @@ import {
 	globalStylesLinksDataKey,
 	sectionRootClientIdKey,
 	mediaEditKey,
+	getMediaSelectKey,
 	essentialFormatKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
@@ -108,6 +109,7 @@ lock( privateApis, {
 	CommentIconSlotFill,
 	CommentIconToolbarSlotFill,
 	mediaEditKey,
+	getMediaSelectKey,
 	essentialFormatKey,
 	useBlockElement,
 	useBlockElementRef,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -4,4 +4,5 @@ export const selectBlockPatternsKey = Symbol( 'selectBlockPatternsKey' );
 export const reusableBlocksSelectKey = Symbol( 'reusableBlocksSelect' );
 export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );
 export const mediaEditKey = Symbol( 'mediaEditKey' );
+export const getMediaSelectKey = Symbol( 'getMediaSelect' );
 export const essentialFormatKey = Symbol( 'essentialFormat' );

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -29,6 +29,7 @@
 @use "./components/block-variation-transforms/style.scss" as *;
 @use "./components/border-radius-control/style.scss" as *;
 @use "./components/colors-gradients/style.scss" as *;
+@use "./components/content-only-controls/styles.scss" as *;
 @use "./components/date-format-picker/style.scss" as *;
 @use "./components/duotone-control/style.scss" as *;
 @use "./components/font-appearance-control/style.scss" as *;

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -33,7 +33,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Audio' ),
 			type: 'Media',

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 
 /**
@@ -30,5 +31,31 @@ export const settings = {
 	edit,
 	save,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Audio' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'id',
+				src: 'src',
+			},
+			args: {
+				allowedTypes: [ 'audio' ],
+				multiple: false,
+			},
+		},
+		{
+			label: __( 'Caption' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'caption',
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -47,7 +47,7 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 		{
 			label: __( 'Link' ),
 			type: 'Link',
-			shownByDefault: true,
+			shownByDefault: false,
 			mapping: {
 				href: 'url',
 				rel: 'rel',

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -34,4 +34,27 @@ export const settings = {
 	} ),
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'text',
+			},
+		},
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: true,
+			mapping: {
+				href: 'url',
+				rel: 'rel',
+				target: 'linkTarget',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -35,7 +35,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -39,4 +39,17 @@ export const settings = {
 	save,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Code' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -40,7 +40,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Code' ),
 			type: 'RichText',

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -52,4 +52,25 @@ export const settings = {
 	variations,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Background' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'id',
+				src: 'url',
+				alt: 'alt',
+			},
+			args: {
+				// TODO - work out how to support video. Also background gradient.
+				// Does this need to be a custom control?
+				allowedTypes: [ 'image' ],
+				multiple: false,
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -59,14 +59,15 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 			type: 'Media',
 			shownByDefault: true,
 			mapping: {
+				type: 'backgroundType',
 				id: 'id',
 				src: 'url',
 				alt: 'alt',
 			},
 			args: {
-				// TODO - work out how to support video. Also background gradient.
-				// Does this need to be a custom control?
-				allowedTypes: [ 'image' ],
+				// TODO - How to support custom gradient?
+				// Build it into Media, or use a custom control?
+				allowedTypes: [ 'image', 'video' ],
 				multiple: false,
 			},
 		},

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -63,6 +63,7 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 				id: 'id',
 				src: 'url',
 				alt: 'alt',
+				featuredImage: 'useFeaturedImage',
 			},
 			args: {
 				// TODO - How to support custom gradient?

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -53,7 +53,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Background' ),
 			type: 'Media',

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -61,4 +61,17 @@ export const settings = {
 	transforms,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Summary' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'summary',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -62,7 +62,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Summary' ),
 			type: 'RichText',

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -33,7 +33,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'File' ),
 			type: 'Media',

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 
 /**
@@ -31,5 +31,39 @@ export const settings = {
 	edit,
 	save,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'File' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'id',
+				src: 'href',
+			},
+			args: {
+				allowedTypes: [],
+				multiple: false,
+			},
+		},
+		{
+			label: __( 'Filename' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'fileName',
+			},
+		},
+		{
+			label: __( 'Button Text' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'downloadButtonText',
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -15,7 +15,11 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "h1,h2,h3,h4,h5,h6",
-			"role": "content"
+			"role": "content",
+			"control": {
+				"type": "RichText",
+				"label": "Content"
+			}
 		},
 		"level": {
 			"type": "number",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -18,7 +18,8 @@
 			"role": "content",
 			"control": {
 				"type": "RichText",
-				"label": "Content"
+				"label": "Content",
+				"shownByDefault": true
 			}
 		},
 		"level": {

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -15,12 +15,7 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "h1,h2,h3,h4,h5,h6",
-			"role": "content",
-			"control": {
-				"type": "RichText",
-				"label": "Content",
-				"shownByDefault": true
-			}
+			"role": "content"
 		},
 		"level": {
 			"type": "number",

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -70,7 +70,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -69,4 +69,17 @@ export const settings = {
 	variations,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -90,6 +90,22 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 				destination: 'linkDestination',
 			},
 		},
+		{
+			label: __( 'Caption' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'caption',
+			},
+		},
+		{
+			label: __( 'Alt text' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'alt',
+			},
+		},
 	];
 }
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -74,6 +74,10 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 				caption: 'caption',
 				alt: 'alt',
 			},
+			args: {
+				allowedTypes: [ 'image' ],
+				multiple: false,
+			},
 		},
 		{
 			label: __( 'Link' ),

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -100,7 +100,7 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 		},
 		{
 			label: __( 'Alt text' ),
-			type: 'RichText',
+			type: 'PlainText',
 			shownByDefault: false,
 			mapping: {
 				value: 'alt',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -63,7 +63,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Image' ),
 			type: 'Media',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -62,4 +62,31 @@ export const settings = {
 	deprecated,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Image' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'id',
+				src: 'url',
+				caption: 'caption',
+				alt: 'alt',
+			},
+		},
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: false,
+			mapping: {
+				href: 'href',
+				rel: 'rel',
+				target: 'linkTarget',
+				destination: 'linkDestination',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -34,7 +34,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { listItem as icon } from '@wordpress/icons';
 import { privateApis } from '@wordpress/block-editor';
 
@@ -31,5 +32,18 @@ export const settings = {
 	transforms,
 	[ unlock( privateApis ).requiresWrapperOnCopy ]: true,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -50,4 +50,33 @@ export const settings = {
 	deprecated,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Media' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'mediaId',
+				type: 'mediaType',
+				src: 'mediaUrl',
+			},
+			args: {
+				allowedTypes: [ 'image', 'video' ],
+				multiple: false,
+			},
+		},
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: false,
+			mapping: {
+				href: 'href',
+				rel: 'rel',
+				target: 'linkTarget',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -51,7 +51,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Media' ),
 			type: 'Media',

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -37,7 +37,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { more as icon } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,5 +35,18 @@ export const settings = {
 	edit,
 	save,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'customText',
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -34,7 +34,8 @@
 			"default": false
 		},
 		"url": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"title": {
 			"type": "string"

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -90,7 +90,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Label' ),
 			type: 'RichText',

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 import { customLink as linkIcon } from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
@@ -88,6 +88,29 @@ export const settings = {
 	],
 	transforms,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Label' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'label',
+			},
+		},
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: false,
+			mapping: {
+				href: 'url',
+				rel: 'rel',
+				// TODO - opens in new tab? id?
+			},
+		},
+	];
+}
 
 export const init = () => {
 	addFilter(

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -29,7 +29,8 @@
 			"default": false
 		},
 		"url": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"title": {
 			"type": "string"

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { page, addSubmenu } from '@wordpress/icons';
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -47,5 +47,28 @@ export const settings = {
 	save,
 	transforms,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Label' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'label',
+			},
+		},
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: false,
+			mapping: {
+				href: 'url',
+				rel: 'rel',
+				// TODO - opens in new tab? id?
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -49,7 +49,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Label' ),
 			type: 'RichText',

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -105,6 +105,7 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"ariaLabel": true,
+		"contentRole": true,
 		"html": false,
 		"inserter": true,
 		"typography": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -139,8 +139,7 @@
 			}
 		},
 		"interactivity": true,
-		"renaming": false,
-		"contentRole": true
+		"renaming": false
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -12,7 +12,11 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "p",
-			"role": "content"
+			"role": "content",
+			"control": {
+				"type": "RichText",
+				"label": "Content"
+			}
 		},
 		"dropCap": {
 			"type": "boolean",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -15,7 +15,8 @@
 			"role": "content",
 			"control": {
 				"type": "RichText",
-				"label": "Content"
+				"label": "Content",
+				"shownByDefault": true
 			}
 		},
 		"dropCap": {

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -12,12 +12,7 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "p",
-			"role": "content",
-			"control": {
-				"type": "RichText",
-				"label": "Content",
-				"shownByDefault": true
-			}
+			"role": "content"
 		},
 		"dropCap": {
 			"type": "boolean",

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -59,7 +59,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -58,4 +58,17 @@ export const settings = {
 	variations,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -39,4 +39,17 @@ export const settings = {
 	},
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -40,7 +40,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -36,4 +36,25 @@ export const settings = {
 	deprecated,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'value',
+			},
+		},
+		{
+			label: __( 'Citation' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'citation',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -37,7 +37,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -27,7 +27,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Label' ),
 			type: 'RichText',

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -26,4 +26,33 @@ export const settings = {
 	edit,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Label' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'label',
+			},
+		},
+		{
+			label: __( 'Button text' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'buttonText',
+			},
+		},
+		{
+			label: __( 'Placeholder' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'placeholder',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { share as icon } from '@wordpress/icons';
 
 /**
@@ -20,5 +21,27 @@ export const settings = {
 	edit,
 	variations,
 };
+
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Link' ),
+			type: 'Link',
+			shownByDefault: true,
+			mapping: {
+				href: 'url',
+				rel: 'rel',
+			},
+		},
+		{
+			label: __( 'Label' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'label',
+			},
+		},
+	];
+}
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -23,7 +23,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Link' ),
 			type: 'Link',

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -42,7 +42,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Content' ),
 			type: 'RichText',

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -41,4 +41,17 @@ export const settings = {
 	save,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Content' ),
+			type: 'RichText',
+			shownByDefault: true,
+			mapping: {
+				value: 'content',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -33,4 +33,32 @@ export const settings = {
 	save,
 };
 
+if ( window.__experimentalContentOnlyPatternInsertion ) {
+	settings.controls = [
+		{
+			label: __( 'Video' ),
+			type: 'Media',
+			shownByDefault: true,
+			mapping: {
+				id: 'id',
+				src: 'src',
+				caption: 'caption',
+				poster: 'poster',
+			},
+			args: {
+				allowedTypes: [ 'video' ],
+				multiple: false,
+			},
+		},
+		{
+			label: __( 'Caption' ),
+			type: 'RichText',
+			shownByDefault: false,
+			mapping: {
+				value: 'caption',
+			},
+		},
+	];
+}
+
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -34,7 +34,7 @@ export const settings = {
 };
 
 if ( window.__experimentalContentOnlyPatternInsertion ) {
-	settings.controls = [
+	settings.fields = [
 		{
 			label: __( 'Video' ),
 			type: 'Media',

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -96,6 +96,7 @@ const {
 	reusableBlocksSelectKey,
 	sectionRootClientIdKey,
 	mediaEditKey,
+	getMediaSelectKey,
 } = unlock( privateApis );
 
 /**
@@ -293,6 +294,13 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			hasFixedToolbar,
 			isDistractionFree,
 			keepCaretInsideBlock,
+			[ getMediaSelectKey ]: ( select, attachmentId ) => {
+				return select( coreStore ).getEntityRecord(
+					'postType',
+					'attachment',
+					attachmentId
+				);
+			},
 			[ mediaEditKey ]: hasUploadPermissions
 				? editMediaEntity
 				: undefined,

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -206,7 +206,7 @@ function Edit( {
 					aria-expanded={ addingLink }
 				/>
 			) }
-			{ addingLink && (
+			{ isVisible && addingLink && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }
 					onFocusOutside={ onFocusOutside }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR builds on https://github.com/WordPress/gutenberg/pull/71730 and (in a hacky way) adds navigation between component controls, and toggles the item in the canvas.

This PR is not perfect, but it enhances the fields, which is behind an experiment.

## Why?

For large patterns, editing using the inspector tools can be confusing you might be editing a block you cannot see. At the very least it breaks the WYSIWYG pattern.

Also keyboard navigation between fields isn't working.

## How?
Wrapping the content controls in a div and adding events that call `toggleBlockSpotlight`

## Testing Instructions

Insert a few patterns/template parts and check that you can edit the fields still, and the block that you're editing is highlighted and visible.

For me it doesn't work ALL the time for some reason, but it's an improvement.

## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/0738bac6-fffe-4e94-b991-3766271c8ac6



