### PR TITLE
Try enabling paragraphs to be added to contentOnly patterns

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -111,6 +111,10 @@ export default function useInput() {
 					// Ensure template is not locked.
 					if (
 						canInsertBlockType(
+							getDefaultBlockName(),
+							getBlockRootClientId( clientId )
+						) ||
+						canInsertBlockType(
 							blockName,
 							getBlockRootClientId( clientId )
 						)

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1704,7 +1704,7 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const blockEditingMode = getBlockEditingMode( state, rootClientId ?? '' );
-	if ( blockEditingMode === 'disabled' ) {
+	if ( blockEditingMode === 'disabled' && blockName !== 'core/paragraph' ) {
 		return false;
 	}
 
@@ -1917,9 +1917,12 @@ export function canRemoveBlock( state, clientId ) {
 
 	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
+	const blockName = getBlockName( state, clientId );
 	// Check if the parent container allows insertion/removal in contentOnly mode
 	if (
-		( isParentSectionBlock || rootBlockEditingMode === 'contentOnly' ) &&
+		( isParentSectionBlock ||
+			rootBlockEditingMode === 'contentOnly' ||
+			blockName === 'core/paragraph' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
@@ -1928,18 +1931,14 @@ export function canRemoveBlock( state, clientId ) {
 	) {
 		// Allow removing a Paragraph block when other Paragraph blocks exist
 		// in contentOnly mode.
-		const blockName = getBlockName( state, clientId );
-		if (
-			rootBlockEditingMode === 'contentOnly' &&
-			blockName === 'core/paragraph'
-		) {
+		if ( blockName === 'core/paragraph' ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
 			const paragraphBlocks = existingBlocks.filter(
 				( id ) => getBlockName( state, id ) === 'core/paragraph'
 			);
 			// Allow removal if there are other paragraph blocks besides this one
-			if ( ! ( paragraphBlocks.length > 0 ) ) {
-				return false;
+			if ( paragraphBlocks.length > 0 ) {
+				return true;
 			}
 		} else {
 			return false;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -5,6 +5,7 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
+	getDefaultBlockName,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	switchToBlockType,
@@ -1704,7 +1705,10 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const blockEditingMode = getBlockEditingMode( state, rootClientId ?? '' );
-	if ( blockEditingMode === 'disabled' && blockName !== 'core/paragraph' ) {
+	if (
+		blockEditingMode === 'disabled' &&
+		blockName !== getDefaultBlockName()
+	) {
 		return false;
 	}
 
@@ -1745,15 +1749,15 @@ const canInsertBlockTypeUnmemoized = (
 			rootClientId
 		)
 	) {
-		// Allow inserting a Paragraph block anywhere that another Paragraph block already exists
+		// Allow inserting the default block anywhere that another default block already exists
 		// when in contentOnly mode.
-		if ( blockName === 'core/paragraph' ) {
+		if ( blockName === getDefaultBlockName() ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
-			const hasParagraphBlock = existingBlocks.some(
+			const hasDefaultBlock = existingBlocks.some(
 				( clientId ) =>
-					getBlockName( state, clientId ) === 'core/paragraph'
+					getBlockName( state, clientId ) === getDefaultBlockName()
 			);
-			if ( ! hasParagraphBlock ) {
+			if ( ! hasDefaultBlock ) {
 				return false;
 			}
 		} else {
@@ -1934,26 +1938,26 @@ export function canRemoveBlock( state, clientId ) {
 
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	const blockName = getBlockName( state, clientId );
-	// Check if the parent container allows insertion/removal in contentOnly mode
+	// Check if the parent container allows insertion/removal in contentOnly mode.
 	if (
 		( isParentSectionBlock ||
 			rootBlockEditingMode === 'contentOnly' ||
-			blockName === 'core/paragraph' ) &&
+			blockName === getDefaultBlockName() ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
 			rootClientId
 		)
 	) {
-		// Allow removing a Paragraph block when other Paragraph blocks exist
+		// Allow removing the default block when other default blocks exist
 		// in contentOnly mode.
-		if ( blockName === 'core/paragraph' ) {
+		if ( blockName === getDefaultBlockName() ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
-			const paragraphBlocks = existingBlocks.filter(
-				( id ) => getBlockName( state, id ) === 'core/paragraph'
+			const defaultBlocks = existingBlocks.filter(
+				( id ) => getBlockName( state, id ) === getDefaultBlockName()
 			);
-			// Allow removal if there are other paragraph blocks besides this one
-			if ( paragraphBlocks.length > 1 ) {
+			// Allow removal if there are other default blocks besides this one
+			if ( defaultBlocks.length > 1 ) {
 				return true;
 			}
 		} else {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1720,8 +1720,8 @@ const canInsertBlockTypeUnmemoized = (
 	// some cases when the block is a content block.
 	const isContentRoleBlock = isContentBlock( blockName );
 	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
-	const parentSection = getParentSectionBlock( state, rootClientId );
-	const isBlockWithinSection = !! parentSection;
+	const parentSectionClientId = getParentSectionBlock( state, rootClientId );
+	const isBlockWithinSection = !! parentSectionClientId;
 	if (
 		( isParentSectionBlock || isBlockWithinSection ) &&
 		! isContentRoleBlock
@@ -1731,8 +1731,8 @@ const canInsertBlockTypeUnmemoized = (
 
 	// Don't allow insertion into synced patterns.
 	if (
-		parentSection &&
-		getBlockName( state, parentSection ) === 'core/block'
+		isBlockWithinSection &&
+		getBlockName( state, parentSectionClientId ) === 'core/block'
 	) {
 		return false;
 	}
@@ -1913,11 +1913,20 @@ export function canRemoveBlock( state, clientId ) {
 
 	// It shouldn't be possible to move in a section block unless in
 	// some cases when the block is a content block.
-	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
+	const parentSectionClientId = getParentSectionBlock( state, clientId );
+	const isBlockWithinSection = !! parentSectionClientId;
 	const isContentRoleBlock = isContentBlock(
 		getBlockName( state, clientId )
 	);
 	if ( isBlockWithinSection && ! isContentRoleBlock ) {
+		return false;
+	}
+
+	// Disallow removal from synced patterns.
+	if (
+		isBlockWithinSection &&
+		getBlockName( state, parentSectionClientId ) === 'core/block'
+	) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1740,7 +1740,20 @@ const canInsertBlockTypeUnmemoized = (
 			rootClientId
 		)
 	) {
-		return false;
+		// Allow inserting a Paragraph block anywhere that another Paragraph block already exists
+		// when in contentOnly mode.
+		if ( blockName === 'core/paragraph' ) {
+			const existingBlocks = getBlockOrder( state, rootClientId );
+			const hasParagraphBlock = existingBlocks.some(
+				( clientId ) =>
+					getBlockName( state, clientId ) === 'core/paragraph'
+			);
+			if ( ! hasParagraphBlock ) {
+				return false;
+			}
+		} else {
+			return false;
+		}
 	}
 
 	const parentName = getBlockName( state, rootClientId );
@@ -1913,7 +1926,24 @@ export function canRemoveBlock( state, clientId ) {
 			rootClientId
 		)
 	) {
-		return false;
+		// Allow removing a Paragraph block when other Paragraph blocks exist
+		// in contentOnly mode.
+		const blockName = getBlockName( state, clientId );
+		if (
+			rootBlockEditingMode === 'contentOnly' &&
+			blockName === 'core/paragraph'
+		) {
+			const existingBlocks = getBlockOrder( state, rootClientId );
+			const paragraphBlocks = existingBlocks.filter(
+				( id ) => getBlockName( state, id ) === 'core/paragraph'
+			);
+			// Allow removal if there are other paragraph blocks besides this one
+			if ( ! ( paragraphBlocks.length > 0 ) ) {
+				return false;
+			}
+		} else {
+			return false;
+		}
 	}
 
 	return rootBlockEditingMode !== 'disabled';

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1720,13 +1720,19 @@ const canInsertBlockTypeUnmemoized = (
 	// some cases when the block is a content block.
 	const isContentRoleBlock = isContentBlock( blockName );
 	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
-	const isBlockWithinSection = !! getParentSectionBlock(
-		state,
-		rootClientId
-	);
+	const parentSection = getParentSectionBlock( state, rootClientId );
+	const isBlockWithinSection = !! parentSection;
 	if (
 		( isParentSectionBlock || isBlockWithinSection ) &&
 		! isContentRoleBlock
+	) {
+		return false;
+	}
+
+	// Don't allow insertion into synced patterns.
+	if (
+		parentSection &&
+		getBlockName( state, parentSection ) === 'core/block'
 	) {
 		return false;
 	}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1937,7 +1937,7 @@ export function canRemoveBlock( state, clientId ) {
 				( id ) => getBlockName( state, id ) === 'core/paragraph'
 			);
 			// Allow removal if there are other paragraph blocks besides this one
-			if ( paragraphBlocks.length > 0 ) {
+			if ( paragraphBlocks.length > 1 ) {
 				return true;
 			}
 		} else {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1720,19 +1720,18 @@ const canInsertBlockTypeUnmemoized = (
 	// some cases when the block is a content block.
 	const isContentRoleBlock = isContentBlock( blockName );
 	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
-	const parentSectionClientId = getParentSectionBlock( state, rootClientId );
-	const isBlockWithinSection = !! parentSectionClientId;
-	if (
-		( isParentSectionBlock || isBlockWithinSection ) &&
-		! isContentRoleBlock
-	) {
+	const sectionClientId = isParentSectionBlock
+		? rootClientId
+		: getParentSectionBlock( state, rootClientId );
+	const isWithinSection = !! sectionClientId;
+	if ( isWithinSection && ! isContentRoleBlock ) {
 		return false;
 	}
 
 	// Don't allow insertion into synced patterns.
 	if (
-		isBlockWithinSection &&
-		getBlockName( state, parentSectionClientId ) === 'core/block'
+		isWithinSection &&
+		getBlockName( state, sectionClientId ) === 'core/block'
 	) {
 		return false;
 	}
@@ -1913,24 +1912,26 @@ export function canRemoveBlock( state, clientId ) {
 
 	// It shouldn't be possible to move in a section block unless in
 	// some cases when the block is a content block.
-	const parentSectionClientId = getParentSectionBlock( state, clientId );
-	const isBlockWithinSection = !! parentSectionClientId;
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
+	const sectionClientId = isParentSectionBlock
+		? rootClientId
+		: getParentSectionBlock( state, rootClientId );
+	const isWithinSection = !! sectionClientId;
 	const isContentRoleBlock = isContentBlock(
 		getBlockName( state, clientId )
 	);
-	if ( isBlockWithinSection && ! isContentRoleBlock ) {
+	if ( isWithinSection && ! isContentRoleBlock ) {
 		return false;
 	}
 
 	// Disallow removal from synced patterns.
 	if (
-		isBlockWithinSection &&
-		getBlockName( state, parentSectionClientId ) === 'core/block'
+		isWithinSection &&
+		getBlockName( state, sectionClientId ) === 'core/block'
 	) {
 		return false;
 	}
 
-	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	const blockName = getBlockName( state, clientId );
 	// Check if the parent container allows insertion/removal in contentOnly mode

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2677,6 +2677,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2691,6 +2692,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
@@ -2728,6 +2730,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(),
 					attributes: new Map(),
 					order: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2676,6 +2676,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
+					order: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2689,6 +2690,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
+					order: new Map(),
 				},
 				blockListSettings: {},
 				settings: {

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -136,6 +136,7 @@ export const getInsertBlockTypeDependants = () => ( state, rootClientId ) => {
 	return [
 		state.blockListSettings[ rootClientId ],
 		state.blocks.byClientId.get( rootClientId ),
+		state.blocks.order.get( rootClientId || '' ),
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 		getBlockEditingMode( state, rootClientId ),

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -10,7 +10,11 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
-import { getSectionRootClientId, isSectionBlock } from './private-selectors';
+import {
+	getSectionRootClientId,
+	isSectionBlock,
+	getParentSectionBlock,
+} from './private-selectors';
 import { getBlockEditingMode } from './selectors';
 import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
@@ -142,5 +146,6 @@ export const getInsertBlockTypeDependants = () => ( state, rootClientId ) => {
 		getBlockEditingMode( state, rootClientId ),
 		getSectionRootClientId( state ),
 		isSectionBlock( state, rootClientId ),
+		getParentSectionBlock( state, rootClientId ),
 	];
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Addresses #71887.

Just playing around for now. This PR adds checks to `canInsertBlockTypeUnmemoized` and `canRemoveBlock` to enable adding/removing Paragraph blocks in contentOnly patterns where other Paragraph blocks already exist.

It sort of works, but doesn't always work. Maybe in investigating why this doesn't always work we can come up with a better solution 😄 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the contentOnly patterns experiment
2. Add some patterns that contain Paragraphs to a template
3. Try creating new Paragraphs in those patterns.


