### PR TITLE
Core Data: Update Attachment type to more accurately reflect fields in media API responses

### DIFF
--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -169,7 +169,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, unknown > | unknown[],
+				Record< string, unknown > | [],
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -15,13 +15,59 @@ import type {
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
 
 interface MediaDetails {
-	width: number;
-	height: number;
-	file: string;
-	filesize: number;
+	width?: number;
+	height?: number;
+	file?: string;
+	filesize?: number;
 	sizes: { [ key: string ]: Size };
-	image_meta: ImageMeta;
+	image_meta?: ImageMeta;
 	original_image?: string;
+	// Audio/video metadata
+	bitrate?: number;
+	mime_type?: string;
+	length?: number;
+	length_formatted?: string;
+	fileformat?: string;
+	dataformat?: string;
+	// Audio-specific
+	channels?: number;
+	sample_rate?: number;
+	codec?: string;
+	encoder?: string;
+	lossless?: boolean;
+	encoder_options?: string;
+	compression_ratio?: number;
+	channelmode?: string;
+	bitrate_mode?: string;
+	// Video-specific
+	audio?: {
+		dataformat?: string;
+		bitrate?: number;
+		codec?: string;
+		sample_rate?: number;
+		channels?: number;
+		bits_per_sample?: number;
+		lossless?: boolean;
+		channelmode?: string;
+		compression_ratio?: number;
+	};
+	created_timestamp?: number;
+	// Audio metadata fields
+	title?: string;
+	artist?: string;
+	track_number?: string;
+	album?: string;
+	recording_time?: string;
+	genre?: string;
+	date?: string;
+	comment?: string;
+	band?: string;
+	year?: string;
+	image?: {
+		mime?: string;
+		width?: number;
+		height?: number;
+	};
 }
 interface ImageMeta {
 	aperture: string;
@@ -123,7 +169,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, unknown >,
+				Record< string, unknown > | unknown[],
 				'view' | 'edit',
 				C
 			>;
@@ -138,7 +184,7 @@ declare module './base-entity-records' {
 			/**
 			 * The attachment caption.
 			 */
-			caption: ContextualField< string, 'edit', C >;
+			caption: ContextualField< RenderedText< C >, 'edit', C >;
 			/**
 			 * The attachment description.
 			 */
@@ -162,7 +208,7 @@ declare module './base-entity-records' {
 			/**
 			 * The ID for the associated post of the attachment.
 			 */
-			post: ContextualField< number, 'view' | 'edit', C >;
+			post: ContextualField< number | null, 'view' | 'edit', C >;
 			/**
 			 * URL to the original attachment file.
 			 */
@@ -171,6 +217,18 @@ declare module './base-entity-records' {
 			 * List of the missing image sizes of the attachment.
 			 */
 			missing_image_sizes: ContextualField< string[], 'edit', C >;
+			/**
+			 * The ID of the featured media of the attachment.
+			 */
+			featured_media: number;
+			/**
+			 * An array of class names for the post.
+			 */
+			class_list: string[];
+			/**
+			 * Links to related resources.
+			 */
+			_links?: Record< string, unknown >;
 		}
 	}
 }

--- a/packages/core-data/src/entity-types/helpers.ts
+++ b/packages/core-data/src/entity-types/helpers.ts
@@ -110,7 +110,7 @@ export type OmitNevers<
  * rendering to a page view. Similarly, plugins might modify
  * content or replace shortcodes.
  */
-export interface RenderedText< C extends Context > {
+export type RenderedText< C extends Context > = OmitNevers< {
 	/**
 	 * The source string which will be rendered on page views.
 	 */
@@ -119,7 +119,7 @@ export interface RenderedText< C extends Context > {
 	 * The output of the raw source after processing and filtering on the server.
 	 */
 	rendered: string;
-}
+} >;
 
 /**
  * Updatable<EntityRecord> is a type describing Edited Entity Records. They are like

--- a/packages/core-data/src/entity-types/helpers.ts
+++ b/packages/core-data/src/entity-types/helpers.ts
@@ -110,7 +110,7 @@ export type OmitNevers<
  * rendering to a page view. Similarly, plugins might modify
  * content or replace shortcodes.
  */
-export type RenderedText< C extends Context > = OmitNevers< {
+export interface RenderedText< C extends Context > {
 	/**
 	 * The source string which will be rendered on page views.
 	 */
@@ -119,7 +119,7 @@ export type RenderedText< C extends Context > = OmitNevers< {
 	 * The output of the raw source after processing and filtering on the server.
 	 */
 	rendered: string;
-} >;
+}
 
 /**
  * Updatable<EntityRecord> is a type describing Edited Entity Records. They are like

--- a/packages/core-data/src/entity-types/test/attachment.test.ts
+++ b/packages/core-data/src/entity-types/test/attachment.test.ts
@@ -3,7 +3,7 @@
  *
  * These tests validate the Attachment type definition by comparing it with
  * real JSON responses from the WordPress REST API's media endpoint. The fixtures
- * are from the REST API's view context, which excludes edit-only fields like
+ * are from the REST API's edit context, which includes edit-only fields like
  * permalink_template, generated_slug, and missing_image_sizes.
  */
 
@@ -19,50 +19,78 @@ import videoAttachmentFixture from './fixtures/attachment-video.json';
 describe( 'Attachment type', () => {
 	describe( 'Image attachment', () => {
 		it( 'should validate against real image attachment from REST API', () => {
-			const attachment: Attachment< 'view' > =
-				imageAttachmentFixture as Attachment< 'view' >;
+			const attachment: Attachment< 'edit' > =
+				imageAttachmentFixture as Attachment< 'edit' >;
 
-			expect( attachment.id ).toBeDefined();
-			expect( attachment.id ).toBeGreaterThan( 0 );
-			expect( attachment.media_type ).toBeDefined();
-			expect( attachment.mime_type ).toBeDefined();
-			expect( attachment.source_url ).toBeDefined();
+			// Edit-context fields
+			expect( attachment.permalink_template ).toBeDefined();
+			expect( attachment.generated_slug ).toBeDefined();
+			expect( attachment.missing_image_sizes ).toBeDefined();
+
+			// Image-specific properties
+			expect( attachment.media_type ).toBe( 'image' );
+			expect( attachment.media_details.width ).toBeGreaterThan( 0 );
+			expect( attachment.media_details.height ).toBeGreaterThan( 0 );
+			expect( attachment.media_details.sizes ).toBeDefined();
 		} );
 	} );
 
 	describe( 'Zip file attachment', () => {
 		it( 'should validate against real zip file attachment from REST API', () => {
-			const attachment: Attachment< 'view' > =
-				zipAttachmentFixture as Attachment< 'view' >;
+			const attachment: Attachment< 'edit' > =
+				zipAttachmentFixture as Attachment< 'edit' >;
 
-			expect( attachment.id ).toBeDefined();
-			expect( attachment.media_type ).toBeDefined();
-			expect( attachment.mime_type ).toBeDefined();
-			expect( attachment.source_url ).toBeDefined();
+			// Edit-context fields
+			expect( attachment.permalink_template ).toBeDefined();
+			expect( attachment.generated_slug ).toBeDefined();
+
+			// File-type properties
+			expect( attachment.media_type ).toBe( 'file' );
+			expect( attachment.mime_type ).toBe( 'application/zip' );
+			expect( attachment.media_details.filesize ).toBeGreaterThan( 0 );
+
+			// Files don't have dimensions
+			expect( attachment.media_details.width ).toBeUndefined();
+			expect( attachment.media_details.height ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'Audio file attachment', () => {
 		it( 'should validate against real audio attachment from REST API', () => {
-			const attachment: Attachment< 'view' > =
-				audioAttachmentFixture as Attachment< 'view' >;
+			const attachment: Attachment< 'edit' > =
+				audioAttachmentFixture as Attachment< 'edit' >;
 
-			expect( attachment.id ).toBeDefined();
-			expect( attachment.media_type ).toBeDefined();
-			expect( attachment.mime_type ).toBeDefined();
-			expect( attachment.source_url ).toBeDefined();
+			// Edit-context fields
+			expect( attachment.permalink_template ).toBeDefined();
+			expect( attachment.generated_slug ).toBeDefined();
+
+			// Audio-type properties
+			expect( attachment.media_type ).toBe( 'file' );
+			expect( attachment.mime_type ).toBe( 'audio/mpeg' );
+			expect( attachment.media_details.length ).toBeGreaterThan( 0 );
+			expect( attachment.media_details.bitrate ).toBeGreaterThan( 0 );
+
+			// Audio files don't have dimensions
+			expect( attachment.media_details.width ).toBeUndefined();
+			expect( attachment.media_details.height ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'Video file attachment', () => {
 		it( 'should validate against real video attachment from REST API', () => {
-			const attachment: Attachment< 'view' > =
-				videoAttachmentFixture as Attachment< 'view' >;
+			const attachment: Attachment< 'edit' > =
+				videoAttachmentFixture as Attachment< 'edit' >;
 
-			expect( attachment.id ).toBeDefined();
-			expect( attachment.media_type ).toBeDefined();
-			expect( attachment.mime_type ).toBeDefined();
-			expect( attachment.source_url ).toBeDefined();
+			// Edit-context fields
+			expect( attachment.permalink_template ).toBeDefined();
+			expect( attachment.generated_slug ).toBeDefined();
+
+			// Video-type properties
+			expect( attachment.media_type ).toBe( 'file' );
+			expect( attachment.mime_type ).toBe( 'video/mp4' );
+			expect( attachment.media_details.width ).toBeGreaterThan( 0 );
+			expect( attachment.media_details.height ).toBeGreaterThan( 0 );
+			expect( attachment.media_details.length ).toBeGreaterThan( 0 );
 		} );
 	} );
 } );

--- a/packages/core-data/src/entity-types/test/attachment.test.ts
+++ b/packages/core-data/src/entity-types/test/attachment.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the Attachment type against real REST API responses.
+ *
+ * These tests validate the Attachment type definition by comparing it with
+ * real JSON responses from the WordPress REST API's media endpoint. The fixtures
+ * are from the REST API's view context, which excludes edit-only fields like
+ * permalink_template, generated_slug, and missing_image_sizes.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { Attachment } from '../attachment';
+import imageAttachmentFixture from './fixtures/attachment-image.json';
+import zipAttachmentFixture from './fixtures/attachment-zip.json';
+import audioAttachmentFixture from './fixtures/attachment-audio.json';
+import videoAttachmentFixture from './fixtures/attachment-video.json';
+
+describe( 'Attachment type', () => {
+	describe( 'Image attachment', () => {
+		it( 'should validate against real image attachment from REST API', () => {
+			const attachment: Attachment< 'view' > =
+				imageAttachmentFixture as Attachment< 'view' >;
+
+			expect( attachment.id ).toBeDefined();
+			expect( attachment.id ).toBeGreaterThan( 0 );
+			expect( attachment.media_type ).toBeDefined();
+			expect( attachment.mime_type ).toBeDefined();
+			expect( attachment.source_url ).toBeDefined();
+		} );
+	} );
+
+	describe( 'Zip file attachment', () => {
+		it( 'should validate against real zip file attachment from REST API', () => {
+			const attachment: Attachment< 'view' > =
+				zipAttachmentFixture as Attachment< 'view' >;
+
+			expect( attachment.id ).toBeDefined();
+			expect( attachment.media_type ).toBeDefined();
+			expect( attachment.mime_type ).toBeDefined();
+			expect( attachment.source_url ).toBeDefined();
+		} );
+	} );
+
+	describe( 'Audio file attachment', () => {
+		it( 'should validate against real audio attachment from REST API', () => {
+			const attachment: Attachment< 'view' > =
+				audioAttachmentFixture as Attachment< 'view' >;
+
+			expect( attachment.id ).toBeDefined();
+			expect( attachment.media_type ).toBeDefined();
+			expect( attachment.mime_type ).toBeDefined();
+			expect( attachment.source_url ).toBeDefined();
+		} );
+	} );
+
+	describe( 'Video file attachment', () => {
+		it( 'should validate against real video attachment from REST API', () => {
+			const attachment: Attachment< 'view' > =
+				videoAttachmentFixture as Attachment< 'view' >;
+
+			expect( attachment.id ).toBeDefined();
+			expect( attachment.media_type ).toBeDefined();
+			expect( attachment.mime_type ).toBeDefined();
+			expect( attachment.source_url ).toBeDefined();
+		} );
+	} );
+} );

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-audio.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-audio.json
@@ -3,7 +3,8 @@
 	"date": "2025-11-12T23:02:13",
 	"date_gmt": "2025-11-12T23:02:13",
 	"guid": {
-		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3"
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3",
+		"raw": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3"
 	},
 	"modified": "2025-11-12T23:03:26",
 	"modified_gmt": "2025-11-12T23:03:26",
@@ -12,6 +13,7 @@
 	"type": "attachment",
 	"link": "http://localhost:8888/sample-audio/",
 	"title": {
+		"raw": "Sample Audio",
 		"rendered": "Sample Audio"
 	},
 	"author": 1,
@@ -20,6 +22,8 @@
 	"ping_status": "closed",
 	"template": "",
 	"meta": [],
+	"permalink_template": "http://localhost:8888/?attachment_id=125",
+	"generated_slug": "sample-audio",
 	"class_list": [
 		"post-125",
 		"attachment",
@@ -29,9 +33,11 @@
 		"hentry"
 	],
 	"description": {
-		"rendered": "<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif]-->\n<audio class=\"wp-audio-shortcode\" id=\"audio-125-1\" preload=\"none\" style=\"width: 100%;\" controls=\"controls\"><source type=\"audio/mpeg\" src=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3?_=1\" /><a href=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3\">http://localhost:8888/wp-content/uploads/2025/11/sample.mp3</a></audio>\n"
+		"raw": "Sample audio file",
+		"rendered": "<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif]-->\n<audio class=\"wp-audio-shortcode\" id=\"audio-125-1\" preload=\"none\" style=\"width: 100%;\" controls=\"controls\"><source type=\"audio/mpeg\" src=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3?_=1\" /><a href=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3\">http://localhost:8888/wp-content/uploads/2025/11/sample.mp3</a></audio>\n<p>Sample audio file</p>\n"
 	},
 	"caption": {
+		"raw": "",
 		"rendered": "<p>Sample audio file</p>\n"
 	},
 	"alt_text": "",
@@ -73,6 +79,7 @@
 	},
 	"post": null,
 	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3",
+	"missing_image_sizes": [],
 	"_links": {
 		"self": [
 			{
@@ -84,7 +91,7 @@
 		],
 		"collection": [
 			{
-				"href": "http://localhost:8888/wp-json/wp/media"
+				"href": "http://localhost:8888/wp-json/wp/v2/media"
 			}
 		],
 		"about": [
@@ -108,6 +115,16 @@
 			{
 				"embeddable": true,
 				"href": "http://localhost:8888/wp-json/wp/v2/media/126"
+			}
+		],
+		"wp:action-unfiltered-html": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/125"
+			}
+		],
+		"wp:action-assign-author": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/125"
 			}
 		],
 		"curies": [

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-audio.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-audio.json
@@ -1,0 +1,121 @@
+{
+	"id": 125,
+	"date": "2025-11-12T23:02:13",
+	"date_gmt": "2025-11-12T23:02:13",
+	"guid": {
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3"
+	},
+	"modified": "2025-11-12T23:03:26",
+	"modified_gmt": "2025-11-12T23:03:26",
+	"slug": "sample-audio",
+	"status": "inherit",
+	"type": "attachment",
+	"link": "http://localhost:8888/sample-audio/",
+	"title": {
+		"rendered": "Sample Audio"
+	},
+	"author": 1,
+	"featured_media": 126,
+	"comment_status": "open",
+	"ping_status": "closed",
+	"template": "",
+	"meta": [],
+	"class_list": [
+		"post-125",
+		"attachment",
+		"type-attachment",
+		"status-inherit",
+		"has-post-thumbnail",
+		"hentry"
+	],
+	"description": {
+		"rendered": "<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif]-->\n<audio class=\"wp-audio-shortcode\" id=\"audio-125-1\" preload=\"none\" style=\"width: 100%;\" controls=\"controls\"><source type=\"audio/mpeg\" src=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3?_=1\" /><a href=\"http://localhost:8888/wp-content/uploads/2025/11/sample.mp3\">http://localhost:8888/wp-content/uploads/2025/11/sample.mp3</a></audio>\n"
+	},
+	"caption": {
+		"rendered": "<p>Sample audio file</p>\n"
+	},
+	"alt_text": "",
+	"media_type": "file",
+	"mime_type": "audio/mpeg",
+	"media_details": {
+		"dataformat": "mp3",
+		"channels": 2,
+		"sample_rate": 44100,
+		"bitrate": 320000,
+		"channelmode": "joint stereo",
+		"bitrate_mode": "cbr",
+		"codec": "LAME",
+		"encoder": "LAME3.99r",
+		"lossless": false,
+		"encoder_options": "--preset insane",
+		"compression_ratio": 0.22675736961451248,
+		"fileformat": "mp3",
+		"filesize": 7373059,
+		"mime_type": "audio/mpeg",
+		"length": 182,
+		"length_formatted": "3:02",
+		"title": "Sample Audio",
+		"artist": "",
+		"track_number": "",
+		"album": "",
+		"recording_time": "2025-11-12T23:02:13",
+		"genre": "",
+		"date": "2025-11-12 23:02:13",
+		"comment": "",
+		"band": "",
+		"year": "",
+		"image": {
+			"mime": "image/jpeg",
+			"width": 700,
+			"height": 700
+		},
+		"sizes": {}
+	},
+	"post": null,
+	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/sample.mp3",
+	"_links": {
+		"self": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/125",
+				"targetHints": {
+					"allow": [ "GET", "POST", "PUT", "PATCH", "DELETE" ]
+				}
+			}
+		],
+		"collection": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/media"
+			}
+		],
+		"about": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/types/attachment"
+			}
+		],
+		"author": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/users/1"
+			}
+		],
+		"replies": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=125"
+			}
+		],
+		"wp:featuredmedia": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/media/126"
+			}
+		],
+		"curies": [
+			{
+				"name": "wp",
+				"href": "https://api.w.org/{rel}",
+				"templated": true
+			}
+		]
+	}
+}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-image.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-image.json
@@ -1,0 +1,151 @@
+{
+	"id": 71,
+	"date": "2025-11-03T05:34:25",
+	"date_gmt": "2025-11-03T05:34:25",
+	"guid": {
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141.jpeg"
+	},
+	"modified": "2025-11-12T23:17:38",
+	"modified_gmt": "2025-11-12T23:17:38",
+	"slug": "img_8141",
+	"status": "inherit",
+	"type": "attachment",
+	"link": "http://localhost:8888/?attachment_id=71",
+	"title": {
+		"rendered": "IMG_8141"
+	},
+	"author": 1,
+	"featured_media": 0,
+	"comment_status": "open",
+	"ping_status": "closed",
+	"template": "",
+	"meta": [],
+	"class_list": [
+		"post-71",
+		"attachment",
+		"type-attachment",
+		"status-inherit",
+		"hentry"
+	],
+	"description": {
+		"rendered": "<p class=\"attachment\"><a href='http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-scaled.jpeg'><img loading=\"lazy\" decoding=\"async\" width=\"300\" height=\"225\" src=\"http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-300x225.jpeg\" class=\"attachment-medium size-medium\" alt=\"\" srcset=\"http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-300x225.jpeg 300w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1024x768.jpeg 1024w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-768x576.jpeg 768w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1536x1152.jpeg 1536w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-2048x1536.jpeg 2048w\" sizes=\"auto, (max-width: 300px) 100vw, 300px\" /></a></p>\n"
+	},
+	"caption": {
+		"rendered": "<p>A caption for the image</p>\n"
+	},
+	"alt_text": "",
+	"media_type": "image",
+	"mime_type": "image/jpeg",
+	"media_details": {
+		"width": 2560,
+		"height": 1920,
+		"file": "2025/11/IMG_8141-scaled.jpeg",
+		"filesize": 751579,
+		"sizes": {
+			"medium": {
+				"file": "IMG_8141-300x225.jpeg",
+				"width": 300,
+				"height": 225,
+				"filesize": 22105,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-300x225.jpeg"
+			},
+			"large": {
+				"file": "IMG_8141-1024x768.jpeg",
+				"width": 1024,
+				"height": 768,
+				"filesize": 155739,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1024x768.jpeg"
+			},
+			"thumbnail": {
+				"file": "IMG_8141-150x150.jpeg",
+				"width": 150,
+				"height": 150,
+				"filesize": 10260,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-150x150.jpeg"
+			},
+			"medium_large": {
+				"file": "IMG_8141-768x576.jpeg",
+				"width": 768,
+				"height": 576,
+				"filesize": 97570,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-768x576.jpeg"
+			},
+			"1536x1536": {
+				"file": "IMG_8141-1536x1152.jpeg",
+				"width": 1536,
+				"height": 1152,
+				"filesize": 303572,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1536x1152.jpeg"
+			},
+			"2048x2048": {
+				"file": "IMG_8141-2048x1536.jpeg",
+				"width": 2048,
+				"height": 1536,
+				"filesize": 502729,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-2048x1536.jpeg"
+			},
+			"full": {
+				"file": "IMG_8141-scaled.jpeg",
+				"width": 2560,
+				"height": 1920,
+				"mime_type": "image/jpeg",
+				"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-scaled.jpeg"
+			}
+		},
+		"image_meta": {
+			"aperture": "1.78",
+			"credit": "",
+			"camera": "iPhone 14 Pro",
+			"caption": "",
+			"created_timestamp": "1761765212",
+			"copyright": "",
+			"focal_length": "6.86",
+			"iso": "1600",
+			"shutter_speed": "0.058823529411765",
+			"title": "",
+			"orientation": "1",
+			"keywords": []
+		},
+		"original_image": "IMG_8141.jpeg"
+	},
+	"post": 49,
+	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-scaled.jpeg",
+	"_links": {
+		"self": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/71",
+				"targetHints": {
+					"allow": [ "GET", "POST", "PUT", "PATCH", "DELETE" ]
+				}
+			}
+		],
+		"collection": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media"
+			}
+		],
+		"about": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/types/attachment"
+			}
+		],
+		"author": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/users/1"
+			}
+		],
+		"replies": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=71"
+			}
+		]
+	}
+}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-image.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-image.json
@@ -3,7 +3,8 @@
 	"date": "2025-11-03T05:34:25",
 	"date_gmt": "2025-11-03T05:34:25",
 	"guid": {
-		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141.jpeg"
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141.jpeg",
+		"raw": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141.jpeg"
 	},
 	"modified": "2025-11-12T23:17:38",
 	"modified_gmt": "2025-11-12T23:17:38",
@@ -12,6 +13,7 @@
 	"type": "attachment",
 	"link": "http://localhost:8888/?attachment_id=71",
 	"title": {
+		"raw": "IMG_8141",
 		"rendered": "IMG_8141"
 	},
 	"author": 1,
@@ -20,6 +22,8 @@
 	"ping_status": "closed",
 	"template": "",
 	"meta": [],
+	"permalink_template": "http://localhost:8888/?attachment_id=71",
+	"generated_slug": "img_8141",
 	"class_list": [
 		"post-71",
 		"attachment",
@@ -28,9 +32,11 @@
 		"hentry"
 	],
 	"description": {
+		"raw": "",
 		"rendered": "<p class=\"attachment\"><a href='http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-scaled.jpeg'><img loading=\"lazy\" decoding=\"async\" width=\"300\" height=\"225\" src=\"http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-300x225.jpeg\" class=\"attachment-medium size-medium\" alt=\"\" srcset=\"http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-300x225.jpeg 300w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1024x768.jpeg 1024w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-768x576.jpeg 768w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-1536x1152.jpeg 1536w, http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-2048x1536.jpeg 2048w\" sizes=\"auto, (max-width: 300px) 100vw, 300px\" /></a></p>\n"
 	},
 	"caption": {
+		"raw": "A caption for the image",
 		"rendered": "<p>A caption for the image</p>\n"
 	},
 	"alt_text": "",
@@ -116,6 +122,7 @@
 	},
 	"post": 49,
 	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/IMG_8141-scaled.jpeg",
+	"missing_image_sizes": [],
 	"_links": {
 		"self": [
 			{
@@ -145,6 +152,23 @@
 			{
 				"embeddable": true,
 				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=71"
+			}
+		],
+		"wp:action-unfiltered-html": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/71"
+			}
+		],
+		"wp:action-assign-author": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/71"
+			}
+		],
+		"curies": [
+			{
+				"name": "wp",
+				"href": "https://api.w.org/{rel}",
+				"templated": true
 			}
 		]
 	}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-video.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-video.json
@@ -3,7 +3,8 @@
 	"date": "2025-11-06T05:11:23",
 	"date_gmt": "2025-11-06T05:11:23",
 	"guid": {
-		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4"
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4",
+		"raw": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4"
 	},
 	"modified": "2025-11-06T05:11:23",
 	"modified_gmt": "2025-11-06T05:11:23",
@@ -12,6 +13,7 @@
 	"type": "attachment",
 	"link": "http://localhost:8888/sample-video/",
 	"title": {
+		"raw": "Sample Video",
 		"rendered": "Sample Video"
 	},
 	"author": 1,
@@ -20,6 +22,8 @@
 	"ping_status": "closed",
 	"template": "",
 	"meta": [],
+	"permalink_template": "http://localhost:8888/?attachment_id=93",
+	"generated_slug": "sample-video",
 	"class_list": [
 		"post-93",
 		"attachment",
@@ -28,9 +32,11 @@
 		"hentry"
 	],
 	"description": {
+		"raw": "",
 		"rendered": "<div style=\"width: 1920px;\" class=\"wp-video\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->\n<video class=\"wp-video-shortcode\" id=\"video-93-1\" width=\"1920\" height=\"1080\" preload=\"metadata\" controls=\"controls\"><source type=\"video/mp4\" src=\"http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4?_=1\" /><a href=\"http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4\">http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4</a></video></div>\n"
 	},
 	"caption": {
+		"raw": "",
 		"rendered": "<p>Sample video file</p>\n"
 	},
 	"alt_text": "",
@@ -62,6 +68,7 @@
 	},
 	"post": 75,
 	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4",
+	"missing_image_sizes": [],
 	"_links": {
 		"self": [
 			{
@@ -91,6 +98,23 @@
 			{
 				"embeddable": true,
 				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=93"
+			}
+		],
+		"wp:action-unfiltered-html": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/93"
+			}
+		],
+		"wp:action-assign-author": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/93"
+			}
+		],
+		"curies": [
+			{
+				"name": "wp",
+				"href": "https://api.w.org/{rel}",
+				"templated": true
 			}
 		]
 	}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-video.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-video.json
@@ -1,0 +1,97 @@
+{
+	"id": 93,
+	"date": "2025-11-06T05:11:23",
+	"date_gmt": "2025-11-06T05:11:23",
+	"guid": {
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4"
+	},
+	"modified": "2025-11-06T05:11:23",
+	"modified_gmt": "2025-11-06T05:11:23",
+	"slug": "sample-video",
+	"status": "inherit",
+	"type": "attachment",
+	"link": "http://localhost:8888/sample-video/",
+	"title": {
+		"rendered": "Sample Video"
+	},
+	"author": 1,
+	"featured_media": 0,
+	"comment_status": "open",
+	"ping_status": "closed",
+	"template": "",
+	"meta": [],
+	"class_list": [
+		"post-93",
+		"attachment",
+		"type-attachment",
+		"status-inherit",
+		"hentry"
+	],
+	"description": {
+		"rendered": "<div style=\"width: 1920px;\" class=\"wp-video\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->\n<video class=\"wp-video-shortcode\" id=\"video-93-1\" width=\"1920\" height=\"1080\" preload=\"metadata\" controls=\"controls\"><source type=\"video/mp4\" src=\"http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4?_=1\" /><a href=\"http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4\">http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4</a></video></div>\n"
+	},
+	"caption": {
+		"rendered": "<p>Sample video file</p>\n"
+	},
+	"alt_text": "",
+	"media_type": "file",
+	"mime_type": "video/mp4",
+	"media_details": {
+		"bitrate": 3828466,
+		"filesize": 2848208,
+		"mime_type": "video/mp4",
+		"length": 6,
+		"length_formatted": "0:06",
+		"width": 1920,
+		"height": 1080,
+		"fileformat": "mp4",
+		"dataformat": "quicktime",
+		"audio": {
+			"dataformat": "mp4",
+			"bitrate": 127998,
+			"codec": "ISO/IEC 14496-3 AAC",
+			"sample_rate": 44100,
+			"channels": 2,
+			"bits_per_sample": 16,
+			"lossless": false,
+			"channelmode": "stereo",
+			"compression_ratio": 0.0907015306122449
+		},
+		"created_timestamp": -2082844800,
+		"sizes": {}
+	},
+	"post": 75,
+	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/sample-5s.mp4",
+	"_links": {
+		"self": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/93",
+				"targetHints": {
+					"allow": [ "GET", "POST", "PUT", "PATCH", "DELETE" ]
+				}
+			}
+		],
+		"collection": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media"
+			}
+		],
+		"about": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/types/attachment"
+			}
+		],
+		"author": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/users/1"
+			}
+		],
+		"replies": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=93"
+			}
+		]
+	}
+}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-zip.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-zip.json
@@ -3,7 +3,8 @@
 	"date": "2025-11-06T05:13:54",
 	"date_gmt": "2025-11-06T05:13:54",
 	"guid": {
-		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip"
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip",
+		"raw": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip"
 	},
 	"modified": "2025-11-06T05:13:54",
 	"modified_gmt": "2025-11-06T05:13:54",
@@ -12,6 +13,7 @@
 	"type": "attachment",
 	"link": "http://localhost:8888/gutenberg-v22-0-0/",
 	"title": {
+		"raw": "gutenberg-v22-0-0",
 		"rendered": "gutenberg-v22-0-0"
 	},
 	"author": 1,
@@ -20,6 +22,8 @@
 	"ping_status": "closed",
 	"template": "",
 	"meta": [],
+	"permalink_template": "http://localhost:8888/?attachment_id=95",
+	"generated_slug": "gutenberg-v22-0-0",
 	"class_list": [
 		"post-95",
 		"attachment",
@@ -28,9 +32,11 @@
 		"hentry"
 	],
 	"description": {
+		"raw": "",
 		"rendered": "<p class=\"attachment\"><a href='http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip'>gutenberg-v22-0-0</a></p>\n"
 	},
 	"caption": {
+		"raw": "",
 		"rendered": "<p>gutenberg-v22-0-0</p>\n"
 	},
 	"alt_text": "",
@@ -42,6 +48,7 @@
 	},
 	"post": null,
 	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip",
+	"missing_image_sizes": [],
 	"_links": {
 		"self": [
 			{
@@ -71,6 +78,23 @@
 			{
 				"embeddable": true,
 				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=95"
+			}
+		],
+		"wp:action-unfiltered-html": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/95"
+			}
+		],
+		"wp:action-assign-author": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/95"
+			}
+		],
+		"curies": [
+			{
+				"name": "wp",
+				"href": "https://api.w.org/{rel}",
+				"templated": true
 			}
 		]
 	}

--- a/packages/core-data/src/entity-types/test/fixtures/attachment-zip.json
+++ b/packages/core-data/src/entity-types/test/fixtures/attachment-zip.json
@@ -1,0 +1,77 @@
+{
+	"id": 95,
+	"date": "2025-11-06T05:13:54",
+	"date_gmt": "2025-11-06T05:13:54",
+	"guid": {
+		"rendered": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip"
+	},
+	"modified": "2025-11-06T05:13:54",
+	"modified_gmt": "2025-11-06T05:13:54",
+	"slug": "gutenberg-v22-0-0",
+	"status": "inherit",
+	"type": "attachment",
+	"link": "http://localhost:8888/gutenberg-v22-0-0/",
+	"title": {
+		"rendered": "gutenberg-v22-0-0"
+	},
+	"author": 1,
+	"featured_media": 0,
+	"comment_status": "open",
+	"ping_status": "closed",
+	"template": "",
+	"meta": [],
+	"class_list": [
+		"post-95",
+		"attachment",
+		"type-attachment",
+		"status-inherit",
+		"hentry"
+	],
+	"description": {
+		"rendered": "<p class=\"attachment\"><a href='http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip'>gutenberg-v22-0-0</a></p>\n"
+	},
+	"caption": {
+		"rendered": "<p>gutenberg-v22-0-0</p>\n"
+	},
+	"alt_text": "",
+	"media_type": "file",
+	"mime_type": "application/zip",
+	"media_details": {
+		"filesize": 19988723,
+		"sizes": {}
+	},
+	"post": null,
+	"source_url": "http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip",
+	"_links": {
+		"self": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media/95",
+				"targetHints": {
+					"allow": [ "GET", "POST", "PUT", "PATCH", "DELETE" ]
+				}
+			}
+		],
+		"collection": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/media"
+			}
+		],
+		"about": [
+			{
+				"href": "http://localhost:8888/wp-json/wp/v2/types/attachment"
+			}
+		],
+		"author": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/users/1"
+			}
+		],
+		"replies": [
+			{
+				"embeddable": true,
+				"href": "http://localhost:8888/wp-json/wp/v2/comments?post=95"
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of: #72612

Update the Attachment type to more accurately reflect the properties found in actual API responses.

<details>
<summary>A Claude-generated overview of what's changed</summary>

  ## MediaDetails interface
  - Made core properties optional (`width?`, `height?`, `file?`, `filesize?`, `image_meta?`)
  - Added support for audio/video/file metadata (bitrate, channels, codec, length, sample_rate, etc.) — this is based on data found in REST API responses

  ## caption field (add support for handling rich text)
  - Now uses `RenderedText< C >` instead of a plain string
  - Makes it structured with `raw` and `rendered` properties

  ## meta field
  - Changed from `Record< string, unknown >` to `Record< string, unknown > | []`
  - More precise typing

  ## post field (previously this expected the media item to always be attached to a post)
  - Updated to allow `null` (`number | null`) instead of just `number`

  ## New fields (these are always present in API responses)
  - Added `featured_media`
  - Added `class_list`
  - Added optional `_links`
</details>

These changes broaden the attachment type definition to properly support all (I hope!) attachment media types (images, audio, video, files) and their specific metadata properties.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While hacking around on support for media as part of dedicated media fields over in https://github.com/WordPress/gutenberg/pull/73071, I kept running into issues where properties weren't typed in a way that actually matched the API responses I was working with.

This PR seeks to better match the typing to actual responses, which should (hopefully) make it easier to work with attachment types in TypeScript.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the types with the additional fields for different media types, and make many of the properties optional as if we have an arbitrary media item, we won't necessarily know ahead of time whether we're dealing with an image, a video, or a file.
* Add some test fixtures with example JSON files of API responses for attachments.
* Add a few tests — these are very simple tests, and the main reason they exist is really so that we have some code in this package that is using the types.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Make sure the tests and linting jobs pass
* Take a look over the types — do these changes make sense? The main thing that kicked this off for me was while working on a field for `caption` and I noticed our types didn't allow for rich text to be handled, and then the rest of this PR came about because I thought if I'm going to update one property, I'd better check the whole thing against real API responses.