### PR TITLE
WP_Theme_JSON: deprecate is_safe_css_declaration() and replace with is_safe() 

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1741,7 +1741,7 @@ class WP_Theme_JSON_Gutenberg {
 								// Iterate over each of the styling rules and substitute non-string values such as `null` with the real `blockGap` value.
 								foreach ( $spacing_rule['rules'] as $css_property => $css_value ) {
 									$current_css_value = is_string( $css_value ) ? $css_value : $block_gap_value;
-									if ( static::is_safe_css_declaration( $css_property, $current_css_value ) ) {
+									if ( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $css_property, $current_css_value ) ) {
 										$declarations[] = array(
 											'name'  => $css_property,
 											'value' => $current_css_value,
@@ -1834,7 +1834,7 @@ class WP_Theme_JSON_Gutenberg {
 									continue;
 								}
 
-								if ( static::is_safe_css_declaration( $css_property, $css_value ) ) {
+								if ( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $css_property, $css_value ) ) {
 									$declarations[] = array(
 										'name'  => $css_property,
 										'value' => $css_value,
@@ -3105,9 +3105,9 @@ class WP_Theme_JSON_Gutenberg {
 		*/
 		if ( isset( $settings['layout']['contentSize'] ) || isset( $settings['layout']['wideSize'] ) ) {
 			$content_size = isset( $settings['layout']['contentSize'] ) ? $settings['layout']['contentSize'] : $settings['layout']['wideSize'];
-			$content_size = static::is_safe_css_declaration( 'max-width', $content_size ) ? $content_size : 'initial';
+			$content_size = WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'max-width', $content_size ) ? $content_size : 'initial';
 			$wide_size    = isset( $settings['layout']['wideSize'] ) ? $settings['layout']['wideSize'] : $settings['layout']['contentSize'];
-			$wide_size    = static::is_safe_css_declaration( 'max-width', $wide_size ) ? $wide_size : 'initial';
+			$wide_size    = WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'max-width', $wide_size ) ? $wide_size : 'initial';
 			$css         .= static::ROOT_CSS_PROPERTIES_SELECTOR . ' { --wp--style--global--content-size: ' . $content_size . ';';
 			$css         .= '--wp--style--global--wide-size: ' . $wide_size . '; }';
 		}
@@ -3742,7 +3742,7 @@ class WP_Theme_JSON_Gutenberg {
 
 						$preset_is_valid = true;
 						foreach ( $preset_metadata['properties'] as $property ) {
-							if ( ! static::is_safe_css_declaration( $property, $value ) ) {
+							if ( ! WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $property, $value ) ) {
 								$preset_is_valid = false;
 								break;
 							}
@@ -3781,7 +3781,7 @@ class WP_Theme_JSON_Gutenberg {
 		$declarations = static::compute_style_properties( $input );
 
 		foreach ( $declarations as $declaration ) {
-			if ( static::is_safe_css_declaration( $declaration['name'], $declaration['value'] ) ) {
+			if ( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $declaration['name'], $declaration['value'] ) ) {
 				$path = static::PROPERTIES_METADATA[ $declaration['name'] ];
 
 				// Check the value isn't an array before adding so as to not
@@ -3803,15 +3803,17 @@ class WP_Theme_JSON_Gutenberg {
 	 * Checks that a declaration provided by the user is safe.
 	 *
 	 * @since 5.9.0
+	 * @deprecated Gutenberg 7.0.0 Use WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe() instead.
 	 *
 	 * @param string $property_name  Property name in a CSS declaration, i.e. the `color` in `color: red`.
 	 * @param string $property_value Value in a CSS declaration, i.e. the `red` in `color: red`.
 	 * @return bool
 	 */
 	protected static function is_safe_css_declaration( $property_name, $property_value ) {
-		$style_to_validate = $property_name . ': ' . $property_value;
-		$filtered          = esc_html( safecss_filter_attr( $style_to_validate ) );
-		return ! empty( trim( $filtered ) );
+		_deprecated_function( __METHOD__, 'Gutenberg 7.0.0', 'WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe()' );
+
+		// Delegate to Style Engine, which handles sanitization.
+		return WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $property_name, $property_value );
 	}
 
 	/**
@@ -3826,13 +3828,13 @@ class WP_Theme_JSON_Gutenberg {
 	private static function remove_indirect_properties( $input, &$output ) {
 		foreach ( static::INDIRECT_PROPERTIES_METADATA as $property => $paths ) {
 			foreach ( $paths as $path ) {
-				$value = _wp_array_get( $input, $path );
-				if (
-					is_string( $value ) &&
-					static::is_safe_css_declaration( $property, $value )
-				) {
-					_wp_array_set( $output, $path, $value );
-				}
+			$value = _wp_array_get( $input, $path );
+			if (
+				is_string( $value ) &&
+				WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( $property, $value )
+			) {
+				_wp_array_set( $output, $path, $value );
+			}
 			}
 		}
 	}

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -130,10 +130,32 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		}
 
 		/**
+		 * Checks that a CSS property and value pair is safe.
+		 *
+		 * Validates CSS declarations using safecss_filter_attr() on the full declaration string.
+		 * This is a temporary theme.json compatibility method.
+		 *
+		 * @param string $property_name  Property name in a CSS declaration, i.e. the `color` in `color: red`.
+		 * @param string $property_value Value in a CSS declaration, i.e. the `red` in `color: red`.
+		 * @return bool True if the declaration is safe, false otherwise.
+		 */
+		public static function is_safe( $property_name, $property_value ) {
+			// Empty values are not safe.
+			if ( '' === trim( $property_value ) ) {
+				return false;
+			}
+
+			// Check the full declaration string to catch XSS before any tag stripping.
+			$style_to_validate = $property_name . ': ' . $property_value;
+			$filtered          = safecss_filter_attr( $style_to_validate );
+			return ! empty( trim( $filtered ) );
+		}
+
+		/**
 		 * Filters and compiles the CSS declarations.
 		 *
-		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
-		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 * @param bool $should_prettify Whether to add spacing, new lines and indents.
+		 * @param int  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
 		 *
 		 * @return string The CSS declarations.
 		 */

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -677,5 +677,6 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 			$processor->add_rules( $css_rules );
 			return $processor->get_css( $options );
 		}
+
 	}
 }

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -794,4 +794,77 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '.foo{@media (orientation: landscape){background-color:blue;}}.foo{@media (min-width > 1024px){background-color:cotton-blue;}}', $compiled_stylesheet );
 	}
+
+	/**
+	 * Tests that valid CSS declarations return true.
+	 *
+	 * @covers WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe
+	 */
+	public function test_is_safe_css_declaration_valid_declarations() {
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', 'red' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'background-color', '#ffffff' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'font-size', '16px' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'margin', '10px 20px' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'border-radius', '5px' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'max-width', '100%' ) );
+	}
+
+	/**
+	 * Tests that invalid CSS declarations return false.
+	 *
+	 * @covers WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe
+	 */
+	public function test_is_safe_css_declaration_invalid_declarations() {
+		// Invalid property names.
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'javascript:alert(1)', 'value' ) );
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'expression(evil)', 'value' ) );
+
+		// Invalid values.
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', 'javascript:alert(1)' ) );
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'background', 'expression(evil)' ) );
+	}
+
+	/**
+	 * Tests that HTML tags in values are stripped.
+	 *
+	 * @covers WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe
+	 */
+	public function test_is_safe_css_declaration_strips_html_tags() {
+		// Values with script tags should be caught by safecss_filter_attr.
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', '<script>alert(1)</script>' ) );
+
+		// Empty values are not safe.
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', '' ) );
+
+		// Valid CSS values should pass.
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', 'red' ) );
+	}
+
+	/**
+	 * Tests that empty values return false.
+	 *
+	 * @covers WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe
+	 */
+	public function test_is_safe_css_declaration_empty_values() {
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'color', '' ) );
+		$this->assertFalse( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'font-size', '   ' ) );
+	}
+
+	/**
+	 * Tests edge cases for is_safe_css_declaration.
+	 *
+	 * @covers WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe
+	 */
+	public function test_is_safe_css_declaration_edge_cases() {
+		// Zero value should be valid.
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'opacity', '0' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'z-index', '0' ) );
+
+		// CSS custom properties should be valid.
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( '--wp--preset--color--background', '#ffffff' ) );
+
+		// Complex CSS values should be valid.
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'background', 'linear-gradient(135deg, rgba(0,0,0) 0%, rgb(0,0,0) 100%)' ) );
+		$this->assertTrue( WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe( 'font-size', 'clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.156), 16px)' ) );
+	}
 }


### PR DESCRIPTION
WIP

Part of https://github.com/WordPress/gutenberg/issues/65728

Similar to 
https://github.com/WordPress/gutenberg/pull/73117


Refactor CSS declaration safety checks to use WP_Style_Engine_CSS_Declarations_Gutenberg::is_safe() method

- Replaced static::is_safe_css_declaration() calls with the new is_safe() method for improved safety checks.
- Updated related tests to validate the new method's functionality and edge cases.
- Marked the old is_safe_css_declaration() method as deprecated.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
