### PR TITLE
Tabs block: Improve store functionality

### DIFF
--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -186,21 +186,19 @@ store( 'core/tabs', {
 		/**
 		 * Gets the index of the active tab element whether it
 		 * is a tab label or tab panel.
-		 * Public API for third-party access.
 		 *
 		 * @type {number|null}
 		 */
 		get tabIndex() {
-			return createReadOnlyProxy( privateState.tabIndex );
+			return privateState.tabIndex;
 		},
 		/**
 		 * Whether the tab panel or tab label is the active tab.
-		 * Public API for third-party access.
 		 *
 		 * @type {boolean}
 		 */
 		get isActiveTab() {
-			return createReadOnlyProxy( privateState.isActiveTab );
+			return privateState.isActiveTab;
 		},
 	},
 	actions: {

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -9,8 +9,25 @@ import {
 } from '@wordpress/interactivity';
 
 function createReadOnlyProxy( obj ) {
+	const arrayMutationMethods = new Set( [
+		'push',
+		'pop',
+		'shift',
+		'unshift',
+		'splice',
+		'sort',
+		'reverse',
+		'copyWithin',
+		'fill',
+	] );
+
 	return new Proxy( obj, {
 		get( target, prop ) {
+			// If accessing an array mutation method, return a no-op function.
+			if ( Array.isArray( target ) && arrayMutationMethods.has( prop ) ) {
+				return () => {};
+			}
+
 			const value = target[ prop ];
 			if ( typeof value === 'object' && value !== null ) {
 				return createReadOnlyProxy( value );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses these comments: https://github.com/WordPress/gutenberg/pull/69789#pullrequestreview-3410447043

cc @sethrubenstein

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Small PR to address the feedback on the tabs store functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removes `createReadOnlyProxy` where an object or array isn't used.
- Updated the `createReadOnlyProxy` function to intercept array mutation methods. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert the Tabs block.
2. Ensure the block still behaves as before.
