### PR TITLE
Notes: Ignore flood and duplicate checks

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -115,21 +115,3 @@ function gutenberg_filter_comment_count_query_exclude_block_comments( $query ) {
 	return $query;
 }
 add_filter( 'query', 'gutenberg_filter_comment_count_query_exclude_block_comments' );
-
-/**
- * Allows duplicate block comment.
- *
- * @since 6.9.0
- *
- * @param int $dupe_id The duplicate comment ID.
- * @param array $commentdata The comment data.
- *
- * @return int ID of the comment identified as a duplicate.
- */
-function gutenberg_allow_duplicate_note_resolution( $dupe_id, $commentdata ) {
-	if ( isset( $commentdata['comment_type'] ) && 'note' === $commentdata['comment_type'] ) {
-		return false;
-	}
-	return $dupe_id;
-}
-add_filter( 'duplicate_comment_id', 'gutenberg_allow_duplicate_note_resolution', 10, 2 );

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
@@ -378,7 +378,11 @@ class Gutenberg_REST_Comment_Controller_6_9 extends WP_REST_Comments_Controller 
 			);
 		}
 
-		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
+		// Don't check for duplicates or flooding for notes.
+		$prepared_comment['comment_approved'] =
+			'note' === $prepared_comment['comment_type'] ?
+			'1' :
+			wp_allow_comment( $prepared_comment, true );
 
 		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
 			$error_code    = $prepared_comment['comment_approved']->get_error_code();


### PR DESCRIPTION
## What?
Sync changes from https://github.com/WordPress/wordpress-develop/pull/10448.
Part of #73141.

Updates now flood and duplicate checks are handled for notes.

## Testing Instructions
1. Login as low cap user.
2. Create a post.
3. Add blocks.
4. Add notes with same content as quickly as possible.
5. The notes should be added correctly without an error.
