### PR TITLE
E2E Tests: Skip flaky list view test

### DIFF
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -334,7 +334,7 @@ test.describe( 'List View', () => {
 	// If list view sidebar is open and focus is not inside the sidebar, move
 	// focus to the sidebar when using the shortcut. If focus is inside the
 	// sidebar, shortcut should close the sidebar.
-	test( 'ensures List View global shortcut works properly', async ( {
+	test.skip( 'ensures List View global shortcut works properly', async ( {
 		editor,
 		page,
 		pageUtils,


### PR DESCRIPTION
## What?
Closes #51533.

PR skips flaky "ensures List View global shortcut works properly" test.

## Why?

The test is too flaky. I tried fixing it a couple of times, but each fix uncovered different issues and so on. This requires more detailed debugging of List View feature and its test.

## Testing Instructions
CI checks are green.
