### PR TITLE
E2E Tests: Remove movie CPTs after block bindings tests

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -22,12 +22,16 @@ export interface CreatePostPayload {
  * Delete all posts using REST API.
  *
  * @param this
+ * @param postType The type of post to delete. Defaults to 'posts'.
  */
-export async function deleteAllPosts( this: RequestUtils ) {
+export async function deleteAllPosts(
+	this: RequestUtils,
+	postType: string = 'posts'
+) {
 	// List all posts.
 	// https://developer.wordpress.org/rest-api/reference/posts/#list-posts
 	const posts = await this.rest< Post[] >( {
-		path: '/wp/v2/posts',
+		path: `/wp/v2/${ postType }`,
 		params: {
 			per_page: 100,
 			// All possible statuses.
@@ -42,7 +46,7 @@ export async function deleteAllPosts( this: RequestUtils ) {
 		posts.map( ( post ) =>
 			this.rest( {
 				method: 'DELETE',
-				path: `/wp/v2/posts/${ post.id }`,
+				path: `/wp/v2/${ postType }/${ post.id }`,
 				params: {
 					force: true,
 				},

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -19,10 +19,6 @@ test.describe( 'Post Data source', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
-	} );
-
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -11,11 +11,8 @@ test.describe( 'Post Meta source', () => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts( 'movie' );
-	} );
-
 	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts( 'movie' );
 		await requestUtils.deleteAllMedia();
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Post Meta source', () => {
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllPosts( 'movie' );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?
Delete `movie` posts after running Block Bindings e2e tests.

## Why?
They weren't previously deleted and instead lingered.

## How?
By adding an extra argument to the `deleteAllPosts()` e2e util that allows specifying the post type.

## Testing Instructions

Run the following Block Bindings related e2e tests while on `trunk`:

```
npm run test:e2e -- test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
```

(Ignore locally failing tests; they pass in CI, and will be fixed for local environments by https://github.com/WordPress/gutenberg/pull/72974.)

After they've finished, navigate to your test instance (e.g. `localhost:8889/wp-admin`), and activate the "Gutenberg Test Block Bindings" plugin. This will enable a "Movie" CPT and corresponding menu item in wp-admin. Click on that menu item, and verify that there are some drafts called "Test bindings"

Now switch to this branch, re-run tests, and repeat the above steps. Verify that this time around, there are no "Movie" posts left behind by tests.

## Screenshots

| Before | After |
|--------|------|
| <img width="950" height="924" alt="image" src="https://github.com/user-attachments/assets/f0e79f51-f7cc-4a5f-b4a5-db054fac0c28" /> | <img width="950" height="924" alt="image" src="https://github.com/user-attachments/assets/76d8146c-96c4-41f3-9627-bc9b9ce03446" /> |
