### PR TITLE
Lazy Editor: Fix script modules loading

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -544,12 +544,31 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 				}
 			}
 
+			// Build an import map from registered script modules.
+			// the import map need to be dynamically extended in the frontend.
+			$script_modules = wp_script_modules();
+			$registered     = array();
+			$reflection     = new ReflectionClass( $script_modules );
+			$property       = $reflection->getProperty( 'registered' );
+			$property->setAccessible( true );
+			$registered = $property->getValue( $script_modules );
+			$import_map = array();
+			foreach ( $registered as $id => $module ) {
+				// Handle both array and object formats.
+				if ( is_array( $module ) && isset( $module['src'] ) ) {
+					$import_map[ $id ] = $module['src'];
+				} elseif ( is_object( $module ) && isset( $module->src ) ) {
+					$import_map[ $id ] = $module->src;
+				}
+			}
+
 			return array(
 				'scripts'        => $scripts_data,
 				'styles'         => $styles_data,
 				'inline_scripts' => $inline_scripts,
 				'inline_styles'  => $inline_styles,
 				'html_templates' => $html_templates,
+				'script_modules' => $import_map,
 			);
 		}
 
@@ -624,6 +643,11 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 					),
 					'inline_styles'  => array(
 						'description' => __( 'Inline styles for editor assets.', 'gutenberg' ),
+						'type'        => 'object',
+						'readonly'    => true,
+					),
+					'script_modules' => array(
+						'description' => __( 'Script modules to load into the import map.', 'gutenberg' ),
 						'type'        => 'object',
 						'readonly'    => true,
 					),

--- a/packages/lazy-editor/src/hooks/use-editor-assets.tsx
+++ b/packages/lazy-editor/src/hooks/use-editor-assets.tsx
@@ -23,7 +23,8 @@ export async function loadEditorAssets() {
 			editorAssets.inline_scripts || { before: {}, after: {} },
 			editorAssets.styles || {},
 			editorAssets.inline_styles || { before: {}, after: {} },
-			editorAssets.html_templates || []
+			editorAssets.html_templates || [],
+			editorAssets.script_modules || {}
 		);
 	};
 


### PR DESCRIPTION
## What?

Related #72982 

When trying to load the editor lazily, it needs the mathml script modules for the math block. The issue though is that the asset loader doesn't update the "import map" properly with new changes that might be needed by the lazy editor. This PR fixes it.

## Testing Instructions

 - Open the boot package page http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot
 - Open "posts"
 - Open any random post in the editor
 - Try using the Math block. 
