### PR TITLE
Stretchy text: Hide variations in Block Inspector (hack)

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -213,17 +213,36 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	 */
 	const variations = useMemo( () => {
 		if ( blockName === 'core/paragraph' ) {
+			// Always hide options when active variation is stretchy, but
+			// ensure that there are no third-party variations before doing the
+			// same elsewhere.
+			if (
+				activeBlockVariation?.name === 'stretchy-paragraph' ||
+				unfilteredVariations.every( ( v ) =>
+					[ 'paragraph', 'stretchy-paragraph' ].includes( v.name )
+				)
+			) {
+				return [];
+			}
+			// If there are other variations, only hide the stretchy one.
 			return unfilteredVariations.filter(
-				( v ) =>
-					v.name !== 'paragraph' && v.name !== 'stretchy-paragraph'
+				( v ) => v.name !== 'stretchy-paragraph'
 			);
 		} else if ( blockName === 'core/heading' ) {
+			if (
+				activeBlockVariation?.name === 'stretchy-heading' ||
+				unfilteredVariations.every( ( v ) =>
+					[ 'heading', 'stretchy-heading' ].includes( v.name )
+				)
+			) {
+				return [];
+			}
 			return unfilteredVariations.filter(
-				( v ) => v.name !== 'heading' && v.name !== 'stretchy-heading'
+				( v ) => v.name !== 'stretchy-heading'
 			);
 		}
 		return unfilteredVariations;
-	}, [ unfilteredVariations ] );
+	}, [ activeBlockVariation?.name, blockName, unfilteredVariations ] );
 
 	const selectedValue = activeBlockVariation?.name;
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -147,41 +147,83 @@ function VariationsToggleGroupControl( {
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { activeBlockVariation, variations, isContentOnly, isSection } =
-		useSelect(
-			( select ) => {
-				const { getActiveBlockVariation, getBlockVariations } =
-					select( blocksStore );
+	const {
+		activeBlockVariation,
+		unfilteredVariations,
+		blockName,
+		isContentOnly,
+		isSection,
+	} = useSelect(
+		( select ) => {
+			const { getActiveBlockVariation, getBlockVariations } =
+				select( blocksStore );
 
-				const {
-					getBlockName,
-					getBlockAttributes,
-					getBlockEditingMode,
-					isSectionBlock,
-				} = unlock( select( blockEditorStore ) );
+			const {
+				getBlockName,
+				getBlockAttributes,
+				getBlockEditingMode,
+				isSectionBlock,
+			} = unlock( select( blockEditorStore ) );
 
-				const name = blockClientId && getBlockName( blockClientId );
+			const name = blockClientId && getBlockName( blockClientId );
 
-				const { hasContentRoleAttribute } = unlock(
-					select( blocksStore )
-				);
-				const isContentBlock = hasContentRoleAttribute( name );
+			const { hasContentRoleAttribute } = unlock( select( blocksStore ) );
+			const isContentBlock = hasContentRoleAttribute( name );
 
-				return {
-					activeBlockVariation: getActiveBlockVariation(
-						name,
-						getBlockAttributes( blockClientId ),
-						'transform'
-					),
-					variations: name && getBlockVariations( name, 'transform' ),
-					isContentOnly:
-						getBlockEditingMode( blockClientId ) ===
-							'contentOnly' && ! isContentBlock,
-					isSection: isSectionBlock( blockClientId ),
-				};
-			},
-			[ blockClientId ]
-		);
+			return {
+				activeBlockVariation: getActiveBlockVariation(
+					name,
+					getBlockAttributes( blockClientId ),
+					'transform'
+				),
+				unfilteredVariations:
+					name && getBlockVariations( name, 'transform' ),
+				blockName: name,
+				isContentOnly:
+					getBlockEditingMode( blockClientId ) === 'contentOnly' &&
+					! isContentBlock,
+				isSection: isSectionBlock( blockClientId ),
+			};
+		},
+		[ blockClientId ]
+	);
+
+	/*
+	 * Hack for WordPress 6.9
+	 *
+	 * The Stretchy blocks shipped in 6.9 were ultimately
+	 * implemented as block variations of the base types Paragraph
+	 * and Heading. See #73056 for discussion and trade-offs.
+	 *
+	 * The main drawback of this choice is that the Variations API
+	 * doesn't offer enough control over how prominent and how tied
+	 * to the base type a variation should be.
+	 *
+	 * In order to ship these new "blocks" with an acceptable UX,
+	 * we need two hacks until the Variations API is improved:
+	 *
+	 * - Don't show the variations switcher in the block inspector
+	 *   for Paragraph, Heading, Stretchy Paragraph and Stretchy
+	 *   Heading (implemented below). Transformations are still
+	 *   available in the block switcher.
+	 *
+	 * - Move the stretchy variations to the end of the core blocks
+	 *   list in the block inserter (implemented in
+	 *   getInserterItems in #73056).
+	 */
+	const variations = useMemo( () => {
+		if ( blockName === 'core/paragraph' ) {
+			return unfilteredVariations.filter(
+				( v ) =>
+					v.name !== 'paragraph' && v.name !== 'stretchy-paragraph'
+			);
+		} else if ( blockName === 'core/heading' ) {
+			return unfilteredVariations.filter(
+				( v ) => v.name !== 'heading' && v.name !== 'stretchy-heading'
+			);
+		}
+		return unfilteredVariations;
+	}, [ unfilteredVariations ] );
 
 	const selectedValue = activeBlockVariation?.name;
 


### PR DESCRIPTION
Follow-up of #73056.

Best read [with whitespace ignored](https://github.com/WordPress/gutenberg/pull/73238/files?w=1).

Implementing Stretchy Paragraph and Stretchy Heading as block variations makes them too prominent in the editor for what they are. This was already known in the base PR, but was worth the tradeoffs. One workaround done in the base PR was to patch `getInserterItems` to push the variations down the list. This PR applies the same idea to block transformations, so that they are still available but not via the block inspector:

|Before|After|
|-|-|
|<img width="253" height="207" alt="Screenshot 2025-11-13 at 12 21 26" src="https://github.com/user-attachments/assets/9e664866-6f0a-4181-b0b4-a60060b5eca2" />|<img width="254" height="115" alt="Screenshot 2025-11-13 at 13 00 01" src="https://github.com/user-attachments/assets/413d53e3-9b0b-4dad-a7ae-4bb34bb4265d" />|
|<img width="278" height="160" alt="Screenshot 2025-11-13 at 13 00 25" src="https://github.com/user-attachments/assets/2660675e-1a16-49d1-b877-f5130a9ac73b" />|<img width="258" height="103" alt="Screenshot 2025-11-13 at 13 00 11" src="https://github.com/user-attachments/assets/378564ae-0926-4407-9aa8-9be2b5bd1cfa" />|
|Likewise for Heading|Likewise for Heading|
|**Block switcher unchanged**<br> <img width="620" height="299" alt="Screenshot 2025-11-13 at 13 02 35" src="https://github.com/user-attachments/assets/1f3cb30c-589d-4dfe-891c-5082a58118a5" />|**Block switcher unchanged**<br> <img width="620" height="299" alt="Screenshot 2025-11-13 at 13 02 35" src="https://github.com/user-attachments/assets/1f3cb30c-589d-4dfe-891c-5082a58118a5" />|