### PR TITLE
Fix: Custom font size taking over fit text.

### DIFF
--- a/backport-changelog/6.9/10517.md
+++ b/backport-changelog/6.9/10517.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10517
+
+* https://github.com/WordPress/gutenberg/pull/73241

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -260,6 +260,7 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 				$block_content = $processor->get_updated_html();
 			}
 		}
+		// fitText supersedes any other typography features
 		return $block_content;
 	}
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -260,6 +260,7 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 				$block_content = $processor->get_updated_html();
 			}
 		}
+		return $block_content;
 	}
 
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -244,7 +244,7 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
  * @return string                Filtered block content.
  */
 function gutenberg_render_typography_support( $block_content, $block ) {
-	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
+	if ( ! empty( $block['attrs']['fitText'] ) && $block['attrs']['fitText'] && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 
 		// Add Interactivity API directives for fit text to work with client-side navigation.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/73211

Fixes an issue where if a paragraph/heading had a custom font size and then was conververted to the stretchy variation. The custom font size on the front end was applied instead of fit text.

cc: @mrwweb

## How?
Insert Paragraph block
Type some text in it
Set a non-default font size for the Paragraph block
Switch the Paragraph to the fit text Paragraph variation
The front-end of the site should not use the font size setting selected in Step 3 and should instead show fit text working normally as in the editor.
