### PR TITLE
Fix resolution comment actions becoming enabled after reopening

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -733,35 +733,35 @@ const CommentBoard = ( {
 		actionButtonRef.current?.focus();
 	};
 
-	const isParentComment = thread.parent === 0;
-	const hasResolved =
-		thread.status === 'approved' || parent?.status === 'approved';
-	const isReopenComment = thread.meta?._wp_note_status === 'reopen';
-	const isResolvedComment = thread.meta?._wp_note_status === 'resolved';
-	const isResolutionComment = isReopenComment || isResolvedComment;
+	const isParent = thread.parent === 0;
+	const metaStatus = thread.meta?._wp_note_status;
+	const isResolvedComment = metaStatus === 'resolved';
+	const isReopenComment = metaStatus === 'reopen';
+	const isResolutionComment = isResolvedComment || isReopenComment;
+
+	const hasResolved = ( status ) =>
+		status === 'approved' || parent?.status === 'approved';
 
 	const actions = [
 		{
 			id: 'edit',
 			title: __( 'Edit' ),
-			isEligible: () => ! isResolvedComment && ! hasResolved,
-			onClick: () => {
-				setActionState( 'edit' );
-			},
+			isEligible: ( { status } ) =>
+				! isResolvedComment && ! hasResolved( status ),
+			onClick: () => setActionState( 'edit' ),
 		},
 		{
 			id: 'reopen',
 			title: _x( 'Reopen', 'Reopen note' ),
-			isEligible: () => isParentComment && hasResolved,
-			onClick: () => {
-				onEdit( { id: thread.id, status: 'hold' } );
-			},
+			isEligible: ( { status } ) => isParent && hasResolved( status ),
+			onClick: () => onEdit( { id: thread.id, status: 'hold' } ),
 		},
 		{
 			id: 'delete',
 			title: __( 'Delete' ),
-			isEligible: () =>
-				isParentComment || ( ! isResolutionComment && ! hasResolved ),
+			isEligible: ( { status } ) =>
+				isParent ||
+				( ! isResolutionComment && ! hasResolved( status ) ),
 			onClick: () => {
 				setActionState( 'delete' );
 				setShowConfirmDialog( true );
@@ -770,7 +770,7 @@ const CommentBoard = ( {
 	];
 
 	const canResolve = thread.parent === 0;
-	const moreActions = actions.filter( ( item ) => item.isEligible() );
+	const moreActions = actions.filter( ( item ) => item.isEligible( thread ) );
 
 	return (
 		<VStack
@@ -870,7 +870,8 @@ const CommentBoard = ( {
 						'editor-collab-sidebar-panel__user-comment',
 						{
 							'editor-collab-sidebar-panel__resolution-text':
-								isResolutionComment,
+								metaStatus === 'resolved' ||
+								metaStatus === 'reopen',
 						}
 					) }
 				>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -734,11 +734,13 @@ const CommentBoard = ( {
 	};
 
 	// Check if this is a resolution comment by checking metadata.
+	const hasUserContent =
+		thread?.content?.raw && String( thread.content.raw ).trim() !== '';
 	const isResolutionComment =
 		thread.type === 'note' &&
 		thread.meta &&
 		( thread.meta._wp_note_status === 'resolved' ||
-			thread.meta._wp_note_status === 'reopen' );
+			( thread.meta._wp_note_status === 'reopen' && ! hasUserContent ) );
 
 	const actions = [
 		{
@@ -769,10 +771,12 @@ const CommentBoard = ( {
 	];
 
 	const canResolve = thread.parent === 0;
-	const moreActions =
-		parent?.status !== 'approved'
-			? actions.filter( ( item ) => item.isEligible( thread ) )
-			: [];
+
+	let moreActions = [];
+
+	if ( ! isResolutionComment && parent?.status !== 'approved' ) {
+		moreActions = actions.filter( ( item ) => item.isEligible( thread ) );
+	}
 
 	return (
 		<VStack

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -736,11 +736,16 @@ const CommentBoard = ( {
 	// Check if this is a resolution comment by checking metadata.
 	const hasUserContent =
 		thread?.content?.raw && String( thread.content.raw ).trim() !== '';
-	const isResolutionComment =
+	const isReopenComment =
 		thread.type === 'note' &&
 		thread.meta &&
-		( thread.meta._wp_note_status === 'resolved' ||
-			( thread.meta._wp_note_status === 'reopen' && ! hasUserContent ) );
+		thread.meta._wp_note_status === 'reopen';
+	const isResolvedComment =
+		thread.type === 'note' &&
+		thread.meta &&
+		thread.meta._wp_note_status === 'resolved';
+	const isResolutionComment =
+		isResolvedComment || ( isReopenComment && ! hasUserContent );
 
 	const actions = [
 		{
@@ -762,7 +767,7 @@ const CommentBoard = ( {
 		{
 			id: 'delete',
 			title: __( 'Delete' ),
-			isEligible: () => true,
+			isEligible: () => ! isReopenComment,
 			onClick: () => {
 				setActionState( 'delete' );
 				setShowConfirmDialog( true );
@@ -876,11 +881,11 @@ const CommentBoard = ( {
 						'editor-collab-sidebar-panel__user-comment',
 						{
 							'editor-collab-sidebar-panel__resolution-text':
-								isResolutionComment,
+								isResolvedComment || isReopenComment,
 						}
 					) }
 				>
-					{ isResolutionComment
+					{ isResolvedComment || isReopenComment
 						? ( () => {
 								const actionText =
 									thread.meta._wp_note_status === 'resolved'

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -733,25 +733,18 @@ const CommentBoard = ( {
 		actionButtonRef.current?.focus();
 	};
 
-	// Check if this is a resolution comment by checking metadata.
-	const hasUserContent =
-		thread?.content?.raw && String( thread.content.raw ).trim() !== '';
-	const isReopenComment =
-		thread.type === 'note' &&
-		thread.meta &&
-		thread.meta._wp_note_status === 'reopen';
-	const isResolvedComment =
-		thread.type === 'note' &&
-		thread.meta &&
-		thread.meta._wp_note_status === 'resolved';
-	const isResolutionComment =
-		isResolvedComment || ( isReopenComment && ! hasUserContent );
+	const isParentComment = thread.parent === 0;
+	const hasResolved =
+		thread.status === 'approved' || parent?.status === 'approved';
+	const isReopenComment = thread.meta?._wp_note_status === 'reopen';
+	const isResolvedComment = thread.meta?._wp_note_status === 'resolved';
+	const isResolutionComment = isReopenComment || isResolvedComment;
 
 	const actions = [
 		{
 			id: 'edit',
 			title: __( 'Edit' ),
-			isEligible: ( { status } ) => status !== 'approved',
+			isEligible: () => ! isResolvedComment && ! hasResolved,
 			onClick: () => {
 				setActionState( 'edit' );
 			},
@@ -759,7 +752,7 @@ const CommentBoard = ( {
 		{
 			id: 'reopen',
 			title: _x( 'Reopen', 'Reopen note' ),
-			isEligible: ( { status } ) => status === 'approved',
+			isEligible: () => isParentComment && hasResolved,
 			onClick: () => {
 				onEdit( { id: thread.id, status: 'hold' } );
 			},
@@ -767,7 +760,8 @@ const CommentBoard = ( {
 		{
 			id: 'delete',
 			title: __( 'Delete' ),
-			isEligible: () => ! isReopenComment,
+			isEligible: () =>
+				isParentComment || ( ! isResolutionComment && ! hasResolved ),
 			onClick: () => {
 				setActionState( 'delete' );
 				setShowConfirmDialog( true );
@@ -776,12 +770,7 @@ const CommentBoard = ( {
 	];
 
 	const canResolve = thread.parent === 0;
-
-	let moreActions = [];
-
-	if ( ! isResolutionComment && parent?.status !== 'approved' ) {
-		moreActions = actions.filter( ( item ) => item.isEligible( thread ) );
-	}
+	const moreActions = actions.filter( ( item ) => item.isEligible() );
 
 	return (
 		<VStack
@@ -881,11 +870,11 @@ const CommentBoard = ( {
 						'editor-collab-sidebar-panel__user-comment',
 						{
 							'editor-collab-sidebar-panel__resolution-text':
-								isResolvedComment || isReopenComment,
+								isResolutionComment,
 						}
 					) }
 				>
-					{ isResolvedComment || isReopenComment
+					{ isResolutionComment
 						? ( () => {
 								const actionText =
 									thread.meta._wp_note_status === 'resolved'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73236

Fixes an issue where menu actions (Edit, Delete) were incorrectly enabled for system-generated resolution comments after using "Reopen & Reply".

<!-- In a few words, what is the PR actually doing? -->

## Why?
When a note is resolved, a system-generated "Marked as resolved" comment is created. These resolution messages should always remain non-interactive and immutable. However, after using "Reopen & Reply", the menu actions became incorrectly enabled for the previously resolved entry, allowing users to interact with system-generated resolution messages in ways that should not be permitted.


## How?
**Disable menu actions for resolution comments**: Ensures that resolution comments always have an empty `moreActions` array, preventing any menu interactions.

## Testing Instructions

1. **Test system-generated resolution messages remain immutable:**
   - Create a new Note on any block
   - Click "Resolve" — a system-generated "Marked as resolved" comment appears
   - Verify menu actions are disabled (menu button should be disabled)
   - Add a reply to the note
   - Click "Reopen & Reply"
   - Verify the original "Marked as resolved" note still has disabled menu actions

2. **Test user replies via "Reopen & Reply" remain editable:**
   - Create a new Note on any block
   - Click "Resolve"
   - Click "Reopen & Reply" and add some text in the reply box
   - Submit the reply
   - Verify the newly created reply (with your text) has enabled menu actions (Edit, Delete should be available)

3. **Test system-generated "Reopened" messages:**
   - Create a new Note on any block
   - Click "Resolve"
   - Reopen the note without adding a reply (if this action exists)
   - Verify any system-generated "Reopened" message has disabled menu actions

## Video 


https://github.com/user-attachments/assets/586ed0db-e2ef-4636-a6ae-19671a1a6770

