### PR TITLE
DataViews: Only apply hover styles when there are bulk actions

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -394,6 +394,7 @@ function ViewTable< Item >( {
 						[ 'compact', 'comfortable' ].includes(
 							view.layout.density
 						),
+					'has-bulk-actions': hasBulkActions,
 				} ) }
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -127,9 +127,12 @@
 	// Hover styles only apply when bulk actions are available
 	&.has-bulk-actions {
 		tr {
-			&.is-hovered,
-			&.is-hovered .dataviews-view-table__actions-column--sticky {
-				background-color: #f8f8f8;
+			// Only apply hover background to non-selected rows
+			&:not(.is-selected) {
+				&.is-hovered,
+				&.is-hovered .dataviews-view-table__actions-column--sticky {
+					background-color: #f8f8f8;
+				}
 			}
 
 			&:focus-within,

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -79,11 +79,6 @@
 			border-bottom: 0;
 		}
 
-		&.is-hovered,
-		&.is-hovered .dataviews-view-table__actions-column--sticky {
-			background-color: #f8f8f8;
-		}
-
 		.components-checkbox-control__input.components-checkbox-control__input {
 			opacity: 0;
 
@@ -96,15 +91,6 @@
 
 		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
 			opacity: 0;
-		}
-
-		&:focus-within,
-		&.is-hovered,
-		&:hover {
-			.components-checkbox-control__input,
-			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
-				opacity: 1;
-			}
 		}
 
 		@media (hover: none) {
@@ -137,6 +123,26 @@
 			}
 		}
 	}
+
+	// Hover styles only apply when bulk actions are available
+	&.has-bulk-actions {
+		tr {
+			&.is-hovered,
+			&.is-hovered .dataviews-view-table__actions-column--sticky {
+				background-color: #f8f8f8;
+			}
+
+			&:focus-within,
+			&.is-hovered,
+			&:hover {
+				.components-checkbox-control__input,
+				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+					opacity: 1;
+				}
+			}
+		}
+	}
+
 	thead {
 		position: sticky;
 		inset-block-start: 0;


### PR DESCRIPTION
closes #65009 

## What?

As title :)

<!-- In a few words, what is the PR actually doing? -->

## Why?
The hover styles make the row appear interactive which can be misleading.

## How?
1. Added a conditional class to the table element: when `hasBulkActions` is true, the table gets the `has-bulk-actions class`.
2. Scoped the hover styles: moved the hover styles (background color on hover and opacity changes for checkboxes/actions) into a block that only applies when the table has the `has-bulk-actions` class.

## Testing Instructions
1. `npm run storybook`
2. Observe the [default DataViews story](http://localhost:50240/?path=/story/dataviews-dataviews--default) and check that the hover styles work as they do on trunk. 
3. Observe the [minimal UI DataViews story](http://localhost:50240/?path=/story/dataviews-dataviews--minimal-ui) and check that there are no hover styles when hovering a table row.