### PR TITLE
Breadcrumbs: Add `attachment` handling

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -118,7 +118,8 @@ export default function BreadcrumbEdit( {
 
 	// Try to determine breadcrumb type for more accurate previews.
 	let _showTerms;
-	// For non-hierarchical post types with a parent (e.g., attachments) use ancestor-based breadcrumbs.
+	// Some non-hierarchical post types (e.g., attachments) can have parents.
+	// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
 	if ( ! isPostTypeHierarchical && ! post?.parent ) {
 		_showTerms = true;
 	} else if ( ! postTypeHasTaxonomies ) {

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -116,9 +116,10 @@ export default function BreadcrumbEdit( {
 		);
 	}
 
-	// Determine breadcrumb type for accurate previews (matching PHP logic).
+	// Try to determine breadcrumb type for more accurate previews.
 	let _showTerms;
-	if ( ! isPostTypeHierarchical ) {
+	// For non-hierarchical post types with a parent (e.g., attachments) use ancestor-based breadcrumbs.
+	if ( ! isPostTypeHierarchical && ! post?.parent ) {
 		_showTerms = true;
 	} else if ( ! postTypeHasTaxonomies ) {
 		// Hierarchical post type without taxonomies can only use ancestors.

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -77,25 +77,24 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		}
 
 		// For non-hierarchical post types with parents (e.g., attachments), build trail for the parent.
-		$trail_post_id     = $post_id;
-		$trail_post_type   = $post_type;
-		$trail_post_parent = $post->post_parent;
-		$parent_post       = null;
-		if ( ! is_post_type_hierarchical( $post_type ) && $post->post_parent ) {
-			$parent_post = get_post( $post->post_parent );
+		$post_parent = $post->post_parent;
+		$parent_post = null;
+		if ( ! is_post_type_hierarchical( $post_type ) && $post_parent ) {
+			$parent_post = get_post( $post_parent );
 			if ( $parent_post ) {
-				// Use parent post for the breadcrumb trail.
-				$trail_post_id     = $parent_post->ID;
-				$trail_post_type   = $parent_post->post_type;
-				$trail_post_parent = $parent_post->post_parent;
+				$post_id     = $parent_post->ID;
+				$post_type   = $parent_post->post_type;
+				$post_parent = $parent_post->post_parent;
 			}
 		}
 
 		// Determine breadcrumb type.
+		// Some non-hierarchical post types (e.g., attachments) can have parents.
+		// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
 		$show_terms = false;
-		if ( ! is_post_type_hierarchical( $trail_post_type ) && ! $trail_post_parent ) {
+		if ( ! is_post_type_hierarchical( $post_type ) && ! $post_parent ) {
 			$show_terms = true;
-		} elseif ( empty( get_object_taxonomies( $trail_post_type, 'objects' ) ) ) {
+		} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
 			$show_terms = false;
 		} else {
 			$show_terms = $attributes['prefersTaxonomy'];
@@ -103,9 +102,9 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 
 		// Build breadcrumb trail.
 		if ( ! $show_terms ) {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $trail_post_id ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
 		} else {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $trail_post_id, $trail_post_type ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
 
 		// Add parent post title if applicable.

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -76,24 +76,48 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			return '';
 		}
 
-		// Determine breadcrumb type for accurate rendering (matching JavaScript logic).
+		// For non-hierarchical post types with parents (e.g., attachments), build trail for the parent.
+		$trail_post_id     = $post_id;
+		$trail_post_type   = $post_type;
+		$trail_post_parent = $post->post_parent;
+		$parent_post       = null;
+		if ( ! is_post_type_hierarchical( $post_type ) && $post->post_parent ) {
+			$parent_post = get_post( $post->post_parent );
+			if ( $parent_post ) {
+				// Use parent post for the breadcrumb trail.
+				$trail_post_id     = $parent_post->ID;
+				$trail_post_type   = $parent_post->post_type;
+				$trail_post_parent = $parent_post->post_parent;
+			}
+		}
+
+		// Determine breadcrumb type.
 		$show_terms = false;
-		if ( ! is_post_type_hierarchical( $post_type ) ) {
+		if ( ! is_post_type_hierarchical( $trail_post_type ) && ! $trail_post_parent ) {
 			$show_terms = true;
-		} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
-			// Hierarchical post type without taxonomies can only use ancestors.
+		} elseif ( empty( get_object_taxonomies( $trail_post_type, 'objects' ) ) ) {
 			$show_terms = false;
 		} else {
-			// For hierarchical post types with taxonomies, use the attribute.
 			$show_terms = $attributes['prefersTaxonomy'];
 		}
 
+		// Build breadcrumb trail.
 		if ( ! $show_terms ) {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $trail_post_id ) );
 		} else {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $trail_post_id, $trail_post_type ) );
 		}
-		// Add current post title (not linked).
+
+		// Add parent post title if applicable.
+		if ( $parent_post ) {
+			$breadcrumb_items[] = block_core_breadcrumbs_create_link(
+				get_permalink( $parent_post->ID ),
+				block_core_breadcrumbs_get_post_title( $parent_post ),
+				true
+			);
+		}
+
+		// Add current post title.
 		$breadcrumb_items[] = block_core_breadcrumbs_create_current_item( block_core_breadcrumbs_get_post_title( $post ), true );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498

This PR adds `attachment` handling. The code handles other custom post types similar to `attachments` that are not hierarchical, but have values in `post_parent`.



## Testing Instructions
1. Enable GB experimental blocks.
2.  Navigate to [settings](http://localhost:8888/wp-admin/options.php), and change the value of `wp_attachment_pages_enabled` setting to `1`. Save changes.
3. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various cases in the front end.
4. You can get any attachment URL by visiting media library and selecting an image. Then click `View attachment page`
5. Upload an attachment directly from media library -> The trail should include just the title of the attachment.
6. Upload an attachment in a page (hierarchical) -> The trail should include the page's ancestors.
7. Upload an attachment in a post with terms -> The trail should include the terms' trail of the post.

## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added x3p0-breadcrumbs plugin and the core block in the main header.
Above is x3p0-breadcrumbs and below is the core block.

#### With terms

<img width="531" height="122" alt="terms" src="https://github.com/user-attachments/assets/42c4fb4e-8177-4235-9c2a-9a597170760f" />

#### With ancestors


<img width="531" height="122" alt="page-hierarchical" src="https://github.com/user-attachments/assets/1938baa7-5bdf-4f5d-8516-da14008b5498" />

#### No parent (upload in media library)

<img width="531" height="122" alt="Screenshot 2025-11-13 at 6 30 22 PM" src="https://github.com/user-attachments/assets/6a699395-ee8e-4013-a835-ed845eac23b7" />


