### PR TITLE
Template activation: move to experiment

### DIFF
--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -2,7 +2,7 @@
 
 // Migrate existing "edited" templates. By existing, it means that the template
 // is active.
-function gutenberg_migrate_existing_templates() {
+function gutenberg_get_migrated_active_templates() {
 	// Query all templates in the database. See `get_block_templates`.
 	$wp_query_args = array(
 		'post_status'         => 'publish',

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -1,5 +1,52 @@
 <?php
 
+// Migrate existing "edited" templates. By existing, it means that the template
+// is active.
+function gutenberg_migrate_existing_templates() {
+	// Query all templates in the database. See `get_block_templates`.
+	$wp_query_args = array(
+		'post_status'         => 'publish',
+		'post_type'           => 'wp_template',
+		'posts_per_page'      => -1,
+		'no_found_rows'       => true,
+		'lazy_load_term_meta' => false,
+		'tax_query'           => array(
+			array(
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => get_stylesheet(),
+			),
+		),
+		// Only get templates that are not inactive by default.
+		'meta_query'          => array(
+			'relation' => 'OR',
+			array(
+				'key'     => 'is_inactive_by_default',
+				'compare' => 'NOT EXISTS',
+			),
+			array(
+				'key'     => 'is_inactive_by_default',
+				'value'   => false,
+				'compare' => '=',
+			),
+		),
+	);
+
+	$template_query   = new WP_Query( $wp_query_args );
+	$active_templates = array();
+
+	foreach ( $template_query->posts as $post ) {
+		$active_templates[ $post->post_name ] = $post->ID;
+	}
+
+	return $active_templates;
+}
+
+// Only load template activation system if the experiment is enabled.
+if ( ! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
+	return;
+}
+
 require_once __DIR__ . '/class-gutenberg-rest-old-templates-controller.php';
 
 // How does this work?
@@ -498,55 +545,6 @@ function gutenberg_set_active_template_theme( $changes, $request ) {
 		'is_inactive_by_default' => true,
 	);
 	return $changes;
-}
-
-// Migrate existing "edited" templates. By existing, it means that the template
-// is active.
-add_action( 'init', 'gutenberg_migrate_existing_templates' );
-function gutenberg_migrate_existing_templates() {
-	$active_templates = get_option( 'active_templates', false );
-
-	if ( false !== $active_templates ) {
-		return;
-	}
-
-	// Query all templates in the database. See `get_block_templates`.
-	$wp_query_args = array(
-		'post_status'         => 'publish',
-		'post_type'           => 'wp_template',
-		'posts_per_page'      => -1,
-		'no_found_rows'       => true,
-		'lazy_load_term_meta' => false,
-		'tax_query'           => array(
-			array(
-				'taxonomy' => 'wp_theme',
-				'field'    => 'name',
-				'terms'    => get_stylesheet(),
-			),
-		),
-		// Only get templates that are not inactive by default.
-		'meta_query'          => array(
-			'relation' => 'OR',
-			array(
-				'key'     => 'is_inactive_by_default',
-				'compare' => 'NOT EXISTS',
-			),
-			array(
-				'key'     => 'is_inactive_by_default',
-				'value'   => false,
-				'compare' => '=',
-			),
-		),
-	);
-
-	$template_query   = new WP_Query( $wp_query_args );
-	$active_templates = array();
-
-	foreach ( $template_query->posts as $post ) {
-		$active_templates[ $post->post_name ] = $post->ID;
-	}
-
-	update_option( 'active_templates', $active_templates );
 }
 
 add_action( 'save_post_wp_template', 'gutenberg_maybe_update_active_templates' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -37,6 +37,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalTemplateActivate = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -22,10 +22,12 @@ if ( ! function_exists( 'the_gutenberg_experiments' ) ) {
 		<form method="post" action="options.php">
 			<?php settings_fields( 'gutenberg-experiments' ); ?>
 			<?php do_settings_sections( 'gutenberg-experiments' ); ?>
+			<!-- We use a separate table for the template activation experiment because the option is managed separately. -->
 			<table class="form-table">
 				<tr>
 					<th scope="row">
 						<label for="active_templates"><?php echo __( 'Template Activation', 'gutenberg' ); ?></label>
+						<br><a href="https://github.com/WordPress/gutenberg/issues/66950" target="_blank"><?php echo __( 'Learn more', 'gutenberg' ); ?></a>
 					</th>
 					<td>
 						<label for="active_templates">
@@ -284,7 +286,7 @@ function gutenberg_handle_template_activate_setting_submission() {
 	}
 
 	if ( isset( $_POST['active_templates'] ) && '1' === $_POST['active_templates'] ) {
-		update_option( 'active_templates', gutenberg_migrate_existing_templates() );
+		update_option( 'active_templates', gutenberg_get_migrated_active_templates() );
 	} else {
 		delete_option( 'active_templates' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -22,6 +22,26 @@ if ( ! function_exists( 'the_gutenberg_experiments' ) ) {
 		<form method="post" action="options.php">
 			<?php settings_fields( 'gutenberg-experiments' ); ?>
 			<?php do_settings_sections( 'gutenberg-experiments' ); ?>
+			<table class="form-table">
+				<tr>
+					<th scope="row">
+						<label for="active_templates"><?php echo __( 'Template Activation', 'gutenberg' ); ?></label>
+					</th>
+					<td>
+						<label for="active_templates">
+							<input
+								type="checkbox"
+								name="active_templates"
+								id="active_templates"
+								value="1"
+								<?php checked( 1, gutenberg_is_experiment_enabled( 'active_templates' ) ); ?>
+							/>
+							<?php echo __( 'Allows multiple templates of the same type to be created, of which one can be active at a time.', 'gutenberg' ); ?>
+							<p class="description"><?php echo __( 'Warning: when you deactivate this experiment, it is best to delete all created templates except for the active ones.', 'gutenberg' ); ?></p>
+						</label>
+					</td>
+				</tr>
+			</table>
 			<?php submit_button(); ?>
 		</form>
 		</div>
@@ -247,4 +267,25 @@ function gutenberg_display_experiment_section() {
 	<p><?php echo __( "The block editor includes experimental features that are usable while they're in development. Select the ones you'd like to enable. These features are likely to change, so avoid using them in production.", 'gutenberg' ); ?></p>
 
 	<?php
+}
+
+add_action( 'admin_init', 'gutenberg_handle_template_activate_setting_submission' );
+function gutenberg_handle_template_activate_setting_submission() {
+	if ( ! isset( $_POST['option_page'] ) || 'gutenberg-experiments' !== $_POST['option_page'] ) {
+		return;
+	}
+
+	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'gutenberg-experiments-options' ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	if ( isset( $_POST['active_templates'] ) && '1' === $_POST['active_templates'] ) {
+		update_option( 'active_templates', gutenberg_migrate_existing_templates() );
+	} else {
+		delete_option( 'active_templates' );
+	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -30,6 +30,12 @@ if ( file_exists( $build_registration ) ) {
  * @return bool True when the experiment is enabled.
  */
 function gutenberg_is_experiment_enabled( $name ) {
+	// Special handling for active_templates - check if the active_templates option exists.
+	// This is not stored in the experiments array but as a separate option.
+	if ( 'active_templates' === $name ) {
+		return is_array( get_option( 'active_templates' ) );
+	}
+
 	$experiments = get_option( 'gutenberg-experiments' );
 	return ! empty( $experiments[ $name ] );
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -317,9 +317,10 @@ export const deleteEntityRecord =
 			if (
 				kind === 'postType' &&
 				name === 'wp_template' &&
-				recordId &&
-				typeof recordId === 'string' &&
-				! /^\d+$/.test( recordId )
+				( ( recordId &&
+					typeof recordId === 'string' &&
+					! /^\d+$/.test( recordId ) ) ||
+					! window?.__experimentalTemplateActivate )
 			) {
 				baseURL =
 					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +
@@ -571,9 +572,10 @@ export const saveEntityRecord =
 			if (
 				kind === 'postType' &&
 				name === 'wp_template' &&
-				recordId &&
-				typeof recordId === 'string' &&
-				! /^\d+$/.test( recordId )
+				( ( recordId &&
+					typeof recordId === 'string' &&
+					! /^\d+$/.test( recordId ) ) ||
+					! window?.__experimentalTemplateActivate )
 			) {
 				baseURL =
 					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -329,7 +329,10 @@ async function loadPostTypeEntities() {
 				}/${ parentId }/revisions${
 					revisionId ? '/' + revisionId : ''
 				}`,
-			revisionKey: DEFAULT_ENTITY_KEY,
+			revisionKey:
+				isTemplate && ! window?.__experimentalTemplateActivate
+					? 'wp_id'
+					: DEFAULT_ENTITY_KEY,
 		};
 
 		if ( window.__experimentalEnableSync ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -118,9 +118,8 @@ export const getEntityRecord =
 			if (
 				kind === 'postType' &&
 				name === 'wp_template' &&
-				key &&
-				typeof key === 'string' &&
-				! /^\d+$/.test( key )
+				( ( key && typeof key === 'string' && ! /^\d+$/.test( key ) ) ||
+					! window?.__experimentalTemplateActivate )
 			) {
 				baseURL =
 					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +

--- a/packages/edit-site/src/components/add-new-template-legacy/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/add-custom-generic-template-modal-content.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { paramCase as kebabCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+function AddCustomGenericTemplateModalContent( { createTemplate, onBack } ) {
+	const [ title, setTitle ] = useState( '' );
+	const defaultTitle = __( 'Custom Template' );
+	const [ isBusy, setIsBusy ] = useState( false );
+	const inputRef = useRef();
+
+	// Set focus to the name input when the component mounts
+	useEffect( () => {
+		if ( inputRef.current ) {
+			inputRef.current.focus();
+		}
+	}, [] );
+
+	async function onCreateTemplate( event ) {
+		event.preventDefault();
+		if ( isBusy ) {
+			return;
+		}
+		setIsBusy( true );
+		try {
+			await createTemplate(
+				{
+					slug:
+						kebabCase( title || defaultTitle ) ||
+						'wp-custom-template',
+					title: title || defaultTitle,
+				},
+				false
+			);
+		} finally {
+			setIsBusy( false );
+		}
+	}
+	return (
+		<form onSubmit={ onCreateTemplate }>
+			<VStack spacing={ 6 }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					placeholder={ defaultTitle }
+					disabled={ isBusy }
+					ref={ inputRef }
+					help={ __(
+						// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
+					) }
+				/>
+				<HStack
+					className="edit-site-custom-generic-template__modal-actions"
+					justify="right"
+				>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onBack }
+					>
+						{ __( 'Back' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						isBusy={ isBusy }
+						aria-disabled={ isBusy }
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}
+
+export default AddCustomGenericTemplateModalContent;

--- a/packages/edit-site/src/components/add-new-template-legacy/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/add-custom-template-modal-content.js
@@ -1,0 +1,314 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	SearchControl,
+	TextHighlight,
+	Composite,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useDebouncedInput } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
+import { safeDecodeURI } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { mapToIHasNameAndId } from './utils';
+
+const EMPTY_ARRAY = [];
+
+function SuggestionListItem( {
+	suggestion,
+	search,
+	onSelect,
+	entityForSuggestions,
+} ) {
+	const baseCssClass =
+		'edit-site-custom-template-modal__suggestions_list__list-item';
+	return (
+		<Composite.Item
+			render={
+				<Button
+					__next40pxDefaultSize
+					role="option"
+					className={ baseCssClass }
+					onClick={ () =>
+						onSelect(
+							entityForSuggestions.config.getSpecificTemplate(
+								suggestion
+							)
+						)
+					}
+				/>
+			}
+		>
+			<Text
+				size="body"
+				lineHeight={ 1.53846153846 } // 20px
+				weight={ 500 }
+				className={ `${ baseCssClass }__title` }
+			>
+				<TextHighlight
+					text={ decodeEntities( suggestion.name ) }
+					highlight={ search }
+				/>
+			</Text>
+			{ suggestion.link && (
+				<Text
+					size="body"
+					lineHeight={ 1.53846153846 } // 20px
+					className={ `${ baseCssClass }__info` }
+				>
+					{ safeDecodeURI( suggestion.link ) }
+				</Text>
+			) }
+		</Composite.Item>
+	);
+}
+
+function useSearchSuggestions( entityForSuggestions, search ) {
+	const { config } = entityForSuggestions;
+	const query = useMemo(
+		() => ( {
+			order: 'asc',
+			context: 'view',
+			search,
+			per_page: search ? 20 : 10,
+			...config.queryArgs( search ),
+		} ),
+		[ search, config ]
+	);
+	const { records: searchResults, hasResolved: searchHasResolved } =
+		useEntityRecords(
+			entityForSuggestions.type,
+			entityForSuggestions.slug,
+			query
+		);
+	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
+	useEffect( () => {
+		if ( ! searchHasResolved ) {
+			return;
+		}
+		let newSuggestions = EMPTY_ARRAY;
+		if ( searchResults?.length ) {
+			newSuggestions = searchResults;
+			if ( config.recordNamePath ) {
+				newSuggestions = mapToIHasNameAndId(
+					newSuggestions,
+					config.recordNamePath
+				);
+			}
+		}
+		// Update suggestions only when the query has resolved, so as to keep
+		// the previous results in the UI.
+		setSuggestions( newSuggestions );
+	}, [ searchResults, searchHasResolved ] );
+	return suggestions;
+}
+
+function SuggestionList( { entityForSuggestions, onSelect } ) {
+	const [ search, setSearch, debouncedSearch ] = useDebouncedInput();
+	const suggestions = useSearchSuggestions(
+		entityForSuggestions,
+		debouncedSearch
+	);
+	const { labels } = entityForSuggestions;
+	const [ showSearchControl, setShowSearchControl ] = useState( false );
+	if ( ! showSearchControl && suggestions?.length > 9 ) {
+		setShowSearchControl( true );
+	}
+	return (
+		<>
+			{ showSearchControl && (
+				<SearchControl
+					__nextHasNoMarginBottom
+					onChange={ setSearch }
+					value={ search }
+					label={ labels.search_items }
+					placeholder={ labels.search_items }
+				/>
+			) }
+			{ !! suggestions?.length && (
+				<Composite
+					orientation="vertical"
+					role="listbox"
+					className="edit-site-custom-template-modal__suggestions_list"
+					aria-label={ __( 'Suggestions list' ) }
+				>
+					{ suggestions.map( ( suggestion ) => (
+						<SuggestionListItem
+							key={ suggestion.slug }
+							suggestion={ suggestion }
+							search={ debouncedSearch }
+							onSelect={ onSelect }
+							entityForSuggestions={ entityForSuggestions }
+						/>
+					) ) }
+				</Composite>
+			) }
+			{ debouncedSearch && ! suggestions?.length && (
+				<Text
+					as="p"
+					className="edit-site-custom-template-modal__no-results"
+				>
+					{ labels.not_found }
+				</Text>
+			) }
+		</>
+	);
+}
+
+function AddCustomTemplateModalContent( {
+	onSelect,
+	entityForSuggestions,
+	onBack,
+	containerRef,
+} ) {
+	const [ showSearchEntities, setShowSearchEntities ] = useState(
+		entityForSuggestions.hasGeneralTemplate
+	);
+
+	// Focus on the first focusable element when the modal opens.
+	// We handle focus management in the parent modal, just need to focus on the first focusable element.
+	useEffect( () => {
+		if ( containerRef.current ) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ showSearchEntities ] );
+
+	return (
+		<VStack
+			spacing={ 4 }
+			className="edit-site-custom-template-modal__contents-wrapper"
+			alignment="left"
+		>
+			{ ! showSearchEntities && (
+				<>
+					<Text as="p">
+						{ __(
+							'Select whether to create a single template for all items or a specific one.'
+						) }
+					</Text>
+					<Flex
+						className="edit-site-custom-template-modal__contents"
+						gap="4"
+						align="initial"
+					>
+						<FlexItem
+							isBlock
+							as={ Button }
+							onClick={ () => {
+								const {
+									slug,
+									title,
+									description,
+									templatePrefix,
+								} = entityForSuggestions.template;
+								onSelect( {
+									slug,
+									title,
+									description,
+									templatePrefix,
+								} );
+							} }
+						>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{ entityForSuggestions.labels.all_items }
+							</Text>
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
+									__( 'For all items' )
+								}
+							</Text>
+						</FlexItem>
+						<FlexItem
+							isBlock
+							as={ Button }
+							onClick={ () => {
+								setShowSearchEntities( true );
+							} }
+						>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{ entityForSuggestions.labels.singular_name }
+							</Text>
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
+									__( 'For a specific item' )
+								}
+							</Text>
+						</FlexItem>
+					</Flex>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onBack }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
+				</>
+			) }
+			{ showSearchEntities && (
+				<>
+					<Text as="p">
+						{ __(
+							'This template will be used only for the specific item chosen.'
+						) }
+					</Text>
+					<SuggestionList
+						entityForSuggestions={ entityForSuggestions }
+						onSelect={ onSelect }
+					/>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => {
+								// If general template exists, go directly back to main screen
+								// instead of showing the choice screen
+								if ( entityForSuggestions.hasGeneralTemplate ) {
+									onBack();
+								} else {
+									setShowSearchEntities( false );
+								}
+							} }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
+				</>
+			) }
+		</VStack>
+	);
+}
+
+export default AddCustomTemplateModalContent;

--- a/packages/edit-site/src/components/add-new-template-legacy/index.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/index.js
@@ -1,0 +1,454 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Modal,
+	__experimentalGrid as Grid,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Flex,
+	Icon,
+} from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState, memo, useRef, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useViewportMatch } from '@wordpress/compose';
+import {
+	archive,
+	blockMeta,
+	calendar,
+	category,
+	commentAuthorAvatar,
+	pencil,
+	home,
+	layout,
+	list,
+	media,
+	notFound,
+	page,
+	pin,
+	verse,
+	search,
+	tag,
+} from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { focus } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+
+/**
+ * Internal dependencies
+ */
+import AddCustomTemplateModalContent from './add-custom-template-modal-content';
+import {
+	useExistingTemplates,
+	useDefaultTemplateTypes,
+	useTaxonomiesMenuItems,
+	usePostTypeMenuItems,
+	useAuthorMenuItem,
+	usePostTypeArchiveMenuItems,
+} from './utils';
+import AddCustomGenericTemplateModalContent from './add-custom-generic-template-modal-content';
+import { unlock } from '../../lock-unlock';
+
+const { useHistory } = unlock( routerPrivateApis );
+
+const DEFAULT_TEMPLATE_SLUGS = [
+	'front-page',
+	'home',
+	'single',
+	'page',
+	'index',
+	'archive',
+	'author',
+	'category',
+	'date',
+	'tag',
+	'search',
+	'404',
+];
+
+const TEMPLATE_ICONS = {
+	'front-page': home,
+	home: verse,
+	single: pin,
+	page,
+	archive,
+	search,
+	404: notFound,
+	index: list,
+	category,
+	author: commentAuthorAvatar,
+	taxonomy: blockMeta,
+	date: calendar,
+	tag,
+	attachment: media,
+};
+
+function TemplateListItem( {
+	title,
+	direction,
+	className,
+	description,
+	icon,
+	onClick,
+	children,
+} ) {
+	return (
+		<Button
+			__next40pxDefaultSize
+			className={ className }
+			onClick={ onClick }
+			label={ description }
+			showTooltip={ !! description }
+		>
+			<Flex
+				as="span"
+				spacing={ 2 }
+				align="center"
+				justify="center"
+				style={ { width: '100%' } }
+				direction={ direction }
+			>
+				<div className="edit-site-add-new-template__template-icon">
+					<Icon icon={ icon } />
+				</div>
+				<VStack
+					className="edit-site-add-new-template__template-name"
+					alignment="center"
+					spacing={ 0 }
+				>
+					<Text
+						align="center"
+						weight={ 500 }
+						lineHeight={ 1.53846153846 } // 20px
+					>
+						{ title }
+					</Text>
+					{ children }
+				</VStack>
+			</Flex>
+		</Button>
+	);
+}
+
+const modalContentMap = {
+	templatesList: 1,
+	customTemplate: 2,
+	customGenericTemplate: 3,
+};
+
+function NewTemplateModal( { onClose } ) {
+	const [ modalContent, setModalContent ] = useState(
+		modalContentMap.templatesList
+	);
+	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const missingTemplates = useMissingTemplates( setEntityForSuggestions, () =>
+		setModalContent( modalContentMap.customTemplate )
+	);
+	const history = useHistory();
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+	const containerRef = useRef( null );
+	const isMobile = useViewportMatch( 'medium', '<' );
+
+	const homeUrl = useSelect( ( select ) => {
+		// Site index.
+		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			?.home;
+	}, [] );
+
+	const TEMPLATE_SHORT_DESCRIPTIONS = {
+		'front-page': homeUrl,
+		date: sprintf(
+			// translators: %s: The homepage url.
+			__( 'E.g. %s' ),
+			homeUrl + '/' + new Date().getFullYear()
+		),
+	};
+
+	useEffect( () => {
+		// Focus the first focusable element when component mounts or UI changes
+		// We don't want to focus on the other modals because they have their own focus management.
+		if (
+			containerRef.current &&
+			modalContent === modalContentMap.templatesList
+		) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ modalContent ] );
+
+	async function createTemplate( template, isWPSuggestion = true ) {
+		if ( isSubmitting ) {
+			return;
+		}
+		setIsSubmitting( true );
+		try {
+			const { title, description, slug } = template;
+			const newTemplate = await saveEntityRecord(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					description,
+					// Slugs need to be strings, so this is for template `404`
+					slug: slug.toString(),
+					status: 'publish',
+					title,
+					// This adds a post meta field in template that is part of `is_custom` value calculation.
+					is_wp_suggestion: isWPSuggestion,
+				},
+				{ throwOnError: true }
+			);
+
+			// Navigate to the created template editor.
+			history.navigate(
+				`/${ TEMPLATE_POST_TYPE }/${ newTemplate.id }?canvas=edit`
+			);
+
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: Title of the created post or template, e.g: "Hello world".
+					__( '"%s" successfully created.' ),
+					decodeEntities( newTemplate.title?.rendered || title ) ||
+						__( '(no title)' )
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the template.' );
+
+			createErrorNotice( errorMessage, {
+				type: 'snackbar',
+			} );
+		} finally {
+			setIsSubmitting( false );
+		}
+	}
+	const onModalClose = () => {
+		onClose();
+		setModalContent( modalContentMap.templatesList );
+	};
+
+	let modalTitle = __( 'Add template' );
+	if ( modalContent === modalContentMap.customTemplate ) {
+		modalTitle = sprintf(
+			// translators: %s: Name of the post type e.g: "Post".
+			__( 'Add template: %s' ),
+			entityForSuggestions.labels.singular_name
+		);
+	} else if ( modalContent === modalContentMap.customGenericTemplate ) {
+		modalTitle = __( 'Create custom template' );
+	}
+
+	return (
+		<Modal
+			title={ modalTitle }
+			className={ clsx( 'edit-site-add-new-template__modal', {
+				'edit-site-add-new-template__modal_template_list':
+					modalContent === modalContentMap.templatesList,
+				'edit-site-custom-template-modal':
+					modalContent === modalContentMap.customTemplate,
+			} ) }
+			onRequestClose={ onModalClose }
+			overlayClassName={
+				modalContent === modalContentMap.customGenericTemplate
+					? 'edit-site-custom-generic-template__modal'
+					: undefined
+			}
+			ref={ containerRef }
+		>
+			{ modalContent === modalContentMap.templatesList && (
+				<Grid
+					columns={ isMobile ? 2 : 3 }
+					gap={ 4 }
+					align="flex-start"
+					justify="center"
+					className="edit-site-add-new-template__template-list__contents"
+				>
+					<Flex className="edit-site-add-new-template__template-list__prompt">
+						{ __(
+							'Select what the new template should apply to:'
+						) }
+					</Flex>
+					{ missingTemplates.map( ( template ) => {
+						const { title, slug, onClick } = template;
+						return (
+							<TemplateListItem
+								key={ slug }
+								title={ title }
+								direction="column"
+								className="edit-site-add-new-template__template-button"
+								description={
+									TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
+								}
+								icon={ TEMPLATE_ICONS[ slug ] || layout }
+								onClick={ () =>
+									onClick
+										? onClick( template )
+										: createTemplate( template )
+								}
+							/>
+						);
+					} ) }
+					<TemplateListItem
+						title={ __( 'Custom template' ) }
+						direction="row"
+						className="edit-site-add-new-template__custom-template-button"
+						icon={ pencil }
+						onClick={ () =>
+							setModalContent(
+								modalContentMap.customGenericTemplate
+							)
+						}
+					>
+						<Text
+							lineHeight={ 1.53846153846 } // 20px
+						>
+							{ __(
+								'A custom template can be manually applied to any post or page.'
+							) }
+						</Text>
+					</TemplateListItem>
+				</Grid>
+			) }
+			{ modalContent === modalContentMap.customTemplate && (
+				<AddCustomTemplateModalContent
+					onSelect={ createTemplate }
+					entityForSuggestions={ entityForSuggestions }
+					onBack={ () =>
+						setModalContent( modalContentMap.templatesList )
+					}
+					containerRef={ containerRef }
+				/>
+			) }
+			{ modalContent === modalContentMap.customGenericTemplate && (
+				<AddCustomGenericTemplateModalContent
+					createTemplate={ createTemplate }
+					onBack={ () =>
+						setModalContent( modalContentMap.templatesList )
+					}
+				/>
+			) }
+		</Modal>
+	);
+}
+
+function NewTemplate() {
+	const [ showModal, setShowModal ] = useState( false );
+
+	const { postType } = useSelect( ( select ) => {
+		const { getPostType } = select( coreStore );
+
+		return {
+			postType: getPostType( TEMPLATE_POST_TYPE ),
+		};
+	}, [] );
+
+	if ( ! postType ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Button
+				variant="primary"
+				onClick={ () => setShowModal( true ) }
+				label={ postType.labels.add_new_item }
+				__next40pxDefaultSize
+			>
+				{ postType.labels.add_new_item }
+			</Button>
+			{ showModal && (
+				<NewTemplateModal onClose={ () => setShowModal( false ) } />
+			) }
+		</>
+	);
+}
+
+function useMissingTemplates( setEntityForSuggestions, onClick ) {
+	const existingTemplates = useExistingTemplates();
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	const existingTemplateSlugs = ( existingTemplates || [] ).map(
+		( { slug } ) => slug
+	);
+	const missingDefaultTemplates = ( defaultTemplateTypes || [] ).filter(
+		( template ) =>
+			DEFAULT_TEMPLATE_SLUGS.includes( template.slug ) &&
+			! existingTemplateSlugs.includes( template.slug )
+	);
+	const onClickMenuItem = ( _entityForSuggestions ) => {
+		onClick?.();
+		setEntityForSuggestions( _entityForSuggestions );
+	};
+	// We need to replace existing default template types with
+	// the create specific template functionality. The original
+	// info (title, description, etc.) is preserved in the
+	// used hooks.
+	const enhancedMissingDefaultTemplateTypes = [ ...missingDefaultTemplates ];
+	const { defaultTaxonomiesMenuItems, taxonomiesMenuItems } =
+		useTaxonomiesMenuItems( onClickMenuItem );
+	const { defaultPostTypesMenuItems, postTypesMenuItems } =
+		usePostTypeMenuItems( onClickMenuItem );
+
+	const authorMenuItem = useAuthorMenuItem( onClickMenuItem );
+	[
+		...defaultTaxonomiesMenuItems,
+		...defaultPostTypesMenuItems,
+		authorMenuItem,
+	].forEach( ( menuItem ) => {
+		if ( ! menuItem ) {
+			return;
+		}
+		const matchIndex = enhancedMissingDefaultTemplateTypes.findIndex(
+			( template ) => template.slug === menuItem.slug
+		);
+		// Some default template types might have been filtered above from
+		// `missingDefaultTemplates` because they only check for the general
+		// template. So here we either replace or append the item, augmented
+		// with the check if it has available specific item to create a
+		// template for.
+		if ( matchIndex > -1 ) {
+			enhancedMissingDefaultTemplateTypes[ matchIndex ] = menuItem;
+		} else {
+			enhancedMissingDefaultTemplateTypes.push( menuItem );
+		}
+	} );
+	// Update the sort order to match the DEFAULT_TEMPLATE_SLUGS order.
+	enhancedMissingDefaultTemplateTypes?.sort( ( template1, template2 ) => {
+		return (
+			DEFAULT_TEMPLATE_SLUGS.indexOf( template1.slug ) -
+			DEFAULT_TEMPLATE_SLUGS.indexOf( template2.slug )
+		);
+	} );
+	const missingTemplates = [
+		...enhancedMissingDefaultTemplateTypes,
+		...usePostTypeArchiveMenuItems(),
+		...postTypesMenuItems,
+		...taxonomiesMenuItems,
+	];
+	return missingTemplates;
+}
+
+export default memo( NewTemplate );

--- a/packages/edit-site/src/components/add-new-template-legacy/utils.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/utils.js
@@ -1,0 +1,760 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useMemo, useCallback } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { blockMeta, post, archive } from '@wordpress/icons';
+import { safeDecodeURI } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+
+const EMPTY_OBJECT = {};
+
+/**
+ * @typedef IHasNameAndId
+ * @property {string|number} id   The entity's id.
+ * @property {string}        name The entity's name.
+ */
+
+const getValueFromObjectPath = ( object, path ) => {
+	let value = object;
+	path.split( '.' ).forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+};
+
+/**
+ * Helper that adds a prefix to a post slug. The slug needs to be URL-decoded first,
+ * so that we have raw Unicode characters there. The server will truncate the slug to
+ * 200 characters, respecing Unicode char boundary. On the other hand, the server
+ * doesn't detect urlencoded octet boundary and can possibly construct slugs that
+ * are not valid urlencoded strings.
+ * @param {string} prefix The prefix to add to the slug.
+ * @param {string} slug   The slug to add the prefix to.
+ * @return {string} The slug with the prefix.
+ */
+function prefixSlug( prefix, slug ) {
+	return `${ prefix }-${ safeDecodeURI( slug ) }`;
+}
+
+/**
+ * Helper util to map records to add a `name` prop from a
+ * provided path, in order to handle all entities in the same
+ * fashion(implementing`IHasNameAndId` interface).
+ *
+ * @param {Object[]} entities The array of entities.
+ * @param {string}   path     The path to map a `name` property from the entity.
+ * @return {IHasNameAndId[]} An array of entities that now implement the `IHasNameAndId` interface.
+ */
+export const mapToIHasNameAndId = ( entities, path ) => {
+	return ( entities || [] ).map( ( entity ) => ( {
+		...entity,
+		name: decodeEntities( getValueFromObjectPath( entity, path ) ),
+	} ) );
+};
+
+/**
+ * @typedef {Object} EntitiesInfo
+ * @property {boolean}  hasEntities         If an entity has available records(posts, terms, etc..).
+ * @property {number[]} existingEntitiesIds An array of the existing entities ids.
+ */
+
+export const useExistingTemplates = () => {
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					per_page: -1,
+				}
+			),
+		[]
+	);
+};
+
+export const useDefaultTemplateTypes = () => {
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getCurrentTheme()?.default_template_types || [],
+		[]
+	);
+};
+
+const usePublicPostTypes = () => {
+	const postTypes = useSelect(
+		( select ) => select( coreStore ).getPostTypes( { per_page: -1 } ),
+		[]
+	);
+	return useMemo( () => {
+		const excludedPostTypes = [ 'attachment' ];
+		return postTypes
+			?.filter(
+				( { viewable, slug } ) =>
+					viewable && ! excludedPostTypes.includes( slug )
+			)
+			.sort( ( a, b ) => {
+				// Sort post types alphabetically by name,
+				// but exclude the built-in 'post' type from sorting.
+				if ( a.slug === 'post' || b.slug === 'post' ) {
+					return 0;
+				}
+
+				return a.name.localeCompare( b.name );
+			} );
+	}, [ postTypes ] );
+};
+
+const usePublicTaxonomies = () => {
+	const taxonomies = useSelect(
+		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ),
+		[]
+	);
+	return useMemo( () => {
+		return taxonomies?.filter(
+			( { visibility } ) => visibility?.publicly_queryable
+		);
+	}, [ taxonomies ] );
+};
+
+export function usePostTypeArchiveMenuItems() {
+	const publicPostTypes = usePublicPostTypes();
+	const postTypesWithArchives = useMemo(
+		() => publicPostTypes?.filter( ( postType ) => postType.has_archive ),
+		[ publicPostTypes ]
+	);
+	const existingTemplates = useExistingTemplates();
+	// We need to keep track of naming conflicts. If a conflict
+	// occurs, we need to add slug.
+	const postTypeLabels = useMemo(
+		() =>
+			publicPostTypes?.reduce( ( accumulator, { labels } ) => {
+				const singularName = labels.singular_name.toLowerCase();
+				accumulator[ singularName ] =
+					( accumulator[ singularName ] || 0 ) + 1;
+				return accumulator;
+			}, {} ),
+		[ publicPostTypes ]
+	);
+	const needsUniqueIdentifier = useCallback(
+		( { labels, slug } ) => {
+			const singularName = labels.singular_name.toLowerCase();
+			return postTypeLabels[ singularName ] > 1 && singularName !== slug;
+		},
+		[ postTypeLabels ]
+	);
+	return useMemo(
+		() =>
+			postTypesWithArchives
+				?.filter(
+					( postType ) =>
+						! ( existingTemplates || [] ).some(
+							( existingTemplate ) =>
+								existingTemplate.slug ===
+								'archive-' + postType.slug
+						)
+				)
+				.map( ( postType ) => {
+					let title;
+					if ( needsUniqueIdentifier( postType ) ) {
+						title = sprintf(
+							// translators: %1s: Name of the post type e.g: "Post"; %2s: Slug of the post type e.g: "book".
+							__( 'Archive: %1$s (%2$s)' ),
+							postType.labels.singular_name,
+							postType.slug
+						);
+					} else {
+						title = sprintf(
+							// translators: %s: Name of the post type e.g: "Post".
+							__( 'Archive: %s' ),
+							postType.labels.singular_name
+						);
+					}
+					return {
+						slug: 'archive-' + postType.slug,
+						description: sprintf(
+							// translators: %s: Name of the post type e.g: "Post".
+							__(
+								'Displays an archive with the latest posts of type: %s.'
+							),
+							postType.labels.singular_name
+						),
+						title,
+						// `icon` is the `menu_icon` property of a post type. We
+						// only handle `dashicons` for now, even if the `menu_icon`
+						// also supports urls and svg as values.
+						icon:
+							typeof postType.icon === 'string' &&
+							postType.icon.startsWith( 'dashicons-' )
+								? postType.icon.slice( 10 )
+								: archive,
+						templatePrefix: 'archive',
+					};
+				} ) || [],
+		[ postTypesWithArchives, existingTemplates, needsUniqueIdentifier ]
+	);
+}
+
+export const usePostTypeMenuItems = ( onClickMenuItem ) => {
+	const publicPostTypes = usePublicPostTypes();
+	const existingTemplates = useExistingTemplates();
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	// We need to keep track of naming conflicts. If a conflict
+	// occurs, we need to add slug.
+	const templateLabels = useMemo(
+		() =>
+			publicPostTypes?.reduce( ( accumulator, { labels } ) => {
+				const templateName = (
+					labels.template_name || labels.singular_name
+				).toLowerCase();
+				accumulator[ templateName ] =
+					( accumulator[ templateName ] || 0 ) + 1;
+				return accumulator;
+			}, {} ),
+		[ publicPostTypes ]
+	);
+	const needsUniqueIdentifier = useCallback(
+		( { labels, slug } ) => {
+			const templateName = (
+				labels.template_name || labels.singular_name
+			).toLowerCase();
+			return templateLabels[ templateName ] > 1 && templateName !== slug;
+		},
+		[ templateLabels ]
+	);
+
+	// `page`is a special case in template hierarchy.
+	const templatePrefixes = useMemo(
+		() =>
+			publicPostTypes?.reduce( ( accumulator, { slug } ) => {
+				let suffix = slug;
+				if ( slug !== 'page' ) {
+					suffix = `single-${ suffix }`;
+				}
+				accumulator[ slug ] = suffix;
+				return accumulator;
+			}, {} ),
+		[ publicPostTypes ]
+	);
+	const postTypesInfo = useEntitiesInfo( 'postType', templatePrefixes );
+	const existingTemplateSlugs = ( existingTemplates || [] ).map(
+		( { slug } ) => slug
+	);
+	const menuItems = ( publicPostTypes || [] ).reduce(
+		( accumulator, postType ) => {
+			const { slug, labels, icon } = postType;
+			// We need to check if the general template is part of the
+			// defaultTemplateTypes. If it is, just use that info and
+			// augment it with the specific template functionality.
+			const generalTemplateSlug = templatePrefixes[ slug ];
+			const defaultTemplateType = defaultTemplateTypes?.find(
+				( { slug: _slug } ) => _slug === generalTemplateSlug
+			);
+			const hasGeneralTemplate =
+				existingTemplateSlugs?.includes( generalTemplateSlug );
+			const _needsUniqueIdentifier = needsUniqueIdentifier( postType );
+			let menuItemTitle =
+				labels.template_name ||
+				sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Single item: %s' ),
+					labels.singular_name
+				);
+			if ( _needsUniqueIdentifier ) {
+				menuItemTitle = labels.template_name
+					? sprintf(
+							// translators: 1: Name of the template e.g: "Single Item: Post". 2: Slug of the post type e.g: "book".
+							_x( '%1$s (%2$s)', 'post type menu label' ),
+							labels.template_name,
+							slug
+					  )
+					: sprintf(
+							// translators: 1: Name of the post type e.g: "Post". 2: Slug of the post type e.g: "book".
+							_x(
+								'Single item: %1$s (%2$s)',
+								'post type menu label'
+							),
+							labels.singular_name,
+							slug
+					  );
+			}
+			const menuItem = defaultTemplateType
+				? {
+						...defaultTemplateType,
+						templatePrefix: templatePrefixes[ slug ],
+				  }
+				: {
+						slug: generalTemplateSlug,
+						title: menuItemTitle,
+						description: sprintf(
+							// translators: %s: Name of the post type e.g: "Post".
+							__( 'Displays a single item: %s.' ),
+							labels.singular_name
+						),
+						// `icon` is the `menu_icon` property of a post type. We
+						// only handle `dashicons` for now, even if the `menu_icon`
+						// also supports urls and svg as values.
+						icon:
+							typeof icon === 'string' &&
+							icon.startsWith( 'dashicons-' )
+								? icon.slice( 10 )
+								: post,
+						templatePrefix: templatePrefixes[ slug ],
+				  };
+			const hasEntities = postTypesInfo?.[ slug ]?.hasEntities;
+			// We have a different template creation flow only if they have entities.
+			if ( hasEntities ) {
+				menuItem.onClick = ( template ) => {
+					onClickMenuItem( {
+						type: 'postType',
+						slug,
+						config: {
+							recordNamePath: 'title.rendered',
+							queryArgs: ( { search } ) => {
+								return {
+									_fields: 'id,title,slug,link',
+									orderBy: search ? 'relevance' : 'modified',
+									exclude:
+										postTypesInfo[ slug ]
+											.existingEntitiesIds,
+								};
+							},
+							getSpecificTemplate: ( suggestion ) => {
+								const templateSlug = prefixSlug(
+									templatePrefixes[ slug ],
+									suggestion.slug
+								);
+								return {
+									title: templateSlug,
+									slug: templateSlug,
+									templatePrefix: templatePrefixes[ slug ],
+								};
+							},
+						},
+						labels,
+						hasGeneralTemplate,
+						template,
+					} );
+				};
+			}
+			// We don't need to add the menu item if there are no
+			// entities and the general template exists.
+			if ( ! hasGeneralTemplate || hasEntities ) {
+				accumulator.push( menuItem );
+			}
+			return accumulator;
+		},
+		[]
+	);
+	// Split menu items into two groups: one for the default post types
+	// and one for the rest.
+	const postTypesMenuItems = useMemo(
+		() =>
+			menuItems.reduce(
+				( accumulator, postType ) => {
+					const { slug } = postType;
+					let key = 'postTypesMenuItems';
+					if ( slug === 'page' ) {
+						key = 'defaultPostTypesMenuItems';
+					}
+					accumulator[ key ].push( postType );
+					return accumulator;
+				},
+				{ defaultPostTypesMenuItems: [], postTypesMenuItems: [] }
+			),
+		[ menuItems ]
+	);
+	return postTypesMenuItems;
+};
+
+export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
+	const publicTaxonomies = usePublicTaxonomies();
+	const existingTemplates = useExistingTemplates();
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	// `category` and `post_tag` are special cases in template hierarchy.
+	const templatePrefixes = useMemo(
+		() =>
+			publicTaxonomies?.reduce( ( accumulator, { slug } ) => {
+				let suffix = slug;
+				if ( ! [ 'category', 'post_tag' ].includes( slug ) ) {
+					suffix = `taxonomy-${ suffix }`;
+				}
+				if ( slug === 'post_tag' ) {
+					suffix = `tag`;
+				}
+				accumulator[ slug ] = suffix;
+				return accumulator;
+			}, {} ),
+		[ publicTaxonomies ]
+	);
+	// We need to keep track of naming conflicts. If a conflict
+	// occurs, we need to add slug.
+	const taxonomyLabels = publicTaxonomies?.reduce(
+		( accumulator, { labels } ) => {
+			const templateName = (
+				labels.template_name || labels.singular_name
+			).toLowerCase();
+			accumulator[ templateName ] =
+				( accumulator[ templateName ] || 0 ) + 1;
+			return accumulator;
+		},
+		{}
+	);
+	const needsUniqueIdentifier = ( labels, slug ) => {
+		if ( [ 'category', 'post_tag' ].includes( slug ) ) {
+			return false;
+		}
+		const templateName = (
+			labels.template_name || labels.singular_name
+		).toLowerCase();
+		return taxonomyLabels[ templateName ] > 1 && templateName !== slug;
+	};
+	const taxonomiesInfo = useEntitiesInfo( 'taxonomy', templatePrefixes );
+	const existingTemplateSlugs = ( existingTemplates || [] ).map(
+		( { slug } ) => slug
+	);
+	const menuItems = ( publicTaxonomies || [] ).reduce(
+		( accumulator, taxonomy ) => {
+			const { slug, labels } = taxonomy;
+			// We need to check if the general template is part of the
+			// defaultTemplateTypes. If it is, just use that info and
+			// augment it with the specific template functionality.
+			const generalTemplateSlug = templatePrefixes[ slug ];
+			const defaultTemplateType = defaultTemplateTypes?.find(
+				( { slug: _slug } ) => _slug === generalTemplateSlug
+			);
+			const hasGeneralTemplate =
+				existingTemplateSlugs?.includes( generalTemplateSlug );
+			const _needsUniqueIdentifier = needsUniqueIdentifier(
+				labels,
+				slug
+			);
+			let menuItemTitle = labels.template_name || labels.singular_name;
+			if ( _needsUniqueIdentifier ) {
+				menuItemTitle = labels.template_name
+					? sprintf(
+							// translators: 1: Name of the template e.g: "Products by Category". 2: Slug of the taxonomy e.g: "product_cat".
+							_x( '%1$s (%2$s)', 'taxonomy template menu label' ),
+							labels.template_name,
+							slug
+					  )
+					: sprintf(
+							// translators: 1: Name of the taxonomy e.g: "Category". 2: Slug of the taxonomy e.g: "product_cat".
+							_x( '%1$s (%2$s)', 'taxonomy menu label' ),
+							labels.singular_name,
+							slug
+					  );
+			}
+			const menuItem = defaultTemplateType
+				? {
+						...defaultTemplateType,
+						templatePrefix: templatePrefixes[ slug ],
+				  }
+				: {
+						slug: generalTemplateSlug,
+						title: menuItemTitle,
+						description: sprintf(
+							// translators: %s: Name of the taxonomy e.g: "Product Categories".
+							__( 'Displays taxonomy: %s.' ),
+							labels.singular_name
+						),
+						icon: blockMeta,
+						templatePrefix: templatePrefixes[ slug ],
+				  };
+			const hasEntities = taxonomiesInfo?.[ slug ]?.hasEntities;
+			// We have a different template creation flow only if they have entities.
+			if ( hasEntities ) {
+				menuItem.onClick = ( template ) => {
+					onClickMenuItem( {
+						type: 'taxonomy',
+						slug,
+						config: {
+							queryArgs: ( { search } ) => {
+								return {
+									_fields: 'id,name,slug,link',
+									orderBy: search ? 'name' : 'count',
+									exclude:
+										taxonomiesInfo[ slug ]
+											.existingEntitiesIds,
+								};
+							},
+							getSpecificTemplate: ( suggestion ) => {
+								const templateSlug = prefixSlug(
+									templatePrefixes[ slug ],
+									suggestion.slug
+								);
+								return {
+									title: templateSlug,
+									slug: templateSlug,
+									templatePrefix: templatePrefixes[ slug ],
+								};
+							},
+						},
+						labels,
+						hasGeneralTemplate,
+						template,
+					} );
+				};
+			}
+			// We don't need to add the menu item if there are no
+			// entities and the general template exists.
+			if ( ! hasGeneralTemplate || hasEntities ) {
+				accumulator.push( menuItem );
+			}
+			return accumulator;
+		},
+		[]
+	);
+	// Split menu items into two groups: one for the default taxonomies
+	// and one for the rest.
+	const taxonomiesMenuItems = useMemo(
+		() =>
+			menuItems.reduce(
+				( accumulator, taxonomy ) => {
+					const { slug } = taxonomy;
+					let key = 'taxonomiesMenuItems';
+					if ( [ 'category', 'tag' ].includes( slug ) ) {
+						key = 'defaultTaxonomiesMenuItems';
+					}
+					accumulator[ key ].push( taxonomy );
+					return accumulator;
+				},
+				{ defaultTaxonomiesMenuItems: [], taxonomiesMenuItems: [] }
+			),
+		[ menuItems ]
+	);
+	return taxonomiesMenuItems;
+};
+
+const USE_AUTHOR_MENU_ITEM_TEMPLATE_PREFIX = { user: 'author' };
+const USE_AUTHOR_MENU_ITEM_QUERY_PARAMETERS = { user: { who: 'authors' } };
+export function useAuthorMenuItem( onClickMenuItem ) {
+	const existingTemplates = useExistingTemplates();
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	const authorInfo = useEntitiesInfo(
+		'root',
+		USE_AUTHOR_MENU_ITEM_TEMPLATE_PREFIX,
+		USE_AUTHOR_MENU_ITEM_QUERY_PARAMETERS
+	);
+	let authorMenuItem = defaultTemplateTypes?.find(
+		( { slug } ) => slug === 'author'
+	);
+	if ( ! authorMenuItem ) {
+		authorMenuItem = {
+			description: __(
+				'Displays latest posts written by a single author.'
+			),
+			slug: 'author',
+			title: 'Author',
+		};
+	}
+	const hasGeneralTemplate = !! existingTemplates?.find(
+		( { slug } ) => slug === 'author'
+	);
+	if ( authorInfo.user?.hasEntities ) {
+		authorMenuItem = { ...authorMenuItem, templatePrefix: 'author' };
+		authorMenuItem.onClick = ( template ) => {
+			onClickMenuItem( {
+				type: 'root',
+				slug: 'user',
+				config: {
+					queryArgs: ( { search } ) => {
+						return {
+							_fields: 'id,name,slug,link',
+							orderBy: search ? 'name' : 'registered_date',
+							exclude: authorInfo.user.existingEntitiesIds,
+							who: 'authors',
+						};
+					},
+					getSpecificTemplate: ( suggestion ) => {
+						const templateSlug = prefixSlug(
+							'author',
+							suggestion.slug
+						);
+						return {
+							title: templateSlug,
+							slug: templateSlug,
+							templatePrefix: 'author',
+						};
+					},
+				},
+				labels: {
+					singular_name: __( 'Author' ),
+					search_items: __( 'Search Authors' ),
+					not_found: __( 'No authors found.' ),
+					all_items: __( 'All Authors' ),
+				},
+				hasGeneralTemplate,
+				template,
+			} );
+		};
+	}
+	if ( ! hasGeneralTemplate || authorInfo.user?.hasEntities ) {
+		return authorMenuItem;
+	}
+}
+
+/**
+ * Helper hook that filters all the existing templates by the given
+ * object with the entity's slug as key and the template prefix as value.
+ *
+ * Example:
+ * `existingTemplates` is: [ { slug: 'tag-apple' }, { slug: 'page-about' }, { slug: 'tag' } ]
+ * `templatePrefixes` is: { post_tag: 'tag' }
+ * It will return: { post_tag: ['apple'] }
+ *
+ * Note: We append the `-` to the given template prefix in this function for our checks.
+ *
+ * @param {Record<string,string>} templatePrefixes An object with the entity's slug as key and the template prefix as value.
+ * @return {Record<string,string[]>} An object with the entity's slug as key and an array with the existing template slugs as value.
+ */
+const useExistingTemplateSlugs = ( templatePrefixes ) => {
+	const existingTemplates = useExistingTemplates();
+	const existingSlugs = useMemo( () => {
+		return Object.entries( templatePrefixes || {} ).reduce(
+			( accumulator, [ slug, prefix ] ) => {
+				const slugsWithTemplates = ( existingTemplates || [] ).reduce(
+					( _accumulator, existingTemplate ) => {
+						const _prefix = `${ prefix }-`;
+						if ( existingTemplate.slug.startsWith( _prefix ) ) {
+							_accumulator.push(
+								existingTemplate.slug.substring(
+									_prefix.length
+								)
+							);
+						}
+						return _accumulator;
+					},
+					[]
+				);
+				if ( slugsWithTemplates.length ) {
+					accumulator[ slug ] = slugsWithTemplates;
+				}
+				return accumulator;
+			},
+			{}
+		);
+	}, [ templatePrefixes, existingTemplates ] );
+	return existingSlugs;
+};
+
+/**
+ * Helper hook that finds the existing records with an associated template,
+ * as they need to be excluded from the template suggestions.
+ *
+ * @param {string}                entityName                The entity's name.
+ * @param {Record<string,string>} templatePrefixes          An object with the entity's slug as key and the template prefix as value.
+ * @param {Record<string,Object>} additionalQueryParameters An object with the entity's slug as key and additional query parameters as value.
+ * @return {Record<string,EntitiesInfo>} An object with the entity's slug as key and the existing records as value.
+ */
+const useTemplatesToExclude = (
+	entityName,
+	templatePrefixes,
+	additionalQueryParameters = {}
+) => {
+	const slugsToExcludePerEntity =
+		useExistingTemplateSlugs( templatePrefixes );
+	const recordsToExcludePerEntity = useSelect(
+		( select ) => {
+			return Object.entries( slugsToExcludePerEntity || {} ).reduce(
+				( accumulator, [ slug, slugsWithTemplates ] ) => {
+					const entitiesWithTemplates = select(
+						coreStore
+					).getEntityRecords( entityName, slug, {
+						_fields: 'id',
+						context: 'view',
+						slug: slugsWithTemplates,
+						...additionalQueryParameters[ slug ],
+					} );
+					if ( entitiesWithTemplates?.length ) {
+						accumulator[ slug ] = entitiesWithTemplates;
+					}
+					return accumulator;
+				},
+				{}
+			);
+		},
+		[ slugsToExcludePerEntity ]
+	);
+	return recordsToExcludePerEntity;
+};
+
+/**
+ * Helper hook that returns information about an entity having
+ * records that we can create a specific template for.
+ *
+ * For example we can search for `terms` in `taxonomy` entity or
+ * `posts` in `postType` entity.
+ *
+ * First we need to find the existing records with an associated template,
+ * to query afterwards for any remaining record, by excluding them.
+ *
+ * @param {string}                entityName                The entity's name.
+ * @param {Record<string,string>} templatePrefixes          An object with the entity's slug as key and the template prefix as value.
+ * @param {Record<string,Object>} additionalQueryParameters An object with the entity's slug as key and additional query parameters as value.
+ * @return {Record<string,EntitiesInfo>} An object with the entity's slug as key and the EntitiesInfo as value.
+ */
+const useEntitiesInfo = (
+	entityName,
+	templatePrefixes,
+	additionalQueryParameters = EMPTY_OBJECT
+) => {
+	const recordsToExcludePerEntity = useTemplatesToExclude(
+		entityName,
+		templatePrefixes,
+		additionalQueryParameters
+	);
+	const entitiesHasRecords = useSelect(
+		( select ) => {
+			return Object.keys( templatePrefixes || {} ).reduce(
+				( accumulator, slug ) => {
+					const existingEntitiesIds =
+						recordsToExcludePerEntity?.[ slug ]?.map(
+							( { id } ) => id
+						) || [];
+					accumulator[ slug ] = !! select(
+						coreStore
+					).getEntityRecords( entityName, slug, {
+						per_page: 1,
+						_fields: 'id',
+						context: 'view',
+						exclude: existingEntitiesIds,
+						...additionalQueryParameters[ slug ],
+					} )?.length;
+					return accumulator;
+				},
+				{}
+			);
+		},
+		[
+			templatePrefixes,
+			recordsToExcludePerEntity,
+			entityName,
+			additionalQueryParameters,
+		]
+	);
+	const entitiesInfo = useMemo( () => {
+		return Object.keys( templatePrefixes || {} ).reduce(
+			( accumulator, slug ) => {
+				const existingEntitiesIds =
+					recordsToExcludePerEntity?.[ slug ]?.map(
+						( { id } ) => id
+					) || [];
+				accumulator[ slug ] = {
+					hasEntities: entitiesHasRecords[ slug ],
+					existingEntitiesIds,
+				};
+				return accumulator;
+			},
+			{}
+		);
+	}, [ templatePrefixes, recordsToExcludePerEntity, entitiesHasRecords ] );
+	return entitiesInfo;
+};

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -100,15 +100,19 @@ export const previewField = {
 export const descriptionField = {
 	label: __( 'Description' ),
 	id: 'description',
-	render: function RenderDescription( { item } ) {
-		const defaultTemplateTypes = useAllDefaultTemplateTypes();
-		const defaultTemplateType = defaultTemplateTypes.find(
-			( type ) => type.slug === item.slug
-		);
-		return item.description
-			? decodeEntities( item.description )
-			: defaultTemplateType?.description;
-	},
+	render: window?.__experimentalTemplateActivate
+		? function RenderDescription( { item } ) {
+				const defaultTemplateTypes = useAllDefaultTemplateTypes();
+				const defaultTemplateType = defaultTemplateTypes.find(
+					( type ) => type.slug === item.slug
+				);
+				return item.description
+					? decodeEntities( item.description )
+					: defaultTemplateType?.description;
+		  }
+		: ( { item } ) => {
+				return item.description && decodeEntities( item.description );
+		  },
 	enableSorting: false,
 	enableGlobalSearch: true,
 };

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -1,0 +1,166 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { privateApis as corePrivateApis } from '@wordpress/core-data';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { addQueryArgs } from '@wordpress/url';
+import { useEvent } from '@wordpress/compose';
+import { useView } from '@wordpress/views';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import AddNewTemplate from '../add-new-template-legacy';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import { unlock } from '../../lock-unlock';
+import { useEditPostAction } from '../dataviews-actions';
+import { authorField, descriptionField, previewField } from './fields';
+import { defaultLayouts, getDefaultView } from './view-utils';
+
+const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
+
+export default function PageTemplates() {
+	const { path, query } = useLocation();
+	const { activeView = 'active', postId } = query;
+	const [ selection, setSelection ] = useState( [ postId ] );
+
+	const defaultView = useMemo( () => {
+		return getDefaultView( activeView );
+	}, [ activeView ] );
+	const { view, updateView, isModified, resetToDefault } = useView( {
+		kind: 'postType',
+		name: TEMPLATE_POST_TYPE,
+		slug: activeView,
+		defaultView,
+		queryParams: {
+			page: query.pageNumber,
+			search: query.search,
+		},
+		onChangeQueryParams: ( newQueryParams ) => {
+			history.navigate(
+				addQueryArgs( path, {
+					...query,
+					pageNumber: newQueryParams.page,
+					search: newQueryParams.search || undefined,
+				} )
+			);
+		},
+	} );
+
+	const { records, isResolving: isLoadingData } =
+		useEntityRecordsWithPermissions( 'postType', TEMPLATE_POST_TYPE, {
+			per_page: -1,
+		} );
+	const history = useHistory();
+	const onChangeSelection = useCallback(
+		( items ) => {
+			setSelection( items );
+			if ( view?.type === 'list' ) {
+				history.navigate(
+					addQueryArgs( path, {
+						postId: items.length === 1 ? items[ 0 ] : undefined,
+					} )
+				);
+			}
+		},
+		[ history, path, view?.type ]
+	);
+
+	const authors = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		const authorsSet = new Set();
+		records.forEach( ( template ) => {
+			authorsSet.add( template.author_text );
+		} );
+		return Array.from( authorsSet ).map( ( author ) => ( {
+			value: author,
+			label: author,
+		} ) );
+	}, [ records ] );
+
+	const fields = useMemo(
+		() => [
+			previewField,
+			templateTitleField,
+			descriptionField,
+			{
+				...authorField,
+				elements: authors,
+			},
+		],
+		[ authors ]
+	);
+
+	const { data, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( records, view, fields );
+	}, [ records, view, fields ] );
+
+	const postTypeActions = usePostActions( {
+		postType: TEMPLATE_POST_TYPE,
+		context: 'list',
+	} );
+	const editAction = useEditPostAction();
+	const actions = useMemo(
+		() => [ editAction, ...postTypeActions ],
+		[ postTypeActions, editAction ]
+	);
+
+	const onChangeView = useEvent( ( newView ) => {
+		if ( newView.type !== view.type ) {
+			// Retrigger the routing areas resolution.
+			history.invalidate();
+		}
+		updateView( newView );
+	} );
+
+	return (
+		<Page
+			className="edit-site-page-templates"
+			title={ __( 'Templates' ) }
+			actions={
+				<>
+					{ isModified && (
+						<Button
+							__next40pxDefaultSize
+							onClick={ () => {
+								resetToDefault();
+								history.invalidate();
+							} }
+						>
+							{ __( 'Reset view' ) }
+						</Button>
+					) }
+					<AddNewTemplate />
+				</>
+			}
+		>
+			<DataViews
+				key={ activeView }
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				actions={ actions }
+				data={ data }
+				isLoading={ isLoadingData }
+				view={ view }
+				onChangeView={ onChangeView }
+				onChangeSelection={ onChangeSelection }
+				isItemClickable={ () => true }
+				onClickItem={ ( { id } ) => {
+					history.navigate( `/wp_template/${ id }?canvas=edit` );
+				} }
+				selection={ selection }
+				defaultLayouts={ defaultLayouts }
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityRecords } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { useAddedBy } from '../page-templates/hooks';
+import { layout } from '@wordpress/icons';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+const EMPTY_ARRAY = [];
+
+function TemplateDataviewItem( { template, isActive } ) {
+	const { text, icon } = useAddedBy( template.type, template.id );
+
+	return (
+		<SidebarNavigationItem
+			to={ addQueryArgs( '/template', { activeView: text } ) }
+			icon={ icon }
+			aria-current={ isActive }
+		>
+			{ text }
+		</SidebarNavigationItem>
+	);
+}
+
+export default function DataviewsTemplatesSidebarContent() {
+	const {
+		query: { activeView = 'all' },
+	} = useLocation();
+	const { records } = useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
+		per_page: -1,
+	} );
+	const firstItemPerAuthorText = useMemo( () => {
+		const firstItemPerAuthor = records?.reduce( ( acc, template ) => {
+			const author = template.author_text;
+			if ( author && ! acc[ author ] ) {
+				acc[ author ] = template;
+			}
+			return acc;
+		}, {} );
+		return (
+			( firstItemPerAuthor && Object.values( firstItemPerAuthor ) ) ??
+			EMPTY_ARRAY
+		);
+	}, [ records ] );
+
+	return (
+		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
+			<SidebarNavigationItem
+				to="/template"
+				icon={ layout }
+				aria-current={ activeView === 'all' }
+			>
+				{ __( 'All templates' ) }
+			</SidebarNavigationItem>
+			{ firstItemPerAuthorText.map( ( template ) => {
+				return (
+					<TemplateDataviewItem
+						key={ template.author_text }
+						template={ template }
+						isActive={ activeView === template.author_text }
+					/>
+				);
+			} ) }
+		</ItemGroup>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import DataviewsTemplatesSidebarContent from './content';
+import DataviewsTemplatesSidebarContentLegacy from './content-legacy';
 
 export default function SidebarNavigationScreenTemplatesBrowse( { backPath } ) {
 	return (
@@ -17,7 +18,13 @@ export default function SidebarNavigationScreenTemplatesBrowse( { backPath } ) {
 				'Create new templates, or reset any customizations made to the templates supplied by your theme.'
 			) }
 			backPath={ backPath }
-			content={ <DataviewsTemplatesSidebarContent /> }
+			content={
+				window?.__experimentalTemplateActivate ? (
+					<DataviewsTemplatesSidebarContent />
+				) : (
+					<DataviewsTemplatesSidebarContentLegacy />
+				)
+			}
 		/>
 	);
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -10,6 +10,7 @@ import Editor from '../editor';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import PageTemplates from '../page-templates';
+import PageTemplatesLegacy from '../page-templates/index-legacy';
 import { getDefaultView } from '../page-templates/view-utils';
 
 async function isTemplateListView( query ) {
@@ -37,7 +38,16 @@ export const templatesRoute = {
 		},
 		content( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? <PageTemplates /> : undefined;
+			if ( ! isBlockTheme ) {
+				return undefined;
+			}
+			// Use the new template activation system if experiment is enabled,
+			// otherwise use the legacy simple template list.
+			return window?.__experimentalTemplateActivate ? (
+				<PageTemplates />
+			) : (
+				<PageTemplatesLegacy />
+			);
 		},
 		async preview( { query, siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
@@ -49,10 +59,19 @@ export const templatesRoute = {
 		},
 		mobile( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isBlockTheme ) {
+				return <SidebarNavigationScreenUnsupported />;
+			}
+			// Check if the template activation experiment is enabled.
+			const isTemplateActivateEnabled =
+				typeof window !== 'undefined' &&
+				window.__experimentalTemplateActivate;
+			// Use the new template activation system if experiment is enabled,
+			// otherwise use the legacy simple template list.
+			return isTemplateActivateEnabled ? (
 				<PageTemplates />
 			) : (
-				<SidebarNavigationScreenUnsupported />
+				<PageTemplatesLegacy />
 			);
 		},
 	},

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -148,7 +148,10 @@ export default function BlockThemeControl( { id } ) {
 										// duplication explicit, so there
 										// wouldn't be an "edit" button for
 										// static theme templates.
-										if ( ! hasSpecificTemplate ) {
+										if (
+											! hasSpecificTemplate &&
+											window?.__experimentalTemplateActivate
+										) {
 											const activeTemplates =
 												await getEntityRecord(
 													'root',

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -73,7 +73,7 @@ export function useAvailableTemplates( postType ) {
 			allowSwitchingTemplate &&
 			templates?.filter(
 				( template ) =>
-					( template.is_custom || template.type === 'wp_template' ) &&
+					template.is_custom &&
 					template.slug !== currentTemplateSlug &&
 					!! template.content.raw // Skip empty templates.
 			),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -318,8 +318,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronizes the active post with the state
 		useEffect( () => {
 			setEditedPost( post.type, post.id );
-			// Clear any notices dependent on the post context.
-			removeNotice( 'template-activate-notice' );
+			if (
+				typeof window !== 'undefined' &&
+				window.__experimentalTemplateActivate
+			) {
+				// Clear any notices dependent on the post context.
+				removeNotice( 'template-activate-notice' );
+			}
 		}, [ post.type, post.id, setEditedPost, removeNotice ] );
 
 		// Synchronize the editor settings as they change.

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -43,6 +43,12 @@ import { store as editorStore } from '../../store';
 import postPreviewField from '../fields/content-preview';
 import { unlock } from '../../lock-unlock';
 
+declare global {
+	interface Window {
+		__experimentalTemplateActivate?: boolean;
+	}
+}
+
 export function registerEntityAction< Item >(
 	kind: string,
 	name: string,
@@ -146,6 +152,15 @@ export const registerPostTypeSchema =
 			if ( 'wp_template' !== postTypeConfig.slug ) {
 				canDuplicate = undefined;
 			}
+		}
+
+		// When template activation experiment is disabled, templates cannot be duplicated.
+		// @ts-ignore
+		if (
+			postTypeConfig.slug === 'wp_template' &&
+			! window?.__experimentalTemplateActivate
+		) {
+			canDuplicate = undefined;
 		}
 
 		const actions = [

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -274,6 +274,8 @@ export const savePost =
 		dispatch( { type: 'REQUEST_POST_UPDATE_FINISH', options } );
 
 		if (
+			typeof window !== 'undefined' &&
+			window.__experimentalTemplateActivate &&
 			! options.isAutosave &&
 			previousRecord.type === 'wp_template' &&
 			( typeof previousRecord.id === 'number' ||

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -22,30 +22,18 @@ test.describe( 'Site editor browser history', () => {
 		await page
 			.locator( '.fields-field__title', { hasText: 'Index' } )
 			.click();
-		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
 		await expect( page ).toHaveURL(
-			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
-		);
-		await page
-			.getByRole( 'button', { name: 'Index (Copy)' } )
-			.first()
-			.click();
-		await expect( page ).toHaveURL(
-			/\/wp-admin\/site-editor\.php\?p=%2Fwp_template%2F\d+&canvas=edit$/
+			'/wp-admin/site-editor.php?p=%2Fwp_template%2Femptytheme%2F%2Findex&canvas=edit'
 		);
 
 		// Navigate back to the template list
 		await page.goBack();
 		await expect( page ).toHaveURL(
-			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
-		);
-		await page.goBack();
-		await expect( page ).toHaveURL(
 			'/wp-admin/site-editor.php?p=%2Ftemplate'
 		);
+
 		// Navigate back to the dashboard
 		await page.goBack();
-		await expect( page ).toHaveURL( '/wp-admin/site-editor.php' );
 		await page.goBack();
 		await expect( page ).toHaveURL( '/wp-admin/index.php' );
 	} );

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -54,7 +54,7 @@ test.describe( 'Templates', () => {
 		await page
 			.getByRole( 'button', { name: 'Reset search', exact: true } )
 			.click();
-		await expect( titles ).toHaveCount( 5 );
+		await expect( titles ).toHaveCount( 6 );
 
 		// Filter by author.
 		await page.getByRole( 'button', { name: 'Add filter' } ).click();

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -6,9 +6,13 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		// Enable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		// Disable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -34,6 +34,9 @@ test.describe( 'Site editor url navigation', () => {
 		await admin.visitSiteEditor();
 		await page.click( 'role=button[name="Templates"]' );
 		await page.click( 'role=button[name="Add Template"i]' );
+		// Wait for network idle to avoid flaky tests.
+		// eslint-disable-next-line playwright/no-networkidle
+		await page.waitForLoadState( 'networkidle' );
 		await page
 			.getByRole( 'button', {
 				name: 'Single item: Post',
@@ -44,7 +47,7 @@ test.describe( 'Site editor url navigation', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'Demo' } ).click();
 		await expect( page ).toHaveURL(
-			/wp-admin\/site-editor\.php\?p=%2Fwp_template%2F\d+&canvas=edit/
+			'/wp-admin/site-editor.php?p=%2Fwp_template%2Femptytheme%2F%2Fsingle-post-demo&canvas=edit'
 		);
 	} );
 

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -8,11 +8,15 @@ test.describe( 'Template Activate', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+		// Enable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		// Disable the template activation experiment.
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -15,11 +15,15 @@ test.describe( 'Block template registration', () => {
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
+		// Enable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
+		// Disable the template activation experiment.
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -1,0 +1,257 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.use( {
+	templateRevertUtils: async ( { editor, page }, use ) => {
+		await use( new TemplateRevertUtils( { editor, page } ) );
+	},
+} );
+
+test.describe( 'Template Revert', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await admin.visitSiteEditor( { canvas: 'edit' } );
+	} );
+
+	test( 'should delete the template after saving the reverted template', async ( {
+		editor,
+		page,
+		templateRevertUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await templateRevertUtils.revertTemplate();
+
+		const isTemplateTabVisible = await page
+			.locator(
+				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
+			)
+			.isVisible();
+		if ( isTemplateTabVisible ) {
+			await page.click(
+				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
+			);
+		}
+
+		// The revert button isn't visible anymore.
+		await expect(
+			page.locator(
+				'role=region[name="Editor settings"i] >> role=button[name="Actions"i]'
+			)
+		).toBeDisabled();
+	} );
+
+	test( 'should show the original content after revert', async ( {
+		editor,
+		templateRevertUtils,
+	} ) => {
+		const contentBefore =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await templateRevertUtils.revertTemplate();
+
+		const contentAfter =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfter ).toEqual( contentBefore );
+	} );
+
+	test( 'should show the original content after revert and page reload', async ( {
+		admin,
+		editor,
+		templateRevertUtils,
+	} ) => {
+		const contentBefore =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await templateRevertUtils.revertTemplate();
+		await admin.visitSiteEditor();
+
+		const contentAfter =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfter ).toEqual( contentBefore );
+	} );
+
+	test( 'should show the edited content after revert and clicking undo in the header toolbar', async ( {
+		editor,
+		page,
+		templateRevertUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		const contentBefore =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+
+		// Revert template and check state.
+		await templateRevertUtils.revertTemplate();
+		const contentAfterSave =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfterSave ).not.toEqual( contentBefore );
+
+		// Undo revert by clicking header button and check state again.
+		await page.click(
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
+		);
+		const contentAfterUndo =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfterUndo ).toEqual( contentBefore );
+	} );
+
+	test( 'should show the original content after revert, clicking undo then redo in the header toolbar', async ( {
+		editor,
+		page,
+		templateRevertUtils,
+	} ) => {
+		const contentBefore =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await templateRevertUtils.revertTemplate();
+		await page.click(
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
+		);
+
+		const contentAfterUndo =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfterUndo ).not.toEqual( contentBefore );
+
+		await page.click(
+			'role=region[name="Editor top bar"i] >> role=button[name="Redo"i]'
+		);
+
+		const contentAfterRedo =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfterRedo ).toEqual( contentBefore );
+	} );
+
+	test( 'should show the edited content after revert, clicking undo in the header toolbar, save and reload', async ( {
+		admin,
+		editor,
+		page,
+		templateRevertUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Test' },
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.getByText( /(updated|published)\./ )
+			.click();
+		const contentBefore =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+
+		await templateRevertUtils.revertTemplate();
+
+		await page.click(
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
+		);
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await admin.visitSiteEditor();
+
+		const contentAfter =
+			await templateRevertUtils.getCurrentSiteEditorContent();
+		expect( contentAfter ).toEqual( contentBefore );
+	} );
+} );
+
+class TemplateRevertUtils {
+	constructor( { editor, page } ) {
+		this.editor = editor;
+		this.page = page;
+	}
+
+	async revertTemplate() {
+		await this.editor.openDocumentSettingsSidebar();
+		const isTemplateTabVisible = await this.page
+			.locator(
+				'role=region[name="Editor settings"i] >> role=tab[name="Template"i]'
+			)
+			.isVisible();
+		if ( isTemplateTabVisible ) {
+			await this.page.click(
+				'role=region[name="Editor settings"i] >> role=tab[name="Template"i]'
+			);
+		}
+		await this.page.click(
+			'role=region[name="Editor settings"i] >> role=button[name="Actions"i]'
+		);
+		await this.page.click( 'role=menuitem[name=/Reset/i]' );
+		await this.page.getByRole( 'button', { name: 'Reset' } ).click();
+		await this.page.waitForSelector(
+			'role=button[name="Dismiss this notice"i] >> text=/ reset./'
+		);
+	}
+
+	async getCurrentSiteEditorContent() {
+		return this.page.evaluate( () => {
+			const postId = window.wp.data
+				.select( 'core/editor' )
+				.getCurrentPostId();
+			const postType = window.wp.data
+				.select( 'core/editor' )
+				.getCurrentPostType();
+			const record = window.wp.data
+				.select( 'core' )
+				.getEditedEntityRecord( 'postType', postType, postId );
+			if ( record ) {
+				if ( typeof record.content === 'function' ) {
+					return record.content( record );
+				} else if ( record.blocks ) {
+					return window.wp.blocks.__unstableSerializeAndClean(
+						record.blocks
+					);
+				} else if ( record.content ) {
+					return record.content;
+				}
+			}
+			return '';
+		} );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
We need to look through #73025 and make sure we wrap everything is conditions and otherwise restore the old code. Basically we want both versions at the same time. I've also restored the old e2e test file, and we should keep the current one as well.

<!-- In a few words, what is the PR actually doing? -->

One issue: when you start duplicating and create multiple of the same template, the old system might get confused about which template is active. Generally we don't really want people to switch between these experiments as it's hard to migrate back.

~~Perhaps we should delete all newly created templates? But that would be content loss. Maybe we should disallow unchecking the experiment and put a big warning before enabling? IDK.~~

What I went for in the end is warn about toggling it off. People should make sure they don't have any templates other than active ones.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need some more time to make template activation work well UI wise.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For anyone who has a version of GB where template activation was active, we auto-enable the experiment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Toggle the experiment on/off. If you earlier had GH trunk, it will already be on.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
