### PR TITLE
Fix navigation tag entity binding

### DIFF
--- a/packages/block-library/src/navigation-link/shared/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/use-entity-binding.js
@@ -98,10 +98,13 @@ export function useEntityBinding( { clientId, attributes } ) {
 
 			// Use the correct entity type based on kind.
 			const entityType = isTaxonomy ? 'taxonomy' : 'postType';
-			const entityRecord = getEntityRecord( entityType, type, id );
+			// Convert 'tag' back to 'post_tag' for the API call
+			// (it was converted from 'post_tag' to 'tag' for storage in updateAttributes)
+			const typeForAPI = type === 'tag' ? 'post_tag' : type;
+			const entityRecord = getEntityRecord( entityType, typeForAPI, id );
 			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
 				entityType,
-				type,
+				typeForAPI,
 				id,
 			] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73296

<!-- In a few words, what is the PR actually doing? -->
Fixes Tag Link navigation links

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
They are not creating correctly. They are creating without a url.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Convert to appropriate api call (post_tag)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a navigation link
- In the creation flow:
  - Select Add Block
  - Select Tag Link
  - Select a Tag
- Look in the Inspector for the newly created link. There should be a url value and the item should be synced

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/99725a86-6da6-49bf-a497-90ea243fdd60

**After**

https://github.com/user-attachments/assets/d7adb2f2-1f40-4542-971f-529b43b44a14



