### PR TITLE
Add missing package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51643,6 +51643,9 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/annotations": {
@@ -53978,6 +53981,9 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/interactivity": {
@@ -54214,6 +54220,9 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/notices": {

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -42,6 +42,9 @@
 		"@wordpress/element": "file:../element",
 		"clsx": "^2.1.1"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -40,6 +40,9 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/primitives": "file:../primitives"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -47,6 +47,9 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73257

<!-- In a few words, what is the PR actually doing? -->
Add missing dependencies on `react`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Build code transformations can introduce dependencies on packages such as `react`. These need to be declared if the package is to function correctly with yarn's p'n'p or pnpm with hoisting disabled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add missing dependencies on `react`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Follow the reproduction instructions in the linked bug to set up the test and reproduce the bug.
2. Do `yarn add <package>@file:/path/to/gutenberg/packages/<package>` or `pnpm add <package>@file:/path/to/gutenberg/packages/<package>` to point yarn or pnpm at the locally built version of the package.
3. Repeat the final instruction in the reproduction to check that the bug is fixed.