### PR TITLE
Sections: Remove hover outlines in outline mode.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -563,6 +563,7 @@ function BlockListBlockProvider( props ) {
 				isSelectionEnabled,
 				getTemplateLock,
 				isSectionBlock: _isSectionBlock,
+				getParentSectionBlock,
 				getBlockWithoutAttributes,
 				getBlockAttributes,
 				canRemoveBlock,
@@ -674,6 +675,9 @@ function BlockListBlockProvider( props ) {
 				isSelectionEnabled: isSelectionEnabled(),
 				isLocked: !! getTemplateLock( rootClientId ),
 				isSectionBlock: _isSectionBlock( clientId ),
+				isWithinSectionBlock:
+					_isSectionBlock( clientId ) ||
+					!! getParentSectionBlock( clientId ),
 				canRemove,
 				canMove,
 				isSelected: _isSelected,
@@ -756,6 +760,7 @@ function BlockListBlockProvider( props ) {
 		isDragging,
 		hasChildSelected,
 		isSectionBlock,
+		isWithinSectionBlock,
 		isEditingDisabled,
 		hasEditableOutline,
 		className,
@@ -802,6 +807,7 @@ function BlockListBlockProvider( props ) {
 		isDragging,
 		hasChildSelected,
 		isSectionBlock,
+		isWithinSectionBlock,
 		isEditingDisabled,
 		hasEditableOutline,
 		isEditingContentOnlySection,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -100,6 +100,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isEditingContentOnlySection,
 		defaultClassName,
 		isSectionBlock,
+		isWithinSectionBlock,
 		canMove,
 		isBlockHidden,
 	} = useContext( PrivateBlockContext );
@@ -108,13 +109,14 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 	const ffDragRef = useFirefoxDraggableCompatibility();
+	const isHoverEnabled = ! isWithinSectionBlock;
 	const mergedRefs = useMergeRefs( [
 		props.ref,
 		useFocusFirstElement( { clientId, initialPosition } ),
 		useBlockRefProvider( clientId ),
 		useFocusHandler( clientId ),
 		useEventHandlers( { clientId, isSelected } ),
-		useIsHovered(),
+		useIsHovered( { isEnabled: isHoverEnabled } ),
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),
 		useDisabled( { isDisabled: ! hasOverlay } ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -15,21 +15,33 @@ function listener( event ) {
 	);
 }
 
-/*
+/**
  * Adds `is-hovered` class when the block is hovered and in navigation or
  * outline mode.
+ *
+ * @param {Object}  options           Options object.
+ * @param {boolean} options.isEnabled Whether to enable hover detection. Default true.
+ *
+ * @return {Function} Ref callback.
  */
-export function useIsHovered() {
-	return useRefEffect( ( node ) => {
-		node.addEventListener( 'mouseout', listener );
-		node.addEventListener( 'mouseover', listener );
+export function useIsHovered( { isEnabled = true } = {} ) {
+	return useRefEffect(
+		( node ) => {
+			if ( ! isEnabled ) {
+				return;
+			}
 
-		return () => {
-			node.removeEventListener( 'mouseout', listener );
-			node.removeEventListener( 'mouseover', listener );
+			node.addEventListener( 'mouseout', listener );
+			node.addEventListener( 'mouseover', listener );
 
-			// Remove class in case it lingers.
-			node.classList.remove( 'is-hovered' );
-		};
-	}, [] );
+			return () => {
+				node.removeEventListener( 'mouseout', listener );
+				node.removeEventListener( 'mouseover', listener );
+
+				// Remove class in case it lingers.
+				node.classList.remove( 'is-hovered' );
+			};
+		},
+		[ isEnabled ]
+	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -19,8 +19,8 @@ function listener( event ) {
  * Adds `is-hovered` class when the block is hovered and in navigation or
  * outline mode.
  *
- * @param {Object}  options           Options object.
- * @param {boolean} options.isEnabled Whether to enable hover detection. Default true.
+ * @param {Object}  options                     Options object.
+ * @param {boolean} [options.isEnabled=true]     Whether to enable hover detection.
  *
  * @return {Function} Ref callback.
  */

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -19,8 +19,8 @@ function listener( event ) {
  * Adds `is-hovered` class when the block is hovered and in navigation or
  * outline mode.
  *
- * @param {Object}  options                     Options object.
- * @param {boolean} [options.isEnabled=true]     Whether to enable hover detection.
+ * @param {Object}  options                  Options object.
+ * @param {boolean} [options.isEnabled=true] Whether to enable hover detection.
  *
  * @return {Function} Ref callback.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- In a few words, what is the PR actually doing? -->
This removes outlines when hovering inner blocks inside sections. At the moment they show up when "Show template" is selected.

## Why?
We shouldn't show outlines when hovering inner blocks in sections.

## How?
Pass `isWithinSectionBlock` through context - I'm concerned that this might have performance implications.

## Testing Instructions
0. Enable the experiment
1. Insert a section block
2. Turn on "Show template"
3. Hover the section
4. Check that the inner blocks don't get outlines

## Screenshots or screencast <!-- if applicable -->

<img width="1395" height="425" alt="Screenshot 2025-11-13 at 23 32 24" src="https://github.com/user-attachments/assets/5491c8a9-1fde-46ef-a02d-d5041e6e1514" />
