### PR TITLE
Patterns: double-click on pattern to edit pattern

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -25,15 +25,20 @@ function isColorTransparent( color ) {
  * @param {string} clientId Block client ID.
  */
 export function useEventHandlers( { clientId, isSelected } ) {
-	const { getBlockRootClientId, isZoomOut, hasMultiSelection } = unlock(
-		useSelect( blockEditorStore )
-	);
+	const {
+		getBlockRootClientId,
+		isZoomOut,
+		hasMultiSelection,
+		isSectionBlock,
+		editedContentOnlySection,
+	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		insertAfterBlock,
 		removeBlock,
 		resetZoomLevel,
 		startDraggingBlocks,
 		stopDraggingBlocks,
+		editContentOnlySection,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	return useRefEffect(
@@ -279,12 +284,30 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.documentElement.classList.add( 'is-dragging' );
 			}
 
+			/**
+			 * Handles double-click events on section blocks to edit content only section.
+			 *
+			 * @param {MouseEvent} event Double-click event.
+			 */
+			function onDoubleClick( event ) {
+				// Check if this block is a section block and not already being edited
+				const isSection = isSectionBlock( clientId );
+				const isAlreadyEditing = editedContentOnlySection === clientId;
+
+				if ( isSection && ! isAlreadyEditing ) {
+					event.preventDefault();
+					editContentOnlySection( clientId );
+				}
+			}
+
 			node.addEventListener( 'keydown', onKeyDown );
 			node.addEventListener( 'dragstart', onDragStart );
+			node.addEventListener( 'dblclick', onDoubleClick );
 
 			return () => {
 				node.removeEventListener( 'keydown', onKeyDown );
 				node.removeEventListener( 'dragstart', onDragStart );
+				node.removeEventListener( 'dblclick', onDoubleClick );
 			};
 		},
 		[
@@ -298,6 +321,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			hasMultiSelection,
 			startDraggingBlocks,
 			stopDraggingBlocks,
+			isSectionBlock,
+			editedContentOnlySection,
+			editContentOnlySection,
 		]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -284,13 +284,15 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.documentElement.classList.add( 'is-dragging' );
 			}
 
+			node.addEventListener( 'keydown', onKeyDown );
+			node.addEventListener( 'dragstart', onDragStart );
+
 			/**
 			 * Handles double-click events on section blocks to edit content only section.
 			 *
 			 * @param {MouseEvent} event Double-click event.
 			 */
 			function onDoubleClick( event ) {
-				// Check if this block is a section block and not already being edited
 				const isSection = isSectionBlock( clientId );
 				const isAlreadyEditing = editedContentOnlySection === clientId;
 
@@ -300,14 +302,17 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				}
 			}
 
-			node.addEventListener( 'keydown', onKeyDown );
-			node.addEventListener( 'dragstart', onDragStart );
-			node.addEventListener( 'dblclick', onDoubleClick );
+			// Only add double-click listener if experimental flag is enabled
+			if ( window?.__experimentalContentOnlyPatternInsertion ) {
+				node.addEventListener( 'dblclick', onDoubleClick );
+			}
 
 			return () => {
 				node.removeEventListener( 'keydown', onKeyDown );
 				node.removeEventListener( 'dragstart', onDragStart );
-				node.removeEventListener( 'dblclick', onDoubleClick );
+				if ( window?.__experimentalContentOnlyPatternInsertion ) {
+					node.removeEventListener( 'dblclick', onDoubleClick );
+				}
 			};
 		},
 		[


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes https://github.com/WordPress/gutenberg/issues/73266

Add double-click functionality for editing section blocks and include related state management in useEventHandlers.

## Why?

To complement the "click outside" behaviour of existing editing mode.

## How?

Adding a double click event handler to the `useEventHandlers` hook.

## Testing Instructions

Once you've enabled the content only experiment:


1.  Open the Editor and insert a pattern  (template parts, blocks with templateLock: 'contentOnly' or synced patterns will also work)
2. Select a section block
3. Double-click on the selected section block
4. Verify that the content-only edit mode is activated (same behavior as clicking the "Edit section" button)
5. Exit the section editing mode
6. Verify that double-clicking a non-section block does not trigger any unexpected behavior
7. Verify that double-clicking an already-editing section does nothing (doesn't toggle or cause issues)

Check that the behaviour is non-existent with the experiment turned off.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fc541f47-265b-49e6-8eca-a2cd36d2b794


