### PR TITLE
Preferences: Add TypeScript types to package.json exports

### DIFF
--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -28,6 +28,7 @@
 	"module": "build-module/index.js",
 	"exports": {
 		".": {
+			"types": "./build-types/index.d.ts",
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/73275

This PR adds the TypeScript type definitions export to the `@wordpress/preferences` package.json exports field.

## Why?
The `@wordpress/preferences` package includes TypeScript type definitions in the `build-types` folder, but these are not listed in the package.json "exports" field. When a package defines an "exports" field, Node.js and TypeScript treat any unlisted paths as private/inaccessible, causing TypeScript resolution to fail with the error:

> "There are types at node_modules/@wordpress/preferences/build-types/index.d.ts, but this result could not be resolved when respecting package.json exports."

This issue affects projects using strict module resolution settings (`"node16"` or `"bundler"`), including frameworks like Next.js and build tools like Vite.

All other packages that include type definitions in their package.json have already added the `"types"` field to their main export entry. For example:

https://github.com/WordPress/gutenberg/blob/34d7cc927b762cad4bd849d3417db68178168d38/packages/data/package.json#L28-L35

## How?
The fix adds a `"types"` field to the main export entry in package.json, pointing to `"./build-types/index.d.ts"`. This allows TypeScript to properly resolve the type definitions while respecting the package exports configuration.

## Testing Instructions
1. Install the `@wordpress/preferences` package in a TypeScript project using strict module resolution (e.g., `"moduleResolution": "bundler"` or `"node16"`)
2. Import from `@wordpress/preferences` in a TypeScript file
3. Verify that TypeScript can resolve the types without errors
4. Confirm that IDE autocomplete and type checking work correctly

Alternatively:
1. Build the package locally with `npm run build`
2. In a test TypeScript project with `"moduleResolution": "bundler"`, install the local build
3. Try importing: `import { store as preferencesStore } from '@wordpress/preferences';`
4. Verify no TypeScript errors appear