### PR TITLE
Implements the image-cropper package in the editor.

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1764,6 +1764,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/image-cropper",
+		"slug": "packages-image-cropper",
+		"markdown_source": "../packages/image-cropper/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/interactivity-router",
 		"slug": "packages-interactivity-router",
 		"markdown_source": "../packages/interactivity-router/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53011,6 +53011,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/image-cropper": "file:../image-cropper",
 				"@wordpress/interactivity": "file:../interactivity",
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -76,6 +76,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/image-cropper": "file:../image-cropper",
 		"@wordpress/interactivity": "file:../interactivity",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",

--- a/packages/block-editor/src/components/image-editor/cropper.js
+++ b/packages/block-editor/src/components/image-editor/cropper.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import Cropper from 'react-easy-crop';
 import clsx from 'clsx';
 
 /**
@@ -9,12 +8,11 @@ import clsx from 'clsx';
  */
 import { Spinner } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
+import { ImageCropper as ImageCropperComponent } from '@wordpress/image-cropper';
 
 /**
  * Internal dependencies
  */
-import { MIN_ZOOM, MAX_ZOOM } from './constants';
-
 import { useImageEditingContext } from './context';
 
 export default function ImageCropper( {
@@ -25,17 +23,7 @@ export default function ImageCropper( {
 	naturalWidth,
 	borderProps,
 } ) {
-	const {
-		isInProgress,
-		editedUrl,
-		position,
-		zoom,
-		aspect,
-		setPosition,
-		setCrop,
-		setZoom,
-		rotation,
-	} = useImageEditingContext();
+	const { isInProgress, editedUrl, rotation } = useImageEditingContext();
 	const [ contentResizeListener, { width: clientWidth } ] =
 		useResizeObserver();
 
@@ -60,24 +48,7 @@ export default function ImageCropper( {
 				height: editedHeight,
 			} }
 		>
-			<Cropper
-				image={ editedUrl || url }
-				disabled={ isInProgress }
-				minZoom={ MIN_ZOOM / 100 }
-				maxZoom={ MAX_ZOOM / 100 }
-				crop={ position }
-				zoom={ zoom / 100 }
-				aspect={ aspect }
-				onCropChange={ ( pos ) => {
-					setPosition( pos );
-				} }
-				onCropComplete={ ( newCropPercent ) => {
-					setCrop( newCropPercent );
-				} }
-				onZoomChange={ ( newZoom ) => {
-					setZoom( newZoom * 100 );
-				} }
-			/>
+			<ImageCropperComponent src={ editedUrl || url } />
 			{ isInProgress && <Spinner /> }
 		</div>
 	);

--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import { ImageCropperProvider } from '@wordpress/image-cropper';
 
 /**
  * Internal dependencies
@@ -26,36 +27,40 @@ export default function ImageEditor( {
 	borderProps,
 } ) {
 	return (
-		<ImageEditingProvider
-			id={ id }
-			url={ url }
-			naturalWidth={ naturalWidth }
-			naturalHeight={ naturalHeight }
-			onSaveImage={ onSaveImage }
-			onFinishEditing={ onFinishEditing }
-		>
-			<Cropper
-				borderProps={ borderProps }
+		<ImageCropperProvider>
+			<ImageEditingProvider
+				id={ id }
 				url={ url }
-				width={ width }
-				height={ height }
-				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
-			/>
-			<BlockControls>
-				<ToolbarGroup>
-					<ZoomDropdown />
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<AspectRatioDropdown toggleProps={ toggleProps } />
-						) }
-					</ToolbarItem>
-					<RotationButton />
-				</ToolbarGroup>
-				<ToolbarGroup>
-					<FormControls />
-				</ToolbarGroup>
-			</BlockControls>
-		</ImageEditingProvider>
+				naturalHeight={ naturalHeight }
+				onSaveImage={ onSaveImage }
+				onFinishEditing={ onFinishEditing }
+			>
+				<Cropper
+					borderProps={ borderProps }
+					url={ url }
+					width={ width }
+					height={ height }
+					naturalHeight={ naturalHeight }
+					naturalWidth={ naturalWidth }
+				/>
+				<BlockControls>
+					<ToolbarGroup>
+						<ZoomDropdown />
+						<ToolbarItem>
+							{ ( toggleProps ) => (
+								<AspectRatioDropdown
+									toggleProps={ toggleProps }
+								/>
+							) }
+						</ToolbarItem>
+						<RotationButton />
+					</ToolbarGroup>
+					<ToolbarGroup>
+						<FormControls />
+					</ToolbarGroup>
+				</BlockControls>
+			</ImageEditingProvider>
+		</ImageCropperProvider>
 	);
 }

--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -40,7 +40,7 @@ export default function useTransformImage( {
 	 * rotateClockwise rotates the image by 90° clockwise by drawing the original image onto a canvas with rotation applied,
 	 * then saves it as a new blob URL (editedUrl).
 	 * This creates a new rotated image file, bypassing the image-cropper’s CSS transform rotation.
-	 * It's a bespoke solution to ensure that the rotated image fills the entire canvas.
+	 * It's a bespoke solution to ensure that the rotated image fills the content width.
 	 */
 	const [ internalRotation, setInternalRotation ] = useState( 0 );
 	const rotateClockwise = useCallback( () => {

--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -42,16 +42,16 @@ export default function useTransformImage( {
 	 * This creates a new rotated image file, bypassing the image-cropper’s CSS transform rotation.
 	 * It's a bespoke solution to ensure that the rotated image fills the entire canvas.
 	 */
-	const [ iternalRotation, setInternalRotation ] = useState( 0 );
+	const [ internalRotation, setInternalRotation ] = useState( 0 );
 	const rotateClockwise = useCallback( () => {
-		const angle = ( iternalRotation + 90 ) % 360;
+		const angle = ( internalRotation + 90 ) % 360;
 
 		let naturalAspectRatio = defaultAspect;
 		const isDefaultAspect =
 			defaultAspect === aspectRatio || rotatedAspect === aspectRatio;
 		const shouldResetAspect = zoom !== 1 || ! isDefaultAspect;
 
-		if ( iternalRotation % 180 === 90 ) {
+		if ( internalRotation % 180 === 90 ) {
 			naturalAspectRatio = 1 / defaultAspect;
 		}
 
@@ -128,7 +128,7 @@ export default function useTransformImage( {
 			el.crossOrigin = imgCrossOrigin;
 		}
 	}, [
-		iternalRotation,
+		internalRotation,
 		defaultAspect,
 		url,
 		setCropperState,
@@ -146,7 +146,7 @@ export default function useTransformImage( {
 			crop: croppedArea,
 			zoom,
 			setZoom,
-			rotation: iternalRotation,
+			rotation: internalRotation,
 			rotateClockwise,
 			aspect: aspectRatio,
 			setAspect: setAspectRatio,
@@ -157,7 +157,7 @@ export default function useTransformImage( {
 			croppedArea,
 			zoom,
 			setZoom,
-			iternalRotation,
+			internalRotation,
 			rotateClockwise,
 			aspectRatio,
 			setAspectRatio,

--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
+import { useImageCropper } from '@wordpress/image-cropper';
 
 export default function useTransformImage( {
 	url,
@@ -10,30 +11,63 @@ export default function useTransformImage( {
 	naturalHeight,
 } ) {
 	const [ editedUrl, setEditedUrl ] = useState();
-	const [ crop, setCrop ] = useState();
-	const [ position, setPosition ] = useState( { x: 0, y: 0 } );
-	const [ zoom, setZoom ] = useState( 100 );
-	const [ rotation, setRotation ] = useState( 0 );
-	const defaultAspect = naturalWidth / naturalHeight;
-	const [ aspect, setAspect ] = useState( defaultAspect );
+	const { cropperState, setCropperState } = useImageCropper();
+	const { zoom, aspectRatio, crop, croppedArea } = cropperState;
 
+	const setZoom = useCallback(
+		( newZoom ) => {
+			setCropperState( { zoom: newZoom } );
+		},
+		[ setCropperState ]
+	);
+
+	const setAspectRatio = useCallback(
+		( newAspect ) => {
+			setCropperState( { aspectRatio: newAspect } );
+		},
+		[ setCropperState ]
+	);
+
+	const defaultAspect = naturalWidth / naturalHeight;
+	const rotatedAspect = naturalHeight / naturalWidth;
+
+	// Initialize aspect ratio on mount or when defaultAspect changes
+	useEffect( () => {
+		setAspectRatio( defaultAspect );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	/**
+	 * rotateClockwise rotates the image by 90° clockwise by drawing the original image onto a canvas with rotation applied,
+	 * then saves it as a new blob URL (editedUrl).
+	 * This creates a new rotated image file, bypassing the image-cropper’s CSS transform rotation.
+	 * It's a bespoke solution to ensure that the rotated image fills the entire canvas.
+	 */
+	const [ iternalRotation, setInternalRotation ] = useState( 0 );
 	const rotateClockwise = useCallback( () => {
-		const angle = ( rotation + 90 ) % 360;
+		const angle = ( iternalRotation + 90 ) % 360;
 
 		let naturalAspectRatio = defaultAspect;
+		const isDefaultAspect =
+			defaultAspect === aspectRatio || rotatedAspect === aspectRatio;
+		const shouldResetAspect = zoom !== 1 || ! isDefaultAspect;
 
-		if ( rotation % 180 === 90 ) {
+		if ( iternalRotation % 180 === 90 ) {
 			naturalAspectRatio = 1 / defaultAspect;
 		}
 
 		if ( angle === 0 ) {
 			setEditedUrl();
-			setRotation( angle );
-			setAspect( defaultAspect );
-			setPosition( ( prevPosition ) => ( {
-				x: -( prevPosition.y * naturalAspectRatio ),
-				y: prevPosition.x * naturalAspectRatio,
-			} ) );
+			setInternalRotation( angle );
+			const newAspectRatio = shouldResetAspect
+				? aspectRatio
+				: defaultAspect;
+			setCropperState( {
+				aspectRatio: newAspectRatio,
+				crop: {
+					x: -( crop.y * naturalAspectRatio ),
+					y: crop.x * naturalAspectRatio,
+				},
+			} );
 			return;
 		}
 
@@ -67,12 +101,17 @@ export default function useTransformImage( {
 
 			canvas.toBlob( ( blob ) => {
 				setEditedUrl( URL.createObjectURL( blob ) );
-				setRotation( angle );
-				setAspect( canvas.width / canvas.height );
-				setPosition( ( prevPosition ) => ( {
-					x: -( prevPosition.y * naturalAspectRatio ),
-					y: prevPosition.x * naturalAspectRatio,
-				} ) );
+				setInternalRotation( angle );
+				const newAspectRatio = shouldResetAspect
+					? aspectRatio
+					: canvas.width / canvas.height;
+				setCropperState( {
+					aspectRatio: newAspectRatio,
+					crop: {
+						x: -( crop.y * naturalAspectRatio ),
+						y: crop.x * naturalAspectRatio,
+					},
+				} );
 			} );
 		}
 
@@ -88,33 +127,40 @@ export default function useTransformImage( {
 		if ( typeof imgCrossOrigin === 'string' ) {
 			el.crossOrigin = imgCrossOrigin;
 		}
-	}, [ rotation, defaultAspect, url ] );
+	}, [
+		iternalRotation,
+		defaultAspect,
+		url,
+		setCropperState,
+		crop,
+		zoom,
+		aspectRatio,
+		rotatedAspect,
+		setInternalRotation,
+	] );
 
 	return useMemo(
 		() => ( {
 			editedUrl,
 			setEditedUrl,
-			crop,
-			setCrop,
-			position,
-			setPosition,
+			crop: croppedArea,
 			zoom,
 			setZoom,
-			rotation,
-			setRotation,
+			rotation: iternalRotation,
 			rotateClockwise,
-			aspect,
-			setAspect,
+			aspect: aspectRatio,
+			setAspect: setAspectRatio,
 			defaultAspect,
 		} ),
 		[
 			editedUrl,
-			crop,
-			position,
+			croppedArea,
 			zoom,
-			rotation,
+			setZoom,
+			iternalRotation,
 			rotateClockwise,
-			aspect,
+			aspectRatio,
+			setAspectRatio,
 			defaultAspect,
 		]
 	);

--- a/packages/block-editor/src/components/image-editor/zoom-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/zoom-dropdown.js
@@ -39,8 +39,8 @@ export default function ZoomDropdown() {
 						label={ __( 'Zoom' ) }
 						min={ MIN_ZOOM }
 						max={ MAX_ZOOM }
-						value={ Math.round( zoom ) }
-						onChange={ setZoom }
+						value={ Math.round( zoom * 100 ) }
+						onChange={ ( newZoom ) => setZoom( newZoom / 100 ) }
 					/>
 				</DropdownContentWrapper>
 			) }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -23,6 +23,7 @@
 		{ "path": "../html-entities" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../image-cropper" },
 		{ "path": "../interactivity" },
 		{ "path": "../is-shallow-equal" },
 		{ "path": "../keycodes" },

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -44,6 +44,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
Relies on https://github.com/WordPress/gutenberg/pull/72414

## What? How?

Implements the [image-cropper package](https://github.com/WordPress/gutenberg/pull/72414) in the editor.

https://github.com/user-attachments/assets/9c7e854b-a618-4aff-b174-0f72ec6a4e7d

## Why?

The image cropper component and hooks have been moved to their own package so they can be used across the app, and not just in side the block editor.

## Testing

Insert an image block in the editor and crop the image. Make sure to rotate, zoom, and select different aspect ratios.

Save different crops.

There should be no regressions in the way images are cropped in the editor.

There are 2 main differences:

- When rotating, if the user has chosen a non-default aspect ratio from the drop down, the aspect ratio will persist 
- When rotating, if the user has zoomed, the aspect ratio will persist 



