### PR TITLE
Layout: Prevent empty contentSize and wideSize values ​​from being saved

### DIFF
--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -89,7 +89,10 @@ export default {
 										: nextWidth;
 								onChange( {
 									...layout,
-									contentSize: nextWidth || undefined,
+									contentSize:
+										nextWidth !== ''
+											? nextWidth
+											: undefined,
 								} );
 							} }
 							units={ units }
@@ -111,7 +114,10 @@ export default {
 										: nextWidth;
 								onChange( {
 									...layout,
-									wideSize: nextWidth || undefined,
+									wideSize:
+										nextWidth !== ''
+											? nextWidth
+											: undefined,
 								} );
 							} }
 							units={ units }

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -89,7 +89,7 @@ export default {
 										: nextWidth;
 								onChange( {
 									...layout,
-									contentSize: nextWidth,
+									contentSize: nextWidth || undefined,
 								} );
 							} }
 							units={ units }
@@ -111,7 +111,7 @@ export default {
 										: nextWidth;
 								onChange( {
 									...layout,
-									wideSize: nextWidth,
+									wideSize: nextWidth || undefined,
 								} );
 							} }
 							units={ units }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/71716

## What?

<img width="298" height="167" alt="image" src="https://github.com/user-attachments/assets/9076ed11-d57c-42bb-a794-7cbe934ac4b3" />

This PR prevents empty `contentSize` and `wideSize` attributes from being saved. As a result, this prevents the unstable display of wide and full-width controls on child blocks.

## Why?

In a constrained layout, such as a Group block, child blocks refer to the global ( or block instance) width setting to determine whether they can use wide or full-width controls:

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group">
<!-- /wp:group -->
```

However, if you enter a number and then delete it, the block will change to this, even though the text control will remain empty as before:

```html
<!-- wp:group {"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```

This means that the conditional statement [here](https://github.com/WordPress/gutenberg/blob/18c9f239b5088cd5f3c6d330eedd66adcb33a73c/packages/block-editor/src/layouts/constrained.js#L299-L305) will no longer be met, and the child block will no longer be able to use the wide/full width options.

## How?

From my understanding, empty strings should not be stored in the first place.

## Testing Instructions

- Insert a Group block.
- Insert a Heading block inside that block.
- Confirm that the Heading block has both  "Wide width" and "Full width" settings.
- Select the Group block and open the layout panel.
- Enter numbers in both "Content width" and "Widewidth" and delete each one.
- Select the Heading block:
  - Before: The Heading block does not have either "Wide width" or "Full width".
  - After: The Heading block has both  "Wide width" and "Fullwidth" settings.