### PR TITLE
Breadcrumbs: Add filter for preferred taxonomy and term per post type

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -8,7 +8,7 @@
 /**
  * Renders the `core/breadcrumbs` block on the server.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
@@ -163,7 +163,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 /**
  * Checks if we're on a paginated view (page 2 or higher).
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @return bool True if paged > 1, false otherwise.
  */
@@ -175,7 +175,7 @@ function block_core_breadcrumbs_is_paged() {
 /**
  * Creates a "Page X" breadcrumb item for paginated views.
  *
- * @since 6.9.0
+ * @since 7.0.0
  * @param string $query_var Optional. Query variable to get current page number. Default 'paged'.
  * @return string The "Page X" breadcrumb HTML.
  */
@@ -191,7 +191,7 @@ function block_core_breadcrumbs_create_page_number_item( $query_var = 'paged' ) 
 /**
  * Creates a breadcrumb link item.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param string $url        The URL for the link (will be escaped).
  * @param string $text       The link text (will be escaped).
@@ -210,7 +210,7 @@ function block_core_breadcrumbs_create_link( $url, $text, $allow_html = false ) 
 /**
  * Creates a breadcrumb current page item.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param string $text       The text content (will be escaped).
  * @param bool   $allow_html Whether to allow HTML in the text. If true, uses wp_kses_post(), otherwise uses esc_html(). Default false.
@@ -230,7 +230,7 @@ function block_core_breadcrumbs_create_current_item( $text, $allow_html = false 
  * When paginated (is_paged is true), creates a link to page 1.
  * Otherwise, creates a span marked as the current page.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param string $text       The text content (will be escaped).
  * @param bool   $is_paged   Whether we're on a paginated view.
@@ -248,7 +248,7 @@ function block_core_breadcrumbs_create_item( $text, $is_paged = false, $allow_ht
 /**
  * Gets a post title with fallback for empty titles.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param int|WP_Post $post_id_or_object The post ID or post object.
  *
@@ -265,7 +265,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
 /**
  * Generates breadcrumb items from hierarchical post type ancestors.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param int $post_id   The post ID.
  *
@@ -291,7 +291,7 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
  *
  * For hierarchical taxonomies, retrieves and formats ancestor terms as breadcrumb links.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param int    $term_id  The term ID.
  * @param string $taxonomy The taxonomy name.
@@ -325,7 +325,7 @@ function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) 
  * Handles taxonomy archives, post type archives, date archives, and author archives.
  * For hierarchical taxonomies, includes ancestor terms in the breadcrumb trail.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @return array Array of breadcrumb HTML items.
  */
@@ -457,7 +457,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
  * Finds the first publicly queryable taxonomy with terms assigned to the post
  * and generates breadcrumb links, including hierarchical term ancestors if applicable.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param int    $post_id   The post ID.
  * @param string $post_type The post type name.
@@ -479,21 +479,69 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 		return array();
 	}
 
-	// Find the first taxonomy that has terms assigned to this post.
+	/**
+	 * Filters the preferred taxonomy and term for breadcrumbs on a per-post-type basis.
+	 *
+	 * Allows developers to specify which taxonomy and term should be used in breadcrumbs
+	 * when a post has multiple taxonomies or terms assigned.
+	 *
+	 * The preferred taxonomy must have terms assigned to the post, otherwise falls back to the first available taxonomy.
+	 *
+	 * The preferred term must exist and be assigned to the post. If the post has only one term, it's used regardless of preference.
+	 * If the preferred term is not found, falls back to the first term.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array  $preferences {
+	 *     Array of breadcrumb preferences. Default empty array.
+	 *
+	 *     @type string $preferred_taxonomy Optional. Taxonomy slug to prefer for breadcrumbs.
+	 *     @type string $preferred_term     Optional. Term slug to prefer when post has multiple terms.
+	 * }
+	 * @param string $post_type   The post type slug.
+	 */
+	$preferences = apply_filters( 'block_core_breadcrumbs_post_type_preferences', array(), $post_type );
+
 	$taxonomy_name = null;
 	$terms         = array();
-	foreach ( $taxonomies as $taxonomy ) {
-		$post_terms = get_the_terms( $post_id, $taxonomy->name );
-		if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
-			$taxonomy_name = $taxonomy->name;
-			$terms         = $post_terms;
-			break;
+
+	// Try preferred taxonomy first if specified.
+	if ( ! empty( $preferences['preferred_taxonomy'] ) ) {
+		$preferred_taxonomy = wp_list_filter( $taxonomies, array( 'name' => $preferences['preferred_taxonomy'] ) );
+		if ( ! empty( $preferred_taxonomy ) ) {
+			$preferred_taxonomy = reset( $preferred_taxonomy );
+			$post_terms         = get_the_terms( $post_id, $preferred_taxonomy->name );
+			if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+				$taxonomy_name = $preferred_taxonomy->name;
+				$terms         = $post_terms;
+			}
+		}
+	}
+
+	// If no preferred taxonomy or it didn't have terms, find the first taxonomy with terms.
+	if ( empty( $terms ) ) {
+		foreach ( $taxonomies as $taxonomy ) {
+			$post_terms = get_the_terms( $post_id, $taxonomy->name );
+			if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+				$taxonomy_name = $taxonomy->name;
+				$terms         = $post_terms;
+				break;
+			}
 		}
 	}
 
 	if ( ! empty( $terms ) ) {
-		// Use the first term (if multiple are assigned).
+		// Select which term to use.
 		$term = reset( $terms );
+
+		// Try preferred term if specified and post has multiple terms.
+		if ( ! empty( $preferences['preferred_term'] ) && count( $terms ) > 1 ) {
+			$preferred_term = wp_list_filter( $terms, array( 'slug' => $preferences['preferred_term'] ) );
+			if ( ! empty( $preferred_term ) ) {
+				$term = reset( $preferred_term );
+			}
+		}
+
 		// Add hierarchical term ancestors if applicable.
 		$breadcrumb_items   = array_merge(
 			$breadcrumb_items,
@@ -510,7 +558,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 /**
  * Registers the `core/breadcrumbs` block on the server.
  *
- * @since 6.9.0
+ * @since 7.0.0
  */
 function register_block_core_breadcrumbs() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -480,40 +480,41 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	}
 
 	/**
-	 * Filters the preferred taxonomy and term for breadcrumbs on a per-post-type basis.
+	 * Filters breadcrumb settings on a per-post-type basis.
 	 *
-	 * Allows developers to specify which taxonomy and term should be used in breadcrumbs
-	 * when a post has multiple taxonomies or terms assigned.
-	 *
-	 * The preferred taxonomy must have terms assigned to the post, otherwise falls back to the first available taxonomy.
-	 *
-	 * The preferred term must exist and be assigned to the post. If the post has only one term, it's used regardless of preference.
-	 * If the preferred term is not found, falls back to the first term.
+	 * Allow developers to customize breadcrumb behavior for specific post types.
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array  $preferences {
-	 *     Array of breadcrumb preferences. Default empty array.
+	 * @param array  $settings {
+	 *     Array of breadcrumb settings. Default empty array.
 	 *
-	 *     @type string $preferred_taxonomy Optional. Taxonomy slug to prefer for breadcrumbs.
-	 *     @type string $preferred_term     Optional. Term slug to prefer when post has multiple terms.
+	 *     @type string $taxonomy Optional. Taxonomy slug to use for breadcrumbs.
+	 *                            The taxonomy must be registered for the post type and have
+	 *                            terms assigned to the post. If not found or has no terms,
+	 *                            fall back to the first available taxonomy with terms.
+	 *     @type string $term     Optional. Term slug to use when the post has multiple terms
+	 *                            in the selected taxonomy. If the term is not found or not
+	 *                            assigned to the post, fall back to the first term. If the
+	 *                            post has only one term, that term is used regardless.
 	 * }
-	 * @param string $post_type   The post type slug.
+	 * @param string $post_type The post type slug.
 	 */
-	$preferences = apply_filters( 'block_core_breadcrumbs_post_type_preferences', array(), $post_type );
+	$settings = apply_filters( 'block_core_breadcrumbs_post_type_settings', array(), $post_type );
 
 	$taxonomy_name = null;
 	$terms         = array();
 
 	// Try preferred taxonomy first if specified.
-	if ( ! empty( $preferences['preferred_taxonomy'] ) ) {
-		$preferred_taxonomy = wp_list_filter( $taxonomies, array( 'name' => $preferences['preferred_taxonomy'] ) );
-		if ( ! empty( $preferred_taxonomy ) ) {
-			$preferred_taxonomy = reset( $preferred_taxonomy );
-			$post_terms         = get_the_terms( $post_id, $preferred_taxonomy->name );
-			if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
-				$taxonomy_name = $preferred_taxonomy->name;
-				$terms         = $post_terms;
+	if ( ! empty( $settings['taxonomy'] ) ) {
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( $taxonomy->name === $settings['taxonomy'] ) {
+				$post_terms = get_the_terms( $post_id, $taxonomy->name );
+				if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+					$taxonomy_name = $taxonomy->name;
+					$terms         = $post_terms;
+				}
+				break;
 			}
 		}
 	}
@@ -535,10 +536,12 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 		$term = reset( $terms );
 
 		// Try preferred term if specified and post has multiple terms.
-		if ( ! empty( $preferences['preferred_term'] ) && count( $terms ) > 1 ) {
-			$preferred_term = wp_list_filter( $terms, array( 'slug' => $preferences['preferred_term'] ) );
-			if ( ! empty( $preferred_term ) ) {
-				$term = reset( $preferred_term );
+		if ( ! empty( $settings['term'] ) && count( $terms ) > 1 ) {
+			foreach ( $terms as $candidate_term ) {
+				if ( $candidate_term->slug === $settings['term'] ) {
+					$term = $candidate_term;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72649

Add a PHP filter for users to set their preferred main taxonomy and term per post type. This is needed to have control over the breadcrumbs trail in case a post has multiple taxonomies and/or terms assigned.

This PR Introduces the `block_core_breadcrumbs_post_type_settings` PHP filter to allow developers to specify which taxonomy and term should be used in breadcrumbs when a post has multiple taxonomies or terms assigned.

**Parameters**: $post_type (string): The post type slug
**Returns**: (array) Settings array with the following keys:
  - `taxonomy` (string)
  - `term` (string)

### Fallback behavior:
  - If the preferred taxonomy doesn't exist or has no terms assigned, fall back to the first available taxonomy with terms assigned.
  - If the preferred term doesn't exist or isn't assigned to the post, fall back to the first term
  - If the post has only one term, that term is used regardless of setting

### Example

```
  add_filter(
  'block_core_breadcrumbs_post_type_settings', function(
   $settings, $post_type ) {
      if ( $post_type === 'post' ) {
          $settings['taxonomy'] = 'category';
          $settings['term'] = 'news';
      }
      return $settings;
  }, 10, 2 );
```


## Testing Instructions
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various cases in the front end.
3. Add the PHP filter and test various cases. See below for test snippet.

```
add_filter( 'block_core_breadcrumbs_post_type_settings', 'my_breadcrumb_settings', 10, 2 );

function my_breadcrumb_settings( $settings, $post_type ) {
  if ( $post_type === 'post' ) {
       $settings['taxonomy'] = 'category';
       $settings['term'] = 'news';
  }
  if ( $post_type === 'product' ) {
      $settings['taxonomy'] = 'product_tag';
      //   $settings['term'] = 'rigotag';
  }
  return $settings;
}
```

You can create your own taxonomies/terms to test, but specifically for the above snippet you'll need:

### For the `post` post type
Create a couple of categories and assign them to a post. Replace `$settings['term'] = 'news';` with one of your created categories `slug`. See the front end.

### For the `product` post type from Woo
1. Create a product with a category and one `product_tag`. 
2. Test that the trail shows the tag.







## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added x3p0-breadcrumbs plugin and the core block in the main header.
Above is x3p0-breadcrumbs and below is the core block.


#### Preferred taxonomy `product_tag` for Woo products

<img width="621" height="122" alt="Screenshot 2025-11-14 at 1 12 44 PM" src="https://github.com/user-attachments/assets/7d66b863-083e-4143-9284-9cb471ee076d" />

#### Preferred term `phones` for posts
<img width="621" height="122" alt="Screenshot 2025-11-14 at 1 13 03 PM" src="https://github.com/user-attachments/assets/d6ae3c52-9e21-4520-bce8-47948864060e" />


