### PR TITLE
Routing: Add init modules

### DIFF
--- a/lib/experimental/pages/gutenberg-boot.php
+++ b/lib/experimental/pages/gutenberg-boot.php
@@ -25,8 +25,9 @@ add_action( 'admin_menu', 'gutenberg_register_boot_admin_page' );
  */
 function gutenberg_boot_register_default_menu_items() {
 	register_gutenberg_boot_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
-	register_gutenberg_boot_menu_item( 'posts', __( 'Posts', 'gutenberg' ), '/types/post', '' );
-	register_gutenberg_boot_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	register_gutenberg_boot_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
+	register_gutenberg_boot_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
+	register_gutenberg_boot_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
+	register_gutenberg_boot_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '', 'drilldown' );
 }
 add_action( 'gutenberg-boot_init', 'gutenberg_boot_register_default_menu_items', 5 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17373,6 +17373,10 @@
 			"resolved": "packages/edit-site",
 			"link": true
 		},
+		"node_modules/@wordpress/edit-site-init": {
+			"resolved": "packages/edit-site-init",
+			"link": true
+		},
 		"node_modules/@wordpress/edit-widgets": {
 			"resolved": "packages/edit-widgets",
 			"link": true
@@ -53589,6 +53593,20 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/edit-site-init": {
+			"name": "@wordpress/edit-site-init",
+			"version": "1.0.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/boot": "file:../boot",
+				"@wordpress/data": "file:../data",
+				"@wordpress/icons": "file:../icons"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"packages/edit-widgets": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,12 @@
 		"scriptGlobal": "wp",
 		"packageNamespace": "wordpress",
 		"pages": [
-			"gutenberg-boot"
+			{
+				"id": "gutenberg-boot",
+				"init": [
+					"@wordpress/edit-site-init"
+				]
+			}
 		]
 	},
 	"config": {

--- a/packages/boot/src/components/app/index.tsx
+++ b/packages/boot/src/components/app/index.tsx
@@ -22,10 +22,12 @@ export async function init( {
 	mountId,
 	menuItems,
 	routes,
+	initModules,
 }: {
 	mountId: string;
 	menuItems?: MenuItem[];
 	routes?: Route[];
+	initModules?: string[];
 } ) {
 	( menuItems ?? [] ).forEach( ( menuItem ) => {
 		dispatch( store ).registerMenuItem( menuItem.id, menuItem );
@@ -34,6 +36,11 @@ export async function init( {
 	( routes ?? [] ).forEach( ( route ) => {
 		dispatch( store ).registerRoute( route );
 	} );
+
+	for ( const moduleId of initModules ?? [] ) {
+		const module = await import( moduleId );
+		await module.init();
+	}
 
 	// Render the app
 	const rootElement = document.getElementById( mountId );

--- a/packages/boot/src/index.tsx
+++ b/packages/boot/src/index.tsx
@@ -3,3 +3,4 @@
  */
 import './style.scss';
 export { init, initSinglePage } from './components/app';
+export { store } from './store';

--- a/packages/boot/src/store/actions.ts
+++ b/packages/boot/src/store/actions.ts
@@ -11,6 +11,14 @@ export function registerMenuItem( id: string, menuItem: MenuItem ) {
 	};
 }
 
+export function updateMenuItem( id: string, updates: Partial< MenuItem > ) {
+	return {
+		type: 'UPDATE_MENU_ITEM' as const,
+		id,
+		updates,
+	};
+}
+
 export function registerRoute( route: Route ) {
 	return {
 		type: 'REGISTER_ROUTE' as const,
@@ -20,4 +28,5 @@ export function registerRoute( route: Route ) {
 
 export type Action =
 	| ReturnType< typeof registerMenuItem >
+	| ReturnType< typeof updateMenuItem >
 	| ReturnType< typeof registerRoute >;

--- a/packages/boot/src/store/reducer.ts
+++ b/packages/boot/src/store/reducer.ts
@@ -20,6 +20,18 @@ export function reducer( state: State = initialState, action: Action ): State {
 				},
 			};
 
+		case 'UPDATE_MENU_ITEM':
+			return {
+				...state,
+				menuItems: {
+					...state.menuItems,
+					[ action.id ]: {
+						...state.menuItems[ action.id ],
+						...action.updates,
+					},
+				},
+			};
+
 		case 'REGISTER_ROUTE':
 			return {
 				...state,

--- a/packages/edit-site-init/package.json
+++ b/packages/edit-site-init/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@wordpress/edit-site-init",
+	"version": "1.0.0",
+	"description": "Initialization module for edit-site (gutenberg-boot) page.",
+	"private": true,
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/edit-site-init/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/edit-site-init"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"wpScriptModuleExports": "./build-module/index.js",
+	"dependencies": {
+		"@wordpress/boot": "file:../boot",
+		"@wordpress/data": "file:../data",
+		"@wordpress/icons": "file:../icons"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { home, styles, navigation, page, symbol } from '@wordpress/icons';
+import { dispatch } from '@wordpress/data';
+import { store as bootStore } from '@wordpress/boot';
+
+/**
+ * Initialize edit-site menu items with icons.
+ * This function is mandatory - all init modules must export 'init'.
+ */
+export async function init() {
+	// Define icons for menu items
+	const menuIcons: Record< string, { icon: React.ReactElement } > = {
+		home: { icon: home },
+		styles: { icon: styles },
+		navigation: { icon: navigation },
+		pages: { icon: page },
+		patterns: { icon: symbol },
+	};
+
+	// Update each menu item with its icon
+	Object.entries( menuIcons ).forEach( ( [ id, { icon } ] ) => {
+		dispatch( bootStore ).updateMenuItem( id, { icon } );
+	} );
+}

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -39,12 +39,13 @@ if ( ! function_exists( 'register_{{PAGE_SLUG_UNDERSCORE}}_menu_item' ) ) {
 	/**
 	 * Register a menu item for the {{PAGE_SLUG}} page.
 	 *
-	 * @param string $id        Menu item ID.
-	 * @param string $label     Display label.
-	 * @param string $to        Route path to navigate to.
-	 * @param string $parent_id Optional. Parent menu item ID.
+	 * @param string $id          Menu item ID.
+	 * @param string $label       Display label.
+	 * @param string $to          Route path to navigate to.
+	 * @param string $parent_id   Optional. Parent menu item ID.
+	 * @param string $parent_type Optional. Parent type: 'drilldown' or 'dropdown'.
 	 */
-	function register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $to, $parent_id = '' ) {
+	function register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $to, $parent_id = '', $parent_type = '' ) {
 		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
 
 		$menu_item = array(
@@ -55,6 +56,10 @@ if ( ! function_exists( 'register_{{PAGE_SLUG_UNDERSCORE}}_menu_item' ) ) {
 
 		if ( ! empty( $parent_id ) ) {
 			$menu_item['parent'] = $parent_id;
+		}
+
+		if ( ! empty( $parent_type ) && in_array( $parent_type, array( 'drilldown', 'dropdown' ), true ) ) {
+			$menu_item['parent_type'] = $parent_type;
 		}
 
 		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items[] = $menu_item;
@@ -157,13 +162,15 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 			wp_register_script( '{{PAGE_SLUG}}-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
 			// Add inline script to initialize the app
+			$init_modules = {{INIT_MODULES_JSON}};
 			wp_add_inline_script(
 				'{{PAGE_SLUG}}-prerequisites',
 				sprintf(
-					'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s}));',
+					'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s}));',
 					'{{PAGE_SLUG}}-app',
 					wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-					wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+					wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+					wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 				)
 			);
 
@@ -183,6 +190,9 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 					'id'     => '@wordpress/boot',
 				),
 			);
+
+			// Add init modules as static dependencies
+{{INIT_MODULES_PHP_ARRAY}}
 
 			// Add all registered routes as dependencies
 			foreach ( $routes as $route ) {


### PR DESCRIPTION
Related #70862 

## What?

Adds support for "init modules" to pages generation. These modules allow triggering some JS on init to set icons and things like that, things that can't be done in php. Important that these init modules stay as lean as possible.

## Testing Instructions

 - Open `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot`
 - Menu items have icons.