### PR TITLE
Block Editor: Fix block edit component hook dependencies

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -100,10 +100,10 @@ const EditWithGeneratedProps = ( props ) => {
 			),
 		};
 	}, [
-		name,
 		blockType?.usesContext,
 		blockContext,
 		attributes?.metadata?.bindings,
+		bindableAttributes,
 		registeredSources,
 	] );
 
@@ -180,7 +180,6 @@ const EditWithGeneratedProps = ( props ) => {
 			blockBindings,
 			clientId,
 			context,
-			name,
 			registeredSources,
 		]
 	);
@@ -262,7 +261,6 @@ const EditWithGeneratedProps = ( props ) => {
 			hasPatternOverrides,
 			setAttributes,
 			registeredSources,
-			name,
 			registry,
 		]
 	);


### PR DESCRIPTION
## What?
Related #67523.

PR adds missing dependency for `useMemo` hook and remove unused deps for `useSelect`.

## Why?
A minor code quality improvement.

## Testing Instructions
The feature has good e2e test coverage. Confirm that CI checks are passing.
