### PR TITLE
Routing: Add template part route

### DIFF
--- a/lib/experimental/pages/gutenberg-boot.php
+++ b/lib/experimental/pages/gutenberg-boot.php
@@ -28,6 +28,7 @@ function gutenberg_boot_register_default_menu_items() {
 	register_gutenberg_boot_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 	register_gutenberg_boot_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	register_gutenberg_boot_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
-	register_gutenberg_boot_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '', 'drilldown' );
+	register_gutenberg_boot_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
+	register_gutenberg_boot_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
 }
 add_action( 'gutenberg-boot_init', 'gutenberg_boot_register_default_menu_items', 5 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17629,6 +17629,14 @@
 			"resolved": "packages/sync",
 			"link": true
 		},
+		"node_modules/@wordpress/template-part": {
+			"resolved": "routes/template-part",
+			"link": true
+		},
+		"node_modules/@wordpress/template-part-list": {
+			"resolved": "routes/template-part-list",
+			"link": true
+		},
 		"node_modules/@wordpress/theme": {
 			"resolved": "packages/theme",
 			"link": true
@@ -54176,13 +54184,16 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/asset-loader": "file:../asset-loader",
+				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
+				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
 				"@wordpress/editor": "file:../editor",
 				"@wordpress/element": "file:../element",
 				"@wordpress/global-styles-engine": "file:../global-styles-engine",
+				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/private-apis": "file:../private-apis"
 			},
 			"engines": {
@@ -55436,6 +55447,40 @@
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/url": "file:../../packages/url"
+			}
+		},
+		"routes/template-part": {
+			"name": "@wordpress/template-part",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/route": "file:../../packages/route"
+			}
+		},
+		"routes/template-part-list": {
+			"name": "@wordpress/template-part-list",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/block-editor": "file:../../packages/block-editor",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/dom": "file:../../packages/dom",
+				"@wordpress/editor": "file:../../packages/editor",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/fields": "file:../../packages/fields",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/keycodes": "file:../../packages/keycodes",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/views": "file:../../packages/views",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3"
 			}
 		}
 	}

--- a/packages/core-data/src/entity-types/wp-template-part.ts
+++ b/packages/core-data/src/entity-types/wp-template-part.ts
@@ -57,6 +57,11 @@ declare module './base-entity-records' {
 				'view' | 'edit',
 				C
 			>;
+			blocks: ContextualField<
+				Array< Record< string, any > > | undefined,
+				'edit',
+				C
+			>;
 			/**
 			 * Title of template.
 			 */

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -1,7 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { home, styles, navigation, page, symbol } from '@wordpress/icons';
+import {
+	home,
+	styles,
+	navigation,
+	page,
+	symbol,
+	symbolFilled,
+} from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
 
@@ -16,6 +23,7 @@ export async function init() {
 		styles: { icon: styles },
 		navigation: { icon: navigation },
 		pages: { icon: page },
+		templateParts: { icon: symbolFilled },
 		patterns: { icon: symbol },
 	};
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -36,8 +36,8 @@ A React component that renders a modal for creating a template part. The modal d
 
 _Parameters_
 
--   _props_ `Object`: The component props.
--   _props.modalTitle_ `{ modalTitle: string; } & CreateTemplatePartModalContentsProps[ 'modalTitle' ]`:
+-   _props_ `{ modalTitle?: string; } & CreateTemplatePartModalContentsProps`: The component props.
+-   _props.modalTitle_ `{ modalTitle?: string; } & CreateTemplatePartModalContentsProps[ 'modalTitle' ]`:
 
 ### dateField
 

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -56,14 +56,14 @@ type CreateTemplatePartModalContentsProps = {
 /**
  * A React component that renders a modal for creating a template part. The modal displays a title and the contents for creating the template part.
  * This component should not live in this package, it should be moved to a dedicated package responsible for managing template.
- * @param {Object} props            The component props.
- * @param          props.modalTitle
+ * @param props            The component props.
+ * @param props.modalTitle
  */
 export default function CreateTemplatePartModal( {
 	modalTitle,
 	...restProps
 }: {
-	modalTitle: string;
+	modalTitle?: string;
 } & CreateTemplatePartModalContentsProps ) {
 	const defaultModalTitle = useSelect(
 		( select ) =>

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -39,13 +39,16 @@
 	"types": "build-types",
 	"dependencies": {
 		"@wordpress/asset-loader": "file:../asset-loader",
+		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",
+		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/global-styles-engine": "file:../global-styles-engine",
+		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
 	"publishConfig": {

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -15,10 +15,10 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useStylesId } from './hooks/use-styles-id';
-import { useEditorSettings } from './hooks/use-editor-settings';
-import { useEditorAssets } from './hooks/use-editor-assets';
-import { unlock } from './lock-unlock';
+import { useStylesId } from '../../hooks/use-styles-id';
+import { useEditorSettings } from '../../hooks/use-editor-settings';
+import { useEditorAssets } from '../../hooks/use-editor-assets';
+import { unlock } from '../../lock-unlock';
 
 const { Editor: PrivateEditor, BackButton } = unlock( editorPrivateApis );
 

--- a/packages/lazy-editor/src/components/preview/index.tsx
+++ b/packages/lazy-editor/src/components/preview/index.tsx
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useId, useMemo } from '@wordpress/element';
+// @ts-expect-error Block Editor not fully typed yet.
+import { BlockPreview, BlockEditorProvider } from '@wordpress/block-editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+// @ts-expect-error Blocks not fully typed yet.
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { unlock } from '../../lock-unlock';
+import { useEditorAssets } from '../../hooks/use-editor-assets';
+import { useEditorSettings } from '../../hooks/use-editor-settings';
+import { useStylesId } from '../../hooks/use-styles-id';
+
+const { useStyle } = unlock( editorPrivateApis );
+
+function PreviewContent( {
+	item,
+	description,
+}: {
+	item: { blocks?: any[]; content: { raw: string } };
+	description: string;
+} ) {
+	const descriptionId = useId();
+	const backgroundColor = useStyle( 'color.background' );
+	const blocks = useMemo( () => {
+		return (
+			item.blocks ??
+			parse( item.content.raw, {
+				__unstableSkipMigrationLogs: true,
+			} )
+		);
+	}, [ item?.content?.raw, item.blocks ] );
+	const isEmpty = ! blocks?.length;
+
+	return (
+		<div
+			className="lazy-editor-block-preview__container"
+			style={ { backgroundColor } }
+			aria-describedby={ !! description ? descriptionId : undefined }
+		>
+			{ isEmpty && __( 'Empty template part' ) }
+			{ ! isEmpty && (
+				<BlockPreview.Async>
+					<BlockPreview blocks={ blocks } />
+				</BlockPreview.Async>
+			) }
+			{ !! description && (
+				<div hidden id={ descriptionId }>
+					{ description }
+				</div>
+			) }
+		</div>
+	);
+}
+
+export function Preview( {
+	item,
+	description,
+}: {
+	item: { blocks?: any[]; content: { raw: string } };
+	description: string;
+} ) {
+	// Resolve styles ID from template
+	const stylesId = useStylesId();
+
+	// Load editor settings and assets
+	const { isReady: settingsReady, editorSettings } = useEditorSettings( {
+		stylesId,
+	} );
+	const { isReady: assetsReady } = useEditorAssets();
+	const finalSettings = useMemo(
+		() => ( {
+			...editorSettings,
+			isPreviewMode: true,
+		} ),
+		[ editorSettings ]
+	);
+	if ( ! settingsReady || ! assetsReady ) {
+		return null;
+	}
+	return (
+		<BlockEditorProvider settings={ finalSettings }>
+			<PreviewContent item={ item } description={ description } />
+		</BlockEditorProvider>
+	);
+}

--- a/packages/lazy-editor/src/components/preview/style.scss
+++ b/packages/lazy-editor/src/components/preview/style.scss
@@ -1,0 +1,23 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.lazy-editor-block-preview__container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+	height: 100%;
+	border-radius: $radius-medium;
+
+	.dataviews-view-grid & {
+		.block-editor-block-preview__container {
+			height: 100%;
+		}
+	}
+
+	.dataviews-view-table & {
+		width: 96px;
+		flex-grow: 0;
+		text-wrap: balance; // Fallback for Safari.
+		text-wrap: pretty;
+	}
+}

--- a/packages/lazy-editor/src/hooks/use-styles-id.tsx
+++ b/packages/lazy-editor/src/hooks/use-styles-id.tsx
@@ -19,7 +19,7 @@ interface Template {
  * @param {string} [props.templateId] - The ID of the template to use.
  * @return The styles ID.
  */
-export function useStylesId( { templateId }: { templateId?: string } ) {
+export function useStylesId( { templateId }: { templateId?: string } = {} ) {
 	const { globalStylesId, stylesId } = useSelect(
 		( select ) => {
 			const coreDataSelect = select( coreStore );

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -1,5 +1,6 @@
 /**
  * Internal dependencies
  */
-export { Editor } from './component';
+export { Editor } from './components/editor';
+export { Preview } from './components/preview';
 export { useEditorAssets, loadEditorAssets } from './hooks/use-editor-assets';

--- a/packages/lazy-editor/tsconfig.json
+++ b/packages/lazy-editor/tsconfig.json
@@ -13,6 +13,7 @@
 		{ "path": "../element" },
 		{ "path": "../editor" },
 		{ "path": "../global-styles-engine" },
+		{ "path": "../i18n" },
 		{ "path": "../private-apis" }
 	]
 }

--- a/routes/template-part-list/fields/preview.tsx
+++ b/routes/template-part-list/fields/preview.tsx
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Preview } from '@wordpress/lazy-editor';
+import type { WpTemplatePart } from '@wordpress/core-data';
+
+function PreviewField( { item }: { item: WpTemplatePart } ) {
+	const description = item.description;
+
+	return <Preview item={ item } description={ description } />;
+}
+
+export const previewField = {
+	label: __( 'Preview' ),
+	id: 'preview',
+	render: PreviewField,
+	enableSorting: false,
+};

--- a/routes/template-part-list/package.json
+++ b/routes/template-part-list/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@wordpress/template-part-list",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/template-parts/list/$area",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/block-editor": "file:../../packages/block-editor",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/dom": "file:../../packages/dom",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/fields": "file:../../packages/fields",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/keycodes": "file:../../packages/keycodes",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/views": "file:../../packages/views",
+		"clsx": "^2.1.1",
+		"dequal": "^2.0.3"
+	}
+}

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -21,10 +21,11 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import type { WpTemplatePart } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { CreateTemplatePartModal } from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -73,6 +74,9 @@ function TemplatePartList() {
 			} ),
 		[]
 	);
+
+	const [ showTemplatePartModal, setShowTemplatePartModal ] =
+		useState( false );
 
 	const defaultView: View = useMemo( () => {
 		return getDefaultView( postTypeObject, area );
@@ -258,11 +262,7 @@ function TemplatePartList() {
 					{ labels?.add_new_item && canCreateRecord && (
 						<Button
 							variant="primary"
-							onClick={ () => {
-								navigate( {
-									to: '/template-parts/new',
-								} );
-							} }
+							onClick={ () => setShowTemplatePartModal( true ) }
 							size="compact"
 						>
 							{ labels.add_new_item }
@@ -338,6 +338,22 @@ function TemplatePartList() {
 					/>
 				) }
 			/>
+			{ showTemplatePartModal && (
+				<CreateTemplatePartModal
+					closeModal={ () => setShowTemplatePartModal( false ) }
+					blocks={ [] }
+					onCreate={ ( templatePart ) => {
+						setShowTemplatePartModal( false );
+						navigate( {
+							to: `/types/wp_template_part/edit/${ encodeURIComponent(
+								templatePart.id
+							) }`,
+						} );
+					} }
+					onError={ () => setShowTemplatePartModal( false ) }
+					defaultArea={ area !== 'all' ? area : 'uncategorized' }
+				/>
+			) }
 		</Page>
 	);
 }

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -1,0 +1,345 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useParams,
+	useNavigate,
+	useSearch,
+	Link,
+	useInvalidate,
+} from '@wordpress/route';
+import { useView } from '@wordpress/views';
+import { DataViews } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type { View, Action } from '@wordpress/dataviews';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useCallback } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import type { WpTemplatePart } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import {
+	getDefaultView,
+	DEFAULT_VIEWS,
+	DEFAULT_LAYOUTS,
+	viewToQuery,
+} from './view-utils';
+import { previewField } from './fields/preview';
+
+// Unlock WordPress private APIs
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+const { usePostActions, usePostFields } = unlock( editorPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function getItemId( item: WpTemplatePart ) {
+	return item.id.toString();
+}
+
+function TemplatePartList() {
+	const invalidate = useInvalidate();
+	const { area = 'all' } = useParams( {
+		from: '/template-parts/list/$area',
+	} );
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/template-parts/list/$area' } );
+	const postTypeObject = useSelect(
+		( select ) => select( coreStore ).getPostType( 'wp_template_part' ),
+		[]
+	);
+
+	const labels = postTypeObject?.labels;
+	const canCreateRecord = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template_part',
+			} ),
+		[]
+	);
+
+	const defaultView: View = useMemo( () => {
+		return getDefaultView( postTypeObject, area );
+	}, [ postTypeObject, area ] );
+
+	// Callback to handle URL query parameter changes
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+
+	// Use the new view persistence hook
+	const { view, isModified, updateView, resetToDefault } = useView( {
+		kind: 'postType',
+		name: 'wp_template_part',
+		slug: area,
+		defaultView,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
+
+	const onReset = () => {
+		resetToDefault();
+		invalidate();
+	};
+	const onChangeView = ( newView: View ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			// The rendered surfaces depend on the view type,
+			// so we need to retrigger the router loader when switching the view type.
+			// try switching from list to table and vice versa.
+			invalidate();
+		}
+	};
+
+	const postTypeQuery = useMemo( () => viewToQuery( view ), [ view ] );
+	const {
+		records: posts,
+		totalItems,
+		totalPages,
+		isResolving,
+	} = useEntityRecordsWithPermissions(
+		'postType',
+		'wp_template_part',
+		postTypeQuery
+	);
+
+	const allFields = usePostFields( {
+		postType: 'wp_template_part',
+	} );
+
+	// Hide area column except in 'All' tab, hide status, and disable area filtering
+	const fields = useMemo( () => {
+		return [ previewField ].concat(
+			allFields
+				.filter( ( field: { id: string } ) => {
+					// Hide area column in specific area tabs
+					if ( field.id === 'area' && area !== 'all' ) {
+						return false;
+					}
+					// Hide status - template parts don't use status
+					if ( field.id === 'status' ) {
+						return false;
+					}
+					return true;
+				} )
+				.map( ( field: { id: string; filterBy?: any } ) => {
+					// Disable area field filtering since we use tabs
+					if ( field.id === 'area' ) {
+						return { ...field, filterBy: false };
+					}
+					return field;
+				} )
+		);
+	}, [ allFields, area ] );
+
+	// Helper function to clean up postIds from URL after deletion
+	const cleanupDeletedPostIdsFromUrl = useCallback(
+		( deletedItems: WpTemplatePart[] ) => {
+			const deletedIds = deletedItems.map( ( item: WpTemplatePart ) =>
+				item.id.toString()
+			);
+			const currentPostIds = searchParams.postIds || [];
+			const remainingPostIds = currentPostIds.filter(
+				( id: string ) => ! deletedIds.includes( id )
+			);
+
+			if ( remainingPostIds.length !== currentPostIds.length ) {
+				navigate( {
+					search: {
+						...searchParams,
+						postIds:
+							remainingPostIds.length > 0
+								? remainingPostIds
+								: undefined,
+					},
+				} );
+			} else {
+				// If no change in the url, the first item might have changed.
+				invalidate();
+			}
+		},
+		[ invalidate, searchParams, navigate ]
+	);
+
+	const postTypeActions: Action< WpTemplatePart >[] = usePostActions( {
+		postType: 'wp_template_part',
+		context: 'list',
+		onActionPerformed: ( actionId: string, items: WpTemplatePart[] ) => {
+			// Clean up URL when delete actions are performed
+			if (
+				actionId === 'move-to-trash' ||
+				actionId === 'permanently-delete'
+			) {
+				cleanupDeletedPostIdsFromUrl( items );
+			}
+		},
+	} );
+
+	const actions = useMemo( () => {
+		return [
+			...postTypeActions?.flatMap< Action< WpTemplatePart > >(
+				( action ) => {
+					// Skip revisions as the admin does not support it
+					if ( action.id === 'view-post-revisions' ) {
+						return [];
+					}
+
+					return [ action ];
+				}
+			),
+		];
+	}, [ postTypeActions ] );
+
+	const handleTabChange = useCallback(
+		( areaSlug: string ) => {
+			navigate( {
+				to: `/template-parts/list/${ areaSlug }`,
+			} );
+		},
+		[ navigate ]
+	);
+
+	if ( ! postTypeObject ) {
+		return null;
+	}
+
+	const selection = searchParams.postIds ?? [];
+
+	// Auto-select first template part in list view if none selected
+	if ( view.type === 'list' && selection.length === 0 && posts?.length > 0 ) {
+		selection.push( posts[ 0 ].id.toString() );
+	}
+
+	// Until list view supports multi selection, only keep the first item.
+	if ( view.type === 'list' ) {
+		selection.splice( 1 );
+	}
+
+	return (
+		<Page
+			title={ postTypeObject.labels?.name }
+			subTitle={ postTypeObject.labels?.description }
+			className="template-part-page"
+			actions={
+				<>
+					{ isModified && (
+						<Button
+							variant="tertiary"
+							size="compact"
+							onClick={ onReset }
+						>
+							{ __( 'Reset view' ) }
+						</Button>
+					) }
+					{ labels?.add_new_item && canCreateRecord && (
+						<Button
+							variant="primary"
+							onClick={ () => {
+								navigate( {
+									to: '/template-parts/new',
+								} );
+							} }
+							size="compact"
+						>
+							{ labels.add_new_item }
+						</Button>
+					) }
+				</>
+			}
+			hasPadding={ false }
+		>
+			{ DEFAULT_VIEWS.length > 1 && (
+				<div className="routes-template-part-list__tabs-wrapper">
+					<Tabs
+						onSelect={ handleTabChange }
+						selectedTabId={ area ?? 'all' }
+					>
+						<Tabs.TabList>
+							{ DEFAULT_VIEWS.map(
+								( filter: { slug: string; label: string } ) => (
+									<Tabs.Tab
+										tabId={ filter.slug }
+										key={ filter.slug }
+									>
+										{ filter.label }
+									</Tabs.Tab>
+								)
+							) }
+						</Tabs.TabList>
+					</Tabs>
+				</div>
+			) }
+			<DataViews
+				data={ posts }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				isLoading={ isResolving }
+				paginationInfo={ {
+					totalItems,
+					totalPages,
+				} }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ getItemId }
+				selection={ selection }
+				onChangeSelection={ ( items: string[] ) => {
+					navigate( {
+						search: {
+							...searchParams,
+							postIds: items.length > 0 ? items : undefined,
+							edit:
+								items.length === 0
+									? undefined
+									: searchParams.edit,
+						},
+					} );
+				} }
+				renderItemLink={ ( {
+					item,
+					...props
+				}: {
+					item: WpTemplatePart;
+				} ) => (
+					<Link
+						to={ `/types/wp_template_part/edit/${ encodeURIComponent(
+							item.id
+						) }` }
+						{ ...props }
+						onClick={ ( event ) => {
+							// Temporary fix to prevent triggering
+							// onChangeSelection, which would override the URL.
+							event.stopPropagation();
+						} }
+					/>
+				) }
+			/>
+		</Page>
+	);
+}
+
+export const stage = TemplatePartList;

--- a/routes/template-part-list/style.scss
+++ b/routes/template-part-list/style.scss
@@ -1,0 +1,11 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/fields/build-style/style.css" as fields;
+
+.routes-template-part-list__tabs-wrapper {
+	border-bottom: 1px solid $gray-100;
+	padding: 0 $grid-unit-60;
+	@container (max-width: 430px) {
+		padding: 0 $grid-unit-30;
+	}
+}

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -1,0 +1,157 @@
+/**
+ * WordPress dependencies
+ */
+import { loadView } from '@wordpress/views';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import type { Type } from '@wordpress/core-data';
+import type { View } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW: View = {
+	type: 'grid' as const,
+	sort: {
+		field: 'date',
+		direction: 'desc' as const,
+	},
+	fields: [],
+	titleField: 'title',
+	mediaField: 'preview',
+};
+
+export const DEFAULT_LAYOUTS = {
+	table: {},
+	grid: {},
+	list: {},
+};
+
+export const DEFAULT_VIEWS: {
+	slug: string;
+	label: string;
+	view: View;
+}[] = [
+	{
+		slug: 'all',
+		label: 'All Template Parts',
+		view: {
+			...DEFAULT_VIEW,
+		},
+	},
+	{
+		slug: 'header',
+		label: 'Headers',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'area',
+					operator: 'is',
+					value: 'header',
+				},
+			],
+		},
+	},
+	{
+		slug: 'footer',
+		label: 'Footers',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'area',
+					operator: 'is',
+					value: 'footer',
+				},
+			],
+		},
+	},
+	{
+		slug: 'sidebar',
+		label: 'Sidebars',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'area',
+					operator: 'is',
+					value: 'sidebar',
+				},
+			],
+		},
+	},
+	{
+		slug: 'uncategorized',
+		label: 'General',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'area',
+					operator: 'is',
+					value: 'uncategorized',
+				},
+			],
+		},
+	},
+];
+
+export function getDefaultView(
+	postType: Type | undefined,
+	area?: string
+): View {
+	// Find the view configuration by area
+	const viewConfig = DEFAULT_VIEWS.find( ( v ) => v.slug === area );
+
+	// Use the view from the config if found, otherwise use default
+	return viewConfig?.view || DEFAULT_VIEW;
+}
+
+export async function ensureView(
+	area?: string,
+	search?: { page?: number; search?: string }
+) {
+	const postTypeObject =
+		await resolveSelect( coreStore ).getPostType( 'wp_template_part' );
+	const defaultView = getDefaultView( postTypeObject, area );
+	return loadView( {
+		kind: 'postType',
+		name: 'wp_template_part',
+		slug: area ?? 'all',
+		defaultView,
+		queryParams: search,
+	} );
+}
+
+export function viewToQuery( view: View ) {
+	const result: Record< string, any > = {};
+
+	// Pagination, sorting, search.
+	if ( undefined !== view.perPage ) {
+		result.per_page = view.perPage;
+	}
+
+	if ( undefined !== view.page ) {
+		result.page = view.page;
+	}
+
+	if ( ! [ undefined, '' ].includes( view.search ) ) {
+		result.search = view.search;
+	}
+
+	if ( undefined !== view.sort?.field ) {
+		result.orderby = view.sort.field;
+	}
+
+	if ( undefined !== view.sort?.direction ) {
+		result.order = view.sort.direction;
+	}
+
+	// Area filtering for template parts
+	const areaFilter = view.filters?.find(
+		( filter ) => filter.field === 'area'
+	);
+	if ( areaFilter ) {
+		result.area = areaFilter.value;
+	}
+
+	return result;
+}

--- a/routes/template-part/package.json
+++ b/routes/template-part/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@wordpress/template-part",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/template-parts",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/template-part/route.ts
+++ b/routes/template-part/route.ts
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+/**
+ * Route configuration for template part redirect.
+ */
+export const route = {
+	beforeLoad: () => {
+		throw redirect( {
+			throw: true,
+			to: '/template-parts/list/$area',
+			params: {
+				area: 'all',
+			},
+		} );
+	},
+};


### PR DESCRIPTION
Related #70862 

## What?

This PR implements the template part route (separate from patterns) into the new Gutenberg-boot routing based site editor.

This follows the designs proposed in #73251 

There's a lot of small details missing but the goal for me now is to embrace iterations, get the big of the work done and once we get close to parity with the site editor, audit each page deeply and add/polish all the details.

## Testing Instructions

 - Open `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Ftemplate-parts%2Flist%2Fall`
 - Try using the page and editing template parts...