### PR TITLE
Update: Improve checkbox clickable area and styling

### DIFF
--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -122,8 +122,8 @@ export function CheckboxControl(
 						onClick={ ( event ) => {
 							// Compat code for Safari to ensure that the checkbox is focused when clicked.
 							event.currentTarget.focus();
+
 							onClick?.( event );
-							event.stopPropagation();
 						} }
 						{ ...additionalProps }
 					/>

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -110,48 +110,37 @@ export function CheckboxControl(
 		>
 			<HStack spacing={ 0 } justify="start" alignment="top">
 				<span className="components-checkbox-control__input-container">
-					<span
-						className="components-checkbox-control__input-container-area"
-						aria-hidden="true"
+					<input
+						ref={ ref }
+						id={ id }
+						className="components-checkbox-control__input"
+						type="checkbox"
+						value="1"
+						onChange={ onChangeValue }
+						checked={ checked }
+						aria-describedby={ !! help ? id + '__help' : undefined }
 						onClick={ ( event ) => {
-							event.currentTarget.firstElementChild?.click();
+							// Compat code for Safari to ensure that the checkbox is focused when clicked.
+							event.currentTarget.focus();
+							onClick?.( event );
 							event.stopPropagation();
 						} }
-					>
-						<input
-							ref={ ref }
-							id={ id }
-							className="components-checkbox-control__input"
-							type="checkbox"
-							value="1"
-							onChange={ onChangeValue }
-							checked={ checked }
-							aria-describedby={
-								!! help ? id + '__help' : undefined
-							}
-							onClick={ ( event ) => {
-								// Compat code for Safari to ensure that the checkbox is focused when clicked.
-								event.currentTarget.focus();
-								onClick?.( event );
-								event.stopPropagation();
-							} }
-							{ ...additionalProps }
+						{ ...additionalProps }
+					/>
+					{ showIndeterminateIcon ? (
+						<Icon
+							icon={ reset }
+							className="components-checkbox-control__indeterminate"
+							role="presentation"
 						/>
-						{ showIndeterminateIcon ? (
-							<Icon
-								icon={ reset }
-								className="components-checkbox-control__indeterminate"
-								role="presentation"
-							/>
-						) : null }
-						{ showCheckedIcon ? (
-							<Icon
-								icon={ check }
-								className="components-checkbox-control__checked"
-								role="presentation"
-							/>
-						) : null }
-					</span>
+					) : null }
+					{ showCheckedIcon ? (
+						<Icon
+							icon={ check }
+							className="components-checkbox-control__checked"
+							role="presentation"
+						/>
+					) : null }
 				</span>
 				{ label && (
 					<label

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -110,37 +110,48 @@ export function CheckboxControl(
 		>
 			<HStack spacing={ 0 } justify="start" alignment="top">
 				<span className="components-checkbox-control__input-container">
-					<input
-						ref={ ref }
-						id={ id }
-						className="components-checkbox-control__input"
-						type="checkbox"
-						value="1"
-						onChange={ onChangeValue }
-						checked={ checked }
-						aria-describedby={ !! help ? id + '__help' : undefined }
+					<span
+						className="components-checkbox-control__input-container-area"
+						aria-hidden="true"
 						onClick={ ( event ) => {
-							// Compat code for Safari to ensure that the checkbox is focused when clicked.
-							event.currentTarget.focus();
-
-							onClick?.( event );
+							event.currentTarget.firstElementChild?.click();
+							event.stopPropagation();
 						} }
-						{ ...additionalProps }
-					/>
-					{ showIndeterminateIcon ? (
-						<Icon
-							icon={ reset }
-							className="components-checkbox-control__indeterminate"
-							role="presentation"
+					>
+						<input
+							ref={ ref }
+							id={ id }
+							className="components-checkbox-control__input"
+							type="checkbox"
+							value="1"
+							onChange={ onChangeValue }
+							checked={ checked }
+							aria-describedby={
+								!! help ? id + '__help' : undefined
+							}
+							onClick={ ( event ) => {
+								// Compat code for Safari to ensure that the checkbox is focused when clicked.
+								event.currentTarget.focus();
+								onClick?.( event );
+								event.stopPropagation();
+							} }
+							{ ...additionalProps }
 						/>
-					) : null }
-					{ showCheckedIcon ? (
-						<Icon
-							icon={ check }
-							className="components-checkbox-control__checked"
-							role="presentation"
-						/>
-					) : null }
+						{ showIndeterminateIcon ? (
+							<Icon
+								icon={ reset }
+								className="components-checkbox-control__indeterminate"
+								role="presentation"
+							/>
+						) : null }
+						{ showCheckedIcon ? (
+							<Icon
+								icon={ check }
+								className="components-checkbox-control__checked"
+								role="presentation"
+							/>
+						) : null }
+					</span>
 				</span>
 				{ label && (
 					<label

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -35,6 +35,7 @@
 	vertical-align: top;
 	width: var(--checkbox-input-size);
 	height: var(--checkbox-input-size);
+	position: relative;
 
 	appearance: none;
 
@@ -60,6 +61,19 @@
 	&:checked::before {
 		content: none;
 	}
+
+	&::after {
+		content: "";
+		display: block;
+		inset: 0;
+		position: absolute;
+		width: calc(var(--checkbox-input-size) + var(--checkbox-input-margin) * 2);
+		height: calc(var(--checkbox-input-size) + var(--checkbox-input-margin) * 2);
+		padding: var(--checkbox-input-margin);
+		margin-left: calc(-1 * var(--checkbox-input-margin));
+		margin-top: calc(-1 * var(--checkbox-input-margin));
+		cursor: pointer;
+	}
 }
 
 .components-checkbox-control__input-container {
@@ -71,23 +85,6 @@
 	aspect-ratio: 1;
 	line-height: 1; // maintains proper height even with WP common.css
 	flex-shrink: 0;
-}
-
-.components-checkbox-control__input-container-area {
-	position: absolute;
-	inset: 0;
-	padding: 8px;
-	margin-left: -8px;
-	margin-top: -8px;
-	width: calc(var(--checkbox-input-size) + 16px);
-	height: calc(var(--checkbox-input-size) + 16px);
-	transition: cubic-bezier(0.075, 0.82, 0.165, 1) background-color 150ms;
-}
-
-.components-checkbox-control__input-container-area:hover {
-	cursor: pointer;
-	background-color: color-mix(in srgb, $components-color-accent 8%, $white);
-	border-radius: 50%;
 }
 
 svg.components-checkbox-control__checked,

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -73,6 +73,23 @@
 	flex-shrink: 0;
 }
 
+.components-checkbox-control__input-container-area {
+	position: absolute;
+	inset: 0;
+	padding: 8px;
+	margin-left: -8px;
+	margin-top: -8px;
+	width: calc(var(--checkbox-input-size) + 16px);
+	height: calc(var(--checkbox-input-size) + 16px);
+	transition: cubic-bezier(0.075, 0.82, 0.165, 1) background-color 150ms;
+}
+
+.components-checkbox-control__input-container-area:hover {
+	cursor: pointer;
+	background-color: color-mix(in srgb, $components-color-accent 8%, $white);
+	border-radius: 50%;
+}
+
 svg.components-checkbox-control__checked,
 svg.components-checkbox-control__indeterminate {
 	--checkmark-size: var(--checkbox-input-size);

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -35,7 +35,6 @@
 	vertical-align: top;
 	width: var(--checkbox-input-size);
 	height: var(--checkbox-input-size);
-	position: relative;
 
 	appearance: none;
 
@@ -62,9 +61,8 @@
 		content: none;
 	}
 
-	&::after {
+	&::after { /* increase clickable area */
 		content: "";
-		display: block;
 		inset: 0;
 		position: absolute;
 		width: calc(var(--checkbox-input-size) + var(--checkbox-input-margin) * 2);
@@ -72,7 +70,6 @@
 		padding: var(--checkbox-input-margin);
 		margin-left: calc(-1 * var(--checkbox-input-margin));
 		margin-top: calc(-1 * var(--checkbox-input-margin));
-		cursor: pointer;
 	}
 }
 


### PR DESCRIPTION
Wraps the checkbox input in an additional span to expand the clickable area, improving accessibility and usability. Adds new styles for the expanded area, including hover effects and proper positioning.

This PR expands increase the click area of the checkbox and adds a hover backgound so that it is more clear to the user what checkbox will be selected.

This PR is a follow up to https://github.com/WordPress/gutenberg/pull/73146 


## What?
* Adds a span that is clickable so has a hover class that increases the click area of checkboxes.

## Why?
Checkboxes can be hard to click since the click area is so small and in Dataview this can be an issue since missclicking a checkbox selection can cause the user to loose the selection. 

## How?
We add a new span that wraps the current checkbox. We absolute position this new chechbox area so that it shows up in the same place as before. 

## Testing Instructions
Visit the storybook and noctice that eveything still works as before. 
But now when you have a checkbox you also see the new cirlcle background when you hover over a checkbox.

### Testing Instructions for Keyboard
Key board should work as before. 


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/944e25b2-182d-4216-ab13-8614d8dad3e9



