### PR TITLE
Framework: Sync lockfile changes under Node.js v24 build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9487,51 +9487,6 @@
 				"streamx": "^2.15.0"
 			}
 		},
-		"node_modules/@radix-ui/primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
-			"integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			}
-		},
-		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
-			"integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-context": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
-			"integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-dialog": {
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
@@ -9859,24 +9814,6 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-focus-guards": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
-			"integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-focus-scope": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
@@ -9966,25 +9903,6 @@
 			"peerDependencies": {
 				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-id": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
-			"integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-layout-effect": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -10141,86 +10059,6 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-primitive": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
-			"integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-slot": "1.0.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-slot": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
-			"integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
-			"integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-controllable-state": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
-			"integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-use-effect-event": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
@@ -10247,43 +10085,6 @@
 			"peerDependencies": {
 				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-escape-keydown": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
-			"integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
-			"integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -42687,31 +42488,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-remove-scroll": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
-			"license": "MIT",
-			"dependencies": {
-				"react-remove-scroll-bar": "^2.3.3",
-				"react-style-singleton": "^2.2.1",
-				"tslib": "^2.1.0",
-				"use-callback-ref": "^1.3.0",
-				"use-sidecar": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/react-remove-scroll-bar": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
@@ -53452,220 +53228,6 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dialog": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
-			"integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.1",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-context": "1.0.1",
-				"@radix-ui/react-dismissable-layer": "1.0.5",
-				"@radix-ui/react-focus-guards": "1.0.1",
-				"@radix-ui/react-focus-scope": "1.0.4",
-				"@radix-ui/react-id": "1.0.1",
-				"@radix-ui/react-portal": "1.0.4",
-				"@radix-ui/react-presence": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-slot": "1.0.2",
-				"@radix-ui/react-use-controllable-state": "1.0.1",
-				"aria-hidden": "^1.1.1",
-				"react-remove-scroll": "2.5.5"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dialog/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
-			"integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.1",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-use-callback-ref": "1.0.1",
-				"@radix-ui/react-use-escape-keydown": "1.0.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dismissable-layer/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-focus-scope": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
-			"integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-focus-scope/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-portal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
-			"integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-primitive": "1.0.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-portal/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-presence": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
-			"integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-use-layout-effect": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-presence/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/cmdk": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
-			"integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
-			"dependencies": {
-				"@radix-ui/react-dialog": "1.0.5",
-				"@radix-ui/react-primitive": "1.0.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/commands/node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"license": "MIT"
 		},
 		"packages/components": {
 			"name": "@wordpress/components",


### PR DESCRIPTION
## What?

Updates `package-lock.json` to commit changes after running `npm install` with the version of NPM shipped with Node.js v24.

Follow-up to #72703

Related to #72143

## Why?

Fix build failures on `trunk`

Example: https://github.com/WordPress/gutenberg/actions/runs/19374127875/job/55437158928

## How?

Commit changes produced after switching to Node.js v24:

```
nvm install 24 && nvm use 24
npm install
```

## Testing Instructions

Verify that no changes are produced to `package-lock.json` in both Node.js v20 and v24:

```
nvm install && nvm use
npm install
nvm install 24 && nvm use 24
npm install
```