### PR TITLE
fix: YouTube embed previews render valid referrer

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -11,7 +11,6 @@ import {
 	createPortal,
 	forwardRef,
 	useMemo,
-	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs, useRefEffect, useDisabled } from '@wordpress/compose';
@@ -255,7 +254,6 @@ function Iframe( {
 <html>
 	<head>
 		<meta charset="utf-8">
-		<base href="${ window.location.origin }">
 		<script>window.frameElement._load()</script>
 		<style>
 			html{
@@ -278,14 +276,8 @@ function Iframe( {
 	</body>
 </html>`;
 
-	const [ src, cleanup ] = useMemo( () => {
-		const _src = URL.createObjectURL(
-			new window.Blob( [ html ], { type: 'text/html' } )
-		);
-		return [ _src, () => URL.revokeObjectURL( _src ) ];
-	}, [ html ] );
-
-	useEffect( () => cleanup, [ cleanup ] );
+	// Use html directly for srcDoc instead of blob URL to preserve referrer in Safari
+	const srcDoc = useMemo( () => html, [ html ] );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.
@@ -304,10 +296,9 @@ function Iframe( {
 				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }
-				// Correct doctype is required to enable rendering in standards
-				// mode. Also preload the styles to avoid a flash of unstyled
-				// content.
-				src={ src }
+				// Using srcDoc instead of blob URL src to preserve referrer
+				// context in Safari, allowing YouTube embeds to work correctly.
+				srcDoc={ srcDoc }
 				title={ title }
 				onKeyDown={ ( event ) => {
 					if ( props.onKeyDown ) {

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -69,26 +69,32 @@ export default function EmbedPreview( {
 	// as far as the user is concerned. We're just catching the first click so that
 	// the block can be selected without interacting with the embed preview that the overlay covers.
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
-	const embedWrapper =
-		'wp-embed' === type ? (
-			<WpEmbedPreview html={ html } />
-		) : (
-			<div className="wp-block-embed__wrapper">
-				<SandBox
-					html={ html }
-					scripts={ scripts }
-					title={ iframeTitle }
-					type={ sandboxClassnames }
-					onFocus={ hideOverlay }
+	// YouTube requires referrer information and doesn't work in sandboxed contexts
+	// Use direct iframe rendering like wp-embed to preserve referrer
+	const useDirectIframe =
+		'wp-embed' === type ||
+		url.includes( 'youtube.com' ) ||
+		url.includes( 'youtu.be' );
+
+	const embedWrapper = useDirectIframe ? (
+		<WpEmbedPreview html={ html } />
+	) : (
+		<div className="wp-block-embed__wrapper">
+			<SandBox
+				html={ html }
+				scripts={ scripts }
+				title={ iframeTitle }
+				type={ sandboxClassnames }
+				onFocus={ hideOverlay }
+			/>
+			{ ! interactive && (
+				<div
+					className="block-library-embed__interactive-overlay"
+					onMouseUp={ hideOverlay }
 				/>
-				{ ! interactive && (
-					<div
-						className="block-library-embed__interactive-overlay"
-						onMouseUp={ hideOverlay }
-					/>
-				) }
-			</div>
-		);
+			) }
+		</div>
+	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 	return (

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -69,32 +69,26 @@ export default function EmbedPreview( {
 	// as far as the user is concerned. We're just catching the first click so that
 	// the block can be selected without interacting with the embed preview that the overlay covers.
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
-	// YouTube requires referrer information and doesn't work in sandboxed contexts
-	// Use direct iframe rendering like wp-embed to preserve referrer
-	const useDirectIframe =
-		'wp-embed' === type ||
-		url.includes( 'youtube.com' ) ||
-		url.includes( 'youtu.be' );
-
-	const embedWrapper = useDirectIframe ? (
-		<WpEmbedPreview html={ html } />
-	) : (
-		<div className="wp-block-embed__wrapper">
-			<SandBox
-				html={ html }
-				scripts={ scripts }
-				title={ iframeTitle }
-				type={ sandboxClassnames }
-				onFocus={ hideOverlay }
-			/>
-			{ ! interactive && (
-				<div
-					className="block-library-embed__interactive-overlay"
-					onMouseUp={ hideOverlay }
+	const embedWrapper =
+		'wp-embed' === type ? (
+			<WpEmbedPreview html={ html } />
+		) : (
+			<div className="wp-block-embed__wrapper">
+				<SandBox
+					html={ html }
+					scripts={ scripts }
+					title={ iframeTitle }
+					type={ sandboxClassnames }
+					onFocus={ hideOverlay }
 				/>
-			) }
-		</div>
-	);
+				{ ! interactive && (
+					<div
+						className="block-library-embed__interactive-overlay"
+						onMouseUp={ hideOverlay }
+					/>
+				) }
+			</div>
+		);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 	return (

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	renderToString,
-	useRef,
-	useState,
-	useEffect,
-} from '@wordpress/element';
+import { useRef, useState, useEffect, useMemo } from '@wordpress/element';
 import { useFocusableIframe, useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -138,86 +133,7 @@ function SandBox( {
 	const [ width, setWidth ] = useState( 0 );
 	const [ height, setHeight ] = useState( 0 );
 
-	function isFrameAccessible() {
-		try {
-			return !! ref.current?.contentDocument?.body;
-		} catch ( e ) {
-			return false;
-		}
-	}
-
-	function trySandBox( forceRerender = false ) {
-		if ( ! isFrameAccessible() ) {
-			return;
-		}
-
-		const { contentDocument, ownerDocument } =
-			ref.current as HTMLIFrameElement & {
-				contentDocument: Document;
-			};
-
-		if (
-			! forceRerender &&
-			null !==
-				contentDocument?.body.getAttribute(
-					'data-resizable-iframe-connected'
-				)
-		) {
-			return;
-		}
-
-		// Put the html snippet into a html document, and then write it to the iframe's document
-		// we can use this in the future to inject custom styles or scripts.
-		// Scripts go into the body rather than the head, to support embedded content such as Instagram
-		// that expect the scripts to be part of the body.
-		const htmlDoc = (
-			<html
-				lang={ ownerDocument.documentElement.lang }
-				className={ type }
-			>
-				<head>
-					<title>{ title }</title>
-					<style dangerouslySetInnerHTML={ { __html: style } } />
-					{ styles.map( ( rules, i ) => (
-						<style
-							key={ i }
-							dangerouslySetInnerHTML={ { __html: rules } }
-						/>
-					) ) }
-				</head>
-				<body
-					data-resizable-iframe-connected="data-resizable-iframe-connected"
-					className={ type }
-				>
-					<div dangerouslySetInnerHTML={ { __html: html } } />
-					<script
-						type="text/javascript"
-						dangerouslySetInnerHTML={ {
-							__html: `(${ observeAndResizeJS.toString() })();`,
-						} }
-					/>
-					{ scripts.map( ( src ) => (
-						<script key={ src } src={ src } />
-					) ) }
-				</body>
-			</html>
-		);
-
-		// Writing the document like this makes it act in the same way as if it was
-		// loaded over the network, so DOM creation and mutation, script execution, etc.
-		// all work as expected.
-		contentDocument.open();
-		contentDocument.write( '<!DOCTYPE html>' + renderToString( htmlDoc ) );
-		contentDocument.close();
-	}
-
 	useEffect( () => {
-		trySandBox();
-
-		function tryNoForceSandBox() {
-			trySandBox( false );
-		}
-
 		function checkMessageForResize( event: MessageEvent ) {
 			const iframe = ref.current;
 
@@ -248,15 +164,10 @@ function SandBox( {
 		const iframe = ref.current;
 		const defaultView = iframe?.ownerDocument?.defaultView;
 
-		// This used to be registered using <iframe onLoad={} />, but it made the iframe blank
-		// after reordering the containing block. See these two issues for more details:
-		// https://github.com/WordPress/gutenberg/issues/6146
-		// https://github.com/facebook/react/issues/18752
-		iframe?.addEventListener( 'load', tryNoForceSandBox, false );
+		// Listen for resize messages from the iframe content (sent by observeAndResizeJS)
 		defaultView?.addEventListener( 'message', checkMessageForResize );
 
 		return () => {
-			iframe?.removeEventListener( 'load', tryNoForceSandBox, false );
 			defaultView?.removeEventListener(
 				'message',
 				checkMessageForResize
@@ -266,17 +177,27 @@ function SandBox( {
 		// See https://github.com/WordPress/gutenberg/pull/44378
 	}, [] );
 
-	useEffect( () => {
-		trySandBox();
-		// Passing `exhaustive-deps` will likely involve a more detailed refactor.
-		// See https://github.com/WordPress/gutenberg/pull/44378
-	}, [ title, styles, scripts ] );
-
-	useEffect( () => {
-		trySandBox( true );
-		// Passing `exhaustive-deps` will likely involve a more detailed refactor.
-		// See https://github.com/WordPress/gutenberg/pull/44378
-	}, [ html, type ] );
+	// Generate the HTML for srcdoc attribute
+	// Using srcdoc instead of document.write() preserves referrer information in Safari
+	const srcDocHtml = useMemo( () => {
+		const docLang =
+			typeof document !== 'undefined'
+				? document.documentElement.lang
+				: 'en';
+		return `<!DOCTYPE html>
+<html lang="${ docLang }" class="${ type || '' }">
+	<head>
+		<title>${ title }</title>
+		<style>${ style }</style>
+		${ styles.map( ( rules ) => `<style>${ rules }</style>` ).join( '' ) }
+	</head>
+	<body data-resizable-iframe-connected class="${ type || '' }">
+		<div>${ html }</div>
+		<script type="text/javascript">(${ observeAndResizeJS.toString() })();</script>
+		${ scripts.map( ( src ) => `<script src="${ src }"></script>` ).join( '' ) }
+	</body>
+</html>`;
+	}, [ html, title, type, styles, scripts ] );
 
 	return (
 		<iframe
@@ -284,6 +205,7 @@ function SandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
+			srcDoc={ srcDocHtml }
 			sandbox="allow-scripts allow-same-origin allow-presentation"
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

> [!important]
> This was opened primarily for demonstrative purposes. We need to better understand the implications of these changes before merging this. These changes likely have repercussions, there may also be a better approach altogether. 

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Relates to https://github.com/WordPress/gutenberg/issues/73288. Fix failing YouTube embed previews in Safari. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
YouTube embed previews currently fail with `Error 153` due to YouTube's new [policies requiring a valid referrer](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the editor `iframe` to use `srcDoc` rather than a `Blob` URL so that a valid `origin` is set. 
- ~Allow YouTube embeds to use `WpEmbedPreview` rather than `Sandbox` to pass along the referrer.~
- Update `Sandbox` to use `srcDoc` rather than writing to the document to preserve the referrer.  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See https://github.com/WordPress/gutenberg/issues/73288. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 
