### PR TITLE
Routing: Add pattern routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17911,6 +17911,14 @@
 			"resolved": "packages/nux",
 			"link": true
 		},
+		"node_modules/@wordpress/pattern": {
+			"resolved": "routes/pattern",
+			"link": true
+		},
+		"node_modules/@wordpress/pattern-list": {
+			"resolved": "routes/pattern-list",
+			"link": true
+		},
 		"node_modules/@wordpress/patterns": {
 			"resolved": "packages/patterns",
 			"link": true
@@ -55612,6 +55620,34 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/views": "file:../../packages/views"
+			}
+		},
+		"routes/pattern": {
+			"name": "@wordpress/pattern",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/route": "file:../../packages/route"
+			}
+		},
+		"routes/pattern-list": {
+			"name": "@wordpress/pattern-list",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
+				"@wordpress/block-editor": "file:../../packages/block-editor",
+				"@wordpress/blocks": "file:../../packages/blocks",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/editor": "file:../../packages/editor",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/patterns": "file:../../packages/patterns",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/views": "file:../../packages/views"
 			}

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -87,6 +87,10 @@ Parent field for BasePost.
 
 Password field for BasePost.
 
+### Pattern
+
+Undocumented declaration.
+
 ### patternTitleField
 
 Title for the pattern entity.

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -1,4 +1,9 @@
 export * from './fields';
 export * from './actions';
 export { default as CreateTemplatePartModal } from './components/create-template-part-modal';
-export type { BasePostWithEmbeddedAuthor, BasePost, PostType } from './types';
+export type {
+	BasePostWithEmbeddedAuthor,
+	BasePost,
+	PostType,
+	Pattern,
+} from './types';

--- a/packages/lazy-editor/src/components/preview/index.tsx
+++ b/packages/lazy-editor/src/components/preview/index.tsx
@@ -21,23 +21,25 @@ import { useStylesId } from '../../hooks/use-styles-id';
 const { useStyle } = unlock( editorPrivateApis );
 
 function PreviewContent( {
-	item,
+	blocks,
+	content,
 	description,
 }: {
-	item: { blocks?: any[]; content: { raw: string } };
+	blocks?: any[];
+	content?: string;
 	description: string;
 } ) {
 	const descriptionId = useId();
 	const backgroundColor = useStyle( 'color.background' );
-	const blocks = useMemo( () => {
+	const actualBlocks = useMemo( () => {
 		return (
-			item.blocks ??
-			parse( item.content.raw, {
+			blocks ??
+			parse( content, {
 				__unstableSkipMigrationLogs: true,
 			} )
 		);
-	}, [ item?.content?.raw, item.blocks ] );
-	const isEmpty = ! blocks?.length;
+	}, [ content, blocks ] );
+	const isEmpty = ! actualBlocks?.length;
 
 	return (
 		<div
@@ -45,10 +47,10 @@ function PreviewContent( {
 			style={ { backgroundColor } }
 			aria-describedby={ !! description ? descriptionId : undefined }
 		>
-			{ isEmpty && __( 'Empty template part' ) }
+			{ isEmpty && __( 'Empty.' ) }
 			{ ! isEmpty && (
 				<BlockPreview.Async>
-					<BlockPreview blocks={ blocks } />
+					<BlockPreview blocks={ actualBlocks } />
 				</BlockPreview.Async>
 			) }
 			{ !! description && (
@@ -61,10 +63,12 @@ function PreviewContent( {
 }
 
 export function Preview( {
-	item,
+	blocks,
+	content,
 	description,
 }: {
-	item: { blocks?: any[]; content: { raw: string } };
+	blocks?: any[];
+	content?: string;
 	description: string;
 } ) {
 	// Resolve styles ID from template
@@ -87,7 +91,11 @@ export function Preview( {
 	}
 	return (
 		<BlockEditorProvider settings={ finalSettings }>
-			<PreviewContent item={ item } description={ description } />
+			<PreviewContent
+				blocks={ blocks }
+				content={ content }
+				description={ description }
+			/>
 		</BlockEditorProvider>
 	);
 }

--- a/routes/pattern-list/fields/category.tsx
+++ b/routes/pattern-list/fields/category.tsx
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { NormalizedPattern } from '../use-patterns';
+
+const OPERATOR_IS = 'is';
+
+function CategoryField( { item }: { item: NormalizedPattern } ) {
+	const blockPatternCategories = useSelect(
+		( select ) => select( coreStore ).getBlockPatternCategories(),
+		[]
+	);
+
+	const categoryLabels = useMemo( () => {
+		if ( ! item.categories || ! Array.isArray( item.categories ) ) {
+			return [];
+		}
+
+		return item.categories
+			.map( ( catSlug: string ) => {
+				const category = blockPatternCategories?.find(
+					( cat: any ) => cat.name === catSlug
+				);
+				return category ? category.label || category.name : null;
+			} )
+			.filter( Boolean );
+	}, [ item.categories, blockPatternCategories ] );
+
+	if ( categoryLabels.length === 0 ) {
+		return <span className="pattern-category-field__empty">—</span>;
+	}
+
+	return (
+		<span className="pattern-category-field">
+			{ categoryLabels.join( ', ' ) }
+		</span>
+	);
+}
+
+/**
+ * Hook to get all available pattern categories from both user and theme sources.
+ */
+export function usePatternCategories() {
+	const userPatternCategories = useSelect(
+		( select ) => select( coreStore ).getUserPatternCategories(),
+		[]
+	);
+
+	const blockPatternCategories = useSelect(
+		( select ) => select( coreStore ).getBlockPatternCategories(),
+		[]
+	);
+
+	return useMemo( () => {
+		const categoryMap = new Map();
+
+		// Add user pattern categories
+		userPatternCategories?.forEach( ( cat: any ) => {
+			if ( ! categoryMap.has( cat.name ) ) {
+				categoryMap.set( cat.name, {
+					value: cat.name,
+					label: cat.label || cat.name,
+				} );
+			}
+		} );
+
+		// Add block pattern categories
+		blockPatternCategories?.forEach( ( cat: any ) => {
+			if ( ! categoryMap.has( cat.name ) ) {
+				categoryMap.set( cat.name, {
+					value: cat.name,
+					label: cat.label || cat.name,
+				} );
+			}
+		} );
+
+		// Convert map to array and sort by label
+		return Array.from( categoryMap.values() ).sort( ( a, b ) =>
+			a.label.localeCompare( b.label )
+		);
+	}, [ userPatternCategories, blockPatternCategories ] );
+}
+
+/**
+ * Pattern category field configuration for DataViews.
+ * This field shows pattern categories and provides filtering capabilities.
+ */
+export function usePatternCategoryField() {
+	const categories = usePatternCategories();
+
+	return {
+		label: __( 'Category' ),
+		id: 'category',
+		render: CategoryField,
+		elements: categories,
+		getValue: ( { item }: { item: NormalizedPattern } ) => {
+			return item.categories;
+		},
+		filterBy: {
+			operators: [ OPERATOR_IS ],
+			isPrimary: true,
+		},
+		enableSorting: false,
+	};
+}

--- a/routes/pattern-list/fields/preview.tsx
+++ b/routes/pattern-list/fields/preview.tsx
@@ -3,16 +3,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Preview } from '@wordpress/lazy-editor';
-import type { WpTemplatePart } from '@wordpress/core-data';
 
-function PreviewField( { item }: { item: WpTemplatePart } ) {
-	const description = item.description;
+/**
+ * Internal dependencies
+ */
+import type { NormalizedPattern } from '../use-patterns';
 
+function PreviewField( { item }: { item: NormalizedPattern } ) {
 	return (
 		<Preview
-			content={ item?.content?.raw }
 			blocks={ item.blocks }
-			description={ description }
+			content={ item.content }
+			description={ item.description }
 		/>
 	);
 }

--- a/routes/pattern-list/fields/sync-status.tsx
+++ b/routes/pattern-list/fields/sync-status.tsx
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { privateApis as patternPrivateApis } from '@wordpress/patterns';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import type { NormalizedPattern } from '../use-patterns';
+
+const { PATTERN_SYNC_TYPES } = unlock( patternPrivateApis );
+
+const OPERATOR_IS = 'is';
+
+const SYNC_FILTERS = [
+	{
+		value: PATTERN_SYNC_TYPES.full,
+		label: _x( 'Synced', 'pattern (singular)' ),
+		description: __( 'Patterns that are kept in sync across the site.' ),
+	},
+	{
+		value: PATTERN_SYNC_TYPES.unsynced,
+		label: _x( 'Not synced', 'pattern (singular)' ),
+		description: __(
+			'Patterns that can be changed freely without affecting the site.'
+		),
+	},
+];
+
+export const patternStatusField = {
+	label: __( 'Sync status' ),
+	id: 'sync-status',
+	render: ( { item }: { item: NormalizedPattern } ) => {
+		const syncStatus = item.syncStatus;
+		return (
+			<span
+				className={ `routes-pattern-list__field-sync-status-${ syncStatus }` }
+			>
+				{
+					SYNC_FILTERS.find( ( { value } ) => value === syncStatus )
+						?.label
+				}
+			</span>
+		);
+	},
+	elements: SYNC_FILTERS,
+	filterBy: {
+		operators: [ OPERATOR_IS ],
+		isPrimary: true,
+	},
+	enableSorting: false,
+};

--- a/routes/pattern-list/package.json
+++ b/routes/pattern-list/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@wordpress/pattern-list",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/patterns/list/$type",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
+		"@wordpress/block-editor": "file:../../packages/block-editor",
+		"@wordpress/blocks": "file:../../packages/blocks",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/patterns": "file:../../packages/patterns",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/views": "file:../../packages/views"
+	}
+}

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -1,0 +1,376 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useParams,
+	useNavigate,
+	useSearch,
+	Link,
+	useInvalidate,
+} from '@wordpress/route';
+import { useView } from '@wordpress/views';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type { View, Action } from '@wordpress/dataviews';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useCallback, useState } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { privateApis as patternPrivateApis } from '@wordpress/patterns';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import { DEFAULT_VIEW, DEFAULT_VIEWS, DEFAULT_LAYOUTS } from './view-utils';
+import { previewField } from './fields/preview';
+import { patternStatusField } from './fields/sync-status';
+import { usePatternCategoryField } from './fields/category';
+import usePatterns, { useAugmentPatternsWithPermissions } from './use-patterns';
+import type { NormalizedPattern } from './use-patterns';
+
+// Unlock WordPress private APIs
+const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
+const { PATTERN_TYPES, CreatePatternModal } = unlock( patternPrivateApis );
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function PatternList() {
+	const invalidate = useInvalidate();
+	const { type = 'all' } = useParams( {
+		from: '/patterns/list/$type',
+	} );
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/patterns/list/$type' } );
+
+	const postTypeObject = useSelect(
+		( select ) => select( coreStore ).getPostType( 'wp_block' ),
+		[]
+	);
+
+	const labels = postTypeObject?.labels;
+	const canCreateRecord = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_block',
+			} ),
+		[]
+	);
+
+	const [ showPatternModal, setShowPatternModal ] = useState( false );
+
+	// Callback to handle URL query parameter changes
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+
+	// Use the new view persistence hook
+	const { view, isModified, updateView, resetToDefault } = useView( {
+		kind: 'postType',
+		name: 'wp_block',
+		slug: type,
+		defaultView: DEFAULT_VIEW,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
+
+	const onReset = () => {
+		resetToDefault();
+		invalidate();
+	};
+	const onChangeView = ( newView: View ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			// The rendered surfaces depend on the view type,
+			// so we need to retrigger the router loader when switching the view type.
+			// try switching from list to table and vice versa.
+			invalidate();
+		}
+	};
+
+	// Extract filter values from view
+	const categoryFilter = useMemo( () => {
+		const filter = view.filters?.find( ( f ) => f.field === 'category' );
+		// Default to PATTERN_DEFAULT_CATEGORY if no category filter is set
+		return filter?.value || 'all-patterns';
+	}, [ view.filters ] );
+
+	const syncStatusFilter = useMemo( () => {
+		const filter = view.filters?.find( ( f ) => f.field === 'sync-status' );
+		return filter?.value;
+	}, [ view.filters ] );
+
+	// Determine which pattern type(s) to fetch based on current tab
+	const patternType = useMemo( () => {
+		if ( type === 'my-patterns' ) {
+			return PATTERN_TYPES.user;
+		} else if ( type === 'registered' ) {
+			return PATTERN_TYPES.theme;
+		}
+		return null; // null means fetch all types
+	}, [ type ] );
+
+	// Use the usePatterns hook to fetch and filter patterns
+	const { patterns, isResolving } = usePatterns(
+		patternType,
+		categoryFilter,
+		{
+			search: view.search,
+			syncStatus: syncStatusFilter,
+		}
+	);
+
+	// Augment patterns with permissions
+	const patternsWithPermissions =
+		useAugmentPatternsWithPermissions( patterns );
+
+	// Add pattern-specific fields
+	const patternCategoryField = usePatternCategoryField();
+	const fields = useMemo( () => {
+		const patternFields = [
+			previewField,
+			patternTitleField,
+			patternCategoryField,
+		];
+
+		// Add sync status field for user patterns
+		if ( type === 'my-patterns' || type === 'all' ) {
+			patternFields.push( patternStatusField );
+		}
+
+		// Filter and add other fields
+		return patternFields;
+	}, [ type, patternCategoryField ] );
+
+	// Apply client-side sorting and pagination, but NOT filtering
+	// Filtering is done server-side in usePatterns hook
+	const { data: posts, paginationInfo } = useMemo( () => {
+		// Remove filters from view - filtering is managed server-side
+		const viewWithoutFilters = { ...view };
+		delete viewWithoutFilters.search; // Search also done server-side
+		viewWithoutFilters.filters = []; // Remove all filters
+		return filterSortAndPaginate(
+			patternsWithPermissions,
+			viewWithoutFilters,
+			fields
+		);
+	}, [ patternsWithPermissions, view, fields ] );
+
+	const { totalItems, totalPages } = paginationInfo;
+
+	// Helper function to clean up postIds from URL after deletion
+	const cleanupDeletedPostIdsFromUrl = useCallback(
+		( deletedItems: NormalizedPattern[] ) => {
+			const deletedIds = deletedItems.map( ( item ) => item.id );
+			const currentPostIds = searchParams.postIds || [];
+			const remainingPostIds = currentPostIds.filter(
+				( id: string ) => ! deletedIds.includes( id )
+			);
+
+			if ( remainingPostIds.length !== currentPostIds.length ) {
+				navigate( {
+					search: {
+						...searchParams,
+						postIds:
+							remainingPostIds.length > 0
+								? remainingPostIds
+								: undefined,
+					},
+				} );
+			} else {
+				// If no change in the url, the first item might have changed.
+				invalidate();
+			}
+		},
+		[ invalidate, searchParams, navigate ]
+	);
+
+	const postTypeActions: Action< any >[] = usePostActions( {
+		postType: 'wp_block',
+		context: 'list',
+		onActionPerformed: ( actionId: string, items: NormalizedPattern[] ) => {
+			// Clean up URL when delete actions are performed
+			if (
+				actionId === 'move-to-trash' ||
+				actionId === 'permanently-delete'
+			) {
+				cleanupDeletedPostIdsFromUrl( items );
+			}
+		},
+	} );
+
+	const actions = useMemo( () => {
+		return [
+			...postTypeActions?.flatMap< Action< any > >( ( action ) => {
+				// Skip revisions as the admin does not support it
+				if ( action.id === 'view-post-revisions' ) {
+					return [];
+				}
+
+				return [ action ];
+			} ),
+		];
+	}, [ postTypeActions ] );
+
+	const handleTabChange = useCallback(
+		( typeSlug: string ) => {
+			navigate( {
+				to: `/patterns/list/${ typeSlug }`,
+			} );
+		},
+		[ navigate ]
+	);
+
+	if ( ! postTypeObject ) {
+		return null;
+	}
+
+	const selection = searchParams.postIds ?? [];
+
+	// Auto-select first pattern in list view if none selected
+	if ( view.type === 'list' && selection.length === 0 && posts?.length > 0 ) {
+		selection.push( posts[ 0 ].id );
+	}
+
+	// Until list view supports multi selection, only keep the first item.
+	if ( view.type === 'list' ) {
+		selection.splice( 1 );
+	}
+
+	return (
+		<Page
+			title={ __( 'Patterns' ) }
+			subTitle={ __(
+				'Reusable design elements for your site. Create once, use everywhere.'
+			) }
+			className="pattern-page"
+			actions={
+				<>
+					{ isModified && (
+						<Button
+							variant="tertiary"
+							size="compact"
+							onClick={ onReset }
+						>
+							{ __( 'Reset view' ) }
+						</Button>
+					) }
+					{ labels?.add_new_item && canCreateRecord && (
+						<Button
+							variant="primary"
+							onClick={ () => setShowPatternModal( true ) }
+							size="compact"
+						>
+							{ labels.add_new_item }
+						</Button>
+					) }
+				</>
+			}
+			hasPadding={ false }
+		>
+			{ DEFAULT_VIEWS.length > 1 && (
+				<div className="routes-pattern-list__tabs-wrapper">
+					<Tabs
+						onSelect={ handleTabChange }
+						selectedTabId={ type ?? 'all' }
+					>
+						<Tabs.TabList>
+							{ DEFAULT_VIEWS.map(
+								( filter: { slug: string; label: string } ) => (
+									<Tabs.Tab
+										tabId={ filter.slug }
+										key={ filter.slug }
+									>
+										{ filter.label }
+									</Tabs.Tab>
+								)
+							) }
+						</Tabs.TabList>
+					</Tabs>
+				</div>
+			) }
+			<DataViews
+				data={ posts }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				isLoading={ isResolving }
+				paginationInfo={ {
+					totalItems,
+					totalPages,
+				} }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				selection={ selection }
+				onChangeSelection={ ( items: string[] ) => {
+					navigate( {
+						search: {
+							...searchParams,
+							postIds: items.length > 0 ? items : undefined,
+							edit:
+								items.length === 0
+									? undefined
+									: searchParams.edit,
+						},
+					} );
+				} }
+				renderItemLink={ ( {
+					item,
+					...props
+				}: {
+					item: NormalizedPattern;
+				} ) => (
+					<Link
+						to={ `/types/wp_block/edit/${ encodeURIComponent(
+							item.id
+						) }` }
+						{ ...props }
+						onClick={ ( event ) => {
+							// Temporary fix to prevent triggering
+							// onChangeSelection, which would override the URL.
+							event.stopPropagation();
+						} }
+					/>
+				) }
+			/>
+			{ showPatternModal && (
+				<CreatePatternModal
+					onClose={ () => setShowPatternModal( false ) }
+					onSuccess={ ( {
+						pattern,
+					}: {
+						pattern: NormalizedPattern;
+					} ) => {
+						setShowPatternModal( false );
+						navigate( {
+							to: `/types/wp_block/edit/${ encodeURIComponent(
+								pattern.id
+							) }`,
+						} );
+					} }
+					content={ [] }
+				/>
+			) }
+		</Page>
+	);
+}
+
+export const stage = PatternList;

--- a/routes/pattern-list/style.scss
+++ b/routes/pattern-list/style.scss
@@ -1,0 +1,19 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/patterns/build-style/style.css" as patterns;
+
+.routes-pattern-list__tabs-wrapper {
+	border-bottom: 1px solid $gray-100;
+	padding: 0 $grid-unit-60;
+	@container (max-width: 430px) {
+		padding: 0 $grid-unit-30;
+	}
+}
+
+// Colorize synced pattern badges in grid view
+.dataviews-view-grid__badge-fields {
+	.dataviews-view-grid__field-value:has(.routes-pattern-list__field-sync-status-fully) {
+		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
+		color: var(--wp-block-synced-color);
+	}
+}

--- a/routes/pattern-list/use-patterns.ts
+++ b/routes/pattern-list/use-patterns.ts
@@ -1,0 +1,518 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, createSelector } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+import { privateApis as patternPrivateApis } from '@wordpress/patterns';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { filterOutDuplicatesByName } from './utils';
+import { unlock } from '../lock-unlock';
+
+const {
+	PATTERN_TYPES,
+	PATTERN_SYNC_TYPES,
+	EXCLUDED_PATTERN_SOURCES,
+	PATTERN_DEFAULT_CATEGORY,
+} = unlock( patternPrivateApis );
+
+const { extractWords, getNormalizedSearchTerms, normalizeString } = unlock(
+	blockEditorPrivateApis
+);
+
+/**
+ * Type for theme patterns from the pattern registry.
+ */
+interface ThemePattern {
+	name: string;
+	title: string;
+	content: string;
+	description: string;
+	source?: string;
+	inserter?: boolean;
+	keywords?: string[];
+	categories?: string[];
+	viewportWidth?: number;
+	blockTypes?: string[];
+	postTypes?: string[];
+	templateTypes?: string[];
+}
+
+/**
+ * Type for user patterns from wp_block post type.
+ */
+interface UserPattern {
+	id: number;
+	name: string;
+	title: { raw: string; rendered?: string };
+	content: { raw: string; rendered?: string };
+	excerpt?: { raw: string; rendered?: string };
+	description?: string;
+	wp_pattern_sync_status?: string;
+	wp_pattern_category?: number[];
+	blocks?: any[];
+}
+
+/**
+ * Unified pattern type after normalization.
+ * All patterns have these properties after going through normalizers.
+ */
+export interface NormalizedPattern {
+	// Required properties (normalized for both user and theme patterns)
+	id: string;
+	title: string;
+	content: string;
+	description: string;
+	keywords: string[];
+	type: string;
+	categories: string[];
+	syncStatus: string;
+	blocks?: any[];
+	// Internal property for permissions lookup (user patterns only)
+	_recordId?: number;
+}
+
+/**
+ * Type for pattern category.
+ */
+interface PatternCategory {
+	id: number;
+	name: string;
+	label: string;
+}
+
+/**
+ * Normalize theme pattern to unified structure.
+ *
+ * @param pattern Theme pattern object.
+ * @return Normalized pattern object.
+ */
+function normalizeThemePattern( pattern: ThemePattern ): NormalizedPattern {
+	return {
+		id: pattern.name,
+		title: pattern.title,
+		content: pattern.content,
+		keywords: pattern.keywords || [],
+		type: PATTERN_TYPES.theme,
+		// Normalize categories to always be an array of slugs
+		categories: pattern.categories || [],
+		// Theme patterns are always unsynced
+		syncStatus: PATTERN_SYNC_TYPES.unsynced,
+		description: pattern.description || '',
+	};
+}
+
+/**
+ * Normalize user pattern to unified structure.
+ *
+ * @param pattern               User pattern object.
+ * @param userPatternCategories List of available user pattern categories.
+ * @return Normalized pattern object.
+ */
+function normalizeUserPattern(
+	pattern: UserPattern,
+	userPatternCategories: PatternCategory[]
+): NormalizedPattern {
+	// Convert category IDs to slugs
+	const categories: string[] = [];
+	if (
+		pattern.wp_pattern_category &&
+		Array.isArray( pattern.wp_pattern_category )
+	) {
+		pattern.wp_pattern_category.forEach( ( catId: number ) => {
+			const category = userPatternCategories?.find(
+				( cat ) => cat.id === catId
+			);
+			if ( category ) {
+				categories.push( category.name );
+			}
+		} );
+	}
+
+	const numericId = pattern.id;
+	return {
+		id: pattern.name || pattern.id.toString(),
+		_recordId: numericId, // Keep numeric ID for permissions lookup
+		keywords: [],
+		type: PATTERN_TYPES.user,
+		// Normalize categories to always be an array of slugs
+		categories,
+		// Normalize sync status
+		syncStatus: pattern.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,
+		title:
+			typeof pattern.title === 'string'
+				? pattern.title
+				: pattern.title.raw,
+		content:
+			typeof pattern.content === 'string'
+				? pattern.content
+				: pattern.content.raw,
+		description: pattern.excerpt?.raw || '',
+		blocks: pattern.blocks,
+	};
+}
+
+/**
+ * Search configuration type.
+ */
+interface SearchConfig {
+	categoryId?: string;
+	hasCategory?: ( item: NormalizedPattern, categoryId: string ) => boolean;
+	onlyFilterByCategory?: boolean;
+}
+
+/**
+ * Remove matching terms from unmatched terms list.
+ * @param unmatchedTerms   List of unmatched terms.
+ * @param unprocessedTerms Unprocessed terms string.
+ * @return Filtered unmatched terms.
+ */
+const removeMatchingTerms = (
+	unmatchedTerms: string[],
+	unprocessedTerms: string
+): string[] => {
+	return unmatchedTerms.filter(
+		( term ) =>
+			! getNormalizedSearchTerms( unprocessedTerms ).some(
+				( unprocessedTerm: string ) => unprocessedTerm.includes( term )
+			)
+	);
+};
+
+/**
+ * Get the search rank for a given pattern and search term.
+ * @param item       Normalized pattern.
+ * @param searchTerm Search term string.
+ * @param config     Search configuration.
+ * @return Search rank number.
+ */
+function getItemSearchRank(
+	item: NormalizedPattern,
+	searchTerm: string,
+	config: SearchConfig
+): number {
+	const { categoryId, hasCategory, onlyFilterByCategory } = config;
+
+	// Check if item matches the category filter
+	let rank =
+		categoryId === PATTERN_DEFAULT_CATEGORY ||
+		( categoryId === 'my-patterns' && item.type === PATTERN_TYPES.user ) ||
+		( hasCategory && hasCategory( item, categoryId || '' ) )
+			? 1
+			: 0;
+
+	if ( ! rank || onlyFilterByCategory ) {
+		return rank;
+	}
+
+	// Access pattern properties directly
+	const normalizedSearchInput = normalizeString( searchTerm );
+	const normalizedTitle = normalizeString( item.title );
+
+	// Exact title matches get highest rank
+	if ( normalizedSearchInput === normalizedTitle ) {
+		rank += 30;
+	} else if ( normalizedTitle.startsWith( normalizedSearchInput ) ) {
+		rank += 20;
+	} else {
+		// Search in all text fields
+		const terms = [
+			item.id,
+			item.title,
+			item.description,
+			...item.keywords,
+		].join( ' ' );
+		const normalizedSearchTerms = extractWords( normalizedSearchInput );
+		const unmatchedTerms = removeMatchingTerms(
+			normalizedSearchTerms,
+			terms
+		);
+
+		if ( unmatchedTerms.length === 0 ) {
+			rank += 10;
+		}
+	}
+
+	return rank;
+}
+
+/**
+ * Filter and search patterns.
+ * @param items       List of normalized patterns.
+ * @param searchInput Search input string.
+ * @param config      Search configuration.
+ *
+ * @return Filtered and searched patterns.
+ */
+function searchItems(
+	items: NormalizedPattern[] = [],
+	searchInput = '',
+	config: SearchConfig = {}
+): NormalizedPattern[] {
+	const normalizedSearchTerms = getNormalizedSearchTerms( searchInput );
+
+	const onlyFilterByCategory =
+		config.categoryId !== PATTERN_DEFAULT_CATEGORY &&
+		! normalizedSearchTerms.length;
+	const searchRankConfig = { ...config, onlyFilterByCategory };
+
+	const threshold = onlyFilterByCategory ? 0 : 1;
+
+	const rankedItems = items
+		.map( ( item ) => {
+			return [
+				item,
+				getItemSearchRank( item, searchInput, searchRankConfig ),
+			] as [ NormalizedPattern, number ];
+		} )
+		.filter( ( [ , rank ] ) => rank > threshold );
+
+	// If no search terms, no need to sort
+	if ( normalizedSearchTerms.length === 0 ) {
+		return rankedItems.map( ( [ item ] ) => item );
+	}
+
+	rankedItems.sort( ( [ , rank1 ], [ , rank2 ] ) => rank2 - rank1 );
+	return rankedItems.map( ( [ item ] ) => item );
+}
+
+const selectThemePatterns = createSelector(
+	( select ) => {
+		const { getBlockPatterns } = select( coreStore );
+		const { isResolving: isResolvingSelector } = select( coreStore );
+
+		const restBlockPatterns = getBlockPatterns() as ThemePattern[];
+
+		const patterns = ( restBlockPatterns || [] )
+			.filter(
+				( pattern ) =>
+					! EXCLUDED_PATTERN_SOURCES.includes( pattern.source )
+			)
+			.filter( filterOutDuplicatesByName )
+			.filter( ( pattern ) => pattern.inserter !== false )
+			.map( normalizeThemePattern );
+		return {
+			patterns,
+			isResolving: isResolvingSelector( 'getBlockPatterns' ),
+		};
+	},
+	( select ) => [
+		select( coreStore ).getBlockPatterns(),
+		select( coreStore ).isResolving( 'getBlockPatterns' ),
+	]
+);
+
+const selectUserPatterns = createSelector(
+	( select, syncStatus = undefined, search = '' ) => {
+		const {
+			getEntityRecords,
+			isResolving: isResolvingSelector,
+			getUserPatternCategories,
+		} = select( coreStore );
+
+		const query = { per_page: -1 };
+		const patternPosts = getEntityRecords(
+			'postType',
+			PATTERN_TYPES.user,
+			query
+		) as UserPattern[] | null;
+		const userPatternCategories =
+			getUserPatternCategories() as PatternCategory[];
+		let patterns = ( patternPosts ?? [] ).map( ( pattern ) =>
+			normalizeUserPattern( pattern, userPatternCategories )
+		);
+		const isResolving = isResolvingSelector( 'getEntityRecords', [
+			'postType',
+			PATTERN_TYPES.user,
+			query,
+		] );
+
+		if ( syncStatus ) {
+			patterns = patterns.filter(
+				( pattern ) => pattern.syncStatus === syncStatus
+			);
+		}
+
+		patterns = searchItems( patterns, search, {
+			// We exit user pattern retrieval early if we aren't in the
+			// catch-all category for user created patterns, so it has
+			// to be in the category.
+			categoryId: PATTERN_DEFAULT_CATEGORY,
+			hasCategory: () => true,
+		} );
+
+		return {
+			patterns,
+			isResolving,
+			categories: userPatternCategories,
+		};
+	},
+	( select ) => [
+		select( coreStore ).getEntityRecords( 'postType', PATTERN_TYPES.user, {
+			per_page: -1,
+		} ),
+		select( coreStore ).isResolving( 'getEntityRecords', [
+			'postType',
+			PATTERN_TYPES.user,
+			{ per_page: -1 },
+		] ),
+		select( coreStore ).getUserPatternCategories(),
+	]
+);
+
+const selectPatterns = createSelector(
+	( select, categoryId, syncStatus, search = '' ) => {
+		const {
+			patterns: themePatterns,
+			isResolving: isResolvingThemePatterns,
+		} = selectThemePatterns( select );
+		const { patterns: userPatterns, isResolving: isResolvingUserPatterns } =
+			selectUserPatterns( select );
+
+		let patterns = [
+			...( themePatterns || [] ),
+			...( userPatterns || [] ),
+		];
+
+		if ( syncStatus ) {
+			patterns = patterns.filter(
+				( pattern ) => pattern.syncStatus === syncStatus
+			);
+		}
+
+		if ( categoryId && categoryId !== PATTERN_DEFAULT_CATEGORY ) {
+			patterns = searchItems( patterns, search, {
+				categoryId,
+				hasCategory: (
+					item: NormalizedPattern,
+					currentCategory: string
+				) => {
+					return item.categories?.includes( currentCategory );
+				},
+			} );
+		} else {
+			// Show all patterns (categoryId is PATTERN_DEFAULT_CATEGORY or undefined)
+			patterns = searchItems( patterns, search, {
+				categoryId: PATTERN_DEFAULT_CATEGORY,
+				hasCategory: () => true,
+			} );
+		}
+		return {
+			patterns,
+			isResolving: isResolvingThemePatterns || isResolvingUserPatterns,
+		};
+	},
+	( select ) => [
+		selectThemePatterns( select ),
+		selectUserPatterns( select ),
+	]
+);
+
+interface PermissionsMap {
+	[ id: string ]: {
+		delete?: boolean;
+		update?: boolean;
+	};
+}
+
+export function useAugmentPatternsWithPermissions(
+	patterns: NormalizedPattern[]
+) {
+	const idsAndTypes: [ string, number | undefined, string ][] = useMemo(
+		() =>
+			patterns
+				?.filter( ( record ) => record.type !== PATTERN_TYPES.theme )
+				.map( ( record ) => [
+					record.type,
+					record._recordId,
+					record.id,
+				] ) ?? [],
+		[ patterns ]
+	);
+
+	const permissions = useSelect(
+		( select ) => {
+			const { getEntityRecordPermissions } = unlock(
+				select( coreStore )
+			);
+			return idsAndTypes.reduce(
+				( acc: PermissionsMap, [ type, numericId, stringId ] ) => {
+					acc[ stringId ] = getEntityRecordPermissions(
+						'postType',
+						type,
+						numericId
+					);
+					return acc;
+				},
+				{} as PermissionsMap
+			);
+		},
+		[ idsAndTypes ]
+	);
+
+	return useMemo(
+		() =>
+			patterns?.map( ( record ) => ( {
+				...record,
+				permissions: permissions?.[ record.id ] ?? {},
+			} ) ) ?? [],
+		[ patterns, permissions ]
+	);
+}
+
+export const usePatterns = (
+	postType: string | null,
+	categoryId?: string,
+	{ search = '', syncStatus }: { search?: string; syncStatus?: string } = {}
+) => {
+	return useSelect(
+		( select ) => {
+			if ( postType === PATTERN_TYPES.user ) {
+				const result = selectUserPatterns( select, syncStatus, search );
+				let { patterns } = result;
+
+				// Apply category filtering if specified
+				if ( categoryId && categoryId !== PATTERN_DEFAULT_CATEGORY ) {
+					patterns = patterns.filter( ( pattern ) =>
+						pattern.categories.includes( categoryId )
+					);
+				}
+
+				return {
+					patterns,
+					isResolving: result.isResolving,
+				};
+			} else if ( postType === PATTERN_TYPES.theme ) {
+				const result = selectThemePatterns( select );
+				let { patterns } = result;
+
+				// Apply category filtering if specified
+				if ( categoryId && categoryId !== PATTERN_DEFAULT_CATEGORY ) {
+					patterns = patterns.filter( ( pattern ) =>
+						pattern.categories.includes( categoryId )
+					);
+				}
+
+				// Apply search filtering
+				patterns = searchItems( patterns, search, {
+					categoryId: categoryId || PATTERN_DEFAULT_CATEGORY,
+					hasCategory: () => true,
+				} );
+
+				return {
+					patterns,
+					isResolving: result.isResolving,
+				};
+			}
+			// null postType means all patterns
+			return selectPatterns( select, categoryId, syncStatus, search );
+		},
+		[ categoryId, postType, search, syncStatus ]
+	);
+};
+
+export default usePatterns;

--- a/routes/pattern-list/utils.ts
+++ b/routes/pattern-list/utils.ts
@@ -1,0 +1,5 @@
+export const filterOutDuplicatesByName = (
+	currentItem: any,
+	index: number,
+	items: any[]
+) => index === items.findIndex( ( item ) => currentItem.name === item.name );

--- a/routes/pattern-list/view-utils.ts
+++ b/routes/pattern-list/view-utils.ts
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { View } from '@wordpress/dataviews';
+
+const LAYOUT_GRID = 'grid';
+const LAYOUT_TABLE = 'table';
+
+export const DEFAULT_VIEW: View = {
+	type: LAYOUT_GRID,
+	perPage: 20,
+	sort: {
+		field: 'title',
+		direction: 'asc',
+	},
+	filters: [],
+	fields: [ 'sync-status' ],
+	layout: {
+		badgeFields: [ 'sync-status' ],
+	},
+	titleField: 'title',
+	mediaField: 'preview',
+};
+
+export const DEFAULT_VIEWS: {
+	slug: string;
+	label: string;
+}[] = [
+	{
+		slug: 'all',
+		label: __( 'All patterns' ),
+	},
+	{
+		slug: 'my-patterns',
+		label: __( 'My patterns' ),
+	},
+	{
+		slug: 'registered',
+		label: __( 'Registered' ),
+	},
+];
+
+export const DEFAULT_LAYOUTS = {
+	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_GRID ]: {
+		layout: {
+			badgeFields: [ 'sync-status' ],
+		},
+	},
+};

--- a/routes/pattern/package.json
+++ b/routes/pattern/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@wordpress/pattern",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/patterns",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/pattern/route.ts
+++ b/routes/pattern/route.ts
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+/**
+ * Route configuration for pattern redirect.
+ */
+export const route = {
+	beforeLoad: () => {
+		throw redirect( {
+			throw: true,
+			to: '/patterns/list/$type',
+			params: {
+				type: 'all',
+			},
+		} );
+	},
+};


### PR DESCRIPTION
Related #70862 

## What?

This PR implements the pattern route into the new Gutenberg-boot routing based site editor.

This follows the designs proposed in #73251 

There's a lot of small details missing but the goal for me now is to embrace iterations, get the big of the work done and once we get close to parity with the site editor, audit each page deeply and add/polish all the details.

## Testing Instructions

 - Open `http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Fpatterns%2Flist%2Fall`
 - Try using the page and editing patterns...