### PR TITLE
Block Editor: Border Radius Control: Empty Values triggers unintended px unit conversion

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/single-input-control.js
+++ b/packages/block-editor/src/components/border-radius-control/single-input-control.js
@@ -74,6 +74,7 @@ export default function SingleInputControl( {
 	const onChangeUnit = ( next ) => {
 		const newUnits = { ...selectedUnits };
 		if ( corner === 'all' ) {
+			newUnits.flat = next;
 			newUnits.topLeft = next;
 			newUnits.topRight = next;
 			newUnits.bottomLeft = next;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #73291

If we remove the value of a Border Radius (in a paragraph or a group or anywhere where we have this control), the unit flips to `px` instead of retaining the selected value `rem` or whatever.

## How?
We forgot to add the `flat` (single value), unit to the `onChangeUnit` in the input control when `corner` equals `all`. At first I thought there could be a difference between `corner` to `all` and the multiple options alternative, but I think that I any case the `newUnits` should be set for the corner that is being switched (including the `all` option). So there is no point on differentiating them.

This was introduced in #67544 but I can't really see in the PR why this differentiation was necessary, so I assume it's a little bug.

## Testing Instructions
1. Add a group block
2. Go to the styles and select `rem` for the units in the Border radius
3. Add any value, 1 for example
4. Remove the value. The unit should not flip to `px`

## Additional Testing ideas
1. Play around with other Border radius units. Not only the "all" but the individual radius (topLeft, bottomLeft, etc...)

### Testing Instructions for Keyboard
1. Remove the value with the backspace; the unit should not flip to `px`

## Screenshots or screencast
|Before|After|
|-|-|
|<img width="315" height="177" alt="image" src="https://github.com/user-attachments/assets/a0c2ada6-9fe1-4d06-b1b2-6e84c8994149" />|<img width="376" height="163" alt="image" src="https://github.com/user-attachments/assets/cbc633c4-55a5-4c52-9964-7f04836ec62f" />|
