### PR TITLE
Merge "Icon Size" and "Icon size" translation strings

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -183,7 +183,7 @@ export function SocialLinksEdit( props ) {
 						<SelectControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={ __( 'Icon Size' ) }
+							label={ __( 'Icon size' ) }
 							onChange={ ( newSize ) => {
 								setAttributes( {
 									size: newSize === '' ? undefined : newSize,


### PR DESCRIPTION
## What?
This merges the "Icon Size" and "Icon size" translation strings to avoir multiple translation for similar strings.

## Why?
Translation performance.

## How?
Replaces "Icon Size" with "Icon size".