### PR TITLE
Navigation: flag deleted taxonomy links as invalid

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -104,12 +104,13 @@ const useIsDraggingWithin = ( elementRef ) => {
 const useIsInvalidLink = ( kind, type, id, enabled ) => {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
+	const isTaxonomy = kind === 'taxonomy';
 	const hasId = Number.isInteger( id );
 	const blockEditingMode = useBlockEditingMode();
 
 	const { postStatus, isDeleted } = useSelect(
 		( select ) => {
-			if ( ! isPostType ) {
+			if ( ! isPostType && ! isTaxonomy ) {
 				return { postStatus: null, isDeleted: false };
 			}
 
@@ -122,9 +123,10 @@ const useIsInvalidLink = ( kind, type, id, enabled ) => {
 
 			const { getEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const entityRecord = getEntityRecord( 'postType', type, id );
+			const entityKind = isTaxonomy ? 'taxonomy' : 'postType';
+			const entityRecord = getEntityRecord( entityKind, type, id );
 			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
-				'postType',
+				entityKind,
 				type,
 				id,
 			] );
@@ -133,26 +135,27 @@ const useIsInvalidLink = ( kind, type, id, enabled ) => {
 			const deleted = hasResolved && entityRecord === undefined;
 
 			return {
-				postStatus: entityRecord?.status,
+				postStatus: isPostType ? entityRecord?.status : null,
 				isDeleted: deleted,
 			};
 		},
-		[ isPostType, blockEditingMode, enabled, type, id ]
+		[ isPostType, isTaxonomy, blockEditingMode, enabled, type, id ]
 	);
 
 	// Check Navigation Link validity if:
-	// 1. Link is 'post-type'.
+	// 1. Link is 'post-type' or 'taxonomy'.
 	// 2. It has an id.
 	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
 	// If those conditions are met, check if
-	// 1. The post status is trash (trashed).
+	// 1. For post types, the post status is trash (trashed).
 	// 2. The entity doesn't exist (deleted).
 	// If either of those is true, invalidate.
 	const isInvalid =
-		isPostType &&
-		hasId &&
-		( isDeleted || ( postStatus && 'trash' === postStatus ) );
-	const isDraft = 'draft' === postStatus;
+		( isPostType &&
+			hasId &&
+			( isDeleted || ( postStatus && 'trash' === postStatus ) ) ) ||
+		( isTaxonomy && hasId && isDeleted );
+	const isDraft = isPostType && 'draft' === postStatus;
 
 	return [ isInvalid, isDraft ];
 };

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1226,6 +1226,49 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 		} );
 
+		test( 'marks taxonomy link as invalid when term is missing', async ( {
+			editor,
+			admin,
+			navigation,
+			requestUtils,
+		} ) => {
+			await test.step( 'Setup - Create navigation with missing taxonomy term', async () => {
+				await admin.createNewPost();
+
+				const nonExistentTermId = 99999;
+				const menu = await requestUtils.createNavigationMenu( {
+					title: 'Test Menu with Missing Term',
+					content: `<!-- wp:navigation-link {"label":"Unavailable Category","type":"category","id":${ nonExistentTermId },"kind":"taxonomy","metadata":{"bindings":{"url":{"source":"core/term-data","args":{"field":"link"}}}}} /-->`,
+				} );
+
+				await editor.insertBlock( {
+					name: 'core/navigation',
+					attributes: {
+						ref: menu.id,
+					},
+				} );
+			} );
+
+			await test.step( 'Verify Nav Link shows "Invalid" suffix for taxonomy term', async () => {
+				const navBlock = navigation.getNavBlock();
+				await editor.selectBlocks( navBlock );
+
+				const navLinkBlock = navBlock
+					.getByRole( 'document', {
+						name: 'Block: Category Link',
+					} )
+					.first();
+
+				await editor.selectBlocks( navLinkBlock );
+
+				const placeholderText = navLinkBlock.locator(
+					'.wp-block-navigation-link__placeholder-text'
+				);
+				await expect( placeholderText ).toBeVisible();
+				await expect( placeholderText ).toContainText( '(Invalid)' );
+			} );
+		} );
+
 		test( 'handles unavailable entity binding', async ( {
 			editor,
 			page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:

https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #73188

Adds invalid-state detection (and coverage) for navigation links that point to deleted taxonomy terms.

## Why?

Navigation blocks already show “(Invalid)” on links to deleted posts, but taxonomy-linked items stayed silent after the underlying term was removed. Editors therefore had no cue that a menu item needed fixing.

## How?

- Extend `useIsInvalidLink` so taxonomy entities are checked via `core-data` and marked invalid when resolution fails.
- Keep draft-state handling scoped to post types.
- Add a Playwright spec that builds a menu referencing a non-existent term and verifies the “(Invalid)” suffix displays.

## Testing Instructions

1. `npm install && composer install`
2. `npm run wp-env start`
3. `npm run test:e2e -- test/e2e/specs/editor/blocks/navigation.spec.js`

### Testing Instructions for Keyboard

1. Insert a Navigation block that includes a taxonomy link (e.g., category).
2. Delete the linked term in another tab.
3. Return to the editor and Tab to the affected link; confirm the label shows “(Invalid)” and Enter opens the Link UI so the link can be repaired.

