### PR TITLE
Fix: Stretch Text overflows into the padding area.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -17,11 +17,28 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	let maxSize = 2400;
 	let bestSize = minSize;
 
+	const computedStyle = window.getComputedStyle( textElement );
+	const paddingLeft = parseFloat( computedStyle.paddingLeft ) || 0;
+	const paddingRight = parseFloat( computedStyle.paddingRight ) || 0;
+	const range = document.createRange();
+	range.selectNodeContents( textElement );
+
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
 		applyFontSize( midSize );
 
-		const fitsWidth = textElement.scrollWidth <= textElement.clientWidth;
+		// When there is padding if the text overflows to the
+		// padding area, it should be considered overflowing.
+		// Use Range API to measure actual text content dimensions.
+		const rect = range.getBoundingClientRect();
+		const textWidth = rect.width;
+
+		// Check if text fits within the element's width and is not
+		// overflowing into the padding area.
+		const fitsWidth =
+			textElement.scrollWidth <= textElement.clientWidth &&
+			textWidth <= textElement.clientWidth - paddingLeft - paddingRight;
+		// Check if text fits within the element's height.
 		const fitsHeight =
 			alreadyHasScrollableHeight ||
 			textElement.scrollHeight <= textElement.clientHeight;
@@ -33,6 +50,7 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 			maxSize = midSize - 1;
 		}
 	}
+	range.detach();
 
 	return bestSize;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/73218.
Fixes an issue reported by @t-hamano where if there is padding on the paragraph the text may overflow into the padding area (it fits the container but the padding area stops being a real padding).

## How?
Paddings does not changes scrollWidth and clientWidth, which were using for the binary search, in order to fix the issue we need to get the real text dimensions, and the available space.

To get the real text dimensions of a text node the way to do it is using a range plus getBoundingClientRect (as far as I know that's the only way).

To get the available width we subtract the paddings to the clientWidth.


## Video

https://github.com/user-attachments/assets/51c079e8-90bc-4661-8c54-f276c8319563

(works the same as a normal paragraph)

## Testing Instructions
Add a Stretch Paragraph, add some padding.
Verify no matter the text or padding the text never overflows into the padding area.

