### PR TITLE
Add package-json-lint rules and configuration for ESLint plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32493,6 +32493,48 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-eslint-parser": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.1.tgz",
+			"integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.5.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			}
+		},
+		"node_modules/jsonc-eslint-parser/node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -54020,6 +54062,7 @@
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
+				"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
 				"@wordpress/prettier-config": "file:../prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
@@ -54033,6 +54076,7 @@
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
+				"jsonc-eslint-parser": "^2.4.0",
 				"requireindex": "^1.2.0"
 			},
 			"engines": {
@@ -54042,10 +54086,14 @@
 			"peerDependencies": {
 				"@babel/core": ">=7",
 				"eslint": ">=8",
+				"npm-package-json-lint": ">=6.0.0",
 				"prettier": ">=3",
 				"typescript": ">=5"
 			},
 			"peerDependenciesMeta": {
+				"npm-package-json-lint": {
+					"optional": true
+				},
 				"prettier": {
 					"optional": true
 				},

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -89,6 +89,7 @@ The granular rulesets will not define any environment globals. As such, if they 
 | [no-wp-process-env](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/no-wp-process-env.md)                                         | Disallow legacy usage of WordPress variables via `process.env` like `process.env.SCRIPT_DEBUG`. | ✓           |
 | [react-no-unsafe-timeout](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)                             | Disallow unsafe `setTimeout` in component.                                                      |             |
 | [valid-sprintf](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/valid-sprintf.md)                                                 | Enforce valid sprintf usage.                                                                    | ✓           |
+| [validate-package-json](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/validate-package-json.md)                                 | Validate package.json files using `npm-package-json-lint` configuration.    | ✓           |
 | [wp-global-usage](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/wp-global-usage.md)                                             | Enforce correct usage of WordPress globals like `globalThis.SCRIPT_DEBUG`.                      |             |
 
 ### Legacy

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -50,6 +50,7 @@ Alternatively, you can opt-in to only the more granular rulesets offered by the 
 -   `i18n` – rules for internationalization.
 -   `jsdoc` – rules for JSDoc comments.
 -   `jsx-a11y` – rules for accessibility in JSX.
+-   `package-json-lint` – rules for linting package.json via [@wordpress/npm-package-json-lint-config](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-npm-package-json-lint-config/)
 -   `react` – rules for React components.
 -   `test-e2e` – rules for end-to-end tests written in Puppeteer.
 -   `test-unit`– rules for unit tests written in Jest.

--- a/packages/eslint-plugin/configs/package-json-lint.js
+++ b/packages/eslint-plugin/configs/package-json-lint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+	plugins: [ '@wordpress' ],
+	overrides: [
+		{
+			files: [ '**/package.json' ],
+			parser: require.resolve( 'jsonc-eslint-parser' ),
+			rules: {
+				'@wordpress/validate-package-json': 'error',
+			},
+		},
+	],
+};

--- a/packages/eslint-plugin/docs/rules/validate-package-json.md
+++ b/packages/eslint-plugin/docs/rules/validate-package-json.md
@@ -26,6 +26,23 @@ The `package-json-lint` preset automatically enables this rule for `package.json
 }
 ```
 
+**Note:** When using this preset alongside other presets (like `recommended` or `recommended-with-formatting`), you need to configure the JSON parser in an override to prevent conflicts:
+
+```json
+{
+	"extends": [
+		"plugin:@wordpress/eslint-plugin/recommended-with-formatting",
+		"plugin:@wordpress/eslint-plugin/package-json-lint"
+	],
+	"overrides": [
+		{
+			"files": ["package.json"],
+			"parser": "jsonc-eslint-parser"
+		}
+	]
+}
+```
+
 ### Rule Options
 
 You can override specific npm-package-json-lint rules using the `rules` option:
@@ -35,6 +52,7 @@ You can override specific npm-package-json-lint rules using the `rules` option:
 	"overrides": [
 		{
 			"files": ["package.json"],
+			"parser": "jsonc-eslint-parser",
 			"rules": {
 				"@wordpress/validate-package-json": [
 					"error",
@@ -49,32 +67,6 @@ You can override specific npm-package-json-lint rules using the `rules` option:
 		}
 	]
 }
-```
-
-### Flat Config (ESLint 9+)
-
-```javascript
-export default [
-	{
-		files: ['package.json'],
-		languageOptions: {
-			parser: jsoncParser,
-		},
-		plugins: {
-			'@wordpress': wordpress,
-		},
-		rules: {
-			'@wordpress/validate-package-json': [
-				'error',
-				{
-					rules: {
-						'valid-values-license': 'off',
-					},
-				},
-			],
-		},
-	},
-];
 ```
 
 ## Examples
@@ -132,6 +124,7 @@ To disable specific checks for your project:
 	"overrides": [
 		{
 			"files": ["package.json"],
+			"parser": "jsonc-eslint-parser",
 			"rules": {
 				"@wordpress/validate-package-json": [
 					"error",

--- a/packages/eslint-plugin/docs/rules/validate-package-json.md
+++ b/packages/eslint-plugin/docs/rules/validate-package-json.md
@@ -1,0 +1,163 @@
+# Validate package.json (validate-package-json)
+
+Validates **package.json** files using the WordPress `npm-package-json-lint` configuration. This rule ensures package.json files follow WordPress coding standards and best practices.
+
+## Rule Details
+
+This rule:
+
+- Validates package.json structure and content
+- Enforces property ordering
+- Ensures dependencies are sorted alphabetically
+- Validates required fields (name, version, description, author, license, etc.)
+- Supports auto-fixing for ordering and formatting issues
+
+The rule uses [@wordpress/npm-package-json-lint-config](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-npm-package-json-lint-config/) under the hood.
+
+## Usage
+
+### Basic Usage
+
+The `package-json-lint` preset automatically enables this rule for `package.json` files:
+
+```json
+{
+	"extends": ["plugin:@wordpress/eslint-plugin/package-json-lint"]
+}
+```
+
+### Rule Options
+
+You can override specific npm-package-json-lint rules using the `rules` option:
+
+```json
+{
+	"overrides": [
+		{
+			"files": ["package.json"],
+			"rules": {
+				"@wordpress/validate-package-json": [
+					"error",
+					{
+						"rules": {
+							"valid-values-license": "off",
+							"require-homepage": "off"
+						}
+					}
+				]
+			}
+		}
+	]
+}
+```
+
+### Flat Config (ESLint 9+)
+
+```javascript
+export default [
+	{
+		files: ['package.json'],
+		languageOptions: {
+			parser: jsoncParser,
+		},
+		plugins: {
+			'@wordpress': wordpress,
+		},
+		rules: {
+			'@wordpress/validate-package-json': [
+				'error',
+				{
+					rules: {
+						'valid-values-license': 'off',
+					},
+				},
+			],
+		},
+	},
+];
+```
+
+## Examples
+
+### Invalid
+
+```json
+{
+	"version": "1.0.0",
+	"name": "my-package",
+	"dependencies": {
+		"zebra": "^1.0.0",
+		"alpha": "^2.0.0"
+	}
+}
+```
+
+Issues:
+- Properties are not in the correct order (version before name)
+- Dependencies are not sorted alphabetically
+
+### Valid (after fix)
+
+```json
+{
+	"name": "my-package",
+	"version": "1.0.0",
+	"dependencies": {
+		"alpha": "^2.0.0",
+		"zebra": "^1.0.0"
+	}
+}
+```
+
+## Configuration
+
+### Available Rules
+
+All rules from [@wordpress/npm-package-json-lint-config](https://github.com/WordPress/gutenberg/tree/trunk/packages/npm-package-json-lint-config) can be configured:
+
+- `prefer-property-order` - Enforce property order
+- `prefer-alphabetical-dependencies` - Sort dependencies
+- `prefer-alphabetical-devDependencies` - Sort devDependencies
+- `prefer-alphabetical-peerDependencies` - Sort peerDependencies
+- `require-*` rules - Require specific fields
+- `valid-values-*` rules - Validate field values
+- And many more...
+
+### Disabling Specific Checks
+
+To disable specific checks for your project:
+
+```json
+{
+	"overrides": [
+		{
+			"files": ["package.json"],
+			"rules": {
+				"@wordpress/validate-package-json": [
+					"error",
+					{
+						"rules": {
+							"valid-values-license": "off",
+							"require-homepage": "off",
+							"require-keywords": "off"
+						}
+					}
+				]
+			}
+		}
+	]
+}
+```
+
+## Auto-Fixing
+
+Run ESLint with the `--fix` flag to automatically fix ordering issues:
+
+```bash
+eslint package.json --fix
+```
+
+## Related
+
+- [@wordpress/npm-package-json-lint-config](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-npm-package-json-lint-config/)
+- [npm-package-json-lint](https://npmpackagejsonlint.org/)

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -41,6 +41,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.4.1",
 		"@typescript-eslint/parser": "^6.4.1",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
+		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^8.3.0",
@@ -54,15 +55,20 @@
 		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
 		"globals": "^13.12.0",
+		"jsonc-eslint-parser": "^2.4.0",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7",
 		"eslint": ">=8",
+		"npm-package-json-lint": ">=6.0.0",
 		"prettier": ">=3",
 		"typescript": ">=5"
 	},
 	"peerDependenciesMeta": {
+		"npm-package-json-lint": {
+			"optional": true
+		},
 		"prettier": {
 			"optional": true
 		},

--- a/packages/eslint-plugin/rules/__tests__/validate-package-json.js
+++ b/packages/eslint-plugin/rules/__tests__/validate-package-json.js
@@ -1,0 +1,378 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../validate-package-json';
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( 'jsonc-eslint-parser' ),
+} );
+
+ruleTester.run( 'validate-package-json', rule, {
+	valid: [
+		{
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			filename: 'package.json',
+		},
+		{
+			code: `{
+	"name": "@wordpress/another-package",
+	"version": "2.0.0",
+	"description": "Another test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"gutenberg"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"alpha": "^1.0.0",
+		"beta": "^2.0.0",
+		"gamma": "^3.0.0"
+	}
+}
+`,
+			filename: 'package.json',
+		},
+	],
+	invalid: [
+		{
+			// Invalid license value - reports error but no autofix available
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "MIT",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'valid-values-license: Invalid value for license. Current value is MIT. Valid values include: GPL-2.0-or-later.',
+				},
+			],
+		},
+		{
+			// Wrong property order - has autofix
+			code: `{
+	"version": "1.0.0",
+	"name": "@wordpress/test-package",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			output: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'prefer-property-order: Your package.json properties are not in the desired order. Please move "version" after "name".',
+				},
+			],
+		},
+		{
+			// Unsorted dependencies - has autofix
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"zebra": "^1.0.0",
+		"alpha": "^2.0.0",
+		"beta": "^3.0.0"
+	}
+}
+`,
+			output: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"alpha": "^2.0.0",
+		"beta": "^3.0.0",
+		"zebra": "^1.0.0"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'prefer-alphabetical-dependencies: Your dependencies are not in alphabetical order. Please move zebra after alpha.',
+				},
+			],
+		},
+		{
+			// Unsorted devDependencies - has autofix
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"devDependencies": {
+		"webpack": "^5.0.0",
+		"eslint": "^8.0.0",
+		"babel": "^7.0.0"
+	}
+}
+`,
+			output: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"devDependencies": {
+		"babel": "^7.0.0",
+		"eslint": "^8.0.0",
+		"webpack": "^5.0.0"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'prefer-alphabetical-devDependencies: Your devDependencies are not in alphabetical order. Please move webpack after babel.',
+				},
+			],
+		},
+		{
+			// Unsorted peerDependencies - has autofix
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"peerDependencies": {
+		"react-dom": "^18.0.0",
+		"react": "^18.0.0"
+	}
+}
+`,
+			output: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'prefer-alphabetical-peerDependencies: Your peerDependencies are not in alphabetical order. Please move react-dom after react.',
+				},
+			],
+		},
+		{
+			// Multiple issues - property order + unsorted dependencies
+			code: `{
+	"version": "1.0.0",
+	"name": "@wordpress/test-package",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"zebra": "^1.0.0",
+		"alpha": "^2.0.0"
+	}
+}
+`,
+			output: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"dependencies": {
+		"alpha": "^2.0.0",
+		"zebra": "^1.0.0"
+	}
+}
+`,
+			filename: 'package.json',
+			errors: [
+				{
+					message:
+						'prefer-property-order: Your package.json properties are not in the desired order. Please move "version" after "name".',
+				},
+				{
+					message:
+						'prefer-alphabetical-dependencies: Your dependencies are not in alphabetical order. Please move zebra after alpha.',
+				},
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/validate-package-json.js
+++ b/packages/eslint-plugin/rules/__tests__/validate-package-json.js
@@ -63,6 +63,65 @@ ruleTester.run( 'validate-package-json', rule, {
 `,
 			filename: 'package.json',
 		},
+		{
+			// With rule overrides - disable valid-values-license
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "MIT",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			filename: 'package.json',
+			options: [
+				{
+					rules: {
+						'valid-values-license': 'off',
+					},
+				},
+			],
+		},
+		{
+			// With rule overrides - disable require-homepage
+			code: `{
+	"name": "@wordpress/test-package",
+	"version": "1.0.0",
+	"description": "A test package",
+	"author": "WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	}
+}
+`,
+			filename: 'package.json',
+			options: [
+				{
+					rules: {
+						'require-homepage': 'off',
+					},
+				},
+			],
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/rules/validate-package-json.js
+++ b/packages/eslint-plugin/rules/validate-package-json.js
@@ -1,0 +1,273 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { NpmPackageJsonLint } = require( 'npm-package-json-lint' );
+
+/**
+ * WordPress dependencies
+ */
+const wpConfig = require( '@wordpress/npm-package-json-lint-config' );
+
+/**
+ * Find the line and column for a specific property in the source text
+ * @param {string} text         - The full source text
+ * @param {string} propertyName - The property name to find
+ * @return {Object|null} Object with line and column, or null
+ */
+function findPropertyLocation( text, propertyName ) {
+	const lines = text.split( '\n' );
+	const pattern = new RegExp(
+		`^\\s*"${ propertyName.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) }"\\s*:`
+	);
+
+	for ( let i = 0; i < lines.length; i++ ) {
+		if ( pattern.test( lines[ i ] ) ) {
+			const column = lines[ i ].indexOf( `"${ propertyName }"` );
+			return {
+				line: i + 1,
+				column,
+			};
+		}
+	}
+
+	return null;
+}
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Validate package.json using npm-package-json-lint',
+		},
+		fixable: 'code',
+		schema: [],
+	},
+	create( context ) {
+		const filename = context.getFilename();
+
+		if ( ! filename.endsWith( 'package.json' ) ) {
+			return {};
+		}
+
+		return {
+			Program() {
+				const sourceCode = context.getSourceCode();
+				const packageJsonText = sourceCode.getText();
+
+				try {
+					const packageJsonObject = JSON.parse( packageJsonText );
+
+					const linter = new NpmPackageJsonLint( {
+						cwd: process.cwd(),
+						packageJsonObject,
+						packageJsonFilePath: filename,
+						config: wpConfig,
+					} );
+
+					const results = linter.lint();
+
+					if ( results.results && results.results.length > 0 ) {
+						const fileResults = results.results[ 0 ];
+
+						// Define rule mappings
+						const ALPHABETICAL_RULES = {
+							'prefer-alphabetical-dependencies': 'dependencies',
+							'prefer-alphabetical-devDependencies':
+								'devDependencies',
+							'prefer-alphabetical-peerDependencies':
+								'peerDependencies',
+							'prefer-alphabetical-bundledDependencies':
+								'bundledDependencies',
+							'prefer-alphabetical-optionalDependencies':
+								'optionalDependencies',
+						};
+
+						// Track if we need to apply fixes
+						let needsPropertyReorder = false;
+						const fieldsToSort = [];
+
+						// Collect all issues and determine what needs fixing
+						fileResults.issues.forEach( ( issue ) => {
+							if ( issue.lintId === 'prefer-property-order' ) {
+								needsPropertyReorder = true;
+							}
+
+							if ( ALPHABETICAL_RULES[ issue.lintId ] ) {
+								const field =
+									ALPHABETICAL_RULES[ issue.lintId ];
+								if ( packageJsonObject[ field ] ) {
+									fieldsToSort.push( field );
+								}
+							}
+						} );
+
+						let updatedPackageJson = { ...packageJsonObject };
+						let hasAnyFixes = false;
+
+						// Property reordering
+						if ( needsPropertyReorder ) {
+							const propertyOrder =
+								wpConfig.rules[ 'prefer-property-order' ][ 1 ];
+							const originalKeys =
+								Object.keys( packageJsonObject );
+
+							const sortedKeys = originalKeys
+								.slice()
+								.sort( ( a, b ) => {
+									const indexA = propertyOrder.indexOf( a );
+									const indexB = propertyOrder.indexOf( b );
+									const orderA =
+										indexA === -1 ? Infinity : indexA;
+									const orderB =
+										indexB === -1 ? Infinity : indexB;
+
+									if ( orderA !== orderB ) {
+										return orderA - orderB;
+									}
+
+									// For properties not in the list, maintain original order
+									return (
+										originalKeys.indexOf( a ) -
+										originalKeys.indexOf( b )
+									);
+								} );
+
+							const reordered = {};
+							sortedKeys.forEach( ( key ) => {
+								reordered[ key ] = updatedPackageJson[ key ];
+							} );
+
+							updatedPackageJson = reordered;
+							hasAnyFixes = true;
+						}
+
+						// Alphabetical sorting to dependency fields
+						if ( fieldsToSort.length > 0 ) {
+							fieldsToSort.forEach( ( field ) => {
+								const sorted = {};
+								Object.keys( updatedPackageJson[ field ] )
+									.sort()
+									.forEach( ( key ) => {
+										sorted[ key ] =
+											updatedPackageJson[ field ][ key ];
+									} );
+								updatedPackageJson[ field ] = sorted;
+							} );
+							hasAnyFixes = true;
+						}
+
+						// Helper function to create fix that updates package.json
+						const createJsonFix = ( fixer ) => {
+							const fixedJson =
+								JSON.stringify(
+									updatedPackageJson,
+									null,
+									'\t'
+								) + '\n';
+							return fixer.replaceText(
+								sourceCode.ast,
+								fixedJson
+							);
+						};
+
+						// Report all issues
+						let fixAdded = false;
+						fileResults.issues.forEach( ( issue ) => {
+							// Determine which property to highlight
+							let propertyName = null;
+
+							if ( issue.lintId === 'prefer-property-order' ) {
+								// Highlight the first property (opening brace area)
+								propertyName =
+									Object.keys( packageJsonObject )[ 0 ];
+							} else if ( ALPHABETICAL_RULES[ issue.lintId ] ) {
+								// Highlight the dependency section name
+								propertyName =
+									ALPHABETICAL_RULES[ issue.lintId ];
+							} else if (
+								issue.lintId.startsWith( 'require-' )
+							) {
+								// Handle require-* rules (e.g., require-license -> license)
+								propertyName = issue.lintId.replace(
+									'require-',
+									''
+								);
+							} else if (
+								issue.lintId.startsWith( 'valid-values-' )
+							) {
+								// Handle valid-values-* rules (e.g., valid-values-license -> license)
+								propertyName = issue.lintId.replace(
+									'valid-values-',
+									''
+								);
+							} else if ( issue.lintId.endsWith( '-type' ) ) {
+								// Handle *-type rules (e.g., license-type -> license)
+								propertyName = issue.lintId.replace(
+									/-type$/,
+									''
+								);
+							} else if ( issue.lintId.endsWith( '-format' ) ) {
+								// Handle *-format rules (e.g., name-format -> name)
+								propertyName = issue.lintId.replace(
+									/-format$/,
+									''
+								);
+							}
+
+							// Try to find specific location for the property
+							let loc = null;
+							if ( propertyName ) {
+								const propLoc = findPropertyLocation(
+									packageJsonText,
+									propertyName
+								);
+								if ( propLoc ) {
+									loc = {
+										start: {
+											line: propLoc.line,
+											column: propLoc.column,
+										},
+										end: {
+											line: propLoc.line,
+											column:
+												propLoc.column +
+												propertyName.length +
+												2, // +2 for quotes
+										},
+									};
+								}
+							}
+
+							const report = {
+								loc: loc || {
+									start: { line: 1, column: 0 },
+									end: { line: 1, column: 1 },
+								},
+								message: `${ issue.lintId }: ${ issue.lintMessage }`,
+								severity: issue.severity === 'error' ? 2 : 1,
+							};
+
+							// Only add fix to the first issue if we have fixes to apply
+							// This prevents multiple conflicting fixes
+							if ( hasAnyFixes && ! fixAdded ) {
+								report.fix = createJsonFix;
+								fixAdded = true;
+							}
+
+							context.report( report );
+						} );
+					}
+				} catch ( error ) {
+					// Only catch JSON parsing errors, rethrow others
+					if ( error instanceof SyntaxError ) {
+						return;
+					}
+
+					throw error;
+				}
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin/rules/validate-package-json.js
+++ b/packages/eslint-plugin/rules/validate-package-json.js
@@ -42,10 +42,33 @@ module.exports = {
 			description: 'Validate package.json using npm-package-json-lint',
 		},
 		fixable: 'code',
-		schema: [],
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					rules: {
+						type: 'object',
+					},
+				},
+				additionalProperties: false,
+			},
+		],
 	},
 	create( context ) {
+		const options = ( context.options && context.options[ 0 ] ) || {};
 		const filename = context.getFilename();
+
+		// Merge WordPress config with user overrides
+		let lintConfig = wpConfig;
+		if ( options.rules ) {
+			lintConfig = {
+				...wpConfig,
+				rules: {
+					...wpConfig.rules,
+					...options.rules,
+				},
+			};
+		}
 
 		if ( ! filename.endsWith( 'package.json' ) ) {
 			return {};
@@ -63,7 +86,7 @@ module.exports = {
 						cwd: process.cwd(),
 						packageJsonObject,
 						packageJsonFilePath: filename,
-						config: wpConfig,
+						config: lintConfig,
 					} );
 
 					const results = linter.lint();
@@ -109,7 +132,9 @@ module.exports = {
 						// Property reordering
 						if ( needsPropertyReorder ) {
 							const propertyOrder =
-								wpConfig.rules[ 'prefer-property-order' ][ 1 ];
+								lintConfig.rules[
+									'prefer-property-order'
+								][ 1 ];
 							const originalKeys =
 								Object.keys( packageJsonObject );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a new ESLint rule @wordpress/validate-package-json that validates package.json files using the WordPress npm-package-json-lint configuration.

## Why?
Currently, @wordpress/scripts provides a `lint-pkg-json` command that validates package.json files, but it has limitations:

- Not integrated with ESLint - runs as a separate command (`wp-scripts lint-pkg-json`)
- No editor integration - developers don't see errors in real-time while editing
- Manual execution required - easy to forget to run before committing

This leads to:

- Inconsistent property ordering across packages
- Unsorted dependencies making diffs harder to review
- Missing required fields like homepage, keywords, etc.
- License value inconsistencies

By integrating `npm-package-json-lint` into ESLint, developers get:

Immediate feedback in their editor as they type
- Auto-fix capabilities for ordering issues (`eslint --fix`)
- Single linting workflow - same tool for both code and package.json
- Consistent enforcement across all packages without manual intervention
- Better DX - errors appear inline with other ESLint diagnostics

## How?

**New ESLint Rule:**

- Created `validate-package-json` rule that wraps `npm-package-json-lint`
- Integrates with `@wordpress/npm-package-json-lint-config`
- Supports auto-fixing for:
   - Property ordering (prefer-property-order)
   - Alphabetical dependency sorting (all dependency types)

**Features:**

- Reports all npm-package-json-lint issues as ESLint diagnostics
- Highlights specific properties in error locations
- Configurable via `rules` option to disable/override specific checks

**New Config Preset:**

- Added `package-json-lint` preset: `plugin:@wordpress/eslint-plugin/package-json-lint`
- Automatically applies to all `package.json` files

## Testing Instructions

Sample eslint configuration:

```json
{
	"extends": [
		"plugin:@wordpress/eslint-plugin/package-json-lint",
		"plugin:@wordpress/eslint-plugin/recommended-with-formatting"
	],
	// Necessary if using other rules for JS/TS files in addition to package.json rules
	"overrides": [
		{
			"files": ["package.json"],
			"parser": "jsonc-eslint-parser"
		}
	]
}

```
