### PR TITLE
ContentOnly mode: Exclude template parts for now

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -526,9 +526,8 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const attributes = getBlockAttributes( state, clientId );
-	const isTemplatePart = blockName === 'core/template-part';
 	if (
-		( attributes?.metadata?.patternName || isTemplatePart ) &&
+		attributes?.metadata?.patternName &&
 		!! window?.__experimentalContentOnlyPatternInsertion
 	) {
 		return true;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2305,9 +2305,6 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
-		...( window?.__experimentalContentOnlyPatternInsertion
-			? templatePartClientIds
-			: [] ),
 	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4540,16 +4540,11 @@ describe( 'state', () => {
 					);
 				} );
 
-				it( 'returns the expected block editing modes for synced patterns', () => {
+				it( 'returns the expected block editing modes for template parts', () => {
+					// Currently, template parts are not considered sections, so
+					// child blocks are not set to contentOnly.
 					expect( initialState.derivedBlockEditingModes ).toEqual(
-						new Map(
-							Object.entries( {
-								'template-part-paragraph': 'contentOnly',
-								'template-part-group': 'disabled',
-								'template-part-grouped-paragraph':
-									'contentOnly',
-							} )
-						)
+						new Map()
 					);
 				} );
 
@@ -4573,7 +4568,7 @@ describe( 'state', () => {
 					expect( derivedBlockEditingModes ).toEqual( new Map() );
 				} );
 
-				it( 'allows explicitly set blockEditingModes to override the template part editing modes', () => {
+				it( 'does not set contentOnly mode for children of template parts', () => {
 					const { derivedBlockEditingModes } = dispatchActions(
 						[
 							{
@@ -4587,13 +4582,8 @@ describe( 'state', () => {
 					);
 
 					expect( derivedBlockEditingModes ).toEqual(
-						new Map(
-							Object.entries( {
-								'template-part-paragraph': 'contentOnly',
-								'template-part-group': 'disabled',
-								// template-part-grouped-paragraph already has an explicit mode, so isn't set as a derived mode.
-							} )
-						)
+						// template-part-grouped-paragraph already has an explicit mode, so isn't set as a derived mode.
+						new Map()
 					);
 				} );
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #71517

Exclude template parts from content only mode for now (i.e. don't consider template parts a section block)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR is based on some feedback from @jasmussen:

* We already have an Edit action in the toolbar for template parts
* And when you go to insert a template part block or create a new template part, currently it sets it to be in contentOnly mode, so you need to unlock the template part in order to do anything with it

The suggestion was to exclude template parts from this mode for now, as there's more nuance to resolve in getting it to feel good to use, and right now it adds friction to editing headers and footers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Partially revert #71627 — just those bits that relate to considering a template part a section block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. enable the experiment in Gutenberg > Experiments from wp admin:

<img width="1864" height="340" alt="image" src="https://github.com/user-attachments/assets/f863dcae-530e-485d-a01b-0de702587587" />

2. Open the site editor and open a template that has headers, footers, or other template parts (i.e. the Home template in TT4 or TT5 themes)
3. Select the header or footer blocks, and check that they behave as if you don't have the contentOnly experiment running
4. To be extra sure of this PR, switch off the contentOnly experiment and ensure it's still working as expected

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1440" height="512" alt="image" src="https://github.com/user-attachments/assets/307f3742-54e2-466b-900e-c845244bc73a" />

### After

<img width="1440" height="1128" alt="image" src="https://github.com/user-attachments/assets/0ebd36a4-f816-4ac7-9a24-5589560eef9b" />
