### PR TITLE
DataViews: ensure primary actions are not wrapped in the list layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 
+### Bug fixes
+
+- Fix: ensure primary actions are not wrapped in the list layout. [#73333](https://github.com/WordPress/gutenberg/pull/73333)
+
 ## 10.3.0 (2025-11-12)
 
 ### Enhancements

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -24,6 +24,7 @@ div.dataviews-view-list {
 			width: max-content;
 			flex: 0 0 auto;
 			gap: $grid-unit-05;
+			white-space: nowrap;
 
 			.components-button {
 				position: relative;


### PR DESCRIPTION
## What?

I found that the primary action button text is unexpectedly wrapped in some locales.

| Locale |Before|After|
|-|-|-|
| Japanese (`ja`) | <img width="402" height="308" alt="ja-before" src="https://github.com/user-attachments/assets/364c7996-77fe-448f-8692-63041f9b7414" /> | <img width="400" height="319" alt="ja-after" src="https://github.com/user-attachments/assets/2f32e586-a099-4aa7-9780-c1f8575d78b5" /> |
| Chinese (`zh_CN`) | <img width="400" height="320" alt="zh_before" src="https://github.com/user-attachments/assets/5a3224c9-e624-45a5-9838-50d3ec568358" /> | <img width="406" height="315" alt="zh_after" src="https://github.com/user-attachments/assets/66085257-a498-4167-928d-4374dc6dde1d" /> |

## Why? How?

As with [the table layout](https://github.com/WordPress/gutenberg/blob/4bceb4052487909f3cc310a4a4ec6f91c50d78f3/packages/dataviews/src/dataviews-layouts/table/style.scss#L226), `white-space: nowrap` is required.

## Testing Instructions

- Change the site location to `日本語`.
- Access http://localhost:8888/wp-admin/site-editor.php?p=%2Fpage.
- Change to list layout.



