### PR TITLE
DataViews: Try using 24px padding for consistency across different uses

### DIFF
--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -29,12 +29,8 @@ export default function Header( {
 } ) {
 	return (
 		<VStack className="admin-ui-page__header" as="header">
-			<HStack
-				className="admin-ui-page__header-title"
-				justify="space-between"
-				spacing={ 2 }
-			>
-				<HStack spacing={ 2 } justify="flex-start">
+			<HStack justify="space-between" spacing={ 2 }>
+				<HStack spacing={ 2 } justify="left">
 					{ showSidebarToggle && (
 						<SidebarToggleSlot
 							bubblesVirtually

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -11,23 +11,18 @@
 	position: relative;
 	z-index: 1;
 	flex-flow: column;
-	container: admin-ui-page / inline-size;
-
-	@media not (prefers-reduced-motion) {
-		transition: width ease-out 0.2s;
-	}
 }
 
 .admin-ui-page__header {
-	padding: $grid-unit-20 $grid-unit-60;
+	padding: $grid-unit-20 $grid-unit-30;
 	border-bottom: 1px solid $gray-100;
 	background: $white;
 	position: sticky;
 	top: 0;
+}
 
-	@container (max-width: 430px) {
-		padding: $grid-unit-20 $grid-unit-30;
-	}
+.admin-ui-page__sidebar-toggle-slot:empty {
+	display: none;
 }
 
 .admin-ui-page__header-subtitle {
@@ -44,10 +39,7 @@
 	flex-direction: column;
 
 	&.has-padding {
-		padding: $grid-unit-20 $grid-unit * 2.5;
-		@container (max-width: 430px) {
-			padding: $grid-unit-20 $grid-unit-30;
-		}
+		padding: $grid-unit-20 $grid-unit-30;
 	}
 }
 
@@ -71,4 +63,3 @@
 
 	}
 }
-

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -383,7 +383,7 @@ $block-inserter-tabs-height: 44px;
 		left: 0;
 		bottom: 0;
 		width: $sidebar-width;
-		padding: $grid-unit-30 $grid-unit-40 $grid-unit-40;
+		padding: $grid-unit-30 $grid-unit-30 $grid-unit-30;
 		overflow-x: visible;
 		overflow-y: auto;
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Menu` and othr menu items: change default size to be 32px tall rather than 40px to improve menu density. ([#73429](https://github.com/WordPress/gutenberg/pull/73429)).
+-   Unify padding using for DataViews, Modals and other container components. ([#73334](https://github.com/WordPress/gutenberg/pull/73334))
 
 ### Bug Fixes
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -59,7 +59,7 @@
 		height: $button-size;
 		justify-content: center;
 		margin: 0 0 $grid-unit-30 0;
-		padding: 0 $grid-unit-40;
+		padding: 0 $grid-unit-30;
 		position: relative;
 		width: 100%;
 	}
@@ -103,11 +103,11 @@
 	}
 
 	&.components-guide__back-button {
-		left: $grid-unit-40;
+		left: $grid-unit-30;
 	}
 
 	&.components-guide__forward-button,
 	&.components-guide__finish-button {
-		right: $grid-unit-40;
+		right: $grid-unit-30;
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -112,7 +112,7 @@
 		:where(.components-modal__content) {
 			display: flex;
 			// If this container is scrollable, bottom padding won't apply so we use margin instead.
-			margin-bottom: $grid-unit-40;
+			margin-bottom: $grid-unit-30;
 			padding-bottom: 0;
 
 			> :last-child {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -152,7 +152,7 @@
 .components-modal__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid transparent;
-	padding: $grid-unit-30 $grid-unit-40 $grid-unit-10;
+	padding: $grid-unit-30;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -206,12 +206,12 @@
 	flex: 1;
 	margin-top: $header-height + $grid-unit-10;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.
-	padding: $grid-unit-05 $grid-unit-40 $grid-unit-40;
+	padding: $grid-unit-05 $grid-unit-30 $grid-unit-30;
 	overflow: auto;
 
 	&.hide-header {
 		margin-top: 0;
-		padding-top: $grid-unit-40;
+		padding-top: $grid-unit-30;
 	}
 
 	&.is-scrollable:focus-visible {

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Field API: move validation to the field type. [#73642](https://github.com/WordPress/gutenberg/pull/73642)
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
+- DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -7,7 +7,7 @@
 	bottom: 0;
 	left: 0;
 	background-color: inherit;
-	padding: $grid-unit-15 $grid-unit-60;
+	padding: $grid-unit-15 $grid-unit-30;
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
 
@@ -16,12 +16,6 @@
 	}
 
 	z-index: z-index(".dataviews-footer");
-}
-
-@container (max-width: 430px) {
-	.dataviews-footer {
-		padding: $grid-unit-15 $grid-unit-30;
-	}
 }
 
 @container (max-width: 560px) {

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -110,11 +110,3 @@
 	padding: $grid-unit-10 0 0;
 	overflow: hidden; // Prevent cells with white backgrounds overflowing the card
 }
-
-/**
- * When DataViews are placed within modals, apply a consistent padding to match the header.
- */
-.components-modal__content:has(.components-modal__children-container > .dataviews-wrapper:first-child),
-.components-modal__content:has(.components-modal__children-container > .dataviews-picker-wrapper:first-child) {
-	padding: $grid-unit-10 $grid-unit-10 $grid-unit-10;
-}

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -103,7 +103,7 @@
 }
 
 /**
- * When DataViews are placed within cards, apply a consistent 10px top padding.
+ * When DataViews are placed within cards, apply a consistent top padding.
  */
 .components-card__body:has(> .dataviews-wrapper),
 .components-card__body:has(> .dataviews-picker-wrapper) {
@@ -112,7 +112,7 @@
 }
 
 /**
- * When DataViews are placed within modals, apply a consistent 10px top padding.
+ * When DataViews are placed within modals, apply a consistent padding to match the header.
  */
 .components-modal__content:has(.components-modal__children-container > .dataviews-wrapper:first-child),
 .components-modal__content:has(.components-modal__children-container > .dataviews-picker-wrapper:first-child) {

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -20,7 +20,7 @@
 .dataviews__view-actions,
 .dataviews-filters__container {
 	box-sizing: border-box;
-	padding: $grid-unit-20 $grid-unit-60;
+	padding: $grid-unit-20 $grid-unit-30;
 	flex-shrink: 0;
 	position: sticky;
 	left: 0;
@@ -33,7 +33,7 @@
 
 .dataviews-no-results,
 .dataviews-loading {
-	padding: 0 $grid-unit-60;
+	padding: 0 $grid-unit-30;
 	flex-grow: 1;
 	display: flex;
 	align-items: center;
@@ -52,12 +52,6 @@
 	.dataviews__view-actions,
 	.dataviews-filters__container {
 		padding: $grid-unit-15 $grid-unit-30;
-	}
-
-	.dataviews-no-results,
-	.dataviews-loading {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
 	}
 }
 
@@ -109,29 +103,18 @@
 }
 
 /**
- * Applying a consistent 24px padding when DataViews are placed within cards.
+ * When DataViews are placed within cards, apply a consistent 10px top padding.
  */
 .components-card__body:has(> .dataviews-wrapper),
 .components-card__body:has(> .dataviews-picker-wrapper) {
 	padding: $grid-unit-10 0 0;
 	overflow: hidden; // Prevent cells with white backgrounds overflowing the card
+}
 
-	.dataviews__view-actions,
-	.dataviews-filters__container,
-	.dataviews-footer,
-	.dataviews-view-grid,
-	.dataviews-loading,
-	.dataviews-no-results {
-		padding-inline: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:first-child,
-	.dataviews-view-table tr th:first-child {
-		padding-inline-start: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:last-child,
-	.dataviews-view-table tr th:last-child {
-		padding-inline-end: $grid-unit-30;
-	}
+/**
+ * When DataViews are placed within modals, apply a consistent 10px top padding.
+ */
+.components-modal__content:has(.components-modal__children-container > .dataviews-wrapper:first-child),
+.components-modal__content:has(.components-modal__children-container > .dataviews-picker-wrapper:first-child) {
+	padding: $grid-unit-10 $grid-unit-10 $grid-unit-10;
 }

--- a/packages/dataviews/src/dataviews-layouts/activity/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/activity/style.scss
@@ -3,7 +3,7 @@
 
 .dataviews-view-activity {
 	margin: 0 0 auto;
-	padding: $grid-unit-10 $grid-unit-60;
+	padding: $grid-unit-10 $grid-unit-30;
 
 	.dataviews-view-activity__group-header {
 		font-size: $font-size-large;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -224,11 +224,6 @@
 	font-weight: $font-weight-medium;
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
-	padding: 0 $grid-unit-60;
+	padding: 0 $grid-unit-30;
 	container-type: inline-size;
-
-	@container (max-width: 430px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -5,7 +5,7 @@
 @use "../utils/grid-items.scss" as *;
 
 .dataviews-view-grid {
-	padding: 0 $grid-unit-60 $grid-unit-30;
+	padding: 0 $grid-unit-30 $grid-unit-30;
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-40;
@@ -14,11 +14,6 @@
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;
-	}
-
-	@container (max-width: 430px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
 	}
 
 	.dataviews-view-grid__row {

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -61,12 +61,16 @@
 
 		td:first-child,
 		th:first-child {
-			padding-left: $grid-unit-60;
+			padding-left: $grid-unit-30;
+
+			.dataviews-view-table-header-button {
+				margin-left: - #{$grid-unit-10};
+			}
 		}
 
 		td:last-child,
 		th:last-child {
-			padding-right: $grid-unit-60;
+			padding-right: $grid-unit-30;
 		}
 
 		&:last-child {
@@ -260,17 +264,6 @@
 	}
 }
 
-@container (max-width: 430px) {
-	.dataviews-view-table tr td:first-child,
-	.dataviews-view-table tr th:first-child {
-		padding-left: $grid-unit-30;
-	}
-
-	.dataviews-view-table tr td:last-child,
-	.dataviews-view-table tr th:last-child {
-		padding-right: $grid-unit-30;
-	}
-}
 
 .dataviews-view-table-selection-checkbox {
 	--checkbox-input-size: 24px;
@@ -316,7 +309,7 @@
 .dataviews-view-table__group-header-row {
 	.dataviews-view-table__group-header-cell {
 		font-weight: $font-weight-medium;
-		padding: $grid-unit-15 $grid-unit-60;
+		padding: $grid-unit-15 $grid-unit-30;
 		color: $gray-900;
 	}
 }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -62,10 +62,6 @@
 		td:first-child,
 		th:first-child {
 			padding-left: $grid-unit-30;
-
-			.dataviews-view-table-header-button {
-				margin-left: - #{$grid-unit-10};
-			}
 		}
 
 		td:last-child,

--- a/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
@@ -6,16 +6,8 @@
 	gap: $grid-unit-40;
 	grid-template-rows: max-content;
 	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-	padding: 0 $grid-unit-60 $grid-unit-30;
+	padding: 0 $grid-unit-30 $grid-unit-30;
 	container-type: inline-size;
-	/**
-		* Breakpoints were adjusted from media queries breakpoints to account for
-		* the sidebar width. This was done to match the existing styles we had.
-		*/
-	@container (max-width: 430px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -265,23 +265,33 @@ export const WithModal = ( {
 				</p>
 			) }
 			{ isModalOpen && (
-				<Modal
-					title="Select Items"
-					onRequestClose={ () => setIsModalOpen( false ) }
-					isFullScreen={ false }
-					size="fill"
-				>
-					<DataViewsPickerContent
-						perPageSizes={ perPageSizes }
-						isMultiselectable={ isMultiselectable }
-						isGrouped={ isGrouped }
-						infiniteScrollEnabled={ infiniteScrollEnabled }
-						actions={ modalActions }
-						selection={ selectedItems.map( ( item ) =>
-							String( item.id )
-						) }
-					/>
-				</Modal>
+				<>
+					<style>{ `
+						.components-modal__content {
+							padding: 0;
+						}
+						.components-modal__frame.is-full-screen .components-modal__content {
+							margin-bottom: 0;
+						}
+					` }</style>
+					<Modal
+						title="Select Items"
+						onRequestClose={ () => setIsModalOpen( false ) }
+						isFullScreen={ false }
+						size="fill"
+					>
+						<DataViewsPickerContent
+							perPageSizes={ perPageSizes }
+							isMultiselectable={ isMultiselectable }
+							isGrouped={ isGrouped }
+							infiniteScrollEnabled={ infiniteScrollEnabled }
+							actions={ modalActions }
+							selection={ selectedItems.map( ( item ) =>
+								String( item.id )
+							) }
+						/>
+					</Modal>
+				</>
 			) }
 		</>
 	);

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -20,14 +20,14 @@
 		font-size: 24px;
 		line-height: 1.4;
 		margin: $grid-unit-20 0 $grid-unit-20 0;
-		padding: 0 $grid-unit-40;
+		padding: 0 $grid-unit-30;
 	}
 
 	&__text {
 		font-size: $default-font-size;
 		line-height: 1.4;
 		margin: 0 0 $grid-unit-30 0;
-		padding: 0 $grid-unit-40;
+		padding: 0 $grid-unit-30;
 	}
 
 	&__inserter-icon {

--- a/packages/edit-site/src/components/sidebar-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles/style.scss
@@ -15,14 +15,6 @@
 		overflow-y: auto;
 		padding-left: 0;
 		padding-right: 0;
-
-		.global-styles-ui-sidebar__navigator-screen {
-			padding-top: $grid-unit-15;
-			padding-left: $grid-unit-15;
-			padding-right: $grid-unit-15;
-			padding-bottom: $grid-unit-15;
-			outline: none;
-		}
 	}
 	.edit-site-sidebar-button {
 		color: $gray-900;

--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -10,8 +10,8 @@
 		flex: 1;
 	}
 
-	.components-navigator-screen {
-		padding: 0;
+	.global-styles-ui-sidebar__navigator-screen.components-navigator-screen {
+		padding: $grid-unit-15;
 	}
 }
 

--- a/packages/global-styles-ui/src/font-library-modal/style.scss
+++ b/packages/global-styles-ui/src/font-library-modal/style.scss
@@ -4,7 +4,7 @@
 
 // Fixed height for the modal footer.
 // Ensures that the footer is always visible when the modal content is scrollable.
-$footer-height: 70px;
+$footer-height: 60px;
 
 .font-library-modal {
 	// @todo If a new prop is added to the Modal component that constrains
@@ -22,7 +22,7 @@ $footer-height: 70px;
 
 	.components-modal__content {
 		padding-top: 0;
-		margin-bottom: $footer-height;
+		margin-bottom: $footer-height !important;
 	}
 
 	.font-library-modal__subtitle {
@@ -38,7 +38,7 @@ $footer-height: 70px;
 }
 
 .font-library-modal__tabpanel-layout {
-	margin-top: variables.$grid-unit-40;
+	margin-top: variables.$grid-unit-30;
 
 	.font-library-modal__loading {
 		width: 100%;
@@ -59,10 +59,10 @@ $footer-height: 70px;
 
 .font-library-modal__footer {
 	border-top: 1px solid colors.$gray-300;
-	margin: 0 #{variables.$grid-unit-40 * -1} #{variables.$grid-unit-40 * -1};
-	padding: variables.$grid-unit-20 variables.$grid-unit-40;
+	margin: 0 #{variables.$grid-unit-30 * -1} #{variables.$grid-unit-30 * -1};
+	padding: variables.$grid-unit-20 variables.$grid-unit-30;
 	position: absolute;
-	bottom: variables.$grid-unit-40;
+	bottom: variables.$grid-unit-30;
 	width: 100%;
 	height: $footer-height;
 	background-color: colors.$white;
@@ -148,7 +148,7 @@ $footer-height: 70px;
 	top: 0;
 	border-bottom: 1px solid colors.$gray-300;
 	background: colors.$white;
-	margin: 0 #{variables.$grid-unit-40 * -1};
+	margin: 0 #{variables.$grid-unit-30 * -1};
 	padding: 0 variables.$grid-unit-20;
 	z-index: 1;
 

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -4,9 +4,7 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
 	__experimentalHeading as Heading,
-	__experimentalView as View,
 	Navigator,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
@@ -24,28 +22,22 @@ export function ScreenHeader( {
 	onBack,
 }: ScreenHeaderProps ) {
 	return (
-		<VStack spacing={ 0 }>
-			<View>
-				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
-					<HStack spacing={ 2 }>
-						<Navigator.BackButton
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							size="small"
-							label={ __( 'Back' ) }
-							onClick={ onBack }
-						/>
-						<Spacer>
-							<Heading
-								className="global-styles-ui-header"
-								level={ 2 }
-								size={ 13 }
-							>
-								{ title }
-							</Heading>
-						</Spacer>
-					</HStack>
-				</Spacer>
-			</View>
+		<VStack spacing={ 0 } className="global-styles-ui-screen-header">
+			<HStack spacing={ 2 } justify="flex-start">
+				<Navigator.BackButton
+					icon={ isRTL() ? chevronRight : chevronLeft }
+					size="small"
+					label={ __( 'Back' ) }
+					onClick={ onBack }
+				/>
+				<Heading
+					className="global-styles-ui-header"
+					level={ 2 }
+					size={ 13 }
+				>
+					{ title }
+				</Heading>
+			</HStack>
 			{ description && (
 				<p className="global-styles-ui-header__description">
 					{ description }

--- a/packages/global-styles-ui/src/screen-root.tsx
+++ b/packages/global-styles-ui/src/screen-root.tsx
@@ -34,7 +34,7 @@ function ScreenRoot() {
 
 	return (
 		<Card
-			size="small"
+			size="none"
 			isBorderless
 			className="global-styles-ui-screen-root"
 			isRounded={ false }

--- a/packages/global-styles-ui/src/screen-style-variations.tsx
+++ b/packages/global-styles-ui/src/screen-style-variations.tsx
@@ -21,7 +21,7 @@ function ScreenStyleVariations() {
 			/>
 
 			<Card
-				size="small"
+				size="none"
 				isBorderless
 				className="global-styles-ui-screen-style-variations"
 			>

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -44,10 +44,6 @@
 	color: #757575;
 }
 
-.global-styles-ui-screen {
-	margin: 12px 16px 16px;
-}
-
 .global-styles-ui-screen-typography__indicator {
 	height: 24px;
 	width: 24px;
@@ -79,13 +75,17 @@
 	row-gap: calc(4px * 3);
 }
 
-.global-styles-ui-header__description {
-	padding: 0 16px;
+.global-styles-ui-screen-header {
+	margin-bottom: variables.$grid-unit-15;
 }
 
 .global-styles-ui-header {
 	// Need to override the too specific bottom margin for complementary areas.
 	margin-bottom: 0 !important;
+}
+
+.global-styles-ui-header__description {
+	margin: variables.$grid-unit-15 0 !important;
 }
 
 .global-styles-ui-subtitle {
@@ -248,10 +248,12 @@
 	height: 100%;
 }
 
-.global-styles-ui-sidebar__navigator-screen {
+.global-styles-ui-sidebar__navigator-screen.components-navigator-screen {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	padding: variables.$grid-unit-30;
+	outline: none;
 }
 
 .global-styles-ui-sidebar__navigator-screen .single-column {

--- a/routes/styles/style.scss
+++ b/routes/styles/style.scss
@@ -15,14 +15,6 @@
 		overflow-y: auto;
 		padding-left: 0;
 		padding-right: 0;
-
-		.global-styles-ui-sidebar__navigator-screen {
-			padding-top: $grid-unit-15;
-			padding-left: $grid-unit-15;
-			padding-right: $grid-unit-15;
-			padding-bottom: $grid-unit-15;
-			outline: none;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72336 (in the event that this lands — this PR is fairly speculative)

Try updating DataViews (and DataViewsPicker) to use `24px` padding in all circumstances.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in #72336, DataViews can look a bit awkward in a number of different circumstances (used within Card, used within Modal) due to the DataViews padding. But it's also hard to change the padding in a way that doesn't adversely affect existing usage, and that doesn't add complex APIs (like configurable padding).

The idea in this PR, based on [this discussion](https://github.com/WordPress/gutenberg/issues/72336#issuecomment-3533304671) is to see if we can standardize on `24px`. There's a few reasons why:

* We already use `24px` in narrower container sizes, so if we settle on `24px` in all cases, we can simplify some of the CSS
* We already use `24px` when displaying within a Card, so this allows us to simplify the Card CSS
* `24px` gets us closer to what we need for displaying within a Modal
* The existing `48px` adds too much padding for most existing cases
* Updating to `24px` even if it isn't quite what existing use cases are expecting, looks much less broken than removing the padding altogether.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the CSS rules for DataViews to standardize to `24px`
* Update the CSS rules for when it's displayed within a Card so that the only thing it does is zero out the padding on the Card
* Add some CSS rules to update the padding for the Modal case. This _is_ additional CSS, but it's hopefully not too intrusive — not that I had to still include _some_ padding for the modal case for things to line up. It's very close, though.

## Testing Instructions

* Run `npm run storybook:dev` to test in Storybook, and try out each of the different configurations of DataViews.
* The "With Card" story should look effectively the same as on trunk.
* The "With Modal" story for DataViewsPicker should look much better than on trunk (see screenshots below).
* Test each of the different layout types and check how it's all looking
* Once satisfied with how it's looking in Storybook, run `npm run dev` to run a dev build and test in the site editor, looking at things like Pages, Templates, and Patterns to see how the DataViews looks in these situations. Note a caveat below that the DataViews no longer lines up with the page admin header padding. I'm interested in feedback here and whether we should update that padding, too. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1440" height="1107" alt="image" src="https://github.com/user-attachments/assets/f5b3b197-cd06-454a-88c6-5b12fefe29a9" />

### After

<img width="1440" height="1104" alt="image" src="https://github.com/user-attachments/assets/d03e3fa7-b9e5-4046-a460-dc301c7c2f2a" />

### Questions

This is how it's looking in the site editor, where it's now further to the left / right than the header. If we go with this, should we also update the padding on the `.admin-ui-page__header`?

<img width="1390" height="880" alt="image" src="https://github.com/user-attachments/assets/306178ad-d55a-4aeb-9192-45007cf81fec" />

### A caveat for the Modal case

When in a modal, there is still a tiny bit of padding around the outside, which you can see in the footer. Is this a deal breaker?

<img width="1532" height="194" alt="image" src="https://github.com/user-attachments/assets/99b193c2-b9e8-4fd3-890c-ceb8615a2d73" />

