### PR TITLE
Add OPERATOR_BETWEEN to filter operators in datetime field type

### DIFF
--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -17,6 +17,7 @@ import {
 	OPERATOR_AFTER_INC,
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
+	OPERATOR_BETWEEN,
 } from '../constants';
 
 function sort( a: any, b: any, direction: SortDirection ) {
@@ -61,6 +62,7 @@ export default {
 			OPERATOR_AFTER_INC,
 			OPERATOR_IN_THE_PAST,
 			OPERATOR_OVER,
+			OPERATOR_BETWEEN,
 		],
 		validOperators: [
 			OPERATOR_ON,
@@ -71,6 +73,7 @@ export default {
 			OPERATOR_AFTER_INC,
 			OPERATOR_IN_THE_PAST,
 			OPERATOR_OVER,
+			OPERATOR_BETWEEN,
 		],
 	},
 } satisfies FieldTypeDefinition< any >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73329

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
