### PR TITLE
UnitControl: Improve handling of long values in unit select - #42879

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `UnitControl`: Add maxUnitWidth Prop to customize max width for suffix (units). ([#73336](https://github.com/WordPress/gutenberg/pull/73336)).
+
 ## 30.8.0 (2025-11-12)
 
 ### Bug Fixes

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -49,6 +49,7 @@ function UnforwardedUnitControl(
 		isResetValueOnUnitChange = false,
 		isUnitSelectTabbable = true,
 		label,
+		maxUnitWidth = 48,
 		onChange: onChangeProp,
 		onUnitChange,
 		size = 'default',
@@ -205,6 +206,7 @@ function UnforwardedUnitControl(
 			}
 			unit={ unit }
 			units={ units }
+			maxUnitWidth={ maxUnitWidth }
 			onFocus={ onFocusProp }
 			onBlur={ unitControlProps.onBlur }
 		/>

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -16,6 +16,7 @@ import { space } from '../../utils/space';
 // `size` HTML attribute of the `select` element.
 type SelectProps = {
 	selectSize: SelectSize;
+	maxUnitWidth?: number;
 };
 
 // TODO: Resolve need to use &&& to increase specificity
@@ -34,7 +35,7 @@ export const ValueInput = styled( NumberControl )`
 	}
 `;
 
-const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
+const baseUnitLabelStyles = ( { selectSize, maxUnitWidth }: SelectProps ) => {
 	const sizes = {
 		small: css`
 			box-sizing: border-box;
@@ -53,7 +54,9 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 		default: css`
 			box-sizing: border-box;
 			min-width: 24px;
-			max-width: 48px;
+			${ maxUnitWidth
+				? `max-width: ${ maxUnitWidth.toString() }px;`
+				: `max-width: 48px;` }
 			height: 24px;
 			margin-inline-end: ${ space( 2 ) };
 			padding: ${ space( 1 ) };

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -66,6 +66,13 @@ export type UnitSelectControlProps = {
 	 * @default CSS_UNITS
 	 */
 	units?: WPUnitControlUnit[];
+	/**
+	 * Maximum width for the unit select control. If not specified, will use
+	 * default width of 48px.
+	 *
+	 * @default 48
+	 */
+	maxUnitWidth?: number;
 };
 
 export type UnitControlProps = Pick< InputControlProps, 'size' > &

--- a/packages/components/src/unit-control/unit-select-control.tsx
+++ b/packages/components/src/unit-control/unit-select-control.tsx
@@ -21,6 +21,7 @@ function UnitSelectControl(
 	{
 		className,
 		isUnitSelectTabbable: isTabbable = true,
+		maxUnitWidth = 48,
 		onChange,
 		size = 'default',
 		unit = 'px',
@@ -33,6 +34,7 @@ function UnitSelectControl(
 		return (
 			<UnitLabel
 				className="components-unit-control__unit-label"
+				maxUnitWidth={ maxUnitWidth }
 				selectSize={ size }
 			>
 				{ unit }
@@ -53,6 +55,7 @@ function UnitSelectControl(
 		<UnitSelect
 			ref={ ref }
 			className={ classes }
+			maxUnitWidth={ maxUnitWidth }
 			onChange={ handleOnChange }
 			selectSize={ size }
 			tabIndex={ isTabbable ? undefined : -1 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of - https://github.com/WordPress/gutenberg/issues/42879

<!-- In a few words, what is the PR actually doing? -->

## Why?
- Dev needs some customization for the truncation for the big suffix values in UnitControl. See - https://github.com/WordPress/gutenberg/issues/73060

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added new prop to customize the max width for the suffix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add `UnitControlComponent` with units which has large suffix.
2. Check it has only max-width of 48px applied which is less for larger suffix.
3. Add `maxUnitWidth` prop to you control and apply the width you need.
4. You will see that the truncation is now not seen until the max-width hit.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None
