### PR TITLE
[DataForm]: The ModalContent component doesn't properly check for fields validity - [#73330]

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
+- DataForm Panel Layout: Update modal button to use isValid and disable based on validation output. [#73339](https://github.com/WordPress/gutenberg/pull/73339)
 
 ## 10.3.0 (2025-11-12)
 

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -60,7 +60,7 @@ function ModalContent< Item >( {
 		[ field ]
 	);
 
-	const { validity } = useFormValidity(
+	const { validity, isValid } = useFormValidity(
 		modalData,
 		fields as Field< any >[],
 		form
@@ -114,6 +114,8 @@ function ModalContent< Item >( {
 				</Button>
 				<Button
 					variant="primary"
+					disabled={ ! isValid }
+					accessibleWhenDisabled
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73330

<!-- In a few words, what is the PR actually doing? -->

## Why?
- When using modal and isValid is false, we still have apply button enabled, instead it should be disabled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Get `isValid` from `useFormValidity` custom hook and add disabled attribute in the button based on validity.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a field with:
```
isValid: {
	required: true,
},
```
2. In the form, set its layout to:
```
layout: {
	type: 'panel' as const,
	openAs: 'modal',
},
```
3. Add it to a DataForm. 
4. Click to edit it. 
5. Don't fill in a value -- notice that an error message shows up below the field.
6. Notice that you are now not able to click the Apply button, and validating the input. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1003" height="301" alt="Screenshot 2025-11-17 at 1 44 29 PM" src="https://github.com/user-attachments/assets/ff4419eb-50e4-482b-aa9e-507b7826572b" /> | <img width="1003" height="301" alt="Screenshot 2025-11-17 at 1 44 03 PM" src="https://github.com/user-attachments/assets/1acf381f-6eef-4461-ba2f-9eabc0c75f32" /> |
