### PR TITLE
DataViews: ensure primary actions are not wrapped in the list layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)
 - Fix: Table layout column spacing. [#72969](https://github.com/WordPress/gutenberg/pull/72969)
+- Fix: ensure primary actions are not wrapped in the list layout. [#73333](https://github.com/WordPress/gutenberg/pull/73333)
 
 ## 10.2.0 (2025-10-29)
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -24,6 +24,7 @@ div.dataviews-view-list {
 			width: max-content;
 			flex: 0 0 auto;
 			gap: $grid-unit-05;
+			white-space: nowrap;
 
 			.components-button {
 				position: relative;


### PR DESCRIPTION
## What?

Manually backport #73333 into `wp/6.9` branch

## Testing Instructions

See #73333