### PR TITLE
HTML Block: Remove `editorStyles` from `HTMLEditModal`.

### DIFF
--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	Modal,
@@ -40,31 +40,16 @@ export default function HTMLEditModal( {
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 
 	// Check if user has permission to save scripts and get editor styles
-	const { canUserUseUnfilteredHTML, editorStyles } = useSelect(
-		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
-			return {
-				canUserUseUnfilteredHTML:
-					settings.__experimentalCanUserUseUnfilteredHTML,
-				editorStyles: settings.styles,
-			};
-		},
-		[]
-	);
+	const { canUserUseUnfilteredHTML } = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return {
+			canUserUseUnfilteredHTML:
+				settings.__experimentalCanUserUseUnfilteredHTML,
+		};
+	}, [] );
 
 	// Show JS tab if user has permission OR if block contains JavaScript
 	const shouldShowJsTab = canUserUseUnfilteredHTML || js.trim() !== '';
-
-	// Combine all editor styles to inject into modal
-	const styleContent = useMemo( () => {
-		if ( ! editorStyles ) {
-			return '';
-		}
-		return editorStyles
-			.filter( ( style ) => style.css )
-			.map( ( style ) => style.css )
-			.join( '\n' );
-	}, [ editorStyles ] );
 
 	if ( ! isOpen ) {
 		return null;
@@ -131,11 +116,6 @@ export default function HTMLEditModal( {
 				isFullScreen={ isFullscreen }
 				__experimentalHideHeader
 			>
-				{ styleContent && (
-					<style
-						dangerouslySetInnerHTML={ { __html: styleContent } }
-					/>
-				) }
 				<Tabs orientation="horizontal" defaultTabId="html">
 					<VStack spacing={ 4 } style={ { height: '100%' } }>
 						<HStack justify="space-between">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73322

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When HTMLEditModal is open, the button font and background admin font change.

`EditorStyles` are added in the `Preview` component, so there is no need to add an inline style.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove `editorStyles` from `HTMLEditModal`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to site editor.
2. Insert HTML block.
3. You can see that the button font has changed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/6edcf979-239a-4705-a263-dffbecbd83bd


### After

https://github.com/user-attachments/assets/50247c93-e476-46ba-a6d4-d20299a1a7c5


