### PR TITLE
Routing: Support canvas clicks

### DIFF
--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -3,6 +3,7 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
+import { useNavigate } from '@wordpress/route';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ interface CanvasProps {
  */
 export default function Canvas( { canvas }: CanvasProps ) {
 	const [ Editor, setEditor ] = useState< any >( null );
+	const navigate = useNavigate();
 
 	useEffect( () => {
 		// Dynamically import the lazy-editor module
@@ -63,17 +65,39 @@ export default function Canvas( { canvas }: CanvasProps ) {
 
 	// Render the editor with canvas data
 	return (
-		<div
-			style={ { height: '100%' } }
-			// @ts-expect-error inert untyped properly.
-			inert={ canvas.isPreview ? 'true' : undefined }
-		>
-			<Editor
-				postType={ canvas.postType }
-				postId={ canvas.postId }
-				settings={ { isPreviewMode: canvas.isPreview } }
-				backButton={ backButton }
-			/>
+		<div style={ { height: '100%', position: 'relative' } }>
+			<div
+				style={ { height: '100%' } }
+				// @ts-expect-error inert not typed properly
+				inert={ canvas.isPreview ? 'true' : undefined }
+			>
+				<Editor
+					postType={ canvas.postType }
+					postId={ canvas.postId }
+					settings={ { isPreviewMode: canvas.isPreview } }
+					backButton={ backButton }
+				/>
+			</div>
+			{ canvas.isPreview && canvas.editLink && (
+				<div
+					onClick={ () => navigate( { to: canvas.editLink } ) }
+					onKeyDown={ ( e ) => {
+						if ( e.key === 'Enter' || e.key === ' ' ) {
+							e.preventDefault();
+							navigate( { to: canvas.editLink } );
+						}
+					} }
+					style={ {
+						position: 'absolute',
+						inset: 0,
+						cursor: 'pointer',
+						zIndex: 1,
+					} }
+					role="button"
+					tabIndex={ 0 }
+					aria-label="Click to edit"
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -42,9 +42,25 @@ export interface RouteLoaderContext {
  * Canvas data returned by route's canvas function.
  */
 export interface CanvasData {
+	/**
+	 * Post type to render in the canvas.
+	 */
 	postType: string;
+
+	/**
+	 * Post ID to render in the canvas.
+	 */
 	postId: string;
+
+	/**
+	 * Indicates if the canvas is in preview mode.
+	 */
 	isPreview?: boolean;
+	/**
+	 * Optional edit link for click-to-edit navigation.
+	 * When provided with isPreview: true, clicking the canvas navigates to this URL.
+	 */
+	editLink?: string;
 }
 
 /**

--- a/routes/navigation-edit/route.ts
+++ b/routes/navigation-edit/route.ts
@@ -14,10 +14,12 @@ export const route = {
 			id: string;
 		};
 	} ) => {
+		const postId = parseInt( params.id );
 		return {
 			postType: NAVIGATION_POST_TYPE,
-			postId: parseInt( params.id ),
+			postId,
 			isPreview: true,
+			editLink: `/types/wp_navigation/edit/${ postId }`,
 		};
 	},
 	loader: async ( {

--- a/routes/navigation-list/route.ts
+++ b/routes/navigation-list/route.ts
@@ -35,12 +35,15 @@ export const route = {
 			return { postType: NAVIGATION_POST_TYPE, isPreview: true };
 		}
 
+		const postId = search.ids
+			? parseInt( search.ids[ 0 ] )
+			: firstNavigation.id;
+
 		return {
 			postType: NAVIGATION_POST_TYPE,
-			postId: search.ids
-				? parseInt( search.ids[ 0 ] )
-				: firstNavigation.id,
+			postId,
 			isPreview: true,
+			editLink: `/types/wp_navigation/edit/${ postId }`,
 		};
 	},
 	loader: async () => {

--- a/routes/post-list/route.ts
+++ b/routes/post-list/route.ts
@@ -39,10 +39,12 @@ export const route = {
 
 		// Check if postId is provided in query params
 		if ( search.postIds && search.postIds.length > 0 ) {
+			const postId = search.postIds[ 0 ].toString();
 			return {
 				postType: params.type,
-				postId: search.postIds[ 0 ].toString(),
+				postId,
 				isPreview: true,
+				editLink: `/types/${ params.type }/edit/${ postId }`,
 			};
 		}
 
@@ -56,10 +58,12 @@ export const route = {
 
 		// Return first post if available
 		if ( posts && posts.length > 0 ) {
+			const postId = ( posts[ 0 ] as any ).id.toString();
 			return {
 				postType: params.type,
-				postId: ( posts[ 0 ] as any ).id.toString(),
+				postId,
 				isPreview: true,
+				editLink: `/types/${ params.type }/edit/${ postId }`,
 			};
 		}
 

--- a/routes/template-part-list/route.ts
+++ b/routes/template-part-list/route.ts
@@ -38,10 +38,14 @@ export const route = {
 
 		// Check if postId is provided in query params
 		if ( search.postIds && search.postIds.length > 0 ) {
+			const postId = search.postIds[ 0 ].toString();
 			return {
 				postType: 'wp_template_part',
-				postId: search.postIds[ 0 ].toString(),
+				postId,
 				isPreview: true,
+				editLink: `/types/wp_template_part/edit/${ encodeURIComponent(
+					postId
+				) }`,
 			};
 		}
 
@@ -55,10 +59,14 @@ export const route = {
 
 		// Return first template part if available
 		if ( posts && posts.length > 0 ) {
+			const postId = ( posts[ 0 ] as any ).id.toString();
 			return {
 				postType: 'wp_template_part',
-				postId: ( posts[ 0 ] as any ).id.toString(),
+				postId,
 				isPreview: true,
+				editLink: `/types/wp_template_part/edit/${ encodeURIComponent(
+					postId
+				) }`,
 			};
 		}
 


### PR DESCRIPTION
Related #70862 

## What?

This PR adds support for canvas clicks to the routing infrastructure and implements it in existing routes 

## Testing Instructions

- Go to the "posts experiments" page http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot-wp-admin&p=%2Ftypes%2Fpost%2Flist%2Fall
- Switch to "list" 
- Click on the canvas
- You should land in the full screen editor page.
