### PR TITLE
Blocks: Fix schema merging of classes, attributes

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -128,7 +128,9 @@ describe( 'getBlockContentSchema', () => {
 						children: {
 							sub: {},
 							sup: {},
-							strong: {},
+							strong: {
+								classes: [ 'test-class' ],
+							},
 						},
 					},
 				},
@@ -146,7 +148,9 @@ describe( 'getBlockContentSchema', () => {
 		const output = {
 			pre: {
 				children: {
-					strong: {},
+					strong: {
+						classes: [ 'test-class' ],
+					},
 					em: {},
 					sub: {},
 					sup: {},
@@ -185,6 +189,38 @@ describe( 'getBlockContentSchema', () => {
 			pre: {
 				children: myContentSchema,
 				attributes: [ 'data-chicken', 'data-ribs' ],
+			},
+		};
+		expect( getBlockContentSchemaFromTransforms( transforms ) ).toEqual(
+			output
+		);
+	} );
+
+	it( 'should handle classes merging', () => {
+		const transforms = deepFreeze( [
+			{
+				blockName: 'core/paragraph',
+				type: 'raw',
+				selector: 'p',
+				schema: {
+					p: {},
+				},
+			},
+			{
+				blockName: 'test/block',
+				type: 'raw',
+				selector: 'p',
+				schema: {
+					p: {
+						classes: [ 'test-class' ],
+					},
+				},
+			},
+		] );
+		const output = {
+			p: {
+				attributes: [ 'id' ],
+				classes: [ 'test-class' ],
 			},
 		};
 		expect( getBlockContentSchemaFromTransforms( transforms ) ).toEqual(

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -227,4 +227,35 @@ describe( 'getBlockContentSchema', () => {
 			output
 		);
 	} );
+
+	it( 'should handle attributes merging without anchor supports', () => {
+		const transforms = deepFreeze( [
+			{
+				blockName: 'test/a',
+				type: 'raw',
+				selector: 'p',
+				schema: {
+					p: {},
+				},
+			},
+			{
+				blockName: 'test/b',
+				type: 'raw',
+				selector: 'p',
+				schema: {
+					p: {
+						attributes: [ 'data-test-attribute' ],
+					},
+				},
+			},
+		] );
+		const output = {
+			p: {
+				attributes: [ 'data-test-attribute' ],
+			},
+		};
+		expect( getBlockContentSchemaFromTransforms( transforms ) ).toEqual(
+			output
+		);
+	} );
 } );

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -53,12 +53,15 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 					return '*';
 				}
 
-				return { ...objValue, ...srcValue };
+				return mergeSchemas( { ...objValue }, srcValue );
 			}
+
 			case 'attributes':
+			case 'classes':
 			case 'require': {
 				return [ ...( objValue || [] ), ...( srcValue || [] ) ];
 			}
+
 			case 'isMatch': {
 				// If one of the values being merge is undefined (matches everything),
 				// the result of the merge will be undefined.
@@ -78,9 +81,19 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 	// isMatch properties.
 	function mergeTagNameSchemas( a, b ) {
 		for ( const key in b ) {
-			a[ key ] = a[ key ]
-				? mergeTagNameSchemaProperties( a[ key ], b[ key ], key )
-				: { ...b[ key ] };
+			const bValue = b[ key ];
+
+			if ( a[ key ] ) {
+				a[ key ] = mergeTagNameSchemaProperties(
+					a[ key ],
+					bValue,
+					key
+				);
+			} else {
+				a[ key ] = Array.isArray( bValue )
+					? [ ...bValue ]
+					: { ...bValue };
+			}
 		}
 		return a;
 	}


### PR DESCRIPTION
## What?

Fix an issue with raw transform schemas where some properties are not merged or are not merged correctly.

Fixes #70612.

## Why?

The schema determines what HTML is available to block transforms. I experienced a case where the `class` attribute was always stripped despite being correctly defined in the schema.

[The documentation is lacking mention of `classes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/#schemas-and-content-models), however it does point to [this source file](https://github.com/wordpress/gutenberg/blob/trunk/packages/dom/src/dom/clean-node-list.js) where the schema type is documented. There's an opportunity to improve documentation as well.

There were issues with merging of `classes` as well as nested merging.

I do have remaining concerns about the `*` short-circuit which may prevent nested `classes` or `attributes` from being processed:

https://github.com/WordPress/gutenberg/blob/6263d4a01d392f197460c8ead57e77d7fb466361/packages/blocks/src/api/raw-handling/utils.js#L52-L54

I experienced an issue with a raw handler and this schema, `classes` were never included.

```json
{
	"pre": {
		"children": {
			"code": {
				"classes": [ "*" ],
				"children": { "#text": {} },
			},
		},
	},
}

```

## How?

- Apply array or object cloning correctly.
- Add `classes` to property merging.
- Add recursive merging of nested schemas.

## Testing Instructions

CI has new tests that failed and and fixed on this branch.