### PR TITLE
Build: Use the wpPlugin.handle config properly to register scripts and styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"name": "gutenberg",
 		"scriptGlobal": "wp",
 		"packageNamespace": "wordpress",
+		"handlePrefix": "wp",
 		"pages": [
 			{
 				"id": "gutenberg-boot",

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -362,7 +362,7 @@ async function bundlePackage( packageName ) {
 		);
 
 		builtScripts.push( {
-			handle: `wp-${ packageName }`,
+			handle: `${ HANDLE_PREFIX }-${ packageName }`,
 			path: `${ packageName }/index`,
 			asset: `${ packageName }/index.min.asset.php`,
 		} );
@@ -594,7 +594,7 @@ async function bundlePackage( packageName ) {
 		const styleDeps = await inferStyleDependencies( scriptDependencies );
 
 		builtStyles.push( {
-			handle: `wp-${ packageName }`,
+			handle: `${ HANDLE_PREFIX }-${ packageName }`,
 			path: `${ packageName }/style`,
 			dependencies: styleDeps,
 		} );


### PR DESCRIPTION
Related to #72032

## What?
The build tool was not using `wpPlugin.handlePrefix` config properly to register the scripts and styles, it was hard-coding `wp-*`

## Why?

Plugins should be able to define their own prefixes.
