### PR TITLE
Add experiment flag for Customizable Navigation Overlays

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -34,6 +34,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -199,6 +199,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-customizable-navigation-overlays',
+		__( 'Customizable Navigation Overlays', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables custom mobile overlay design and content control for Navigation blocks, allowing you to create flexible, professional menu experiences.', 'gutenberg' ),
+			'id'    => 'gutenberg-customizable-navigation-overlays',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'


### PR DESCRIPTION
## What

This PR adds a new Gutenberg experiment flag "Customizable Navigation Overlays" as the first step in implementing customizable navigation overlays (issue #73084). The experiment can be enabled from the Gutenberg experiments settings page and sets a JavaScript flag (`window.__experimentalNavigationOverlays`) that will be used by subsequent PRs to conditionally enable overlay customization features.

## Why

This experiment flag provides a safe way to develop the customizable navigation overlays feature without disrupting current Navigation block behavior. By gating the feature behind an experiment, we can iterate on the implementation while keeping the existing functionality stable for all users.

## How

The implementation follows the standard Gutenberg experiment pattern:
- Registers a new experiment checkbox in the experiments settings page
- Sets a global JavaScript variable when the experiment is enabled
- Uses the same infrastructure as other experiments for consistency

## Testing Instructions

1. Navigate to Gutenberg → Experiments in the WordPress admin
2. Verify the "Customizable Navigation Overlays" checkbox appears in the list
3. Enable the experiment and save
4. In the browser console, verify `window.__experimentalNavigationOverlays` is set to `true`
5. Disable the experiment and verify the flag is no longer set