### PR TITLE
Unit testing: Allow Composer to auto-detect PHP version

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -189,7 +189,8 @@ jobs:
                 wordpress: ['', 'previous major version']
                 exclude:
                     # On PRs: Only test PHP 8.3, single-site, latest WP
-                    # TEMP: PHP 7.2 enabled for testing the Composer fix - do not merge
+                    - event: 'pull_request'
+                      php: '7.2'
                     - event: 'pull_request'
                       php: '7.3'
                     - event: 'pull_request'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -184,7 +184,7 @@ jobs:
             fail-fast: true
             matrix:
                 event: ['${{ github.event_name }}']
-                php: ['7.2.24', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -184,13 +184,13 @@ jobs:
             fail-fast: true
             matrix:
                 event: ['${{ github.event_name }}']
-                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+                php: ['7.2.24', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
                     # On PRs: Only test PHP 8.3, single-site, latest WP
                     - event: 'pull_request'
-                      php: '7.2'
+                      php: '7.2.24'
                     - event: 'pull_request'
                       php: '7.3'
                     - event: 'pull_request'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -189,8 +189,7 @@ jobs:
                 wordpress: ['', 'previous major version']
                 exclude:
                     # On PRs: Only test PHP 8.3, single-site, latest WP
-                    - event: 'pull_request'
-                      php: '7.2'
+                    # TEMP: PHP 7.2 enabled for testing the Composer fix - do not merge
                     - event: 'pull_request'
                       php: '7.3'
                     - event: 'pull_request'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -189,8 +189,7 @@ jobs:
                 wordpress: ['', 'previous major version']
                 exclude:
                     # On PRs: Only test PHP 8.3, single-site, latest WP
-                    - event: 'pull_request'
-                      php: '7.2.24'
+                    # TEMP: PHP 7.2 enabled for testing the Composer fix - do not merge
                     - event: 'pull_request'
                       php: '7.3'
                     - event: 'pull_request'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -242,12 +242,6 @@ jobs:
                   ini-file: development
                   coverage: none
 
-            # Ensure that Composer installs the correct versions of packages.
-            - name: Override PHP version in composer.json
-              env:
-                  VERSION: ${{ matrix.php }}
-              run: composer config platform.php "$VERSION"
-
             # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
             # passing a custom cache suffix ensures that the cache is flushed at least once per week.
             - name: Install Composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"config": {
 		"process-timeout": 0,
 		"platform": {
-			"php": "7.4"
+			"php": "7.2"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
 	},
 	"config": {
 		"process-timeout": 0,
-		"platform": {
-			"php": "7.2.24"
-		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"composer/installers": true
@@ -44,6 +41,7 @@
 		}
 	],
 	"require": {
+		"php": ">=7.2.24",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
 	},
 	"config": {
 		"process-timeout": 0,
+		"platform": {
+			"php": "7.2.24"
+		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"composer/installers": true

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
 	},
 	"config": {
 		"process-timeout": 0,
-		"platform": {
-			"php": "7.2"
-		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"composer/installers": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes composer settings and unit test workflow so that Composer can auto-detect the right PHP executing the Unit Test job matrix.

## Why?
It caused dependency resolution failures and broke unit tests for PHP 7.2 versions.
<!-- In a few words, what is the PR actually doing? -->

## How?
- Removing the `platform.php` setting
- Setting the `require.php` setting  to >=7.2.24, the current minimum PHP version supported by WordPress
- Removing the composer override step from the unit tests workflow