### PR TITLE
Add Overlay template part area behind Experiment

### DIFF
--- a/backport-changelog/6.9/10581.md
+++ b/backport-changelog/6.9/10581.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/10581
+
+* https://github.com/WordPress/gutenberg/pull/73359
+

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -54,7 +54,7 @@ add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_tem
  * @param array $areas Array of template part area definitions.
  * @return array Modified array of template part area definitions.
  */
-if ( ! gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
+if ( gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
 	function gutenberg_register_overlay_template_part_area( $areas ) {
 
 		$areas[] = array(

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -47,3 +47,25 @@ function gutenberg_modify_wp_template_part_post_type_args_7_0( $args ) {
 	return $args;
 }
 add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_template_part_post_type_args_7_0' );
+
+/**
+ * Registers the 'overlay' template part area when the experiment is enabled.
+ *
+ * @param array $areas Array of template part area definitions.
+ * @return array Modified array of template part area definitions.
+ */
+if ( ! gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
+	function gutenberg_register_overlay_template_part_area( $areas ) {
+
+		$areas[] = array(
+			'area'        => 'overlay',
+			'label'       => __( 'Overlay', 'gutenberg' ),
+			'description' => __( 'Custom overlay area for navigation overlays.', 'gutenberg' ),
+			'icon'        => 'overlay',
+			'area_tag'    => 'div',
+		);
+
+		return $areas;
+	}
+	add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_template_part_area' );
+}

--- a/packages/block-library/src/template-part/edit/utils/get-template-part-icon.js
+++ b/packages/block-library/src/template-part/edit/utils/get-template-part-icon.js
@@ -5,16 +5,35 @@ import {
 	header as headerIcon,
 	footer as footerIcon,
 	sidebar as sidebarIcon,
+	tableColumnAfter as overlayIcon,
 	symbolFilled as symbolFilledIcon,
 } from '@wordpress/icons';
 
-export const getTemplatePartIcon = ( iconName ) => {
-	if ( 'header' === iconName ) {
+/**
+ * Helper function to retrieve the corresponding icon by area name or icon name.
+ *
+ * @param {string} areaOrIconName The area name (e.g., 'header', 'overlay') or icon name (e.g., 'menu').
+ *
+ * @return {Object} The corresponding icon.
+ */
+export const getTemplatePartIcon = ( areaOrIconName ) => {
+	// Handle area names first
+	if ( 'header' === areaOrIconName ) {
 		return headerIcon;
-	} else if ( 'footer' === iconName ) {
+	} else if ( 'footer' === areaOrIconName ) {
 		return footerIcon;
-	} else if ( 'sidebar' === iconName ) {
+	} else if ( 'sidebar' === areaOrIconName ) {
 		return sidebarIcon;
+	} else if ( 'overlay' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
+	}
+	// Handle icon names for backwards compatibility
+	if ( 'menu' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
 	}
 	return symbolFilledIcon;
 };

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
@@ -29,6 +29,7 @@ const useTemplatePartsGroupedByArea = ( items ) => {
 		footer: {},
 		sidebar: {},
 		uncategorized: {},
+		overlay: {},
 	};
 
 	templatePartAreas.forEach(

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -442,11 +442,11 @@ getDerivedStateFromError is used to render a fallback UI after an error has been
 
 ### getTemplatePartIcon
 
-Helper function to retrieve the corresponding icon by name.
+Helper function to retrieve the corresponding icon by area name or icon name.
 
 _Parameters_
 
--   _iconName_ `string`: The name of the icon.
+-   _areaOrIconName_ `string`: The area name (e.g., 'header', 'overlay') or icon name (e.g., 'menu').
 
 _Returns_
 

--- a/packages/editor/src/utils/get-template-part-icon.js
+++ b/packages/editor/src/utils/get-template-part-icon.js
@@ -5,22 +5,35 @@ import {
 	header as headerIcon,
 	footer as footerIcon,
 	sidebar as sidebarIcon,
+	tableColumnAfter as overlayIcon,
 	symbolFilled as symbolFilledIcon,
 } from '@wordpress/icons';
+
 /**
- * Helper function to retrieve the corresponding icon by name.
+ * Helper function to retrieve the corresponding icon by area name or icon name.
  *
- * @param {string} iconName The name of the icon.
+ * @param {string} areaOrIconName The area name (e.g., 'header', 'overlay') or icon name (e.g., 'menu').
  *
  * @return {Object} The corresponding icon.
  */
-export function getTemplatePartIcon( iconName ) {
-	if ( 'header' === iconName ) {
+export function getTemplatePartIcon( areaOrIconName ) {
+	// Handle area names first
+	if ( 'header' === areaOrIconName ) {
 		return headerIcon;
-	} else if ( 'footer' === iconName ) {
+	} else if ( 'footer' === areaOrIconName ) {
 		return footerIcon;
-	} else if ( 'sidebar' === iconName ) {
+	} else if ( 'sidebar' === areaOrIconName ) {
 		return sidebarIcon;
+	} else if ( 'overlay' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
+	}
+	// Handle icon names for backwards compatibility
+	if ( 'menu' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
 	}
 	return symbolFilledIcon;
 }

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -21,6 +21,7 @@ import {
 	footer as footerIcon,
 	header as headerIcon,
 	sidebar as sidebarIcon,
+	tableColumnAfter as overlayIcon,
 	symbolFilled as symbolFilledIcon,
 } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -84,13 +85,31 @@ export default function CreateTemplatePartModal( {
 	);
 }
 
-const getTemplatePartIcon = ( iconName: string ) => {
-	if ( 'header' === iconName ) {
+/**
+ * Helper function to retrieve the corresponding icon by area name or icon name.
+ *
+ * @param {string} areaOrIconName The area name (e.g., 'header', 'overlay') or icon name (e.g., 'menu').
+ *
+ * @return {Object} The corresponding icon.
+ */
+const getTemplatePartIcon = ( areaOrIconName: string ) => {
+	// Handle area names first
+	if ( 'header' === areaOrIconName ) {
 		return headerIcon;
-	} else if ( 'footer' === iconName ) {
+	} else if ( 'footer' === areaOrIconName ) {
 		return footerIcon;
-	} else if ( 'sidebar' === iconName ) {
+	} else if ( 'sidebar' === areaOrIconName ) {
 		return sidebarIcon;
+	} else if ( 'overlay' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
+	}
+	// Handle icon names for backwards compatibility
+	if ( 'menu' === areaOrIconName ) {
+		// TODO: Replace with a proper overlay icon when available.
+		// Using tableColumnAfter as a placeholder.
+		return overlayIcon;
 	}
 	return symbolFilledIcon;
 };

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -79,6 +79,20 @@ export const DEFAULT_VIEWS: {
 		},
 	},
 	{
+		slug: 'overlay',
+		label: 'Overlays',
+		view: {
+			...DEFAULT_VIEW,
+			filters: [
+				{
+					field: 'area',
+					operator: 'is',
+					value: 'overlay',
+				},
+			],
+		},
+	},
+	{
 		slug: 'uncategorized',
 		label: 'General',
 		view: {


### PR DESCRIPTION
## What

Adds support for a new "Overlay" template part area type, enabling users to create and design custom mobile navigation overlays as reusable template parts. This work is part of #73079 and focuses solely on the template part area registration infrastructure.

The overlay area is gated behind the `gutenberg-customizable-navigation-overlays` experiment flag.

## Why

This provides the foundation for customizable navigation overlays by allowing users to create overlay template parts. Making overlays template parts gives both users and theme authors flexibility to define bespoke mobile navigation experiences. This work establishes the template part area infrastructure needed before the Navigation block can select or assign custom overlays (which will be handled in #73080).

## How

- ~Registers the "Customizable Navigation Overlays" experiment flag (re-implementing what was in PR #73356)~
- Registers the "overlay" template part area in WordPress 7.0 compatibility layer when the experiment is enabled
- Adds overlay icon support across all template part icon functions (using `tableColumnAfter` as a placeholder)
- Adds "Overlays" view to template part list views (positioned before "Uncategorized")
- Updates sidebar navigation to display overlay template parts
- Updates template part areas hook to include overlay in known areas

The overlay area uses `tableColumnAfter` icon as a placeholder (with TODO comments) until a proper overlay icon is available.

## Testing Instructions

1. Enable the "Customizable Navigation Overlays" experiment in Gutenberg → Experiments
2. Verify `window.__experimentalNavigationOverlays` is set to `true` in browser console
3. Navigate to Site Editor → Patterns
4. Verify "Overlays" appears in the template parts list (before "General")
5. Verify overlay icon displays correctly in sidebar navigation
6. Create a new template part and verify "Overlay" area option appears in the creation modal
7. Verify overlay icon displays correctly in the template part editor
8. Disable the experiment and verify overlay area no longer appears
