### PR TITLE
Revert "[DataForm]: The ModalContent component doesn't properly check for fields validity - [#73330]"

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,7 +9,6 @@
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
-- DataForm Panel Layout: Update modal button to use isValid and disable based on validation output. [#73339](https://github.com/WordPress/gutenberg/pull/73339)
 
 ### Bug fixes
 

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -60,7 +60,7 @@ function ModalContent< Item >( {
 		[ field ]
 	);
 
-	const { validity, isValid } = useFormValidity(
+	const { validity } = useFormValidity(
 		modalData,
 		fields as Field< any >[],
 		form
@@ -114,8 +114,6 @@ function ModalContent< Item >( {
 				</Button>
 				<Button
 					variant="primary"
-					disabled={ ! isValid }
-					accessibleWhenDisabled
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>


### PR DESCRIPTION
Reverts WordPress/gutenberg#73339

See: https://github.com/WordPress/gutenberg/pull/73339#discussion_r2534533165