### PR TITLE
Fix block selection when navigation link ui is open

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -214,7 +214,7 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
-	const isNewLink = useRef( ! url );
+	const isNewLink = useRef( ! url && ! metadata?.bindings?.url );
 
 	const {
 		isAtMaxNesting,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/73178

<!-- In a few words, what is the PR actually doing? -->
With the addition of entity binding for navigation links, there are issues with how isNewLink gets set, which breaks the UX flow for popovers and block selection when popovers close. Anytime the link popover closes, it will always return focus back to the navigation link instead of respecting block selection.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes serious UX issues with block selection

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Before entity bindings, we would determine if we were working with a new link or not with: `isNewLink = useRef( ! url )`. If we didn't have a url, we were working with a new link and used the UX states for that. Now, if a navigation link is bound to an entity, it initially loads [with `url = null` while the block bindings are resolving their values](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-edit/edit.js#L164). This means, all blocks end up being considered isNewLink = true. 

To fix this, we also need to check to see if there are block bindings for the block, and if so, don't consider this a new link.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open the popover for a navigation item by selecting it and then pressing command + k or using the toolbar.
- With the popover still open, click another navigation item
- The popover should close and the block you selected should remain selected

Try this for various navigation block types: Synced, unsynced, invalid, custom...

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**


https://github.com/user-attachments/assets/b506f83d-ff72-4b16-9b39-f0373a755f7b




**After**





https://github.com/user-attachments/assets/02d544e2-9417-46db-aea4-55436c54b7ee


