### PR TITLE
Project: Add CODEOWNERS entries for ui and theme packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,7 +89,9 @@
 /packages/base-styles
 /packages/icons
 /packages/primitives
-/packages/dataviews                              @oandregal @gigitux @ntsekouras 
+/packages/dataviews                             @oandregal @gigitux @ntsekouras
+/packages/theme                                 @WordPress/gutenberg-components
+/packages/ui                                    @WordPress/gutenberg-components
 
 # Utilities
 /packages/a11y


### PR DESCRIPTION
## What?

Adds a pair of entries to the `CODEOWNERS` file for the new `@wordpress/ui` and `@wordpress/theme` packages, currently assigned to the @WordPress/gutenberg-components GitHub team.

## Why?

- To improve collective awareness to changes ongoing in these early-stage packages
- As a basis to extend for others who may be interested to review changes in these packages

## Testing Instructions

Verify correct syntax and accurate assignee naming in the CODEOWNERS file.

Verifying review assignment is only possible after these changes are merged.