### PR TITLE
Preserve active formats when applying annotations.

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -64,6 +64,7 @@ export function useRichText( {
 	const recordRef = useRef();
 
 	function setRecordFromProps() {
+		const previousRecord = recordRef.current;
 		_valueRef.current = value;
 		recordRef.current = value;
 		if ( ! ( value instanceof RichTextData ) ) {
@@ -88,6 +89,33 @@ export function useRichText( {
 		}
 		recordRef.current.start = selectionStart;
 		recordRef.current.end = selectionEnd;
+
+		// When the value is updated via props, the active formats are reset.
+		// We need to preserve them if the selection hasn't changed to avoid
+		// losing the active formats when the value is updated programmatically
+		// (e.g. by an annotation).
+		if (
+			previousRecord &&
+			previousRecord.activeFormats &&
+			previousRecord.start === selectionStart &&
+			previousRecord.end === selectionEnd
+		) {
+			// If the active formats are preserved, we need to make sure that
+			// any formats that are not allowed (e.g. because they are not
+			// in the allowedFormats list) are removed. This is because
+			// previousRecord.activeFormats may contain formats that are
+			// no longer valid.
+			//
+			// We also need to filter out formats that are not interactive,
+			// like annotations, because they should not be preserved.
+			recordRef.current.activeFormats =
+				previousRecord.activeFormats.filter( ( format ) => {
+					const formatType = registry
+						.select( 'core/rich-text' )
+						.getFormatType( format.type );
+					return formatType && formatType.interactive !== false;
+				} );
+		}
 	}
 
 	const hadSelectionUpdateRef = useRef( false );

--- a/test/e2e/specs/editor/plugins/annotations.spec.js
+++ b/test/e2e/specs/editor/plugins/annotations.spec.js
@@ -159,6 +159,33 @@ test.describe( 'Annotations', () => {
 			},
 		] );
 	} );
+
+	test( 'preserves active formats when applying annotation', async ( {
+		editor,
+		page,
+		annotations,
+	} ) => {
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Title' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Mod+i' );
+		await page.keyboard.type( 'Text' );
+
+		await annotations.openAnnotationsSidebar();
+		await annotations.annotateFirstBlock( 0, 4 );
+
+		// The selection should still be at the end, and italic should still be active.
+		await page.keyboard.type( ' is Italic' );
+		await annotations.removeAnnotations();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '<em>Text is Italic</em>' },
+			},
+		] );
+	} );
 } );
 
 class AnnotationsUtils {

--- a/test/e2e/specs/editor/plugins/annotations.spec.js
+++ b/test/e2e/specs/editor/plugins/annotations.spec.js
@@ -164,12 +164,13 @@ test.describe( 'Annotations', () => {
 		editor,
 		page,
 		annotations,
+		pageUtils,
 	} ) => {
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Title' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Mod+i' );
+		await pageUtils.pressKeys( 'primary+i' );
 		await page.keyboard.type( 'Text' );
 
 		await annotations.openAnnotationsSidebar();


### PR DESCRIPTION
## What?
Fixes #71698

Preserve active formatting during programmatic annotation changes.

## Why?
See the original report in #71698.

When typing with active formatting, programmatic changes to the annotations would cause active formats to be lost.

## How?
Filters out annotation formats (editor-only) from activeFormats in getActiveFormats and related code paths, and preserves user activeFormats (e.g., bold) when annotations are applied programmatically, so annotations don't interfere with typing.

## Testing Instructions
Instructions copied from the original issue:
1. Using word-example.js from the gist
2. enable bold formatting in a paragraph
3. start typing words
4. Type the word apple
5. continue typing
6. see that bold has been disabled after the word apple
---
1. Using shortcut-example.js
2. Create a paragraph with some text
3. hit mod+shift+L
4. The whole paragraph should be annotated now in the centre of the annotation
5. Enable bold by clicking the tool bar
6. type two letters
7. the first will be bold the second will not

### Testing Instructions for Keyboard
This change is entirely about typing in editable areas.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b8770682-7bcb-4fd8-8cfc-5edefad5d527

https://github.com/user-attachments/assets/9835986c-a3d3-49af-ae6b-fa0b3b080c86









