### PR TITLE
contentOnly patterns: mark patterns as contentOnly by adding metadata.patternName to the root block (patterns endpoint)

### DIFF
--- a/backport-changelog/7.0/10248.md
+++ b/backport-changelog/7.0/10248.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10248
 
 * https://github.com/WordPress/gutenberg/pull/72988
+* https://github.com/WordPress/gutenberg/pull/73375

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Block_Patterns_Controller_7_0 class
+ *
+ * @package gutenberg
+ */
+
+
+/**
+ * Core class used to access block patterns via the REST API.
+ *
+ * @see WP_REST_Block_Patterns_Controller
+ */
+class Gutenberg_REST_Block_Patterns_Controller_7_0 extends WP_REST_Block_Patterns_Controller {
+	public function __construct() {
+		parent::__construct();
+	}
+
+	/**
+	 * Note: no changes have been made to this class.
+	 * This class extension exists only to override the core route,
+	 * and to ensure the gutenberg_resolve_pattern_blocks function is used in the prepare_item_for_response method.
+	 * See: https://github.com/WordPress/gutenberg/pull/72988
+	 *
+	 * @since 6.0.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+			true // Override the core route.
+		);
+	}
+
+	/**
+	 * Note: no changes have been made to this class.
+	 * This class extension exists only to override the core route,
+	 * and to ensure the gutenberg_resolve_pattern_blocks function is used in the prepare_item_for_response method.
+	 * See: https://github.com/WordPress/gutenberg/pull/72988
+	 *
+	 * @since 6.0.0
+	 * @since 6.3.0 Added `source` property.
+	 *
+	 * @param array           $item    Raw pattern as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$blocks          = parse_blocks( $item['content'] );
+		$blocks          = gutenberg_resolve_pattern_blocks( $blocks );
+		$item['content'] = serialize_blocks( $blocks );
+
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array(
+			'name'          => 'name',
+			'title'         => 'title',
+			'content'       => 'content',
+			'description'   => 'description',
+			'viewportWidth' => 'viewport_width',
+			'inserter'      => 'inserter',
+			'categories'    => 'categories',
+			'keywords'      => 'keywords',
+			'blockTypes'    => 'block_types',
+			'postTypes'     => 'post_types',
+			'templateTypes' => 'template_types',
+			'source'        => 'source',
+		);
+		$data   = array();
+		foreach ( $keys as $item_key => $rest_key ) {
+			if ( isset( $item[ $item_key ] ) && rest_is_field_included( $rest_key, $fields ) ) {
+				$data[ $rest_key ] = $item[ $item_key ];
+			}
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+		return rest_ensure_response( $data );
+	}
+}

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php
@@ -5,7 +5,6 @@
  * @package gutenberg
  */
 
-
 /**
  * Core class used to access block patterns via the REST API.
  *

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -65,3 +65,12 @@ function gutenberg_parse_pattern_blocks_in_block_templates( $query_result, $quer
 }
 
 add_filter( 'get_block_templates', 'gutenberg_parse_pattern_blocks_in_block_templates', 10, 3 );
+
+/**
+ * Registers the Block Patterns REST API routes.
+ */
+function gutenberg_register_block_patterns_controller_endpoints() {
+	$block_patterns_controller = new Gutenberg_REST_Block_Patterns_Controller_7_0();
+	$block_patterns_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_block_patterns_controller_endpoints' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -57,6 +57,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php';
 
 	// WordPress 7.0 compat.
+	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
 
 	// Plugin specific code.

--- a/phpunit/class-resolve-patterns-in-patterns-test.php
+++ b/phpunit/class-resolve-patterns-in-patterns-test.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for pattern block resolution in patterns via REST API.
+ *
+ * @package gutenberg
+ *
+ * @group rest-api
+ * @covers Gutenberg_REST_Block_Patterns_Controller_7_0::prepare_item_for_response
+ */
+class Tests_Resolve_Patterns_In_Patterns extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register test patterns.
+		register_block_pattern(
+			'test/single-block-pattern-1',
+			array(
+				'title'       => 'Single Block Pattern 1',
+				'content'     => '<!-- wp:paragraph -->Single block pattern 1 content<!-- /wp:paragraph -->',
+				'description' => 'A single block pattern 1.',
+				'categories'  => array( 'text' ),
+			)
+		);
+
+		register_block_pattern(
+			'test/single-block-pattern-2',
+			array(
+				'title'       => 'Single Block Pattern 2',
+				'content'     => '<!-- wp:paragraph -->Single block pattern 2 content<!-- /wp:paragraph -->',
+				'description' => 'A single block pattern 2.',
+			)
+		);
+
+		register_block_pattern(
+			'test/sibling-patterns',
+			array(
+				'title'       => 'Sibling Patterns Pattern',
+				'content'     => '<!-- wp:pattern {"slug":"test/single-block-pattern-1"} /--><!-- wp:pattern {"slug":"test/single-block-pattern-2"} /-->',
+				'description' => 'A sibling patterns pattern with two patterns at the root level.',
+				'categories'  => array( 'text' ),
+			)
+		);
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		unregister_block_pattern( 'test/sibling-patterns' );
+		unregister_block_pattern( 'test/single-block-pattern-1' );
+		unregister_block_pattern( 'test/single-block-pattern-2' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_register_routes() {
+		// We are testing prepare_item_for_response, not controller routes.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {
+		// We are testing prepare_item_for_response, not controller context.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {
+		// We are testing prepare_item_for_response, not controller get_items().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {
+		// We are testing prepare_item_for_response, not controller get_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {
+		// We are testing prepare_item_for_response, not controller create_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {
+		// We are testing prepare_item_for_response, not controller update_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {
+		// We are testing prepare_item_for_response, not controller delete_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {
+		// We are testing prepare_item_for_response, not controller prepare_item().
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {
+		// We are testing prepare_item_for_response, not controller schema.
+	}
+
+	/**
+	 * Test that sibling patterns are fully resolved when fetching patterns via REST API.
+	 */
+	public function test_get_patterns_resolves_sibling_patterns() {
+		wp_set_current_user( self::$admin_id );
+
+		// Get patterns via REST API.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-patterns/patterns' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+
+		// Find the nested pattern.
+
+		$nested_pattern = null;
+		foreach ( $data as $pattern ) {
+			if ( isset( $pattern['name'] ) && 'test/sibling-patterns' === $pattern['name'] ) {
+				$nested_pattern = $pattern;
+				break;
+			}
+		}
+
+		$this->assertSame(
+			'<!-- wp:paragraph {"metadata":{"patternName":"test/single-block-pattern-1","name":"Single Block Pattern 1","description":"A single block pattern 1.","categories":["text"]}} -->Single block pattern 1 content<!-- /wp:paragraph --><!-- wp:paragraph {"metadata":{"patternName":"test/single-block-pattern-2","name":"Single Block Pattern 2","description":"A single block pattern 2."}} -->Single block pattern 2 content<!-- /wp:paragraph -->',
+			$nested_pattern['content'],
+			'Sibling patterns pattern should contain the two resolved patterns.'
+		);
+	}
+}

--- a/phpunit/class-resolve-patterns-in-templates-test.php
+++ b/phpunit/class-resolve-patterns-in-templates-test.php
@@ -49,7 +49,7 @@ class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testca
 			'test/nested-pattern',
 			array(
 				'title'       => 'Nested Pattern',
-				'content'     => '<!-- wp:group --><!-- wp:paragraph -->Nested content<!-- /wp:paragraph --><!-- wp:pattern {"slug":"test/single-root"} /--><!-- /wp:group -->',
+				'content'     => '<!-- wp:pattern {"slug":"test/single-root"} /--><!-- wp:pattern {"slug":"test/multiple-blocks"} /-->',
 				'description' => 'A nested pattern.',
 				'categories'  => array( 'featured' ),
 			)

--- a/phpunit/class-resolve-patterns-in-templates-test.php
+++ b/phpunit/class-resolve-patterns-in-templates-test.php
@@ -49,7 +49,7 @@ class Tests_Resolve_Patterns_In_Templates extends WP_Test_REST_Controller_Testca
 			'test/nested-pattern',
 			array(
 				'title'       => 'Nested Pattern',
-				'content'     => '<!-- wp:pattern {"slug":"test/single-root"} /--><!-- wp:pattern {"slug":"test/multiple-blocks"} /-->',
+				'content'     => '<!-- wp:group --><!-- wp:paragraph -->Nested content<!-- /wp:paragraph --><!-- wp:pattern {"slug":"test/single-root"} /--><!-- /wp:group -->',
 				'description' => 'A nested pattern.',
 				'categories'  => array( 'featured' ),
 			)


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How?

Partly addresses https://github.com/WordPress/gutenberg/issues/73262

Follow up to https://github.com/WordPress/gutenberg/pull/72988

This PR extends `WP_REST_Block_Patterns_Controller` so that it can call `gutenberg_resolve_pattern_blocks`, which was introduced in https://github.com/WordPress/gutenberg/pull/72988

`WP_REST_Block_Patterns_Controller` calls [resolve_pattern_blocks here in Core](https://github.com/WordPress/wordpress-develop/blob/4198141ea6b0e00a8643df1026b13833f05c0c25/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php#L168).

## Why?

Some patterns comprise other patterns, e.g., see TT5's page templates

> [Business homepage](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/patterns/page-business-home.php)
> [Landing page for book](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/patterns/page-landing-book.php)
> [Landing page for event](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/patterns/page-landing-event.php)
> [Landing page for podcast](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/patterns/page-landing-podcast.php)

Sibling patterns should be parsed.

### Before

<img width="335" height="362" alt="Image" src="https://github.com/user-attachments/assets/01b46b03-6d95-4eb5-a777-9149c502be9e" />


### After

<img width="327" height="368" alt="Screenshot 2025-11-18 at 2 23 46 pm" src="https://github.com/user-attachments/assets/a0ec1444-bbe6-4a6a-9edc-f4db34367380" />



## Testing Instructions

Fire up this PR and enable the content only experiment.

<img width="904" height="120" alt="Screenshot 2025-11-18 at 4 55 29 pm" src="https://github.com/user-attachments/assets/f2149576-325e-41c4-95e1-79abf345ffcc" />

Open a new page or post and insert of the page patterns mentioned above.

The patterns within those patterns should be parsed, and therefore, they'll be in "content only" mode in the editor.

You'll be able to tell because the list view will show the pattern icons, and the block inspector will show their editable fields.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/cce447c3-0aaa-41fe-84cc-6bba03ed662e


