### PR TITLE
Build: Make pages building using the routing infrastructure independent of Gutenberg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55583,6 +55583,26 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@wordpress/boot": "^0.2.0",
+				"@wordpress/private-apis": "^1.0.0",
+				"@wordpress/route": "^1.0.0",
+				"@wordpress/theme": "^1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@wordpress/boot": {
+					"optional": true
+				},
+				"@wordpress/private-apis": {
+					"optional": true
+				},
+				"@wordpress/route": {
+					"optional": true
+				},
+				"@wordpress/theme": {
+					"optional": true
+				}
 			}
 		},
 		"routes/home": {},

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -51,6 +51,26 @@
 		"rtlcss": "4.3.0",
 		"toposort": "2.0.2"
 	},
+	"peerDependencies": {
+		"@wordpress/boot": "^0.2.0",
+		"@wordpress/private-apis": "^1.0.0",
+		"@wordpress/route": "^1.0.0",
+		"@wordpress/theme": "^1.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@wordpress/boot": {
+			"optional": true
+		},
+		"@wordpress/private-apis": {
+			"optional": true
+		},
+		"@wordpress/route": {
+			"optional": true
+		},
+		"@wordpress/theme": {
+			"optional": true
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -501,7 +501,7 @@ async function bundlePackage( packageName, options = {} ) {
 
 	if ( packageJson.wpCopyFiles ) {
 		const { files, transforms = {} } = packageJson.wpCopyFiles;
-		const sourceDir = path.join( packageDir, 'src' );
+		const packageSourceDir = path.join( packageDir, 'src' );
 		const outputDir = path.join( BUILD_DIR, 'scripts', packageName );
 
 		for ( const filePattern of files ) {
@@ -510,7 +510,10 @@ async function bundlePackage( packageName, options = {} ) {
 			);
 
 			for ( const sourceFile of matchedFiles ) {
-				const relativePath = path.relative( sourceDir, sourceFile );
+				const relativePath = path.relative(
+					packageSourceDir,
+					sourceFile
+				);
 				const destPath = path.join( outputDir, relativePath );
 				const destDir = path.dirname( destPath );
 

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -289,15 +289,23 @@ function resolveEntryPoint( packageDir, packageJson ) {
  * Bundle a package for WordPress using esbuild.
  *
  * @param {string} packageName Package name.
+ * @param {Object} options     Optional bundling options.
  * @return {Promise<boolean>} True if the package was bundled, false otherwise.
  */
-async function bundlePackage( packageName ) {
+async function bundlePackage( packageName, options = {} ) {
+	const {
+		sourceDir = PACKAGES_DIR,
+		handlePrefix = HANDLE_PREFIX,
+		scriptGlobal = SCRIPT_GLOBAL,
+		packageNamespace = PACKAGE_NAMESPACE,
+	} = options;
+
 	const builtModules = [];
 	const builtScripts = [];
 	const builtStyles = [];
-	const packageDir = path.join( PACKAGES_DIR, packageName );
+	const packageDir = path.join( sourceDir, packageName );
 	const packageJson = getPackageInfoFromFile(
-		path.join( PACKAGES_DIR, packageName, 'package.json' )
+		path.join( sourceDir, packageName, 'package.json' )
 	);
 
 	const builds = [];
@@ -310,12 +318,12 @@ async function bundlePackage( packageName ) {
 		// Check if package matches the namespace and should expose a global
 		const packageFullName = packageJson.name;
 		const matchesNamespace = packageFullName.startsWith(
-			`@${ PACKAGE_NAMESPACE }/`
+			`@${ packageNamespace }/`
 		);
-		const shouldExposeGlobal = matchesNamespace && SCRIPT_GLOBAL !== false;
+		const shouldExposeGlobal = matchesNamespace && scriptGlobal !== false;
 
 		const globalName = shouldExposeGlobal
-			? `${ SCRIPT_GLOBAL }.${ camelCase( packageName ) }`
+			? `${ scriptGlobal }.${ camelCase( packageName ) }`
 			: undefined;
 
 		const baseConfig = {
@@ -362,7 +370,7 @@ async function bundlePackage( packageName ) {
 		);
 
 		builtScripts.push( {
-			handle: `${ HANDLE_PREFIX }-${ packageName }`,
+			handle: `${ handlePrefix }-${ packageName }`,
 			path: `${ packageName }/index`,
 			asset: `${ packageName }/index.min.asset.php`,
 		} );
@@ -594,7 +602,7 @@ async function bundlePackage( packageName ) {
 		const styleDeps = await inferStyleDependencies( scriptDependencies );
 
 		builtStyles.push( {
-			handle: `${ HANDLE_PREFIX }-${ packageName }`,
+			handle: `${ handlePrefix }-${ packageName }`,
 			path: `${ packageName }/style`,
 			dependencies: styleDeps,
 		} );
@@ -1462,6 +1470,51 @@ async function buildAll() {
 			initModules: page.init,
 		};
 	} );
+
+	// Bundle boot, route, and theme packages from node_modules when pages exist
+	if ( pageData.length > 0 ) {
+		try {
+			const { createRequire } = await import( 'module' );
+			const require = createRequire( import.meta.url );
+
+			// Resolve the @wordpress packages directory from node_modules
+			const bootPackageJson = require.resolve(
+				'@wordpress/boot/package.json',
+				{ paths: [ ROOT_DIR ] }
+			);
+			const wordpressPackagesDir = path.dirname(
+				path.dirname( bootPackageJson )
+			);
+
+			// Bundle boot, route, theme, and private-apis packages
+			const externalPackages = [
+				'boot',
+				'route',
+				'theme',
+				'private-apis',
+			];
+			for ( const pkgName of externalPackages ) {
+				const result = await bundlePackage( pkgName, {
+					sourceDir: wordpressPackagesDir,
+					handlePrefix: 'wp',
+					scriptGlobal: 'wp',
+					packageNamespace: 'wordpress',
+				} );
+
+				if ( result && result.modules ) {
+					modules.push( ...result.modules );
+				}
+				if ( result && result.scripts ) {
+					scripts.push( ...result.scripts );
+				}
+			}
+		} catch ( error ) {
+			console.warn(
+				'\n⚠️  Warning: Could not bundle WordPress packages for pages:',
+				error.message
+			);
+		}
+	}
 
 	console.log( '\n📄 Generating PHP registration files...\n' );
 	const phpReplacements = await getPhpReplacements( ROOT_DIR );


### PR DESCRIPTION
Related #72032 
Related #70862 

## What?

Enables third-party plugins to use the Pages functionality by automatically bundling required WordPress packages (boot, route, theme, private-apis) that aren't yet available in WordPress core yet.

##  Why?

Pages functionality depends on packages like @wordpress/theme and @wordpress/boot which don't exist in WordPress core yet. Previously, third-party plugins couldn't use pages because these dependencies were missing.

Now when a plugin configures pages, the build tool automatically:

  1. Bundles the required packages from node_modules
  2. Registers them with standard WordPress handles (wp-theme, wp-boot, etc.)
  3. Exposes proper wp.* globals or as script modules.

This makes pages fully functional in any plugin without requiring WordPress core updates.

**Note** I'm not fully satisfied with this solution to be honest. It's a little bit fragile in the sense that it can break again if we introduce new script modules or new scripts that are used by the boot package in Gutenberg. That said, I've spent some time on this and I believe this is the simplest approach possible. Ideally we should remove this from the build tool when these scripts and modules become "core" APIs.

## Testing Instructions

  1. Create a plugin with pages configuration in package.json
  2. Run wp-build
  3. Verify build/scripts/theme, build/modules/boot, build/modules/route exist
  4. Load the page in WordPress - should render without console errors
