### PR TITLE
Build: Fix CSS rebuilds

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1549,6 +1549,7 @@ async function watchMode() {
 				const script = fullToShort.get( fullScript );
 				try {
 					const rebundleStartTime = Date.now();
+					await compileStyles( script );
 					await bundlePackage( script );
 					const rebundleTime = Date.now() - rebundleStartTime;
 					console.log(


### PR DESCRIPTION
 ## What?

Fixes SCSS file changes in dependencies not being reflected in dependent packages during watch mode.

## Why?

When editing SCSS files in one package (e.g., `global-styles-ui`), packages that import the compiled CSS from that package's `build-style/` directory (e.g., `edit-site`) weren't automatically rebuilding. The watch mode was only rebundling scripts but not recompiling styles for dependent packages.

## How?

Added `compileStyles()` call for affected packages before rebundling them in watch mode. This ensures CSS is recompiled for all packages that depend on the changed package.

## Testing Instructions

  1. Run `npm run dev`
  2. Edit `packages/global-styles-ui/src/style.scss` and save
  3. Verify that `packages/edit-site/build-style/style.css` is automatically updated
  4. Verify no manual save of `edit-site/src/style.scss` is needed

Closes #73373