### PR TITLE
Routing: Preload routes properly

### DIFF
--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -4,6 +4,7 @@
 import { parseHref } from '@tanstack/history';
 import {
 	createBrowserHistory,
+	createLazyRoute,
 	createLink,
 	createRootRoute,
 	createRoute,
@@ -32,6 +33,7 @@ export const privateApis = {};
 lock( privateApis, {
 	// Router creation and setup
 	createBrowserHistory,
+	createLazyRoute,
 	createRouter,
 	createRootRoute,
 	createRoute,


### PR DESCRIPTION
Related #70862 

## What?

This PR adds preloading when you hover links to the routing infrastructure. It also refactors route registration properly to ensure that the route content modules are preloaded as well.

## Testing Instructions

 - Open http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2F
 - Hover "pages" in the menu item
 - Notice two requests are preloaded (data and js)
 - Click the link, notice it's instant.