### PR TITLE
Prototype: Customizable Navigation Overlays Editor Experience

### DIFF
--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -65,3 +65,26 @@ function gutenberg_parse_pattern_blocks_in_block_templates( $query_result, $quer
 }
 
 add_filter( 'get_block_templates', 'gutenberg_parse_pattern_blocks_in_block_templates', 10, 3 );
+
+/**
+ * Registers the 'overlay' template part area when the experiment is enabled.
+ *
+ * @param array $areas Array of template part area definitions.
+ * @return array Modified array of template part area definitions.
+ */
+function gutenberg_register_overlay_template_part_area( $areas ) {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
+		return $areas;
+	}
+
+	$areas[] = array(
+		'area'        => 'overlay',
+		'label'       => __( 'Overlay', 'gutenberg' ),
+		'description' => __( 'Custom overlay area for navigation overlays.', 'gutenberg' ),
+		'icon'        => 'overlay',
+		'area_tag'    => 'div',
+	);
+
+	return $areas;
+}
+add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_template_part_area' );

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -88,3 +88,48 @@ function gutenberg_register_overlay_template_part_area( $areas ) {
 	return $areas;
 }
 add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_template_part_area' );
+
+/**
+ * Registers the 'overlay' pattern category when the experiment is enabled.
+ */
+function gutenberg_register_overlay_pattern_category() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
+		return;
+	}
+
+	register_block_pattern_category(
+		'overlay',
+		array( 'label' => __( 'Overlay', 'gutenberg' ) )
+	);
+}
+add_action( 'init', 'gutenberg_register_overlay_pattern_category' );
+
+/**
+ * Registers the default overlay pattern when the experiment is enabled.
+ */
+function gutenberg_register_overlay_pattern() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
+		return;
+	}
+
+	register_block_pattern(
+		'gutenberg/overlay-default',
+		array(
+			'title'      => __( 'Overlay', 'gutenberg' ),
+			'categories' => array( 'overlay' ),
+			'blockTypes' => array( 'core/template-part/overlay' ),
+			'content'    => '<!-- wp:group {"metadata":{"name":"Overlay"},"style":{"dimensions":{"minHeight":"100%"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="min-height:100%;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:overlay-close {"className":"has-text-align-left","style":{"typography":{"textAlign":"left"}}} -->
+<div class="wp-block-overlay-close has-text-align-left"><button type="button" class="wp-block-overlay-close__button" aria-label="Close overlay"><span class="wp-block-overlay-close__icon">×</span></button></div>
+<!-- /wp:overlay-close --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Overlay Content"},"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->',
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_overlay_pattern' );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -82,6 +82,7 @@ import * as navigation from './navigation';
 import * as navigationLink from './navigation-link';
 import * as navigationSubmenu from './navigation-submenu';
 import * as nextpage from './nextpage';
+import * as overlayClose from './overlay-close';
 import * as pattern from './pattern';
 import * as pageList from './page-list';
 import * as pageListItem from './page-list-item';
@@ -187,6 +188,7 @@ const getAllBlocks = () => {
 		missing,
 		more,
 		nextpage,
+		overlayClose,
 		pageList,
 		pageListItem,
 		pattern,

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -86,7 +86,7 @@
 			"enum": [ "all", "insert", "contentOnly", false ]
 		},
 		"overlayTemplatePartId": {
-			"type": "number"
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -84,6 +84,9 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"overlayTemplatePartId": {
+			"type": "number"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -43,6 +43,7 @@ import {
 	Notice,
 	ToolbarButton,
 	ToolbarGroup,
+	PanelBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -646,20 +647,8 @@ function Navigation( {
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
-				{ hasSubmenuIndicatorSetting && (
-					<ToolsPanel
-						label={ __( 'Display' ) }
-						resetAll={ () => {
-							setAttributes( {
-								showSubmenuIcon: true,
-								openSubmenusOnClick: false,
-								overlayMenu: 'mobile',
-								hasIcon: true,
-								icon: 'handle',
-							} );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
+				<PanelBody title={ __( 'Overlay' ) } initialOpen={ true }>
+					<VStack spacing={ 4 }>
 						{ isResponsive && (
 							<>
 								<Button
@@ -706,63 +695,59 @@ function Navigation( {
 							</>
 						) }
 
-						<ToolsPanelItem
-							hasValue={ () => overlayMenu !== 'mobile' }
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Overlay Menu' ) }
-							onDeselect={ () =>
-								setAttributes( { overlayMenu: 'mobile' } )
+							aria-label={ __( 'Configure overlay menu' ) }
+							value={ overlayMenu }
+							help={ __(
+								'Collapses the navigation options in a menu icon opening an overlay.'
+							) }
+							onChange={ ( value ) =>
+								setAttributes( { overlayMenu: value } )
 							}
-							isShownByDefault
+							isBlock
 						>
-							<ToggleGroupControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ __( 'Overlay Menu' ) }
-								aria-label={ __( 'Configure overlay menu' ) }
-								value={ overlayMenu }
-								help={ __(
-									'Collapses the navigation options in a menu icon opening an overlay.'
-								) }
-								onChange={ ( value ) =>
-									setAttributes( { overlayMenu: value } )
-								}
-								isBlock
-							>
-								<ToggleGroupControlOption
-									value="never"
-									label={ __( 'Off' ) }
-								/>
-								<ToggleGroupControlOption
-									value="mobile"
-									label={ __( 'Mobile' ) }
-								/>
-								<ToggleGroupControlOption
-									value="always"
-									label={ __( 'Always' ) }
-								/>
-							</ToggleGroupControl>
-						</ToolsPanelItem>
-
-						<ToolsPanelItem
-							hasValue={ () => !! overlayTemplatePartId }
-							label={ __( 'Overlay Template Part' ) }
-							onDeselect={ () =>
-								setAttributes( {
-									overlayTemplatePartId: undefined,
-								} )
-							}
-							isShownByDefault
-						>
-							<OverlaySelector
-								value={ overlayTemplatePartId }
-								onChange={ ( newValue ) => {
-									setAttributes( {
-										overlayTemplatePartId: newValue,
-									} );
-								} }
+							<ToggleGroupControlOption
+								value="never"
+								label={ __( 'Off' ) }
 							/>
-						</ToolsPanelItem>
+							<ToggleGroupControlOption
+								value="mobile"
+								label={ __( 'Mobile' ) }
+							/>
+							<ToggleGroupControlOption
+								value="always"
+								label={ __( 'Always' ) }
+							/>
+						</ToggleGroupControl>
 
+						<OverlaySelector
+							value={ overlayTemplatePartId }
+							onChange={ ( newValue ) => {
+								setAttributes( {
+									overlayTemplatePartId: newValue,
+								} );
+							} }
+						/>
+					</VStack>
+				</PanelBody>
+			</InspectorControls>
+			<InspectorControls>
+				{ hasSubmenuIndicatorSetting && (
+					<ToolsPanel
+						label={ __( 'Display' ) }
+						resetAll={ () => {
+							setAttributes( {
+								showSubmenuIcon: true,
+								openSubmenusOnClick: false,
+								hasIcon: true,
+								icon: 'handle',
+							} );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
 						{ hasSubmenus && (
 							<>
 								<h3 className="wp-block-navigation__submenu-header">

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -682,12 +682,27 @@ function Navigation( {
 		[]
 	);
 
+	// Check if the experiment is enabled
+	const isExperimentEnabled =
+		typeof window !== 'undefined' &&
+		window.__experimentalNavigationOverlays;
+
 	const stylingInspectorControls = (
 		<>
 			{ ! isInOverlayTemplatePart && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Overlay' ) } initialOpen={ true }>
 						<VStack spacing={ 4 }>
+							{ ! isExperimentEnabled && (
+								<Notice
+									status="warning"
+									isDismissible={ false }
+								>
+									{ __(
+										'Please enable the "Customizable Navigation Overlays" experiment in Gutenberg settings to test this feature.'
+									) }
+								</Notice>
+							) }
 							{ isResponsive && (
 								<>
 									<Button

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -675,6 +675,13 @@ function Navigation( {
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
+	// Get navigation function for overlay template parts
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
+	);
+
 	const stylingInspectorControls = (
 		<>
 			{ ! isInOverlayTemplatePart && (
@@ -926,6 +933,8 @@ function Navigation( {
 					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					overlayTemplatePartId={ overlayTemplatePartId }
+					onNavigateToEntityRecord={ onNavigateToEntityRecord }
 				>
 					<UnsavedInnerBlocks
 						createNavigationMenu={ createNavigationMenu }
@@ -1088,6 +1097,10 @@ function Navigation( {
 									overlayBackgroundColor
 								}
 								overlayTextColor={ overlayTextColor }
+								overlayTemplatePartId={ overlayTemplatePartId }
+								onNavigateToEntityRecord={
+									onNavigateToEntityRecord
+								}
 							>
 								{ isEntityAvailable && (
 									<NavigationInnerBlocks

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -768,14 +768,26 @@ function Navigation( {
 								/>
 							</ToggleGroupControl>
 
-							<OverlaySelector
-								value={ overlayTemplatePartId }
-								onChange={ ( newValue ) => {
-									setAttributes( {
-										overlayTemplatePartId: newValue,
-									} );
-								} }
-							/>
+							{ /*
+							 * Hide custom overlay controls when overlay visibility is "Off".
+							 * Attributes are preserved (not modified) so that if the user
+							 * toggles back to "Mobile" or "Always", their configured overlay
+							 * will still be available.
+							 *
+							 * Note: PHP rendering code will need to account for this situation
+							 * and should not render custom overlays when overlayMenu is "never",
+							 * even if overlayTemplatePartId is set.
+							 */ }
+							{ overlayMenu !== 'never' && (
+								<OverlaySelector
+									value={ overlayTemplatePartId }
+									onChange={ ( newValue ) => {
+										setAttributes( {
+											overlayTemplatePartId: newValue,
+										} );
+									} }
+								/>
+							) }
 						</VStack>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -698,8 +698,8 @@ function Navigation( {
 						<ToggleGroupControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={ __( 'Overlay Menu' ) }
-							aria-label={ __( 'Configure overlay menu' ) }
+							label={ __( 'Overlay Visibility' ) }
+							aria-label={ __( 'Configure overlay visibility' ) }
 							value={ overlayMenu }
 							help={ __(
 								'Collapses the navigation options in a menu icon opening an overlay.'

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -77,6 +77,7 @@ import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
+import OverlaySelector from './overlay-selector';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { DEFAULT_BLOCK } from '../constants';
@@ -272,6 +273,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		overlayTemplatePartId,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -739,6 +741,26 @@ function Navigation( {
 									label={ __( 'Always' ) }
 								/>
 							</ToggleGroupControl>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! overlayTemplatePartId }
+							label={ __( 'Overlay Template Part' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									overlayTemplatePartId: undefined,
+								} )
+							}
+							isShownByDefault
+						>
+							<OverlaySelector
+								value={ overlayTemplatePartId }
+								onChange={ ( newValue ) => {
+									setAttributes( {
+										overlayTemplatePartId: newValue,
+									} );
+								} }
+							/>
 						</ToolsPanelItem>
 
 						{ hasSubmenus && (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -29,6 +29,7 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -81,6 +82,8 @@ import AccessibleMenuDescription from './accessible-menu-description';
 import OverlaySelector from './overlay-selector';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
+
+const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 import { DEFAULT_BLOCK } from '../constants';
 
 /**
@@ -264,7 +267,7 @@ function Navigation( {
 } ) {
 	const {
 		openSubmenusOnClick,
-		overlayMenu,
+		overlayMenu: savedOverlayMenu,
 		showSubmenuIcon,
 		templateLock,
 		layout: {
@@ -274,8 +277,36 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
-		overlayTemplatePartId,
+		overlayTemplatePartId: savedOverlayTemplatePartId,
 	} = attributes;
+
+	// Check if we're inside an overlay template part
+	const isInOverlayTemplatePart = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = unlock(
+			select( editorStore )
+		);
+		const { getEditedEntityRecord } = select( coreStore );
+		const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+
+		if ( postType !== TEMPLATE_PART_POST_TYPE || ! postId ) {
+			return false;
+		}
+
+		const templatePart = getEditedEntityRecord(
+			'postType',
+			TEMPLATE_PART_POST_TYPE,
+			postId
+		);
+
+		return templatePart?.area === 'overlay';
+	}, [] );
+
+	// Ignore overlay attributes if we're inside an overlay template part
+	const overlayMenu = isInOverlayTemplatePart ? 'never' : savedOverlayMenu;
+	const overlayTemplatePartId = isInOverlayTemplatePart
+		? undefined
+		: savedOverlayTemplatePartId;
 
 	const ref = attributes.ref;
 
@@ -646,94 +677,102 @@ function Navigation( {
 
 	const stylingInspectorControls = (
 		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Overlay' ) } initialOpen={ true }>
-					<VStack spacing={ 4 }>
-						{ isResponsive && (
-							<>
-								<Button
-									__next40pxDefaultSize
-									className={ overlayMenuPreviewClasses }
-									onClick={ () => {
-										setOverlayMenuPreview(
-											! overlayMenuPreview
-										);
-									} }
-									aria-label={ __( 'Overlay menu controls' ) }
-									aria-controls={ overlayMenuPreviewId }
-									aria-expanded={ overlayMenuPreview }
-								>
-									{ hasIcon && (
-										<>
-											<OverlayMenuIcon icon={ icon } />
-											<Icon icon={ close } />
-										</>
-									) }
-									{ ! hasIcon && (
-										<>
-											<span>{ __( 'Menu' ) }</span>
-											<span>{ __( 'Close' ) }</span>
-										</>
-									) }
-								</Button>
-								{ overlayMenuPreview && (
-									<VStack
-										id={ overlayMenuPreviewId }
-										spacing={ 4 }
-										style={ {
-											gridColumn: 'span 2',
+			{ ! isInOverlayTemplatePart && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Overlay' ) } initialOpen={ true }>
+						<VStack spacing={ 4 }>
+							{ isResponsive && (
+								<>
+									<Button
+										__next40pxDefaultSize
+										className={ overlayMenuPreviewClasses }
+										onClick={ () => {
+											setOverlayMenuPreview(
+												! overlayMenuPreview
+											);
 										} }
+										aria-label={ __(
+											'Overlay menu controls'
+										) }
+										aria-controls={ overlayMenuPreviewId }
+										aria-expanded={ overlayMenuPreview }
 									>
-										<OverlayMenuPreview
-											setAttributes={ setAttributes }
-											hasIcon={ hasIcon }
-											icon={ icon }
-											hidden={ ! overlayMenuPreview }
-										/>
-									</VStack>
-								) }
-							</>
-						) }
-
-						<ToggleGroupControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Overlay Visibility' ) }
-							aria-label={ __( 'Configure overlay visibility' ) }
-							value={ overlayMenu }
-							help={ __(
-								'Collapses the navigation options in a menu icon opening an overlay.'
+										{ hasIcon && (
+											<>
+												<OverlayMenuIcon
+													icon={ icon }
+												/>
+												<Icon icon={ close } />
+											</>
+										) }
+										{ ! hasIcon && (
+											<>
+												<span>{ __( 'Menu' ) }</span>
+												<span>{ __( 'Close' ) }</span>
+											</>
+										) }
+									</Button>
+									{ overlayMenuPreview && (
+										<VStack
+											id={ overlayMenuPreviewId }
+											spacing={ 4 }
+											style={ {
+												gridColumn: 'span 2',
+											} }
+										>
+											<OverlayMenuPreview
+												setAttributes={ setAttributes }
+												hasIcon={ hasIcon }
+												icon={ icon }
+												hidden={ ! overlayMenuPreview }
+											/>
+										</VStack>
+									) }
+								</>
 							) }
-							onChange={ ( value ) =>
-								setAttributes( { overlayMenu: value } )
-							}
-							isBlock
-						>
-							<ToggleGroupControlOption
-								value="never"
-								label={ __( 'Off' ) }
-							/>
-							<ToggleGroupControlOption
-								value="mobile"
-								label={ __( 'Mobile' ) }
-							/>
-							<ToggleGroupControlOption
-								value="always"
-								label={ __( 'Always' ) }
-							/>
-						</ToggleGroupControl>
 
-						<OverlaySelector
-							value={ overlayTemplatePartId }
-							onChange={ ( newValue ) => {
-								setAttributes( {
-									overlayTemplatePartId: newValue,
-								} );
-							} }
-						/>
-					</VStack>
-				</PanelBody>
-			</InspectorControls>
+							<ToggleGroupControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Overlay Visibility' ) }
+								aria-label={ __(
+									'Configure overlay visibility'
+								) }
+								value={ overlayMenu }
+								help={ __(
+									'Collapses the navigation options in a menu icon opening an overlay.'
+								) }
+								onChange={ ( value ) =>
+									setAttributes( { overlayMenu: value } )
+								}
+								isBlock
+							>
+								<ToggleGroupControlOption
+									value="never"
+									label={ __( 'Off' ) }
+								/>
+								<ToggleGroupControlOption
+									value="mobile"
+									label={ __( 'Mobile' ) }
+								/>
+								<ToggleGroupControlOption
+									value="always"
+									label={ __( 'Always' ) }
+								/>
+							</ToggleGroupControl>
+
+							<OverlaySelector
+								value={ overlayTemplatePartId }
+								onChange={ ( newValue ) => {
+									setAttributes( {
+										overlayTemplatePartId: newValue,
+									} );
+								} }
+							/>
+						</VStack>
+					</PanelBody>
+				</InspectorControls>
+			) }
 			<InspectorControls>
 				{ hasSubmenuIndicatorSetting && (
 					<ToolsPanel

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Component to select an overlay template part for the Navigation block.
+ *
+ * @param {Object} props          Component props.
+ * @param {number} props.value    Current overlay template part ID.
+ * @param {Function} props.onChange Callback when overlay is selected.
+ * @return {JSX.Element} Overlay selector component.
+ */
+export default function OverlaySelector( { value, onChange } ) {
+	const { records: templateParts, isResolving } = useEntityRecords(
+		'postType',
+		'wp_template_part',
+		{
+			per_page: -1,
+		}
+	);
+
+	// Filter to only overlay template parts
+	const overlayTemplateParts =
+		templateParts?.filter( ( part ) => part.area === 'overlay' ) || [];
+
+	const options = [
+		{ label: __( 'None' ), value: '' },
+		...overlayTemplateParts.map( ( part ) => ( {
+			label: part.title?.rendered || part.slug || __( 'Untitled' ),
+			value: part.id,
+		} ) ),
+	];
+
+	if ( isResolving ) {
+		return null;
+	}
+
+	return (
+		<SelectControl
+			__nextHasNoMarginBottom
+			label={ __( 'Overlay Template Part' ) }
+			value={ value || '' }
+			options={ options }
+			onChange={ ( newValue ) => {
+				onChange( newValue ? parseInt( newValue, 10 ) : undefined );
+			} }
+			help={ __(
+				'Select a custom overlay template part for this navigation menu.'
+			) }
+		/>
+	);
+}

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -29,7 +29,7 @@ export default function OverlaySelector( { value, onChange } ) {
 		templateParts?.filter( ( part ) => part.area === 'overlay' ) || [];
 
 	const options = [
-		{ label: __( 'None' ), value: '' },
+		{ label: __( 'Default' ), value: '' },
 		...overlayParts.map( ( part ) => ( {
 			label: part.title?.rendered || part.slug || __( 'Untitled' ),
 			value: part.id,

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -6,6 +6,7 @@ import { useState, useMemo } from '@wordpress/element';
 import {
 	SelectControl,
 	Button,
+	Tooltip,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { pencil } from '@wordpress/icons';
@@ -172,39 +173,41 @@ export default function OverlaySelector( { value, onChange } ) {
 				previewBlocks &&
 				previewBlocks.length > 0 && (
 					<div className="block-editor-block-patterns-list__list-item">
-						<div
-							className="block-editor-block-patterns-list__item"
-							onClick={
-								onNavigateToEntityRecord
-									? handleEditClick
-									: undefined
-							}
-							style={ {
-								cursor: onNavigateToEntityRecord
-									? 'pointer'
-									: 'default',
-							} }
-							role="button"
-							tabIndex={ onNavigateToEntityRecord ? 0 : -1 }
-							onKeyDown={ ( event ) => {
-								if (
-									( event.key === 'Enter' ||
-										event.key === ' ' ) &&
+						<Tooltip text={ __( 'Edit Overlay' ) }>
+							<div
+								className="block-editor-block-patterns-list__item"
+								onClick={
 									onNavigateToEntityRecord
-								) {
-									event.preventDefault();
-									handleEditClick();
+										? handleEditClick
+										: undefined
 								}
-							} }
-							aria-label={ __( 'Edit overlay' ) }
-						>
-							<BlockPreview.Async>
-								<BlockPreview
-									blocks={ previewBlocks }
-									viewportWidth={ 500 }
-								/>
-							</BlockPreview.Async>
-						</div>
+								style={ {
+									cursor: onNavigateToEntityRecord
+										? 'pointer'
+										: 'default',
+								} }
+								role="button"
+								tabIndex={ onNavigateToEntityRecord ? 0 : -1 }
+								onKeyDown={ ( event ) => {
+									if (
+										( event.key === 'Enter' ||
+											event.key === ' ' ) &&
+										onNavigateToEntityRecord
+									) {
+										event.preventDefault();
+										handleEditClick();
+									}
+								} }
+								aria-label={ __( 'Edit overlay' ) }
+							>
+								<BlockPreview.Async>
+									<BlockPreview
+										blocks={ previewBlocks }
+										viewportWidth={ 480 }
+									/>
+								</BlockPreview.Async>
+							</div>
+						</Tooltip>
 					</div>
 				) }
 			<SelectControl

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -46,16 +46,19 @@ export default function OverlaySelector( { value, onChange } ) {
 	};
 
 	return (
-		<VStack spacing={ 4 }>
+		<VStack spacing={ 1 }>
 			<SelectControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
-				label={ __( 'Overlay Template Part' ) }
+				label={ __( 'Overlay Template' ) }
 				value={ value || '' }
 				options={ options }
 				onChange={ ( newValue ) => {
 					onChange( newValue === '' ? undefined : newValue );
 				} }
+				help={ __(
+					'Select a template part to use as the custom overlay or create a new one.'
+				) }
 			/>
 			<Button
 				__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -2,14 +2,27 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { SelectControl } from '@wordpress/components';
+import {
+	SelectControl,
+	Button,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { pencil } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 export default function OverlaySelector( { value, onChange } ) {
 	const { records: templateParts } = useEntityRecords(
 		'postType',
 		'wp_template_part',
 		{ per_page: -1 }
+	);
+
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
 	);
 
 	const overlayParts =
@@ -23,16 +36,37 @@ export default function OverlaySelector( { value, onChange } ) {
 		} ) ),
 	];
 
+	const handleEditClick = () => {
+		if ( value && onNavigateToEntityRecord ) {
+			onNavigateToEntityRecord( {
+				postId: value,
+				postType: 'wp_template_part',
+			} );
+		}
+	};
+
 	return (
-		<SelectControl
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-			label={ __( 'Overlay Template Part' ) }
-			value={ value || '' }
-			options={ options }
-			onChange={ ( newValue ) => {
-				onChange( newValue === '' ? undefined : newValue );
-			} }
-		/>
+		<VStack spacing={ 4 }>
+			<SelectControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Overlay Template Part' ) }
+				value={ value || '' }
+				options={ options }
+				onChange={ ( newValue ) => {
+					onChange( newValue === '' ? undefined : newValue );
+				} }
+			/>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				icon={ pencil }
+				onClick={ handleEditClick }
+				disabled={ ! value || ! onNavigateToEntityRecord }
+				style={ { maxWidth: 'fit-content' } }
+			>
+				{ __( 'Edit Overlay' ) }
+			</Button>
+		</VStack>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -5,51 +5,34 @@ import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 
-/**
- * Component to select an overlay template part for the Navigation block.
- *
- * @param {Object} props          Component props.
- * @param {number} props.value    Current overlay template part ID.
- * @param {Function} props.onChange Callback when overlay is selected.
- * @return {JSX.Element} Overlay selector component.
- */
 export default function OverlaySelector( { value, onChange } ) {
-	const { records: templateParts, isResolving } = useEntityRecords(
+	const { records: templateParts } = useEntityRecords(
 		'postType',
 		'wp_template_part',
-		{
-			per_page: -1,
-		}
+		{ per_page: -1 }
 	);
 
-	// Filter to only overlay template parts
-	const overlayTemplateParts =
+	const overlayParts =
 		templateParts?.filter( ( part ) => part.area === 'overlay' ) || [];
 
 	const options = [
 		{ label: __( 'None' ), value: '' },
-		...overlayTemplateParts.map( ( part ) => ( {
+		...overlayParts.map( ( part ) => ( {
 			label: part.title?.rendered || part.slug || __( 'Untitled' ),
 			value: part.id,
 		} ) ),
 	];
 
-	if ( isResolving ) {
-		return null;
-	}
-
 	return (
 		<SelectControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			label={ __( 'Overlay Template Part' ) }
 			value={ value || '' }
 			options={ options }
 			onChange={ ( newValue ) => {
-				onChange( newValue ? parseInt( newValue, 10 ) : undefined );
+				onChange( newValue === '' ? undefined : newValue );
 			} }
-			help={ __(
-				'Select a custom overlay template part for this navigation menu.'
-			) }
 		/>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -166,6 +166,13 @@ export default function OverlaySelector( { value, onChange } ) {
 		}
 	}, [ selectedTemplatePart ] );
 
+	// Check if we can edit (value exists, template part exists, and navigation is available)
+	const canEdit =
+		value &&
+		selectedTemplatePart &&
+		onNavigateToEntityRecord &&
+		! isCreating;
+
 	return (
 		<VStack spacing={ 1 }>
 			{ value &&
@@ -177,22 +184,18 @@ export default function OverlaySelector( { value, onChange } ) {
 							<div
 								className="block-editor-block-patterns-list__item"
 								onClick={
-									onNavigateToEntityRecord
-										? handleEditClick
-										: undefined
+									canEdit ? handleEditClick : undefined
 								}
 								style={ {
-									cursor: onNavigateToEntityRecord
-										? 'pointer'
-										: 'default',
+									cursor: canEdit ? 'pointer' : 'default',
 								} }
 								role="button"
-								tabIndex={ onNavigateToEntityRecord ? 0 : -1 }
+								tabIndex={ canEdit ? 0 : -1 }
 								onKeyDown={ ( event ) => {
 									if (
 										( event.key === 'Enter' ||
 											event.key === ' ' ) &&
-										onNavigateToEntityRecord
+										canEdit
 									) {
 										event.preventDefault();
 										handleEditClick();
@@ -253,7 +256,7 @@ export default function OverlaySelector( { value, onChange } ) {
 				variant="secondary"
 				icon={ pencil }
 				onClick={ handleEditClick }
-				disabled={ ! value || ! onNavigateToEntityRecord || isCreating }
+				disabled={ ! canEdit }
 				style={ { maxWidth: 'fit-content' } }
 			>
 				{ __( 'Edit Overlay' ) }

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -2,22 +2,34 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import {
 	SelectControl,
 	Button,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { pencil } from '@wordpress/icons';
-import { useEntityRecords } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { serialize } from '@wordpress/blocks';
+import { paramCase as kebabCase } from 'change-case';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
 
 export default function OverlaySelector( { value, onChange } ) {
+	const [ isCreating, setIsCreating ] = useState( false );
+
 	const { records: templateParts } = useEntityRecords(
 		'postType',
 		'wp_template_part',
 		{ per_page: -1 }
 	);
+
+	const { saveEntityRecord } = useDispatch( coreStore );
 
 	const onNavigateToEntityRecord = useSelect(
 		( select ) =>
@@ -29,11 +41,17 @@ export default function OverlaySelector( { value, onChange } ) {
 		templateParts?.filter( ( part ) => part.area === 'overlay' ) || [];
 
 	const options = [
-		{ label: __( 'Default' ), value: '' },
-		...overlayParts.map( ( part ) => ( {
-			label: part.title?.rendered || part.slug || __( 'Untitled' ),
-			value: part.id,
-		} ) ),
+		{ label: __( 'None' ), value: '' },
+		...overlayParts.map( ( part ) => {
+			const templatePartId = createTemplatePartId(
+				part.theme,
+				part.slug
+			);
+			return {
+				label: part.title?.rendered || part.slug || __( 'Untitled' ),
+				value: templatePartId,
+			};
+		} ),
 	];
 
 	const handleEditClick = () => {
@@ -42,6 +60,63 @@ export default function OverlaySelector( { value, onChange } ) {
 				postId: value,
 				postType: 'wp_template_part',
 			} );
+		}
+	};
+
+	const handleCreateNew = async () => {
+		setIsCreating( true );
+
+		// Generate a unique title by checking existing overlay template parts
+		const baseTitle = __( 'Overlay' );
+		const existingTitles = overlayParts.map(
+			( part ) => part.title?.rendered || ''
+		);
+
+		// Find the next available number
+		let titleNumber = 1;
+		let uniqueTitle = baseTitle;
+		while ( existingTitles.includes( uniqueTitle ) ) {
+			titleNumber++;
+			uniqueTitle = `${ baseTitle } ${ titleNumber }`;
+		}
+
+		const cleanSlug =
+			kebabCase( uniqueTitle ).replace( /[^\w-]+/g, '' ) ||
+			'wp-custom-overlay';
+
+		try {
+			const templatePart = await saveEntityRecord(
+				'postType',
+				'wp_template_part',
+				{
+					title: uniqueTitle,
+					slug: cleanSlug,
+					content: serialize( [] ),
+					area: 'overlay',
+				},
+				{ throwOnError: true }
+			);
+
+			// Create the proper template part ID format (theme//slug)
+			const templatePartId = createTemplatePartId(
+				templatePart.theme,
+				templatePart.slug
+			);
+
+			// Set the new template part as the selected overlay
+			onChange( templatePartId );
+
+			// Navigate to the new template part for editing
+			if ( onNavigateToEntityRecord && templatePartId ) {
+				onNavigateToEntityRecord( {
+					postId: templatePartId,
+					postType: 'wp_template_part',
+				} );
+			}
+		} catch ( error ) {
+			console.error( 'Failed to create overlay template part:', error );
+		} finally {
+			setIsCreating( false );
 		}
 	};
 
@@ -56,16 +131,41 @@ export default function OverlaySelector( { value, onChange } ) {
 				onChange={ ( newValue ) => {
 					onChange( newValue === '' ? undefined : newValue );
 				} }
-				help={ __(
-					'Select a template part to use as the custom overlay or create a new one.'
-				) }
+				disabled={ isCreating }
+				help={
+					<>
+						{ __(
+							'Select a template part to use as the custom overlay or '
+						) }
+						<button
+							type="button"
+							onClick={ handleCreateNew }
+							disabled={ isCreating }
+							style={ {
+								background: 'none',
+								border: 'none',
+								color: isCreating
+									? 'var(--wp-components-color-foreground)'
+									: 'var(--wp-admin-theme-color)',
+								cursor: isCreating ? 'not-allowed' : 'pointer',
+								textDecoration: 'underline',
+								padding: 0,
+								font: 'inherit',
+								opacity: isCreating ? 0.5 : 1,
+							} }
+						>
+							{ __( 'create a new one' ) }
+						</button>
+						.
+					</>
+				}
 			/>
 			<Button
 				__next40pxDefaultSize
 				variant="secondary"
 				icon={ pencil }
 				onClick={ handleEditClick }
-				disabled={ ! value || ! onNavigateToEntityRecord }
+				disabled={ ! value || ! onNavigateToEntityRecord || isCreating }
 				style={ { maxWidth: 'fit-content' } }
 			>
 				{ __( 'Edit Overlay' ) }

--- a/packages/block-library/src/navigation/edit/overlay-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-selector.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	SelectControl,
 	Button,
@@ -11,8 +11,11 @@ import {
 import { pencil } from '@wordpress/icons';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { serialize } from '@wordpress/blocks';
+import {
+	store as blockEditorStore,
+	BlockPreview,
+} from '@wordpress/block-editor';
+import { serialize, parse } from '@wordpress/blocks';
 import { paramCase as kebabCase } from 'change-case';
 
 /**
@@ -120,8 +123,90 @@ export default function OverlaySelector( { value, onChange } ) {
 		}
 	};
 
+	// Get the selected template part entity
+	const selectedTemplatePart = useSelect(
+		( select ) => {
+			if ( ! value ) {
+				return null;
+			}
+			const { getEditedEntityRecord } = select( coreStore );
+			try {
+				return getEditedEntityRecord(
+					'postType',
+					'wp_template_part',
+					value
+				);
+			} catch {
+				return null;
+			}
+		},
+		[ value ]
+	);
+
+	// Parse template part content to blocks for preview
+	const previewBlocks = useMemo( () => {
+		if ( ! selectedTemplatePart ) {
+			return null;
+		}
+		// Content can be either a string directly or content.raw
+		const contentString =
+			selectedTemplatePart.content?.raw || selectedTemplatePart.content;
+		if ( ! contentString || typeof contentString !== 'string' ) {
+			return null;
+		}
+		try {
+			const blocks = parse( contentString );
+			// Filter out null blocks that parse can return
+			const validBlocks = blocks?.filter( Boolean ) || [];
+			return validBlocks.length > 0 ? validBlocks : null;
+		} catch ( error ) {
+			console.error( 'Error parsing blocks:', error );
+			return null;
+		}
+	}, [ selectedTemplatePart ] );
+
 	return (
 		<VStack spacing={ 1 }>
+			{ value &&
+				! isCreating &&
+				previewBlocks &&
+				previewBlocks.length > 0 && (
+					<div className="block-editor-block-patterns-list__list-item">
+						<div
+							className="block-editor-block-patterns-list__item"
+							onClick={
+								onNavigateToEntityRecord
+									? handleEditClick
+									: undefined
+							}
+							style={ {
+								cursor: onNavigateToEntityRecord
+									? 'pointer'
+									: 'default',
+							} }
+							role="button"
+							tabIndex={ onNavigateToEntityRecord ? 0 : -1 }
+							onKeyDown={ ( event ) => {
+								if (
+									( event.key === 'Enter' ||
+										event.key === ' ' ) &&
+									onNavigateToEntityRecord
+								) {
+									event.preventDefault();
+									handleEditClick();
+								}
+							} }
+							aria-label={ __( 'Edit overlay' ) }
+						>
+							<BlockPreview.Async>
+								<BlockPreview
+									blocks={ previewBlocks }
+									viewportWidth={ 500 }
+								/>
+							</BlockPreview.Async>
+						</div>
+					</div>
+				) }
 			<SelectControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -27,6 +27,8 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	overlayTemplatePartId,
+	onNavigateToEntityRecord,
 } ) {
 	if ( ! isResponsive ) {
 		return children;
@@ -75,6 +77,18 @@ export default function ResponsiveWrapper( {
 		} ),
 	};
 
+	const handleOpenClick = () => {
+		// If there's a custom overlay template part, navigate to it
+		if ( overlayTemplatePartId && onNavigateToEntityRecord && ! isOpen ) {
+			onNavigateToEntityRecord( {
+				postId: overlayTemplatePartId,
+				postType: 'wp_template_part',
+			} );
+		} else {
+			onToggle( true );
+		}
+	};
+
 	return (
 		<>
 			{ ! isOpen && (
@@ -83,7 +97,7 @@ export default function ResponsiveWrapper( {
 					aria-haspopup="true"
 					aria-label={ hasIcon && __( 'Open menu' ) }
 					className={ openButtonClasses }
-					onClick={ () => onToggle( true ) }
+					onClick={ handleOpenClick }
 				>
 					{ hasIcon && <OverlayMenuIcon icon={ icon } /> }
 					{ ! hasIcon && __( 'Menu' ) }

--- a/packages/block-library/src/overlay-close/block.json
+++ b/packages/block-library/src/overlay-close/block.json
@@ -6,7 +6,12 @@
 	"category": "design",
 	"description": "A close button for navigation overlays.",
 	"textdomain": "default",
-	"attributes": {},
+	"attributes": {
+		"displayMode": {
+			"type": "string",
+			"default": "icon"
+		}
+	},
 	"supports": {
 		"html": false,
 		"anchor": true,

--- a/packages/block-library/src/overlay-close/block.json
+++ b/packages/block-library/src/overlay-close/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/overlay-close",
+	"title": "Overlay Close",
+	"category": "design",
+	"description": "A close button for navigation overlays.",
+	"textdomain": "default",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"anchor": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"editorStyle": "wp-block-overlay-close-editor",
+	"style": "wp-block-overlay-close"
+}
+

--- a/packages/block-library/src/overlay-close/block.json
+++ b/packages/block-library/src/overlay-close/block.json
@@ -10,6 +10,13 @@
 	"supports": {
 		"html": false,
 		"anchor": true,
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
 		"spacing": {
 			"margin": true,
 			"padding": true

--- a/packages/block-library/src/overlay-close/edit.js
+++ b/packages/block-library/src/overlay-close/edit.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export default function OverlayCloseEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( {
+		className: 'wp-block-overlay-close',
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<Button
+				icon={ close }
+				label={ __( 'Close overlay' ) }
+				className="wp-block-overlay-close__button"
+			>
+				{ __( 'Close' ) }
+			</Button>
+		</div>
+	);
+}

--- a/packages/block-library/src/overlay-close/edit.js
+++ b/packages/block-library/src/overlay-close/edit.js
@@ -7,14 +7,21 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
+	InspectorControls,
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	PanelBody,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-export default function OverlayCloseEdit( { attributes } ) {
+export default function OverlayCloseEdit( { attributes, setAttributes } ) {
+	const { displayMode = 'icon' } = attributes;
 	const colorProps = useColorProps( attributes );
 	const blockProps = useBlockProps( {
 		className: 'wp-block-overlay-close',
@@ -23,20 +30,52 @@ export default function OverlayCloseEdit( { attributes } ) {
 		},
 	} );
 
+	const showIcon = displayMode === 'icon' || displayMode === 'both';
+	const showText = displayMode === 'text' || displayMode === 'both';
+
 	return (
-		<div { ...blockProps }>
-			<Button
-				__next40pxDefaultSize
-				icon={ close }
-				label={ __( 'Close overlay' ) }
-				className={ clsx(
-					'wp-block-overlay-close__button',
-					colorProps.className
-				) }
-				style={ colorProps.style }
-			>
-				{ __( 'Close' ) }
-			</Button>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Display' ) }>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Display mode' ) }
+						value={ displayMode }
+						onChange={ ( value ) =>
+							setAttributes( { displayMode: value } )
+						}
+						isBlock
+					>
+						<ToggleGroupControlOption
+							value="icon"
+							label={ __( 'Icon' ) }
+						/>
+						<ToggleGroupControlOption
+							value="text"
+							label={ __( 'Text' ) }
+						/>
+						<ToggleGroupControlOption
+							value="both"
+							label={ __( 'Both' ) }
+						/>
+					</ToggleGroupControl>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<Button
+					__next40pxDefaultSize
+					icon={ showIcon ? close : undefined }
+					label={ __( 'Close overlay' ) }
+					className={ clsx(
+						'wp-block-overlay-close__button',
+						colorProps.className
+					) }
+					style={ colorProps.style }
+				>
+					{ showText ? __( 'Close' ) : null }
+				</Button>
+			</div>
+		</>
 	);
 }

--- a/packages/block-library/src/overlay-close/edit.js
+++ b/packages/block-library/src/overlay-close/edit.js
@@ -1,22 +1,39 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	__experimentalUseColorProps as useColorProps,
+} from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-export default function OverlayCloseEdit( { attributes, setAttributes } ) {
+export default function OverlayCloseEdit( { attributes } ) {
+	const colorProps = useColorProps( attributes );
 	const blockProps = useBlockProps( {
 		className: 'wp-block-overlay-close',
+		style: {
+			...colorProps.style,
+		},
 	} );
 
 	return (
 		<div { ...blockProps }>
 			<Button
+				__next40pxDefaultSize
 				icon={ close }
 				label={ __( 'Close overlay' ) }
-				className="wp-block-overlay-close__button"
+				className={ clsx(
+					'wp-block-overlay-close__button',
+					colorProps.className
+				) }
+				style={ colorProps.style }
 			>
 				{ __( 'Close' ) }
 			</Button>

--- a/packages/block-library/src/overlay-close/editor.scss
+++ b/packages/block-library/src/overlay-close/editor.scss
@@ -1,0 +1,17 @@
+.wp-block-overlay-close {
+	.wp-block-overlay-close__button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		color: currentColor;
+
+		&:hover {
+			opacity: 0.8;
+		}
+	}
+}
+

--- a/packages/block-library/src/overlay-close/index.js
+++ b/packages/block-library/src/overlay-close/index.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { close } from '@wordpress/icons';
+import { select as dataSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { unlock } from '../lock-unlock';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+const { name } = metadata;
+const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+
+export { metadata, name };
+
+export const settings = {
+	icon: close,
+	edit,
+	save,
+};
+
+export const init = () => {
+	initBlock( { name, metadata, settings } );
+
+	// Restrict overlay-close block to only overlay template parts
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'core/overlay-close/restrict-to-overlay',
+		( canInsert, blockType ) => {
+			if ( blockType.name !== 'core/overlay-close' ) {
+				return canInsert;
+			}
+
+			// Check if we're in an overlay template part
+			const { getCurrentPostType, getCurrentPostId } = unlock(
+				dataSelect( editorStore )
+			);
+			const { getEditedEntityRecord } = dataSelect( coreStore );
+			const postType = getCurrentPostType();
+			const postId = getCurrentPostId();
+
+			if ( postType !== TEMPLATE_PART_POST_TYPE || ! postId ) {
+				return false;
+			}
+
+			const templatePart = getEditedEntityRecord(
+				'postType',
+				TEMPLATE_PART_POST_TYPE,
+				postId
+			);
+
+			return templatePart?.area === 'overlay';
+		}
+	);
+};

--- a/packages/block-library/src/overlay-close/save.js
+++ b/packages/block-library/src/overlay-close/save.js
@@ -12,7 +12,11 @@ import {
 } from '@wordpress/block-editor';
 
 export default function OverlayCloseSave( { attributes, className } ) {
+	const { displayMode = 'icon' } = attributes;
 	const colorProps = getColorClassesAndStyles( attributes );
+
+	const showIcon = displayMode === 'icon' || displayMode === 'both';
+	const showText = displayMode === 'text' || displayMode === 'both';
 
 	return (
 		<div
@@ -29,8 +33,12 @@ export default function OverlayCloseSave( { attributes, className } ) {
 				style={ colorProps.style }
 				aria-label="Close overlay"
 			>
-				<span className="wp-block-overlay-close__icon">×</span>
-				<span className="wp-block-overlay-close__text">Close</span>
+				{ showIcon && (
+					<span className="wp-block-overlay-close__icon">×</span>
+				) }
+				{ showText && (
+					<span className="wp-block-overlay-close__text">Close</span>
+				) }
 			</button>
 		</div>
 	);

--- a/packages/block-library/src/overlay-close/save.js
+++ b/packages/block-library/src/overlay-close/save.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+export default function OverlayCloseSave() {
+	return (
+		<div className="wp-block-overlay-close">
+			<button
+				type="button"
+				className="wp-block-overlay-close__button"
+				aria-label="Close overlay"
+			>
+				<span className="wp-block-overlay-close__icon">×</span>
+				<span className="wp-block-overlay-close__text">Close</span>
+			</button>
+		</div>
+	);
+}

--- a/packages/block-library/src/overlay-close/save.js
+++ b/packages/block-library/src/overlay-close/save.js
@@ -1,12 +1,32 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-export default function OverlayCloseSave() {
+import {
+	useBlockProps,
+	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
+} from '@wordpress/block-editor';
+
+export default function OverlayCloseSave( { attributes, className } ) {
+	const colorProps = getColorClassesAndStyles( attributes );
+
 	return (
-		<div className="wp-block-overlay-close">
+		<div
+			{ ...useBlockProps.save( {
+				className: clsx( className, 'wp-block-overlay-close' ),
+			} ) }
+		>
 			<button
 				type="button"
-				className="wp-block-overlay-close__button"
+				className={ clsx(
+					'wp-block-overlay-close__button',
+					colorProps.className
+				) }
+				style={ colorProps.style }
 				aria-label="Close overlay"
 			>
 				<span className="wp-block-overlay-close__icon">×</span>

--- a/packages/block-library/src/overlay-close/style.scss
+++ b/packages/block-library/src/overlay-close/style.scss
@@ -1,0 +1,26 @@
+.wp-block-overlay-close {
+	.wp-block-overlay-close__button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		color: currentColor;
+
+		&:hover {
+			opacity: 0.8;
+		}
+	}
+
+	.wp-block-overlay-close__icon {
+		font-size: 1.5rem;
+		line-height: 1;
+	}
+
+	.wp-block-overlay-close__text {
+		margin-left: 0.5rem;
+	}
+}
+

--- a/packages/block-library/src/overlay-close/use-template-part-area.js
+++ b/packages/block-library/src/overlay-close/use-template-part-area.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { unlock } from '../lock-unlock';
+
+const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+
+/**
+ * Hook to check if we're currently editing an overlay template part.
+ *
+ * @return {boolean} True if editing an overlay template part, false otherwise.
+ */
+export function useIsOverlayTemplatePart() {
+	return useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = unlock(
+			select( editorStore )
+		);
+		const { getEditedEntityRecord } = select( coreStore );
+		const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+
+		if ( postType !== TEMPLATE_PART_POST_TYPE || ! postId ) {
+			return false;
+		}
+
+		const templatePart = getEditedEntityRecord(
+			'postType',
+			TEMPLATE_PART_POST_TYPE,
+			postId
+		);
+
+		return templatePart?.area === 'overlay';
+	}, [] );
+}

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -117,6 +117,7 @@ function VisualEditor( {
 		isPreview,
 		styles,
 		canvasMinHeight,
+		isOverlayTemplatePart,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -150,6 +151,20 @@ function VisualEditor( {
 			  )
 			: undefined;
 
+		// Check if we're editing an overlay template part
+		let _isOverlayTemplatePart = false;
+		if ( postTypeSlug === TEMPLATE_PART_POST_TYPE ) {
+			const currentPostId = getCurrentPostId();
+			const templatePart = currentPostId
+				? getEditedEntityRecord(
+						'postType',
+						TEMPLATE_PART_POST_TYPE,
+						currentPostId
+				  )
+				: null;
+			_isOverlayTemplatePart = templatePart?.area === 'overlay';
+		}
+
 		return {
 			renderingMode: _renderingMode,
 			postContentAttributes: editorSettings.postContentAttributes,
@@ -168,6 +183,7 @@ function VisualEditor( {
 			isPreview: editorSettings.isPreviewMode,
 			styles: editorSettings.styles,
 			canvasMinHeight: getCanvasMinHeight(),
+			isOverlayTemplatePart: _isOverlayTemplatePart,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -357,6 +373,11 @@ function VisualEditor( {
 	);
 
 	const iframeStyles = useMemo( () => {
+		// Full-height styles for overlay template parts
+		const overlayFullHeightCSS = isOverlayTemplatePart
+			? `.block-editor-iframe__html{height:100vh;overflow:hidden;}.block-editor-iframe__body{height:100vh;min-height:100vh;display:flex;flex-direction:column;}.is-root-container{min-height:100vh;height:100%;flex:1;display:flex;flex-direction:column;}`
+			: '';
+
 		return [
 			...( styles ?? [] ),
 			{
@@ -377,12 +398,19 @@ function VisualEditor( {
 					enableResizing
 						? `.block-editor-iframe__html{background:var(--wp-editor-canvas-background);display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
 						: ''
-				}`,
+				}
+				${ overlayFullHeightCSS }`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
 			},
 		];
-	}, [ styles, enableResizing, calculatedMinHeight, paddingStyle ] );
+	}, [
+		styles,
+		enableResizing,
+		calculatedMinHeight,
+		paddingStyle,
+		isOverlayTemplatePart,
+	] );
 
 	const typewriterRef = useTypewriter();
 	contentRef = useMergeRefs( [
@@ -411,6 +439,7 @@ function VisualEditor( {
 					'has-padding': isFocusedEntity || enableResizing,
 					'is-resizable': enableResizing,
 					'is-iframed': ! disableIframe,
+					'is-overlay-template-part': isOverlayTemplatePart,
 				}
 			) }
 		>


### PR DESCRIPTION
⚠️ **PROTOTYPE ONLY - NOT PRODUCTION CODE** ⚠️

This PR contains a working prototype implementation of customizable navigation overlays for early feedback and issue discovery. This code is **NOT intended for production** and may contain shortcuts, hardcoded values, and experimental approaches.

## What

This prototype implements the editor-side experience for customizable navigation overlays as outlined in #73084. It enables users to:

- Register "Overlay" template parts as a new template part area
- Create and select custom overlay template parts from the Navigation block sidebar
- Edit overlays in focused template part mode with full-height canvas
- Use an "Overlay Close" block that's restricted to overlay template parts
- Preview selected overlays inline in the Navigation block sidebar
- Navigate between Navigation block and overlay template part editing

## Why

This prototype is designed to:
- Gather early feedback on the user experience and workflow
- Uncover potential issues and edge cases before production implementation
- Validate the architectural approach and identify any gaps
- Test the integration between Navigation block and template part editing

The prototype intentionally focuses on the editor experience only and does not include front-end PHP rendering.

## How

The implementation includes:

- **Overlay Template Part Area**: Registered via PHP filter in the WordPress 7.0 compatibility layer, gated by the `gutenberg-customizable-navigation-overlays` experiment
- **Overlay Close Block**: A new block type restricted to overlay template parts only, with display mode controls (icon, text, or both) and color support
- **Navigation Block Integration**: New "Overlay" panel in the Navigation block sidebar with overlay visibility controls, template part selector, and preview
- **Full-Height Canvas**: Overlay template parts render at full viewport height in the editor for accurate preview
- **Pattern Support**: Default overlay pattern registered for quick starting points
- **Recursion Prevention**: Logic to prevent "overlay inception" when Navigation blocks are placed within overlay template parts

**Note**: This prototype contains intentional shortcuts including hardcoded values, code duplication, and simplified error handling. These are acceptable for prototype purposes but would need to be addressed before production.