### PR TITLE
Apply background to DataViews wrapper

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
 - DataViews: add support for activity layout. [#72780](https://github.com/WordPress/gutenberg/pull/72780)
 - DataViews: Add grid keyboard navigation. [#72997](https://github.com/WordPress/gutenberg/pull/72997)
+- DataViews: Introduce CSS var to enable users to apply a different background color to DataViews containers. [#73390](https://github.com/WordPress/gutenberg/pull/73390)
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 - Field API: fix display format for date. [#73538](https://github.com/WordPress/gutenberg/pull/73538)
 - Documentation: improve Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -459,6 +459,12 @@ Optional. Pass an object with a list of `perPageSizes` to control the available 
 
 An element to display when the `data` prop is empty. Defaults to `<p>No results</p>`.
 
+### Styling
+
+These are the CSS Custom Properties that can be used to tweak the appearance of the component:
+
+`--wp-dataviews-color-background`: sets the background color.
+
 ### Composition modes
 
 The `DataViews` component supports two composition modes:

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -14,7 +14,7 @@
 	flex-direction: column;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
-	background-color: var(--wp-dataviews-background, $white);
+	background-color: var(--wp-dataviews-color-background, $white);
 }
 
 .dataviews__view-actions,

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -14,7 +14,7 @@
 	flex-direction: column;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
-	background-color: inherit;
+	background-color: var(--wp-dataviews-background, $white);
 }
 
 .dataviews__view-actions,

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -83,6 +83,10 @@ export const Default = ( {
 	perPageSizes = [ 10, 25, 50, 100 ],
 	hasClickableItems = true,
 	backgroundColor,
+}: {
+	perPageSizes?: number[];
+	hasClickableItems?: boolean;
+	backgroundColor?: string;
 } ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
@@ -95,7 +99,13 @@ export const Default = ( {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
 	return (
-		<div style={ { '--wp-dataviews-color-background': backgroundColor } }>
+		<div
+			style={
+				{
+					'--wp-dataviews-color-background': backgroundColor,
+				} as React.CSSProperties
+			}
+		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
 				paginationInfo={ paginationInfo }

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -82,6 +82,7 @@ const defaultLayouts = {
 export const Default = ( {
 	perPageSizes = [ 10, 25, 50, 100 ],
 	hasClickableItems = true,
+	backgroundColor,
 } ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
@@ -94,28 +95,39 @@ export const Default = ( {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
 	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ paginationInfo }
-			data={ shownData }
-			view={ view }
-			fields={ fields }
-			onChangeView={ setView }
-			actions={ actions }
-			renderItemLink={ ( { item, ...props }: { item: SpaceObject } ) => (
-				<button
-					style={ { background: 'none', border: 'none', padding: 0 } }
-					onClick={ () => {
-						// eslint-disable-next-line no-alert
-						alert( 'Clicked: ' + item.name.title );
-					} }
-					{ ...props }
-				/>
-			) }
-			isItemClickable={ () => hasClickableItems }
-			defaultLayouts={ defaultLayouts }
-			config={ { perPageSizes } }
-		/>
+		<div style={ { '--wp-dataviews-color-background': backgroundColor } }>
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ shownData }
+				view={ view }
+				fields={ fields }
+				onChangeView={ setView }
+				actions={ actions }
+				renderItemLink={ ( {
+					item,
+					...props
+				}: {
+					item: SpaceObject;
+				} ) => (
+					<button
+						style={ {
+							background: 'none',
+							border: 'none',
+							padding: 0,
+						} }
+						onClick={ () => {
+							// eslint-disable-next-line no-alert
+							alert( 'Clicked: ' + item.name.title );
+						} }
+						{ ...props }
+					/>
+				) }
+				isItemClickable={ () => hasClickableItems }
+				defaultLayouts={ defaultLayouts }
+				config={ { perPageSizes } }
+			/>
+		</div>
 	);
 };
 
@@ -132,6 +144,10 @@ Default.argTypes = {
 	hasClickableItems: {
 		control: 'boolean',
 		description: 'Are the items clickable',
+	},
+	backgroundColor: {
+		control: 'color',
+		description: 'Background color of the DataViews component',
 	},
 };
 


### PR DESCRIPTION
## What?
Small follow-up to #73240.

* Applies a background color to `.dataviews-wrapper` and `.dataviews-picker-wrapper`
* Introduces `--wp-dataviews-background`

<!-- In a few words, what is the PR actually doing? -->

## Why?
Allows consumers to apply a different background color to DataViews.

## Testing Instructions
1. `npm run storybook`
2. Observe the DataViews story
3. Check sticky elements have an applied background color
4. Using browser Inspector apply a custom background to `.dataviews-wrapper`
5. Check that sticky elements inherit the custom background color and still work as expected


