### PR TITLE
Fix react/jsx-runtime import in built files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52134,9 +52134,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/api-fetch": {
@@ -52933,10 +52930,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/block-editor": {
@@ -53000,10 +52993,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/block-editor/node_modules/postcss-urlrebase": {
@@ -53095,10 +53084,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/block-serialization-default-parser": {
@@ -53158,9 +53143,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/blocks/node_modules/react-is": {
@@ -53197,10 +53179,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/browserslist-config": {
@@ -53231,10 +53209,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/components": {
@@ -53292,10 +53266,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/components/node_modules/framer-motion": {
@@ -53351,9 +53321,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/compose/node_modules/clipboard": {
@@ -53388,10 +53355,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/core-data": {
@@ -53424,10 +53387,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/create-block": {
@@ -53507,10 +53466,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/data": {
@@ -53536,9 +53491,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/data-controls": {
@@ -53553,9 +53505,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/dataviews": {
@@ -53587,10 +53536,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/dataviews/node_modules/date-fns": {
@@ -53766,10 +53711,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/edit-site": {
@@ -53832,10 +53773,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/edit-site-init": {
@@ -53889,10 +53826,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/editor": {
@@ -53952,10 +53885,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/element": {
@@ -54118,9 +54047,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/format-library": {
@@ -54145,10 +54071,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/global-styles-engine": {
@@ -54199,10 +54121,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/hooks": {
@@ -54304,10 +54222,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/is-shallow-equal": {
@@ -54384,9 +54298,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/keycodes": {
@@ -54467,10 +54378,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/media-utils": {
@@ -54505,9 +54412,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/npm-package-json-lint-config": {
@@ -54539,10 +54443,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/patterns": {
@@ -54569,10 +54469,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/plugins": {
@@ -54592,10 +54488,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/postcss-plugins-preset": {
@@ -54647,10 +54539,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/preferences-persistence": {
@@ -54688,9 +54576,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/priority-queue": {
@@ -54970,10 +54855,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/rich-text": {
@@ -54995,9 +54876,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/route": {
@@ -55012,9 +54890,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/router": {
@@ -55032,9 +54907,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/scripts": {
@@ -55176,10 +55048,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/shortcode": {
@@ -55355,10 +55223,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/token-list": {
@@ -55384,10 +55248,6 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/undo-manager": {
@@ -55421,10 +55281,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/url": {
@@ -55451,9 +55307,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"packages/views": {
@@ -55515,10 +55368,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/wordcount": {
@@ -55550,10 +55399,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/wp-build": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54983,9 +54983,7 @@
 			},
 			"peerDependencies": {
 				"@playwright/test": "^1.56.1",
-				"@wordpress/env": "^10.0.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+				"@wordpress/env": "^10.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@wordpress/env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55216,6 +55216,7 @@
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
+				"@types/react": "18.3.1",
 				"esbuild-esm-loader": "0.3.3"
 			},
 			"engines": {
@@ -55241,6 +55242,7 @@
 				"@wordpress/private-apis": "file:../private-apis"
 			},
 			"devDependencies": {
+				"@types/react": "18.3.1",
 				"@wordpress/theme": "file:../theme"
 			},
 			"engines": {

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -40,9 +40,6 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -56,10 +56,6 @@
 		"change-case": "^4.1.2",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -105,10 +105,6 @@
 		"react-easy-crop": "^5.0.6",
 		"remove-accents": "^0.5.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -127,10 +127,6 @@
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -64,9 +64,6 @@
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -55,10 +55,6 @@
 		"@wordpress/url": "file:../url",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -47,10 +47,6 @@
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Fixed an issue where the `Guide` component’s close button became invisible on hover when used on light backgrounds. The component's close button now relies on the default button hover effect, and the custom hover color is applied only within `welcome-guide` implementations to maintain consistency. ([#73220](https://github.com/WordPress/gutenberg/pull/73220))
 
+### Internal
+
+- Remove "react" and "react-dom" from peer dependencies. [#73391](https://github.com/WordPress/gutenberg/pull/73391)
+
 ## 30.8.0 (2025-11-12)
 
 ### Bug Fixes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -90,10 +90,6 @@
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -11,6 +11,7 @@ import {
 	useRef,
 	useEffect,
 	useState,
+	createPortal,
 } from '@wordpress/element';
 import { useAnchor } from '@wordpress/rich-text';
 import { useDebounce, useMergeRefs, useRefEffect } from '@wordpress/compose';
@@ -24,7 +25,6 @@ import getDefaultUseItems from './get-default-use-items';
 import Button from '../button';
 import Popover from '../popover';
 import { VisuallyHidden } from '../visually-hidden';
-import { createPortal } from 'react-dom';
 import type { AutocompleterUIProps, KeyedOption, WPCompleter } from './types';
 
 type ListBoxProps = {

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -52,9 +52,6 @@
 		"mousetrap": "^1.6.5",
 		"use-memo-one": "^1.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -49,10 +49,6 @@
 		"@wordpress/router": "file:../router",
 		"@wordpress/url": "file:../url"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -62,10 +62,6 @@
 		"memize": "^2.1.0",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -56,10 +56,6 @@
 		"clsx": "^2.1.1",
 		"fast-deep-equal": "^3.1.3"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -41,9 +41,6 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -53,9 +53,6 @@
 		"rememo": "^4.0.2",
 		"use-memo-one": "^1.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - Fix: ensure primary actions are not wrapped in the list layout. [#73333](https://github.com/WordPress/gutenberg/pull/73333)
 
+### Internal
+
+- Remove "react" and "react-dom" from peer dependencies. [#73391](https://github.com/WordPress/gutenberg/pull/73391)
+
 ## 10.3.0 (2025-11-12)
 
 ### Enhancements

--- a/packages/dataviews/build.js
+++ b/packages/dataviews/build.js
@@ -7,6 +7,13 @@ const esbuild = require( 'esbuild' );
 const wpExternals = {
 	name: 'wordpress-externals',
 	setup( build ) {
+		// Don't bundle JSX runtime - let it be resolved externally
+		build.onResolve(
+			{ filter: /^@wordpress\/element\/(jsx-runtime|jsx-dev-runtime)$/ },
+			( args ) => {
+				return { path: args.path, external: true };
+			}
+		);
 		build.onResolve(
 			{ filter: /^@wordpress\/(data|hooks|i18n|date)(\/|$)/ },
 			( args ) => {
@@ -35,6 +42,7 @@ esbuild.build( {
 	outdir: 'build-wp',
 	plugins: [ wpExternals ],
 	jsx: 'automatic',
+	jsxImportSource: '@wordpress/element',
 	logLevel: 'info',
 	format: 'esm',
 } );

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -64,10 +64,6 @@
 		"fast-deep-equal": "^3.1.3",
 		"remove-accents": "^0.5.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -74,10 +74,6 @@
 		"clsx": "^2.1.1",
 		"memize": "^2.1.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -91,10 +91,6 @@
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -69,10 +69,6 @@
 		"@wordpress/widgets": "file:../widgets",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -101,10 +101,6 @@
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -31,6 +31,16 @@
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},
+		"./jsx-runtime": {
+			"types": "./build-types/jsx-runtime.d.ts",
+			"import": "./build-module/jsx-runtime.js",
+			"require": "./build/jsx-runtime.js"
+		},
+		"./jsx-dev-runtime": {
+			"types": "./build-types/jsx-dev-runtime.d.ts",
+			"import": "./build-module/jsx-dev-runtime.js",
+			"require": "./build/jsx-dev-runtime.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",

--- a/packages/element/src/jsx-dev-runtime.ts
+++ b/packages/element/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'react/jsx-dev-runtime';

--- a/packages/element/src/jsx-runtime.ts
+++ b/packages/element/src/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'react/jsx-runtime';

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -68,9 +68,6 @@
 		"clsx": "2.1.1",
 		"remove-accents": "^0.5.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -48,10 +48,6 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/url": "file:../url"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -56,10 +56,6 @@
 		"clsx": "^2.1.0",
 		"colord": "^2.7.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -54,10 +54,6 @@
 		"@wordpress/viewport": "file:../viewport",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -38,9 +38,6 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -44,10 +44,6 @@
 		"@wordpress/i18n": "file:../i18n",
 		"change-case": "^4.1.2"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -39,9 +39,6 @@
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/data": "file:../data"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -49,10 +49,6 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -55,10 +55,6 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -45,10 +45,6 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"memize": "^2.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -54,10 +54,6 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -43,9 +43,6 @@
 		"@wordpress/element": "file:../element",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -50,10 +50,6 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -51,9 +51,6 @@
 		"colord": "2.9.3",
 		"memize": "^2.1.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/route/package.json
+++ b/packages/route/package.json
@@ -40,9 +40,6 @@
 		"@tanstack/react-router": "^1.120.5",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -43,9 +43,6 @@
 		"history": "^5.3.0",
 		"route-recognizer": "^0.3.4"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,9 +95,7 @@
 	},
 	"peerDependencies": {
 		"@playwright/test": "^1.56.1",
-		"@wordpress/env": "^10.0.0",
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
+		"@wordpress/env": "^10.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@wordpress/env": {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -46,10 +46,6 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -51,10 +51,6 @@
 	"devDependencies": {
 		"esbuild-esm-loader": "0.3.3"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -49,6 +49,7 @@
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {
+		"@types/react": "18.3.1",
 		"esbuild-esm-loader": "0.3.3"
 	},
 	"publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/private-apis": "file:../private-apis"
 	},
 	"devDependencies": {
+		"@types/react": "18.3.1",
 		"@wordpress/theme": "file:../theme"
 	},
 	"publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,10 +39,6 @@
 	"devDependencies": {
 		"@wordpress/theme": "file:../theme"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -45,10 +45,6 @@
 		"@wordpress/url": "file:../url",
 		"uuid": "^9.0.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -38,9 +38,6 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -70,10 +70,6 @@
 		"@wordpress/notices": "file:../notices",
 		"clsx": "^2.1.1"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -50,10 +50,6 @@
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.0"
 	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -994,6 +994,15 @@ async function transpilePackage( packageName ) {
 	const emotionPlugin = babel( {
 		filter: /\.[jt]sx?$/,
 		config: {
+			presets: [
+				[
+					'@babel/preset-react',
+					{
+						runtime: 'automatic',
+						importSource: '@wordpress/element',
+					},
+				],
+			],
 			plugins: [ '@emotion/babel-plugin' ],
 		},
 	} );
@@ -1035,7 +1044,7 @@ async function transpilePackage( packageName ) {
 				sourcemap: true,
 				target,
 				jsx: 'automatic',
-				jsxImportSource: 'react',
+				jsxImportSource: '@wordpress/element',
 				loader: {
 					'.js': 'jsx',
 				},
@@ -1067,7 +1076,7 @@ async function transpilePackage( packageName ) {
 				sourcemap: true,
 				target,
 				jsx: 'automatic',
-				jsxImportSource: 'react',
+				jsxImportSource: '@wordpress/element',
 				loader: {
 					'.js': 'jsx',
 				},


### PR DESCRIPTION
An attempt to fix #73257 and an alternative to #73258 as discussed in https://github.com/WordPress/gutenberg/pull/73258#issuecomment-3543997492

Ideally, the consumer packages should never really need to install `react` or `react-dom` as a dependency, nor should we mention it as a peer dependency because all of our react packages use `@wordpress/element` as a dependency. But, our build output contains jsx import from `react/jsx-runtime` which causes build issues for the consumer build tools.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
- Remove react and react-dom from peer deps where not needed
- Expose `/jsx-runtime` and `/jsx-dev-runtime` sub-paths from the element package
- Update build scripts to use `jsx-runtime` from `@wordpress/element`

## Testing Instructions

- Run `npm run build`
- Verify that none of the built files contains a reference to `react/jsx-runtime`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
