### PR TITLE
contentOnly Patterns experiment: Add content only support again for template parts

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -526,8 +526,9 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const attributes = getBlockAttributes( state, clientId );
+	const isTemplatePart = blockName === 'core/template-part';
 	if (
-		attributes?.metadata?.patternName &&
+		( attributes?.metadata?.patternName || isTemplatePart ) &&
 		!! window?.__experimentalContentOnlyPatternInsertion
 	) {
 		return true;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2305,6 +2305,9 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
+		...( window?.__experimentalContentOnlyPatternInsertion
+			? templatePartClientIds
+			: [] ),
 	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4540,11 +4540,16 @@ describe( 'state', () => {
 					);
 				} );
 
-				it( 'returns the expected block editing modes for template parts', () => {
-					// Currently, template parts are not considered sections, so
-					// child blocks are not set to contentOnly.
+				it( 'returns the expected block editing modes for synced patterns', () => {
 					expect( initialState.derivedBlockEditingModes ).toEqual(
-						new Map()
+						new Map(
+							Object.entries( {
+								'template-part-paragraph': 'contentOnly',
+								'template-part-group': 'disabled',
+								'template-part-grouped-paragraph':
+									'contentOnly',
+							} )
+						)
 					);
 				} );
 
@@ -4568,7 +4573,7 @@ describe( 'state', () => {
 					expect( derivedBlockEditingModes ).toEqual( new Map() );
 				} );
 
-				it( 'does not set contentOnly mode for children of template parts', () => {
+				it( 'allows explicitly set blockEditingModes to override the template part editing modes', () => {
 					const { derivedBlockEditingModes } = dispatchActions(
 						[
 							{
@@ -4582,8 +4587,13 @@ describe( 'state', () => {
 					);
 
 					expect( derivedBlockEditingModes ).toEqual(
-						// template-part-grouped-paragraph already has an explicit mode, so isn't set as a derived mode.
-						new Map()
+						new Map(
+							Object.entries( {
+								'template-part-paragraph': 'contentOnly',
+								'template-part-group': 'disabled',
+								// template-part-grouped-paragraph already has an explicit mode, so isn't set as a derived mode.
+							} )
+						)
 					);
 				} );
 			} );

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -41,6 +41,16 @@ import {
 } from './utils/hooks';
 import { unlock } from '../../lock-unlock';
 
+function getTemplatePartEditButtonTitle( clientId, editedContentOnlySection ) {
+	if ( ! window?.__experimentalContentOnlyPatternInsertion ) {
+		return __( 'Edit' );
+	}
+
+	return editedContentOnlySection === clientId
+		? __( 'Exit section' )
+		: __( 'Edit section' );
+}
+
 function ReplaceButton( {
 	isEntityAvailable,
 	area,
@@ -272,10 +282,10 @@ export default function TemplatePartEdit( {
 									} );
 								} }
 							>
-								{ window?.__experimentalContentOnlyPatternInsertion &&
-								editedContentOnlySection === clientId
-									? __( 'Exit section' )
-									: __( 'Edit section' ) }
+								{ getTemplatePartEditButtonTitle(
+									clientId,
+									editedContentOnlySection
+								) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -274,8 +274,8 @@ export default function TemplatePartEdit( {
 							>
 								{ window?.__experimentalContentOnlyPatternInsertion &&
 								editedContentOnlySection === clientId
-									? __( 'Exit' )
-									: __( 'Edit' ) }
+									? __( 'Exit section' )
+									: __( 'Edit section' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -273,9 +273,9 @@ export default function TemplatePartEdit( {
 								} }
 							>
 								{ window?.__experimentalContentOnlyPatternInsertion &&
-								editedContentOnlySection !== clientId
-									? __( 'Edit' )
-									: __( 'Exit' ) }
+								editedContentOnlySection === clientId
+									? __( 'Exit' )
+									: __( 'Edit' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -39,6 +39,7 @@ import {
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
 } from './utils/hooks';
+import { unlock } from '../../lock-unlock';
 
 function ReplaceButton( {
 	isEntityAvailable,
@@ -108,8 +109,18 @@ export default function TemplatePartEdit( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { editEntityRecord } = useDispatch( coreStore );
-	const currentTheme = useSelect(
-		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+	const { editContentOnlySection, stopEditingContentOnlySection } = unlock(
+		useDispatch( blockEditorStore )
+	);
+	const { currentTheme, editedContentOnlySection } = useSelect(
+		( select ) => {
+			return {
+				currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
+				editedContentOnlySection: unlock(
+					select( blockEditorStore )
+				).getEditedContentOnlySection(),
+			};
+		},
 		[]
 	);
 	const { slug, theme = currentTheme, tagName, layout = {} } = attributes;
@@ -240,14 +251,31 @@ export default function TemplatePartEdit( {
 					canUserEdit && (
 						<BlockControls group="other">
 							<ToolbarButton
-								onClick={ () =>
+								onClick={ () => {
+									if (
+										window?.__experimentalContentOnlyPatternInsertion
+									) {
+										if (
+											editedContentOnlySection !==
+											clientId
+										) {
+											editContentOnlySection( clientId );
+										} else {
+											stopEditingContentOnlySection();
+										}
+										return;
+									}
+
 									onNavigateToEntityRecord( {
 										postId: templatePartId,
 										postType: 'wp_template_part',
-									} )
-								}
+									} );
+								} }
 							>
-								{ __( 'Edit' ) }
+								{ window?.__experimentalContentOnlyPatternInsertion &&
+								editedContentOnlySection !== clientId
+									? __( 'Edit' )
+									: __( 'Exit' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -83,10 +83,8 @@ export function useAlternativeBlockPatterns( area, clientId ) {
 			const blockNameWithArea = area
 				? `core/template-part/${ area }`
 				: 'core/template-part';
-			const { getBlockRootClientId, getPatternsByBlockTypes } =
-				select( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
-			return getPatternsByBlockTypes( blockNameWithArea, rootClientId );
+			const { getPatternsByBlockTypes } = select( blockEditorStore );
+			return getPatternsByBlockTypes( blockNameWithArea, clientId );
 		},
 		[ area, clientId ]
 	);


### PR DESCRIPTION
## What?
Revisits #73332 to see if we can incorprate template parts into the experiment again

## Why?
The idea is to achieve consistent behavior across any blocks considered 'sections'. I think it's worth trying this so at least we get some feedback about whether it's good / ok / terrible.

Also, by incorporating template parts, whatever improvements we make are required to work well for template parts too, so it means we're required to consider the breadth of the problem.

## How?
Changes the behavior of the template part 'Edit' toolbar button to also initiate the spotlight style inline editing.

With #73268 now merged, users can also double-click, which works I've found to be a very natural interaction once you discover it.

I don't think the button implementation is perfect though, as the button has to toggle between 'Edit' and 'Exit', and users will need to reselect the template part to get back to the 'Exit' button (or they can also click outside / press 'Escape'):

https://github.com/user-attachments/assets/d6f212be-e165-44c2-b16e-edc510dc83c0

Maybe this is something we can continue to iterate on as part of [#73126](https://github.com/WordPress/gutenberg/issues/73126). We might try some of the ideas around surfacing the interaction in the editor document bar.

I think we could also consider keeping the old 'Edit' action in the block settings menu. Perhaps 'Open in new editor' is a good way to phrase it? It'd be great to get thoughts on that.

## Testing Instructions
1. With the experiment active, open a template
2. Select a header template part
3. Click the edit button (or try double-clicking)
4. Observe that the button becomes 'Exit' and you can now make any changes to the header
5. Click exit (or click outside)
6. Observe that the template part is now content locked again

Also worth testing - check that template parts work as they do normally with the experiment inactive.