### PR TITLE
Build: Add post-processing step to ensure fully specified ESM relative import paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1757,6 +1757,15 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
@@ -55570,6 +55579,8 @@
 			"version": "0.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@babel/parser": "7.28.5",
+				"@babel/traverse": "7.28.5",
 				"@emotion/babel-plugin": "11.11.0",
 				"@types/toposort": "2.0.7",
 				"autoprefixer": "10.4.21",
@@ -55612,6 +55623,134 @@
 				"@wordpress/theme": {
 					"optional": true
 				}
+			}
+		},
+		"packages/wp-build/node_modules/@babel/code-frame": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/generator": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.28.5",
+				"@babel/types": "^7.28.5",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/parser": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.5"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/template": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/traverse": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.5",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@babel/types": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"packages/wp-build/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"packages/wp-build/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"routes/home": {},

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -35,6 +35,8 @@
 		"wp-build": "./src/build.mjs"
 	},
 	"dependencies": {
+		"@babel/parser": "7.28.5",
+		"@babel/traverse": "7.28.5",
 		"@emotion/babel-plugin": "11.11.0",
 		"@types/toposort": "2.0.7",
 		"autoprefixer": "10.4.21",

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -256,13 +256,13 @@ function momentTimezoneAliasPlugin() {
  */
 async function ensureFullySpecifiedImports( outputPath ) {
 	try {
-		const source = await readFile( outputPath, 'utf8' );
-		const outputDir = path.dirname( outputPath );
-
 		// Only process .js files
 		if ( ! outputPath.endsWith( '.js' ) ) {
 			return;
 		}
+
+		const source = await readFile( outputPath, 'utf8' );
+		const outputDir = path.dirname( outputPath );
 
 		// Regex to match import/export statements with relative paths that lack extensions
 		// Matched:

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -3,7 +3,14 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, copyFile, mkdir, unlink, stat } from 'fs/promises';
+import {
+	readFile,
+	writeFile,
+	copyFile,
+	mkdir,
+	unlink,
+	stat,
+} from 'fs/promises';
 import path from 'path';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -18,6 +18,8 @@ import cssnano from 'cssnano';
 import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
 import fs from 'node:fs';
+import * as babelParser from '@babel/parser';
+import traverse from '@babel/traverse';
 
 /**
  * Internal dependencies
@@ -249,6 +251,7 @@ function momentTimezoneAliasPlugin() {
 
 /**
  * Post-process ESM output files to ensure fully specified relative import paths.
+ * Uses Babel AST parser to deterministically identify and update import statements.
  * Adds .js extensions or /index.js for directory imports as required by ESM spec.
  *
  * @param {string} outputPath Path to the output file to process.
@@ -264,61 +267,97 @@ async function ensureFullySpecifiedImports( outputPath ) {
 		const source = await readFile( outputPath, 'utf8' );
 		const outputDir = path.dirname( outputPath );
 
-		// Regex to match import/export statements with relative paths that lack extensions
-		// Matched:
-		//   from './path'        (no extension)
-		//   from './path.js'     (with extension)
-		//   from "../dir"        (directory)
-		const importRegex = /\bfrom\s+(['"`])(\.\.?\/)([^'"`;]+)\1/g;
+		// Parse source code into an AST
+		let ast;
+		try {
+			ast = babelParser.parse( source, {
+				sourceType: 'module',
+				allowImportExportEverywhere: true,
+				plugins: [ 'jsx', 'typescript' ],
+			} );
+		} catch ( parseError ) {
+			// If parsing fails, silently skip (file might be non-ES modules or invalid)
+			return;
+		}
 
-		const updated = source.replace(
-			importRegex,
-			( match, quote, relativePath, modulePath ) => {
-				// Skip if already has a file extension
-				if ( /\.[a-z]+$/i.test( modulePath ) ) {
-					return match;
+		let modified = false;
+		const imports = [];
+
+		// Walk the AST to find all import/export declarations
+		traverse.default( ast, {
+			ImportDeclaration( nodePath ) {
+				const node = nodePath.node;
+				const sourceNode = node.source;
+
+				// Only process relative imports
+				if ( sourceNode.value && /^\.\.?\//.test( sourceNode.value ) ) {
+					// Get string content position (excludes quotes)
+					// sourceNode.start includes the quote, so add 1 to get the content start
+					const contentStart = sourceNode.start + 1;
+					const contentEnd = sourceNode.end - 1;
+					imports.push( {
+						original: sourceNode.value,
+						start: contentStart,
+						end: contentEnd,
+					} );
 				}
+			},
+		} );
 
-				// Resolve the full path
-				const fullPath = path.resolve(
-					outputDir,
-					relativePath,
-					modulePath
-				);
+		// Process imports in reverse order to maintain correct positions
+		let updated = source;
+		for ( let i = imports.length - 1; i >= 0; i-- ) {
+			const imp = imports[ i ];
 
-				// Check if it's a directory with index.js
-				try {
-					const stat = fs.statSync( fullPath );
-					if ( stat.isDirectory() ) {
-						const indexPath = path.join( fullPath, 'index.js' );
-						if ( fs.statSync( indexPath ).isFile() ) {
-							// Directory with index.js - add /index.js
-							return `from ${ quote }${ relativePath }${ modulePath }/index.js${ quote }`;
-						}
-					}
-				} catch ( error ) {
-					// Path doesn't exist as directory - expected, continue to next check
-					// (ENOENT errors are normal when path doesn't exist)
-				}
-
-				// Check if it's a .js file
-				try {
-					const stat = fs.statSync( `${ fullPath }.js` );
-					if ( stat.isFile() ) {
-						// File exists, add .js extension
-						return `from ${ quote }${ relativePath }${ modulePath }.js${ quote }`;
-					}
-				} catch ( error ) {
-					// File doesn't exist with .js extension - expected, will return original import
-					// (ENOENT errors are normal when file doesn't exist)
-				}
-
-				// Return original import if nothing matched
-				return match;
+			// Skip if already has file extension
+			if ( /\.[a-z]+$/i.test( imp.original ) ) {
+				continue;
 			}
-		);
 
-		if ( updated !== source ) {
+			// Resolve the full path
+			const fullPath = path.resolve( outputDir, imp.original );
+
+			let newPath = null;
+
+			// Check if it's a directory with index.js
+			try {
+				const stat = fs.statSync( fullPath );
+				if ( stat.isDirectory() ) {
+					const indexPath = path.join( fullPath, 'index.js' );
+					try {
+						fs.statSync( indexPath );
+						// Directory with index.js - add /index.js
+						newPath = `${ imp.original }/index.js`;
+					} catch {
+						// index.js doesn't exist, skip this import
+					}
+				}
+			} catch {
+				// Path doesn't exist as directory, try as .js file
+			}
+
+			// Check if it's a .js file (if not already set as directory)
+			if ( ! newPath ) {
+				try {
+					fs.statSync( `${ fullPath }.js` );
+					// File exists, add .js extension
+					newPath = `${ imp.original }.js`;
+				} catch {
+					// File doesn't exist with .js extension, skip this import
+				}
+			}
+
+			// Update source if we found a valid path
+			if ( newPath ) {
+				updated =
+					updated.slice( 0, imp.start ) +
+					newPath +
+					updated.slice( imp.end );
+				modified = true;
+			}
+		}
+
+		if ( modified ) {
 			await writeFile( outputPath, updated, 'utf8' );
 		}
 	} catch ( error ) {
@@ -667,7 +706,7 @@ async function bundlePackage( packageName, options = {} ) {
 			packageName
 		);
 		const jsFiles = await glob(
-			normalizePath( path.join( rootBuildModuleDir, '*.js' ) )
+			normalizePath( path.join( rootBuildModuleDir, '**/*.js' ) )
 		);
 		await Promise.all(
 			jsFiles.map( ( file ) => ensureFullySpecifiedImports( file ) )

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -283,24 +283,38 @@ async function ensureFullySpecifiedImports( outputPath ) {
 		let modified = false;
 		const imports = [];
 
-		// Walk the AST to find all import/export declarations
+		// Helper function to process source nodes from both import and export declarations
+		const processSourceNode = ( sourceNode ) => {
+			if ( ! sourceNode || ! sourceNode.value ) {
+				return;
+			}
+
+			// Only process relative imports
+			if ( /^\.\.?\//.test( sourceNode.value ) ) {
+				// Get string content position (excludes quotes)
+				// sourceNode.start includes the quote, so add 1 to get the content start
+				const contentStart = sourceNode.start + 1;
+				const contentEnd = sourceNode.end - 1;
+				imports.push( {
+					original: sourceNode.value,
+					start: contentStart,
+					end: contentEnd,
+				} );
+			}
+		};
+
+		// Walk the AST to find all import/export declarations with source paths
 		traverse.default( ast, {
 			ImportDeclaration( nodePath ) {
-				const node = nodePath.node;
-				const sourceNode = node.source;
-
-				// Only process relative imports
-				if ( sourceNode.value && /^\.\.?\//.test( sourceNode.value ) ) {
-					// Get string content position (excludes quotes)
-					// sourceNode.start includes the quote, so add 1 to get the content start
-					const contentStart = sourceNode.start + 1;
-					const contentEnd = sourceNode.end - 1;
-					imports.push( {
-						original: sourceNode.value,
-						start: contentStart,
-						end: contentEnd,
-					} );
-				}
+				processSourceNode( nodePath.node.source );
+			},
+			ExportNamedDeclaration( nodePath ) {
+				// export { foo } from './module' or export { foo as bar } from './module'
+				processSourceNode( nodePath.node.source );
+			},
+			ExportAllDeclaration( nodePath ) {
+				// export * from './module' or export * as ns from './module'
+				processSourceNode( nodePath.node.source );
 			},
 		} );
 

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -288,8 +288,11 @@ async function ensureFullySpecifiedImports( outputPath ) {
 				return;
 			}
 
-			// Only process relative imports
-			if ( /^\.\.?\//.test( sourceNode.value ) ) {
+			// Only process relative imports (including '.', '..', './path', '../path')
+			// The pattern matches:
+			//   . or .. - current/parent directory (less common but valid ESM)
+			//   ./ or ../ - explicit relative path prefix
+			if ( /^\.\.?(?:\/|$)/.test( sourceNode.value ) ) {
 				// Get string content position (excludes quotes)
 				// sourceNode.start includes the quote, so add 1 to get the content start
 				const contentStart = sourceNode.start + 1;
@@ -327,8 +330,10 @@ async function ensureFullySpecifiedImports( outputPath ) {
 				continue;
 			}
 
-			// Resolve the full path
-			const fullPath = path.resolve( outputDir, imp.original );
+			// Normalize edge cases: '.' and '..' should become './' and '../'
+			// This ensures they resolve correctly and can be treated uniformly
+			const normalizedPath = imp.original.replace( /^(\.)($|\/)/, '$1/' );
+			const fullPath = path.resolve( outputDir, normalizedPath );
 
 			let newPath = null;
 
@@ -340,7 +345,7 @@ async function ensureFullySpecifiedImports( outputPath ) {
 					try {
 						await stat( indexPath );
 						// Directory with index.js - add /index.js
-						newPath = `${ imp.original }/index.js`;
+						newPath = `${ normalizedPath }/index.js`;
 					} catch {
 						// index.js doesn't exist, skip this import
 					}
@@ -354,7 +359,7 @@ async function ensureFullySpecifiedImports( outputPath ) {
 				try {
 					await stat( `${ fullPath }.js` );
 					// File exists, add .js extension
-					newPath = `${ imp.original }.js`;
+					newPath = `${ normalizedPath }.js`;
 				} catch {
 					// File doesn't exist with .js extension, skip this import
 				}

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -17,6 +17,7 @@ import rtlcss from 'rtlcss';
 import cssnano from 'cssnano';
 import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
+import fs from 'node:fs';
 
 /**
  * Internal dependencies
@@ -244,6 +245,87 @@ function momentTimezoneAliasPlugin() {
 			} );
 		},
 	};
+}
+
+/**
+ * Post-process ESM output files to ensure fully specified relative import paths.
+ * Adds .js extensions or /index.js for directory imports as required by ESM spec.
+ *
+ * @param {string} outputPath Path to the output file to process.
+ * @return {Promise<void>}
+ */
+async function ensureFullySpecifiedImports( outputPath ) {
+	try {
+		const source = await readFile( outputPath, 'utf8' );
+		const outputDir = path.dirname( outputPath );
+
+		// Only process .js files
+		if ( ! outputPath.endsWith( '.js' ) ) {
+			return;
+		}
+
+		// Regex to match import/export statements with relative paths that lack extensions
+		// Matched:
+		//   from './path'        (no extension)
+		//   from './path.js'     (with extension)
+		//   from "../dir"        (directory)
+		const importRegex = /\bfrom\s+(['"`])(\.\.?\/)([^'"`;]+)\1/g;
+
+		const updated = source.replace(
+			importRegex,
+			( match, quote, relativePath, modulePath ) => {
+				// Skip if already has a file extension
+				if ( /\.[a-z]+$/i.test( modulePath ) ) {
+					return match;
+				}
+
+				// Resolve the full path
+				const fullPath = path.resolve(
+					outputDir,
+					relativePath,
+					modulePath
+				);
+
+				// Check if it's a directory with index.js
+				try {
+					const stat = fs.statSync( fullPath );
+					if ( stat.isDirectory() ) {
+						const indexPath = path.join( fullPath, 'index.js' );
+						if ( fs.statSync( indexPath ).isFile() ) {
+							// Directory with index.js - add /index.js
+							return `from ${ quote }${ relativePath }${ modulePath }/index.js${ quote }`;
+						}
+					}
+				} catch ( error ) {
+					// Path doesn't exist as directory - expected, continue to next check
+					// (ENOENT errors are normal when path doesn't exist)
+				}
+
+				// Check if it's a .js file
+				try {
+					const stat = fs.statSync( `${ fullPath }.js` );
+					if ( stat.isFile() ) {
+						// File exists, add .js extension
+						return `from ${ quote }${ relativePath }${ modulePath }.js${ quote }`;
+					}
+				} catch ( error ) {
+					// File doesn't exist with .js extension - expected, will return original import
+					// (ENOENT errors are normal when file doesn't exist)
+				}
+
+				// Return original import if nothing matched
+				return match;
+			}
+		);
+
+		if ( updated !== source ) {
+			await writeFile( outputPath, updated, 'utf8' );
+		}
+	} catch ( error ) {
+		console.warn(
+			`⚠️  Failed to process ESM imports in ${ outputPath }: ${ error.message }`
+		);
+	}
 }
 
 /**
@@ -576,6 +658,21 @@ async function bundlePackage( packageName, options = {} ) {
 	}
 
 	await Promise.all( builds );
+
+	// Post-process bundled ESM modules to ensure fully specified imports
+	if ( packageJson.wpScriptModuleExports ) {
+		const rootBuildModuleDir = path.join(
+			BUILD_DIR,
+			'modules',
+			packageName
+		);
+		const jsFiles = await glob(
+			normalizePath( path.join( rootBuildModuleDir, '*.js' ) )
+		);
+		await Promise.all(
+			jsFiles.map( ( file ) => ensureFullySpecifiedImports( file ) )
+		);
+	}
 
 	// Collect style metadata after builds complete (so asset files exist)
 	// Only register the main style.css file - complex cases handled manually in lib/client-assets.php
@@ -1089,6 +1186,16 @@ async function transpilePackage( packageName ) {
 
 	await Promise.all( builds );
 
+	// Post-process ESM build-module files to ensure fully specified imports
+	if ( packageJson.module ) {
+		const jsFiles = await glob(
+			normalizePath( path.join( buildModuleDir, '**/*.js' ) )
+		);
+		await Promise.all(
+			jsFiles.map( ( file ) => ensureFullySpecifiedImports( file ) )
+		);
+	}
+
 	await compileStyles( packageName );
 
 	return Date.now() - startTime;
@@ -1348,6 +1455,14 @@ async function buildRoute( routeName ) {
 
 		await unlink( tempEntryPath );
 	}
+
+	// Post-process route ESM files to ensure fully specified imports
+	const routeJsFiles = await glob(
+		normalizePath( path.join( outputDir, '*.js' ) )
+	);
+	await Promise.all(
+		routeJsFiles.map( ( file ) => ensureFullySpecifiedImports( file ) )
+	);
 
 	return Date.now() - startTime;
 }

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, copyFile, mkdir, unlink } from 'fs/promises';
+import { readFile, writeFile, copyFile, mkdir, unlink, stat } from 'fs/promises';
 import path from 'path';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
@@ -17,7 +17,6 @@ import rtlcss from 'rtlcss';
 import cssnano from 'cssnano';
 import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
-import fs from 'node:fs';
 import * as babelParser from '@babel/parser';
 import traverse from '@babel/traverse';
 
@@ -335,11 +334,11 @@ async function ensureFullySpecifiedImports( outputPath ) {
 
 			// Check if it's a directory with index.js
 			try {
-				const stat = fs.statSync( fullPath );
-				if ( stat.isDirectory() ) {
+				const stats = await stat( fullPath );
+				if ( stats.isDirectory() ) {
 					const indexPath = path.join( fullPath, 'index.js' );
 					try {
-						fs.statSync( indexPath );
+						await stat( indexPath );
 						// Directory with index.js - add /index.js
 						newPath = `${ imp.original }/index.js`;
 					} catch {
@@ -353,7 +352,7 @@ async function ensureFullySpecifiedImports( outputPath ) {
 			// Check if it's a .js file (if not already set as directory)
 			if ( ! newPath ) {
 				try {
-					fs.statSync( `${ fullPath }.js` );
+					await stat( `${ fullPath }.js` );
 					// File exists, add .js extension
 					newPath = `${ imp.original }.js`;
 				} catch {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #73362 by adding a post-processing step to the build script that ensures all relative imports in ESM output have explicit file extensions or `/index.js` paths. This allows Gutenberg packages to be consumed in ESM-compliant environments without requiring `resolve.fullySpecified` bundler configuration.

## Why?

ESM spec requires that relative imports be fully specified with file extensions:
- ✗ `import stuff from './subdir'`
- ✓ `import stuff from './subdir/index.js'`
- ✗ `import file from './a-file'`
- ✓ `import file from './a-file.js'`

While some bundlers are lenient, others, like Webpack, enforce this strictly when processing ESM code. Without this fix, packages built by Gutenberg can't be reliably consumed in strict ESM environments.

## How?

Added `ensureFullySpecifiedImports()` function that:
1. **Post-processes built .js files** after esbuild completes
2. **Identifies bare relative imports** using AST parser
3. **Validates and adds appropriate extensions**:
   - Directories with `index.js` → `./dir/index.js`
   - Files → `./file.js`


## Testing Instructions

- Run `npm run build`
- Check some build output files, e.g. `packages/components/build-module/autocomplete/autocompleter-ui.js`
- Verify that the relative imports (files and dirs) have extensions added

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Comparison

For example `packages/components/build-module/autocomplete/autocompleter-ui.js`

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

```ts
import { speak } from "@wordpress/a11y";
import { __, _n, sprintf } from "@wordpress/i18n";
import getDefaultUseItems from "./get-default-use-items";
import Button from "../button";
import Popover from "../popover";
import { VisuallyHidden } from "../visually-hidden";
import { createPortal } from "react-dom";
```

</td>
            <td>

```ts
import { speak } from "@wordpress/a11y";
import { __, _n, sprintf } from "@wordpress/i18n";
import getDefaultUseItems from "./get-default-use-items.js";
import Button from "../button/index.js";
import Popover from "../popover/index.js";
import { VisuallyHidden } from "../visually-hidden/index.js";
import { createPortal } from "react-dom";
```

</td>
        </tr>
    </tbody>
</table>