### PR TITLE
templateLock: contentOnly - support content block insertion

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -226,6 +226,8 @@ function Items( {
 				rootClientId === selectedBlockClientId
 			);
 
+			const templateLock = getTemplateLock( rootClientId );
+
 			return {
 				order: _order,
 				selectedBlocks: selectedBlockClientIds,
@@ -238,7 +240,7 @@ function Items( {
 							rootClientId
 						) ) &&
 					getBlockEditingMode( rootClientId ) !== 'disabled' &&
-					! getTemplateLock( rootClientId ) &&
+					( ! templateLock || templateLock === 'contentOnly' ) &&
 					hasAppender &&
 					! _isZoomOut() &&
 					( hasCustomAppender ||

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -518,10 +518,7 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const blockName = getBlockName( state, clientId );
-	if (
-		blockName === 'core/block' ||
-		getTemplateLock( state, clientId ) === 'contentOnly'
-	) {
+	if ( blockName === 'core/block' ) {
 		return true;
 	}
 
@@ -532,6 +529,19 @@ export function isSectionBlock( state, clientId ) {
 	) {
 		return true;
 	}
+
+	// TemplateLock cascades to all inner parent blocks. Only the top-level
+	// block that's contentOnly templateLocked is the true contentLocker,
+	// all the others are mere imitators.
+	const hasContentOnlyTempateLock =
+		getTemplateLock( state, clientId ) === 'contentOnly';
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const hasRootContentOnlyTemplateLock =
+		getTemplateLock( state, rootClientId ) === 'contentOnly';
+	if ( hasContentOnlyTempateLock && ! hasRootContentOnlyTemplateLock ) {
+		return true;
+	}
+
 	return false;
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1693,7 +1693,8 @@ const canInsertBlockTypeUnmemoized = (
 		blockType = getBlockType( blockName );
 	}
 
-	if ( getTemplateLock( state, rootClientId ) ) {
+	const rootTemplateLock = getTemplateLock( state, rootClientId );
+	if ( rootTemplateLock && rootTemplateLock !== 'contentOnly' ) {
 		return false;
 	}
 
@@ -1876,7 +1877,8 @@ export function canRemoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	if ( getTemplateLock( state, rootClientId ) ) {
+	const rootTemplateLock = getTemplateLock( state, rootClientId );
+	if ( rootTemplateLock && rootTemplateLock !== 'contentOnly' ) {
 		return false;
 	}
 
@@ -1937,8 +1939,8 @@ export function canMoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	const templateLock = getTemplateLock( state, rootClientId );
-	if ( templateLock === 'all' || templateLock === 'contentOnly' ) {
+	const rootTemplateLock = getTemplateLock( state, rootClientId );
+	if ( rootTemplateLock === 'all' ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds support for the content insertion behavior introduced in #71232 for `templateLock: contentOnly` blocks.

## Why?
Brings some parity, also this is good to merge early in the 7.0 cycle to gather feedback from plugin users.

## How?
- Adjusts the `canInsertBlockType`, `canMoveBlockType` and `canRemoveBlockType` selectors. These selectors all had clauses that would early return `false` when any type of templateLock is in place. That condition is loosened to allow `contentOnly` templateLock to fall through to the condition added in #71232
- Adjusts the `isSectionBlock` selector. This one is probably a bug that hadn't been spotted yet. `templateLock` cascades down the hierarchy and is applied to all parent blocks. Because of this we don't want every templateLocked block to be considered a section, only top-level templateLocked block in the hierarchy. The reason this is needed is that without it, List Items and Nav Links were being considered 'sections' when in a templateLocked hierarchy, and that prevented a lot of the toolbar from being available.
- Adjusts appender logic to allow visibility of the appender when something is contentOnly templateLocked

## Testing Instructions
1. Here's some markup for a templateLocked group that you can insert:
```html
<!-- wp:group {"templateLock":"contentOnly","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"accent-1","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull has-accent-1-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:navigation {"ref":4} /-->

<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>test<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>test</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>test</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"service":"amazon"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group -->
```
2. Check that you can add/remove nav links, list items and buttons.

## Screenshots or screencast
<img width="869" height="359" alt="Screenshot 2025-11-19 at 3 58 23 pm" src="https://github.com/user-attachments/assets/76de7d37-1f2a-4898-9074-b0bc1b2514b6" />

