### PR TITLE
Try: 32px tall menu items.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Menu` and othr menu items: change default size to be 32px tall rather than 40px to improve menu density. ([#73429](https://github.com/WordPress/gutenberg/pull/73429)).
+
 ### Bug Fixes
 
 -   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -29,7 +29,7 @@
 	height: $button-size;
 	align-items: center;
 	box-sizing: border-box;
-	padding: 6px 12px;
+	padding: 4px 12px; // Allows 32px min-height.
 	border-radius: $radius-small;
 	color: $components-color-foreground;
 

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -164,7 +164,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 						{ controlSets?.flatMap( ( controlSet, indexOfSet ) =>
 							controlSet.map( ( control, indexOfControl ) => (
 								<Button
-									__next40pxDefaultSize
+									size="compact"
 									key={ [
 										indexOfSet,
 										indexOfControl,

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -57,7 +57,7 @@
 
 	.components-menu-item__button,
 	.components-menu-item__button.components-button {
-		min-height: $button-size-next-default-40px;
+		min-height: $grid-unit-40;
 		height: auto;
 		text-align: left;
 		padding-left: $grid-unit-10;

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -56,7 +56,7 @@ function UnforwardedMenuItem(
 
 	return (
 		<Button
-			__next40pxDefaultSize
+			size="compact"
 			ref={ ref }
 			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
 			aria-checked={

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`MenuItem should match snapshot when all props provided 1`] = `
 <button
   aria-checked="true"
-  class="components-button components-menu-item__button my-class is-next-40px-default-size"
+  class="components-button components-menu-item__button my-class is-compact"
   role="menuitemcheckbox"
   type="button"
 >
@@ -35,7 +35,7 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
 
 exports[`MenuItem should match snapshot when info is provided 1`] = `
 <button
-  class="components-button components-menu-item__button is-next-40px-default-size"
+  class="components-button components-menu-item__button is-compact"
   role="menuitem"
   type="button"
 >
@@ -62,7 +62,7 @@ exports[`MenuItem should match snapshot when info is provided 1`] = `
 
 exports[`MenuItem should match snapshot when isSelected and role are optionally provided 1`] = `
 <button
-  class="components-button components-menu-item__button my-class is-next-40px-default-size"
+  class="components-button components-menu-item__button my-class is-compact"
   role="menuitem"
   type="button"
 >
@@ -94,7 +94,7 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
 
 exports[`MenuItem should match snapshot when only label provided 1`] = `
 <button
-  class="components-button components-menu-item__button is-next-40px-default-size"
+  class="components-button components-menu-item__button is-compact"
   role="menuitem"
   type="button"
 >

--- a/packages/components/src/menu/styles.ts
+++ b/packages/components/src/menu/styles.ts
@@ -25,7 +25,7 @@ const ANIMATION_PARAMS = {
 };
 
 const CONTENT_WRAPPER_PADDING = space( 1 );
-const ITEM_PADDING_BLOCK = space( 2 );
+const ITEM_PADDING_BLOCK = space( 1 );
 const ITEM_PADDING_INLINE = space( 3 );
 
 // TODO:
@@ -152,7 +152,7 @@ const baseItem = css`
 	all: unset;
 
 	position: relative;
-	min-height: ${ space( 10 ) };
+	min-height: ${ space( 8 ) };
 	box-sizing: border-box;
 
 	/* Occupy the width of all grid columns (ie. full width) */


### PR DESCRIPTION
## What?

Menus are getting slightly long as we are adding features:

<img width="309" height="757" alt="Screenshot 2025-11-19 at 12 09 47" src="https://github.com/user-attachments/assets/4fb3e4cf-ec8b-4bc9-a677-0196e88072ac" />

Aside careful curation of items, as well as future grouping in flyouts, part of the reason they go long (and therefore occasionally have to scroll, or open upwards instead of downwards), is that all menu items are the default 40px size.

This PR proposes changing all menu items to be 32px by default.

## Why?

It makes menu items far more compact, yet still comfortable in density.

## Screenshots:

<img width="361" height="685" alt="Screenshot 2025-11-19 at 11 46 40" src="https://github.com/user-attachments/assets/17b6d1f7-0ca5-454d-bf05-f68d8a863b9f" />

<img width="564" height="305" alt="Screenshot 2025-11-19 at 11 46 58" src="https://github.com/user-attachments/assets/825e89e3-759d-4d69-8038-f73692fcfa42" />

<img width="387" height="780" alt="Screenshot 2025-11-19 at 11 47 10" src="https://github.com/user-attachments/assets/75567bfb-3cfe-4b62-8712-0efae3581ea0" />

<img width="288" height="472" alt="Screenshot 2025-11-19 at 11 52 25" src="https://github.com/user-attachments/assets/f38200e2-58b2-434f-a701-1c8e90367352" />

<img width="496" height="760" alt="Screenshot 2025-11-19 at 12 03 57" src="https://github.com/user-attachments/assets/c1030089-6e6a-4b97-ab26-e0c135be215a" />


## Testing Instructions

Check out the branch, then test:

* block toolbar kebab menu
* transform menu
* inline text "more" menu
* top toolbar kebab menu
* color flyouts