### PR TITLE
Fix divider appearance between Edit and Edit navigation buttons in top toolbar mode

### DIFF
--- a/packages/editor/src/hooks/template-part-navigation-edit-button/index.js
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button/index.js
@@ -9,11 +9,7 @@ import {
 	BlockControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	ToolbarButton,
-	ToolbarGroup,
-	__experimentalDivider as Divider,
-} from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -97,14 +93,7 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 
 	return (
 		<BlockControls group="other">
-			<ToolbarGroup>
-				{ /*
-				 * Add a vertical divider to visually separate the "Edit navigation"
-				 * button from the template part's "Edit" button. Both buttons share
-				 * the same toolbar group ("other"), so without this divider they
-				 * would appear directly adjacent with no visual separation.
-				 */ }
-				<Divider orientation="vertical" marginEnd={ 3 } />
+			<ToolbarGroup className="wp-block-template-part__navigation-edit-button">
 				<ToolbarButton
 					label={ __( 'Edit navigation' ) }
 					onClick={ onEditNavigation }

--- a/packages/editor/src/hooks/template-part-navigation-edit-button/style.scss
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button/style.scss
@@ -1,0 +1,37 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.wp-block-template-part__navigation-edit-button.components-toolbar-group {
+	// Add a vertical divider before the button to visually separate it
+	// from the template part's "Edit" button.
+	&::before {
+		border: 0;
+		margin: 0;
+		display: inline;
+		border-right: 1px solid currentColor;
+		height: auto;
+		width: 0;
+		margin-right: calc(4px * 3);
+		content: "";
+	}
+
+	// In top toolbar mode, match the divider styling used in the collapsible block toolbar.
+	.editor-collapsible-block-toolbar & {
+		position: relative;
+		margin-left: 6px;
+		padding-right: 0;
+
+		&::before {
+			width: $border-width;
+			height: $grid-unit-30;
+			background-color: $gray-300;
+			border-right: 0;
+			top: $grid-unit-05;
+			position: absolute;
+			left: -$border-width;
+			right: auto;
+			// margin-right: 0;
+		}
+	}
+}
+

--- a/packages/editor/src/hooks/template-part-navigation-edit-button/style.scss
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button/style.scss
@@ -5,32 +5,27 @@
 	// Add a vertical divider before the button to visually separate it
 	// from the template part's "Edit" button.
 	&::before {
-		border: 0;
-		margin: 0;
 		display: inline;
-		border-right: 1px solid currentColor;
-		height: auto;
 		width: 0;
-		margin-right: calc(4px * 3);
+		height: auto;
+		border-right: 1px solid currentColor;
+		margin-right: $grid-unit-15;
 		content: "";
 	}
 
 	// In top toolbar mode, match the divider styling used in the collapsible block toolbar.
 	.editor-collapsible-block-toolbar & {
 		position: relative;
-		margin-left: 6px;
+		margin-left: 0.75 * $grid-unit;
 		padding-right: 0;
 
 		&::before {
-			width: $border-width;
 			height: $grid-unit-30;
-			background-color: $gray-300;
-			border-right: 0;
+			border-right: $border-width solid $gray-300;
 			top: $grid-unit-05;
 			position: absolute;
 			left: -$border-width;
 			right: auto;
-			// margin-right: 0;
 		}
 	}
 }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -61,3 +61,4 @@
 @use "./components/visual-editor/style.scss" as *;
 @use "./dataviews/fields/content-preview/style.scss" as *;
 @use "./hooks/push-changes-to-global-styles/style.scss" as *;
+@use "./hooks/template-part-navigation-edit-button/style.scss" as *;


### PR DESCRIPTION
## What

Fixes #73401 - Fixes the divider appearance between "Edit" and "Edit navigation" buttons in top toolbar mode. The divider was appearing with incorrect height and color, making it look janky.

## Why

When using the top toolbar mode and selecting a template part, the divider line between the "Edit" and "Edit navigation" buttons was not properly styled. It appeared too tall and with the wrong color compared to other dividers in the top toolbar.

## How

- Refactored the template-part-navigation-edit-button hook to use a directory structure (similar to push-changes-to-global-styles) to enable custom CSS styling
- Replaced the Divider component with a CSS-based divider using ::before pseudo-element
- Added conditional styling for top toolbar mode that matches the divider styling used in the collapsible block toolbar
- Standardized on border-based divider approach and replaced hardcoded values with Sass variables

## Screenshots

### Top Toolbar
<img width="822" height="165" alt="Screenshot 2025-11-19 at 11 42 01" src="https://github.com/user-attachments/assets/f0e6fd7c-7d6c-4ea7-8cc1-83cfc2a5b07e" />

### Standard Toolbar
<img width="536" height="285" alt="Screenshot 2025-11-19 at 11 41 51" src="https://github.com/user-attachments/assets/62fbddd1-ee66-42fd-9525-78a9bf7f3b98" />

