### PR TITLE
Breadcrumbs: Add post type archive link if it's not the same as home url

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -100,9 +100,18 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			$show_terms = $attributes['prefersTaxonomy'];
 		}
 
-		// Build breadcrumb trail.
+		// Add post type archive link if applicable.
+		$post_type_object = get_post_type_object( $post_type );
+		$archive_link     = get_post_type_archive_link( $post_type );
+		if ( $archive_link && ( ( $attributes['showHomeLink'] && home_url() !== $archive_link ) || ! $attributes['showHomeLink'] ) ) {
+			$breadcrumb_items[] = array(
+				'label' => $post_type_object->labels->archives,
+				'url'   => $archive_link,
+			);
+		}
+		// Build breadcrumb trail based on hierarchical structure or taxonomy terms.
 		if ( ! $show_terms ) {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) );
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
 		} else {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
 		}
@@ -235,49 +244,18 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
 }
 
 /**
- * Generates post type archive breadcrumb item.
- *
- * Returns the post type archive link item if the post type has archive enabled,
- * otherwise returns null.
- *
- * @since 7.0.0
- *
- * @param string $post_type The post type name.
- *
- * @return array|null The archive breadcrumb item data, or null if not available.
- */
-function block_core_breadcrumbs_get_post_type_archive_item( $post_type ) {
-	$post_type_object = get_post_type_object( $post_type );
-	$archive_link     = get_post_type_archive_link( $post_type );
-	if ( ! $archive_link ) {
-		return null;
-	}
-	return array(
-		'label' => $post_type_object->labels->archives,
-		'url'   => $archive_link,
-	);
-}
-
-/**
  * Generates breadcrumb items from hierarchical post type ancestors.
  *
  * @since 7.0.0
  *
  * @param int    $post_id   The post ID.
- * @param string $post_type The post type name.
  *
  * @return array Array of breadcrumb item data.
  */
-function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
+function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) {
 	$breadcrumb_items = array();
-
-	$archive_item = block_core_breadcrumbs_get_post_type_archive_item( $post_type );
-	if ( $archive_item ) {
-		$breadcrumb_items[] = $archive_item;
-	}
-
-	$ancestors = get_post_ancestors( $post_id );
-	$ancestors = array_reverse( $ancestors );
+	$ancestors        = get_post_ancestors( $post_id );
+	$ancestors        = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
 		$breadcrumb_items[] = array(
@@ -469,11 +447,6 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
  */
 function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
-
-	$archive_item = block_core_breadcrumbs_get_post_type_archive_item( $post_type );
-	if ( $archive_item ) {
-		$breadcrumb_items[] = $archive_item;
-	}
 
 	// Get public taxonomies for this post type.
 	$taxonomies = wp_filter_object_list(

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -104,8 +104,15 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		$post_type_object = get_post_type_object( $post_type );
 		$archive_link     = get_post_type_archive_link( $post_type );
 		if ( $archive_link && untrailingslashit( home_url() ) !== untrailingslashit( $archive_link ) ) {
+			$label = $post_type_object->labels->archives;
+			if ( 'post' === $post_type ) {
+				$page_for_posts = get_option( 'page_for_posts' );
+				if ( $page_for_posts ) {
+					$label = block_core_breadcrumbs_get_post_title( $page_for_posts );
+				}
+			}
 			$breadcrumb_items[] = array(
-				'label' => $post_type_object->labels->archives,
+				'label' => $label,
 				'url'   => $archive_link,
 			);
 		}

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -103,7 +103,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		// Add post type archive link if applicable.
 		$post_type_object = get_post_type_object( $post_type );
 		$archive_link     = get_post_type_archive_link( $post_type );
-		if ( $archive_link && ( ( $attributes['showHomeLink'] && home_url() !== $archive_link ) || ! $attributes['showHomeLink'] ) ) {
+		if ( $archive_link && untrailingslashit( home_url() ) !== untrailingslashit( $archive_link ) ) {
 			$breadcrumb_items[] = array(
 				'label' => $post_type_object->labels->archives,
 				'url'   => $archive_link,


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/72832
Resolves: https://github.com/WordPress/gutenberg/issues/73442

This PR checks whether the post type archive link is the same with the `home url`, and in that case it doesn't add the extra breadcrumb item.

This happens because internally we use [get_post_type_archive_link](https://developer.wordpress.org/reference/functions/get_post_type_archive_link/) that has extra logic for post and page and that results in displaying the archive link even for `post` post type.

Additionally it resolves https://github.com/WordPress/gutenberg/issues/73442. If we've set a specific page for `posts page`, the breadcrumb label is the page title. This is the case only for `post` post type and not CPTs.
###  Testing Instructions for https://github.com/WordPress/gutenberg/issues/73442 - see at that issue




## Testing Instructions for not showing the post type archive link if it's same with home url
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various cases in the front end.
3. `Your latest posts` in reading settings should be selected
4. With `show home link` block attribute (inspector controls) **enabled**, front end of any post **should not** render the post type archive link
5.  With `show home link` block attribute disabled, front end of any post **should** render the post type archive link



## Screenshots or screencast <!-- if applicable -->

Below I'm sharing some screenshots in a site that I've added x3p0-breadcrumbs plugin and the core block in the main header.
Above is x3p0-breadcrumbs and below is the core block.


#### Posts with `show home link` enabled
|Before|After|
|-|-|
|<img width="608" height="112" alt="Screenshot 2025-11-19 at 5 15 23 PM" src="https://github.com/user-attachments/assets/3d83e399-aa3c-447f-bbe6-f8693ef001c1" />|<img width="608" height="112" alt="Screenshot 2025-11-19 at 5 10 06 PM" src="https://github.com/user-attachments/assets/3ffe2b0f-f2d6-4d4c-b86e-0454a90cf535" />|


#### CPT with archive and different URL is the same as before
<img width="608" height="112" alt="Screenshot 2025-11-19 at 5 09 58 PM" src="https://github.com/user-attachments/assets/d19a6e31-2dcb-4af8-a770-1468329fa690" />



#### Posts with `show home link` disabled


<img width="608" height="112" alt="Screenshot 2025-11-19 at 5 25 16 PM" src="https://github.com/user-attachments/assets/3ab6957b-8a72-40e4-8a91-632970fc1c4c" />




