### PR TITLE
Move the Edit Navigation button to the last item in the block toolbar

### DIFF
--- a/packages/editor/src/hooks/template-part-navigation-edit-button.js
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button.js
@@ -6,14 +6,10 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
-	BlockControls,
+	__unstableBlockToolbarLastItem as BlockToolbarLastItem,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	ToolbarButton,
-	ToolbarGroup,
-	__experimentalDivider as Divider,
-} from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -96,15 +92,8 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 	}
 
 	return (
-		<BlockControls group="other">
+		<BlockToolbarLastItem>
 			<ToolbarGroup>
-				{ /*
-				 * Add a vertical divider to visually separate the "Edit navigation"
-				 * button from the template part's "Edit" button. Both buttons share
-				 * the same toolbar group ("other"), so without this divider they
-				 * would appear directly adjacent with no visual separation.
-				 */ }
-				<Divider orientation="vertical" marginEnd={ 3 } />
 				<ToolbarButton
 					label={ __( 'Edit navigation' ) }
 					onClick={ onEditNavigation }
@@ -112,7 +101,7 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 					{ __( 'Edit navigation' ) }
 				</ToolbarButton>
 			</ToolbarGroup>
-		</BlockControls>
+		</BlockToolbarLastItem>
 	);
 }
 


### PR DESCRIPTION
## What

Fixes #73401 
Move the Edit Navigation button to the last item in the block toolbar to ensure that the styling is consistent and simple

## Why
This uses previously established patterns to ensure that the design is consistent.

## How
- Use the `BlockToolbarLastItem` component.

## Screenshots

### Top Toolbar
<img width="822" height="165" alt="Screenshot 2025-11-19 at 11 42 01" src="https://github.com/user-attachments/assets/f0e6fd7c-7d6c-4ea7-8cc1-83cfc2a5b07e" />

### Standard Toolbar
<img width="536" height="285" alt="Screenshot 2025-11-19 at 11 41 51" src="https://github.com/user-attachments/assets/62fbddd1-ee66-42fd-9525-78a9bf7f3b98" />

