### PR TITLE
Run wp/6.9 e2e tests on top of WP trunk

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./schemas/json/wp-env.json",
-	"core": "WordPress/WordPress#6.8.3",
-	"plugins": [ "." ],
+	"core": "WordPress/WordPress",
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"development": {
@@ -9,7 +9,6 @@
 		},
 		"tests": {
 			"mappings": {
-				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",

--- a/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
@@ -8,14 +8,18 @@ import type { RequestUtils } from './index';
  *
  * @param this
  * @param experiments Array of experimental flags to enable. Pass in an empty array to disable all experiments.
+ * @return Returns true if experiments were set successfully, false if Gutenberg plugin is not active.
  */
 async function setGutenbergExperiments(
 	this: RequestUtils,
 	experiments: string[]
-) {
+): Promise< boolean > {
 	const response = await this.request.get(
 		'/wp-admin/admin.php?page=gutenberg-experiments'
 	);
+	if ( response.status() !== 200 ) {
+		return false;
+	}
 	const html = await response.text();
 	const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
 
@@ -35,6 +39,8 @@ async function setGutenbergExperiments(
 		},
 		failOnStatusCode: true,
 	} );
+
+	return true;
 }
 
 export { setGutenbergExperiments };

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -133,6 +133,7 @@ const test = base.extend<
 	{
 		requestUtils: RequestUtils;
 		lighthousePort: number;
+		isGutenbergPluginActive: boolean;
 	}
 >( {
 	admin: async ( { page, pageUtils, editor }, use ) => {
@@ -197,6 +198,19 @@ const test = base.extend<
 	metrics: async ( { page }, use ) => {
 		await use( new Metrics( { page } ) );
 	},
+	isGutenbergPluginActive: [
+		async ( { requestUtils }, use ) => {
+			const plugins = await requestUtils.rest( {
+				path: '/wp/v2/plugins',
+			} );
+			const gutenberg = plugins.find(
+				( p: { plugin: string; status: string } ) =>
+					p.plugin === 'gutenberg/gutenberg'
+			);
+			await use( gutenberg?.status === 'active' );
+		},
+		{ scope: 'worker' },
+	],
 } );
 
 export { test, expect };

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,7 +8,20 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
+		requestUtils,
 	} ) => {
+		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
+		const gutenberg = plugins.find(
+			( p ) => p.plugin === 'gutenberg/gutenberg'
+		);
+		const isGutenbergPluginActive = gutenberg?.status === 'active';
+
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test requires Gutenberg plugin to be active'
+		);
+
 		await admin.visitAdminPage( 'post-new.php', 'gutenberg-demo' );
 		await editor.setPreferences( 'core/edit-site', {
 			welcomeGuide: false,

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,14 +8,8 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
-		requestUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
-		const gutenberg = plugins.find(
-			( p ) => p.plugin === 'gutenberg/gutenberg'
-		);
-		const isGutenbergPluginActive = gutenberg?.status === 'active';
-
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
 			! isGutenbergPluginActive,

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -106,7 +106,13 @@ test.describe( 'Server-side rendered block', () => {
 } );
 
 test.describe( 'PHP-only auto-register blocks', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test suite requires Gutenberg plugin to be active'
+		);
+
 		await requestUtils.activatePlugin(
 			'gutenberg-test-server-side-rendered-block'
 		);

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -549,6 +549,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 	test( 'should allow speaking number of initial results', async ( {
 		page,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
@@ -571,7 +572,10 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		// Get the assertive live region screen reader announcement.
 		await expect(
 			page.getByText(
-				'3 results found, use up and down arrow keys to navigate.'
+				`${
+					// Minus the Table of Contents block.
+					isGutenbergPluginActive ? '3' : '2'
+				} results found, use up and down arrow keys to navigate.`
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -99,15 +99,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		// await this.requestUtils.activatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.activatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		// await this.requestUtils.deactivatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.deactivatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 }

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -99,15 +99,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		await this.requestUtils.activatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.activatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		await this.requestUtils.deactivatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.deactivatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 }

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -40,10 +40,5 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Heading', exact: true } )
 		).toBeVisible();
-		await expect(
-			page.getByRole( 'button', {
-				name: 'Table of Contents',
-			} )
-		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -20,7 +20,10 @@ test.describe( 'Global styles sidebar', () => {
 		} );
 	} );
 
-	test( 'should filter blocks list results', async ( { page } ) => {
+	test( 'should filter blocks list results', async ( {
+		page,
+		isGutenbergPluginActive,
+	} ) => {
 		// Navigate to Styles -> Blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -40,5 +43,12 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Heading', exact: true } )
 		).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Table of Contents',
+				} )
+			).toBeVisible();
+		}
 	} );
 } );

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -291,9 +291,15 @@ test.describe( 'Page List', () => {
 		};
 
 		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.setGutenbergExperiments( [
-				'gutenberg-quick-edit-dataviews',
-			] );
+			const experimentsAvailable =
+				await requestUtils.setGutenbergExperiments( [
+					'gutenberg-quick-edit-dataviews',
+				] );
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! experimentsAvailable,
+				'Gutenberg experiments not available (plugin may not be active)'
+			);
 		} );
 
 		test.beforeEach( async ( { admin, page } ) => {


### PR DESCRIPTION
Not for merge. Disables Gutenberg to check e2e test results on WP trunk only.