### PR TITLE
Disable Term Query blocks in Widgets Editor

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -56,7 +56,8 @@ export function initialize( editorName, blockEditorSettings ) {
 			block.name.startsWith( 'core/post' ) ||
 			block.name.startsWith( 'core/query' ) ||
 			block.name.startsWith( 'core/site' ) ||
-			block.name.startsWith( 'core/navigation' )
+			block.name.startsWith( 'core/navigation' ) ||
+			block.name.startsWith( 'core/term' )
 		);
 	} );
 	registerCoreBlocks( coreBlocks );

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -58,7 +58,8 @@ export function initializeEditor( id, settings ) {
 			block.name.startsWith( 'core/post' ) ||
 			block.name.startsWith( 'core/query' ) ||
 			block.name.startsWith( 'core/site' ) ||
-			block.name.startsWith( 'core/navigation' )
+			block.name.startsWith( 'core/navigation' ) ||
+			block.name.startsWith( 'core/term' )
 		);
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73448

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The widget editor will throw an error because there is no context such as `termId`.
As with other FSE blocks, the widget editor will exclude registration of term-related blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Exclude Term-related blocks from the widget editor.

This issue may be related to this issue.
- #32952
- #32761

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Activate a classic theme (e.g., Twenty Twenty-One).
2. Navigate to the widget editor.
3. You can confirm that the Term Query block does not appear in the inserter.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="3200" height="1800" alt="before-term-widgets" src="https://github.com/user-attachments/assets/a5f2b3aa-e25a-4174-8438-285d0a74a3fb" /> | <img width="3200" height="1800" alt="after-term-widgets" src="https://github.com/user-attachments/assets/878b3738-c61c-445e-8730-c992dd35182b" /> |
