### PR TITLE
Real-time collaboration: Do not call saveRecord when persistence is not supported

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -178,9 +178,11 @@ export function createSyncManager(): SyncManager {
 				syncConfig.applyChangesToCRDTDoc( ydoc, record );
 			}, LOCAL_SYNC_MANAGER_ORIGIN );
 
-			const meta = createEntityMeta( objectType, objectId );
-			handlers.editRecord( { meta } );
-			handlers.saveRecord();
+			// If the entity support CRDT persistence, trigger a save. The entity
+			// will call `createEntityMeta` via its pre-persist hook.
+			if ( syncConfig.supports?.crdtPersistence ) {
+				handlers.saveRecord();
+			}
 		}
 	}
 
@@ -423,7 +425,7 @@ export function createSyncManager(): SyncManager {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
 
-		if ( ! entityState?.syncConfig.supports?.crdtPersistence ) {
+		if ( ! entityState ) {
 			return {};
 		}
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -22,7 +22,6 @@ import {
 	CRDT_RECORD_METADATA_MAP_KEY as RECORD_METADATA_MAP_KEY,
 	CRDT_RECORD_METADATA_SAVED_AT_KEY as SAVED_AT_KEY,
 	CRDT_RECORD_METADATA_SAVED_BY_KEY as SAVED_BY_KEY,
-	WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from '../config';
 import { createPersistedCRDTDoc } from '../persistence';
 import { getProviderCreators } from '../providers';
@@ -304,13 +303,6 @@ describe( 'SyncManager', () => {
 				).not.toHaveBeenCalled();
 
 				// Verify a save operation occurred.
-				expect( mockHandlers.editRecord ).toHaveBeenCalledTimes( 1 );
-				expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
-					meta: {
-						[ WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]:
-							expect.any( String ),
-					},
-				} );
 				expect( mockHandlers.saveRecord ).toHaveBeenCalledTimes( 1 );
 			} );
 
@@ -397,13 +389,6 @@ describe( 'SyncManager', () => {
 				).toHaveBeenCalledWith( expect.any( Y.Doc ), record );
 
 				// Verify a save operation occurred.
-				expect( mockHandlers.editRecord ).toHaveBeenCalledTimes( 1 );
-				expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
-					meta: {
-						[ WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]:
-							expect.any( String ),
-					},
-				} );
 				expect( mockHandlers.saveRecord ).toHaveBeenCalledTimes( 1 );
 			} );
 
@@ -445,12 +430,9 @@ describe( 'SyncManager', () => {
 					mockSyncConfig.getChangesFromCRDTDoc
 				).not.toHaveBeenCalled();
 
-				// Verify a save operation occurred.
-				expect( mockHandlers.editRecord ).toHaveBeenCalledTimes( 1 );
-				expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
-					meta: {},
-				} );
-				expect( mockHandlers.saveRecord ).toHaveBeenCalledTimes( 1 );
+				// Verify that meta was not added and no save operation occurred.
+				expect( mockHandlers.editRecord ).not.toHaveBeenCalled();
+				expect( mockHandlers.saveRecord ).not.toHaveBeenCalled();
 			} );
 		} );
 	} );

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -47,6 +47,9 @@ describe( 'SyncManager', () => {
 	let mockRecord: ObjectData;
 	let mockSyncConfig: jest.MockedObject< SyncConfig >;
 
+	// Capture the Y.Doc from provider creator
+	let capturedDoc: Y.Doc | null = null;
+
 	beforeEach( () => {
 		// Reset all mocks
 		jest.clearAllMocks();
@@ -59,8 +62,15 @@ describe( 'SyncManager', () => {
 		mockProviderResult = {
 			destroy: jest.fn(),
 		};
-		mockProviderCreator = jest.fn( () =>
-			Promise.resolve( mockProviderResult )
+		mockProviderCreator = jest.fn(
+			async (
+				_objectType: string,
+				_objectId: string | null,
+				ydoc: Y.Doc
+			) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			}
 		);
 		mockGetProviderCreators.mockReturnValue( [ mockProviderCreator ] );
 
@@ -90,6 +100,7 @@ describe( 'SyncManager', () => {
 			getEditedRecord: jest.fn( async () =>
 				Promise.resolve( mockRecord )
 			),
+			refetchRecord: jest.fn( async () => Promise.resolve() ),
 			saveRecord: jest.fn( async () => Promise.resolve() ),
 		};
 	} );
@@ -525,19 +536,6 @@ describe( 'SyncManager', () => {
 
 	describe( 'update', () => {
 		it( 'updates CRDT document with local changes', async () => {
-			// Capture the Y.Doc from provider creator
-			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
-
 			const manager = createSyncManager();
 
 			await manager.load(
@@ -578,19 +576,6 @@ describe( 'SyncManager', () => {
 		} );
 
 		it( 'applies changes with specified origin', async () => {
-			// Capture the Y.Doc from provider creator
-			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
-
 			const manager = createSyncManager();
 
 			await manager.load(
@@ -622,19 +607,6 @@ describe( 'SyncManager', () => {
 		} );
 
 		it( 'updates the record metadata when the update is associated with a save', async () => {
-			// Capture the Y.Doc from provider creator.
-			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
-
 			const manager = createSyncManager();
 
 			await manager.load(
@@ -670,19 +642,6 @@ describe( 'SyncManager', () => {
 
 	describe( 'CRDT doc observation', () => {
 		it( 'edits the local entity record when remote updates arrive', async () => {
-			// Capture the Y.Doc from provider creator.
-			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
-
 			const manager = createSyncManager();
 
 			await manager.load(
@@ -719,19 +678,6 @@ describe( 'SyncManager', () => {
 		} );
 
 		it( 'does not edit the local record for local transactions', async () => {
-			// Capture the Y.Doc from provider creator.
-			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
-
 			const manager = createSyncManager();
 
 			await manager.load(


### PR DESCRIPTION

## What?

Prevent the sync manager from calling the `saveRecord` handler when CRDT persistence is not supported.

## Why?

The only purpose of calling the `saveRecord` handler is to persist the CRDT document—either for the first time or after a previously persisted document is invalidated. Therefore, it should be called inside a check for `syncConfig.supports.crdtPersistence`.

For entities that should not or cannot be saved (such as the site settings entity), this bug resulted in a failing API request to save the entity (e.g., `POST /wp-json/wp/v2/settings?_locale=user`).

## How?

1. Wrap the `saveRecord` call in a check.
2. Remove the redundant call to `createEntityMeta`. This was a bad merge artifact. Calling `createEntityMeta` is now handled in the entity's pre-persist hook.

## Testing Instructions

1. Check out this branch.
2. Load a post for editing.
3. Make a change and click Save.
4. Ensure that there is no `POST` request to `/wp-json/wp/v2/settings?_locale=user`.

### Testing Instructions for Keyboard

No UI changes in this PR.