### PR TITLE
 WP_Theme_JSON_Gutenberg: preserve valid non-preset settings when KSES filters are active

### DIFF
--- a/backport-changelog/7.0/10534.md
+++ b/backport-changelog/7.0/10534.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10534
+
+* https://github.com/WordPress/gutenberg/pull/73452

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1312,19 +1312,10 @@ class WP_Theme_JSON_Gutenberg {
 				continue;
 			}
 
-			// Check if the value is an array and requires further processing.
-			if ( is_array( $value ) && is_array( $schema[ $key ] ) ) {
-				// Determine if it is an associative or indexed array.
-				$schema_is_assoc = self::is_assoc( $value );
-
-				if ( $schema_is_assoc ) {
-					// If associative, process as a single object.
-					$tree[ $key ] = self::remove_keys_not_in_schema( $value, $schema[ $key ] );
-
-					if ( empty( $tree[ $key ] ) ) {
-						unset( $tree[ $key ] );
-					}
-				} else {
+			if ( is_array( $schema[ $key ] ) ) {
+				if ( ! is_array( $value ) ) {
+					unset( $tree[ $key ] );
+				} elseif ( wp_is_numeric_array( $value ) ) {
 					// If indexed, process each item in the array.
 					foreach ( $value as $item_key => $item_value ) {
 						if ( isset( $schema[ $key ][0] ) && is_array( $schema[ $key ][0] ) ) {
@@ -1334,27 +1325,18 @@ class WP_Theme_JSON_Gutenberg {
 							$tree[ $key ][ $item_key ] = $item_value;
 						}
 					}
+				} else {
+					// If associative, process as a single object.
+					$tree[ $key ] = self::remove_keys_not_in_schema( $value, $schema[ $key ] );
+
+					if ( empty( $tree[ $key ] ) ) {
+						unset( $tree[ $key ] );
+					}
 				}
-			} elseif ( is_array( $schema[ $key ] ) && ! is_array( $tree[ $key ] ) ) {
-				unset( $tree[ $key ] );
 			}
 		}
 
 		return $tree;
-	}
-
-	/**
-	 * Checks if the given array is associative.
-	 *
-	 * @since 6.5.0
-	 * @param array $data The array to check.
-	 * @return bool True if the array is associative, false otherwise.
-	 */
-	protected static function is_assoc( $data ) {
-		if ( array() === $data ) {
-			return false;
-		}
-		return array_keys( $data ) !== range( 0, count( $data ) - 1 );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3892,14 +3892,14 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $preset_path_map ) {
 			$preset_path_map = array();
 			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-				$path_key                      = implode( '.', $preset_metadata['path'] );
+				$path_key                     = implode( '.', $preset_metadata['path'] );
 				$preset_path_map[ $path_key ] = true;
 			}
 
 			$indirect_path_map = array();
 			foreach ( static::INDIRECT_PROPERTIES_METADATA as $paths ) {
 				foreach ( $paths as $path ) {
-					$path_key                        = implode( '.', $path );
+					$path_key                       = implode( '.', $path );
 					$indirect_path_map[ $path_key ] = true;
 				}
 			}
@@ -3907,7 +3907,7 @@ class WP_Theme_JSON_Gutenberg {
 
 		// Preserve all valid settings.
 		foreach ( static::VALID_SETTINGS as $key => $valid_setting ) {
-			// Skip if this is a preset (O(1) lookup).
+			// Skip if this is a preset.
 			if ( isset( $preset_path_map[ $key ] ) ) {
 				continue;
 			}
@@ -3928,7 +3928,7 @@ class WP_Theme_JSON_Gutenberg {
 				foreach ( $valid_setting as $nested_key => $nested_valid ) {
 					$nested_path_key = $key . '.' . $nested_key;
 
-					// Skip if preset or indirect property (O(1) lookup).
+					// Skip if preset or indirect property.
 					if ( isset( $preset_path_map[ $nested_path_key ] ) || isset( $indirect_path_map[ $nested_path_key ] ) ) {
 						continue;
 					}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -335,6 +335,27 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	/**
+	 * Safe settings that can be preserved without CSS validation.
+	 *
+	 * These are non-preset, non-CSS settings that control behavior rather than styling.
+	 * Each entry defines the setting path and its expected type for validation.
+	 *
+	 * Types: 'boolean', 'string', 'array' (for custom properties)
+	 *
+	 * @since 7.0.0
+	 */
+	const SAFE_SETTINGS = array(
+		array(
+			'path' => array( 'lightbox', 'allowEditing' ),
+			'type' => 'boolean',
+		),
+		array(
+			'path' => array( 'lightbox', 'enabled' ),
+			'type' => 'boolean',
+		),
+	);
+
+	/**
 	 * Protected style properties.
 	 *
 	 * These style properties are only rendered if a setting enables it
@@ -3885,64 +3906,30 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $output The processed node. Passed by reference.
 	 */
 	private static function preserve_valid_settings( $input, &$output ) {
-		static $preset_path_map   = null;
-		static $indirect_path_map = null;
+		// Iterate through safe settings and preserve them with type validation.
+		foreach ( static::SAFE_SETTINGS as $safe_setting ) {
+			$path = $safe_setting['path'];
+			$type = $safe_setting['type'];
 
-		// Build path maps once on first call for O(1) lookups.
-		if ( null === $preset_path_map ) {
-			$preset_path_map = array();
-			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-				$path_key                     = implode( '.', $preset_metadata['path'] );
-				$preset_path_map[ $path_key ] = true;
-			}
+			// Extract the value from input using the path.
+			$value = _wp_array_get( $input, $path, null );
 
-			$indirect_path_map = array();
-			foreach ( static::INDIRECT_PROPERTIES_METADATA as $paths ) {
-				foreach ( $paths as $path ) {
-					$path_key                       = implode( '.', $path );
-					$indirect_path_map[ $path_key ] = true;
-				}
-			}
-		}
-
-		// Preserve all valid settings.
-		foreach ( static::VALID_SETTINGS as $key => $valid_setting ) {
-			// Skip if this is a preset.
-			if ( isset( $preset_path_map[ $key ] ) ) {
+			// Skip if the setting is not present in the input.
+			if ( null === $value ) {
 				continue;
 			}
 
-			if ( null === $valid_setting ) {
-				// Simple setting (e.g., appearanceTools, custom).
-				// For 'custom', allow arrays; for others, only scalars.
-				if ( isset( $input[ $key ] ) ) {
-					if ( 'custom' === $key && is_array( $input[ $key ] ) ) {
-						$output[ $key ] = $input[ $key ];
-					} elseif ( is_scalar( $input[ $key ] ) ) {
-						$output[ $key ] = $input[ $key ];
-					}
-				}
-			} elseif ( is_array( $valid_setting ) && isset( $input[ $key ] ) && is_array( $input[ $key ] ) ) {
-				// Nested setting (e.g., lightbox, layout).
-				$nested_output = $output[ $key ] ?? array();
-				foreach ( $valid_setting as $nested_key => $nested_valid ) {
-					$nested_path_key = $key . '.' . $nested_key;
+			// Validate the type.
+			$is_valid_type = false;
+			switch ( $type ) {
+				case 'boolean':
+					$is_valid_type = is_bool( $value );
+					break;
+			}
 
-					// Skip if preset or indirect property.
-					if ( isset( $preset_path_map[ $nested_path_key ] ) || isset( $indirect_path_map[ $nested_path_key ] ) ) {
-						continue;
-					}
-
-					if ( isset( $input[ $key ][ $nested_key ] ) ) {
-						// Allow scalars and arrays (e.g., spacing.units).
-						if ( is_scalar( $input[ $key ][ $nested_key ] ) || is_array( $input[ $key ][ $nested_key ] ) ) {
-							$nested_output[ $nested_key ] = $input[ $key ][ $nested_key ];
-						}
-					}
-				}
-				if ( ! empty( $nested_output ) ) {
-					$output[ $key ] = $nested_output;
-				}
+			// If the type is valid, set it in the output using the path.
+			if ( $is_valid_type ) {
+				_wp_array_set( $output, $path, $value );
 			}
 		}
 	}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -334,7 +334,6 @@ class WP_Theme_JSON_Gutenberg {
 		),
 	);
 
-
 	/**
 	 * Protected style properties.
 	 *

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3885,24 +3885,30 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $output The processed node. Passed by reference.
 	 */
 	private static function preserve_valid_settings( $input, &$output ) {
-		// Get preset paths to exclude them.
-		$preset_paths = array();
-		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-			$preset_paths[] = $preset_metadata['path'];
-		}
+		static $preset_path_map   = null;
+		static $indirect_path_map = null;
 
-		// Get indirect property paths to exclude them.
-		$indirect_paths = array();
-		foreach ( static::INDIRECT_PROPERTIES_METADATA as $paths ) {
-			foreach ( $paths as $path ) {
-				$indirect_paths[] = $path;
+		// Build path maps once on first call for O(1) lookups.
+		if ( null === $preset_path_map ) {
+			$preset_path_map = array();
+			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+				$path_key                      = implode( '.', $preset_metadata['path'] );
+				$preset_path_map[ $path_key ] = true;
+			}
+
+			$indirect_path_map = array();
+			foreach ( static::INDIRECT_PROPERTIES_METADATA as $paths ) {
+				foreach ( $paths as $path ) {
+					$path_key                        = implode( '.', $path );
+					$indirect_path_map[ $path_key ] = true;
+				}
 			}
 		}
 
 		// Preserve all valid settings.
 		foreach ( static::VALID_SETTINGS as $key => $valid_setting ) {
-			// Skip if this is a preset.
-			if ( in_array( array( $key ), $preset_paths, true ) ) {
+			// Skip if this is a preset (O(1) lookup).
+			if ( isset( $preset_path_map[ $key ] ) ) {
 				continue;
 			}
 
@@ -3920,11 +3926,13 @@ class WP_Theme_JSON_Gutenberg {
 				// Nested setting (e.g., lightbox, layout).
 				$nested_output = isset( $output[ $key ] ) ? $output[ $key ] : array();
 				foreach ( $valid_setting as $nested_key => $nested_valid ) {
-					$nested_path = array( $key, $nested_key );
-					// Skip if this nested path is a preset or indirect property.
-					if ( in_array( $nested_path, $preset_paths, true ) || in_array( $nested_path, $indirect_paths, true ) ) {
+					$nested_path_key = $key . '.' . $nested_key;
+
+					// Skip if preset or indirect property (O(1) lookup).
+					if ( isset( $preset_path_map[ $nested_path_key ] ) || isset( $indirect_path_map[ $nested_path_key ] ) ) {
 						continue;
 					}
+
 					if ( isset( $input[ $key ][ $nested_key ] ) ) {
 						// Allow scalars and arrays (e.g., spacing.units).
 						if ( is_scalar( $input[ $key ][ $nested_key ] ) || is_array( $input[ $key ][ $nested_key ] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -334,27 +334,6 @@ class WP_Theme_JSON_Gutenberg {
 		),
 	);
 
-	/**
-	 * Safe settings that should be preserved by ::remove_insecure_settings().
-	 *
-	 * These are non-preset, non-CSS settings that control behavior rather than styling.
-	 * Each entry defines the setting path and its expected type for validation.
-	 *
-	 * The constant is deliberately private to prevent external usage by plugins.
-	 * Like the class itself, it is intended for internal core usage.
-	 *
-	 * @since 7.0.0
-	 */
-	private const SAFE_SETTINGS = array(
-		array(
-			'path' => array( 'lightbox', 'allowEditing' ),
-			'type' => 'boolean',
-		),
-		array(
-			'path' => array( 'lightbox', 'enabled' ),
-			'type' => 'boolean',
-		),
-	);
 
 	/**
 	 * Protected style properties.
@@ -407,6 +386,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.3.0 Removed `layout.definitions`. Added `typography.writingMode`.
 	 * @since 6.4.0 Added `layout.allowEditing`.
 	 * @since 6.4.0 Added `lightbox`.
+	 * @since 7.0.0 Added type markers to the schema for boolean values.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -454,8 +434,8 @@ class WP_Theme_JSON_Gutenberg {
 			'allowCustomContentAndWideSize' => null,
 		),
 		'lightbox'                      => array(
-			'enabled'      => null,
-			'allowEditing' => null,
+			'enabled'      => true,
+			'allowEditing' => true,
 		),
 		'position'                      => array(
 			'fixed'  => null,
@@ -1319,6 +1299,17 @@ class WP_Theme_JSON_Gutenberg {
 			// Remove keys not in the schema or with null/empty values.
 			if ( ! array_key_exists( $key, $schema ) ) {
 				unset( $tree[ $key ] );
+				continue;
+			}
+
+			// Validate type if schema specifies a boolean marker.
+			if ( is_bool( $schema[ $key ] ) ) {
+				// Schema expects a boolean value - validate the input matches.
+				if ( ! is_bool( $value ) ) {
+					unset( $tree[ $key ] );
+					continue;
+				}
+				// Type matches, keep the value and continue to next key.
 				continue;
 			}
 
@@ -3834,6 +3825,35 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Preserves valid typed settings from input to output based on type markers in schema.
+	 *
+	 * Recursively iterates through the schema and validates/preserves settings
+	 * that have type markers (e.g., boolean) in VALID_SETTINGS.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $input  Input settings to process.
+	 * @param array $output Output settings array (passed by reference).
+	 * @param array $schema Schema to validate against (typically VALID_SETTINGS).
+	 * @param array $path   Current path in the schema (for recursive calls).
+	 */
+	private static function preserve_valid_typed_settings( $input, &$output, $schema, $path = array() ) {
+		foreach ( $schema as $key => $schema_value ) {
+			$current_path = array_merge( $path, array( $key ) );
+
+			// Validate boolean type markers.
+			if ( is_bool( $schema_value ) ) {
+				$value = _wp_array_get( $input, $current_path, null );
+				if ( null !== $value && is_bool( $value ) ) {
+					_wp_array_set( $output, $current_path, $value ); // Preserve boolean value.
+				}
+			} elseif ( is_array( $schema_value ) ) {
+				static::preserve_valid_typed_settings( $input, $output, $schema_value, $current_path ); // Recurse into nested structure.
+			}
+		}
+	}
+
+	/**
 	 * Processes a setting node and returns the same node
 	 * without the insecure settings.
 	 *
@@ -3892,32 +3912,8 @@ class WP_Theme_JSON_Gutenberg {
 		// Ensure indirect properties not included in any `PRESETS_METADATA` value are allowed.
 		static::remove_indirect_properties( $input, $output );
 
-		// Preserve all valid settings that aren't presets or indirect properties.
-		foreach ( static::SAFE_SETTINGS as $safe_setting ) {
-			$path = $safe_setting['path'];
-			$type = $safe_setting['type'];
-
-			// Extract the value from input using the path.
-			$value = _wp_array_get( $input, $path, null );
-
-			// Skip if the setting is not present in the input.
-			if ( null === $value ) {
-				continue;
-			}
-
-			// Validate the type.
-			$is_valid_type = false;
-			switch ( $type ) {
-				case 'boolean':
-					$is_valid_type = is_bool( $value );
-					break;
-			}
-
-			// If the type is valid, set it in the output using the path.
-			if ( $is_valid_type ) {
-				_wp_array_set( $output, $path, $value );
-			}
-		}
+		// Preserve all valid settings that have type markers in VALID_SETTINGS.
+		static::preserve_valid_typed_settings( $input, $output, static::VALID_SETTINGS );
 
 		return $output;
 	}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -340,9 +340,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * These are non-preset, non-CSS settings that control behavior rather than styling.
 	 * Each entry defines the setting path and its expected type for validation.
 	 *
+	 * The constant is deliberately private to prevent external usage by plugins.
+	 * Like the class itself, it is intended for internal core usage.
+	 *
 	 * @since 7.0.0
 	 */
-	const SAFE_SETTINGS = array(
+	private const SAFE_SETTINGS = array(
 		array(
 			'path' => array( 'lightbox', 'allowEditing' ),
 			'type' => 'boolean',

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -340,8 +340,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * These are non-preset, non-CSS settings that control behavior rather than styling.
 	 * Each entry defines the setting path and its expected type for validation.
 	 *
-	 * Types: 'boolean', 'string', 'array' (for custom properties)
-	 *
 	 * @since 7.0.0
 	 */
 	const SAFE_SETTINGS = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3924,7 +3924,7 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			} elseif ( is_array( $valid_setting ) && isset( $input[ $key ] ) && is_array( $input[ $key ] ) ) {
 				// Nested setting (e.g., lightbox, layout).
-				$nested_output = isset( $output[ $key ] ) ? $output[ $key ] : array();
+				$nested_output = $output[ $key ] ?? array();
 				foreach ( $valid_setting as $nested_key => $nested_valid ) {
 					$nested_path_key = $key . '.' . $nested_key;
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3870,7 +3870,73 @@ class WP_Theme_JSON_Gutenberg {
 		// Ensure indirect properties not included in any `PRESETS_METADATA` value are allowed.
 		static::remove_indirect_properties( $input, $output );
 
+		// Preserve all valid settings that aren't presets or indirect properties.
+		static::preserve_valid_settings( $input, $output );
+
 		return $output;
+	}
+
+	/**
+	 * Preserves valid settings from VALID_SETTINGS that aren't presets or indirect CSS properties.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $input  Node to process.
+	 * @param array $output The processed node. Passed by reference.
+	 */
+	private static function preserve_valid_settings( $input, &$output ) {
+		// Get preset paths to exclude them.
+		$preset_paths = array();
+		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+			$preset_paths[] = $preset_metadata['path'];
+		}
+
+		// Get indirect property paths to exclude them.
+		$indirect_paths = array();
+		foreach ( static::INDIRECT_PROPERTIES_METADATA as $paths ) {
+			foreach ( $paths as $path ) {
+				$indirect_paths[] = $path;
+			}
+		}
+
+		// Preserve all valid settings.
+		foreach ( static::VALID_SETTINGS as $key => $valid_setting ) {
+			// Skip if this is a preset.
+			if ( in_array( array( $key ), $preset_paths, true ) ) {
+				continue;
+			}
+
+			if ( null === $valid_setting ) {
+				// Simple setting (e.g., appearanceTools, custom).
+				// For 'custom', allow arrays; for others, only scalars.
+				if ( isset( $input[ $key ] ) ) {
+					if ( 'custom' === $key && is_array( $input[ $key ] ) ) {
+						$output[ $key ] = $input[ $key ];
+					} elseif ( is_scalar( $input[ $key ] ) ) {
+						$output[ $key ] = $input[ $key ];
+					}
+				}
+			} elseif ( is_array( $valid_setting ) && isset( $input[ $key ] ) && is_array( $input[ $key ] ) ) {
+				// Nested setting (e.g., lightbox, layout).
+				$nested_output = isset( $output[ $key ] ) ? $output[ $key ] : array();
+				foreach ( $valid_setting as $nested_key => $nested_valid ) {
+					$nested_path = array( $key, $nested_key );
+					// Skip if this nested path is a preset or indirect property.
+					if ( in_array( $nested_path, $preset_paths, true ) || in_array( $nested_path, $indirect_paths, true ) ) {
+						continue;
+					}
+					if ( isset( $input[ $key ][ $nested_key ] ) ) {
+						// Allow scalars and arrays (e.g., spacing.units).
+						if ( is_scalar( $input[ $key ][ $nested_key ] ) || is_array( $input[ $key ][ $nested_key ] ) ) {
+							$nested_output[ $nested_key ] = $input[ $key ][ $nested_key ];
+						}
+					}
+				}
+				if ( ! empty( $nested_output ) ) {
+					$output[ $key ] = $nested_output;
+				}
+			}
+		}
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -335,7 +335,7 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	/**
-	 * Safe settings that can be preserved without CSS validation.
+	 * Safe settings that should be preserved by ::remove_insecure_settings().
 	 *
 	 * These are non-preset, non-CSS settings that control behavior rather than styling.
 	 * Each entry defines the setting path and its expected type for validation.
@@ -3890,21 +3890,6 @@ class WP_Theme_JSON_Gutenberg {
 		static::remove_indirect_properties( $input, $output );
 
 		// Preserve all valid settings that aren't presets or indirect properties.
-		static::preserve_valid_settings( $input, $output );
-
-		return $output;
-	}
-
-	/**
-	 * Preserves valid settings from VALID_SETTINGS that aren't presets or indirect CSS properties.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param array $input  Node to process.
-	 * @param array $output The processed node. Passed by reference.
-	 */
-	private static function preserve_valid_settings( $input, &$output ) {
-		// Iterate through safe settings and preserve them with type validation.
 		foreach ( static::SAFE_SETTINGS as $safe_setting ) {
 			$path = $safe_setting['path'];
 			$type = $safe_setting['type'];
@@ -3930,6 +3915,8 @@ class WP_Theme_JSON_Gutenberg {
 				_wp_array_set( $output, $path, $value );
 			}
 		}
+
+		return $output;
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2692,8 +2692,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'color'   => array(
-					'custom'  => true,
+				'color'  => array(
 					'palette' => array(
 						'custom' => array(
 							array(
@@ -2714,13 +2713,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'spacing' => array(
-					'padding' => false,
-				),
-				'blocks'  => array(
+				'blocks' => array(
 					'core/group' => array(
-						'color'   => array(
-							'custom'  => true,
+						'color' => array(
 							'palette' => array(
 								'custom' => array(
 									array(
@@ -2741,140 +2736,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
-						'spacing' => array(
-							'padding' => false,
-						),
 					),
-				),
-			),
-		);
-		$this->assertEqualSetsWithIndex( $expected, $actual );
-	}
-
-	public function test_remove_insecure_properties_preserves_valid_block_settings() {
-		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'blocks' => array(
-						'core/image' => array(
-							'lightbox'   => array(
-								'enabled'      => true,
-								'allowEditing' => false,
-							),
-							'layout'     => array(
-								'allowEditing' => true,
-								'allowCustomContentAndWideSize' => false,
-							),
-							'position'   => array(
-								'fixed'  => true,
-								'sticky' => false,
-							),
-							'color'      => array(
-								'background' => true,
-								'text'       => false,
-							),
-							'spacing'    => array(
-								'margin'  => true,
-								'padding' => false,
-								'units'   => array( 'px', 'em' ),
-							),
-							'typography' => array(
-								'fontStyle'  => true,
-								'fontWeight' => false,
-								'textAlign'  => true,
-							),
-						),
-					),
-				),
-			),
-			'custom'
-		);
-
-		$expected = array(
-			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings' => array(
-				'blocks' => array(
-					'core/image' => array(
-						'lightbox'   => array(
-							'enabled'      => true,
-							'allowEditing' => false,
-						),
-						'layout'     => array(
-							'allowEditing' => true,
-							'allowCustomContentAndWideSize' => false,
-						),
-						'position'   => array(
-							'fixed'  => true,
-							'sticky' => false,
-						),
-						'color'      => array(
-							'background' => true,
-							'text'       => false,
-						),
-						'spacing'    => array(
-							'margin'  => true,
-							'padding' => false,
-							'units'   => array( 'px', 'em' ),
-						),
-						'typography' => array(
-							'fontStyle'  => true,
-							'fontWeight' => false,
-							'textAlign'  => true,
-						),
-					),
-				),
-			),
-		);
-		$this->assertEqualSetsWithIndex( $expected, $actual );
-	}
-
-	public function test_remove_insecure_properties_preserves_valid_top_level_settings() {
-		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'appearanceTools'               => true,
-					'useRootPaddingAwareAlignments' => false,
-					'lightbox'                      => array(
-						'enabled'      => true,
-						'allowEditing' => false,
-					),
-					'layout'                        => array(
-						'allowEditing'                  => true,
-						'allowCustomContentAndWideSize' => false,
-					),
-					'position'                      => array(
-						'fixed'  => true,
-						'sticky' => false,
-					),
-					'custom'                        => array(
-						'someCustomProperty' => 'value',
-					),
-				),
-			),
-			'custom'
-		);
-
-		$expected = array(
-			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings' => array(
-				'appearanceTools'               => true,
-				'useRootPaddingAwareAlignments' => false,
-				'lightbox'                      => array(
-					'enabled'      => true,
-					'allowEditing' => false,
-				),
-				'layout'                        => array(
-					'allowEditing'                  => true,
-					'allowCustomContentAndWideSize' => false,
-				),
-				'position'                      => array(
-					'fixed'  => true,
-					'sticky' => false,
-				),
-				'custom'                        => array(
-					'someCustomProperty' => 'value',
 				),
 			),
 		);
@@ -3098,6 +2960,43 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSameSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_remove_insecure_properties_should_allow_safe_settings() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks'                        => array(
+						'core/image' => array(
+							'lightbox' => array(
+								'enabled'      => false,
+								'allowEditing' => true,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'blocks'                        => array(
+					'core/image' => array(
+						'lightbox' => array(
+							'enabled'      => false,
+							'allowEditing' => true,
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2692,7 +2692,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'color'  => array(
+				'color'   => array(
+					'custom'  => true,
 					'palette' => array(
 						'custom' => array(
 							array(
@@ -2713,9 +2714,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'blocks' => array(
+				'spacing' => array(
+					'padding' => false,
+				),
+				'blocks'  => array(
 					'core/group' => array(
-						'color' => array(
+						'color'   => array(
+							'custom'  => true,
 							'palette' => array(
 								'custom' => array(
 									array(
@@ -2736,7 +2741,140 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
+						'spacing' => array(
+							'padding' => false,
+						),
 					),
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	public function test_remove_insecure_properties_preserves_valid_block_settings() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'lightbox' => array(
+								'enabled'      => true,
+								'allowEditing' => false,
+							),
+							'layout'   => array(
+								'allowEditing'                  => true,
+								'allowCustomContentAndWideSize' => false,
+							),
+							'position' => array(
+								'fixed'  => true,
+								'sticky' => false,
+							),
+							'color'    => array(
+								'background' => true,
+								'text'       => false,
+							),
+							'spacing'  => array(
+								'margin'  => true,
+								'padding' => false,
+								'units'   => array( 'px', 'em' ),
+							),
+							'typography' => array(
+								'fontStyle'  => true,
+								'fontWeight' => false,
+								'textAlign'  => true,
+							),
+						),
+					),
+				),
+			),
+			'custom'
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'blocks' => array(
+					'core/image' => array(
+						'lightbox' => array(
+							'enabled'      => true,
+							'allowEditing' => false,
+						),
+						'layout'   => array(
+							'allowEditing'                  => true,
+							'allowCustomContentAndWideSize' => false,
+						),
+						'position' => array(
+							'fixed'  => true,
+							'sticky' => false,
+						),
+						'color'    => array(
+							'background' => true,
+							'text'       => false,
+						),
+						'spacing'  => array(
+							'margin'  => true,
+							'padding' => false,
+							'units'   => array( 'px', 'em' ),
+						),
+						'typography' => array(
+							'fontStyle'  => true,
+							'fontWeight' => false,
+							'textAlign'  => true,
+						),
+					),
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	public function test_remove_insecure_properties_preserves_valid_top_level_settings() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'appearanceTools'               => true,
+					'useRootPaddingAwareAlignments' => false,
+					'lightbox'                      => array(
+						'enabled'      => true,
+						'allowEditing' => false,
+					),
+					'layout'                        => array(
+						'allowEditing'                  => true,
+						'allowCustomContentAndWideSize' => false,
+					),
+					'position'                      => array(
+						'fixed'  => true,
+						'sticky' => false,
+					),
+					'custom'                        => array(
+						'someCustomProperty' => 'value',
+					),
+				),
+			),
+			'custom'
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'appearanceTools'               => true,
+				'useRootPaddingAwareAlignments' => false,
+				'lightbox'                      => array(
+					'enabled'      => true,
+					'allowEditing' => false,
+				),
+				'layout'                        => array(
+					'allowEditing'                  => true,
+					'allowCustomContentAndWideSize' => false,
+				),
+				'position'                      => array(
+					'fixed'  => true,
+					'sticky' => false,
+				),
+				'custom'                        => array(
+					'someCustomProperty' => 'value',
 				),
 			),
 		);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2972,10 +2972,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'settings' => array(
 					'blocks' => array(
 						'core/image' => array(
-							'lightbox' => array(
+							'lightbox'    => array(
 								'enabled'      => false,
 								'allowEditing' => true,
 							),
+							'unsupported' => 'value',
 						),
 					),
 				),
@@ -3002,30 +3003,37 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
 	 */
-	public function test_safe_settings_paths_should_exist_in_valid_settings() {
-		// Verify all paths in SAFE_SETTINGS exist in VALID_SETTINGS.
-		foreach ( WP_Theme_JSON_Gutenberg::SAFE_SETTINGS as $safe_setting ) {
-			$path = $safe_setting['path'];
-			$data = WP_Theme_JSON_Gutenberg::VALID_SETTINGS;
+	public function test_remove_insecure_properties_should_not_allow_unsafe_settings() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'lightbox' => array(
+								'enabled'      => 'false',
+								'allowEditing' => true,
+							),
+						),
+					),
+				),
+			)
+		);
 
-			// Check if path exists by traversing the nested structure.
-			$exists = true;
-			foreach ( $path as $key ) {
-				if ( ! is_array( $data ) || ! array_key_exists( $key, $data ) ) {
-					$exists = false;
-					break;
-				}
-				$data = $data[ $key ];
-			}
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'blocks' => array(
+					'core/image' => array(
+						'lightbox' => array(
+							'allowEditing' => true,
+						),
+					),
+				),
+			),
+		);
 
-			$this->assertTrue(
-				$exists,
-				sprintf(
-					'Path %s from SAFE_SETTINGS should exist in VALID_SETTINGS',
-					implode( '.', $path )
-				)
-			);
-		}
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	public function test_remove_invalid_element_pseudo_selectors() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2970,7 +2970,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'blocks'                        => array(
+					'blocks' => array(
 						'core/image' => array(
 							'lightbox' => array(
 								'enabled'      => false,
@@ -2985,7 +2985,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'blocks'                        => array(
+				'blocks' => array(
 					'core/image' => array(
 						'lightbox' => array(
 							'enabled'      => false,
@@ -2999,6 +2999,34 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_safe_settings_paths_should_exist_in_valid_settings() {
+		// Verify all paths in SAFE_SETTINGS exist in VALID_SETTINGS.
+		foreach ( WP_Theme_JSON_Gutenberg::SAFE_SETTINGS as $safe_setting ) {
+			$path = $safe_setting['path'];
+			$data = WP_Theme_JSON_Gutenberg::VALID_SETTINGS;
+
+			// Check if path exists by traversing the nested structure.
+			$exists = true;
+			foreach ( $path as $key ) {
+				if ( ! is_array( $data ) || ! array_key_exists( $key, $data ) ) {
+					$exists = false;
+					break;
+				}
+				$data = $data[ $key ];
+			}
+
+			$this->assertTrue(
+				$exists,
+				sprintf(
+					'Path %s from SAFE_SETTINGS should exist in VALID_SETTINGS',
+					implode( '.', $path )
+				)
+			);
+		}
+	}
 
 	public function test_remove_invalid_element_pseudo_selectors() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2758,23 +2758,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'settings' => array(
 					'blocks' => array(
 						'core/image' => array(
-							'lightbox' => array(
+							'lightbox'   => array(
 								'enabled'      => true,
 								'allowEditing' => false,
 							),
-							'layout'   => array(
-								'allowEditing'                  => true,
+							'layout'     => array(
+								'allowEditing' => true,
 								'allowCustomContentAndWideSize' => false,
 							),
-							'position' => array(
+							'position'   => array(
 								'fixed'  => true,
 								'sticky' => false,
 							),
-							'color'    => array(
+							'color'      => array(
 								'background' => true,
 								'text'       => false,
 							),
-							'spacing'  => array(
+							'spacing'    => array(
 								'margin'  => true,
 								'padding' => false,
 								'units'   => array( 'px', 'em' ),
@@ -2796,23 +2796,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'blocks' => array(
 					'core/image' => array(
-						'lightbox' => array(
+						'lightbox'   => array(
 							'enabled'      => true,
 							'allowEditing' => false,
 						),
-						'layout'   => array(
-							'allowEditing'                  => true,
+						'layout'     => array(
+							'allowEditing' => true,
 							'allowCustomContentAndWideSize' => false,
 						),
-						'position' => array(
+						'position'   => array(
 							'fixed'  => true,
 							'sticky' => false,
 						),
-						'color'    => array(
+						'color'      => array(
 							'background' => true,
 							'text'       => false,
 						),
-						'spacing'  => array(
+						'spacing'    => array(
 							'margin'  => true,
 							'padding' => false,
 							'units'   => array( 'px', 'em' ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2962,80 +2962,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameSetsWithIndex( $expected, $actual );
 	}
 
-	/**
-	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
-	 */
-	public function test_remove_insecure_properties_should_allow_safe_settings() {
-		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'blocks' => array(
-						'core/image' => array(
-							'lightbox'    => array(
-								'enabled'      => false,
-								'allowEditing' => true,
-							),
-							'unsupported' => 'value',
-						),
-					),
-				),
-			)
-		);
-
-		$expected = array(
-			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings' => array(
-				'blocks' => array(
-					'core/image' => array(
-						'lightbox' => array(
-							'enabled'      => false,
-							'allowEditing' => true,
-						),
-					),
-				),
-			),
-		);
-
-		$this->assertEqualSetsWithIndex( $expected, $actual );
-	}
-
-	/**
-	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
-	 */
-	public function test_remove_insecure_properties_should_not_allow_unsafe_settings() {
-		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'blocks' => array(
-						'core/image' => array(
-							'lightbox' => array(
-								'enabled'      => 'false',
-								'allowEditing' => true,
-							),
-						),
-					),
-				),
-			)
-		);
-
-		$expected = array(
-			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings' => array(
-				'blocks' => array(
-					'core/image' => array(
-						'lightbox' => array(
-							'allowEditing' => true,
-						),
-					),
-				),
-			),
-		);
-
-		$this->assertEqualSetsWithIndex( $expected, $actual );
-	}
-
 	public function test_remove_invalid_element_pseudo_selectors() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
@@ -6649,5 +6575,123 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$actual = $defaults->get_raw_data();
 
 		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
+	public function test_sanitize_preserves_boolean_values_when_schema_expects_boolean() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'lightbox' => array(
+						'enabled'      => true,
+						'allowEditing' => false,
+					),
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$this->assertTrue( $settings['lightbox']['enabled'] );
+		$this->assertFalse( $settings['lightbox']['allowEditing'] );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
+	public function test_sanitize_removes_non_boolean_values_when_schema_expects_boolean() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'lightbox' => array(
+						'enabled'      => 'not-a-boolean',
+						'allowEditing' => 123,
+					),
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$this->assertArrayNotHasKey( 'enabled', $settings['lightbox'] ?? array() );
+		$this->assertArrayNotHasKey( 'allowEditing', $settings['lightbox'] ?? array() );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
+	public function test_sanitize_preserves_boolean_values_in_block_settings() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'lightbox' => array(
+								'enabled'      => true,
+								'allowEditing' => false,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$this->assertTrue( $settings['blocks']['core/image']['lightbox']['enabled'] );
+		$this->assertFalse( $settings['blocks']['core/image']['lightbox']['allowEditing'] );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
+	public function test_sanitize_removes_non_boolean_values_in_block_settings() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'lightbox' => array(
+								'enabled'      => 'string-value',
+								'allowEditing' => array( 'not', 'a', 'boolean' ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$lightbox = $settings['blocks']['core/image']['lightbox'] ?? array();
+		$this->assertArrayNotHasKey( 'enabled', $lightbox );
+		$this->assertArrayNotHasKey( 'allowEditing', $lightbox );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
+	public function test_sanitize_preserves_null_schema_behavior() {
+		// Test that settings with null in schema (no type validation) still accept any type.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'appearanceTools' => 'string-value', // null in schema, should accept any type.
+					'custom'          => array( 'nested' => 'value' ), // null in schema, should accept any type.
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$this->assertSame( 'string-value', $settings['appearanceTools'] );
+		$this->assertSame( array( 'nested' => 'value' ), $settings['custom'] );
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/73157

## Problem

When KSES filters are active (via `add_action( 'init', 'kses_init_filters' )`), valid non-preset settings in Global Styles are being incorrectly filtered out. Specifically:

- `lightbox.enabled` and `lightbox.allowEditing` for Image blocks

The issue occurs because `remove_insecure_settings()` only preserved:
1. Presets (from `PRESETS_METADATA`)
2. Indirect CSS properties (from `INDIRECT_PROPERTIES_METADATA`)

All other valid settings were being stripped, even though they're defined in `VALID_SETTINGS` and are safe scalar values or arrays.


## Solution

Extended `VALID_SETTINGS` to also do type validation (as well as schema key validation) for the lightbox settings only (for now).

The idea is that `VALID_SETTINGS` values will act as type validation for further valid settings.


## Testing Instructions

### Manual Testing

1. **Enable KSES filters**:
   ```php
   add_action( 'init', 'kses_init_filters' );
   ```
   Add this to your theme's `functions.php` or a plugin.

2. **Test Image Block Lightbox Settings**:
   - Go to **Appearance > Editor > Styles**
   - Navigate to **Blocks > Image**
   - Open the **Settings** panel
   - Toggle the **"Enlarge on click"** (lightbox) setting
   - Save the changes
   - **Expected**: The setting should persist after saving and page reload
   - **Before fix**: The setting would revert after saving

3. **Test Other Valid Settings**:
   - Try changing other valid settings in Global Styles (e.g., layout settings, spacing settings)
   - Save and verify they persist
   - **Expected**: All valid settings should be preserved

### Automated Testing

Run the PHPUnit tests:

```bash
npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test
```

