### PR TITLE
Image block: set img_srcset to avoid PHP undefined var warning

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -196,6 +196,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$img_styles        = $processor->get_attribute( 'style' );
 	$img_width         = 'none';
 	$img_height        = 'none';
+	$img_srcset        = false;
 	$aria_label        = __( 'Enlarge' );
 	$dialog_aria_label = __( 'Enlarged image' );
 


### PR DESCRIPTION


## What? How?

Found while testing https://github.com/WordPress/gutenberg/issues/73157



Initialize `$img_srcset` to false before the conditional block, matching the pattern used for other variables and the return value of `wp_get_attachment_image_srcset()` when no attachment ID is available.


## Why?

When "Enlarge on click" (lightbox) is enabled via global styles, a PHP warning occurs for image blocks in post lists (e.g., on the home page's query block).

```
Warning: Undefined variable $img_srcset in /var/www/html/wp-content/plugins/gutenberg/build/scripts/block-library/image.php on line 224
```

In `block_core_image_render_lightbox()`, `$img_srcset` is only set inside `if ( isset( $block['attrs']['id'] ) )`, but it's used later  in `wp_interactivity_state()` regardless of whether the condition was met. 

Unlike `$img_width` and `$img_height`, which are initialized to 'none' before the conditional, `$img_srcset` wasn't initialized.



## Testing Instructions

Setup:

1. Create a new post/page
2. Insert an Image block and save.

Enable the lightbox in global styles:


1. Go to Appearance → Editor → Styles
2. Navigate to Blocks → Image
4. Enable "Enlarge on click" in global settings
5. Save changes

Visit the homepage or a template with a posts query block.

Ensure the following error is not logged:
<img width="1678" height="865" alt="Screenshot 2025-11-20 at 2 01 23 pm" src="https://github.com/user-attachments/assets/862e7be1-9f2d-48af-b457-510673df4f58" />

