### PR TITLE
contentOnly patterns: Fix lock icon appearing on toolbar when editing a section

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -42,7 +42,8 @@ function getTemplateLockValue( lock ) {
 
 export default function BlockLockModal( { clientId, onClose } ) {
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
-	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
+	const { isEditLocked, isMoveLocked, isRemoveLocked } =
+		useBlockLock( clientId );
 	const { allowsEditLocking, templateLock, hasTemplateLock } = useSelect(
 		( select ) => {
 			const { getBlockName, getBlockAttributes } =
@@ -66,11 +67,11 @@ export default function BlockLockModal( { clientId, onClose } ) {
 
 	useEffect( () => {
 		setLock( {
-			move: ! canMove,
-			remove: ! canRemove,
-			...( allowsEditLocking ? { edit: ! canEdit } : {} ),
+			move: isMoveLocked,
+			remove: isRemoveLocked,
+			...( allowsEditLocking ? { edit: isEditLocked } : {} ),
 		} );
-	}, [ canEdit, canMove, canRemove, allowsEditLocking ] );
+	}, [ isEditLocked, isMoveLocked, isRemoveLocked, allowsEditLocking ] );
 
 	const isAllChecked = Object.values( lock ).every( Boolean );
 	const isMixed = Object.values( lock ).some( Boolean ) && ! isAllChecked;

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Return details about the block lock status.
@@ -19,25 +20,20 @@ export default function useBlockLock( clientId ) {
 	return useSelect(
 		( select ) => {
 			const {
-				canEditBlock,
-				canMoveBlock,
-				canRemoveBlock,
 				canLockBlockType,
 				getBlockName,
-				getTemplateLock,
-			} = select( blockEditorStore );
-
-			const canEdit = canEditBlock( clientId );
-			const canMove = canMoveBlock( clientId );
-			const canRemove = canRemoveBlock( clientId );
+				isEditLockedBlock,
+				isMoveLockedBlock,
+				isRemoveLockedBlock,
+				isLockedBlock,
+			} = unlock( select( blockEditorStore ) );
 
 			return {
-				canEdit,
-				canMove,
-				canRemove,
+				isEditLocked: isEditLockedBlock( clientId ),
+				isMoveLocked: isMoveLockedBlock( clientId ),
+				isRemoveLocked: isRemoveLockedBlock( clientId ),
 				canLock: canLockBlockType( getBlockName( clientId ) ),
-				isContentLocked: getTemplateLock( clientId ) === 'contentOnly',
-				isLocked: ! canEdit || ! canMove || ! canRemove,
+				isLocked: isLockedBlock( clientId ),
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -61,36 +61,28 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const {
-		canToggleBlockVisibility,
-		isBlockHidden,
-		isContentOnly,
-		hasPatternName,
-	} = useSelect(
-		( select ) => {
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
-			const { isBlockHidden: _isBlockHidden } = unlock(
-				select( blockEditorStore )
-			);
-			const blockAttributes = getBlockAttributes( clientId );
-			return {
-				canToggleBlockVisibility: hasBlockSupport(
-					getBlockName( clientId ),
-					'blockVisibility',
-					true
-				),
-				isBlockHidden: _isBlockHidden( clientId ),
-				isContentOnly:
-					select( blockEditorStore ).getBlockEditingMode(
-						clientId
-					) === 'contentOnly',
-				hasPatternName: !! blockAttributes?.metadata?.patternName,
-			};
-		},
-		[ clientId ]
-	);
-	const shouldShowLockIcon = isLocked && ! isContentOnly;
+	const { canToggleBlockVisibility, isBlockHidden, hasPatternName } =
+		useSelect(
+			( select ) => {
+				const { getBlockName, getBlockAttributes } =
+					select( blockEditorStore );
+				const { isBlockHidden: _isBlockHidden } = unlock(
+					select( blockEditorStore )
+				);
+				const blockAttributes = getBlockAttributes( clientId );
+				return {
+					canToggleBlockVisibility: hasBlockSupport(
+						getBlockName( clientId ),
+						'blockVisibility',
+						true
+					),
+					isBlockHidden: _isBlockHidden( clientId ),
+					hasPatternName: !! blockAttributes?.metadata?.patternName,
+				};
+			},
+			[ clientId ]
+		);
+	const shouldShowLockIcon = isLocked;
 	const shouldShowBlockVisibilityIcon =
 		canToggleBlockVisibility && isBlockHidden;
 	const isSticky = blockInformation?.positionType === 'sticky';

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -80,7 +80,7 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ settingsAnchorRect, setSettingsAnchorRect ] = useState();
 
-	const { isLocked, canEdit, canMove } = useBlockLock( clientId );
+	const { isLocked } = useBlockLock( clientId );
 
 	const isFirstSelectedBlock =
 		isSelected && selectedClientIds[ 0 ] === clientId;
@@ -112,6 +112,8 @@ function ListViewBlock( {
 		getBlockOrder,
 		getBlockParents,
 		getBlocksByClientId,
+		canEditBlock,
+		canMoveBlock,
 		canRemoveBlocks,
 		isGroupable,
 	} = useSelect( blockEditorStore );
@@ -553,7 +555,7 @@ function ListViewBlock( {
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
 		'is-synced': blockInformation?.isSynced,
-		'is-draggable': canMove,
+		'is-draggable': canMoveBlock,
 		'is-displacement-normal': displacement === 'normal',
 		'is-displacement-up': displacement === 'up',
 		'is-displacement-down': displacement === 'down',
@@ -588,7 +590,7 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 			data-block={ clientId }
-			data-expanded={ canEdit ? isExpanded : undefined }
+			data-expanded={ canEditBlock ? isExpanded : undefined }
 			ref={ rowRef }
 		>
 			<TreeGridCell
@@ -614,7 +616,7 @@ function ListViewBlock( {
 								currentlyEditingBlockInCanvas ? 0 : tabIndex
 							}
 							onFocus={ onFocus }
-							isExpanded={ canEdit ? isExpanded : undefined }
+							isExpanded={ canEditBlock ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
 						/>

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -719,3 +719,107 @@ export const isBlockHidden = ( state, clientId ) => {
 export function hasBlockSpotlight( state ) {
 	return !! state.hasBlockSpotlight || !! state.editedContentOnlySection;
 }
+
+/**
+ * Returns whether a block is locked to prevent editing.
+ *
+ * This selector only reasons about block lock, not associated features
+ * like `blockEditingMode` that might prevent user modifications to a block.
+ * Currently there's also no way to prevent editing via `templateLock`.
+ *
+ * This distinction is important as this selector specifically drives the block lock UI
+ * that a user interacts with. `blockEditingModes` aren't included as a user can't change
+ * them.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId ClientId of the block.
+ *
+ * @return {boolean} Whether the block is currently locked.
+ */
+export function isEditLockedBlock( state, clientId ) {
+	const attributes = getBlockAttributes( state, clientId );
+	return !! attributes?.lock?.edit;
+}
+
+/**
+ * Returns whether a block is locked to prevent moving.
+ *
+ * This selector only reasons about templateLock and block lock, not associated features
+ * like `blockEditingMode` that might prevent user modifications to a block.
+ *
+ * This distinction is important as this selector specifically drives the block lock UI
+ * that a user interacts with. `blockEditingModes` are excluded as a user can't change
+ * them.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId ClientId of the block.
+ *
+ * @return {boolean} Whether the block is currently locked.
+ */
+export function isMoveLockedBlock( state, clientId ) {
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const templateLock = getTemplateLock( state, rootClientId );
+
+	// While `contentOnly` templateLock does sometimes prevent moving, a user can't modify
+	// this, so don't include it in this function. See the `canMoveBlock` selector
+	// as an alternative.
+	if ( templateLock === 'all' ) {
+		return true;
+	}
+
+	const attributes = getBlockAttributes( state, clientId );
+	return !! attributes?.lock?.move;
+}
+
+/**
+ * Returns whether a block is locked to prevent removal.
+ *
+ * This selector only reasons about templateLock and block lock, not associated features
+ * like `blockEditingMode` that might prevent user modifications to a block.
+ *
+ * This distinction is important as this selector specifically drives the block lock UI
+ * that a user interacts with. `blockEditingModes` are excluded as a user can't change
+ * them.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId ClientId of the block.
+ *
+ * @return {boolean} Whether the block is currently locked.
+ */
+export function isRemoveLockedBlock( state, clientId ) {
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const templateLock = getTemplateLock( state, rootClientId );
+
+	// While `contentOnly` templateLock does sometimes prevent removal, a user can't modify
+	// this, so don't include it in this function. See the `canRemoveBlock` selector
+	// as an alternative.
+	if ( templateLock === 'all' ) {
+		return true;
+	}
+
+	const attributes = getBlockAttributes( state, clientId );
+	return !! attributes?.lock?.remove;
+}
+
+/**
+ * Returns whether a block is locked.
+ *
+ * This selector only reasons about templateLock and block lock, not associated features
+ * like `blockEditingMode` that might prevent user modifications to a block.
+ *
+ * This distinction is important as this selector specifically drives the block lock UI
+ * that a user interacts with. `blockEditingModes` are excluded as a user can't change
+ * them.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId ClientId of the block.
+ *
+ * @return {boolean} Whether the block is currently locked.
+ */
+export function isLockedBlock( state, clientId ) {
+	return (
+		isEditLockedBlock( state, clientId ) ||
+		isMoveLockedBlock( state, clientId ) ||
+		isRemoveLockedBlock( state, clientId )
+	);
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -757,18 +757,20 @@ export function isEditLockedBlock( state, clientId ) {
  * @return {boolean} Whether the block is currently locked.
  */
 export function isMoveLockedBlock( state, clientId ) {
+	const attributes = getBlockAttributes( state, clientId );
+	// If a block explicitly has `move` set to `false`, it turns off
+	// any locking that might be inherited from a parent.
+	if ( attributes?.lock?.move !== undefined ) {
+		return !! attributes?.lock?.move;
+	}
+
 	const rootClientId = getBlockRootClientId( state, clientId );
 	const templateLock = getTemplateLock( state, rootClientId );
 
 	// While `contentOnly` templateLock does sometimes prevent moving, a user can't modify
 	// this, so don't include it in this function. See the `canMoveBlock` selector
 	// as an alternative.
-	if ( templateLock === 'all' ) {
-		return true;
-	}
-
-	const attributes = getBlockAttributes( state, clientId );
-	return !! attributes?.lock?.move;
+	return templateLock === 'all';
 }
 
 /**
@@ -787,18 +789,18 @@ export function isMoveLockedBlock( state, clientId ) {
  * @return {boolean} Whether the block is currently locked.
  */
 export function isRemoveLockedBlock( state, clientId ) {
+	const attributes = getBlockAttributes( state, clientId );
+	if ( attributes?.lock?.remove !== undefined ) {
+		return !! attributes?.lock?.remove;
+	}
+
 	const rootClientId = getBlockRootClientId( state, clientId );
 	const templateLock = getTemplateLock( state, rootClientId );
 
 	// While `contentOnly` templateLock does sometimes prevent removal, a user can't modify
 	// this, so don't include it in this function. See the `canRemoveBlock` selector
 	// as an alternative.
-	if ( templateLock === 'all' || templateLock === 'insert' ) {
-		return true;
-	}
-
-	const attributes = getBlockAttributes( state, clientId );
-	return !! attributes?.lock?.remove;
+	return templateLock === 'all' || templateLock === 'insert';
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -793,7 +793,7 @@ export function isRemoveLockedBlock( state, clientId ) {
 	// While `contentOnly` templateLock does sometimes prevent removal, a user can't modify
 	// this, so don't include it in this function. See the `canRemoveBlock` selector
 	// as an alternative.
-	if ( templateLock === 'all' ) {
+	if ( templateLock === 'all' || templateLock === 'insert' ) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -843,7 +843,7 @@ describe( 'private selectors', () => {
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should prioritize templateLock "all" over block lock', () => {
+		it( 'should prioritize templateLock over a block lock of `false`', () => {
 			const state = createState( 'all', { remove: false } );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -10,6 +10,10 @@ import {
 	getExpandedBlock,
 	isDragging,
 	getBlockStyles,
+	isEditLockedBlock,
+	isMoveLockedBlock,
+	isRemoveLockedBlock,
+	isLockedBlock,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 
@@ -679,6 +683,239 @@ describe( 'private selectors', () => {
 				'block-1': { color: 'red' },
 				'non-existent-block': undefined,
 			} );
+		} );
+	} );
+
+	describe( 'isEditLockedBlock', () => {
+		it( 'should return false when block has no lock attribute', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'block-1', { clientId: 'block-1' } ],
+					] ),
+					attributes: new Map( [ [ 'block-1', {} ] ] ),
+				},
+			};
+			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return false when block has lock attribute but edit is false', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'block-1', { clientId: 'block-1' } ],
+					] ),
+					attributes: new Map( [
+						[ 'block-1', { lock: { edit: false, move: true } } ],
+					] ),
+				},
+			};
+			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when block has lock attribute with edit set to true', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'block-1', { clientId: 'block-1' } ],
+					] ),
+					attributes: new Map( [
+						[ 'block-1', { lock: { edit: true } } ],
+					] ),
+				},
+			};
+			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when block has no attributes', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(),
+					attributes: new Map(),
+				},
+			};
+			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isMoveLockedBlock', () => {
+		const createState = ( templateLock, blockLock ) => ( {
+			blocks: {
+				byClientId: new Map( [
+					[ 'block-1', { clientId: 'block-1' } ],
+					[ 'parent-block', { clientId: 'parent-block' } ],
+				] ),
+				attributes: new Map( [
+					[ 'block-1', blockLock ? { lock: blockLock } : {} ],
+					[ 'parent-block', {} ],
+				] ),
+				parents: new Map( [
+					[ 'block-1', 'parent-block' ],
+					[ 'parent-block', '' ],
+				] ),
+			},
+			settings: {},
+			blockListSettings: {
+				'parent-block': templateLock ? { templateLock } : {},
+			},
+		} );
+
+		it( 'should return false when block has no lock and no templateLock', () => {
+			const state = createState( null, null );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when parent has templateLock set to "all"', () => {
+			const state = createState( 'all', null );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when parent has templateLock set to "contentOnly"', () => {
+			const state = createState( 'contentOnly', null );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when block has lock.move set to true', () => {
+			const state = createState( null, { move: true } );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when block has lock.move set to false', () => {
+			const state = createState( null, { move: false } );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should prioritize templateLock "all" over block lock', () => {
+			const state = createState( 'all', { move: false } );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isRemoveLockedBlock', () => {
+		const createState = ( templateLock, blockLock ) => ( {
+			blocks: {
+				byClientId: new Map( [
+					[ 'block-1', { clientId: 'block-1' } ],
+					[ 'parent-block', { clientId: 'parent-block' } ],
+				] ),
+				attributes: new Map( [
+					[ 'block-1', blockLock ? { lock: blockLock } : {} ],
+					[ 'parent-block', {} ],
+				] ),
+				parents: new Map( [
+					[ 'block-1', 'parent-block' ],
+					[ 'parent-block', '' ],
+				] ),
+			},
+			settings: {},
+			blockListSettings: {
+				'parent-block': templateLock ? { templateLock } : {},
+			},
+		} );
+
+		it( 'should return false when block has no lock and no templateLock', () => {
+			const state = createState( null, null );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when parent has templateLock set to "all"', () => {
+			const state = createState( 'all', null );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when parent has templateLock set to "contentOnly"', () => {
+			const state = createState( 'contentOnly', null );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when block has lock.remove set to true', () => {
+			const state = createState( null, { remove: true } );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when block has lock.remove set to false', () => {
+			const state = createState( null, { remove: false } );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should prioritize templateLock "all" over block lock', () => {
+			const state = createState( 'all', { remove: false } );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isLockedBlock', () => {
+		const createState = ( templateLock, blockLock ) => ( {
+			blocks: {
+				byClientId: new Map( [
+					[ 'block-1', { clientId: 'block-1' } ],
+					[ 'parent-block', { clientId: 'parent-block' } ],
+				] ),
+				attributes: new Map( [
+					[ 'block-1', blockLock ? { lock: blockLock } : {} ],
+					[ 'parent-block', {} ],
+				] ),
+				parents: new Map( [
+					[ 'block-1', 'parent-block' ],
+					[ 'parent-block', '' ],
+				] ),
+			},
+			settings: {},
+			blockListSettings: {
+				'parent-block': templateLock ? { templateLock } : {},
+			},
+		} );
+
+		it( 'should return false when block is not locked in any way', () => {
+			const state = createState( null, null );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should return true when block has lock.edit set to true', () => {
+			const state = createState( null, { edit: true } );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true when block has lock.move set to true', () => {
+			const state = createState( null, { move: true } );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true when block has lock.remove set to true', () => {
+			const state = createState( null, { remove: true } );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true when parent has templateLock set to "all"', () => {
+			const state = createState( 'all', null );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true when block has multiple locks', () => {
+			const state = createState( null, {
+				edit: true,
+				move: true,
+				remove: true,
+			} );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true when only one lock type is active', () => {
+			const state = createState( null, {
+				edit: false,
+				move: true,
+				remove: false,
+			} );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false when all lock types are explicitly false', () => {
+			const state = createState( null, {
+				edit: false,
+				move: false,
+				remove: false,
+			} );
+			expect( isLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -823,6 +823,11 @@ describe( 'private selectors', () => {
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
+		it( 'should return true when parent has templateLock set to "insert"', () => {
+			const state = createState( 'insert', null );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
 		it( 'should return false when parent has templateLock set to "contentOnly"', () => {
 			const state = createState( 'contentOnly', null );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -687,7 +687,7 @@ describe( 'private selectors', () => {
 	} );
 
 	describe( 'isEditLockedBlock', () => {
-		it( 'should return false when block has no lock attribute', () => {
+		it( 'returns false when block has no lock attribute', () => {
 			const state = {
 				blocks: {
 					byClientId: new Map( [
@@ -699,7 +699,7 @@ describe( 'private selectors', () => {
 			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return false when block has lock attribute but edit is false', () => {
+		it( 'returns false when block has lock attribute but edit is false', () => {
 			const state = {
 				blocks: {
 					byClientId: new Map( [
@@ -713,7 +713,7 @@ describe( 'private selectors', () => {
 			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when block has lock attribute with edit set to true', () => {
+		it( 'returns true when block has lock attribute with edit set to true', () => {
 			const state = {
 				blocks: {
 					byClientId: new Map( [
@@ -727,7 +727,7 @@ describe( 'private selectors', () => {
 			expect( isEditLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when block has no attributes', () => {
+		it( 'returns false when block has no attributes', () => {
 			const state = {
 				blocks: {
 					byClientId: new Map(),
@@ -760,34 +760,34 @@ describe( 'private selectors', () => {
 			},
 		} );
 
-		it( 'should return false when block has no lock and no templateLock', () => {
+		it( 'returns false when block has no lock and no templateLock', () => {
 			const state = createState( null, null );
 			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when parent has templateLock set to "all"', () => {
+		it( 'returns true when parent has templateLock set to "all"', () => {
 			const state = createState( 'all', null );
 			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when parent has templateLock set to "contentOnly"', () => {
+		it( 'returns false when parent has templateLock set to "contentOnly"', () => {
 			const state = createState( 'contentOnly', null );
 			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when block has lock.move set to true', () => {
+		it( 'returns true when block has lock.move set to true', () => {
 			const state = createState( null, { move: true } );
 			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when block has lock.move set to false', () => {
+		it( 'returns false when block has lock.move set to false', () => {
 			const state = createState( null, { move: false } );
 			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should prioritize templateLock "all" over block lock', () => {
+		it( 'prioritizes block lock over template lock', () => {
 			const state = createState( 'all', { move: false } );
-			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( true );
+			expect( isMoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 	} );
 
@@ -813,39 +813,39 @@ describe( 'private selectors', () => {
 			},
 		} );
 
-		it( 'should return false when block has no lock and no templateLock', () => {
+		it( 'returns false when block has no lock and no templateLock', () => {
 			const state = createState( null, null );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when parent has templateLock set to "all"', () => {
+		it( 'returns true when parent has templateLock set to "all"', () => {
 			const state = createState( 'all', null );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when parent has templateLock set to "insert"', () => {
+		it( 'returns true when parent has templateLock set to "insert"', () => {
 			const state = createState( 'insert', null );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when parent has templateLock set to "contentOnly"', () => {
+		it( 'returns false when parent has templateLock set to "contentOnly"', () => {
 			const state = createState( 'contentOnly', null );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when block has lock.remove set to true', () => {
+		it( 'returns true when block has lock.remove set to true', () => {
 			const state = createState( null, { remove: true } );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when block has lock.remove set to false', () => {
+		it( 'returns false when block has lock.remove set to false', () => {
 			const state = createState( null, { remove: false } );
 			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should prioritize templateLock over a block lock of `false`', () => {
+		it( 'prioritizes block lock over template lock', () => {
 			const state = createState( 'all', { remove: false } );
-			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( true );
+			expect( isRemoveLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 	} );
 
@@ -871,32 +871,32 @@ describe( 'private selectors', () => {
 			},
 		} );
 
-		it( 'should return false when block is not locked in any way', () => {
+		it( 'returns false when block is not locked in any way', () => {
 			const state = createState( null, null );
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( false );
 		} );
 
-		it( 'should return true when block has lock.edit set to true', () => {
+		it( 'returns true when block has lock.edit set to true', () => {
 			const state = createState( null, { edit: true } );
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when block has lock.move set to true', () => {
+		it( 'returns true when block has lock.move set to true', () => {
 			const state = createState( null, { move: true } );
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when block has lock.remove set to true', () => {
+		it( 'returns true when block has lock.remove set to true', () => {
 			const state = createState( null, { remove: true } );
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when parent has templateLock set to "all"', () => {
+		it( 'returns true when parent has templateLock set to "all"', () => {
 			const state = createState( 'all', null );
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when block has multiple locks', () => {
+		it( 'returns true when block has multiple locks', () => {
 			const state = createState( null, {
 				edit: true,
 				move: true,
@@ -905,7 +905,7 @@ describe( 'private selectors', () => {
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return true when only one lock type is active', () => {
+		it( 'returns true when only one lock type is active', () => {
 			const state = createState( null, {
 				edit: false,
 				move: true,
@@ -914,7 +914,7 @@ describe( 'private selectors', () => {
 			expect( isLockedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
-		it( 'should return false when all lock types are explicitly false', () => {
+		it( 'returns false when all lock types are explicitly false', () => {
 			const state = createState( null, {
 				edit: false,
 				move: false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #72159 - the block locking UI being displayed in cases where it shouldn't.

## Why?
The bug happens because the block locking feature uses selectors like `canMoveBlock` and `canRemoveBlock`. These selectors are low level, and what the block editor uses as the source of truth for whether a block can be moved or removed. They reason about a wider range of systems that might prevent moving or removal, like block editing modes.

A user can't change block editing modes from the block locking UI, so this shouldn't be something the block locking features incorporates into its locking logic.

## How?
Introduces some new selectors that specifically reason about the types of locking the user can modify via the UI. Removes usage of selectors like `canMoveBlock`, `canRemoveBlock` and `canEditBlock` for the locking feature.

## Testing Instructions
Do a general smoke test of block locking. Some gotchas about how the feature works in trunk (and maintained in this PR):
- If you select 'Lock removal' and then 'Apply to all blocks inside', this adds `templateLock: 'insert'`. It will also prevent block insertion, though it's not clear from the UI.
- If you select any type of locking and then 'Apply to all blocks inside', you can select an inner block and remove the locking for just that one block. E.g. you can make that block movable again even when parent locks moving.

Also test that the bug is fixed:
1. Enable the 'contentOnly: Make patterns contentOnly by default upon insertion' gutenberg experiment
2. Open the post editor and insert a pattern
3. From the block inspector click 'Edit section'
4. Observe that a lock icon doesn't appear on the toolbar
5. Click 'Exit section', observe that an unlock icon doesn't appear on the toolbar.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/da454ea2-0e27-49b7-acaa-ee9795074846


