### PR TITLE
Components: Allow ExternalLink without icon

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ExternalLink`: Add `withoutIcon` prop to component to allow rendering the link without the external icon (↗ or ↖). ([#73459](https://github.com/WordPress/gutenberg/pull/73459)).
+
 ### Bug Fixes
 
 -   `ExternalLink`: Fix arrow direction for RTL languages. The external link arrow now correctly points to the top-left (↖) instead of top-right (↗) in RTL layouts. ([#73400](https://github.com/WordPress/gutenberg/pull/73400))

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -23,7 +23,14 @@ function UnforwardedExternalLink(
 	>,
 	ref: ForwardedRef< HTMLAnchorElement >
 ) {
-	const { href, children, className, rel = '', ...additionalProps } = props;
+	const {
+		href,
+		children,
+		className,
+		rel = '',
+		withoutIcon,
+		...additionalProps
+	} = props;
 	const optimizedRel = [
 		...new Set(
 			[
@@ -66,15 +73,17 @@ function UnforwardedExternalLink(
 			<span className="components-external-link__contents">
 				{ children }
 			</span>
-			<span
-				className="components-external-link__icon"
-				aria-label={
-					/* translators: accessibility text */
-					__( '(opens in a new tab)' )
-				}
-			>
-				{ isRTL() ? '\u2196' : '\u2197' }
-			</span>
+			{ ! withoutIcon && (
+				<span
+					className="components-external-link__icon"
+					aria-label={
+						/* translators: accessibility text */
+						__( '(opens in a new tab)' )
+					}
+				>
+					{ isRTL() ? '\u2196' : '\u2197' }
+				</span>
+			) }
 		</a>
 		/* eslint-enable react/jsx-no-target-blank */
 	);

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -15,6 +15,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import type { ExternalLinkProps } from './types';
 import type { WordPressComponentProps } from '../context';
+import { VisuallyHidden } from '../visually-hidden';
 
 function UnforwardedExternalLink(
 	props: Omit<
@@ -73,7 +74,12 @@ function UnforwardedExternalLink(
 			<span className="components-external-link__contents">
 				{ children }
 			</span>
-			{ ! withoutIcon && (
+
+			{ withoutIcon ? (
+				<VisuallyHidden>
+					{ __( '(opens in a new tab)' ) }
+				</VisuallyHidden>
+			) : (
 				<span
 					className="components-external-link__icon"
 					aria-label={

--- a/packages/components/src/external-link/stories/index.story.tsx
+++ b/packages/components/src/external-link/stories/index.story.tsx
@@ -25,11 +25,25 @@ const meta: Meta< typeof ExternalLink > = {
 export default meta;
 
 const Template: StoryFn< typeof ExternalLink > = ( { ...args } ) => {
-	return <ExternalLink { ...args } />;
+	return (
+		<p>
+			Link to <ExternalLink { ...args } /> in a new tab
+		</p>
+	);
 };
 
 export const Default: StoryFn< typeof ExternalLink > = Template.bind( {} );
 Default.args = {
 	children: 'WordPress',
 	href: 'https://wordpress.org',
+	withoutIcon: false,
+};
+
+/**
+ * Link without icon
+ */
+export const WithoutIcon = Template.bind( {} );
+WithoutIcon.args = {
+	...Default.args,
+	withoutIcon: true,
 };

--- a/packages/components/src/external-link/types.ts
+++ b/packages/components/src/external-link/types.ts
@@ -12,4 +12,9 @@ export type ExternalLinkProps = {
 	 * The URL of the external resource.
 	 */
 	href: string;
+
+	/**
+	 * Render the link without the external link icon (↗ or ↖).
+	 */
+	withoutIcon?: boolean;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #73458 

## Why?
As mentioned in the linked issue, sometimes we want to render the link in places where we don't need/want the icon to be shown. That use-case is not possible with the current version of the component.

## How?

- Add an optional prop `withoutIcon` to the `ExternalLink` component to allow rendering the link without the icon
- Update the story to better reflect the rendering of the link inline with other text

## Testing Instructions
- Run `npm run storybook:dev`
- Go to Components > Navigation > ExternalLink
- Toggle the `withoutIcon` prop to see the behavior

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

- With icons (default)
    <img width="304" height="104" alt="image" src="https://github.com/user-attachments/assets/dc7de9fc-6138-4fed-8990-fa00d6aca767" />
- Without icon
    <img width="281" height="94" alt="image" src="https://github.com/user-attachments/assets/6c971c64-a197-44c6-8311-a03af903a119" />