### PR TITLE
Try adding generic entity search component with combobox component

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -388,16 +388,16 @@ Undocumented declaration.
 
 EntitySearch component - A combobox for searching and selecting entities.
 
-Provides a searchable dropdown that fetches posts, pages, taxonomies, and other entities from the site as the user types. Uses the WordPress search API to search across all post types (including custom) and taxonomies.
+Provides a searchable dropdown that fetches posts, pages, taxonomies, and other entities from the site as the user types.
 
 _Parameters_
 
 -   _props_ `Object`: - Component props
 -   _props.label_ `string`: - Label for the control
 -   _props.value_ `string`: - Current selected URL value
+-   _props.onSearch_ `Function`: - Function to fetch suggestions, receives searchTerm and should return a Promise - Called with empty string for initial suggestions
 -   _props.onChange_ `Function`: - Callback when selection changes, receives (url, suggestion) - suggestion is the selected entity data when choosing from options, - or null when typing freeform input
 -   _props.help_ `string`: - Optional help text
--   _props.suggestionsQuery_ `Object`: - Query parameters to filter search results - type: 'post' | 'term' | 'attachment' | 'post-format' - subtype: specific post type or taxonomy slug (e.g., 'page', 'post', 'category', 'post_tag')
 -   _props.getDisplayValue_ `Function`: - Function to determine what to display in the input field Receives the suggestion object, should return a string Defaults to showing the URL
 -   _props.allowFreeform_ `boolean`: - Whether to allow freeform input (not from options) on blur Defaults to true. When false, only values selected from options will be committed
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -395,10 +395,11 @@ _Parameters_
 -   _props_ `Object`: - Component props
 -   _props.label_ `string`: - Label for the control
 -   _props.value_ `string`: - Current selected URL value
--   _props.onChange_ `Function`: - Callback when selection changes, receives URL
+-   _props.onChange_ `Function`: - Callback when selection changes, receives (url, suggestion) - suggestion is the selected entity data when choosing from options, - or null when typing freeform input
 -   _props.help_ `string`: - Optional help text
 -   _props.suggestionsQuery_ `Object`: - Query parameters to filter search results - type: 'post' | 'term' | 'attachment' | 'post-format' - subtype: specific post type or taxonomy slug (e.g., 'page', 'post', 'category', 'post_tag')
 -   _props.getDisplayValue_ `Function`: - Function to determine what to display in the input field Receives the suggestion object, should return a string Defaults to showing the URL
+-   _props.allowFreeform_ `boolean`: - Whether to allow freeform input (not from options) on blur Defaults to true. When false, only values selected from options will be committed
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -384,6 +384,26 @@ _Returns_
 
 Undocumented declaration.
 
+### EntitySearch
+
+EntitySearch component - A combobox for searching and selecting entities.
+
+Provides a searchable dropdown that fetches posts, pages, taxonomies, and other entities from the site as the user types. Uses the WordPress search API to search across all post types (including custom) and taxonomies.
+
+_Parameters_
+
+-   _props_ `Object`: - Component props
+-   _props.label_ `string`: - Label for the control
+-   _props.value_ `string`: - Current selected URL value
+-   _props.onChange_ `Function`: - Callback when selection changes, receives URL
+-   _props.help_ `string`: - Optional help text
+-   _props.suggestionsQuery_ `Object`: - Query parameters to filter search results - type: 'post' | 'term' | 'attachment' | 'post-format' - subtype: specific post type or taxonomy slug (e.g., 'page', 'post', 'category', 'post_tag')
+-   _props.getDisplayValue_ `Function`: - Function to determine what to display in the input field Receives the suggestion object, should return a string Defaults to showing the URL
+
+_Returns_
+
+-   `JSX.Element`: The EntitySearch component
+
 ### FontSizePicker
 
 _Related_

--- a/packages/block-editor/src/components/entity-search/README.md
+++ b/packages/block-editor/src/components/entity-search/README.md
@@ -1,0 +1,210 @@
+# EntitySearch
+
+`EntitySearch` is a searchable combobox component for selecting entities from the WordPress site, including posts, pages, custom post types, taxonomies, and more.
+
+## Usage
+
+### Basic Usage
+
+```jsx
+import { EntitySearch } from '@wordpress/block-editor';
+
+function MyComponent() {
+	const [ url, setUrl ] = useState( '' );
+
+	return (
+		<EntitySearch
+			label="Select a link"
+			value={ url }
+			onChange={ ( newUrl ) => setUrl( newUrl ) }
+		/>
+	);
+}
+```
+
+### Customizing Display Value
+
+By default, the URL is shown in the input field. You can customize this with `getDisplayValue`:
+
+```jsx
+// Show title in the input field instead of URL
+<EntitySearch
+	label="Select a link"
+	value={ url }
+	onChange={ setUrl }
+	getDisplayValue={ ( suggestion ) => suggestion.title }
+/>
+
+// Show a custom format
+<EntitySearch
+	label="Select a link"
+	value={ url }
+	onChange={ setUrl }
+	getDisplayValue={ ( suggestion ) =>
+		`${ suggestion.title } (${ suggestion.type })`
+	}
+/>
+
+// Default behavior - shows URL
+<EntitySearch
+	label="Select a link"
+	value={ url }
+	onChange={ setUrl }
+/>
+```
+
+### Filtering by Entity Type
+
+```jsx
+// Search only pages
+<EntitySearch
+	label="Select a page"
+	value={ url }
+	onChange={ setUrl }
+	suggestionsQuery={ { type: 'post', subtype: 'page' } }
+/>
+
+// Search only categories
+<EntitySearch
+	label="Select a category"
+	value={ url }
+	onChange={ setUrl }
+	suggestionsQuery={ { type: 'term', subtype: 'category' } }
+/>
+
+// Search only posts
+<EntitySearch
+	label="Select a post"
+	value={ url }
+	onChange={ setUrl }
+	suggestionsQuery={ { type: 'post', subtype: 'post' } }
+/>
+
+// Search all posts (any post type)
+<EntitySearch
+	label="Select any post"
+	value={ url }
+	onChange={ setUrl }
+	suggestionsQuery={ { type: 'post' } }
+/>
+
+// Search all taxonomies
+<EntitySearch
+	label="Select a term"
+	value={ url }
+	onChange={ setUrl }
+	suggestionsQuery={ { type: 'term' } }
+/>
+```
+
+## Props
+
+### label
+
+The label for the control.
+
+-   Type: `String`
+-   Required: Yes
+
+### value
+
+The current selected URL value.
+
+-   Type: `String`
+-   Required: No
+
+### onChange
+
+Callback function invoked when the user selects an entity. Receives the entity's URL as the argument.
+
+-   Type: `Function`
+-   Required: Yes
+
+### help
+
+Optional help text displayed below the control.
+
+-   Type: `String`
+-   Required: No
+
+### getDisplayValue
+
+Function to determine what text is displayed in the input field when an entity is selected.
+
+-   Type: `Function`
+-   Required: No
+-   Default: `( suggestion ) => suggestion.url`
+
+The function receives a suggestion object with properties:
+-   `title`: The entity title
+-   `url`: The entity URL
+-   `type`: The entity type (e.g., 'post', 'page', 'category')
+-   `kind`: The entity kind (e.g., 'post-type', 'taxonomy')
+-   `id`: The entity ID
+
+#### Examples:
+
+```js
+// Show URL (default)
+getDisplayValue={ ( suggestion ) => suggestion.url }
+
+// Show title
+getDisplayValue={ ( suggestion ) => suggestion.title }
+
+// Show custom format
+getDisplayValue={ ( suggestion ) => `${ suggestion.title } - ${ suggestion.url }` }
+```
+
+### suggestionsQuery
+
+Query parameters to filter the search results by entity type.
+
+-   Type: `Object`
+-   Required: No
+-   Default: `{}`
+
+#### Supported properties:
+
+-   `type`: Filter by entity type
+    -   `'post'` - All post types (posts, pages, custom post types)
+    -   `'term'` - All taxonomies (categories, tags, custom taxonomies)
+    -   `'attachment'` - Media attachments
+    -   `'post-format'` - Post formats
+-   `subtype`: Filter by specific post type or taxonomy slug
+    -   For posts: `'post'`, `'page'`, or any custom post type slug
+    -   For terms: `'category'`, `'post_tag'`, or any custom taxonomy slug
+
+#### Examples:
+
+```js
+// Only pages
+suggestionsQuery={ { type: 'post', subtype: 'page' } }
+
+// Only categories
+suggestionsQuery={ { type: 'term', subtype: 'category' } }
+
+// All posts (any post type)
+suggestionsQuery={ { type: 'post' } }
+
+// All taxonomies
+suggestionsQuery={ { type: 'term' } }
+```
+
+## Features
+
+-   **Multi-type search**: Searches across all post types (including custom), taxonomies, attachments, and post formats
+-   **Filterable**: Optionally filter results to specific entity types using `suggestionsQuery`
+-   **Debounced search**: Search input is debounced (300ms) to reduce API calls
+-   **Initial suggestions**: Shows relevant suggestions when the field is first focused
+-   **Custom formatting**: Each result displays:
+    -   Entity icon (on the left)
+    -   Entity title
+    -   Entity type label (Post, Page, Category, etc.)
+    -   Shortened URL
+-   **Loading states**: Shows a loading indicator while fetching results
+
+## Technical Details
+
+This component uses the `__experimentalFetchLinkSuggestions` function from the block editor settings, which queries the `/wp/v2/search` endpoint to search across all entity types in a single request.
+
+The component follows the same patterns as the `LinkControl` component but provides a simpler combobox-based interface suitable for single-field entity selection scenarios.

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -140,6 +140,12 @@ export const EntitySearch = forwardRef(
 						return;
 					}
 
+					// Only search if term is empty (initial suggestions) or has 2+ characters
+					if ( term.length === 1 ) {
+						// Don't search with single character, keep showing previous results
+						return;
+					}
+
 					setIsLoading( true );
 					onSearch( term )
 						.then( ( results ) => {
@@ -275,7 +281,6 @@ export const EntitySearch = forwardRef(
 						}
 					} }
 					isLoading={ isLoading }
-					hideLabelFromVision
 					expandOnFocus={ false }
 					placeholder={ __( 'Search or type URL' ) }
 					__experimentalRenderItem={ ( { item } ) => {

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -181,7 +181,19 @@ export function EntitySearch( {
 					onChange={ ( newValue ) => {
 						// Clear search term when user selects an option
 						setSearchTerm( '' );
-						onChange( newValue );
+
+						// Find the selected option to get the full suggestion data
+						const selectedOption = options.find(
+							( opt ) => opt.value === newValue
+						);
+
+						// If we have suggestion data, pass it along with the URL
+						// This enables entity binding in navigation links
+						if ( selectedOption?.suggestion ) {
+							onChange( newValue, selectedOption.suggestion );
+						} else {
+							onChange( newValue );
+						}
 					} }
 					isLoading={ isLoading }
 					hideLabelFromVision

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -1,7 +1,18 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-import { ComboboxControl, Icon } from '@wordpress/components';
+import {
+	ComboboxControl,
+	Icon,
+	Flex,
+	FlexItem,
+	FlexBlock,
+} from '@wordpress/components';
 import {
 	useState,
 	useMemo,
@@ -20,6 +31,7 @@ import { filterURLForDisplay } from '@wordpress/url';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import './style.scss';
 
 /**
  * Get an icon for an entity type.
@@ -44,6 +56,28 @@ function getEntityIcon( type ) {
 }
 
 /**
+ * Get a display label for an entity type.
+ *
+ * @param {string} type - The entity type
+ * @return {string} The display label
+ */
+function getEntityTypeLabel( type ) {
+	switch ( type ) {
+		case 'page':
+			return __( 'Page' );
+		case 'post':
+			return __( 'Post' );
+		case 'category':
+			return __( 'Category' );
+		case 'tag':
+		case 'post_tag':
+			return __( 'Tag' );
+		default:
+			return __( 'Item' );
+	}
+}
+
+/**
  * EntitySearch component - A combobox for searching and selecting entities.
  *
  * Provides a searchable dropdown that fetches posts, pages, taxonomies, and other
@@ -53,7 +87,9 @@ function getEntityIcon( type ) {
  * @param {Object}   props                  - Component props
  * @param {string}   props.label            - Label for the control
  * @param {string}   props.value            - Current selected URL value
- * @param {Function} props.onChange         - Callback when selection changes, receives URL
+ * @param {Function} props.onChange         - Callback when selection changes, receives (url, suggestion)
+ *                                          - suggestion is the selected entity data when choosing from options,
+ *                                          - or null when typing freeform input
  * @param {string}   props.help             - Optional help text
  * @param {Object}   props.suggestionsQuery - Query parameters to filter search results
  *                                          - type: 'post' | 'term' | 'attachment' | 'post-format'
@@ -61,6 +97,8 @@ function getEntityIcon( type ) {
  * @param {Function} props.getDisplayValue  - Function to determine what to display in the input field
  *                                          Receives the suggestion object, should return a string
  *                                          Defaults to showing the URL
+ * @param {boolean}  props.allowFreeform    - Whether to allow freeform input (not from options) on blur
+ *                                          Defaults to true. When false, only values selected from options will be committed
  * @return {JSX.Element} The EntitySearch component
  */
 export const EntitySearch = forwardRef(
@@ -72,18 +110,19 @@ export const EntitySearch = forwardRef(
 			help,
 			suggestionsQuery = {},
 			getDisplayValue = ( suggestion ) => suggestion?.url || '',
+			allowFreeform = true,
 		},
 		ref
 	) => {
 		const [ searchTerm, setSearchTerm ] = useState( '' );
 		const [ suggestions, setSuggestions ] = useState( [] );
 		const [ isLoading, setIsLoading ] = useState( false );
-		const inputRef = useRef( null );
+		const entitySearchRef = useRef( null );
 
 		// Expose select method to parent component
 		useImperativeHandle( ref, () => ( {
 			select: () => {
-				const input = inputRef.current?.querySelector( 'input' );
+				const input = entitySearchRef.current?.querySelector( 'input' );
 				if ( input ) {
 					input.focus();
 					input.select();
@@ -110,27 +149,40 @@ export const EntitySearch = forwardRef(
 			[ type, subtype ]
 		);
 
-		// Fetch suggestions only when user has typed something
+		// Create debounced fetch function
+		const debouncedFetch = useMemo(
+			() =>
+				debounce( ( term ) => {
+					if ( ! term || ! fetchLinkSuggestions ) {
+						setSuggestions( [] );
+						setIsLoading( false );
+						return;
+					}
+
+					setIsLoading( true );
+					fetchLinkSuggestions( term, searchOptions )
+						.then( ( results ) => {
+							setSuggestions( results || [] );
+							setIsLoading( false );
+						} )
+						.catch( () => {
+							setSuggestions( [] );
+							setIsLoading( false );
+						} );
+				}, 300 ),
+			[ fetchLinkSuggestions, searchOptions ]
+		);
+
+		// Trigger fetch when searchTerm changes
 		useEffect( () => {
-			// Only fetch if there's a search term
-			if ( ! searchTerm || ! fetchLinkSuggestions ) {
+			if ( ! searchTerm ) {
 				setSuggestions( [] );
 				setIsLoading( false );
+				debouncedFetch.cancel(); // Cancel any pending debounced calls
 				return;
 			}
-
-			setIsLoading( true );
-
-			fetchLinkSuggestions( searchTerm, searchOptions )
-				.then( ( results ) => {
-					setSuggestions( results || [] );
-					setIsLoading( false );
-				} )
-				.catch( () => {
-					setSuggestions( [] );
-					setIsLoading( false );
-				} );
-		}, [ searchTerm, fetchLinkSuggestions, searchOptions ] );
+			debouncedFetch( searchTerm );
+		}, [ searchTerm, debouncedFetch ] );
 
 		// Transform suggestions into combobox options
 		const options = useMemo( () => {
@@ -141,168 +193,144 @@ export const EntitySearch = forwardRef(
 				suggestion,
 			} ) );
 
-			// Add current value as first option when input is empty or matches search
-			if ( value ) {
-				const valueMatchesSearch =
-					! searchTerm ||
-					value.toLowerCase().includes( searchTerm.toLowerCase() );
-
-				// Check if value is already in suggestions to avoid duplicate keys
-				const alreadyInSuggestions = opts.some(
-					( opt ) => opt.value === value
-				);
-
-				if ( valueMatchesSearch && ! alreadyInSuggestions ) {
-					// Add current value at the beginning
-					opts.unshift( {
-						value,
-						label: value,
-						isCurrentValue: true,
-					} );
-				}
-			}
-
-			// Add freeform option for typed values (when user is actively typing)
-			// This allows Enter/blur to commit whatever the user typed
-			if ( searchTerm ) {
-				// Don't add if it duplicates any existing option
-				const alreadyExists = opts.some(
-					( opt ) => opt.value === searchTerm
-				);
-				if ( ! alreadyExists ) {
-					opts.push( {
-						value: searchTerm,
-						label: searchTerm,
-						isFreeformOption: true,
-					} );
-				}
+			// Add current value if it exists and isn't already in suggestions
+			// This is needed for ComboboxControl to display the current value
+			if ( value && ! opts.some( ( opt ) => opt.value === value ) ) {
+				opts.unshift( {
+					value,
+					label: value,
+					isCurrentValue: true,
+				} );
 			}
 
 			return opts;
-		}, [ suggestions, getDisplayValue, searchTerm, value ] );
+		}, [ suggestions, getDisplayValue, value ] );
 
-		// Debounced search term setter
-		const debouncedSetSearchTerm = useMemo(
-			() =>
-				debounce( ( inputValue ) => {
-					setSearchTerm( inputValue );
-				}, 300 ),
-			[]
-		);
-
-		// Handle search input changes (NOT debounced for ignore check)
+		// Handle search input changes - sets search term immediately
 		const handleFilterValueChange = ( inputValue ) => {
-			// Don't search if input is empty
-			// ComboboxControl clears the input on focus - this is intentional
-			// Just show the current value in options and let user type or select
-			if ( inputValue === '' ) {
-				setSearchTerm( '' );
-				return;
-			}
-
-			// Debounce the actual search
-			debouncedSetSearchTerm( inputValue );
+			// Set search term immediately (the fetch will be debounced)
+			setSearchTerm( inputValue );
 		};
 
 		// Handle blur to commit typed value
 		const handleBlur = () => {
 			// Get the actual input value directly from DOM to avoid debounce issues
-			const input = inputRef.current?.querySelector( 'input' );
+			const input = entitySearchRef.current?.querySelector( 'input' );
 			const currentInputValue = input?.value || '';
 
-			// If user typed something that hasn't been committed, commit it
+			// If user typed something different from current value
 			if ( currentInputValue && currentInputValue !== value ) {
-				onChange( currentInputValue );
+				// Check if it was selected from options
+				const matchingOption = options.find(
+					( opt ) => opt.value === currentInputValue
+				);
+
+				if ( matchingOption ) {
+					// Value was selected from options
+					onChange( currentInputValue, matchingOption.suggestion );
+				} else if ( allowFreeform ) {
+					// Freeform input - pass null for suggestion to indicate it's not from options
+					onChange( currentInputValue, null );
+				}
+				// If !allowFreeform and not in options, don't commit (revert to previous value)
 			}
 		};
 
 		return (
-			<>
-				<style>
-					{ `
-					.components-form-token-field__suggestion:has([data-freeform-option]) {
-						display: none !important;
-					}
-				` }
-				</style>
-				<div ref={ inputRef } onBlur={ handleBlur }>
-					<ComboboxControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-						label={ label }
-						help={ help }
-						value={ value }
-						options={ options }
-						onFilterValueChange={ handleFilterValueChange }
-						onChange={ ( newValue ) => {
-							// Clear search term when user selects an option
-							setSearchTerm( '' );
+			<div
+				ref={ entitySearchRef }
+				onBlur={ handleBlur }
+				className={ clsx( 'entity-search', {
+					'is-freeform': allowFreeform,
+				} ) }
+			>
+				<ComboboxControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ label }
+					help={ help }
+					value={ value }
+					options={ options }
+					onFilterValueChange={ handleFilterValueChange }
+					onChange={ ( newValue ) => {
+						// Clear search term when user selects an option
+						setSearchTerm( '' );
 
-							// Find the selected option to get the full suggestion data
-							const selectedOption = options.find(
-								( opt ) => opt.value === newValue
-							);
+						// Find the selected option to get the full suggestion data
+						const selectedOption = options.find(
+							( opt ) => opt.value === newValue
+						);
 
-							// If we have suggestion data, pass it along with the URL
-							// This enables entity binding in navigation links
-							if ( selectedOption?.suggestion ) {
-								onChange( newValue, selectedOption.suggestion );
-							} else {
-								onChange( newValue );
-							}
-						} }
-						isLoading={ isLoading }
-						hideLabelFromVision
-						expandOnFocus={ false }
-						placeholder={ __( 'Search or type URL' ) }
-						__experimentalRenderItem={ ( { item } ) => {
-							// Hide the freeform option visually using CSS :has() selector
-							if ( item.isFreeformOption ) {
-								return <div data-freeform-option="true" />;
-							}
-
-							// Only show rich rendering for actual search results
-							const { suggestion } = item;
-							if ( ! suggestion ) {
-								return <div>{ item.label }</div>;
-							}
-
-							const icon = getEntityIcon( suggestion?.type );
-							const displayURL = filterURLForDisplay(
-								suggestion?.url
-							);
-
+						// If we have suggestion data, pass it along with the URL
+						// This enables entity binding in navigation links
+						if ( selectedOption?.suggestion ) {
+							onChange( newValue, selectedOption.suggestion );
+						} else {
+							onChange( newValue );
+						}
+					} }
+					isLoading={ isLoading }
+					hideLabelFromVision
+					expandOnFocus={ false }
+					placeholder={ __( 'Search or type URL' ) }
+					__experimentalRenderItem={ ( { item } ) => {
+						// Only show rich rendering for actual search results
+						// Hide the current value from dropdown
+						if ( item.isCurrentValue ) {
 							return (
-								<div
-									style={ {
-										display: 'flex',
-										alignItems: 'flex-start',
-										gap: '8px',
-										width: '100%',
-									} }
-								>
-									<Icon
-										icon={ icon }
-										style={ { marginTop: '2px' } }
-									/>
-									<div style={ { flex: 1, minWidth: 0 } }>
-										<div>{ suggestion?.title }</div>
-										<div
-											style={ {
-												fontSize: '12px',
-												color: '#757575',
-												marginTop: '2px',
-											} }
-										>
-											{ displayURL }
-										</div>
-									</div>
-								</div>
+								<div className="entity-search__current-value-hidden" />
 							);
-						} }
-					/>
-				</div>
-			</>
+						}
+
+						const { suggestion } = item;
+						if ( ! suggestion ) {
+							return <div>{ item.label }</div>;
+						}
+
+						const icon = getEntityIcon( suggestion?.type );
+						// Extract just the pathname for site URLs
+						let displayURL;
+						try {
+							const url = new URL(
+								suggestion?.url,
+								window.location.origin
+							);
+							// If it's the same origin, show just the pathname
+							if ( url.origin === window.location.origin ) {
+								displayURL =
+									url.pathname + url.search + url.hash;
+							} else {
+								displayURL = filterURLForDisplay(
+									suggestion?.url
+								);
+							}
+						} catch {
+							displayURL = filterURLForDisplay( suggestion?.url );
+						}
+
+						const typeLabel = getEntityTypeLabel(
+							suggestion?.type
+						);
+
+						return (
+							<Flex gap={ 2 } justify="space-between">
+								<FlexItem>
+									<Icon icon={ icon } />
+								</FlexItem>
+								<FlexBlock>
+									<div>{ suggestion?.title }</div>
+									<div className="entity-search__url">
+										{ displayURL }
+									</div>
+								</FlexBlock>
+								<FlexItem className="entity-search__type">
+									{ typeLabel }
+								</FlexItem>
+							</Flex>
+						);
+					} }
+				/>
+			</div>
 		);
 	}
 );

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -1,0 +1,239 @@
+/**
+ * WordPress dependencies
+ */
+import { ComboboxControl, Icon } from '@wordpress/components';
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { debounce } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { page, postList, category, tag } from '@wordpress/icons';
+import { filterURLForDisplay } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * Get an icon for an entity type.
+ *
+ * @param {string} type - The entity type
+ * @return {Object} The icon object
+ */
+function getEntityIcon( type ) {
+	switch ( type ) {
+		case 'page':
+			return page;
+		case 'post':
+			return postList;
+		case 'category':
+			return category;
+		case 'tag':
+		case 'post_tag':
+			return tag;
+		default:
+			return postList;
+	}
+}
+
+/**
+ * EntitySearch component - A combobox for searching and selecting entities.
+ *
+ * Provides a searchable dropdown that fetches posts, pages, taxonomies, and other
+ * entities from the site as the user types. Uses the WordPress search API to search
+ * across all post types (including custom) and taxonomies.
+ *
+ * @param {Object}   props                  - Component props
+ * @param {string}   props.label            - Label for the control
+ * @param {string}   props.value            - Current selected URL value
+ * @param {Function} props.onChange         - Callback when selection changes, receives URL
+ * @param {string}   props.help             - Optional help text
+ * @param {Object}   props.suggestionsQuery - Query parameters to filter search results
+ *                                          - type: 'post' | 'term' | 'attachment' | 'post-format'
+ *                                          - subtype: specific post type or taxonomy slug (e.g., 'page', 'post', 'category', 'post_tag')
+ * @param {Function} props.getDisplayValue  - Function to determine what to display in the input field
+ *                                          Receives the suggestion object, should return a string
+ *                                          Defaults to showing the URL
+ * @return {JSX.Element} The EntitySearch component
+ */
+export function EntitySearch( {
+	label,
+	value,
+	onChange,
+	help,
+	suggestionsQuery = {},
+	getDisplayValue = ( suggestion ) => suggestion?.url || '',
+} ) {
+	const [ searchTerm, setSearchTerm ] = useState( '' );
+	const [ suggestions, setSuggestions ] = useState( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	// Get the fetchLinkSuggestions function from block editor settings
+	const fetchLinkSuggestions = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().__experimentalFetchLinkSuggestions;
+	}, [] );
+
+	// Destructure suggestionsQuery to track actual values instead of object reference
+	const { type, subtype } = suggestionsQuery;
+
+	// Memoize search options to prevent infinite loops from object references
+	const searchOptions = useMemo(
+		() => ( {
+			perPage: 20,
+			type,
+			subtype,
+		} ),
+		[ type, subtype ]
+	);
+
+	// Fetch suggestions only when user has typed something
+	useEffect( () => {
+		// Only fetch if there's a search term
+		if ( ! searchTerm || ! fetchLinkSuggestions ) {
+			setSuggestions( [] );
+			setIsLoading( false );
+			return;
+		}
+
+		setIsLoading( true );
+
+		fetchLinkSuggestions( searchTerm, searchOptions )
+			.then( ( results ) => {
+				setSuggestions( results || [] );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				setSuggestions( [] );
+				setIsLoading( false );
+			} );
+	}, [ searchTerm, fetchLinkSuggestions, searchOptions ] );
+
+	// Transform suggestions into combobox options
+	const options = useMemo( () => {
+		// Build options from search results
+		const opts = suggestions.map( ( suggestion ) => ( {
+			value: suggestion.url,
+			label: getDisplayValue( suggestion ),
+			suggestion,
+		} ) );
+
+		// Always add a hidden freeform option that accepts any typed value
+		// This allows Enter/blur to commit whatever the user typed
+		opts.push( {
+			value: searchTerm || value || '',
+			label: searchTerm || value || '',
+			isFreeformOption: true,
+		} );
+
+		return opts;
+	}, [ suggestions, getDisplayValue, searchTerm, value ] );
+
+	// Debounced search term setter
+	const debouncedSetSearchTerm = useMemo(
+		() =>
+			debounce( ( inputValue ) => {
+				setSearchTerm( inputValue );
+			}, 300 ),
+		[]
+	);
+
+	// Handle search input changes (NOT debounced for ignore check)
+	const handleFilterValueChange = ( inputValue ) => {
+		// Don't search if input is empty
+		// ComboboxControl clears the input on focus - this is intentional
+		// Just show the current value in options and let user type or select
+		if ( inputValue === '' ) {
+			setSearchTerm( '' );
+			return;
+		}
+
+		// Debounce the actual search
+		debouncedSetSearchTerm( inputValue );
+	};
+
+	// Handle blur to commit typed value
+	const handleBlur = () => {
+		// If user typed something that hasn't been committed, commit it
+		if ( searchTerm && searchTerm !== value ) {
+			onChange( searchTerm );
+		}
+	};
+
+	return (
+		<>
+			<style>
+				{ `
+					.components-form-token-field__suggestion:has([data-freeform-option]) {
+						display: none !important;
+					}
+				` }
+			</style>
+			<div onBlur={ handleBlur }>
+				<ComboboxControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ label }
+					help={ help }
+					value={ value }
+					options={ options }
+					onFilterValueChange={ handleFilterValueChange }
+					onChange={ ( newValue ) => {
+						// Clear search term when user selects an option
+						setSearchTerm( '' );
+						onChange( newValue );
+					} }
+					isLoading={ isLoading }
+					hideLabelFromVision
+					expandOnFocus={ false }
+					placeholder={ __( 'Search or type URL' ) }
+					__experimentalRenderItem={ ( { item } ) => {
+						// Hide the freeform option visually using CSS :has() selector
+						if ( item.isFreeformOption ) {
+							return <div data-freeform-option="true" />;
+						}
+
+						// Only show rich rendering for actual search results
+						const { suggestion } = item;
+						if ( ! suggestion ) {
+							return <div>{ item.label }</div>;
+						}
+
+						const icon = getEntityIcon( suggestion?.type );
+						const displayURL = filterURLForDisplay(
+							suggestion?.url
+						);
+
+						return (
+							<div
+								style={ {
+									display: 'flex',
+									alignItems: 'flex-start',
+									gap: '8px',
+									width: '100%',
+								} }
+							>
+								<Icon
+									icon={ icon }
+									style={ { marginTop: '2px' } }
+								/>
+								<div style={ { flex: 1, minWidth: 0 } }>
+									<div>{ suggestion?.title }</div>
+									<div
+										style={ {
+											fontSize: '12px',
+											color: '#757575',
+											marginTop: '2px',
+										} }
+									>
+										{ displayURL }
+									</div>
+								</div>
+							</div>
+						);
+					} }
+				/>
+			</div>
+		</>
+	);
+}

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -126,6 +126,9 @@ export const EntitySearch = forwardRef(
 			},
 		} ) );
 
+		// Debug logging for state changes
+		useEffect( () => {}, [ value, searchTerm, suggestions ] );
+
 		// Create debounced fetch function
 		const debouncedFetch = useMemo(
 			() =>
@@ -164,14 +167,32 @@ export const EntitySearch = forwardRef(
 				suggestion,
 			} ) );
 
-			// Add current value if it exists and isn't already in suggestions
-			// This is needed for ComboboxControl to display the current value
-			if ( value && ! opts.some( ( opt ) => opt.value === value ) ) {
-				opts.unshift( {
-					value,
-					label: value,
-					isCurrentValue: true,
-				} );
+			// If the current value matches a suggestion, override its label when not searching
+			// This ensures that when editing a plain URL (e.g., after unsyncing), we show just the URL
+			// But when searching, keep the full label with title for ComboboxControl filtering
+			if ( value ) {
+				const matchingOptionIndex = opts.findIndex(
+					( opt ) => opt.value === value
+				);
+				if ( matchingOptionIndex !== -1 ) {
+					// Only override label to URL-only if not actively searching
+					if ( ! searchTerm ) {
+						opts[ matchingOptionIndex ] = {
+							...opts[ matchingOptionIndex ],
+							label: value,
+							isCurrentValue: true,
+						};
+					}
+					// When searching, keep the full label and don't mark as isCurrentValue
+					// so it shows in the dropdown and can be filtered by ComboboxControl
+				} else {
+					// Add current value if it doesn't exist in suggestions
+					opts.unshift( {
+						value,
+						label: value,
+						isCurrentValue: true,
+					} );
+				}
 			}
 
 			// Add current search term as a freeform option if it's not in suggestions

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -107,6 +107,7 @@ export const EntitySearch = forwardRef(
 			help,
 			getDisplayValue = ( suggestion ) => suggestion?.url || '',
 			allowFreeform = true,
+			shouldShowType = true,
 		},
 		ref
 	) => {
@@ -327,9 +328,11 @@ export const EntitySearch = forwardRef(
 										{ displayURL }
 									</div>
 								</FlexBlock>
-								<FlexItem className="entity-search__type">
-									{ typeLabel }
-								</FlexItem>
+								{ shouldShowType && (
+									<FlexItem className="entity-search__type">
+										{ typeLabel }
+									</FlexItem>
+								) }
 							</Flex>
 						);
 					} }

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -118,13 +118,42 @@ export function EntitySearch( {
 			suggestion,
 		} ) );
 
-		// Always add a hidden freeform option that accepts any typed value
+		// Add current value as first option when input is empty or matches search
+		if ( value ) {
+			const valueMatchesSearch =
+				! searchTerm ||
+				value.toLowerCase().includes( searchTerm.toLowerCase() );
+
+			// Check if value is already in suggestions to avoid duplicate keys
+			const alreadyInSuggestions = opts.some(
+				( opt ) => opt.value === value
+			);
+
+			if ( valueMatchesSearch && ! alreadyInSuggestions ) {
+				// Add current value at the beginning
+				opts.unshift( {
+					value,
+					label: value,
+					isCurrentValue: true,
+				} );
+			}
+		}
+
+		// Add freeform option for typed values (when user is actively typing)
 		// This allows Enter/blur to commit whatever the user typed
-		opts.push( {
-			value: searchTerm || value || '',
-			label: searchTerm || value || '',
-			isFreeformOption: true,
-		} );
+		if ( searchTerm ) {
+			// Don't add if it duplicates any existing option
+			const alreadyExists = opts.some(
+				( opt ) => opt.value === searchTerm
+			);
+			if ( ! alreadyExists ) {
+				opts.push( {
+					value: searchTerm,
+					label: searchTerm,
+					isFreeformOption: true,
+				} );
+			}
+		}
 
 		return opts;
 	}, [ suggestions, getDisplayValue, searchTerm, value ] );

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -2,7 +2,14 @@
  * WordPress dependencies
  */
 import { ComboboxControl, Icon } from '@wordpress/components';
-import { useState, useMemo, useEffect } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useEffect,
+	useRef,
+	forwardRef,
+	useImperativeHandle,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { debounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -56,225 +63,242 @@ function getEntityIcon( type ) {
  *                                          Defaults to showing the URL
  * @return {JSX.Element} The EntitySearch component
  */
-export function EntitySearch( {
-	label,
-	value,
-	onChange,
-	help,
-	suggestionsQuery = {},
-	getDisplayValue = ( suggestion ) => suggestion?.url || '',
-} ) {
-	const [ searchTerm, setSearchTerm ] = useState( '' );
-	const [ suggestions, setSuggestions ] = useState( [] );
-	const [ isLoading, setIsLoading ] = useState( false );
+export const EntitySearch = forwardRef(
+	(
+		{
+			label,
+			value,
+			onChange,
+			help,
+			suggestionsQuery = {},
+			getDisplayValue = ( suggestion ) => suggestion?.url || '',
+		},
+		ref
+	) => {
+		const [ searchTerm, setSearchTerm ] = useState( '' );
+		const [ suggestions, setSuggestions ] = useState( [] );
+		const [ isLoading, setIsLoading ] = useState( false );
+		const inputRef = useRef( null );
 
-	// Get the fetchLinkSuggestions function from block editor settings
-	const fetchLinkSuggestions = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings().__experimentalFetchLinkSuggestions;
-	}, [] );
-
-	// Destructure suggestionsQuery to track actual values instead of object reference
-	const { type, subtype } = suggestionsQuery;
-
-	// Memoize search options to prevent infinite loops from object references
-	const searchOptions = useMemo(
-		() => ( {
-			perPage: 20,
-			type,
-			subtype,
-		} ),
-		[ type, subtype ]
-	);
-
-	// Fetch suggestions only when user has typed something
-	useEffect( () => {
-		// Only fetch if there's a search term
-		if ( ! searchTerm || ! fetchLinkSuggestions ) {
-			setSuggestions( [] );
-			setIsLoading( false );
-			return;
-		}
-
-		setIsLoading( true );
-
-		fetchLinkSuggestions( searchTerm, searchOptions )
-			.then( ( results ) => {
-				setSuggestions( results || [] );
-				setIsLoading( false );
-			} )
-			.catch( () => {
-				setSuggestions( [] );
-				setIsLoading( false );
-			} );
-	}, [ searchTerm, fetchLinkSuggestions, searchOptions ] );
-
-	// Transform suggestions into combobox options
-	const options = useMemo( () => {
-		// Build options from search results
-		const opts = suggestions.map( ( suggestion ) => ( {
-			value: suggestion.url,
-			label: getDisplayValue( suggestion ),
-			suggestion,
+		// Expose select method to parent component
+		useImperativeHandle( ref, () => ( {
+			select: () => {
+				const input = inputRef.current?.querySelector( 'input' );
+				if ( input ) {
+					input.focus();
+					input.select();
+				}
+			},
 		} ) );
 
-		// Add current value as first option when input is empty or matches search
-		if ( value ) {
-			const valueMatchesSearch =
-				! searchTerm ||
-				value.toLowerCase().includes( searchTerm.toLowerCase() );
+		// Get the fetchLinkSuggestions function from block editor settings
+		const fetchLinkSuggestions = useSelect( ( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			return getSettings().__experimentalFetchLinkSuggestions;
+		}, [] );
 
-			// Check if value is already in suggestions to avoid duplicate keys
-			const alreadyInSuggestions = opts.some(
-				( opt ) => opt.value === value
-			);
+		// Destructure suggestionsQuery to track actual values instead of object reference
+		const { type, subtype } = suggestionsQuery;
 
-			if ( valueMatchesSearch && ! alreadyInSuggestions ) {
-				// Add current value at the beginning
-				opts.unshift( {
-					value,
-					label: value,
-					isCurrentValue: true,
-				} );
+		// Memoize search options to prevent infinite loops from object references
+		const searchOptions = useMemo(
+			() => ( {
+				perPage: 20,
+				type,
+				subtype,
+			} ),
+			[ type, subtype ]
+		);
+
+		// Fetch suggestions only when user has typed something
+		useEffect( () => {
+			// Only fetch if there's a search term
+			if ( ! searchTerm || ! fetchLinkSuggestions ) {
+				setSuggestions( [] );
+				setIsLoading( false );
+				return;
 			}
-		}
 
-		// Add freeform option for typed values (when user is actively typing)
-		// This allows Enter/blur to commit whatever the user typed
-		if ( searchTerm ) {
-			// Don't add if it duplicates any existing option
-			const alreadyExists = opts.some(
-				( opt ) => opt.value === searchTerm
-			);
-			if ( ! alreadyExists ) {
-				opts.push( {
-					value: searchTerm,
-					label: searchTerm,
-					isFreeformOption: true,
+			setIsLoading( true );
+
+			fetchLinkSuggestions( searchTerm, searchOptions )
+				.then( ( results ) => {
+					setSuggestions( results || [] );
+					setIsLoading( false );
+				} )
+				.catch( () => {
+					setSuggestions( [] );
+					setIsLoading( false );
 				} );
+		}, [ searchTerm, fetchLinkSuggestions, searchOptions ] );
+
+		// Transform suggestions into combobox options
+		const options = useMemo( () => {
+			// Build options from search results
+			const opts = suggestions.map( ( suggestion ) => ( {
+				value: suggestion.url,
+				label: getDisplayValue( suggestion ),
+				suggestion,
+			} ) );
+
+			// Add current value as first option when input is empty or matches search
+			if ( value ) {
+				const valueMatchesSearch =
+					! searchTerm ||
+					value.toLowerCase().includes( searchTerm.toLowerCase() );
+
+				// Check if value is already in suggestions to avoid duplicate keys
+				const alreadyInSuggestions = opts.some(
+					( opt ) => opt.value === value
+				);
+
+				if ( valueMatchesSearch && ! alreadyInSuggestions ) {
+					// Add current value at the beginning
+					opts.unshift( {
+						value,
+						label: value,
+						isCurrentValue: true,
+					} );
+				}
 			}
-		}
 
-		return opts;
-	}, [ suggestions, getDisplayValue, searchTerm, value ] );
+			// Add freeform option for typed values (when user is actively typing)
+			// This allows Enter/blur to commit whatever the user typed
+			if ( searchTerm ) {
+				// Don't add if it duplicates any existing option
+				const alreadyExists = opts.some(
+					( opt ) => opt.value === searchTerm
+				);
+				if ( ! alreadyExists ) {
+					opts.push( {
+						value: searchTerm,
+						label: searchTerm,
+						isFreeformOption: true,
+					} );
+				}
+			}
 
-	// Debounced search term setter
-	const debouncedSetSearchTerm = useMemo(
-		() =>
-			debounce( ( inputValue ) => {
-				setSearchTerm( inputValue );
-			}, 300 ),
-		[]
-	);
+			return opts;
+		}, [ suggestions, getDisplayValue, searchTerm, value ] );
 
-	// Handle search input changes (NOT debounced for ignore check)
-	const handleFilterValueChange = ( inputValue ) => {
-		// Don't search if input is empty
-		// ComboboxControl clears the input on focus - this is intentional
-		// Just show the current value in options and let user type or select
-		if ( inputValue === '' ) {
-			setSearchTerm( '' );
-			return;
-		}
+		// Debounced search term setter
+		const debouncedSetSearchTerm = useMemo(
+			() =>
+				debounce( ( inputValue ) => {
+					setSearchTerm( inputValue );
+				}, 300 ),
+			[]
+		);
 
-		// Debounce the actual search
-		debouncedSetSearchTerm( inputValue );
-	};
+		// Handle search input changes (NOT debounced for ignore check)
+		const handleFilterValueChange = ( inputValue ) => {
+			// Don't search if input is empty
+			// ComboboxControl clears the input on focus - this is intentional
+			// Just show the current value in options and let user type or select
+			if ( inputValue === '' ) {
+				setSearchTerm( '' );
+				return;
+			}
 
-	// Handle blur to commit typed value
-	const handleBlur = () => {
-		// If user typed something that hasn't been committed, commit it
-		if ( searchTerm && searchTerm !== value ) {
-			onChange( searchTerm );
-		}
-	};
+			// Debounce the actual search
+			debouncedSetSearchTerm( inputValue );
+		};
 
-	return (
-		<>
-			<style>
-				{ `
+		// Handle blur to commit typed value
+		const handleBlur = () => {
+			// If user typed something that hasn't been committed, commit it
+			if ( searchTerm && searchTerm !== value ) {
+				onChange( searchTerm );
+			}
+		};
+
+		return (
+			<>
+				<style>
+					{ `
 					.components-form-token-field__suggestion:has([data-freeform-option]) {
 						display: none !important;
 					}
 				` }
-			</style>
-			<div onBlur={ handleBlur }>
-				<ComboboxControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ label }
-					help={ help }
-					value={ value }
-					options={ options }
-					onFilterValueChange={ handleFilterValueChange }
-					onChange={ ( newValue ) => {
-						// Clear search term when user selects an option
-						setSearchTerm( '' );
+				</style>
+				<div ref={ inputRef } onBlur={ handleBlur }>
+					<ComboboxControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ label }
+						help={ help }
+						value={ value }
+						options={ options }
+						onFilterValueChange={ handleFilterValueChange }
+						onChange={ ( newValue ) => {
+							// Clear search term when user selects an option
+							setSearchTerm( '' );
 
-						// Find the selected option to get the full suggestion data
-						const selectedOption = options.find(
-							( opt ) => opt.value === newValue
-						);
+							// Find the selected option to get the full suggestion data
+							const selectedOption = options.find(
+								( opt ) => opt.value === newValue
+							);
 
-						// If we have suggestion data, pass it along with the URL
-						// This enables entity binding in navigation links
-						if ( selectedOption?.suggestion ) {
-							onChange( newValue, selectedOption.suggestion );
-						} else {
-							onChange( newValue );
-						}
-					} }
-					isLoading={ isLoading }
-					hideLabelFromVision
-					expandOnFocus={ false }
-					placeholder={ __( 'Search or type URL' ) }
-					__experimentalRenderItem={ ( { item } ) => {
-						// Hide the freeform option visually using CSS :has() selector
-						if ( item.isFreeformOption ) {
-							return <div data-freeform-option="true" />;
-						}
+							// If we have suggestion data, pass it along with the URL
+							// This enables entity binding in navigation links
+							if ( selectedOption?.suggestion ) {
+								onChange( newValue, selectedOption.suggestion );
+							} else {
+								onChange( newValue );
+							}
+						} }
+						isLoading={ isLoading }
+						hideLabelFromVision
+						expandOnFocus={ false }
+						placeholder={ __( 'Search or type URL' ) }
+						__experimentalRenderItem={ ( { item } ) => {
+							// Hide the freeform option visually using CSS :has() selector
+							if ( item.isFreeformOption ) {
+								return <div data-freeform-option="true" />;
+							}
 
-						// Only show rich rendering for actual search results
-						const { suggestion } = item;
-						if ( ! suggestion ) {
-							return <div>{ item.label }</div>;
-						}
+							// Only show rich rendering for actual search results
+							const { suggestion } = item;
+							if ( ! suggestion ) {
+								return <div>{ item.label }</div>;
+							}
 
-						const icon = getEntityIcon( suggestion?.type );
-						const displayURL = filterURLForDisplay(
-							suggestion?.url
-						);
+							const icon = getEntityIcon( suggestion?.type );
+							const displayURL = filterURLForDisplay(
+								suggestion?.url
+							);
 
-						return (
-							<div
-								style={ {
-									display: 'flex',
-									alignItems: 'flex-start',
-									gap: '8px',
-									width: '100%',
-								} }
-							>
-								<Icon
-									icon={ icon }
-									style={ { marginTop: '2px' } }
-								/>
-								<div style={ { flex: 1, minWidth: 0 } }>
-									<div>{ suggestion?.title }</div>
-									<div
-										style={ {
-											fontSize: '12px',
-											color: '#757575',
-											marginTop: '2px',
-										} }
-									>
-										{ displayURL }
+							return (
+								<div
+									style={ {
+										display: 'flex',
+										alignItems: 'flex-start',
+										gap: '8px',
+										width: '100%',
+									} }
+								>
+									<Icon
+										icon={ icon }
+										style={ { marginTop: '2px' } }
+									/>
+									<div style={ { flex: 1, minWidth: 0 } }>
+										<div>{ suggestion?.title }</div>
+										<div
+											style={ {
+												fontSize: '12px',
+												color: '#757575',
+												marginTop: '2px',
+											} }
+										>
+											{ displayURL }
+										</div>
 									</div>
 								</div>
-							</div>
-						);
-					} }
-				/>
-			</div>
-		</>
-	);
-}
+							);
+						} }
+					/>
+				</div>
+			</>
+		);
+	}
+);

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -21,7 +21,6 @@ import {
 	forwardRef,
 	useImperativeHandle,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { debounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { page, postList, category, tag } from '@wordpress/icons';
@@ -30,7 +29,6 @@ import { filterURLForDisplay } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
 import './style.scss';
 
 /**
@@ -81,24 +79,22 @@ function getEntityTypeLabel( type ) {
  * EntitySearch component - A combobox for searching and selecting entities.
  *
  * Provides a searchable dropdown that fetches posts, pages, taxonomies, and other
- * entities from the site as the user types. Uses the WordPress search API to search
- * across all post types (including custom) and taxonomies.
+ * entities from the site as the user types.
  *
- * @param {Object}   props                  - Component props
- * @param {string}   props.label            - Label for the control
- * @param {string}   props.value            - Current selected URL value
- * @param {Function} props.onChange         - Callback when selection changes, receives (url, suggestion)
- *                                          - suggestion is the selected entity data when choosing from options,
- *                                          - or null when typing freeform input
- * @param {string}   props.help             - Optional help text
- * @param {Object}   props.suggestionsQuery - Query parameters to filter search results
- *                                          - type: 'post' | 'term' | 'attachment' | 'post-format'
- *                                          - subtype: specific post type or taxonomy slug (e.g., 'page', 'post', 'category', 'post_tag')
- * @param {Function} props.getDisplayValue  - Function to determine what to display in the input field
- *                                          Receives the suggestion object, should return a string
- *                                          Defaults to showing the URL
- * @param {boolean}  props.allowFreeform    - Whether to allow freeform input (not from options) on blur
- *                                          Defaults to true. When false, only values selected from options will be committed
+ * @param {Object}   props                 - Component props
+ * @param {string}   props.label           - Label for the control
+ * @param {string}   props.value           - Current selected URL value
+ * @param {Function} props.onSearch        - Function to fetch suggestions, receives searchTerm and should return a Promise
+ *                                         - Called with empty string for initial suggestions
+ * @param {Function} props.onChange        - Callback when selection changes, receives (url, suggestion)
+ *                                         - suggestion is the selected entity data when choosing from options,
+ *                                         - or null when typing freeform input
+ * @param {string}   props.help            - Optional help text
+ * @param {Function} props.getDisplayValue - Function to determine what to display in the input field
+ *                                         Receives the suggestion object, should return a string
+ *                                         Defaults to showing the URL
+ * @param {boolean}  props.allowFreeform   - Whether to allow freeform input (not from options) on blur
+ *                                         Defaults to true. When false, only values selected from options will be committed
  * @return {JSX.Element} The EntitySearch component
  */
 export const EntitySearch = forwardRef(
@@ -106,9 +102,9 @@ export const EntitySearch = forwardRef(
 		{
 			label,
 			value,
+			onSearch,
 			onChange,
 			help,
-			suggestionsQuery = {},
 			getDisplayValue = ( suggestion ) => suggestion?.url || '',
 			allowFreeform = true,
 		},
@@ -130,37 +126,18 @@ export const EntitySearch = forwardRef(
 			},
 		} ) );
 
-		// Get the fetchLinkSuggestions function from block editor settings
-		const fetchLinkSuggestions = useSelect( ( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			return getSettings().__experimentalFetchLinkSuggestions;
-		}, [] );
-
-		// Destructure suggestionsQuery to track actual values instead of object reference
-		const { type, subtype } = suggestionsQuery;
-
-		// Memoize search options to prevent infinite loops from object references
-		const searchOptions = useMemo(
-			() => ( {
-				perPage: 20,
-				type,
-				subtype,
-			} ),
-			[ type, subtype ]
-		);
-
 		// Create debounced fetch function
 		const debouncedFetch = useMemo(
 			() =>
 				debounce( ( term ) => {
-					if ( ! term || ! fetchLinkSuggestions ) {
+					if ( ! onSearch ) {
 						setSuggestions( [] );
 						setIsLoading( false );
 						return;
 					}
 
 					setIsLoading( true );
-					fetchLinkSuggestions( term, searchOptions )
+					onSearch( term )
 						.then( ( results ) => {
 							setSuggestions( results || [] );
 							setIsLoading( false );
@@ -170,17 +147,11 @@ export const EntitySearch = forwardRef(
 							setIsLoading( false );
 						} );
 				}, 300 ),
-			[ fetchLinkSuggestions, searchOptions ]
+			[ onSearch ]
 		);
 
 		// Trigger fetch when searchTerm changes
 		useEffect( () => {
-			if ( ! searchTerm ) {
-				setSuggestions( [] );
-				setIsLoading( false );
-				debouncedFetch.cancel(); // Cancel any pending debounced calls
-				return;
-			}
 			debouncedFetch( searchTerm );
 		}, [ searchTerm, debouncedFetch ] );
 
@@ -232,7 +203,6 @@ export const EntitySearch = forwardRef(
 					// Freeform input - pass null for suggestion to indicate it's not from options
 					onChange( currentInputValue, null );
 				}
-				// If !allowFreeform and not in options, don't commit (revert to previous value)
 			}
 		};
 
@@ -313,7 +283,7 @@ export const EntitySearch = forwardRef(
 						);
 
 						return (
-							<Flex gap={ 2 } justify="space-between">
+							<Flex gap={ 2 }>
 								<FlexItem>
 									<Icon icon={ icon } />
 								</FlexItem>

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -206,9 +206,13 @@ export const EntitySearch = forwardRef(
 
 		// Handle blur to commit typed value
 		const handleBlur = () => {
+			// Get the actual input value directly from DOM to avoid debounce issues
+			const input = inputRef.current?.querySelector( 'input' );
+			const currentInputValue = input?.value || '';
+
 			// If user typed something that hasn't been committed, commit it
-			if ( searchTerm && searchTerm !== value ) {
-				onChange( searchTerm );
+			if ( currentInputValue && currentInputValue !== value ) {
+				onChange( currentInputValue );
 			}
 		};
 

--- a/packages/block-editor/src/components/entity-search/index.js
+++ b/packages/block-editor/src/components/entity-search/index.js
@@ -174,8 +174,21 @@ export const EntitySearch = forwardRef(
 				} );
 			}
 
+			// Add current search term as a freeform option if it's not in suggestions
+			// This ensures typed text is available immediately for blur/selection
+			if (
+				searchTerm &&
+				searchTerm !== value &&
+				! opts.some( ( opt ) => opt.value === searchTerm )
+			) {
+				opts.unshift( {
+					value: searchTerm,
+					label: searchTerm,
+					isCurrentValue: true,
+				} );
+			}
 			return opts;
-		}, [ suggestions, getDisplayValue, value ] );
+		}, [ suggestions, getDisplayValue, value, searchTerm ] );
 
 		// Handle search input changes - sets search term immediately
 		const handleFilterValueChange = ( inputValue ) => {

--- a/packages/block-editor/src/components/entity-search/style.scss
+++ b/packages/block-editor/src/components/entity-search/style.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
 .entity-search {
 	svg {
 		fill: currentColor;
@@ -13,6 +16,25 @@
 	// Hide the current value from dropdown
 	.entity-search__current-value-hidden {
 		display: none !important;
+	}
+
+	// Style for the URL display (smaller, gray)
+	.entity-search__url,
+	.entity-search__type {
+		color: $gray-700;
+		font-size: $helptext-font-size;
+	}
+
+	.entity-search__type {
+		white-space: nowrap;
+	}
+
+	// When item is selected or hovered, make URL and type white
+	[role="option"][aria-selected="true"] {
+		.entity-search__url,
+		.entity-search__type {
+			color: $white;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/entity-search/style.scss
+++ b/packages/block-editor/src/components/entity-search/style.scss
@@ -1,0 +1,22 @@
+.entity-search {
+	svg {
+		fill: currentColor;
+	}
+
+	&.is-freeform {
+		// Hide the empty (no results found) state when in freeform mode
+		.is-empty {
+			display: none;
+		}
+	}
+
+	// Hide the current value from dropdown
+	.entity-search__current-value-hidden {
+		display: none !important;
+	}
+}
+
+// Target the parent li of the hidden item
+.entity-search .components-form-token-field__suggestion:has(.entity-search__current-value-hidden) {
+	display: none !important;
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -45,6 +45,7 @@ export { default as ColorPaletteControl } from './color-palette/control';
 export { default as ContrastChecker } from './contrast-checker';
 export { default as __experimentalDateFormatPicker } from './date-format-picker';
 export { default as __experimentalDuotoneControl } from './duotone-control';
+export { EntitySearch } from './entity-search';
 export { default as __experimentalFontAppearanceControl } from './font-appearance-control';
 export { default as __experimentalFontFamilyControl } from './font-family';
 export { default as __experimentalLetterSpacingControl } from './letter-spacing-control';

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -11,7 +11,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -108,15 +108,40 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		return getSettings().__experimentalFetchLinkSuggestions;
 	}, [] );
 
-	// Search function for EntitySearch
-	const handleSearch = ( searchTerm ) => {
-		if ( ! fetchLinkSuggestions ) {
-			return Promise.resolve( [] );
-		}
-		return fetchLinkSuggestions( searchTerm, {
-			isInitialSuggestions: ! searchTerm,
-		} );
-	};
+	// Search function for EntitySearch - contextual based on current link type
+	const handleSearch = useCallback(
+		( searchTerm ) => {
+			if ( ! fetchLinkSuggestions ) {
+				return Promise.resolve( [] );
+			}
+
+			// Build query based on current link's entity type
+			const suggestionsQuery = {};
+
+			// If link is bound to an entity, search the same type
+			if ( attributes.kind && attributes.type ) {
+				if ( attributes.kind === 'post-type' ) {
+					suggestionsQuery.type = 'post';
+					suggestionsQuery.subtype = attributes.type; // 'post', 'page', etc.
+				} else if ( attributes.kind === 'taxonomy' ) {
+					suggestionsQuery.type = 'term';
+					// Map attribute type to taxonomy slug (e.g., 'tag' -> 'post_tag')
+					const taxonomyMap = {
+						tag: 'post_tag',
+					};
+					suggestionsQuery.subtype =
+						taxonomyMap[ attributes.type ] || attributes.type;
+				}
+			}
+			// If no entity binding, search all post types (default behavior)
+
+			return fetchLinkSuggestions( searchTerm, {
+				...suggestionsQuery,
+				isInitialSuggestions: ! searchTerm,
+			} );
+		},
+		[ fetchLinkSuggestions, attributes.kind, attributes.type ]
+	);
 
 	// Get direct store dispatch to bypass setBoundAttributes wrapper
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -304,6 +329,13 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						label={ __( 'Link' ) }
 						value={ url }
 						onSearch={ handleSearch }
+						getDisplayValue={ ( suggestion ) => {
+							const title = suggestion?.title || '';
+							const suggestionUrl = suggestion?.url || '';
+							return title && suggestionUrl
+								? `${ title } ${ suggestionUrl }`
+								: title || suggestionUrl;
+						} }
 						onChange={ ( newUrl, suggestion ) => {
 							// If we have suggestion data (entity selected from search),
 							// pass the entity information to enable binding

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -16,7 +16,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { linkOff as unlinkIcon } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as blockEditorStore,
 	EntitySearch,
@@ -101,6 +101,22 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		clientId,
 		attributes,
 	} );
+
+	// Get fetchLinkSuggestions from block editor settings
+	const fetchLinkSuggestions = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().__experimentalFetchLinkSuggestions;
+	}, [] );
+
+	// Search function for EntitySearch
+	const handleSearch = ( searchTerm ) => {
+		if ( ! fetchLinkSuggestions ) {
+			return Promise.resolve( [] );
+		}
+		return fetchLinkSuggestions( searchTerm, {
+			isInitialSuggestions: ! searchTerm,
+		} );
+	};
 
 	// Get direct store dispatch to bypass setBoundAttributes wrapper
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -287,6 +303,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						ref={ urlInputRef }
 						label={ __( 'Link' ) }
 						value={ url }
+						onSearch={ handleSearch }
 						onChange={ ( newUrl, suggestion ) => {
 							// If we have suggestion data (entity selected from search),
 							// pass the entity information to enable binding

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -17,7 +17,10 @@ import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { linkOff as unlinkIcon } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	EntitySearch,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -159,105 +162,126 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<InputControl
-					ref={ urlInputRef }
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					id={ inputId }
-					label={ __( 'Link' ) }
-					value={ ( () => {
-						if ( hasUrlBinding && ! isBoundEntityAvailable ) {
-							return '';
+				{ hasUrlBinding ? (
+					<InputControl
+						ref={ urlInputRef }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						id={ inputId }
+						label={ __( 'Link' ) }
+						value={ ( () => {
+							if ( hasUrlBinding && ! isBoundEntityAvailable ) {
+								return '';
+							}
+							return inputValue
+								? safeDecodeURI( inputValue )
+								: '';
+						} )() }
+						autoComplete="off"
+						type="url"
+						disabled={ hasUrlBinding }
+						aria-invalid={
+							hasUrlBinding && ! isBoundEntityAvailable
+								? 'true'
+								: undefined
 						}
-						return inputValue ? safeDecodeURI( inputValue ) : '';
-					} )() }
-					autoComplete="off"
-					type="url"
-					disabled={ hasUrlBinding }
-					aria-invalid={
-						hasUrlBinding && ! isBoundEntityAvailable
-							? 'true'
-							: undefined
-					}
-					aria-describedby={ helpTextId }
-					className={
-						hasUrlBinding && ! isBoundEntityAvailable
-							? 'navigation-link-control__input-with-error-suffix'
-							: undefined
-					}
-					onChange={ ( newValue ) => {
-						if ( isBoundEntityAvailable ) {
-							return;
+						aria-describedby={ helpTextId }
+						className={
+							hasUrlBinding && ! isBoundEntityAvailable
+								? 'navigation-link-control__input-with-error-suffix'
+								: undefined
 						}
+						onChange={ ( newValue ) => {
+							if ( isBoundEntityAvailable ) {
+								return;
+							}
 
-						// Defer updating the url attribute until onBlur to prevent the canvas from
-						// treating a temporary empty value as a committed value, which replaces the
-						// label with placeholder text.
-						setInputValue( newValue );
-					} }
-					onFocus={ () => {
-						if ( isBoundEntityAvailable ) {
-							return;
-						}
-						lastURLRef.current = url;
-					} }
-					onBlur={ () => {
-						if ( isBoundEntityAvailable ) {
-							return;
-						}
+							// Defer updating the url attribute until onBlur to prevent the canvas from
+							// treating a temporary empty value as a committed value, which replaces the
+							// label with placeholder text.
+							setInputValue( newValue );
+						} }
+						onFocus={ () => {
+							if ( isBoundEntityAvailable ) {
+								return;
+							}
+							lastURLRef.current = url;
+						} }
+						onBlur={ () => {
+							if ( isBoundEntityAvailable ) {
+								return;
+							}
 
-						const finalValue = ! inputValue
-							? lastURLRef.current
-							: inputValue;
+							const finalValue = ! inputValue
+								? lastURLRef.current
+								: inputValue;
 
-						// Update local state immediately so input reflects the reverted value if the value was cleared
-						setInputValue( finalValue );
+							// Update local state immediately so input reflects the reverted value if the value was cleared
+							setInputValue( finalValue );
 
-						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
-						updateAttributes( { url: finalValue }, setAttributes, {
-							...attributes,
-							url: lastURLRef.current,
-						} );
-					} }
-					help={
-						hasUrlBinding && ! isBoundEntityAvailable ? (
-							<MissingEntityHelp
-								id={ helpTextId }
-								type={ attributes.type }
-								kind={ attributes.kind }
-							/>
-						) : (
-							isBoundEntityAvailable && (
-								<BindingHelpText
+							// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
+							updateAttributes(
+								{ url: finalValue },
+								setAttributes,
+								{
+									...attributes,
+									url: lastURLRef.current,
+								}
+							);
+						} }
+						help={
+							hasUrlBinding && ! isBoundEntityAvailable ? (
+								<MissingEntityHelp
+									id={ helpTextId }
 									type={ attributes.type }
 									kind={ attributes.kind }
 								/>
+							) : (
+								isBoundEntityAvailable && (
+									<BindingHelpText
+										type={ attributes.type }
+										kind={ attributes.kind }
+									/>
+								)
 							)
-						)
-					}
-					suffix={
-						hasUrlBinding && (
-							<Button
-								icon={ unlinkIcon }
-								onClick={ () => {
-									unsyncBoundLink();
-									// Focus management to send focus to the URL input
-									// on next render after disabled state is removed.
-									shouldFocusURLInputRef.current = true;
-								} }
-								aria-describedby={ helpTextId }
-								showTooltip
-								label={ __( 'Unsync and edit' ) }
-								__next40pxDefaultSize
-								className={
-									hasUrlBinding && ! isBoundEntityAvailable
-										? 'navigation-link-control__error-suffix-button'
-										: undefined
-								}
-							/>
-						)
-					}
-				/>
+						}
+						suffix={
+							hasUrlBinding && (
+								<Button
+									icon={ unlinkIcon }
+									onClick={ () => {
+										unsyncBoundLink();
+										// Focus management to send focus to the URL input
+										// on next render after disabled state is removed.
+										shouldFocusURLInputRef.current = true;
+									} }
+									aria-describedby={ helpTextId }
+									showTooltip
+									label={ __( 'Unsync and edit' ) }
+									__next40pxDefaultSize
+									className={
+										hasUrlBinding &&
+										! isBoundEntityAvailable
+											? 'navigation-link-control__error-suffix-button'
+											: undefined
+									}
+								/>
+							)
+						}
+					/>
+				) : (
+					<EntitySearch
+						label={ __( 'Link' ) }
+						value={ url }
+						onChange={ ( newUrl ) => {
+							updateAttributes(
+								{ url: newUrl },
+								setAttributes,
+								attributes
+							);
+						} }
+					/>
+				) }
 			</ToolsPanelItem>
 
 			<ToolsPanelItem

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -90,11 +90,15 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	}, [ url ] );
 
 	// Use the entity binding hook internally
-	const { hasUrlBinding, isBoundEntityAvailable, clearBinding } =
-		useEntityBinding( {
-			clientId,
-			attributes,
-		} );
+	const {
+		hasUrlBinding,
+		isBoundEntityAvailable,
+		clearBinding,
+		createBinding,
+	} = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
 
 	// Get direct store dispatch to bypass setBoundAttributes wrapper
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -273,12 +277,29 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 					<EntitySearch
 						label={ __( 'Link' ) }
 						value={ url }
-						onChange={ ( newUrl ) => {
+						onChange={ ( newUrl, suggestion ) => {
+							// If we have suggestion data (entity selected from search),
+							// pass the entity information to enable binding
+							const attrs = suggestion
+								? {
+										url: newUrl,
+										id: suggestion.id,
+										kind: suggestion.kind,
+										type: suggestion.type,
+										title: suggestion.title,
+								  }
+								: { url: newUrl };
+
 							updateAttributes(
-								{ url: newUrl },
+								attrs,
 								setAttributes,
 								attributes
 							);
+
+							// Create entity binding if we have entity data
+							if ( suggestion ) {
+								createBinding( attrs );
+							}
 						} }
 					/>
 				) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -76,7 +76,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const urlInputRef = useRef();
+	const unsyncButtonRef = useRef();
 	const shouldFocusURLInputRef = useRef( false );
+	const shouldFocusUnsyncButtonRef = useRef( false );
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
@@ -119,13 +121,19 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	};
 
 	useEffect( () => {
-		// Only want to focus the input if the url is not bound to an entity.
+		// Focus the input when unsyncing (binding removed)
 		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
 			// focuses and highlights the url input value, giving the user
 			// the ability to delete the value quickly or edit it.
 			urlInputRef.current?.select();
+			shouldFocusURLInputRef.current = false;
 		}
-		shouldFocusURLInputRef.current = false;
+
+		// Focus the unsync button when binding is created
+		if ( hasUrlBinding && shouldFocusUnsyncButtonRef.current ) {
+			unsyncButtonRef.current?.focus();
+			shouldFocusUnsyncButtonRef.current = false;
+		}
 	}, [ hasUrlBinding ] );
 
 	return (
@@ -252,6 +260,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						suffix={
 							hasUrlBinding && (
 								<Button
+									ref={ unsyncButtonRef }
 									icon={ unlinkIcon }
 									onClick={ () => {
 										unsyncBoundLink();
@@ -275,6 +284,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 					/>
 				) : (
 					<EntitySearch
+						ref={ urlInputRef }
 						label={ __( 'Link' ) }
 						value={ url }
 						onChange={ ( newUrl, suggestion ) => {
@@ -299,6 +309,8 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 							// Create entity binding if we have entity data
 							if ( suggestion ) {
 								createBinding( attrs );
+								// Focus the unsync button after binding is created
+								shouldFocusUnsyncButtonRef.current = true;
 							}
 						} }
 					/>

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -336,6 +336,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 								? `${ title } ${ suggestionUrl }`
 								: title || suggestionUrl;
 						} }
+						shouldShowType={
+							! ( attributes.kind && attributes.type )
+						}
 						onChange={ ( newUrl, suggestion ) => {
 							// If we have suggestion data (entity selected from search),
 							// pass the entity information to enable binding

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -252,7 +252,9 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	};
 
 	const onClick = () => {
-		setIsExpanded( true );
+		if ( expandOnFocus ) {
+			setIsExpanded( true );
+		}
 	};
 
 	const onFocusOutside = () => {

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -48,7 +48,6 @@ export type ComboboxControlProps = Pick<
 	allowReset?: boolean;
 	/**
 	 * Automatically expand the dropdown when the control is focused.
-	 * If the control is clicked, the dropdown will expand regardless of this prop.
 	 *
 	 * @default true
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Alternate approach to https://github.com/WordPress/gutenberg/pull/71457 and https://github.com/WordPress/gutenberg/pull/71452
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/73310

<!-- In a few words, what is the PR actually doing? -->
Adds a generic entity search component using the `<ComboboxControl/>`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Add a link search to the inspector sidebar. I wanted to see how it might work using the combobox instead of extracting the link ui search. The LinkUI search is pretty bound to the popover, so I wanted to see how it might work.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Create a new component called `<EntitySearch />` and build out similar functionality to the LinkControl search

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
