### PR TITLE
DataViews: update docs for `layout` prop

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,12 +5,13 @@
 ### Enhancements
 
 - DataViews table layout: make checkboxes permanently visible when bulk actions are available. [#73245](https://github.com/WordPress/gutenberg/pull/73245)
-- Documentation: surface better the `type` property in the documentation. [#73349](https://github.com/WordPress/gutenberg/pull/73349)
 - DataViews: Make sticky elements (table headers, footer, actions column) inherit background colors from parent container. This allows DataViews instances to seamlessly adapt to containers with custom background colors. [#73240](https://github.com/WordPress/gutenberg/pull/73240)
 - DataViews table layout: only apply hover styles when bulk actions are available. [#73248](https://github.com/WordPress/gutenberg/pull/73248)
-- Improve docs for Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
-- Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 - DataViews: add support for activity layout. [#72780](https://github.com/WordPress/gutenberg/pull/72780)
+- Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
+- Documentation: improve Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
+- Documentation: surface better the `type` property in the documentation. [#73349](https://github.com/WordPress/gutenberg/pull/73349)
+- Documentation: improve DataView's `layout` prop. [#73470](https://github.com/WordPress/gutenberg/pull/73470/)
 
 ### Bug fixes
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Field API: introduce the `format` prop to format the `date` field type. [#72999](https://github.com/WordPress/gutenberg/pull/72999)
 - Documentation: improve Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Documentation: surface better the `type` property in the documentation. [#73349](https://github.com/WordPress/gutenberg/pull/73349)
-- Documentation: improve DataView's `layout` prop. [#73470](https://github.com/WordPress/gutenberg/pull/73470/)
+- Documentation: improve DataView's `layout` prop. [#73470](https://github.com/WordPress/gutenberg/pull/73470)
 
 ### Bug fixes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -237,6 +237,9 @@ Properties:
 - `enableMoving`: whether the table columns should display moving controls.
 - `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column.
 
+**For column alignment (`align` property), follow these guidelines:**
+Right-align whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment for all other types (text, codes, labels, dates).
+
 `grid` and `pickerGrid` layout:
 
 - `badgeFields`: a list of field's `id` to render without label and styled as badges.
@@ -250,8 +253,6 @@ Properties:
 
 - `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
 
-**For column alignment (`align` property), follow these guidelines:**
-Right-align whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment for all other types (text, codes, labels, dates).
 
 #### `onChangeView`: `function`
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -223,10 +223,32 @@ Properties:
 
 ##### Properties of `layout`
 
-| Properties of `layout`                                                                      | Table | Grid | List |
-| ------------------------------------------------------------------------------------------- | ----- | ---- | ---- |
-| `badgeFields`: a list of field's `id` to render without label and styled as badges.         |       | ✓    |      |
-| `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column. | ✓     |      |      |
+| Props / Layout | `table` | `pickerTable` | `grid` | `pickerGrid` | `list` | `activity` |
+| -------------- | ------- | ------------- | ------ | ------------ | ------ | ---------- |
+| `density`      | ✓       | ✓             |        |	             |        | ✓          |
+| `enableMoving` | ✓       | ✓             |        |	             |        |            |
+| `styles`       | ✓       | ✓             |        |	             |        |            |
+| `badgeFields`  |         |               | ✓      | ✓            |        |            |
+| `previewSize`  |         |               | ✓      | ✓            |        |            |
+
+`table` and `pickerTable` layouts:
+
+- `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
+- `enableMoving`: whether the table columns should display moving controls.
+- `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column.
+
+`grid` and `pickerGrid` layout:
+
+- `badgeFields`: a list of field's `id` to render without label and styled as badges.
+- `previewSize`: a `number` representing the size of the preview.
+
+`list` layout:
+
+- None
+
+`activity` layout:
+
+- `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
 
 **For column alignment (`align` property), follow these guidelines:**
 Right-align whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment for all other types (text, codes, labels, dates).


### PR DESCRIPTION
## What?

This PR updates the documentation for the `layout` prop.

## Why?

There were some missing props.
