### PR TITLE
Automated Testing: Update JSDOM to v27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
 				"glob": "7.1.2",
 				"husky": "7.0.0",
 				"jest": "29.6.2",
-				"jest-environment-jsdom": "^29.6.2",
+				"jest-environment-jsdom": "^30.2.0",
 				"jest-jasmine2": "29.6.2",
 				"jest-junit": "13.0.0",
 				"jest-message-util": "29.6.2",
@@ -172,6 +172,12 @@
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
+		},
+		"node_modules/@acemir/cssom": {
+			"version": "0.9.23",
+			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.23.tgz",
+			"integrity": "sha512-2kJ1HxBKzPLbmhZpxBiTZggjtgCwKg1ma5RHShxvd6zgqhDEdEkzpiwe7jLkI2p2BrZvFCXIihdoMkl1H39VnA==",
+			"license": "MIT"
 		},
 		"node_modules/@actions/core": {
 			"version": "1.9.1",
@@ -1469,6 +1475,84 @@
 				}
 			}
 		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
+			"integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.4",
+				"@csstools/css-color-parser": "^3.1.0",
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"lru-cache": "^11.2.2"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "11.2.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "6.7.4",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.4.tgz",
+			"integrity": "sha512-buQDjkm+wDPXd6c13534URWZqbz0RP5PAhXZ+LIoa5LgwInT9HVJvGIJivg75vi8I13CxDGdTnz+aY5YUJlIAA==",
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.1.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.2.2"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+			"version": "11.2.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"license": "CC0-1.0"
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"license": "MIT"
+		},
 		"node_modules/@axe-core/puppeteer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.0.0.tgz",
@@ -1484,13 +1568,14 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.9.tgz",
-			"integrity": "sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.25.9",
-				"picocolors": "^1.0.0"
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2081,9 +2166,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2150,47 +2235,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
-			"integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/parser": {
@@ -4272,10 +4316,10 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.1.tgz",
-			"integrity": "sha512-lSquqZCHxDfuTg/Sk2hiS0mcSFCEBuj49JfzPHJogDBT0mGCyY5A1AQzBWngitrp7i1/HAZpIgzF/VjhOEIJIg==",
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
 			"funding": [
 				{
 					"type": "github",
@@ -4286,17 +4330,38 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.1"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
-		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.1.tgz",
-			"integrity": "sha512-UBqaiu7kU0lfvaP982/o3khfXccVlHPWp0/vwwiIgDF0GmqqqxoiXC/6FCjlS9u92f7CoEz6nXKQnrn1kIAkOw==",
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
 			"funding": [
 				{
 					"type": "github",
@@ -4307,6 +4372,75 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.16.tgz",
+			"integrity": "sha512-2SpS4/UaWQaGpBINyG5ZuCHnUDeVByOhvbkARwfmnfxDvTaj80yOI1cD8Tw93ICV5Fx4fnyDKWQZI1CDtcWyUg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -5965,6 +6099,257 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
+			"integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.2.0",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-mock": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+			"version": "0.34.41",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+			"integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+			"license": "MIT"
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT"
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jest/expect": {
 			"version": "29.6.2",
 			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.2.tgz",
@@ -6035,6 +6420,28 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern/node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
@@ -12451,9 +12858,10 @@
 			}
 		},
 		"node_modules/@sinonjs/commons": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-			"integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
@@ -15372,9 +15780,10 @@
 			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-report": {
 			"version": "3.0.0",
@@ -15385,9 +15794,10 @@
 			}
 		},
 		"node_modules/@types/istanbul-reports": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-			"integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
@@ -15403,9 +15813,10 @@
 			}
 		},
 		"node_modules/@types/jsdom": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
@@ -15751,9 +16162,10 @@
 			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"license": "MIT"
 		},
 		"node_modules/@types/supports-color": {
 			"version": "8.1.1",
@@ -15787,9 +16199,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/tough-cookie": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-			"integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/triple-beam": {
 			"version": "1.3.3",
@@ -20210,6 +20623,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
+		},
 		"node_modules/big-integer": {
 			"version": "1.6.51",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -23832,14 +24254,45 @@
 			}
 		},
 		"node_modules/cssstyle": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
-			"integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
+			"integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
+			"license": "MIT",
 			"dependencies": {
-				"rrweb-cssom": "^0.7.1"
+				"@asamuzakjp/css-color": "^4.0.3",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+				"css-tree": "^3.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			}
+		},
+		"node_modules/cssstyle/node_modules/css-tree": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/cssstyle/node_modules/mdn-data": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"license": "CC0-1.0"
+		},
+		"node_modules/cssstyle/node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/csstype": {
@@ -23899,46 +24352,50 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+			"integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0"
+				"whatwg-url": "^15.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/data-urls/node_modules/tr46": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-			"integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/data-urls/node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/data-urls/node_modules/whatwg-url": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-			"integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+			"license": "MIT",
 			"dependencies": {
-				"tr46": "^5.0.0",
-				"webidl-conversions": "^7.0.0"
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/date-fns": {
@@ -24021,9 +24478,10 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT"
 		},
 		"node_modules/decode-uri-component": {
 			"version": "0.2.2",
@@ -29179,6 +29637,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -29491,6 +29950,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
 			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-encoding": "^3.1.1"
 			},
@@ -30761,7 +31221,8 @@
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
@@ -31528,29 +31989,251 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom": {
-			"version": "29.6.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.6.2.tgz",
-			"integrity": "sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
+			"integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.6.2",
-				"@jest/fake-timers": "^29.6.2",
-				"@jest/types": "^29.6.1",
-				"@types/jsdom": "^20.0.0",
+				"@jest/environment": "30.2.0",
+				"@jest/environment-jsdom-abstract": "30.2.0",
+				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"jest-mock": "^29.6.2",
-				"jest-util": "^29.6.2",
-				"jsdom": "^20.0.0"
+				"jsdom": "^26.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"canvas": "^2.5.0"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-mock": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+			"version": "0.34.41",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+			"integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+			"license": "MIT"
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT"
+		},
+		"node_modules/jest-environment-jsdom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/jest-environment-node": {
@@ -32241,37 +32924,37 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "25.0.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+			"version": "27.2.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
+			"integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
+			"license": "MIT",
 			"dependencies": {
-				"cssstyle": "^4.1.0",
-				"data-urls": "^5.0.0",
-				"decimal.js": "^10.4.3",
-				"form-data": "^4.0.0",
+				"@acemir/cssom": "^0.9.23",
+				"@asamuzakjp/dom-selector": "^6.7.4",
+				"cssstyle": "^5.3.3",
+				"data-urls": "^6.0.0",
+				"decimal.js": "^10.6.0",
 				"html-encoding-sniffer": "^4.0.0",
 				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.5",
+				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.12",
-				"parse5": "^7.1.2",
-				"rrweb-cssom": "^0.7.1",
+				"parse5": "^8.0.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^5.0.0",
+				"tough-cookie": "^6.0.0",
 				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^7.0.0",
+				"webidl-conversions": "^8.0.0",
 				"whatwg-encoding": "^3.1.1",
 				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0",
-				"ws": "^8.18.0",
+				"whatwg-url": "^15.1.0",
+				"ws": "^8.18.3",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"canvas": "^2.11.2"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
@@ -32288,53 +32971,68 @@
 				"querystring": "^0.2.0"
 			}
 		},
-		"node_modules/jsdom/node_modules/https-proxy-agent": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">= 14"
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/jsdom/node_modules/tr46": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-			"integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/jsdom/node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/jsdom/node_modules/whatwg-url": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-			"integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+			"license": "MIT",
 			"dependencies": {
-				"tr46": "^5.0.0",
-				"webidl-conversions": "^7.0.0"
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/jsdom/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -38297,11 +38995,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/nwsapi": {
-			"version": "2.2.13",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
-			"integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ=="
-		},
 		"node_modules/nx": {
 			"version": "20.2.1",
 			"resolved": "https://registry.npmjs.org/nx/-/nx-20.2.1.tgz",
@@ -39805,20 +40498,22 @@
 			}
 		},
 		"node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
 			"dependencies": {
-				"entities": "^4.4.0"
+				"entities": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/parse5/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -43705,11 +44400,6 @@
 			"integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
 			"license": "MIT"
 		},
-		"node_modules/rrweb-cssom": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
-		},
 		"node_modules/rtlcss": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -44601,6 +45291,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
 			"dependencies": {
 				"xmlchars": "^2.2.0"
 			},
@@ -46083,9 +46774,10 @@
 			}
 		},
 		"node_modules/stack-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
 			},
@@ -47046,6 +47738,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -47175,7 +47868,8 @@
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"license": "MIT"
 		},
 		"node_modules/sync-child-process": {
 			"version": "1.0.2",
@@ -47864,11 +48558,12 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.50",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.50.tgz",
-			"integrity": "sha512-q9GOap6q3KCsLMdOjXhWU5jVZ8/1dIib898JBRLsN+tBhENpBDcAVQbE0epADOjw11FhQQy9AcbqKGBQPUfTQA==",
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.18.tgz",
+			"integrity": "sha512-lCcgTAgMxQ1JKOWrVGo6E69Ukbnx4Gc1wiYLRf6J5NN4HRYJtCby1rPF8rkQ4a6qqoFBK5dvjJ1zJ0F7VfDSvw==",
+			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.50"
+				"tldts-core": "^7.0.18"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
@@ -47888,6 +48583,12 @@
 			"dependencies": {
 				"tldts-core": "^6.1.66"
 			}
+		},
+		"node_modules/tldts/node_modules/tldts-core": {
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.18.tgz",
+			"integrity": "sha512-jqJC13oP4FFAahv4JT/0WTDrCF9Okv7lpKtOZUGPLiAnNbACcSg8Y8T+Z9xthOmRBqi/Sob4yi0TE0miRCvF7Q==",
+			"license": "MIT"
 		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
@@ -48029,11 +48730,12 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"tldts": "^6.1.32"
+				"tldts": "^7.0.5"
 			},
 			"engines": {
 				"node": ">=16"
@@ -49312,6 +50014,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
 			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
 			"dependencies": {
 				"xml-name-validator": "^5.0.0"
 			},
@@ -51203,6 +51906,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
 			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"license": "MIT",
 			"dependencies": {
 				"iconv-lite": "0.6.3"
 			},
@@ -51219,6 +51923,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
 			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -51724,6 +52429,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
 			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
 			}
@@ -51740,7 +52446,8 @@
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT"
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -55084,7 +55791,7 @@
 				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
 				"jest-dev-server": "^10.1.4",
-				"jest-environment-jsdom": "^29.6.2",
+				"jest-environment-jsdom": "^30.2.0",
 				"jest-environment-node": "^29.6.2",
 				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"glob": "7.1.2",
 		"husky": "7.0.0",
 		"jest": "29.6.2",
-		"jest-environment-jsdom": "^29.6.2",
+		"jest-environment-jsdom": "^30.2.0",
 		"jest-jasmine2": "29.6.2",
 		"jest-junit": "13.0.0",
 		"jest-message-util": "29.6.2",
@@ -191,7 +191,7 @@
 		"webpack-bundle-analyzer": "4.9.1"
 	},
 	"overrides": {
-		"jsdom": "25.0.1"
+		"jsdom": "27.2.0"
 	},
 	"scripts": {
 		"build": "node ./bin/build.mjs",

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1560,7 +1560,7 @@ describe( 'Selecting links', () => {
 			name: 'Manage link',
 		} );
 		const currentLinkAnchor = screen.getByRole( 'link', {
-			name: `${ selectedLink.title } (opens in a new tab)`,
+			name: `${ selectedLink.title }(opens in a new tab)`,
 		} );
 
 		expect( currentLink ).toBeVisible();
@@ -1661,7 +1661,7 @@ describe( 'Selecting links', () => {
 				await user.click( firstSearchSuggestion );
 
 				const currentLinkAnchor = screen.getByRole( 'link', {
-					name: `${ selectedLink.title } (opens in a new tab)`,
+					name: `${ selectedLink.title }(opens in a new tab)`,
 				} );
 
 				// Check that this suggestion is now shown as selected.
@@ -1770,7 +1770,7 @@ describe( 'Selecting links', () => {
 					name: 'Manage link',
 				} );
 				const currentLinkAnchor = screen.getByRole( 'link', {
-					name: `${ selectedLink.title } (opens in a new tab)`,
+					name: `${ selectedLink.title }(opens in a new tab)`,
 				} );
 
 				// Make sure focus is retained after submission.
@@ -2735,7 +2735,7 @@ describe( 'Entity handling', () => {
 
 		// Click on a different entity suggestion
 		const differentSuggestion = screen.getByRole( 'option', {
-			name: 'Different Page /different-page Page',
+			name: 'Different Page/different-pagePage',
 		} );
 		await user.click( differentSuggestion );
 

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -75,7 +75,7 @@ describe( 'General media replace flow', () => {
 		);
 
 		const link = screen.getByRole( 'link', {
-			name: 'example.media (opens in a new tab)',
+			name: 'example.media(opens in a new tab)',
 		} );
 
 		await waitFor( () => expect( link ).toBePositionedPopover() );
@@ -98,7 +98,7 @@ describe( 'General media replace flow', () => {
 		await waitFor( () =>
 			expect(
 				screen.getByRole( 'link', {
-					name: 'example.media (opens in a new tab)',
+					name: 'example.media(opens in a new tab)',
 				} )
 			).toBePositionedPopover()
 		);
@@ -125,7 +125,7 @@ describe( 'General media replace flow', () => {
 
 		expect(
 			screen.getByRole( 'link', {
-				name: 'new.example.media (opens in a new tab)',
+				name: 'new.example.media(opens in a new tab)',
 			} )
 		).toHaveAttribute( 'href', 'https://new.example.media' );
 	} );

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -82,7 +82,7 @@ describe( 'Basic rendering', () => {
 		} );
 
 		const defaultControl = screen.getByRole( 'combobox', {
-			name: 'All Controls the padding property for All viewports.',
+			name: 'AllControls the padding property for All viewports.',
 		} );
 
 		const toggleState = screen.getByRole( 'checkbox', {
@@ -169,7 +169,7 @@ describe( 'Basic rendering', () => {
 		);
 
 		const defaultControlLabel = screen.getByRole( 'combobox', {
-			name: 'Everything Controls the padding property for Everything viewports.',
+			name: 'EverythingControls the padding property for Everything viewports.',
 		} );
 
 		expect( defaultControlLabel ).toBeVisible();
@@ -235,7 +235,7 @@ describe( 'Default and Responsive modes', () => {
 		customViewportSet.forEach( ( { label } ) => {
 			responsiveViewportsLabels.push(
 				screen.getByRole( 'combobox', {
-					name: `${ label } Controls the padding property for ${ label } viewports.`,
+					name: `${ label }Controls the padding property for ${ label } viewports.`,
 				} )
 			);
 		} );

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -121,10 +121,10 @@ Snapshot Diff:
 @@ -1,9 +1,8 @@
   Array [
     Object {
-      "background-color": "#fff",
--     "border-radius": "calc(8px - 1px)",
+      "background-color": "rgb(255, 255, 255)",
+-     "border-radius": "calc(7px)",
       "box-shadow": "0 0 0 1px rgba(0, 0, 0, 0.1)",
-      "color": "#1e1e1e",
+      "color": "rgb(30, 30, 30)",
       "outline": "none",
       "position": "relative",
     },

--- a/packages/components/src/divider/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/divider/test/__snapshots__/index.tsx.snap
@@ -23,14 +23,20 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -2,8 +2,10 @@
-    Object {
-      "border": "0",
-      "border-bottom": "1px solid currentColor",
-      "height": "0",
-      "margin": "0",
-+     "margin-bottom": "calc(4px * 7)",
-+     "margin-top": "calc(4px * 7)",
+@@ -19,13 +19,13 @@
+      "border-top-color": "currentcolor",
+      "border-top-style": "none",
+      "border-top-width": "0px",
+      "border-width": "0px 0px 1px",
+      "height": "0px",
+-     "margin": "0px",
+-     "margin-bottom": "0px",
++     "margin": "calc(28px) 0px",
++     "margin-bottom": "calc(28px)",
+      "margin-left": "0px",
+      "margin-right": "0px",
+-     "margin-top": "0px",
++     "margin-top": "calc(28px)",
       "width": "auto",
     },
   ]
@@ -41,16 +47,21 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -2,8 +2,9 @@
-    Object {
-      "border": "0",
-      "border-bottom": "1px solid currentColor",
-      "height": "0",
-      "margin": "0",
-+     "margin-bottom": "calc(4px * 5)",
+@@ -19,12 +19,12 @@
+      "border-top-color": "currentcolor",
+      "border-top-style": "none",
+      "border-top-width": "0px",
+      "border-width": "0px 0px 1px",
+      "height": "0px",
+-     "margin": "0px",
+-     "margin-bottom": "0px",
++     "margin": "0px 0px calc(20px)",
++     "margin-bottom": "calc(20px)",
+      "margin-left": "0px",
+      "margin-right": "0px",
+      "margin-top": "0px",
       "width": "auto",
     },
-  ]
 `;
 
 exports[`props should render marginStart 1`] = `
@@ -58,13 +69,19 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -2,8 +2,9 @@
-    Object {
-      "border": "0",
-      "border-bottom": "1px solid currentColor",
-      "height": "0",
-      "margin": "0",
-+     "margin-top": "calc(4px * 5)",
+@@ -19,13 +19,13 @@
+      "border-top-color": "currentcolor",
+      "border-top-style": "none",
+      "border-top-width": "0px",
+      "border-width": "0px 0px 1px",
+      "height": "0px",
+-     "margin": "0px",
++     "margin": "calc(20px) 0px 0px",
+      "margin-bottom": "0px",
+      "margin-left": "0px",
+      "margin-right": "0px",
+-     "margin-top": "0px",
++     "margin-top": "calc(20px)",
       "width": "auto",
     },
   ]

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -21,7 +21,7 @@ describe( 'ExternalLink', () => {
 		);
 
 		const link = screen.getByRole( 'link', {
-			name: 'WordPress.org (opens in a new tab)',
+			name: 'WordPress.org(opens in a new tab)',
 		} );
 
 		await user.click( link );
@@ -37,7 +37,7 @@ describe( 'ExternalLink', () => {
 		);
 
 		const link = screen.getByRole( 'link', {
-			name: "I'm an anchor link! (opens in a new tab)",
+			name: "I'm an anchor link!(opens in a new tab)",
 		} );
 
 		// We are using this approach so we can test the defaultPrevented
@@ -63,7 +63,7 @@ describe( 'ExternalLink', () => {
 		);
 
 		const link = screen.getByRole( 'link', {
-			name: "I'm an anchor link! (opens in a new tab)",
+			name: "I'm an anchor link!(opens in a new tab)",
 		} );
 
 		await user.click( link );
@@ -83,7 +83,7 @@ describe( 'ExternalLink', () => {
 		);
 
 		const link = screen.getByRole( 'link', {
-			name: "I'm not an anchor link! (opens in a new tab)",
+			name: "I'm not an anchor link!(opens in a new tab)",
 		} );
 
 		// We are using this approach so we can test the defaultPrevented

--- a/packages/components/src/flex/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/flex/test/__snapshots__/index.tsx.snap
@@ -36,24 +36,14 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -1,15 +1,15 @@
+@@ -1,8 +1,8 @@
   Array [
     Object {
--     "-ms-flex-align": "flex-start",
-+     "-ms-flex-align": "center",
-      "-ms-flex-direction": "row",
--     "-webkit-align-items": "flex-start",
--     "-webkit-box-align": "flex-start",
-+     "-webkit-align-items": "center",
-+     "-webkit-box-align": "center",
-      "-webkit-box-pack": "justify",
-      "-webkit-flex-direction": "row",
-      "-webkit-justify-content": "space-between",
 -     "align-items": "flex-start",
 +     "align-items": "center",
       "display": "flex",
       "flex-direction": "row",
-      "gap": "calc(4px * 2)",
+      "gap": "calc(8px)",
       "justify-content": "space-between",
       "width": "100%",
 `;
@@ -129,22 +119,12 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-  Array [
+@@ -2,9 +2,9 @@
     Object {
-      "-ms-flex-align": "center",
-      "-ms-flex-direction": "row",
--     "-ms-flex-pack": "start",
-      "-webkit-align-items": "center",
-      "-webkit-box-align": "center",
--     "-webkit-box-pack": "start",
-+     "-webkit-box-pack": "justify",
-      "-webkit-flex-direction": "row",
--     "-webkit-justify-content": "flex-start",
-+     "-webkit-justify-content": "space-between",
       "align-items": "center",
       "display": "flex",
       "flex-direction": "row",
-      "gap": "calc(4px * 2)",
+      "gap": "calc(8px)",
 -     "justify-content": "flex-start",
 +     "justify-content": "space-between",
       "width": "100%",
@@ -162,10 +142,11 @@ Snapshot Diff:
 -     "min-width": "0",
 -   },
 -   Object {
-      "-ms-flex": "1",
-      "-webkit-flex": "1",
       "display": "block",
-      "flex": "1",
+      "flex": "1 1 0%",
+      "flex-basis": "0%",
+      "flex-grow": "1",
+      "flex-shrink": "1",
       "max-height": "100%",
       "max-width": "100%",
       "min-height": "0",

--- a/packages/components/src/font-size-picker/test/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/test/font-size-picker-select.tsx
@@ -130,7 +130,7 @@ describe( 'FontSizePickerSelect', () => {
 				screen.getByRole( 'combobox', { name: 'Font size' } )
 			);
 			await user.click(
-				screen.getByRole( 'option', { name: 'Small 12px' } )
+				screen.getByRole( 'option', { name: 'Small12px' } )
 			);
 			expect( onChange ).toHaveBeenCalledWith( '12px', fontSizes[ 0 ] );
 		} );

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -133,12 +133,12 @@ describe( 'FontSizePicker', () => {
 			const options = screen.getAllByRole( 'option' );
 			expect( options ).toHaveLength( 7 );
 			expect( options[ 0 ] ).toHaveAccessibleName( 'Default' );
-			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny 8px' );
-			expect( options[ 2 ] ).toHaveAccessibleName( 'Small 12px' );
-			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium 16px' );
-			expect( options[ 4 ] ).toHaveAccessibleName( 'Large 20px' );
-			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large 30px' );
-			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large 40px' );
+			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny8px' );
+			expect( options[ 2 ] ).toHaveAccessibleName( 'Small12px' );
+			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium16px' );
+			expect( options[ 4 ] ).toHaveAccessibleName( 'Large20px' );
+			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large30px' );
+			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large40px' );
 		} );
 
 		test.each( [
@@ -148,7 +148,7 @@ describe( 'FontSizePicker', () => {
 				expectedArguments: [ undefined, undefined ],
 			},
 			{
-				option: 'Tiny 8px',
+				option: 'Tiny8px',
 				value: undefined,
 				expectedArguments: [ '8px', fontSizes[ 0 ] ],
 			},
@@ -221,12 +221,12 @@ describe( 'FontSizePicker', () => {
 			const options = screen.getAllByRole( 'option' );
 			expect( options ).toHaveLength( 7 );
 			expect( options[ 0 ] ).toHaveAccessibleName( 'Default' );
-			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny 8px' );
-			expect( options[ 2 ] ).toHaveAccessibleName( 'Small 1em' );
-			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium 2rem' );
+			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny8px' );
+			expect( options[ 2 ] ).toHaveAccessibleName( 'Small1em' );
+			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium2rem' );
 			expect( options[ 4 ] ).toHaveAccessibleName( 'Large' );
-			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large 30px' );
-			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large 40px' );
+			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large30px' );
+			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large40px' );
 		} );
 
 		test.each( [
@@ -252,17 +252,17 @@ describe( 'FontSizePicker', () => {
 				expectedArguments: [ undefined, undefined ],
 			},
 			{
-				option: 'Tiny 8px',
+				option: 'Tiny8px',
 				value: undefined,
 				expectedArguments: [ '8px', fontSizes[ 0 ] ],
 			},
 			{
-				option: 'Small 1em',
+				option: 'Small1em',
 				value: '8px',
 				expectedArguments: [ '1em', fontSizes[ 1 ] ],
 			},
 			{
-				option: 'Medium 2rem',
+				option: 'Medium2rem',
 				value: '8px',
 				expectedArguments: [ '2rem', fontSizes[ 2 ] ],
 			},
@@ -868,7 +868,7 @@ describe( 'FontSizePicker', () => {
 					screen.getByRole( 'combobox', { name: 'Font size' } )
 				);
 				await user.click(
-					screen.getByRole( 'option', { name: 'Medium 16px' } )
+					screen.getByRole( 'option', { name: 'Medium16px' } )
 				);
 				expect( onChange ).toHaveBeenCalledWith(
 					'16px',
@@ -906,7 +906,7 @@ describe( 'FontSizePicker', () => {
 					screen.getByRole( 'combobox', { name: 'Font size' } )
 				);
 				await user.click(
-					screen.getByRole( 'option', { name: 'Large 20px' } )
+					screen.getByRole( 'option', { name: 'Large20px' } )
 				);
 				expect( onChange ).toHaveBeenCalledWith(
 					'20px',
@@ -1053,7 +1053,7 @@ describe( 'FontSizePicker', () => {
 				screen.getByRole( 'combobox', { name: 'Font size' } )
 			);
 			await user.click(
-				screen.getByRole( 'option', { name: 'Small 12px' } )
+				screen.getByRole( 'option', { name: 'Small12px' } )
 			);
 			expect( onChange ).toHaveBeenCalledWith( '12px', fontSizes[ 0 ] );
 		} );

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -32,13 +32,13 @@ Snapshot Diff:
     Object {
       "color": "var(--wp-components-color-foreground, #1e1e1e)",
       "display": "block",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
+-     "font-size": "calc(16.25px)",
++     "font-size": "calc(25.35px)",
       "font-weight": "600",
       "line-height": "1.4",
-      "margin": "0",
-      "text-wrap": "pretty",
-    },
+      "margin": "0px",
+      "margin-bottom": "0px",
+      "margin-left": "0px",
 `;
 
 exports[`props should render level as a string 1`] = `
@@ -51,11 +51,11 @@ Snapshot Diff:
     Object {
       "color": "var(--wp-components-color-foreground, #1e1e1e)",
       "display": "block",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
+-     "font-size": "calc(16.25px)",
++     "font-size": "calc(25.35px)",
       "font-weight": "600",
       "line-height": "1.4",
-      "margin": "0",
-      "text-wrap": "pretty",
-    },
+      "margin": "0px",
+      "margin-bottom": "0px",
+      "margin-left": "0px",
 `;

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -19,8 +19,8 @@ import { NavigatorToParentButton } from '../legacy';
 import type { NavigateOptions } from '../types';
 
 const INVALID_HTML_ATTRIBUTE = {
-	raw: '/ "\'><=invalid_path',
-	escaped: "/ &quot;'&gt;<=invalid_path",
+	raw: "/ '<=invalid_path",
+	escaped: "/ '<=invalid_path",
 };
 
 const PATHS = {

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -7,11 +7,12 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin": "calc(4px * 10)",
--     "margin-bottom": "calc(4px * 1)",
--     "margin-left": "calc(4px * 3)",
--     "margin-right": "calc(4px * 5)",
-+     "margin-bottom": "calc(4px * 2)",
+-     "margin": "calc(40px) calc(20px) calc(4px) calc(12px)",
+-     "margin-bottom": "calc(4px)",
+-     "margin-left": "calc(12px)",
+-     "margin-right": "calc(20px)",
+-     "margin-top": "calc(40px)",
++     "margin-bottom": "calc(8px)",
     },
   ]
 `;
@@ -23,11 +24,12 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding": "calc(4px * 10)",
--     "padding-bottom": "calc(4px * 2)",
--     "padding-left": "calc(4px * 3)",
--     "padding-top": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding": "calc(20px) calc(40px) calc(8px) calc(12px)",
+-     "padding-bottom": "calc(8px)",
+-     "padding-left": "calc(12px)",
+-     "padding-right": "calc(40px)",
+-     "padding-top": "calc(20px)",
     },
   ]
 `;
@@ -52,8 +54,11 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin": "calc(4px * 5)",
-      "margin-bottom": "calc(4px * 2)",
+-     "margin": "calc(20px) calc(20px) calc(8px)",
+      "margin-bottom": "calc(8px)",
+-     "margin-left": "calc(20px)",
+-     "margin-right": "calc(20px)",
+-     "margin-top": "calc(20px)",
     },
   ]
 `;
@@ -65,8 +70,8 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin-bottom": "calc(4px * 5)",
-+     "margin-bottom": "calc(4px * 2)",
+-     "margin-bottom": "calc(20px)",
++     "margin-bottom": "calc(8px)",
     },
   ]
 `;
@@ -78,8 +83,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "margin-left": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "margin-left": "calc(20px)",
     },
   ]
 `;
@@ -91,8 +96,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "margin-right": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "margin-right": "calc(20px)",
     },
   ]
 `;
@@ -104,8 +109,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "margin-top": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "margin-top": "calc(20px)",
     },
   ]
 `;
@@ -117,9 +122,9 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "margin-left": "calc(4px * 5)",
--     "margin-right": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "margin-left": "calc(20px)",
+-     "margin-right": "calc(20px)",
     },
   ]
 `;
@@ -131,8 +136,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "margin-top": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "margin-top": "calc(20px)",
     },
   ]
 `;
@@ -144,8 +149,12 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding": "calc(20px)",
+-     "padding-bottom": "calc(20px)",
+-     "padding-left": "calc(20px)",
+-     "padding-right": "calc(20px)",
+-     "padding-top": "calc(20px)",
     },
   ]
 `;
@@ -157,8 +166,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-bottom": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-bottom": "calc(20px)",
     },
   ]
 `;
@@ -170,8 +179,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-left": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-left": "calc(20px)",
     },
   ]
 `;
@@ -183,8 +192,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-right": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-right": "calc(20px)",
     },
   ]
 `;
@@ -196,8 +205,8 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-top": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-top": "calc(20px)",
     },
   ]
 `;
@@ -209,9 +218,9 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-left": "calc(4px * 5)",
--     "padding-right": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-left": "calc(20px)",
+-     "padding-right": "calc(20px)",
     },
   ]
 `;
@@ -223,9 +232,9 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
--     "padding-bottom": "calc(4px * 5)",
--     "padding-top": "calc(4px * 5)",
+      "margin-bottom": "calc(8px)",
+-     "padding-bottom": "calc(20px)",
+-     "padding-top": "calc(20px)",
     },
   ]
 `;

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -5,12 +5,12 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -3,8 +3,9 @@
-      "color": "var(--wp-components-color-foreground, #1e1e1e)",
-      "font-size": "calc((13 / 13) * 13px)",
-      "font-weight": "normal",
-      "line-height": "1.4",
-      "margin": "0",
+@@ -7,8 +7,9 @@
+      "margin": "0px",
+      "margin-bottom": "0px",
+      "margin-left": "0px",
+      "margin-right": "0px",
+      "margin-top": "0px",
 +     "text-align": "center",
       "text-wrap": "pretty",
     },

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -381,7 +381,7 @@ describe( 'Tooltip', () => {
 			await waitFor( () =>
 				expect(
 					screen.getByRole( 'tooltip', {
-						name: 'tooltip text shortcut text',
+						name: 'tooltip textshortcut text',
 					} )
 				).toBeVisible()
 			);
@@ -409,13 +409,13 @@ describe( 'Tooltip', () => {
 			await waitFor( () =>
 				expect(
 					screen.getByRole( 'tooltip', {
-						name: 'tooltip text Control + Shift + Comma',
+						name: 'tooltip textControl + Shift + Comma',
 					} )
 				).toBeVisible()
 			);
 			expect(
 				screen.getByRole( 'tooltip', {
-					name: 'tooltip text Control + Shift + Comma',
+					name: 'tooltip textControl + Shift + Comma',
 				} )
 			).toHaveTextContent( /⇧⌘,/i );
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -64,7 +64,7 @@
 		"filenamify": "^4.2.0",
 		"jest": "^29.6.2",
 		"jest-dev-server": "^10.1.4",
-		"jest-environment-jsdom": "^29.6.2",
+		"jest-environment-jsdom": "^30.2.0",
 		"jest-environment-node": "^29.6.2",
 		"json2php": "^0.0.9",
 		"markdownlint-cli": "^0.31.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates JSDOM from v25 to v27 (25.0.1 to 27.2.0).

## Why?

- Helps unblock #73308, since newer versions of JSDOM have better support for CSS properties
- As a regular maintenance task, keeping dependencies up to date reduces future burden and allows us to leverage bug fixes and features

## How?

Besides updating the dependencies themselves, a few tests needed to be changed due to changes in behavior of JSDOM.

These fall into two buckets:

- Computed accessible names for many elements now frequently have whitespace eliminated where element boundaries exist in the DOM
- Differences in DOM selector support due to underlying migration from `nwsapi` to `@asamuzakjp/dom-selector`

For the first, a detailed explanation is available at https://github.com/WordPress/gutenberg/pull/73308#issuecomment-3559764297 :

>It's an interesting nuance of computing accessible names and whether two adjacent elements are joined with any whitespace, where the browser renders these as `<span>I'm an anchor link!</span><span aria-label="(opens in a new tab)"></span>`. Apparently it's an [ongoing discussion in the spec of computing accessible names](https://github.com/w3c/accname/issues/225). After digging into it, I've determined the root cause to be an interaction between [`dom-accessibility-api`](https://github.com/eps1lon/dom-accessibility-api) (which powers the `getByRole` `name` matching) and JSDOM, where [`dom-accessibility-api` considers `getPropertyValue('display')`](https://github.com/eps1lon/dom-accessibility-api/blob/27845ffc0513a9c5e20236d3c3e6aa7ffdf04674/sources/accessible-name-and-description.ts#L412-L415) of an element. In earlier versions of JSDOM, a `<span>` would not report any value here, but in recent versions this is now `'inline'`. Thus, the computed name has no space between the link text and the "(opens in a new tab)".
>
>My read of the [relevant specification](https://w3c.github.io/accname/#comp_name_from_content) is that this is a more accurate reflection of how a browser would be expected to behave:
>
>> §2.6.4 Name From Each Child: For each rendered child node of the current node:
>> [...]
>> §2.6.4.3 Append the result to the accumulated text.

For the second, I was able to confirm in a minimal reproduced example that `@asamuzakjp/dom-selector`'s support of query selectors including HTML-encoded characters is not equivalent to how it would expect to behave in a real browser:

```ts
const { DOMSelector } = require('@asamuzakjp/dom-selector');
const { JSDOM } = require('jsdom');
const { window } = new JSDOM();
const { querySelector } = new DOMSelector(window);
container = window.document.createElement('div');
container.innerHTML = '<div id="&amp;gt;"></div>';
querySelector('[id="&gt;"]', container);
// null
// container.querySelector('[id="&gt;"]') would match in Chrome
```

It's not clear to me if this is a "bug", or if it's just a really bad idea to have HTML-encoded characters in an attribute like this and expect to be able to query it via `querySelector`. _Technically_ it's not invalid per HTML5.

From what I could tell with the affected usage in `<Navigator>`, navigator paths would usually be specified by a developer and should (hopefully?) not be so complex to require this level of handling. Although again noting that the underlying implementation is not revised here and it would continue to behave correctly in a real browser.

## Testing Instructions

Verify that unit tests continue to pass.