### PR TITLE
Fields: Fix `author` field view when editing

### DIFF
--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -10,6 +10,8 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -17,9 +19,33 @@ import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import type { BasePostWithEmbeddedAuthor } from '../../types';
 
 function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
-	const text = item?._embedded?.author?.[ 0 ]?.name;
-	const imageUrl = item?._embedded?.author?.[ 0 ]?.avatar_urls?.[ 48 ];
-
+	// When editing, item.author may differ from _embedded.author (which preserves
+	// the saved record). Fetch the updated author only when they differ, so the
+	// view reflects edits while lists preserve original data.
+	const authorId = item?.author;
+	const embeddedAuthorId = item?._embedded?.author?.[ 0 ]?.id;
+	const shouldFetch = Boolean(
+		authorId && embeddedAuthorId && authorId !== embeddedAuthorId
+	);
+	const author = useSelect(
+		( select ) => {
+			if ( ! shouldFetch ) {
+				return null;
+			}
+			const { getEntityRecord } = select( coreStore );
+			// This doesn't make extra REST requests because the records are
+			// already in the store from the field's getElements function.
+			return authorId
+				? getEntityRecord( 'root', 'user', authorId )
+				: null;
+		},
+		[ authorId, shouldFetch ]
+	);
+	// Use fetched author if available, otherwise use _embedded.
+	const text = author?.name || item?._embedded?.author?.[ 0 ]?.name;
+	const imageUrl =
+		author?.avatar_urls?.[ 48 ] ||
+		item?._embedded?.author?.[ 0 ]?.avatar_urls?.[ 48 ];
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	return (
 		<HStack alignment="left" spacing={ 0 }>

--- a/packages/fields/src/fields/author/index.tsx
+++ b/packages/fields/src/fields/author/index.tsx
@@ -35,6 +35,7 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 			label: name,
 		} ) );
 	},
+	setValue: ( { value } ) => ( { author: Number( value ) } ),
 	render: AuthorView,
 	sort: ( a, b, direction ) => {
 		const nameA = a._embedded?.author?.[ 0 ]?.name || '';

--- a/packages/fields/src/stories/index.story.tsx
+++ b/packages/fields/src/stories/index.story.tsx
@@ -30,6 +30,38 @@ import {
 
 import type { BasePost, BasePostWithEmbeddedAuthor } from '../types';
 
+// Mock users for the story.
+const mockUsers = [
+	{
+		id: 1,
+		name: 'John Doe',
+		avatar_urls: {
+			'24': 'https://gravatar.com/avatar?d=retro&s=24',
+			'48': 'https://gravatar.com/avatar?d=retro&s=48',
+			'96': 'https://gravatar.com/avatar?d=retro&s=96',
+		},
+	},
+	{
+		id: 2,
+		name: 'Jane Smith',
+		avatar_urls: {
+			'24': 'https://gravatar.com/avatar/2?d=retro&s=24',
+			'48': 'https://gravatar.com/avatar/2?d=retro&s=48',
+			'96': 'https://gravatar.com/avatar/2?d=retro&s=96',
+		},
+	},
+];
+
+// Override author field with mock getElements for Storybook.
+const authorFieldForStory: Field< any > = {
+	...authorField,
+	getElements: async () =>
+		mockUsers.map( ( { id, name } ) => ( {
+			value: id,
+			label: name,
+		} ) ),
+};
+
 export default {
 	title: 'Fields/Base Fields',
 	component: DataForm,
@@ -61,16 +93,7 @@ const sampleBasePost: BasePost = {
 const samplePostWithAuthor: BasePostWithEmbeddedAuthor = {
 	...sampleBasePost,
 	_embedded: {
-		author: [
-			{
-				name: 'John Doe',
-				avatar_urls: {
-					'24': 'https://gravatar.com/avatar?d=retro&s=24',
-					'48': 'https://gravatar.com/avatar?d=retro&s=48',
-					'96': 'https://gravatar.com/avatar?d=retro&s=96',
-				},
-			},
-		],
+		author: [ { ...mockUsers[ 0 ] } ],
 	},
 };
 
@@ -83,7 +106,7 @@ const showcaseFields: Field< any >[] = [
 	slugField,
 	statusField,
 	dateField,
-	authorField,
+	authorFieldForStory,
 	commentStatusField,
 	passwordField,
 	orderField,

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -24,6 +24,7 @@ interface Links {
 }
 
 interface Author {
+	id: number;
 	name: string;
 	avatar_urls: Record< string, string >;
 }

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -168,9 +168,20 @@ test.describe( 'Page List', () => {
 					const selectElement = page.locator(
 						'select:has(option[value="1"])'
 					);
-					await selectElement.selectOption( { value: '1' } );
+					await selectElement.selectOption( {
+						label: 'Test Author',
+					} );
 				},
-				assertEditedState: async () => {},
+				assertEditedState: async ( page ) => {
+					const author = page.getByLabel( 'Edit Author' );
+					await expect( author ).toContainText( 'Test Author' );
+					// Check that the list still shows "admin" (changes not yet saved).
+					const selectedItem = page.locator( '.is-selected' );
+					const authorCell = selectedItem.getByRole( 'cell', {
+						name: 'admin',
+					} );
+					await expect( authorCell ).toBeVisible();
+				},
 			},
 			date: {
 				assertInitialState: async ( page ) => {
@@ -294,6 +305,14 @@ test.describe( 'Page List', () => {
 			await requestUtils.setGutenbergExperiments( [
 				'gutenberg-quick-edit-dataviews',
 			] );
+			// Create a test user for `author` field testing.
+			await requestUtils.createUser( {
+				username: 'testauthor',
+				email: 'testauthor@example.com',
+				firstName: 'Test',
+				lastName: 'Author',
+				password: '1',
+			} );
 		} );
 
 		test.beforeEach( async ( { admin, page } ) => {
@@ -423,6 +442,7 @@ test.describe( 'Page List', () => {
 
 		test.afterAll( async ( { requestUtils } ) => {
 			await requestUtils.setGutenbergExperiments( [] );
+			await requestUtils.deleteAllUsers();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73462

View of `author` field used the data from `_embedded.author`. When we edit this value, the change wasn't reflected in the DataForm panel. This happened because we update the `item.author` prop and we don't handle embed data updates in core-data - I explored a bit to update core-data, but I couldn't find a good solution to work seamlessly as it would require complex handling and mapping from `_embed` values to how to fetch the entities, plus possible not needed performance overhead.

So the solution here is to update `AuthorView` and check if `item.author` differs from `item?._embedded?.author?.[ 0 ]?.id`. This indicates when the component is used in an edit context and only then retrieves the edited user from the store. This doesn't make extra REST requests because the records are already in the store from the field's getElements function.

Additionally the displayed list of items still render the saved information (from `embedded.author`).


Finally this PR adds a small fix for Data Forms Preview story (`?path=/story/fields-base-fields--data-forms-preview&args=type:panel`) where clicking to edit the `author` wouldn't display anything. For that story the edited value is not reflected because `AuthorView` uses core-data, but that's fine for the context of storybook, since I'm not even sure we should try to mock the call. Instead I've updated an existing e2e test to cover this change.


## Testing Instructions
1. Go to Gutenberg > Experiments and enable the DataViews QuickEdit experiment.
2. Visit Site Editor > Pages, select the table layout, and open quick edit.
3. Select a different author.
4. Observe that in the form the `author` is updated and in the list is displayed the saved author.
