### PR TITLE
Disable TinyMCE: Polish refresh message

### DIFF
--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -64,15 +64,20 @@ export default function MissingEdit( { attributes, clientId } ) {
 		! hasFreeformBlock &&
 		( ! originalName || originalName === 'core/freeform' )
 	) {
+		const refreshMessage = __(
+			'Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
+		);
 		if ( hasHTMLBlock ) {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely. Alternatively, you can refresh the page to use the Classic block.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.'
 			);
+			messageHTML += refreshMessage;
 			actions.push( convertToHtmlButton );
 		} else {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, or remove it entirely. Alternatively, you can refresh the page to use the Classic block.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, or remove it entirely.'
 			);
+			messageHTML += refreshMessage;
 		}
 	} else if ( hasContent && hasHTMLBlock ) {
 		messageHTML = sprintf(

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -64,20 +64,15 @@ export default function MissingEdit( { attributes, clientId } ) {
 		! hasFreeformBlock &&
 		( ! originalName || originalName === 'core/freeform' )
 	) {
-		const refreshMessage = __(
-			'Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
-		);
 		if ( hasHTMLBlock ) {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely. Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
 			);
-			messageHTML += refreshMessage;
 			actions.push( convertToHtmlButton );
 		} else {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, or remove it entirely.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, or remove it entirely. Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
 			);
-			messageHTML += refreshMessage;
 		}
 	} else if ( hasContent && hasHTMLBlock ) {
 		messageHTML = sprintf(


### PR DESCRIPTION
## What?
As part of the Disable TinyMCE experiment, updating the message the user sees when prompted to convert a classic/freeform block.

## Why?
For clarity that unsaved data needs to be saved before refreshing. See [this thread](https://github.com/WordPress/gutenberg/pull/72972#issuecomment-3498299697) for details.

## How?
Just updating the message. Reusing the string to reduce translator burden - strings are long enough already.

## Testing Instructions
* Go to Gutenberg > Experiments
* Enable the "Blocks: disable TinyMCE and Classic block" experiment
* Start a new post.
* Go to the code editor.
* Insert `<div class="notice">You can include <em>raw HTML</em> here.</div>`.
* Switch back to visual editor. 
* Observe the updated message.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="655" height="155" alt="Screenshot 2025-11-21 at 15 21 20" src="https://github.com/user-attachments/assets/ed718f22-0d43-4498-a2a3-568de9f140a0" />|<img width="655" height="153" alt="Screenshot 2025-11-21 at 15 25 37" src="https://github.com/user-attachments/assets/a1397175-9065-4674-b187-3bfccbaacb4e" />|




