### PR TITLE
Breadcrumbs: Improve home page and front page handling

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -93,7 +93,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showHomeLink, showLastItem, showOnHomePage
+-	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -16,11 +16,11 @@
 			"type": "string",
 			"default": "/"
 		},
-		"showHomeLink": {
+		"showHomeItem": {
 			"type": "boolean",
 			"default": true
 		},
-		"showLastItem": {
+		"showCurrentItem": {
 			"type": "boolean",
 			"default": true
 		},

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -30,8 +30,8 @@ export default function BreadcrumbEdit( {
 } ) {
 	const {
 		separator,
-		showHomeLink,
-		showLastItem,
+		showHomeItem,
+		showCurrentItem,
 		prefersTaxonomy,
 		showOnHomePage,
 	} = attributes;
@@ -143,7 +143,7 @@ export default function BreadcrumbEdit( {
 		( _showTerms && ! hasTermsAssigned );
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
-		if ( showHomeLink ) {
+		if ( showHomeItem ) {
 			placeholderItems.push( __( 'Home' ) );
 		}
 		if ( templateSlug && ! postId ) {
@@ -168,7 +168,7 @@ export default function BreadcrumbEdit( {
 							</a>
 						</li>
 					) ) }
-					{ showLastItem && (
+					{ showCurrentItem && (
 						<li>
 							<span aria-current="page">{ __( 'Current' ) }</span>
 						</li>
@@ -185,48 +185,48 @@ export default function BreadcrumbEdit( {
 					resetAll={ () => {
 						setAttributes( {
 							separator: separatorDefaultValue,
-							showHomeLink: true,
-							showLastItem: true,
+							showHomeItem: true,
+							showCurrentItem: true,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						label={ __( 'Show home link' ) }
+						label={ __( 'Show home breadcrumb' ) }
 						isShownByDefault
-						hasValue={ () => ! showHomeLink }
+						hasValue={ () => ! showHomeItem }
 						onDeselect={ () =>
 							setAttributes( {
-								showHomeLink: true,
+								showHomeItem: true,
 							} )
 						}
 					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show home link' ) }
+							label={ __( 'Show home breadcrumb' ) }
 							onChange={ ( value ) =>
-								setAttributes( { showHomeLink: value } )
+								setAttributes( { showHomeItem: value } )
 							}
-							checked={ showHomeLink }
+							checked={ showHomeItem }
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						label={ __( 'Show last item' ) }
+						label={ __( 'Show current breadcrumb' ) }
 						isShownByDefault
-						hasValue={ () => ! showLastItem }
+						hasValue={ () => ! showCurrentItem }
 						onDeselect={ () =>
 							setAttributes( {
-								showLastItem: true,
+								showCurrentItem: true,
 							} )
 						}
 					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show last item' ) }
+							label={ __( 'Show current breadcrumb' ) }
 							onChange={ ( value ) =>
-								setAttributes( { showLastItem: value } )
+								setAttributes( { showCurrentItem: value } )
 							}
-							checked={ showLastItem }
+							checked={ showCurrentItem }
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73441

This PR improves home page and front page handling. 
The default reading setting for `Your homepage displays` is `Your latest posts`. In this case WP shows a posts list and `is_home` is the same with `is_front_page`.

When users set static pages for `homepage` and `posts page` we need to:
1. Still show the `home` link (front page), when we are in `posts page`
2. Show `Page x` in the case of a paged (with `Break page block`) static homepage.

Additionally and not related to the fix, I've renamed two block attributes. Since the block is experimental, no deprecation is needed.


## Testing Instructions
1. Go to Settings > Reading in your WordPress admin and choose a custom page for the Homepage and one for the Posts page:
2. Visit the page that you selected for the `posts page` option and observe that breadcrumbs items appear
4. Add a `Page Break` block in the `homepage` you selected in reading settings and visit front-end. You should see the correct `Page X` item, when you click in the second page.

## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added x3p0-breadcrumbs plugin and the core block in the main header.
Above is x3p0-breadcrumbs and below is the core block.

#### Specific `posts page` set
<img width="695" height="114" alt="specific-posts-page" src="https://github.com/user-attachments/assets/213b925b-c9c3-4364-a2aa-51e30d91c434" />


#### Specific `homepage` set paged (with Page Break)
<img width="695" height="114" alt="front-page-custom-paged" src="https://github.com/user-attachments/assets/8b7fae2b-16e5-45de-93ff-6e76f581c1ff" />



