### PR TITLE
Validated form controls: Add more validation examples

### DIFF
--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -506,6 +506,7 @@ export const ValidateWithOtherFieldState: StoryObj<
 	},
 	args: {
 		label: 'Text',
+		required: true,
 	},
 };
 
@@ -588,5 +589,6 @@ export const ValidateOnSubmit: StoryObj< typeof ValidatedInputControl > = {
 	},
 	args: {
 		label: 'Link to',
+		required: true,
 	},
 };

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -18,6 +18,9 @@ import { formDecorator } from './story-utils';
 import type { ControlWithError } from '../../control-with-error';
 import Dropdown from '../../../dropdown';
 import { Button } from '../../../button';
+import Modal from '../../../modal';
+import { HStack } from '../../../h-stack';
+import { VStack } from '../../../v-stack';
 
 const meta: Meta< typeof ControlWithError > = {
 	title: 'Components/Selection & Input/Validated Form Controls/Overview',
@@ -294,6 +297,69 @@ const AsyncValidationWithTest: StoryObj< typeof ValidatedInputControl > = {
 };
 
 /**
+ * A `form` wrapper and `type="submit"` button can be used to force validation when
+ * the user tries to commit their changes, while still allowing the modal to be closed.
+ * Optionally, the `shouldCloseOnClickOutside` prop on `Modal` can be disabled
+ * to force users to more explicitly signal whether they are trying to
+ * "submit close" or "cancel close" the dialog.
+ */
+export const ValidateInModal: StoryObj< typeof ValidatedInputControl > = {
+	render: function Template( { ...args } ) {
+		const [ isOpen, setIsOpen ] = useState( false );
+		return (
+			<>
+				<Button
+					variant="secondary"
+					__next40pxDefaultSize
+					onClick={ () => setIsOpen( true ) }
+				>
+					Open in modal
+				</Button>
+				{ isOpen && (
+					<Modal
+						title="Dialog title"
+						onRequestClose={ () => setIsOpen( false ) }
+						shouldCloseOnClickOutside={ false }
+					>
+						<form
+							onSubmit={ ( event ) => {
+								event.preventDefault();
+								setIsOpen( false );
+							} }
+						>
+							<VStack spacing={ 2 }>
+								<ValidatedInputControl
+									required
+									label="Text"
+									{ ...args }
+								/>
+
+								<HStack justify="flex-end" spacing={ 2 }>
+									<Button
+										variant="tertiary"
+										__next40pxDefaultSize
+										onClick={ () => setIsOpen( false ) }
+									>
+										Cancel
+									</Button>
+									<Button
+										variant="primary"
+										__next40pxDefaultSize
+										type="submit"
+									>
+										Save
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					</Modal>
+				) }
+			</>
+		);
+	},
+};
+
+/**
  * [Form methods](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#instance_methods) like
  * `reportValidity()` can be used to validate the fields when a popover is about to be closed,
  * and prevent the closing of the popover when invalid.
@@ -313,7 +379,7 @@ export const ValidateOnPopoverClose: StoryObj< typeof ValidatedInputControl > =
 
 			return (
 				<Dropdown
-					popoverProps={ { placement: 'right' } }
+					popoverProps={ { placement: 'bottom-start' } }
 					open={ isOpen }
 					onToggle={ ( willOpen ) => {
 						if ( ! willOpen ) {
@@ -350,7 +416,7 @@ export const ValidateOnPopoverClose: StoryObj< typeof ValidatedInputControl > =
 						return (
 							<Button
 								__next40pxDefaultSize
-								variant="primary"
+								variant="secondary"
 								onClick={ () => setIsOpen( ! isOpen ) }
 								aria-expanded={ isOpen }
 							>

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -9,6 +9,7 @@ import { expect, userEvent, waitFor, within } from '@storybook/test';
  */
 import { useRef, useCallback, useState } from '@wordpress/element';
 import { debounce } from '@wordpress/compose';
+import { create } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import Dropdown from '../../../dropdown';
 import { Button } from '../../../button';
 import Modal from '../../../modal';
 import { HStack } from '../../../h-stack';
+import { CheckboxControl } from '../../../checkbox-control';
 import { VStack } from '../../../v-stack';
 
 const meta: Meta< typeof ControlWithError > = {
@@ -437,3 +439,154 @@ export const ValidateOnPopoverClose: StoryObj< typeof ValidatedInputControl > =
 			},
 		},
 	};
+
+/**
+ * Sometimes, a field's validity may depend on the state of other fields.
+ *
+ * In this example, the text field must start with "http" if the checkbox is checked.
+ * Validator logic should be added to both fields.
+ */
+export const ValidateWithOtherFieldState: StoryObj<
+	typeof ValidatedInputControl
+> = {
+	decorators: formDecorator,
+	render: function Template( { ...args } ) {
+		const [ text, setText ] = useState( '' );
+		const [ isHttp, setIsHttp ] = useState( false );
+		const [ customValidity, setCustomValidity ] =
+			useState<
+				React.ComponentProps<
+					typeof ValidatedInputControl
+				>[ 'customValidity' ]
+			>( undefined );
+
+		return (
+			<>
+				<ValidatedInputControl
+					{ ...args }
+					value={ text }
+					onChange={ ( newValue ) => {
+						setText( newValue ?? '' );
+					} }
+					onValidate={ ( value ) => {
+						if ( isHttp && value && ! value.startsWith( 'http' ) ) {
+							setCustomValidity( {
+								type: 'invalid',
+								message: 'Text must start with "http".',
+							} );
+						} else {
+							setCustomValidity( undefined );
+						}
+					} }
+					customValidity={ customValidity }
+				/>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label="Text starts with HTTP"
+					checked={ isHttp }
+					onChange={ ( value ) => {
+						setIsHttp( value );
+
+						if (
+							value === true &&
+							text &&
+							! text.startsWith( 'http' )
+						) {
+							setCustomValidity( {
+								type: 'invalid',
+								message: 'Text must start with "http".',
+							} );
+						} else {
+							setCustomValidity( undefined );
+						}
+					} }
+				/>
+			</>
+		);
+	},
+	args: {
+		label: 'Text',
+	},
+};
+
+/**
+ * When a field's validity can only be determined after the submit button is clicked,
+ * `customValidity` can be set within the form's `onSubmit` handler.
+ *
+ * In this example, the text field must start with "http" if the submit button is clicked,
+ * but can be any string if the "Create new page" button is clicked.
+ */
+export const ValidateOnSubmit: StoryObj< typeof ValidatedInputControl > = {
+	render: function Template( { ...args } ) {
+		const [ text, setText ] = useState( '' );
+		const [ customValidity, setCustomValidity ] =
+			useState<
+				React.ComponentProps<
+					typeof ValidatedInputControl
+				>[ 'customValidity' ]
+			>( undefined );
+
+		return (
+			<form
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+
+					if ( text && ! text.startsWith( 'http' ) ) {
+						setCustomValidity( {
+							type: 'invalid',
+							message: 'Text must start with "http".',
+						} );
+						return;
+					}
+					// eslint-disable-next-line no-alert
+					alert( 'Form submitted!' );
+				} }
+			>
+				<VStack style={ { width: 300 } }>
+					<ValidatedInputControl
+						{ ...args }
+						value={ text }
+						onChange={ ( newValue ) => {
+							setText( newValue ?? '' );
+						} }
+						onValidate={ ( value ) => {
+							if (
+								customValidity?.type === 'invalid' &&
+								value &&
+								! value.startsWith( 'http' )
+							) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: 'Text must start with "http".',
+								} );
+							} else {
+								setCustomValidity( undefined );
+							}
+						} }
+						customValidity={ customValidity }
+					/>
+					<Button
+						variant="secondary"
+						__next40pxDefaultSize
+						icon={ create }
+						// eslint-disable-next-line no-alert
+						onClick={ () => alert( 'Created new page!' ) }
+					>
+						Create new page
+					</Button>
+				</VStack>
+				<Button
+					style={ { marginTop: 16 } }
+					type="submit"
+					variant="primary"
+					__next40pxDefaultSize
+				>
+					Submit
+				</Button>
+			</form>
+		);
+	},
+	args: {
+		label: 'Link to',
+	},
+};

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -328,11 +328,7 @@ export const ValidateInModal: StoryObj< typeof ValidatedInputControl > = {
 							} }
 						>
 							<VStack spacing={ 2 }>
-								<ValidatedInputControl
-									required
-									label="Text"
-									{ ...args }
-								/>
+								<ValidatedInputControl { ...args } />
 
 								<HStack justify="flex-end" spacing={ 2 }>
 									<Button
@@ -356,6 +352,10 @@ export const ValidateInModal: StoryObj< typeof ValidatedInputControl > = {
 				) }
 			</>
 		);
+	},
+	args: {
+		label: 'Text',
+		required: true,
 	},
 };
 

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -298,10 +298,10 @@ const AsyncValidationWithTest: StoryObj< typeof ValidatedInputControl > = {
 
 /**
  * A `form` wrapper and `type="submit"` button can be used to force validation when
- * the user tries to commit their changes, while still allowing the modal to be closed.
- * Optionally, the `shouldCloseOnClickOutside` prop on `Modal` can be disabled
- * to force users to more explicitly signal whether they are trying to
- * "submit close" or "cancel close" the dialog.
+ * the user tries to commit their changes, while still allowing the modal to be closed by canceling.
+ * Optionally, the `shouldCloseOnClickOutside`, `isDismissible`, and `shouldCloseOnEsc` props
+ * on `Modal` can be disabled to force users to more explicitly signal whether they are trying to
+ * "submit close" or "cancel close" the dialog, as well as preventing data loss on accidental closures.
  */
 export const ValidateInModal: StoryObj< typeof ValidatedInputControl > = {
 	render: function Template( { ...args } ) {
@@ -320,6 +320,7 @@ export const ValidateInModal: StoryObj< typeof ValidatedInputControl > = {
 						title="Dialog title"
 						onRequestClose={ () => setIsOpen( false ) }
 						shouldCloseOnClickOutside={ false }
+						isDismissible={ false }
 					>
 						<form
 							onSubmit={ ( event ) => {

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -16,11 +16,12 @@ import { debounce } from '@wordpress/compose';
 import { ValidatedInputControl } from '..';
 import { formDecorator } from './story-utils';
 import type { ControlWithError } from '../../control-with-error';
+import Dropdown from '../../../dropdown';
+import { Button } from '../../../button';
 
 const meta: Meta< typeof ControlWithError > = {
 	title: 'Components/Selection & Input/Validated Form Controls/Overview',
 	id: 'components-validated-form-controls-overview',
-	decorators: formDecorator,
 };
 export default meta;
 
@@ -31,6 +32,7 @@ type Story = StoryObj< typeof ControlWithError >;
  * move focus to the first control with an error.
  */
 export const WithMultipleControls: Story = {
+	decorators: formDecorator,
 	render: function Template() {
 		const [ text, setText ] = useState( '' );
 		const [ text2, setText2 ] = useState( '' );
@@ -95,6 +97,7 @@ export const WithMultipleControls: Story = {
  * will depend on context.
  */
 export const WithHelpTextReplacement: Story = {
+	decorators: formDecorator,
 	render: function Template() {
 		const [ text, setText ] = useState( '' );
 		const [ customValidity, setCustomValidity ] =
@@ -140,6 +143,7 @@ export const WithHelpTextReplacement: Story = {
  * They may be unnecessary when responses are generally quick.
  */
 export const AsyncValidation: StoryObj< typeof ValidatedInputControl > = {
+	decorators: formDecorator,
 	render: function Template( { ...args } ) {
 		const [ text, setText ] = useState( '' );
 		const [ customValidity, setCustomValidity ] =
@@ -288,3 +292,81 @@ const AsyncValidationWithTest: StoryObj< typeof ValidatedInputControl > = {
 		);
 	},
 };
+
+/**
+ * [Form methods](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#instance_methods) like
+ * `reportValidity()` can be used to validate the fields when a popover is about to be closed,
+ * and prevent the closing of the popover when invalid.
+ */
+export const ValidateOnPopoverClose: StoryObj< typeof ValidatedInputControl > =
+	{
+		render: function Template( { ...args } ) {
+			const [ isOpen, setIsOpen ] = useState( false );
+			const formRef = useRef< HTMLFormElement >( null );
+			const [ text, setText ] = useState( '' );
+			const [ customValidity, setCustomValidity ] =
+				useState<
+					React.ComponentProps<
+						typeof ValidatedInputControl
+					>[ 'customValidity' ]
+				>( undefined );
+
+			return (
+				<Dropdown
+					popoverProps={ { placement: 'right' } }
+					open={ isOpen }
+					onToggle={ ( willOpen ) => {
+						if ( ! willOpen ) {
+							const isValid = formRef.current?.reportValidity();
+							setIsOpen( ! isValid );
+						} else {
+							setIsOpen( true );
+						}
+					} }
+					renderContent={ () => (
+						<form ref={ formRef }>
+							<ValidatedInputControl
+								{ ...args }
+								value={ text }
+								onChange={ ( newValue ) => {
+									setText( newValue ?? '' );
+								} }
+								onValidate={ ( value ) => {
+									if ( value?.toLowerCase() === 'error' ) {
+										setCustomValidity( {
+											type: 'invalid',
+											message:
+												'The word "error" is not allowed.',
+										} );
+									} else {
+										setCustomValidity( undefined );
+									}
+								} }
+								customValidity={ customValidity }
+							/>
+						</form>
+					) }
+					renderToggle={ () => {
+						return (
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ () => setIsOpen( ! isOpen ) }
+								aria-expanded={ isOpen }
+							>
+								Open in popover
+							</Button>
+						);
+					} }
+				/>
+			);
+		},
+		args: {
+			label: 'Text',
+			help: 'The word "error" will trigger an error.',
+			required: true,
+			style: {
+				width: '200px',
+			},
+		},
+	};


### PR DESCRIPTION
## What?

Adds two more examples to the Validated form control stories:

- Validate with other field state
- Validate on submit

## Why?

Developers were asking about this kind of use case.

## Testing Instructions

See the new stories in the "Validated form controls" Overview section.

## Screenshots or screencast <!-- if applicable -->

<img width="500" alt="New stories" src="https://github.com/user-attachments/assets/56512ecd-502b-42bd-8ee1-f1d50f725324" />