### PR TITLE
Include totals items count in DataView footer

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ### Enhancements
 
+- Include total items count in footer. [#73491](https://github.com/WordPress/gutenberg/pull/73491)
 - Simplify field normalization and types. [#73387](https://github.com/WordPress/gutenberg/pull/73387)
 - DataViews table layout: make checkboxes permanently visible when bulk actions are available. [#73245](https://github.com/WordPress/gutenberg/pull/73245)
 - DataViews: Add insert left/right in table column header. [#72929](https://github.com/WordPress/gutenberg/pull/72929)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - DataViews: Move filtering logic in field types. [#74733](https://github.com/WordPress/gutenberg/pull/74733)
 
+### Enhancements
+
+- Include total items count in footer. [#73491](https://github.com/WordPress/gutenberg/pull/73491)
+
 ## 11.2.0 (2026-01-16)
 
 ### Code Quality
@@ -59,7 +63,6 @@
 
 ### Enhancements
 
-- Include total items count in footer. [#73491](https://github.com/WordPress/gutenberg/pull/73491)
 - Simplify field normalization and types. [#73387](https://github.com/WordPress/gutenberg/pull/73387)
 - DataViews table layout: make checkboxes permanently visible when bulk actions are available. [#73245](https://github.com/WordPress/gutenberg/pull/73245)
 - DataViews: Add insert left/right in table column header. [#72929](https://github.com/WordPress/gutenberg/pull/72929)

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -7,7 +7,7 @@ import type { ReactElement } from 'react';
  * WordPress dependencies
  */
 import { Button, CheckboxControl } from '@wordpress/components';
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useMemo, useState, useRef, useContext } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -7,7 +7,7 @@ import type { ReactElement } from 'react';
  * WordPress dependencies
  */
 import { Button, CheckboxControl } from '@wordpress/components';
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useMemo, useState, useRef, useContext } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
@@ -22,6 +22,7 @@ import { ActionModal } from '../dataviews-item-actions';
 import type { Action, ActionModal as ActionModalType } from '../../types';
 import type { SetSelection } from '../../types/private';
 import type { ActionTriggerProps } from '../dataviews-item-actions';
+import getFooterMessage from '../../utils/get-footer-message';
 
 interface ActionWithModalProps< Item > {
 	action: ActionModalType< Item >;
@@ -152,6 +153,10 @@ interface ToolbarContentProps< Item > {
 	data: Item[];
 	actions: Action< Item >[];
 	getItemId: ( item: Item ) => string;
+	paginationInfo: {
+		totalItems: number;
+		totalPages: number;
+	};
 }
 
 function ActionTrigger< Item >( {
@@ -241,24 +246,17 @@ function renderFooterContent< Item >(
 	selectedItems: Item[],
 	actionInProgress: string | null,
 	setActionInProgress: ( actionId: string | null ) => void,
-	onChangeSelection: SetSelection
+	onChangeSelection: SetSelection,
+	paginationInfo: {
+		totalItems: number;
+		totalPages: number;
+	}
 ) {
-	const message =
-		selectedItems.length > 0
-			? sprintf(
-					/* translators: %d: number of items. */
-					_n(
-						'%d Item selected',
-						'%d Items selected',
-						selectedItems.length
-					),
-					selectedItems.length
-			  )
-			: sprintf(
-					/* translators: %d: number of items. */
-					_n( '%d Item', '%d Items', data.length ),
-					data.length
-			  );
+	const message = getFooterMessage(
+		selection.length,
+		data.length,
+		paginationInfo.totalItems
+	);
 	return (
 		<Stack
 			direction="row"
@@ -317,6 +315,7 @@ function FooterContent< Item >( {
 	onChangeSelection,
 	data,
 	getItemId,
+	paginationInfo,
 }: ToolbarContentProps< Item > ) {
 	const [ actionInProgress, setActionInProgress ] = useState< string | null >(
 		null
@@ -371,7 +370,8 @@ function FooterContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onChangeSelection
+			onChangeSelection,
+			paginationInfo
 		);
 	} else if ( ! footerContentRef.current ) {
 		footerContentRef.current = renderFooterContent(
@@ -383,7 +383,8 @@ function FooterContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onChangeSelection
+			onChangeSelection,
+			paginationInfo
 		);
 	}
 	return footerContentRef.current;
@@ -396,6 +397,7 @@ export function BulkActionsFooter() {
 		actions = EMPTY_ARRAY,
 		onChangeSelection,
 		getItemId,
+		paginationInfo,
 	} = useContext( DataViewsContext );
 	return (
 		<FooterContent
@@ -404,6 +406,7 @@ export function BulkActionsFooter() {
 			data={ data }
 			actions={ actions }
 			getItemId={ getItemId }
+			paginationInfo={ paginationInfo }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
@@ -5,7 +5,7 @@ import { Button, CheckboxControl } from '@wordpress/components';
 import { useRegistry } from '@wordpress/data';
 import { useContext, useMemo, useState } from '@wordpress/element';
 import { Stack } from '@wordpress/ui';
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
@@ -4,8 +4,8 @@
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useRegistry } from '@wordpress/data';
 import { useContext, useMemo, useState } from '@wordpress/element';
-import { __, sprintf, _n } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import DataViewsPagination from '../dataviews-pagination';
 import DataViewsContext from '../dataviews-context';
 import type { SetSelection } from '../../types/private';
 import type { Action } from '../../types';
+import getFooterMessage from '../../utils/get-footer-message';
 
 const EMPTY_ARRAY: [] = [];
 
@@ -134,27 +135,16 @@ export function DataViewsPickerFooter() {
 		onChangeSelection,
 		getItemId,
 		actions = EMPTY_ARRAY,
+		paginationInfo,
 	} = useContext( DataViewsContext );
 
-	const selectionCount = selection.length;
 	const isMultiselect = useIsMultiselectPicker( actions );
 
-	const message =
-		selectionCount > 0
-			? sprintf(
-					/* translators: %d: number of items. */
-					_n(
-						'%d Item selected',
-						'%d Items selected',
-						selectionCount
-					),
-					selectionCount
-			  )
-			: sprintf(
-					/* translators: %d: number of items. */
-					_n( '%d Item', '%d Items', data.length ),
-					data.length
-			  );
+	const message = getFooterMessage(
+		selection.length,
+		data.length,
+		paginationInfo.totalItems
+	);
 
 	const selectedItems = useMemo(
 		() =>

--- a/packages/dataviews/src/utils/get-footer-message.ts
+++ b/packages/dataviews/src/utils/get-footer-message.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Get the footer message for the DataViews footer.
+ *
+ * @param selectionCount - The number of items selected.
+ * @param itemsCount     - The number of items in the current page.
+ * @param totalItems     - The total number of items.
+ * @return               - The footer message.
+ */
+export default function getFooterMessage(
+	selectionCount: number,
+	itemsCount: number,
+	totalItems: number
+): string {
+	if ( selectionCount > 0 ) {
+		return sprintf(
+			/* translators: %d: number of items. */
+			_n( '%d Item selected', '%d Items selected', selectionCount ),
+			selectionCount
+		);
+	}
+
+	if ( totalItems > itemsCount ) {
+		return sprintf(
+			/* translators: %1$d: number of items. %2$d: total number of items. */
+			_n( '%1$d of %2$d Item', '%1$d of %2$d Items', totalItems ),
+			itemsCount,
+			totalItems
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of items. */
+		_n( '%d Item', '%d Items', itemsCount ),
+		itemsCount
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

No public issue for this, but DataViews footer only show how many items are in the current view, but we want to show that + total.

<!-- In a few words, what is the PR actually doing? -->

## Why?

Having only the current count isn't super useful vs knowing how big the dataset is, especially if that value is already passed to pagination.

## How?

We read this from pagination.

## Testing Instructions

1. In Storybook run the tests on both DataView and DataViewPicker.
2. Make sure that for the default, you see 10 of 19 items.
3. If select some items, the text should only say "X items selected"
4. If you change the config to show 25 items per page, the message should only say 19 items.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="145" height="57" alt="image" src="https://github.com/user-attachments/assets/b9d9d292-82e3-4345-b53c-d3abfbd2edb2" />|<img width="120" height="42" alt="image" src="https://github.com/user-attachments/assets/fb69a6f6-c36d-4fa0-97ce-33c01f3eb11b" />|
|<img width="125" height="61" alt="image" src="https://github.com/user-attachments/assets/b5382eb2-3856-4de9-9b71-d9b1d8e7c0c8" />|<img width="124" height="52" alt="image" src="https://github.com/user-attachments/assets/fc9e6109-034e-41cd-865a-5a4211718753" />|
|<img width="177" height="53" alt="image" src="https://github.com/user-attachments/assets/b60c6551-8faa-4529-85ef-2c1613e3d4e2" />|<img width="326" height="43" alt="image" src="https://github.com/user-attachments/assets/23a4cbec-7255-4eec-a34f-1e733f0c15ca" />|
