### PR TITLE
add support for custom labels in Dataviews

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -225,34 +225,33 @@ Properties:
 
 | Props / Layout | `table` | `pickerTable` | `grid` | `pickerGrid` | `list` | `activity` |
 | -------------- | ------- | ------------- | ------ | ------------ | ------ | ---------- |
-| `density`      | ✓       | ✓             |        |	             |        | ✓          |
-| `enableMoving` | ✓       | ✓             |        |	             |        |            |
-| `styles`       | ✓       | ✓             |        |	             |        |            |
+| `density`      | ✓       | ✓             |        |              |        | ✓          |
+| `enableMoving` | ✓       | ✓             |        |              |        |            |
+| `styles`       | ✓       | ✓             |        |              |        |            |
 | `badgeFields`  |         |               | ✓      | ✓            |        |            |
 | `previewSize`  |         |               | ✓      | ✓            |        |            |
 
 `table` and `pickerTable` layouts:
 
-- `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
-- `enableMoving`: whether the table columns should display moving controls.
-- `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column.
+-   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
+-   `enableMoving`: whether the table columns should display moving controls.
+-   `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column.
 
 **For column alignment (`align` property), follow these guidelines:**
 Right-align whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment for all other types (text, codes, labels, dates).
 
 `grid` and `pickerGrid` layout:
 
-- `badgeFields`: a list of field's `id` to render without label and styled as badges.
-- `previewSize`: a `number` representing the size of the preview.
+-   `badgeFields`: a list of field's `id` to render without label and styled as badges.
+-   `previewSize`: a `number` representing the size of the preview.
 
 `list` layout:
 
-- None
+-   None
 
 `activity` layout:
 
-- `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
-
+-   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
 
 #### `onChangeView`: `function`
 
@@ -451,9 +450,14 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
-#### `config`: { perPageSizes: number[] }
+#### `config`: { perPageSizes: number[], labels: { singular: string, plural: string } }
 
 Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page (defaults to `[10, 20, 50, 100]`). `perPageSizes` needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
+
+The `labels` object is used to control the labels for the item count in the bulk actions footer. It contains two properties:
+
+-   `singular`: the singular label for the item. Defaults to `Item`.
+-   `plural`: the plural label for the item. Defaults to `Items`.
 
 #### `empty`: React node
 
@@ -690,9 +694,14 @@ Example:
 }
 ```
 
-#### `config`: { perPageSizes: number[] }
+#### `config`: { perPageSizes: number[], labels: { singular: string, plural: string } }
 
 Same as `DataViews`. Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page.
+
+The `labels` object is used to control the labels for the item count in the bulk actions footer. It contains two properties:
+
+-   `singular`: the singular label for the item. Defaults to `Item`.
+-   `plural`: the plural label for the item. Defaults to `Items`.
 
 #### `empty`: React node
 
@@ -847,29 +856,29 @@ For example:
 
 ```json
 {
-  "title": {
-    "required": {
-      "type": "invalid"
-    }
-  },
-  "author": {
-    "elements": {
-      "type": "invalid",
-      "message": "Value must be one of the elements."
-    }
-  },
-  "publisher": {
-    "custom": {
-      "type": "validating",
-      "message": "Validating..."
-    }
-  },
-  "isbn": {
-    "custom": {
-      "type": "valid",
-      "message": "Valid."
-    }
-  }
+	"title": {
+		"required": {
+			"type": "invalid"
+		}
+	},
+	"author": {
+		"elements": {
+			"type": "invalid",
+			"message": "Value must be one of the elements."
+		}
+	},
+	"publisher": {
+		"custom": {
+			"type": "validating",
+			"message": "Validating..."
+		}
+	},
+	"isbn": {
+		"custom": {
+			"type": "valid",
+			"message": "Valid."
+		}
+	}
 }
 ```
 
@@ -879,11 +888,11 @@ The `message` is the text to be displayed in the UI controls. The message for th
 
 The `type` can be:
 
-- `validating`: when the value is being validated (e.g., custom async rule)
-- `invalid`: when the value is invalid according to the rule
-- `valid`: when the value _became_ valid after having been invalid (e.g., custom async rule)
+-   `validating`: when the value is being validated (e.g., custom async rule)
+-   `invalid`: when the value is invalid according to the rule
+-   `valid`: when the value _became_ valid after having been invalid (e.g., custom async rule)
 
-Note the `valid` status. This is useful for displaying a "Valid." message when the field transitions from invalid to valid.  The `useFormValidity` hook implements this only for the custom async validation.
+Note the `valid` status. This is useful for displaying a "Valid." message when the field transitions from invalid to valid. The `useFormValidity` hook implements this only for the custom async validation.
 
 ## Utilities
 
@@ -958,7 +967,7 @@ The user facing description of the action.
 
 ```js
 {
-	label: Trash
+	label: Trash;
 }
 ```
 
@@ -1375,7 +1384,7 @@ Field authors can override the default Edit control by providing a string that m
 
 Additionally, some of the bundled Edit controls are configurable via a config object:
 
-- `textarea` configuration:
+-   `textarea` configuration:
 
 ```js
 {
@@ -1389,7 +1398,7 @@ Additionally, some of the bundled Edit controls are configurable via a config ob
 }
 ```
 
-- `text` configuration:
+-   `text` configuration:
 
 ```js
 {
@@ -1442,7 +1451,6 @@ Finally, the field author can always provide its own custom `Edit` control. It r
 }
 ```
 
-
 ### `sort`
 
 Function to sort the records.
@@ -1462,9 +1470,9 @@ When the field declares a type, it gets a default sort function:
 
 The default sorting can be overriden by providing a custom sort function. It takes the following arguments:
 
-  -   `a`: the first item to compare
-  -   `b`: the second item to compare
-  -   `direction`: either `asc` (ascending) or `desc` (descending)
+-   `a`: the first item to compare
+-   `b`: the second item to compare
+-   `direction`: either `asc` (ascending) or `desc` (descending)
 
 It should return a number where:
 
@@ -1678,7 +1686,7 @@ Note this function may be called many times in the lifetime of the DataViews/Dat
 
 ### `filterBy`
 
-Configuration of the filters.  Set to `false` to opt the field out of filtering entirely.
+Configuration of the filters. Set to `false` to opt the field out of filtering entirely.
 
 -   Type: `object` | `boolean`.
 -   Optional.
@@ -1804,8 +1812,6 @@ The next table lists all available operators:
 
 `is`, `isNot`, `on`, `notOn`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `before`, `after`, `beforeInc`, `afterInc`, `contains`, `notContains`, and `startsWith` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotAll` are multi-selection. `between` is a special operator that requires two values and it's not supported for preset layout. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
 
-
-
 ### `format`
 
 Display format configuration for fields. Currently supported for date fields. This configuration affects how the field is displayed in the `render` method, the `Edit` control, and filter controls.
@@ -1870,11 +1876,10 @@ For example:
 
 #### Panel
 
-- `type`: `panel`. Required.
-- `labelPosition`: one of `side`, `top`, or `none`. Optional. `top` by default.
-- `summary`: Summary field configuration. Optional. Specifies which field(s) to display in the panel header. Can be:
-   	- A string (single field ID)
-    - An array of strings (multiple field IDs)
+-   `type`: `panel`. Required.
+-   `labelPosition`: one of `side`, `top`, or `none`. Optional. `top` by default.
+-   `summary`: Summary field configuration. Optional. Specifies which field(s) to display in the panel header. Can be: - A string (single field ID)
+    -   An array of strings (multiple field IDs)
 
 When no summary fields are explicitly configured, the panel automatically determines which fields to display using this priority:
 

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -156,6 +156,10 @@ interface ToolbarContentProps< Item > {
 	data: Item[];
 	actions: Action< Item >[];
 	getItemId: ( item: Item ) => string;
+	labels: {
+		singular: string;
+		plural: string;
+	};
 }
 
 function ActionTrigger< Item >( {
@@ -245,23 +249,31 @@ function renderFooterContent< Item >(
 	selectedItems: Item[],
 	actionInProgress: string | null,
 	setActionInProgress: ( actionId: string | null ) => void,
-	onChangeSelection: SetSelection
+	onChangeSelection: SetSelection,
+	labels: {
+		singular: string;
+		plural: string;
+	}
 ) {
 	const message =
 		selectedItems.length > 0
 			? sprintf(
-					/* translators: %d: number of items. */
+					/* translators: %1$d: number of items, %2$s: singular label, %3$s: plural label. */
 					_n(
-						'%d Item selected',
-						'%d Items selected',
+						'%1$d %2$s selected',
+						'%1$d %3$s selected',
 						selectedItems.length
 					),
-					selectedItems.length
+					selectedItems.length,
+					labels.singular,
+					labels.plural
 			  )
 			: sprintf(
-					/* translators: %d: number of items. */
-					_n( '%d Item', '%d Items', data.length ),
-					data.length
+					/* translators: %1$d: number of items, %2$s: singular label, %3$s: plural label. */
+					_n( '%1$d %2$s', '%1$d %3$s', data.length ),
+					data.length,
+					labels.singular,
+					labels.plural
 			  );
 	return (
 		<HStack
@@ -320,6 +332,7 @@ function FooterContent< Item >( {
 	onChangeSelection,
 	data,
 	getItemId,
+	labels,
 }: ToolbarContentProps< Item > ) {
 	const [ actionInProgress, setActionInProgress ] = useState< string | null >(
 		null
@@ -374,7 +387,8 @@ function FooterContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onChangeSelection
+			onChangeSelection,
+			labels
 		);
 	} else if ( ! footerContentRef.current ) {
 		footerContentRef.current = renderFooterContent(
@@ -386,7 +400,8 @@ function FooterContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onChangeSelection
+			onChangeSelection,
+			labels
 		);
 	}
 	return footerContentRef.current;
@@ -399,6 +414,7 @@ export function BulkActionsFooter() {
 		actions = EMPTY_ARRAY,
 		onChangeSelection,
 		getItemId,
+		config,
 	} = useContext( DataViewsContext );
 	return (
 		<FooterContent
@@ -407,6 +423,7 @@ export function BulkActionsFooter() {
 			data={ data }
 			actions={ actions }
 			getItemId={ getItemId }
+			labels={ config.labels }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -7,6 +7,7 @@ import type { ComponentProps, ReactElement, ReactNode } from 'react';
  * WordPress dependencies
  */
 import { createContext, createRef } from '@wordpress/element';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -54,7 +55,10 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	config: { perPageSizes: number[] };
+	config: {
+		perPageSizes: number[];
+		labels: { singular: string; plural: string };
+	};
 	empty?: ReactNode;
 	hasInfiniteScrollHandler: boolean;
 	itemListLabel?: string;
@@ -86,6 +90,10 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	hasInfiniteScrollHandler: false,
 	config: {
 		perPageSizes: [],
+		labels: {
+			singular: _x( 'Item', 'singular label' ),
+			plural: _x( 'Items', 'plural label' ),
+		},
 	},
 } );
 

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -138,6 +138,7 @@ export function DataViewsPickerFooter() {
 		onChangeSelection,
 		getItemId,
 		actions = EMPTY_ARRAY,
+		config,
 	} = useContext( DataViewsContext );
 
 	const selectionCount = selection.length;
@@ -146,18 +147,22 @@ export function DataViewsPickerFooter() {
 	const message =
 		selectionCount > 0
 			? sprintf(
-					/* translators: %d: number of items. */
+					/* translators: %1$d: number of items, %2$s: singular label, %3$s: plural label. */
 					_n(
-						'%d Item selected',
-						'%d Items selected',
+						'%1$d %2$s selected',
+						'%1$d %3$s selected',
 						selectionCount
 					),
-					selectionCount
+					selectionCount,
+					config.labels.singular,
+					config.labels.plural
 			  )
 			: sprintf(
-					/* translators: %d: number of items. */
-					_n( '%d Item', '%d Items', data.length ),
-					data.length
+					/* translators: %1$d: number of items, %2$s: singular label, %3$s: plural label. */
+					_n( '%1$d %2$s', '%1$d %3$s', data.length ),
+					data.length,
+					config.labels.singular,
+					config.labels.plural
 			  );
 
 	const selectedItems = useMemo(

--- a/packages/dataviews/src/components/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/index.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -60,6 +61,7 @@ type DataViewsPickerProps< Item > = {
 	children?: ReactNode;
 	config?: {
 		perPageSizes: number[];
+		labels: { singular: string; plural: string };
 	};
 	itemListLabel?: string;
 	empty?: ReactNode;
@@ -125,7 +127,13 @@ function DataViewsPicker< Item >( {
 	selection,
 	onChangeSelection,
 	children,
-	config = { perPageSizes: [ 10, 20, 50, 100 ] },
+	config = {
+		perPageSizes: [ 10, 20, 50, 100 ],
+		labels: {
+			singular: _x( 'Item', 'singular label' ),
+			plural: _x( 'Items', 'plural label' ),
+		},
+	},
 	itemListLabel,
 	empty,
 }: DataViewsPickerProps< Item > ) {

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -21,7 +21,7 @@ import {
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
 import { cog } from '@wordpress/icons';
 import warning from '@wordpress/warning';
@@ -217,12 +217,18 @@ function ItemsPerPageControl() {
 		return null;
 	}
 
+	const pluralLabel = config.labels.plural;
+
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			isBlock
-			label={ __( 'Items per page' ) }
+			label={ sprintf(
+				/* translators: %s: collection plural label. e.g.: "Posts per page". */
+				__( '%s per page' ),
+				pluralLabel
+			) }
 			value={ view.perPage || 10 }
 			disabled={ ! view?.sort?.field }
 			onChange={ ( newItemsPerPage ) => {

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -9,7 +9,7 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
-
+import { _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -64,6 +64,7 @@ type DataViewsProps< Item > = {
 	children?: ReactNode;
 	config?: {
 		perPageSizes: number[];
+		labels: { singular: string; plural: string };
 	};
 	empty?: ReactNode;
 } & ( Item extends ItemWithId
@@ -140,7 +141,13 @@ function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 	children,
-	config = { perPageSizes: [ 10, 20, 50, 100 ] },
+	config = {
+		perPageSizes: [ 10, 20, 50, 100 ],
+		labels: {
+			singular: _x( 'Item', 'singular label' ),
+			plural: _x( 'Items', 'plural label' ),
+		},
+	},
 	empty,
 }: DataViewsProps< Item > ) {
 	const { infiniteScrollHandler } = paginationInfo;

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -171,7 +171,13 @@ const DataViewsPickerContent = ( {
 				view={ view }
 				fields={ fields }
 				onChangeView={ setView }
-				config={ { perPageSizes } }
+				config={ {
+					perPageSizes,
+					labels: {
+						singular: 'Galactic Body',
+						plural: 'Galactic Bodies',
+					},
+				} }
 				itemListLabel="Galactic Bodies"
 				defaultLayouts={ {
 					[ LAYOUT_PICKER_GRID ]: {},

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -114,7 +114,13 @@ export const Default = ( {
 			) }
 			isItemClickable={ () => hasClickableItems }
 			defaultLayouts={ defaultLayouts }
-			config={ { perPageSizes } }
+			config={ {
+				perPageSizes,
+				labels: {
+					singular: 'Galactic Body',
+					plural: 'Galactic Bodies',
+				},
+			} }
 		/>
 	);
 };

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -170,6 +170,13 @@ function NavigationList() {
 					} }
 					getItemId={ getItemId }
 					selection={ selection }
+					config={ {
+						perPageSizes: [ 10, 20, 50, 100 ],
+						labels: {
+							singular: __( 'Navigation' ),
+							plural: __( 'Navigations' ),
+						},
+					} }
 					onChangeSelection={ ( items: string[] ) => {
 						navigate( {
 							search: {

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -320,6 +320,13 @@ function PatternList() {
 				} }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				selection={ selection }
+				config={ {
+					perPageSizes: [ 10, 20, 50, 100 ],
+					labels: {
+						singular: labels?.singular ?? __( 'Pattern' ),
+						plural: labels?.plural ?? __( 'Patterns' ),
+					},
+				} }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -360,6 +360,13 @@ function PostList() {
 						} }
 					/>
 				) }
+				config={ {
+					perPageSizes: [ 10, 20, 50, 100 ],
+					labels: {
+						singular: labels?.singular ?? __( 'Post' ),
+						plural: labels?.plural ?? __( 'Posts' ),
+					},
+				} }
 			/>
 		</Page>
 	);

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -307,6 +307,13 @@ function TemplatePartList() {
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				getItemId={ getItemId }
 				selection={ selection }
+				config={ {
+					perPageSizes: [ 10, 20, 50, 100 ],
+					labels: {
+						singular: labels?.singular ?? __( 'Template Part' ),
+						plural: labels?.plural ?? __( 'Template Parts' ),
+					},
+				} }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/73483

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR adds support for custom labels in DataViews so instead of a generic "10 items" you get things like "10 posts" or "1 order selected"

## How?
Added this by extending the `config` param on DataViews, but I'm not sure that's the best place, I also didn't want to pollute with another top level setting.

Some issues might arise from this given that translations might want to include articles, I'm hoping this can be solved at the `_n` or `__` level.

## Testing Instructions

1. Enable DataViews for posts in Gutenberg experimental page.
2. Visit posts, make sure the footer says "X posts"
3. Select one post, make sure it says "X post selected"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="117" height="47" alt="image" src="https://github.com/user-attachments/assets/a2737126-aea0-472b-940b-3888a27992b4" />|<img width="129" height="46" alt="image" src="https://github.com/user-attachments/assets/8025fe22-c8a7-483d-b6af-6202b7754360" />|
|<img width="160" height="46" alt="image" src="https://github.com/user-attachments/assets/ec93127d-6cff-4e1a-ab62-3d2db71751f8" />|<img width="162" height="48" alt="image" src="https://github.com/user-attachments/assets/ad10e7a9-339f-40c7-8d0f-aeab8553d202" />|
|<img width="174" height="46" alt="image" src="https://github.com/user-attachments/assets/2dc6d44a-1e4d-47c7-9107-f5fdd1d3bfe4" />|<img width="168" height="48" alt="image" src="https://github.com/user-attachments/assets/ce414cc6-3dcb-4c42-a6d4-6eb5bc22be88" />|
