### PR TITLE
Exclude JS/TS test files from build

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -52,6 +52,7 @@ const IGNORE_PATTERNS = [
 	'**/*.native.*',
 	'**/*.ios.*',
 	'**/*.android.*',
+	'**/*.{spec,test}.*',
 ];
 const TEST_FILE_PATTERNS = [
 	/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,


### PR DESCRIPTION
I randomly discovered this package the other day, and it looks awesome - love what y'all are building here! I started using it right away, although I realize it's early. :)

## What?

When using `wp-build` on a project that has JS/TS tests where files are colocated with their source files (e.g. `/src/panel.test.ts` tests `/src/panel.ts`), the test files will currently be included in the output `build` dir.

## Why?
An exclusion for them is missing in `IGNORE_PATTERNS`. They're already ignored elsewhere, and other tests (entire folders) are already part of `IGNORE_PATTERNS`, so maybe this is just a missing piece.

## Testing Instructions
1. Add some tests in a `*.test.ts` or `*.test.js` file next to your source file.
2. Run `wp-build`.
3. Compare the resulting `build` folder with and without this PR: Without, the `*.test.js` file will show - with, it won't (which is what we want).