### PR TITLE
Storybook: Document arg types for LineHeightControl

### DIFF
--- a/packages/block-editor/src/components/line-height-control/stories/index.story.jsx
+++ b/packages/block-editor/src/components/line-height-control/stories/index.story.jsx
@@ -11,6 +11,51 @@ import LineHeightControl from '../';
 export default {
 	component: LineHeightControl,
 	title: 'BlockEditor/LineHeightControl',
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'LineHeightControl renders a NumberControl with custom spin controls that lets the user enter a line height value.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: { type: null },
+			description: 'The current value of the line height setting.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			description:
+				'A callback function invoked when the value is changed.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		__unstableInputWidth: {
+			control: 'text',
+			description:
+				'Input width to pass through to inner NumberControl. Should be a valid CSS value.',
+			table: {
+				type: { summary: 'string | number | undefined' },
+				defaultValue: { summary: '60px' },
+			},
+		},
+		__next40pxDefaultSize: {
+			control: 'boolean',
+			description:
+				'Start opting into the larger default height that will become the default size in a future version.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+	},
 };
 
 const Template = ( props ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add missing documentation for the `LineHeightControl` component.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To provide docs on all components, so that extenders can make use of them.

## Testing Instructions

Run `nvm use && npm run storybook:dev`, check the `LineHeightControl` docs.
