### PR TITLE
Accordion Item: Don't use grid layout

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,12 +1,4 @@
-// In many classic themes, selectors like `.entry-content h1` are used,
-// potentially applying relatively high specificity (such as `0-1-1`) to
-// heading elements. To properly override those styles, use a selector
-// with a specificity of `0-2-0`.
-.wp-block-accordion-heading.wp-block-accordion-heading {
-	// Some themes may have an explicit width. Since it's unpredictable
-	// what CSS specificity should be used to override them, ensure 100%
-	// width using min-width instead.
-	min-width: 100%;
+.wp-block-accordion-heading {
 	// Some classic themes apply default margins to heading elements,
 	// so those styles need to be reset.
 	margin: 0;

--- a/packages/block-library/src/accordion-item/style.scss
+++ b/packages/block-library/src/accordion-item/style.scss
@@ -1,13 +1,6 @@
 .wp-block-accordion-item {
-	display: grid;
-	grid-template-rows: max-content 0fr;
-
-	&.is-open {
-		grid-template-rows: max-content 1fr;
-
-		> .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon {
-			transform: rotate(45deg);
-		}
+	&.is-open > .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon {
+		transform: rotate(45deg);
 	}
 
 	/* Add transitions only for users who do not prefer reduced motion */

--- a/packages/block-library/src/accordion-panel/style.scss
+++ b/packages/block-library/src/accordion-panel/style.scss
@@ -1,8 +1,4 @@
-// Some classic themes may use selectors like `.wp-block .wp-block`
-// and apply some kind of width to the blocks. To properly override
-// those styles, use a selector with a specificity of `0-2-0`.
-.wp-block-accordion-panel.wp-block-accordion-panel {
-	min-width: 100%;
+.wp-block-accordion-panel {
 
 	// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
 	&[inert],


### PR DESCRIPTION
Fixes #73455

## What?

This PR removes unnecessary grid layout from the Accordion Item block.

This removes several unnecessary CSS hacks, as a result, resolving the issue reported in #73455.

## Why? How?

Perhaps this grid CSS was originally intended to be used to visually hide the accordion panel. However, since the panel is visually hidden [here](https://github.com/WordPress/gutenberg/blob/88424b78ba8c6c5f7b62c83a30fec12e25386e1e/packages/block-library/src/accordion-panel/style.scss#L7-L12) depending on the state, the grid CSS itself is not necessary.

Because the Accordion Item is no longer grid layout, its child elements are guaranteed to be 100% width by default. Therefore, the `min-width` required for the classic theme is no longer necessary.

As a result, overflow issues when padding or borders are added to panels are resolved.

## Testing Instructions

- Insert an Accordion block.
- Add contents inside the Accordion Panel.
- Apply padding to a panel.
- Confirm that the content does not overflow.

### Testing for Block Gap

- Open the global styles > blocks > Accordion Item
- Confirm that the block spacing setting is applied correctly.
- Open the block sidebar.
- Confirm that you can override the block gap at the block instance level.

### Testing for Classic Theme

- Activate Twenty Twenty-One.
- Insert an Accordion block.
- Make sure the width of blocks Accordion Heading and Accordion Panel matches the container width. Previously, these two blocks were children of a grid layout, so we needed to use `min-width` to make them wider, but now they work correctly without this `min-width`.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1249" height="758" alt="before" src="https://github.com/user-attachments/assets/d8d797f6-9d06-4fc3-9ddd-6fcb155a7450" />

### After

<img width="1248" height="753" alt="after" src="https://github.com/user-attachments/assets/b1d118a0-b516-4f24-a721-0de232742995" />
