### PR TITLE
Global Styles: Fix media upload permission check

### DIFF
--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -33,7 +33,7 @@ function useServerData() {
 
 		const canUserUploadMedia = canUser( 'create', {
 			kind: 'postType',
-			name: 'attachement',
+			name: 'attachment',
 		} );
 
 		return {


### PR DESCRIPTION
- Related to #73197
- Fixes #73500

## What? Why? How?

There was a typo in the media upload permission check that caused the add background image button to not work properly.

## Testing Instructions

- Access Appearance > Editor > Styles > Blocks > Group
Click the "Add background image" button

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="401" height="362" alt="image" src="https://github.com/user-attachments/assets/4d339cdd-be65-452f-8711-6ddcc7c32721" /> | <img width="403" height="416" alt="image" src="https://github.com/user-attachments/assets/c146224c-9a9a-442d-bd1f-f43f9d458e84" /> |