### PR TITLE
HTML Block: Fix scrolling within the modal

### DIFF
--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -14,22 +14,20 @@
 
 // Modal styles
 .block-library-html__modal {
-	// Make modal content scrollable
-	.components-modal__content {
-		display: flex;
-		flex-direction: column;
-		padding: 0;
-		min-height: 70vh;
-	}
+	height: 100%;
 
 	.components-modal__children-container {
 		height: 100%;
-		padding: $grid-unit-20;
 	}
 }
 
 .block-library-html__modal-tabs {
-	height: 100%;
+	overflow-y: auto;
+}
+
+.block-library-html__modal-content {
+	flex: 1;
+	min-height: 0;
 }
 
 .block-library-html__modal-tab {
@@ -73,10 +71,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: $grid-unit-60;
-}
-
-.block-library-html__modal-actions {
-	margin-top: $grid-unit-20;
-	padding: 0 $grid-unit-40 $grid-unit-40;
+	padding: $grid-unit-20;
+	flex: 1;
+	min-height: 0;
 }

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -10,7 +10,7 @@ import {
 	Flex,
 	privateApis as componentsPrivateApis,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
+	__experimentalGrid as Grid,
 } from '@wordpress/components';
 import { PlainText, store as blockEditorStore } from '@wordpress/block-editor';
 import { fullscreen, square } from '@wordpress/icons';
@@ -117,8 +117,16 @@ export default function HTMLEditModal( {
 				__experimentalHideHeader
 			>
 				<Tabs orientation="horizontal" defaultTabId="html">
-					<VStack spacing={ 4 } style={ { height: '100%' } }>
-						<HStack justify="space-between">
+					<Grid
+						columns={ 1 }
+						templateRows="auto 1fr auto"
+						gap={ 4 }
+						style={ { height: '100%' } }
+					>
+						<HStack
+							justify="space-between"
+							className="block-library-html__modal-header"
+						>
 							<div>
 								<Tabs.TabList>
 									<Tabs.Tab tabId="html">HTML</Tabs.Tab>
@@ -145,9 +153,8 @@ export default function HTMLEditModal( {
 							justify="flex-start"
 							spacing={ 4 }
 							className="block-library-html__modal-tabs"
-							style={ { flexGrow: 1 } }
 						>
-							<div style={ { flexGrow: 1 } }>
+							<div className="block-library-html__modal-content">
 								<Tabs.TabPanel
 									tabId="html"
 									focusable={ false }
@@ -192,10 +199,7 @@ export default function HTMLEditModal( {
 									</Tabs.TabPanel>
 								) }
 							</div>
-							<div
-								className="block-library-html__preview"
-								style={ { width: '50%' } }
-							>
+							<div className="block-library-html__preview">
 								<Preview
 									content={ serializeContent( {
 										html: editedHtml,
@@ -209,6 +213,7 @@ export default function HTMLEditModal( {
 							alignment="center"
 							justify="flex-end"
 							spacing={ 4 }
+							className="block-library-html__modal-footer"
 						>
 							<Button
 								__next40pxDefaultSize
@@ -225,7 +230,7 @@ export default function HTMLEditModal( {
 								{ __( 'Update' ) }
 							</Button>
 						</HStack>
-					</VStack>
+					</Grid>
 				</Tabs>
 			</Modal>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix a couple of scrolling and modal issues with the new HTML block editing modal introduced in https://github.com/WordPress/gutenberg/pull/73108 and after some modal component changes in https://github.com/WordPress/gutenberg/pull/73150.

Namely, this PR ensures that when there's enough content in the HTML block modal to cause a scrollbar, it's the middle of the content that scrolls, and that content doesn't erroneously appear within the padding area. The issue is a bit clearer in the screenshots below.

Note: this PR doesn't address other existing issues with the modal, like the absence of responsive display in narrow viewports. A separate PR that swaps the side-by-side for a preview toggle could be a good follow-up.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like the existing markup and styling didn't quite work for when the HTML block contains enough content to have a scrollbar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Use a wrapping `Grid` instead of a `VStack` as we don't want the header and footer areas to shrink, and this feels a bit more fit for purpose to me
* Ensure that everything that needs to expand to `height: 100%` does so, and set the content area of the Tabs to `overflow-y: auto` so that _that's_ the area that scrolls

## Testing Instructions

1. Add an HTML block to a post
2. Add a bunch of HTML markup (and CSS if you like)
3. Check that the modal looks like it's rendering okay and scrolling okay (or at least better than on trunk)
4. Also check with an empty HTML block, or one with not very much content in it
5. Double check in both full screen and not-fullscreen

## Screenshots or screencast <!-- if applicable -->

### This is the issue (note that the headers / footers weren't sticky, that the preview extends over the padding area)

<img width="1263" height="889" alt="image" src="https://github.com/user-attachments/assets/ff6309e8-f60c-4404-9298-b7c0c351d517" />

### Before video

Note that in the before video (what's on trunk), things look pretty okay until there's a bunch of content. Then, it falls apart:

https://github.com/user-attachments/assets/d775fd1c-afa2-456e-94bb-937f24e1fb82

### After video

With this PR, things should be looking pretty good irrespective of how much content there is. If there's too much, we scroll the middle area:

https://github.com/user-attachments/assets/9075efca-4052-4622-b2a1-1c515328cb04



