### PR TITLE
Accordion: add box-sizing:border-box rule

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -1,0 +1,4 @@
+.wp-block-accordion {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -1,3 +1,4 @@
+@use "./accordion/style.scss" as *;
 @use "./accordion-item/style.scss" as *;
 @use "./accordion-heading/style.scss" as *;
 @use "./accordion-panel/style.scss" as *;


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/pull/63538

## Why? How?

For blocks that support padding, with some exceptions (Paragraph block and Heading block, it is recommended to add `box-sizing:border-box` to ensure that the block width always fits the container.

## Testing Instructions

- Insert an Accordion block
- Apply padding

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="803" height="280" alt="image" src="https://github.com/user-attachments/assets/f565a59c-9e9c-4eac-990f-17c5546b8d7a" />

### After

<img width="817" height="291" alt="image" src="https://github.com/user-attachments/assets/3a36194d-98ae-45df-9164-51b987b0d980" />
