### PR TITLE
Math block: fix accessibility

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -97,6 +98,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setError( null );
 									} catch ( err ) {
 										setError( err.message );
+										speak( err.message );
 									}
 									setAttributes( {
 										mathML: newMathML,

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -73,6 +73,8 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					offset={ 8 }
 					anchor={ blockRef }
 					focusOnMount="firstContentElement"
+					__unstableSlotName="__unstable-block-tools-after"
+					constrainTabbing={ false }
 				>
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -72,9 +72,8 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					placement="bottom-start"
 					offset={ 8 }
 					anchor={ blockRef }
-					focusOnMount="firstContentElement"
+					focusOnMount={ false }
 					__unstableSlotName="__unstable-block-tools-after"
-					constrainTabbing={ false }
 				>
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -12,6 +12,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { math as icon } from '@wordpress/icons';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -52,6 +53,7 @@ function InlineUI( {
 				setError( null );
 			} catch ( err ) {
 				setError( err.message );
+				speak( err.message );
 				return;
 			}
 		}

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -51,13 +51,13 @@ test.describe( 'Math Block', () => {
 		// Test removing math block.
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Tab' );
-		await page.keyboard.type( '1=' );
+		await page.keyboard.type( '&' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/math',
 				attributes: {
-					latex: '1=x^2',
+					latex: '&x^2',
 				},
 			},
 			{
@@ -67,6 +67,10 @@ test.describe( 'Math Block', () => {
 				},
 			},
 		] );
+
+		await expect( page.locator( '[aria-live="polite"]' ) ).toHaveText(
+			`Expected 'EOF', got '&' at position 1: &̲x^2`
+		);
 
 		// Can delete the math block.
 		await pageUtils.pressKeys( 'shift+Tab' );

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Math Block', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should insert math block with LaTeX', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/math' } );
+
+		// Can access the popover.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'x^2' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/math',
+				attributes: {
+					latex: 'x^2',
+				},
+			},
+		] );
+
+		// Can escape the popover.
+		await pageUtils.pressKeys( 'shift+Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/math',
+				attributes: {
+					latex: 'x^2',
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'b',
+				},
+			},
+		] );
+
+		// Test removing math block.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( '1=' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/math',
+				attributes: {
+					latex: '1=x^2',
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'b',
+				},
+			},
+		] );
+
+		// Can delete the math block.
+		await pageUtils.pressKeys( 'shift+Tab' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'b',
+				},
+			},
+		] );
+	} );
+} );

--- a/test/e2e/specs/editor/various/format-library/math.spec.js
+++ b/test/e2e/specs/editor/various/format-library/math.spec.js
@@ -31,10 +31,8 @@ test.describe( 'Format Library - Math', () => {
 			},
 		] );
 
-		const mathInput = page.locator(
-			'.block-editor-format-toolbar__math-input input'
-		);
-		await mathInput.fill( 'x^2' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'x^2' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #73447.
Fixes #73446.
Fixes #73445.

Makes the popover for the block accessible.

The popover for the _format_ was working correctly, but the popover for the block was not.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the same popover props as the format.
Calls `speak` when there's a LaTeX error.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Pressing tab from the math block should move focus to the text area, then the inspector. Shift tab should move it back to the text area, then the block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
