### PR TITLE
Field API: document missing props

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Documentation: improve Edit component. [#73202](https://github.com/WordPress/gutenberg/pull/73202)
 - Documentation: surface better the `type` property in the documentation. [#73349](https://github.com/WordPress/gutenberg/pull/73349)
 - Documentation: improve DataView's `layout` prop. [#73470](https://github.com/WordPress/gutenberg/pull/73470)
+- Documentation: document `readOnly`, `description`, and `placeholder` properties. [#73515](https://github.com/WordPress/gutenberg/pull/73515)
 - DataForm Panel Layout: Focus the first input element when the panel opens. [#72322](https://github.com/WordPress/gutenberg/pull/72322)
 - DataForm: Pattern validation is now supported on all fields that browsers support it in. [#73156](https://github.com/WordPress/gutenberg/pull/73156)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1198,6 +1198,20 @@ Example:
 }
 ```
 
+### `description`
+
+A string describing the field's purpose or usage. Used to provide context in Edit mode, etc.
+
+-   Type: `string`.
+-   Optional.
+
+### `placeholder`
+
+A string used as a placeholder in Edit mode, etc.
+
+-   Type: `string`.
+-   Optional.
+
 ### `getValue` and `setValue`
 
 These functions control how field values are read from and written to your data structure.
@@ -1442,6 +1456,13 @@ Finally, the field author can always provide its own custom `Edit` control. It r
 }
 ```
 
+### `readOnly`
+
+Boolean indicating that the field is not editable. Fields that are not editable use the `render` function to display their value in Edit contexts.
+
+-   Type: `boolean`.
+-   Optional.
+-   Defaults to `false`.
 
 ### `sort`
 


### PR DESCRIPTION
## What?

Adds docs for `readOnly`, `description`, and `placeholder`.

## Why?

They were missing.

