### PR TITLE
Build: transpile packages into one file per entrypoint

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -41,15 +41,10 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"src/index.js",
 		"src/store/index.js",
 		"src/hooks/**",
 		"build/index.js",
-		"build/store/index.js",
-		"build/hooks/**",
-		"build-module/index.js",
-		"build-module/store/index.js",
-		"build-module/hooks/**"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@react-spring/web": "^9.4.5",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -32,7 +32,11 @@
 		"./babel-plugin": "./babel-plugin.js",
 		"./build-module/*": "./build-module/*",
 		"./build-style/*": "./build-style/*",
-		"./package.json": "./package.json"
+		"./package.json": "./package.json",
+		"./*": {
+			"import": "./build-module/*",
+			"require": "./build/*"
+		}
 	},
 	"react-native": "src/index",
 	"wpScript": true,

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -37,9 +37,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/autop": "file:../autop",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -38,18 +38,11 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"src/index.js",
 		"src/store/index.js",
 		"src/hooks/**",
 		"src/bindings/**",
 		"build/index.js",
-		"build/store/index.js",
-		"build/hooks/**",
-		"build/bindings/**",
-		"build-module/index.js",
-		"build-module/store/index.js",
-		"build-module/hooks/**",
-		"build-module/bindings/**"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@floating-ui/react-dom": "2.0.8",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -40,9 +40,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -40,9 +40,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -39,9 +39,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -37,9 +37,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -40,9 +40,7 @@
 		"src/index.js",
 		"src/store/index.js",
 		"build/index.js",
-		"build/store/index.js",
-		"build-module/index.js",
-		"build-module/store/index.js"
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -964,14 +964,54 @@ async function transpilePackage( packageName ) {
 		);
 	}
 
-	const srcFiles = await glob(
-		normalizePath(
-			path.join( packageDir, `src/**/*.${ SOURCE_EXTENSIONS }` )
-		),
-		{
-			ignore: IGNORE_PATTERNS,
+	const cjsEntryPoints = new Set();
+	const moduleEntryPoints = new Set();
+
+	function addBuildPath( entryPoints, buildPath ) {
+		// Convert an exported path like `./build-module/something.js` to
+		// the corresponding source path like `./src/something.tsx`.
+		const srcPath = buildPath
+			.replace( /\/build-module\/|\/build\//, '/src/' )
+			.replace( /\.[^.]+$/, `.${ SOURCE_EXTENSIONS }` );
+		const srcPathNormalized = normalizePath(
+			path.join( packageDir, srcPath )
+		);
+		// Find the real source file, with one of the supported extensions, with `glob`.
+		const srcFiles = glob.sync( srcPathNormalized );
+		if ( srcFiles.length > 0 ) {
+			entryPoints.add( srcFiles[ 0 ] );
 		}
-	);
+	}
+
+	// Add the `.` exports as entrypoints, both CJS and ESM.
+	if ( packageJson.exports ) {
+		const rootExport = packageJson.exports[ '.' ];
+		if ( typeof rootExport === 'string' ) {
+			addBuildPath( cjsEntryPoints, rootExport );
+			addBuildPath( moduleEntryPoints, rootExport );
+		} else if ( typeof rootExport === 'object' ) {
+			const rootCjsExport = rootExport.require || rootExport.default;
+			if ( rootCjsExport ) {
+				addBuildPath( cjsEntryPoints, rootCjsExport );
+			}
+			const rootModuleExport = rootExport.import || rootExport.default;
+			if ( rootModuleExport ) {
+				addBuildPath( moduleEntryPoints, rootModuleExport );
+			}
+		}
+	}
+
+	// Add the `wpScriptModuleExports` exports as entrypoints, module only.
+	if ( packageJson.wpScriptModuleExports ) {
+		const exports =
+			typeof packageJson.wpScriptModuleExports === 'string'
+				? { '.': packageJson.wpScriptModuleExports }
+				: packageJson.wpScriptModuleExports;
+
+		for ( const exportPath of Object.values( exports ) ) {
+			addBuildPath( moduleEntryPoints, exportPath );
+		}
+	}
 
 	const assetFiles = await glob(
 		normalizePath(
@@ -1003,6 +1043,14 @@ async function transpilePackage( packageName ) {
 		setup( build ) {
 			// Externalize all non-CSS imports
 			build.onResolve( { filter: /.*/ }, ( args ) => {
+				// Skip non-package imports.
+				if (
+					args.path.startsWith( '.' ) ||
+					path.isAbsolute( args.path )
+				) {
+					return;
+				}
+
 				// Skip entry points
 				if ( args.kind === 'entry-point' ) {
 					return null;
@@ -1024,10 +1072,10 @@ async function transpilePackage( packageName ) {
 		...styleBundlingPlugins,
 	].filter( Boolean );
 
-	if ( packageJson.main ) {
+	if ( cjsEntryPoints.size > 0 ) {
 		builds.push(
 			esbuild.build( {
-				entryPoints: srcFiles,
+				entryPoints: Array.from( cjsEntryPoints ),
 				outdir: buildDir,
 				outbase: srcDir,
 				bundle: true,
@@ -1056,10 +1104,10 @@ async function transpilePackage( packageName ) {
 		}
 	}
 
-	if ( packageJson.module ) {
+	if ( moduleEntryPoints.size > 0 ) {
 		builds.push(
 			esbuild.build( {
-				entryPoints: srcFiles,
+				entryPoints: Array.from( moduleEntryPoints ),
 				outdir: buildModuleDir,
 				outbase: srcDir,
 				bundle: true,

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1001,6 +1001,30 @@ async function transpilePackage( packageName ) {
 		}
 	}
 
+	// Add `index` and `init` scripts for each block.
+	if ( packageName === 'block-library' ) {
+		const blockJsonFiles = glob.sync(
+			normalizePath( path.join( packageDir, 'src/*/block.json' ) )
+		);
+
+		// Block name is the folder name.
+		for ( const blockJsonFile of blockJsonFiles ) {
+			const blockName = path.basename( path.dirname( blockJsonFile ) );
+
+			// Add index.js and init.js as entry points for each block
+			for ( const entry of [ 'index.js', 'init.js' ] ) {
+				addBuildPath(
+					cjsEntryPoints,
+					`./build/${ blockName }/${ entry }`
+				);
+				addBuildPath(
+					moduleEntryPoints,
+					`./build-module/${ blockName }/${ entry }`
+				);
+			}
+		}
+	}
+
 	// Add the `wpScriptModuleExports` exports as entrypoints, module only.
 	if ( packageJson.wpScriptModuleExports ) {
 		const exports =


### PR DESCRIPTION
This is an alternative to #73422 that solves the same problem with a different method.

When preparing a package to be consumed by other package or published to NPM, we used to transpile every file individually and copy the entire directory structure to `build` or `build-module`. For example, `packages/block-editor/src/components/block-actions/index.js` would be transpiled (JSX syntax, TypeScript, ...) and written into `packages/block-editor/build-module/components/block-actions/index.js`. One by one.

After this PR, we bundle all the sources together into just one big `packages/block-editor/build-module/index.js` file. That's the only JS export anyway, and the inner structure should be completely hidden to an outside consumer, especially if the consumer respects the modern `exports` field in `package.json`.

There's not always just one export: we also have additional exports defined in `wpScriptModuleExports`, and we respect them and bundle them separately. For example, `block-editor` exports `.` and `./utils/fit-text-frontend`. Therefore, in the `build-module` folder you'll find two output files:
```
build-module/index.js
build-module/utils/fit-text-frontend.js
```

Reasons for doing this:
1. It fully eliminates all internal relative imports, like `import x from './x.js'`, exactly all the import that #73422 tries to post-process. These relative imports are bundled now.
2. We already use a _bundler_ for the `transpilePackage` task, and it already does bundling for CSS imports. These imports are not left unchanged, like the relative JS imports are, but the CSS is inlined. This PR takes the bundling step to its logical end.

This will be a breaking change for anyone who does "internal" imports like `import from '@wordpress/block-editor/build-module/...'`. This will stop working because the imported file will no longer exist. You need to import everything through the official exports, i.e., the root `index.js` file.
