### PR TITLE
Storybook: set media field as readOnly

### DIFF
--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -420,6 +420,7 @@ const fields: Field< DataType >[] = [
 				<img src={ item.media } alt="" style={ { width: '100%' } } />
 			);
 		},
+		readOnly: true,
 	},
 	{
 		id: 'mediaWithElements',


### PR DESCRIPTION
## What?

This PR sets the field `media` as read only, so it is displayed in the DataForm.

## Why?

To add a testcase of a media field that is rendered in the form.

## Testing Instructions

- See storybook > DataViews > Field Types > Media.
- Verify the field is displayed in the form.
