### PR TITLE
iAPI: Fix using `getServerContext` in derived state getters

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-context/render.php
@@ -55,6 +55,7 @@ $child_ctx  = $attributes['childContext'] ?? false;
 		<div data-testid="nonChanging" data-wp-text="context.nonChanging"></div>
 		<div data-testid="onlyInMain" data-wp-text="context.onlyInMain"></div>
 		<div data-testid="onlyInModified" data-wp-text="context.onlyInModified"></div>
+		<div data-testid="serverProp" data-wp-text="state.serverProp"></div>
 
 		<button
 			data-testid="tryToModifyServerContext"

--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-context/view.js
@@ -9,6 +9,11 @@ import {
 } from '@wordpress/interactivity';
 
 store( 'test/get-server-context', {
+	state: {
+		get serverProp() {
+			return getServerContext().prop;
+		},
+	},
 	actions: {
 		navigate: withSyncEvent( function* ( e ) {
 			e.preventDefault();

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Return a deep-clone object from `getServerState` and `getServerContext` functions. ([#73437](https://github.com/WordPress/gutenberg/pull/73437))
+-   Fix using `getServerContext` in derived state getters. ([#73518](https://github.com/WordPress/gutenberg/pull/73518))
 
 ## 6.35.0 (2025-11-12)
 

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -24,7 +24,6 @@ import {
 	splitTask,
 	isPlainObject,
 	deepClone,
-	navigationSignal,
 } from './utils';
 import {
 	directive,
@@ -34,7 +33,7 @@ import {
 	type DirectiveCallback,
 	type DirectiveEntry,
 } from './hooks';
-import { getScope } from './scopes';
+import { getScope, navigationContextSignal } from './scopes';
 import { proxifyState, proxifyContext, deepMerge } from './proxies';
 import { PENDING_GETTER } from './proxies/state';
 
@@ -1027,7 +1026,8 @@ export default () => {
 			// been evaluated and the value of the server context has changed.
 			useLayoutEffect( () => {
 				if ( vdom && typeof vdom.type !== 'string' ) {
-					navigationSignal.value = navigationSignal.peek() + 1;
+					navigationContextSignal.value =
+						navigationContextSignal.peek() + 1;
 				}
 			}, [ vdom ] );
 

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -10,7 +10,7 @@ import {
 	type VNode,
 	type RefObject,
 } from 'preact';
-import { useContext, useMemo, useRef } from 'preact/hooks';
+import { useContext, useLayoutEffect, useMemo, useRef } from 'preact/hooks';
 import { signal, type Signal } from '@preact/signals';
 
 /**
@@ -24,6 +24,7 @@ import {
 	splitTask,
 	isPlainObject,
 	deepClone,
+	navigationSignal,
 } from './utils';
 import {
 	directive,
@@ -1021,6 +1022,14 @@ export default () => {
 
 			// Get the content of this router region.
 			const vdom = routerRegions.get( regionId )!.value;
+
+			// Triggers an invalidation after the directive data-wp-context has
+			// been evaluated and the value of the server context has changed.
+			useLayoutEffect( () => {
+				if ( vdom && typeof vdom.type !== 'string' ) {
+					navigationSignal.value = navigationSignal.peek() + 1;
+				}
+			}, [ vdom ] );
 
 			if ( vdom && typeof vdom.type !== 'string' ) {
 				// The scope needs to be injected.

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -342,6 +342,18 @@ export const routerRegions = new Map<
 	Signal< VNode | null | undefined >
 >();
 
+let isNavigationSignalPending = false;
+const scheduleNavigationInvalidation = () => {
+	if ( isNavigationSignalPending ) {
+		return;
+	}
+	isNavigationSignalPending = true;
+	queueMicrotask( () => {
+		navigationSignal.value = navigationSignal.peek() + 1;
+		isNavigationSignalPending = false;
+	} );
+};
+
 export default () => {
 	// data-wp-context---[unique-id]
 	directive(
@@ -1027,7 +1039,7 @@ export default () => {
 			// been evaluated and the value of the server context has changed.
 			useLayoutEffect( () => {
 				if ( vdom && typeof vdom.type !== 'string' ) {
-					navigationSignal.value = navigationSignal.peek() + 1;
+					scheduleNavigationInvalidation();
 				}
 			}, [ vdom ] );
 

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -342,18 +342,6 @@ export const routerRegions = new Map<
 	Signal< VNode | null | undefined >
 >();
 
-let isNavigationSignalPending = false;
-const scheduleNavigationInvalidation = () => {
-	if ( isNavigationSignalPending ) {
-		return;
-	}
-	isNavigationSignalPending = true;
-	queueMicrotask( () => {
-		navigationSignal.value = navigationSignal.peek() + 1;
-		isNavigationSignalPending = false;
-	} );
-};
-
 export default () => {
 	// data-wp-context---[unique-id]
 	directive(
@@ -1039,7 +1027,7 @@ export default () => {
 			// been evaluated and the value of the server context has changed.
 			useLayoutEffect( () => {
 				if ( vdom && typeof vdom.type !== 'string' ) {
-					scheduleNavigationInvalidation();
+					navigationSignal.value = navigationSignal.peek() + 1;
 				}
 			}, [ vdom ] );
 

--- a/packages/interactivity/src/scopes.ts
+++ b/packages/interactivity/src/scopes.ts
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import type { h as createElement, RefObject } from 'preact';
+import { signal } from '@preact/signals';
 
 /**
  * Internal dependencies
  */
 import { getNamespace } from './namespaces';
-import { deepReadOnly, navigationSignal, deepClone } from './utils';
+import { deepReadOnly, deepClone } from './utils';
 import type { Evaluate } from './hooks';
 
 export interface Scope {
@@ -82,6 +83,8 @@ export const getElement = () => {
 	} );
 };
 
+export const navigationContextSignal = signal( 0 );
+
 /**
  * Gets the context defined and updated from the server.
  *
@@ -125,7 +128,7 @@ export function getServerContext< T extends object >( namespace?: string ): T {
 
 	// Accesses the signal to make this reactive. It assigns it to `subscribe`
 	// to prevent the JavaScript minifier from removing this line.
-	getServerContext.subscribe = navigationSignal.value;
+	getServerContext.subscribe = navigationContextSignal.value;
 
 	return deepClone( scope.serverContext[ namespace || getNamespace() ] );
 }

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -328,7 +328,6 @@ export const populateServerData = ( data?: {
 			}
 		);
 	}
-	navigationSignal.value += 1; // Triggers invalidations.
 };
 
 // Parse and populate the initial state and config.

--- a/test/e2e/specs/interactivity/get-sever-context.spec.ts
+++ b/test/e2e/specs/interactivity/get-sever-context.spec.ts
@@ -259,4 +259,18 @@ test.describe( 'getServerContext()', () => {
 		await expect( prop ).toBeEmpty();
 		await expect( nestedProp ).toBeEmpty();
 	} );
+
+	test( 'should get server context using derived state getters', async ( {
+		page,
+	} ) => {
+		const serverProp = page.getByTestId( 'serverProp' );
+
+		await expect( page ).toHaveTitle( /main/ );
+		await expect( serverProp ).toHaveText( 'child' );
+
+		await page.getByTestId( 'modified' ).click();
+		await expect( page ).toHaveTitle( /modified/ );
+
+		await expect( serverProp ).toHaveText( 'childModified' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes an issue where derived state using `getServerContext` was not updating correctly during client-side navigation in the Interactivity API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When navigating between pages using the Interactivity API router, the server context changes. However, derived state properties that relied on `getServerContext()` were not being re-evaluated or invalidated correctly in some scenarios, causing them to return stale data from the previous page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We added a `useLayoutEffect` in the router region directive to trigger a `navigationSignal` update when the VDOM changes. This ensures that any reactive dependencies, including those relying on `getServerContext`, are properly notified and updated when the router region content is replaced during navigation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Run the newly added e2e test to verify the fix:
   `npm run test:e2e packages/e2e-tests/specs/interactivity/get-sever-context.spec.ts`
2. Ensure the test "should get server context using derived state getters" passes.