### PR TITLE
Routes: Small fixes to the pattern list and template part list routes

### DIFF
--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -332,6 +332,9 @@ function PatternList() {
 						},
 					} );
 				} }
+				isItemClickable={ ( item ) =>
+					item.type !== PATTERN_TYPES.theme
+				}
 				renderItemLink={ ( {
 					item,
 					...props

--- a/routes/template-part-list/fields/preview.tsx
+++ b/routes/template-part-list/fields/preview.tsx
@@ -11,7 +11,7 @@ function PreviewField( { item }: { item: WpTemplatePart } ) {
 	return (
 		<Preview
 			content={ item?.content?.raw }
-			blocks={ item.blocks }
+			blocks={ item?.blocks }
 			description={ description }
 		/>
 	);


### PR DESCRIPTION
Related #70862 

## What?

Just a couple small fixes to template part pattern routes:

 - Opening template parts sometimes failed to load because item.blocks was throwing an error.
 - "click on item" should be disabled for theme patterns. 
