### PR TITLE
Drag and drop: remove grab cursor for multi-selection

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -222,6 +222,11 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		cursor: grab;
 	}
 
+	// Dragging multi selected blocks is not supported yet.
+	&.is-multi-selected {
+		cursor: default;
+	}
+
 	&[contenteditable],
 	[contenteditable] {
 		cursor: text;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently direct dragging of multi selected blocks is not supported, but we're showing a "grab" cursor style, which causes users to thing that a multi selection is draggable.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Remove confusion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the style for multi selection.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Select multiple blocks including an image. Hover over the image. The cursor should NOT be a grab hand.
* Remove the selection. Hover again over the image. The cursor should be a grab hand and the block should be draggable.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
