### PR TITLE
Add template route to the new site editor infrastructure

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -43,6 +43,7 @@ function gutenberg_enable_experiments() {
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );
+add_action( 'gutenberg-boot_init', 'gutenberg_enable_experiments' );
 
 /**
  * Sets a global JS variable used to trigger the availability of form & input blocks.

--- a/lib/experimental/pages/gutenberg-boot.php
+++ b/lib/experimental/pages/gutenberg-boot.php
@@ -28,6 +28,9 @@ function gutenberg_boot_register_default_menu_items() {
 	register_gutenberg_boot_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 	register_gutenberg_boot_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	register_gutenberg_boot_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
+	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
+		register_gutenberg_boot_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );
+	}
 	register_gutenberg_boot_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
 	register_gutenberg_boot_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18047,6 +18047,14 @@
 			"resolved": "packages/sync",
 			"link": true
 		},
+		"node_modules/@wordpress/template": {
+			"resolved": "routes/template",
+			"link": true
+		},
+		"node_modules/@wordpress/template-list": {
+			"resolved": "routes/template-list",
+			"link": true
+		},
 		"node_modules/@wordpress/template-part": {
 			"resolved": "routes/template-part",
 			"link": true
@@ -55746,6 +55754,41 @@
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/url": "file:../../packages/url"
+			}
+		},
+		"routes/template": {
+			"name": "@wordpress/template",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/route": "file:../../packages/route"
+			}
+		},
+		"routes/template-list": {
+			"name": "@wordpress/template-list",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/block-editor": "file:../../packages/block-editor",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/dom": "file:../../packages/dom",
+				"@wordpress/editor": "file:../../packages/editor",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/fields": "file:../../packages/fields",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/keycodes": "file:../../packages/keycodes",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/views": "file:../../packages/views",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3"
 			}
 		},
 		"routes/template-part": {

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -10,6 +10,7 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
 import { privateApis as themePrivateApis } from '@wordpress/theme';
+import { EditorSnackbars } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -43,6 +44,7 @@ export default function Root() {
 				>
 					<CommandMenu />
 					<SavePanel />
+					<EditorSnackbars />
 					{ ! isFullScreen && (
 						<div className="boot-layout__sidebar">
 							<Sidebar />

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -10,6 +10,7 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
 import { privateApis as themePrivateApis } from '@wordpress/theme';
+import { EditorSnackbars } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -46,6 +47,7 @@ export default function RootSinglePage() {
 				>
 					<CommandMenu />
 					<SavePanel />
+					<EditorSnackbars />
 					<div className="boot-layout__surfaces">
 						<ThemeProvider
 							color={ { bg: '#ffffff', primary: '#3858e9' } }

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -43,3 +43,11 @@ body:has(.boot-layout.has-full-canvas) {
 		}
 	}
 }
+
+.boot-layout .components-editor-notices__snackbar {
+	position: fixed;
+	right: 0;
+	bottom: 16px;
+	padding-left: 16px;
+	padding-right: 16px;
+}

--- a/packages/core-data/src/entity-types/wp-template.ts
+++ b/packages/core-data/src/entity-types/wp-template.ts
@@ -57,6 +57,11 @@ declare module './base-entity-records' {
 				'view' | 'edit',
 				C
 			>;
+			blocks: ContextualField<
+				Array< Record< string, any > > | undefined,
+				'edit',
+				C
+			>;
 			/**
 			 * Title of template.
 			 */
@@ -85,6 +90,10 @@ declare module './base-entity-records' {
 			 * The ID for the author of the template.
 			 */
 			author: number;
+			/**
+			 * The display name for the author of the template.
+			 */
+			author_text: string;
 			/**
 			 * Whether a template is a custom template.
 			 */

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -8,6 +8,7 @@ import {
 	page,
 	symbol,
 	symbolFilled,
+	layout,
 } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
@@ -25,6 +26,7 @@ export async function init() {
 		pages: { icon: page },
 		templateParts: { icon: symbolFilled },
 		patterns: { icon: symbol },
+		templates: { icon: layout },
 	};
 
 	// Update each menu item with its icon

--- a/routes/template-list/actions/set-active-template.tsx
+++ b/routes/template-list/actions/set-active-template.tsx
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { Template } from '../types';
+
+/**
+ * Hook to create the "Set Active Template" action.
+ * This action allows users to activate or deactivate templates.
+ *
+ * @return {Action<Template>} The set active template action.
+ */
+export function useSetActiveTemplateAction(): Action< Template > {
+	const activeTheme = useSelect( ( select ) =>
+		select( coreStore ).getCurrentTheme()
+	);
+	const { getEntityRecord } = useSelect( coreStore );
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
+
+	return useMemo(
+		() => ( {
+			id: 'set-active-template',
+			label( items: Template[] ) {
+				return items.some( ( item ) => item._isActive )
+					? __( 'Deactivate' )
+					: __( 'Activate' );
+			},
+			isPrimary: true,
+			icon: pencil,
+			isEligible( item: Template ) {
+				if ( ! activeTheme ) {
+					return false;
+				}
+
+				if ( item.theme !== activeTheme.stylesheet ) {
+					return false;
+				}
+
+				// If it's not a created template but a registered template,
+				// only allow activating (so when it's inactive).
+				if ( typeof item.id !== 'number' ) {
+					return item._isActive === false;
+				}
+
+				return true;
+			},
+			async callback( items: Template[] ) {
+				const deactivate = items.some( ( item ) => item._isActive );
+				// current active templates
+				const activeTemplates = {
+					...( ( await getEntityRecord( 'root', 'site' ) )
+						?.active_templates ?? {} ),
+				};
+				for ( const item of items ) {
+					if ( deactivate ) {
+						delete activeTemplates[ item.slug ];
+					} else {
+						activeTemplates[ item.slug ] = item.id;
+					}
+				}
+				await editEntityRecord( 'root', 'site', undefined, {
+					active_templates: activeTemplates,
+				} );
+				await saveEditedEntityRecord( 'root', 'site' );
+			},
+		} ),
+		[
+			editEntityRecord,
+			saveEditedEntityRecord,
+			getEntityRecord,
+			activeTheme,
+		]
+	);
+}

--- a/routes/template-list/fields/active.tsx
+++ b/routes/template-list/fields/active.tsx
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
+
+export const activeField = {
+	label: __( 'Status' ),
+	id: 'active',
+	type: 'boolean',
+	getValue: ( { item }: { item: any } ) => item._isActive,
+	render: function Render( { item }: { item: any } ) {
+		const activeLabel = item._isCustom
+			? _x( 'Active when used', 'template' )
+			: _x( 'Active', 'template' );
+		const activeIntent = item._isCustom ? 'info' : 'success';
+		const isActive = item._isActive;
+		return (
+			<Badge intent={ isActive ? activeIntent : 'default' }>
+				{ isActive ? activeLabel : _x( 'Inactive', 'template' ) }
+			</Badge>
+		);
+	},
+};

--- a/routes/template-list/fields/author.tsx
+++ b/routes/template-list/fields/author.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+function useAddedBy( type: string, id: any ) {
+	const { author, authorText } = useSelect(
+		( select ) => {
+			const { getUser, getEditedEntityRecord } = select( coreStore );
+			const _record = getEditedEntityRecord( 'postType', type, id );
+			return {
+				author: _record?.author ? getUser( _record.author ) : null,
+				authorText: _record?.author_text,
+			};
+		},
+		[ type, id ]
+	);
+
+	return useMemo( () => {
+		if ( authorText ) {
+			return {
+				text: authorText,
+				icon: 'admin-plugins' as const,
+			};
+		}
+
+		if ( author ) {
+			return {
+				text: author.name,
+				icon: 'admin-users' as const,
+				imageUrl: author.avatar_urls?.[ 48 ],
+			};
+		}
+
+		return {
+			text: __( 'Unknown' ),
+			icon: 'admin-users' as const,
+		};
+	}, [ author, authorText ] );
+}
+
+function AuthorField( { item }: { item: any } ) {
+	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
+
+	return (
+		<HStack alignment="left" spacing={ 0 }>
+			{ imageUrl && (
+				<div
+					className={ clsx(
+						'routes-template-list-author-field__avatar',
+						{
+							'is-loaded': isImageLoaded,
+						}
+					) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt=""
+						src={ imageUrl }
+					/>
+				</div>
+			) }
+			{ ! imageUrl && (
+				<div className="routes-template-list-author-field__icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
+			<span className="routes-template-list-author-field__name">
+				{ text }
+			</span>
+		</HStack>
+	);
+}
+
+export const authorField = {
+	label: __( 'Author' ),
+	id: 'author',
+	getValue: ( { item }: { item: any } ) => item.author_text ?? item.author,
+	render: AuthorField,
+};

--- a/routes/template-list/fields/description.tsx
+++ b/routes/template-list/fields/description.tsx
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { privateApis as corePrivateApis } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
+
+function useAllDefaultTemplateTypes() {
+	const { records: staticRecords } = useEntityRecordsWithPermissions(
+		'root',
+		'registeredTemplate'
+	);
+	return staticRecords
+		?.filter( ( record: any ) => ! record.is_custom )
+		.map( ( record: any ) => {
+			return {
+				slug: record.slug,
+				title: record.title.rendered,
+				description: record.description,
+			};
+		} );
+}
+
+export const descriptionField = {
+	label: __( 'Description' ),
+	id: 'description',
+	render: function RenderDescription( { item }: { item: any } ) {
+		const defaultTemplateTypes = useAllDefaultTemplateTypes();
+		const defaultTemplateType = defaultTemplateTypes?.find(
+			( type: any ) => type.slug === item.slug
+		);
+		return item.description
+			? decodeEntities( item.description )
+			: defaultTemplateType?.description;
+	},
+	enableSorting: false,
+	enableGlobalSearch: true,
+};

--- a/routes/template-list/fields/preview.tsx
+++ b/routes/template-list/fields/preview.tsx
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Preview } from '@wordpress/lazy-editor';
+import type { WpTemplate } from '@wordpress/core-data';
+
+function PreviewField( { item }: { item: WpTemplate } ) {
+	const description = item.description;
+
+	return (
+		<Preview
+			content={ item?.content?.raw }
+			blocks={ item?.blocks }
+			description={ description }
+		/>
+	);
+}
+
+export const previewField = {
+	label: __( 'Preview' ),
+	id: 'preview',
+	render: PreviewField,
+	enableSorting: false,
+};

--- a/routes/template-list/fields/slug.tsx
+++ b/routes/template-list/fields/slug.tsx
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { privateApis as corePrivateApis } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
+
+function useAllDefaultTemplateTypes() {
+	const { records: staticRecords } = useEntityRecordsWithPermissions(
+		'root',
+		'registeredTemplate'
+	);
+	return staticRecords
+		?.filter( ( record: any ) => ! record.is_custom )
+		.map( ( record: any ) => {
+			return {
+				slug: record.slug,
+				title: record.title.rendered,
+				description: record.description,
+			};
+		} );
+}
+
+export const slugField = {
+	label: __( 'Template Type' ),
+	id: 'slug',
+	getValue: ( { item }: { item: any } ) => item.slug,
+	render: function Render( { item }: { item: any } ) {
+		const defaultTemplateTypes = useAllDefaultTemplateTypes();
+		const defaultTemplateType = defaultTemplateTypes?.find(
+			( type: any ) => type.slug === item.slug
+		);
+		return defaultTemplateType?.title || _x( 'Custom', 'template type' );
+	},
+};

--- a/routes/template-list/package.json
+++ b/routes/template-list/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@wordpress/template-list",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/templates/list/$activeView",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/block-editor": "file:../../packages/block-editor",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/dom": "file:../../packages/dom",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/fields": "file:../../packages/fields",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/keycodes": "file:../../packages/keycodes",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/views": "file:../../packages/views",
+		"clsx": "^2.1.1",
+		"dequal": "^2.0.3"
+	}
+}

--- a/routes/template-list/route.ts
+++ b/routes/template-list/route.ts
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { ensureView, viewToQuery } from './view-utils';
+
+/**
+ * Route configuration for template list.
+ */
+export const route = {
+	async canvas( context: {
+		params: {
+			activeView: string;
+		};
+		search: {
+			page?: number;
+			search?: string;
+			postIds?: string[];
+		};
+	} ) {
+		const { params, search } = context;
+
+		// Load the view configuration
+		const view = await ensureView( params.activeView, {
+			page: search.page,
+			search: search.search,
+		} );
+
+		// Only show canvas for list-type views
+		if ( view.type !== 'list' ) {
+			return undefined;
+		}
+
+		// Check if postId is provided in query params
+		if ( search.postIds && search.postIds.length > 0 ) {
+			const postId = search.postIds[ 0 ].toString();
+			return {
+				postType: 'wp_template',
+				postId,
+				isPreview: true,
+				editLink: `/types/wp_template/edit/${ encodeURIComponent(
+					postId
+				) }`,
+			};
+		}
+
+		// Otherwise, fetch the first template from the filtered query
+		const query = viewToQuery( view );
+		const posts = await resolveSelect( coreStore ).getEntityRecords(
+			'postType',
+			'wp_template',
+			{ ...query, per_page: 1 }
+		);
+
+		// Return first template if available
+		if ( posts && posts.length > 0 ) {
+			const postId = ( posts[ 0 ] as any ).id.toString();
+			return {
+				postType: 'wp_template',
+				postId,
+				isPreview: true,
+				editLink: `/types/wp_template/edit/${ encodeURIComponent(
+					postId
+				) }`,
+			};
+		}
+
+		// No templates to display
+		return undefined;
+	},
+};

--- a/routes/template-list/stage.tsx
+++ b/routes/template-list/stage.tsx
@@ -1,0 +1,383 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useParams,
+	useNavigate,
+	useSearch,
+	useInvalidate,
+} from '@wordpress/route';
+import { useView } from '@wordpress/views';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type { View, Action } from '@wordpress/dataviews';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	Button,
+	Modal,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useCallback, useState } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { published, commentAuthorAvatar } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import { getDefaultView, DEFAULT_LAYOUTS } from './view-utils';
+import { previewField } from './fields/preview';
+import { authorField } from './fields/author';
+import { descriptionField } from './fields/description';
+import { activeField } from './fields/active';
+import { slugField } from './fields/slug';
+import { useTemplates } from './use-templates';
+import { useSetActiveTemplateAction } from './actions/set-active-template';
+
+// Unlock WordPress private APIs
+const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+import type { Template } from './types';
+
+function getItemId( item: Template ) {
+	return item.id.toString();
+}
+
+function TemplateList() {
+	const invalidate = useInvalidate();
+	const { activeView = 'active' } = useParams( {
+		from: '/templates/list/$activeView',
+	} );
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/templates/list/$activeView' } );
+	const postTypeObject = useSelect(
+		( select ) => select( coreStore ).getPostType( 'wp_template' ),
+		[]
+	);
+	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
+		useState< Template | null >( null );
+	const defaultView: View = useMemo( () => {
+		return getDefaultView( activeView );
+	}, [ activeView ] );
+
+	// Callback to handle URL query parameter changes
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+
+	// Use the new view persistence hook
+	const { view, isModified, updateView, resetToDefault } = useView( {
+		kind: 'postType',
+		name: 'wp_template',
+		slug: activeView,
+		defaultView,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
+
+	const onReset = () => {
+		resetToDefault();
+		invalidate();
+	};
+	const onChangeView = ( newView: View ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			// The rendered surfaces depend on the view type,
+			// so we need to retrigger the router loader when switching the view type.
+			invalidate();
+		}
+	};
+
+	// Fetch templates using our custom hook
+	const { records, isLoading, staticRecords } = useTemplates( activeView );
+
+	// Get users for author field
+	const users = useSelect(
+		( select ) => {
+			const { getUser } = select( coreStore );
+			return records.reduce( ( acc: any, record: any ) => {
+				if ( record.author_text ) {
+					if ( ! acc[ record.author_text ] ) {
+						acc[ record.author_text ] = record.author_text;
+					}
+				} else if ( record.author ) {
+					if ( ! acc[ record.author ] ) {
+						acc[ record.author ] = getUser( record.author );
+					}
+				}
+				return acc;
+			}, {} );
+		},
+		[ records ]
+	);
+
+	// Build fields array with author elements
+	const fields = useMemo( () => {
+		const elements = [];
+		for ( const author in users ) {
+			elements.push( {
+				value: users[ author ]?.id ?? author,
+				label: users[ author ]?.name ?? author,
+			} );
+		}
+		return [
+			previewField,
+			templateTitleField,
+			descriptionField,
+			activeField,
+			slugField,
+			{
+				...authorField,
+				elements,
+			},
+		];
+	}, [ users ] );
+
+	// Apply filtering, sorting, and pagination on the client side
+	const { data: posts, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( records, view, fields );
+	}, [ records, view, fields ] );
+
+	// Helper function to clean up postIds from URL after deletion
+	const cleanupDeletedPostIdsFromUrl = useCallback(
+		( deletedItems: Template[] ) => {
+			const deletedIds = deletedItems.map( ( item: Template ) =>
+				item.id.toString()
+			);
+			const currentPostIds = searchParams.postIds || [];
+			const remainingPostIds = currentPostIds.filter(
+				( id: string ) => ! deletedIds.includes( id )
+			);
+
+			if ( remainingPostIds.length !== currentPostIds.length ) {
+				navigate( {
+					search: {
+						...searchParams,
+						postIds:
+							remainingPostIds.length > 0
+								? remainingPostIds
+								: undefined,
+					},
+				} );
+			} else {
+				// If no change in the url, the first item might have changed.
+				invalidate();
+			}
+		},
+		[ invalidate, searchParams, navigate ]
+	);
+
+	const onActionPerformed = useCallback(
+		( actionId: string, items: Template[] ) => {
+			// Clean up URL when delete actions are performed
+			if (
+				actionId === 'move-to-trash' ||
+				actionId === 'permanently-delete'
+			) {
+				cleanupDeletedPostIdsFromUrl( items );
+			}
+
+			// Handle duplicate action - navigate to Created templates tab
+			if ( actionId === 'duplicate-post' ) {
+				navigate( {
+					to: `/templates/list/user`,
+				} );
+			}
+		},
+		[ cleanupDeletedPostIdsFromUrl, navigate ]
+	);
+
+	const setActiveTemplateAction = useSetActiveTemplateAction();
+
+	const postTypeActions: Action< Template >[] = usePostActions( {
+		postType: 'wp_template',
+		context: 'list',
+		onActionPerformed,
+	} );
+
+	const actions = useMemo( () => {
+		return [
+			setActiveTemplateAction,
+			...postTypeActions?.flatMap< Action< Template > >( ( action ) => {
+				// Skip revisions as the admin does not support it
+				if ( action.id === 'view-post-revisions' ) {
+					return [];
+				}
+
+				return [ action ];
+			} ),
+		];
+	}, [ setActiveTemplateAction, postTypeActions ] );
+
+	// Build tabs array dynamically
+	const tabs = useMemo( () => {
+		const baseTabs = [
+			{
+				slug: 'active',
+				label: __( 'Active' ),
+				icon: published,
+			},
+			{
+				slug: 'user',
+				label: __( 'Created templates' ),
+				icon: commentAuthorAvatar,
+			},
+		];
+
+		// Extract unique authors from static records
+		const authorMap = new Map();
+		staticRecords.forEach( ( record: Template ) => {
+			if ( record.author_text && ! authorMap.has( record.author_text ) ) {
+				authorMap.set( record.author_text, {
+					slug: record.author_text,
+					label: record.author_text,
+				} );
+			}
+		} );
+
+		const authorTabs = Array.from( authorMap.values() );
+
+		return [ ...baseTabs, ...authorTabs ];
+	}, [ staticRecords ] );
+
+	const handleTabChange = useCallback(
+		( viewSlug: string ) => {
+			navigate( {
+				to: `/templates/list/${ viewSlug }`,
+			} );
+		},
+		[ navigate ]
+	);
+
+	if ( ! postTypeObject ) {
+		return null;
+	}
+
+	const selection = searchParams.postIds ?? [];
+
+	// Auto-select first template in list view if none selected
+	if ( view.type === 'list' && selection.length === 0 && posts?.length > 0 ) {
+		selection.push( posts[ 0 ].id.toString() );
+	}
+
+	// Until list view supports multi selection, only keep the first item.
+	if ( view.type === 'list' ) {
+		selection.splice( 1 );
+	}
+
+	const duplicateAction = actions.find(
+		( action ) => action.id === 'duplicate-post'
+	);
+	if ( duplicateAction && ! ( 'RenderModal' in duplicateAction ) ) {
+		throw new Error(
+			'Expected duplicate action to have a RenderModal component'
+		);
+	}
+
+	return (
+		<Page
+			title={ __( 'Templates' ) }
+			className="template-page"
+			actions={
+				<>
+					{ isModified && (
+						<Button
+							variant="tertiary"
+							size="compact"
+							onClick={ onReset }
+						>
+							{ __( 'Reset view' ) }
+						</Button>
+					) }
+				</>
+			}
+			hasPadding={ false }
+		>
+			{ tabs.length > 1 && (
+				<div className="routes-template-list__tabs-wrapper">
+					<Tabs
+						onSelect={ handleTabChange }
+						selectedTabId={ activeView ?? 'active' }
+					>
+						<Tabs.TabList>
+							{ tabs.map( ( tab ) => (
+								<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
+									{ tab.label }
+								</Tabs.Tab>
+							) ) }
+						</Tabs.TabList>
+					</Tabs>
+				</div>
+			) }
+			<DataViews
+				data={ posts }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ getItemId }
+				selection={ selection }
+				onChangeSelection={ ( items: string[] ) => {
+					navigate( {
+						search: {
+							...searchParams,
+							postIds: items.length > 0 ? items : undefined,
+							edit:
+								items.length === 0
+									? undefined
+									: searchParams.edit,
+						},
+					} );
+				} }
+				isItemClickable={ () => true }
+				onClickItem={ ( item ) => {
+					if ( typeof item.id === 'string' ) {
+						setSelectedRegisteredTemplate( item );
+					} else {
+						navigate( {
+							to: `/types/wp_template/edit/${ encodeURIComponent(
+								item.id
+							) }`,
+						} );
+					}
+				} }
+			/>
+			{ selectedRegisteredTemplate && duplicateAction && (
+				<Modal
+					title={ __( 'Duplicate' ) }
+					onRequestClose={ () =>
+						setSelectedRegisteredTemplate( null )
+					}
+					size="small"
+				>
+					<duplicateAction.RenderModal
+						items={ [ selectedRegisteredTemplate ] }
+						closeModal={ () =>
+							setSelectedRegisteredTemplate( null )
+						}
+					/>
+				</Modal>
+			) }
+		</Page>
+	);
+}
+
+export const stage = TemplateList;

--- a/routes/template-list/style.scss
+++ b/routes/template-list/style.scss
@@ -1,0 +1,45 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/fields/build-style/style.css" as fields;
+
+.routes-template-list__tabs-wrapper {
+	border-bottom: 1px solid $gray-100;
+	padding: 0 $grid-unit-60;
+	@container (max-width: 430px) {
+		padding: 0 $grid-unit-30;
+	}
+}
+
+.routes-template-list-author-field__avatar {
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	overflow: hidden;
+	margin-right: 8px;
+	opacity: 0;
+	transition: opacity 0.1s ease-in;
+
+	&.is-loaded {
+		opacity: 1;
+	}
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+}
+
+.routes-template-list-author-field__icon {
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-right: 8px;
+	color: $gray-700;
+}
+
+.routes-template-list-author-field__name {
+	color: $gray-900;
+}

--- a/routes/template-list/types.ts
+++ b/routes/template-list/types.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import type { WpTemplate } from '@wordpress/core-data';
+
+export type Template = WpTemplate & {
+	_isActive: boolean;
+};

--- a/routes/template-list/use-templates.ts
+++ b/routes/template-list/use-templates.ts
@@ -1,0 +1,132 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import {
+	store as coreStore,
+	privateApis as corePrivateApis,
+	type WpTemplate,
+} from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import type { Template } from './types';
+
+const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
+
+/**
+ * Hook to fetch and return templates based on view type.
+ *
+ * @param {string} activeView - The active view type ('active', 'user', or author name).
+ * @return {Object} Object containing records, loading state, and raw data for tabs.
+ */
+export function useTemplates( activeView: string = 'active' ) {
+	const { activeTemplatesOption, activeTheme, defaultTemplateTypes } =
+		useSelect( ( select ) => {
+			const { getEntityRecord, getCurrentTheme } = select( coreStore );
+			return {
+				activeTemplatesOption: getEntityRecord( 'root', 'site' )
+					?.active_templates,
+				activeTheme: getCurrentTheme(),
+				defaultTemplateTypes:
+					select( coreStore ).getCurrentTheme()
+						?.default_template_types,
+			};
+		}, [] );
+
+	// Fetch user-created templates
+	const { records: userRecords, isResolving: isLoadingUserRecords } =
+		useEntityRecordsWithPermissions( 'postType', 'wp_template', {
+			per_page: -1,
+			combinedTemplates: false,
+		} );
+
+	// Fetch registered templates
+	const { records: staticRecords, isResolving: isLoadingStaticData } =
+		useEntityRecordsWithPermissions( 'root', 'registeredTemplate', {
+			per_page: -1,
+		} );
+
+	// Compute active templates
+	const activeTemplates = useMemo( () => {
+		const _active = [ ...staticRecords ];
+		if ( activeTemplatesOption ) {
+			for ( const activeSlug in activeTemplatesOption ) {
+				const activeId = activeTemplatesOption[ activeSlug ];
+				// Replace the template in the array.
+				const template = userRecords.find(
+					( userRecord: WpTemplate ) =>
+						userRecord.id === activeId &&
+						userRecord.theme === activeTheme.stylesheet
+				);
+				if ( template ) {
+					const index = _active.findIndex(
+						( { slug } ) => slug === template.slug
+					);
+					if ( index !== -1 ) {
+						_active[ index ] = template;
+					} else {
+						_active.push( template );
+					}
+				}
+			}
+		}
+		return _active;
+	}, [ userRecords, staticRecords, activeTemplatesOption, activeTheme ] );
+
+	// Compute records with active status and custom status
+	const records: Template[] = useMemo( () => {
+		function isCustom( record: any ) {
+			// For registered templates, the is_custom field is defined.
+			return (
+				record.is_custom ??
+				// For user templates it's custom if the is_wp_suggestion meta
+				// field is not set and the slug is not found in the default
+				// template types.
+				( ! record.meta?.is_wp_suggestion &&
+					! defaultTemplateTypes.some(
+						( type: any ) => type.slug === record.slug
+					) )
+			);
+		}
+
+		let _records;
+		if ( activeView === 'active' ) {
+			// Active view: show active templates, exclude custom
+			_records = activeTemplates.filter(
+				( record ) => ! isCustom( record )
+			);
+		} else if ( activeView === 'user' ) {
+			// User view: show all user templates
+			_records = userRecords;
+		} else {
+			// Author view: show registered templates
+			_records = staticRecords;
+		}
+
+		return _records.map( ( record: WpTemplate ) => ( {
+			...record,
+			_isActive: activeTemplates.some(
+				( template ) => template.id === record.id
+			),
+			_isCustom: isCustom( record ),
+		} ) );
+	}, [
+		activeTemplates,
+		defaultTemplateTypes,
+		userRecords,
+		staticRecords,
+		activeView,
+	] );
+
+	return {
+		records,
+		isLoading: isLoadingUserRecords || isLoadingStaticData,
+		staticRecords,
+		userRecords,
+		activeTemplates,
+	};
+}

--- a/routes/template-list/view-utils.ts
+++ b/routes/template-list/view-utils.ts
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { loadView } from '@wordpress/views';
+import type { View } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW: View = {
+	type: 'grid' as const,
+	perPage: 20,
+	sort: {
+		field: 'title',
+		direction: 'asc' as const,
+	},
+	fields: [ 'author', 'active', 'slug' ],
+	titleField: 'title',
+	descriptionField: 'description',
+	mediaField: 'preview',
+	filters: [],
+};
+
+export const DEFAULT_LAYOUTS = {
+	table: {
+		showMedia: false,
+	},
+	grid: {
+		showMedia: true,
+	},
+	list: {
+		showMedia: false,
+	},
+};
+
+export function getDefaultView( activeView?: string ): View {
+	// User view: sort by date, newest first, include theme field
+	if ( activeView === 'user' ) {
+		return {
+			...DEFAULT_VIEW,
+			sort: {
+				field: 'date',
+				direction: 'desc' as const,
+			},
+			fields: [ 'author', 'active', 'slug', 'theme' ],
+		};
+	}
+
+	// Active view: default sorting
+	if ( activeView === 'active' || ! activeView ) {
+		return {
+			...DEFAULT_VIEW,
+		};
+	}
+
+	// Author-based view: filter by author
+	return {
+		...DEFAULT_VIEW,
+		filters: [
+			{
+				field: 'author',
+				operator: 'isAny',
+				value: [ activeView ],
+			},
+		],
+	};
+}
+
+export async function ensureView(
+	activeView?: string,
+	search?: { page?: number; search?: string }
+) {
+	const defaultView = getDefaultView( activeView );
+	return loadView( {
+		kind: 'postType',
+		name: 'wp_template',
+		slug: activeView ?? 'active',
+		defaultView,
+		queryParams: search,
+	} );
+}
+
+export function viewToQuery( view: View ) {
+	const result: Record< string, any > = {};
+
+	// Pagination, sorting, search.
+	if ( undefined !== view.perPage ) {
+		result.per_page = view.perPage;
+	}
+
+	if ( undefined !== view.page ) {
+		result.page = view.page;
+	}
+
+	if ( ! [ undefined, '' ].includes( view.search ) ) {
+		result.search = view.search;
+	}
+
+	if ( undefined !== view.sort?.field ) {
+		result.orderby = view.sort.field;
+	}
+
+	if ( undefined !== view.sort?.direction ) {
+		result.order = view.sort.direction;
+	}
+
+	return result;
+}

--- a/routes/template/package.json
+++ b/routes/template/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@wordpress/template",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/templates",
+		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/template/route.ts
+++ b/routes/template/route.ts
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+/**
+ * Route configuration for template redirect.
+ */
+export const route = {
+	beforeLoad: () => {
+		throw redirect( {
+			throw: true,
+			to: '/templates/list/$activeView',
+			params: {
+				activeView: 'active',
+			},
+		} );
+	},
+};


### PR DESCRIPTION
Related #70862 

## What?

Adds new template routes for managing templates with the Template Activation experiment to the site editor built using the new routing infra. I'm making the assumption that by the time the refactored site editor ships, the template activation will have made it as stable.

## Testing Instructions
  **Prerequisites:** Enable the Template Activation experiment

  1. Navigate to the Templates menu item http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Ftemplates%2Flist%2Factive
  2. Switch between the "Active", "Created templates", and author tabs
  3. Try activating/deactivating a template - verify it works correctly
  4. Duplicate a registered template - verify you're navigated to "Created templates" tab and see a success notification
