### PR TITLE
Real-time collaboration: Disable syncing for "synthetic" template posts

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -23,6 +23,7 @@ import {
 	getUserPermissionsFromAllowHeader,
 	ALLOWED_RESOURCE_ACTIONS,
 	RECEIVE_INTERMEDIATE_RESULTS,
+	isNumericID,
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 
@@ -157,6 +158,7 @@ export const getEntityRecord =
 			if (
 				window.__experimentalEnableSync &&
 				entityConfig.syncConfig &&
+				isNumericID( key ) &&
 				! query
 			) {
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {


### PR DESCRIPTION
## What?

Disable syncing for "synthetic" template posts—meaning templates that do not map directly to an entity represented in the database.

## Why?

When the "created template" experiment is enabled, activated templates are synthetically represented in the store with a string identifier and a `wp_id` property pointing to the "real" entity record.

These synthetic entities do not fulfill our expectations around how entities are handled by the store. Specifically, they are not handled by the `editEntityRecord` and `saveEntityRecord` actions in `core-data`. Therefore, they cannot be synced in the same way that "real" entity records are synced.

## How?

Do not sync entity record with non-numeric IDs. 

## Testing Instructions

1. Check out this branch.
2. Open the Site Editor (Appearance > Editor).
3. Ensure that created templates work as expected: creation, update, deletion.

### Testing Instructions for Keyboard

No UI changes in this PR.