### PR TITLE
Scripts: Update license checker to ignore invalid package entries

### DIFF
--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -319,7 +319,11 @@ function checkDeps( deps, options ) {
 			continue;
 		}
 
-		if ( Object.keys( dep ).length === 0 ) {
+		// Don't check for licenses if the package entry is invalid. This can
+		// happen if an incomplete package directory exists in node_modules.
+		// Historically this could happen due to buggy behavior of Windows
+		// environments in handling optional dependenciess
+		if ( ! dep.name || Object.keys( dep ).length === 0 ) {
 			continue;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Relates to #73026

Updates license checker script to avoid checking packages with incomplete installations.

## Why?

This was intended to have been fixed with #73026, but the issue continues to persist infrequently on `trunk` (see [recent example](https://github.com/WordPress/gutenberg/actions/runs/19640815742/job/56243467407)).

## How?

Corrupt packages will be reported in the results of `npm query`, but most of their values are absent. A valid package should include its name in the reported result. The changes here update the logic to expect a valid name before checking the package.

Example of a "corrupt" package:

```js
{
  pkgid: '@unrs/resolver-binding-wasm32-wasi@',
  location: 'node_modules/@unrs/resolver-binding-wasm32-wasi',
  path: '/gutenberg/node_modules/@unrs/resolver-binding-wasm32-wasi',
  realpath: '/gutenberg/node_modules/@unrs/resolver-binding-wasm32-wasi',
  resolved: 'https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz',
  from: [ 'node_modules/unrs-resolver' ],
  to: [],
  dev: false,
  inBundle: false,
  deduped: false,
  overridden: false,
  queryContext: {}
}
```

Compare to a valid package:

```js
{
  name: 'type-fest',
  version: '3.13.1',
  description: 'A collection of essential TypeScript types',
  // ...
  _id: 'type-fest@3.13.1',
  pkgid: 'type-fest@3.13.1',
  location: 'node_modules/@wdio/config/node_modules/parse-json/node_modules/type-fest',
  path: '/gutenberg/node_modules/@wdio/config/node_modules/parse-json/node_modules/type-fest',
  realpath: '/gutenberg/node_modules/@wdio/config/node_modules/parse-json/node_modules/type-fest',
  resolved: 'https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz',
  from: [ 'node_modules/@wdio/config/node_modules/parse-json' ],
  to: [],
  dev: true,
  inBundle: false,
  deduped: false,
  overridden: false,
  queryContext: {}
}
```

(The above were identified by adding a `console.log` debugging statement to print [`packages`](https://github.com/WordPress/gutenberg/blob/011a9b426c77c5b64725aabe8895474e28d861f2/packages/scripts/scripts/check-licenses.js#L48))

I also considered whether some other [query pseudo selectors](https://docs.npmjs.com/cli/v11/using-npm/dependency-selectors#pseudo-selectors) could help here (e.g. "invalid" or "extraneous"), but those may result in more false negatives than the approach considered here, as invalid or extraneous packages can have legitimate issues.

Another option could be to filter the `dev` property, as this particular check is considering "dev"-only packages, and the corrupt package results in `dev: false`. However, I suspect this defaults to `false`, and that this problem could potentially surface for non-development dependencies as well.

## Testing Instructions

I was able to reproduce the issue on `trunk` by creating an empty folder for one of our optional dependencies not installed on my machine:

```
mkdir node_modules/@unrs/resolver-binding-wasm32-wasi
```

Running `npm exec wp-scripts check-licenses -- --dev` previously resulted in an error.

On this branch, the check should succeed.