### PR TITLE
UI: Remove shorthand prop options from Box component

### DIFF
--- a/packages/ui/src/box/box.tsx
+++ b/packages/ui/src/box/box.tsx
@@ -84,9 +84,6 @@ export const Box = forwardRef< HTMLDivElement, BoxProps >( function Box(
 		backgroundColor,
 		color,
 		padding,
-		bg = backgroundColor,
-		fg = color,
-		p = padding,
 		render = DEFAULT_RENDER,
 		...props
 	},
@@ -94,18 +91,18 @@ export const Box = forwardRef< HTMLDivElement, BoxProps >( function Box(
 ) {
 	const style: React.CSSProperties = {};
 
-	if ( bg ) {
-		style.backgroundColor = `var(--wpds-color-bg-${ target }-${ bg }, var(--wpds-color-bg-surface-${ bg }))`;
+	if ( backgroundColor ) {
+		style.backgroundColor = `var(--wpds-color-bg-${ target }-${ backgroundColor }, var(--wpds-color-bg-surface-${ backgroundColor }))`;
 	}
 
-	if ( fg ) {
-		style.color = `var(--wpds-color-fg-${ target }-${ fg }, var(--wpds-color-fg-content-${ fg }))`;
+	if ( color ) {
+		style.color = `var(--wpds-color-fg-${ target }-${ color }, var(--wpds-color-fg-content-${ color }))`;
 	}
 
-	if ( p ) {
+	if ( padding ) {
 		Object.assign(
 			style,
-			getDimensionVariantStyles( 'padding', target, p )
+			getDimensionVariantStyles( 'padding', target, padding )
 		);
 	}
 

--- a/packages/ui/src/box/stories/index.story.tsx
+++ b/packages/ui/src/box/stories/index.story.tsx
@@ -30,10 +30,6 @@ export const Default: Story = {
 		padding: 'sm',
 	},
 	argTypes: {
-		p: {
-			control: 'select',
-			options: [ '2xs', 'xs', 'sm', 'md', 'lg', 1, 2, 3, 4 ],
-		},
 		padding: {
 			control: 'select',
 			options: [ '2xs', 'xs', 'sm', 'md', 'lg', 1, 2, 3, 4 ],

--- a/packages/ui/src/box/types.ts
+++ b/packages/ui/src/box/types.ts
@@ -54,34 +54,13 @@ export interface BoxProps extends ComponentProps< 'div' > {
 
 	/**
 	 * The surface background design token for box background color.
-	 *
-	 * Shorthand for `backgroundColor`.
-	 */
-	bg?: BackgroundColor;
-
-	/**
-	 * The surface background design token for box background color.
 	 */
 	backgroundColor?: BackgroundColor;
 
 	/**
 	 * The surface foreground design token for box text color.
-	 *
-	 * Shorthand for `color`.
-	 */
-	fg?: ForegroundColor;
-
-	/**
-	 * The surface foreground design token for box text color.
 	 */
 	color?: ForegroundColor;
-
-	/**
-	 * The surface spacing design token or base unit multiplier for box padding.
-	 *
-	 * Shorthand for `padding`.
-	 */
-	p?: Size | DimensionVariant< Size >;
 
 	/**
 	 * The surface spacing design token or base unit multiplier for box padding.


### PR DESCRIPTION
## What?

Follow-up to feedback at https://github.com/WordPress/gutenberg/pull/72984#discussion_r2545924307

Removes shorthand prop `p=`, `bg=`, `fg=` alternatives to long-form equivalents `padding=`, `backgroundColor=`, `color=` props.

This could be reevaluated in the future if aliasing proves beneficial.

## Why?

Per feedback at https://github.com/WordPress/gutenberg/pull/72984#discussion_r2545924307 :

> * Adds complexity when doing any kind of AST analysis or modification (e.g. lint rules, codemods, prop usage stats).
> * Has a learning curve for humans who see the shorthand for the first time.
> * Consistency concerns within a single file will subtly add to the cognitive load ("which prop version should I use here?") and affect searchability.
> * Adds noise to documentation.
> * Subtle bugs when both the canonical prop and alias prop are added mistakenly with different values.

Per https://github.com/WordPress/gutenberg/pull/72984#discussion_r2547745113 :

> in reflecting on how the idea with shorthands is often to enable "power users" to have a more expressive APIs, that's not really very considerate of the people who end up maintaining said "power users" code down the line, who may benefit from the more verbose alternative and the consistency of having a consistent way of interacting with these components

## Testing Instructions

Repeat Testing Instructions from #72984, verifying no regressions.