### PR TITLE
Styles Tab: Fix bug where contentOnly experiment forced it to always be displayed

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -99,11 +99,7 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if (
-		hasBlockStyles ||
-		hasStyleFills ||
-		window?.__experimentalContentOnlyPatternInsertion
-	) {
+	if ( hasBlockStyles || hasStyleFills ) {
 		tabs.push( TAB_STYLES );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow up to:

* #71982

This PR fixes a bug where the Styles tab was showing in the block inspector when it shouldn't. I noticed this while testing out the HTML block while I had the contentOnly experiment running.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #71982 the styles tab (and color controls) were enabled to be exposed in content only mode while editing content for patterns. It looks like there's an unnecessary check for the experiment in the styles tab that was forcing it to always be displayed. This isn't needed, because the check is already looking for `hasStyleFills`, and the controls are already adding a fill via `SectionBlockColorControls` which uses `ColorEdit`, which uses `ColorInspectorControl` which uses `InspectorControls` with the color group [here](https://github.com/WordPress/gutenberg/blob/e511b9b48a9f57f29f0626afb5ec7d748457def9/packages/block-editor/src/hooks/color.js#L254).

So, we should be able to remove the experiment from the check, as the component will naturally show the color controls when needed, and this will allow us to hide the styles panel again when it shouldn't be shown (as is the case for the HTML block).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<kbd>DELETE</kbd> the contentOnly experiment from the check in the styles tab.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Switch on the contentOnly experiment:

<img width="905" height="82" alt="image" src="https://github.com/user-attachments/assets/bf158b13-47a1-498f-91f7-b640d869c854" />

* Add an HTML block.
* Give the HTML block some content, e.g.: `<p>A paragraph</p>` and update it
* Take a look at the right hand inspector sidebar
* On trunk, there are tabs, with an empty Styles tab, and the Edit Code button sitting too high
* With this PR applied, the Edit Code button should have enough space around it, and there shouldn't be any tabs
* To make sure this is still playing nicely with patterns, go to insert a pattern (i.e. any of the Banner patterns)
* Open up the inspector sidebar with any blocks within the pattern selected, and 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="2542" height="1010" alt="image" src="https://github.com/user-attachments/assets/904e747a-be0e-475c-ab1c-7382a8cbdb1a" />

### After

<img width="2552" height="750" alt="image" src="https://github.com/user-attachments/assets/75442910-c978-48ab-8f14-b6916387509c" />

### ContentOnly color controls should still be available

<img width="1274" height="742" alt="image" src="https://github.com/user-attachments/assets/9838f26e-d735-4285-be87-e0b1ada8686f" />
