### PR TITLE
Global styles: Update generateGlobalStyles function to include variationStyles option

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1609,6 +1609,7 @@ export interface GlobalStylesRenderOptions {
 	disableLayoutStyles?: boolean;
 	disableRootPadding?: boolean;
 	getBlockStyles?: ( blockName: string ) => any[];
+	styleOptions?: Record< string, boolean >;
 }
 
 /**
@@ -1629,6 +1630,7 @@ export function generateGlobalStyles(
 		hasFallbackGapSupport: hasFallbackGapSupportOption,
 		disableLayoutStyles = false,
 		disableRootPadding = false,
+		styleOptions = {},
 	} = options;
 
 	// Use provided block types or fall back to getBlockTypes()
@@ -1655,7 +1657,7 @@ export function generateGlobalStyles(
 		hasFallbackGapSupport,
 		disableLayoutStyles,
 		disableRootPadding,
-		{ variationStyles: true }
+		styleOptions
 	);
 	const svgs = generateSvgFilters( updatedConfig, blockSelectors );
 	const styles = [

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1654,7 +1654,8 @@ export function generateGlobalStyles(
 		hasBlockGapSupport,
 		hasFallbackGapSupport,
 		disableLayoutStyles,
-		disableRootPadding
+		disableRootPadding,
+		{ variationStyles: true }
 	);
 	const svgs = generateSvgFilters( updatedConfig, blockSelectors );
 	const styles = [

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -139,8 +139,13 @@ export function GlobalStylesUI( {
 		return mergeGlobalStyles( baseValue, value );
 	}, [ baseValue, value ] );
 
-	const [ globalStylesCSS, globalSettings ] =
-		generateGlobalStyles( mergedValue );
+	const [ globalStylesCSS, globalSettings ] = generateGlobalStyles(
+		mergedValue,
+		[],
+		{
+			styleOptions: { variationStyles: true },
+		}
+	);
 	const styles = useMemo(
 		() => [ ...( serverCSS ?? [] ), ...( globalStylesCSS ?? [] ) ],
 		[ serverCSS, globalStylesCSS ]


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

After https://github.com/WordPress/gutenberg/pull/72464/, block style variation previews stopped working. 

This PR fixes that by passing in the required `variationStyles` option from `<GlobalStylesUI />` to inform `transformToStyles` that it needs to generate variation styles.

Props to @tellthemachines for spotting this one in https://github.com/WordPress/gutenberg/pull/73533#pullrequestreview-3503279292

## Why?

So the variation styles work.

## How?

Pass in the object, yo!

## Testing Instructions

Activate TT5 or some other theme with block variations.

Head to /wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks%2Fcore%252Fgroup (using TT5, which has group variations)

Check that you can see the preview of your changes to each variation.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/ea68f240-5a73-4fde-ab8b-37d5ca19ca6f



### After


https://github.com/user-attachments/assets/e509eaa7-6c52-4e16-827a-4d1ba7922df7


