### PR TITLE
Drag: hide block tools popovers

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -262,7 +267,15 @@ export default function BlockTools( {
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div { ...props } onKeyDown={ onKeyDown }>
+		<div
+			{ ...props }
+			onKeyDown={ onKeyDown }
+			// Popover slots cannot be unmounted during dragging because the
+			// will just be rendered in a fallback popover slot instead.
+			className={ clsx( props.className, {
+				'block-editor-block-tools--is-dragging': isDragging,
+			} ) }
+		>
 			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
 				{ ! isTyping && ! isZoomOutMode && (
 					<InsertionPoint

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -206,3 +206,7 @@
 	top: 50%;
 	left: 50%;
 }
+
+.block-editor-block-tools--is-dragging .popover-slot {
+	display: none;
+}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -207,6 +207,6 @@
 	left: 50%;
 }
 
-.block-editor-block-tools--is-dragging .popover-slot {
+.block-editor-block-tools--is-dragging > .popover-slot {
 	display: none;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Hides the block tools popovers during drag. This includes:
* Cover block drag handle
* Math block popover
* Page Link popover

See also https://github.com/WordPress/gutenberg/pull/73521#pullrequestreview-3501067211.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* For the cover block, it's glitchy: the drag handle moves far away from the block.
* For the math block, dragging feels clunky, see https://github.com/WordPress/gutenberg/pull/73521#pullrequestreview-3501067211.
* It's also worth noting that we hide the block toolbar during drag already.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of handling drag in specific cases in the block, we should handle this at the framework level and not render the slot. Not rendering the slot is not possible though, since the fallback slot will be used instead when it's not present. Ideally we can just add a style or class to the slots, but that's currently not supported for _popover_ slots. To keep changes minimal, I opted for a class on the wrapper.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Drag the cover block or math block.

Also test dragging through the block toolbar handle, just to make sure everything generally still works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1352" height="878" alt="Screenshot 2025-11-25 at 10 49 57" src="https://github.com/user-attachments/assets/eb87c65e-76af-4fcd-bce7-47f181f3b5a6" />|<img width="1352" height="878" alt="Screenshot 2025-11-25 at 10 49 15" src="https://github.com/user-attachments/assets/51324242-6bcc-4154-8a09-15468a91c8b1" />|
|<img width="1352" height="878" alt="Screenshot 2025-11-25 at 10 50 07" src="https://github.com/user-attachments/assets/1f2e8ff8-3d2d-4b07-ba48-66998c40a8c3" />|<img width="1352" height="878" alt="Screenshot 2025-11-25 at 10 49 25" src="https://github.com/user-attachments/assets/b310d436-22d8-4c89-a82d-82e449a8edd9" />|
