### PR TITLE
Template Route: Add the 'add new template' button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55786,7 +55786,9 @@
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/private-apis": "file:../../packages/private-apis",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/url": "file:../../packages/url",
 				"@wordpress/views": "file:../../packages/views",
+				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"
 			}

--- a/routes/template-list/add-new-template/add-custom-generic-template-modal-content.tsx
+++ b/routes/template-list/add-new-template/add-custom-generic-template-modal-content.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { paramCase as kebabCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+interface AddCustomGenericTemplateModalContentProps {
+	createTemplate: (
+		template: any,
+		isWPSuggestion: boolean
+	) => Promise< void >;
+	onBack: () => void;
+}
+
+function AddCustomGenericTemplateModalContent( {
+	createTemplate,
+	onBack,
+}: AddCustomGenericTemplateModalContentProps ) {
+	const [ title, setTitle ] = useState( '' );
+	const defaultTitle = __( 'Custom Template' );
+	const [ isBusy, setIsBusy ] = useState( false );
+	const inputRef = useRef< HTMLInputElement >( null );
+
+	// Set focus to the name input when the component mounts
+	useEffect( () => {
+		if ( inputRef.current ) {
+			inputRef.current.focus();
+		}
+	}, [] );
+
+	async function onCreateTemplate( event: React.FormEvent ) {
+		event.preventDefault();
+		if ( isBusy ) {
+			return;
+		}
+		setIsBusy( true );
+		try {
+			await createTemplate(
+				{
+					slug:
+						kebabCase( title || defaultTitle ) ||
+						'wp-custom-template',
+					title: title || defaultTitle,
+				},
+				false
+			);
+		} finally {
+			setIsBusy( false );
+		}
+	}
+	return (
+		<form onSubmit={ onCreateTemplate }>
+			<VStack spacing={ 6 }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					placeholder={ defaultTitle }
+					disabled={ isBusy }
+					ref={ inputRef }
+					help={ __(
+						// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
+					) }
+				/>
+				<HStack
+					className="template-list-custom-generic-template__modal-actions"
+					justify="right"
+				>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onBack }
+					>
+						{ __( 'Back' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						isBusy={ isBusy }
+						aria-disabled={ isBusy }
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}
+
+export default AddCustomGenericTemplateModalContent;

--- a/routes/template-list/add-new-template/add-custom-template-modal-content.tsx
+++ b/routes/template-list/add-new-template/add-custom-template-modal-content.tsx
@@ -1,0 +1,363 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	SearchControl,
+	TextHighlight,
+	Composite,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useDebouncedInput } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
+import { safeDecodeURI } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { mapToIHasNameAndId } from './utils';
+
+const EMPTY_ARRAY: any[] = [];
+
+interface Suggestion {
+	id: string | number;
+	name: string;
+	slug: string;
+	link?: string;
+}
+
+export interface EntityForSuggestions {
+	type: string;
+	slug: string;
+	config: {
+		recordNamePath?: string;
+		queryArgs: ( params: { search: string } ) => Record< string, any >;
+		getSpecificTemplate: ( suggestion: Suggestion ) => any;
+	};
+	labels: {
+		singular_name: string;
+		search_items: string;
+		not_found: string;
+		all_items: string;
+	};
+	hasGeneralTemplate?: boolean;
+	template?: any;
+}
+
+interface SuggestionListItemProps {
+	suggestion: Suggestion;
+	search: string;
+	onSelect: ( template: any ) => void;
+	entityForSuggestions: EntityForSuggestions;
+}
+
+function SuggestionListItem( {
+	suggestion,
+	search,
+	onSelect,
+	entityForSuggestions,
+}: SuggestionListItemProps ) {
+	const baseCssClass =
+		'template-list-custom-template-modal__suggestions_list__list-item';
+	return (
+		<Composite.Item
+			render={
+				<Button
+					__next40pxDefaultSize
+					role="option"
+					className={ baseCssClass }
+					onClick={ () =>
+						onSelect(
+							entityForSuggestions.config.getSpecificTemplate(
+								suggestion
+							)
+						)
+					}
+				/>
+			}
+		>
+			<Text
+				size="body"
+				lineHeight={ 1.53846153846 } // 20px
+				weight={ 500 }
+				className={ `${ baseCssClass }__title` }
+			>
+				<TextHighlight
+					text={ decodeEntities( suggestion.name ) }
+					highlight={ search }
+				/>
+			</Text>
+			{ suggestion.link && (
+				<Text
+					size="body"
+					lineHeight={ 1.53846153846 } // 20px
+					className={ `${ baseCssClass }__info` }
+				>
+					{ safeDecodeURI( suggestion.link ) }
+				</Text>
+			) }
+		</Composite.Item>
+	);
+}
+
+function useSearchSuggestions(
+	entityForSuggestions: EntityForSuggestions,
+	search: string
+): Suggestion[] {
+	const { config } = entityForSuggestions;
+	const query = useMemo(
+		() => ( {
+			order: 'asc',
+			context: 'view',
+			search,
+			per_page: search ? 20 : 10,
+			...config.queryArgs( { search } ),
+		} ),
+		[ search, config ]
+	);
+	const { records: searchResults, hasResolved: searchHasResolved } =
+		useEntityRecords(
+			entityForSuggestions.type,
+			entityForSuggestions.slug,
+			query
+		);
+	const [ suggestions, setSuggestions ] =
+		useState< Suggestion[] >( EMPTY_ARRAY );
+	useEffect( () => {
+		if ( ! searchHasResolved ) {
+			return;
+		}
+		let newSuggestions: Suggestion[] = EMPTY_ARRAY;
+		if ( searchResults?.length ) {
+			newSuggestions = searchResults as Suggestion[];
+			if ( config.recordNamePath ) {
+				newSuggestions = mapToIHasNameAndId(
+					newSuggestions,
+					config.recordNamePath
+				);
+			}
+		}
+		// Update suggestions only when the query has resolved, so as to keep
+		// the previous results in the UI.
+		setSuggestions( newSuggestions );
+	}, [ searchResults, searchHasResolved, config.recordNamePath ] );
+	return suggestions;
+}
+
+interface SuggestionListProps {
+	entityForSuggestions: EntityForSuggestions;
+	onSelect: ( template: any ) => void;
+}
+
+function SuggestionList( {
+	entityForSuggestions,
+	onSelect,
+}: SuggestionListProps ) {
+	const [ search, setSearch, debouncedSearch ] = useDebouncedInput();
+	const suggestions = useSearchSuggestions(
+		entityForSuggestions,
+		debouncedSearch
+	);
+	const { labels } = entityForSuggestions;
+	const [ showSearchControl, setShowSearchControl ] = useState( false );
+	if ( ! showSearchControl && suggestions?.length > 9 ) {
+		setShowSearchControl( true );
+	}
+	return (
+		<>
+			{ showSearchControl && (
+				<SearchControl
+					__nextHasNoMarginBottom
+					onChange={ setSearch }
+					value={ search }
+					label={ labels.search_items }
+					placeholder={ labels.search_items }
+				/>
+			) }
+			{ !! suggestions?.length && (
+				<Composite
+					orientation="vertical"
+					role="listbox"
+					className="template-list-custom-template-modal__suggestions_list"
+					aria-label={ __( 'Suggestions list' ) }
+				>
+					{ suggestions.map( ( suggestion ) => (
+						<SuggestionListItem
+							key={ suggestion.slug }
+							suggestion={ suggestion }
+							search={ debouncedSearch }
+							onSelect={ onSelect }
+							entityForSuggestions={ entityForSuggestions }
+						/>
+					) ) }
+				</Composite>
+			) }
+			{ debouncedSearch && ! suggestions?.length && (
+				<Text
+					as="p"
+					className="template-list-custom-template-modal__no-results"
+				>
+					{ labels.not_found }
+				</Text>
+			) }
+		</>
+	);
+}
+
+interface AddCustomTemplateModalContentProps {
+	onSelect: ( template: any ) => void;
+	entityForSuggestions: EntityForSuggestions;
+	onBack: () => void;
+	containerRef: React.RefObject< HTMLDivElement >;
+}
+
+function AddCustomTemplateModalContent( {
+	onSelect,
+	entityForSuggestions,
+	onBack,
+	containerRef,
+}: AddCustomTemplateModalContentProps ) {
+	const [ showSearchEntities, setShowSearchEntities ] = useState( false );
+
+	// Focus on the first focusable element when the modal opens.
+	// We handle focus management in the parent modal, just need to focus on the first focusable element.
+	useEffect( () => {
+		if ( containerRef.current ) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ showSearchEntities, containerRef ] );
+
+	return (
+		<VStack
+			spacing={ 4 }
+			className="template-list-custom-template-modal__contents-wrapper"
+			alignment="left"
+		>
+			{ ! showSearchEntities && (
+				<>
+					<Text as="p">
+						{ __(
+							'Select whether to create a single template for all items or a specific one.'
+						) }
+					</Text>
+					<Flex
+						className="template-list-custom-template-modal__contents"
+						gap="4"
+						align="initial"
+					>
+						<FlexItem
+							isBlock
+							as={ Button }
+							onClick={ () => {
+								const {
+									slug,
+									title,
+									description,
+									templatePrefix,
+								} = entityForSuggestions.template;
+								onSelect( {
+									slug,
+									title,
+									description,
+									templatePrefix,
+								} );
+							} }
+						>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{ entityForSuggestions.labels.all_items }
+							</Text>
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
+									__( 'For all items' )
+								}
+							</Text>
+						</FlexItem>
+						<FlexItem
+							isBlock
+							as={ Button }
+							onClick={ () => {
+								setShowSearchEntities( true );
+							} }
+						>
+							<Text
+								as="span"
+								weight={ 500 }
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{ entityForSuggestions.labels.singular_name }
+							</Text>
+							<Text
+								as="span"
+								lineHeight={ 1.53846153846 } // 20px
+							>
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
+									__( 'For a specific item' )
+								}
+							</Text>
+						</FlexItem>
+					</Flex>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onBack }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
+				</>
+			) }
+			{ showSearchEntities && (
+				<>
+					<Text as="p">
+						{ __(
+							'This template will be used only for the specific item chosen.'
+						) }
+					</Text>
+					<SuggestionList
+						entityForSuggestions={ entityForSuggestions }
+						onSelect={ onSelect }
+					/>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => {
+								// If general template exists, go directly back to main screen
+								// instead of showing the choice screen
+								if ( entityForSuggestions.hasGeneralTemplate ) {
+									onBack();
+								} else {
+									setShowSearchEntities( false );
+								}
+							} }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
+				</>
+			) }
+		</VStack>
+	);
+}
+
+export default AddCustomTemplateModalContent;

--- a/routes/template-list/add-new-template/index.tsx
+++ b/routes/template-list/add-new-template/index.tsx
@@ -1,0 +1,490 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Modal,
+	__experimentalGrid as Grid,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Flex,
+	Icon,
+} from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState, memo, useRef, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useViewportMatch } from '@wordpress/compose';
+import {
+	archive,
+	blockMeta,
+	calendar,
+	category,
+	commentAuthorAvatar,
+	pencil,
+	home,
+	layout,
+	list,
+	media,
+	notFound,
+	page,
+	pin,
+	verse,
+	search,
+	tag,
+} from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useNavigate, useInvalidate } from '@wordpress/route';
+import { focus } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import AddCustomTemplateModalContent, {
+	type EntityForSuggestions,
+} from './add-custom-template-modal-content';
+import {
+	useDefaultTemplateTypes,
+	useTaxonomiesMenuItems,
+	usePostTypeMenuItems,
+	useAuthorMenuItem,
+	usePostTypeArchiveMenuItems,
+} from './utils';
+import AddCustomGenericTemplateModalContent from './add-custom-generic-template-modal-content';
+
+const TEMPLATE_POST_TYPE = 'wp_template';
+
+const DEFAULT_TEMPLATE_SLUGS = [
+	'front-page',
+	'home',
+	'single',
+	'page',
+	'index',
+	'archive',
+	'author',
+	'category',
+	'date',
+	'tag',
+	'search',
+	'404',
+];
+
+const TEMPLATE_ICONS: Record< string, any > = {
+	'front-page': home,
+	home: verse,
+	single: pin,
+	page,
+	archive,
+	search,
+	404: notFound,
+	index: list,
+	category,
+	author: commentAuthorAvatar,
+	taxonomy: blockMeta,
+	date: calendar,
+	tag,
+	attachment: media,
+};
+
+interface TemplateListItemProps {
+	title: string;
+	direction: 'row' | 'column';
+	className: string;
+	description?: string;
+	icon: any;
+	onClick: () => void;
+	children?: React.ReactNode;
+}
+
+function TemplateListItem( {
+	title,
+	direction,
+	className,
+	description,
+	icon,
+	onClick,
+	children,
+}: TemplateListItemProps ) {
+	return (
+		<Button
+			__next40pxDefaultSize
+			className={ className }
+			onClick={ onClick }
+			label={ description }
+			showTooltip={ !! description }
+		>
+			<Flex
+				as="span"
+				align="center"
+				justify="center"
+				style={ { width: '100%' } }
+				direction={ direction }
+			>
+				<div className="template-list-add-new-template__template-icon">
+					<Icon icon={ icon } />
+				</div>
+				<VStack
+					className="template-list-add-new-template__template-name"
+					alignment="center"
+					spacing={ 0 }
+				>
+					<Text
+						align="center"
+						weight={ 500 }
+						lineHeight={ 1.53846153846 } // 20px
+					>
+						{ title }
+					</Text>
+					{ children }
+				</VStack>
+			</Flex>
+		</Button>
+	);
+}
+
+const modalContentMap = {
+	templatesList: 1,
+	customTemplate: 2,
+	customGenericTemplate: 3,
+} as const;
+
+interface TemplateData {
+	title: string;
+	description?: string;
+	slug: string;
+	templatePrefix?: string;
+}
+
+interface NewTemplateModalProps {
+	onClose: () => void;
+}
+
+function NewTemplateModal( { onClose }: NewTemplateModalProps ) {
+	const [ modalContent, setModalContent ] = useState<
+		( typeof modalContentMap )[ keyof typeof modalContentMap ]
+	>( modalContentMap.templatesList );
+	const [ entityForSuggestions, setEntityForSuggestions ] =
+		useState< EntityForSuggestions | null >();
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const missingTemplates = useMissingTemplates( setEntityForSuggestions, () =>
+		setModalContent( modalContentMap.customTemplate )
+	);
+	const navigate = useNavigate();
+	const invalidate = useInvalidate();
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+	const containerRef = useRef< HTMLDivElement >( null );
+	const isMobile = useViewportMatch( 'medium', '<' );
+
+	const homeUrl = useSelect( ( select ) => {
+		// Site index.
+		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			?.home;
+	}, [] );
+
+	const TEMPLATE_SHORT_DESCRIPTIONS: Record< string, string > = {
+		'front-page': homeUrl,
+		date: sprintf(
+			// translators: %s: The homepage url.
+			__( 'E.g. %s' ),
+			homeUrl + '/' + new Date().getFullYear()
+		),
+	};
+
+	useEffect( () => {
+		// Focus the first focusable element when component mounts or UI changes
+		// We don't want to focus on the other modals because they have their own focus management.
+		if (
+			containerRef.current &&
+			modalContent === modalContentMap.templatesList
+		) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ modalContent ] );
+
+	async function createTemplate(
+		template: TemplateData,
+		isWPSuggestion = true
+	) {
+		if ( isSubmitting ) {
+			return;
+		}
+		setIsSubmitting( true );
+		try {
+			const { title, description, slug } = template;
+			const newTemplate = await saveEntityRecord(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					description,
+					// Slugs need to be strings, so this is for template `404`
+					slug: slug.toString(),
+					status: 'publish',
+					title,
+					// This adds post meta fields in template
+					meta: {
+						is_wp_suggestion: isWPSuggestion,
+						// Mark as inactive by default when template activation is enabled
+						is_inactive_by_default: true,
+					},
+				},
+				{ throwOnError: true }
+			);
+
+			// Navigate to the created template editor.
+			navigate( {
+				to: `/types/wp_template/edit/${ encodeURIComponent(
+					String( newTemplate.id )
+				) }`,
+			} );
+
+			// Invalidate to refresh the list
+			invalidate();
+
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: Title of the created post or template, e.g: "Hello world".
+					__( '"%s" successfully created.' ),
+					decodeEntities( newTemplate.title?.rendered || title ) ||
+						__( '(no title)' )
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+		} catch ( error: any ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the template.' );
+
+			createErrorNotice( errorMessage, {
+				type: 'snackbar',
+			} );
+		} finally {
+			setIsSubmitting( false );
+		}
+	}
+	const onModalClose = () => {
+		onClose();
+		setModalContent( modalContentMap.templatesList );
+	};
+
+	let modalTitle: string = __( 'Add template' );
+	if (
+		modalContent === modalContentMap.customTemplate &&
+		entityForSuggestions
+	) {
+		modalTitle = sprintf(
+			// translators: %s: Name of the post type e.g: "Post".
+			__( 'Add template: %s' ),
+			entityForSuggestions.labels.singular_name
+		);
+	} else if ( modalContent === modalContentMap.customGenericTemplate ) {
+		modalTitle = __( 'Create custom template' );
+	}
+
+	return (
+		<Modal
+			title={ modalTitle }
+			className={ clsx( 'template-list-add-new-template__modal', {
+				'template-list-add-new-template__modal_template_list':
+					modalContent === modalContentMap.templatesList,
+				'template-list-custom-template-modal':
+					modalContent === modalContentMap.customTemplate,
+			} ) }
+			onRequestClose={ onModalClose }
+			overlayClassName={
+				modalContent === modalContentMap.customGenericTemplate
+					? 'template-list-custom-generic-template__modal'
+					: undefined
+			}
+			ref={ containerRef }
+		>
+			{ modalContent === modalContentMap.templatesList && (
+				<Grid
+					columns={ isMobile ? 2 : 3 }
+					gap={ 4 }
+					align="flex-start"
+					justify="center"
+					className="template-list-add-new-template__template-list__contents"
+				>
+					<Flex className="template-list-add-new-template__template-list__prompt">
+						{ __(
+							'Select what the new template should apply to:'
+						) }
+					</Flex>
+					{ missingTemplates.map( ( template ) => {
+						const { title, slug, onClick } = template;
+						return (
+							<TemplateListItem
+								key={ slug }
+								title={ title }
+								direction="column"
+								className="template-list-add-new-template__template-button"
+								description={
+									TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
+								}
+								icon={ TEMPLATE_ICONS[ slug ] || layout }
+								onClick={ () =>
+									onClick
+										? onClick( template )
+										: createTemplate( template )
+								}
+							/>
+						);
+					} ) }
+					<TemplateListItem
+						title={ __( 'Custom template' ) }
+						direction="row"
+						className="template-list-add-new-template__custom-template-button"
+						icon={ pencil }
+						onClick={ () =>
+							setModalContent(
+								modalContentMap.customGenericTemplate
+							)
+						}
+					>
+						<Text
+							lineHeight={ 1.53846153846 } // 20px
+						>
+							{ __(
+								'A custom template can be manually applied to any post or page.'
+							) }
+						</Text>
+					</TemplateListItem>
+				</Grid>
+			) }
+			{ modalContent === modalContentMap.customTemplate &&
+				entityForSuggestions && (
+					<AddCustomTemplateModalContent
+						onSelect={ createTemplate }
+						entityForSuggestions={ entityForSuggestions }
+						onBack={ () =>
+							setModalContent( modalContentMap.templatesList )
+						}
+						containerRef={ containerRef }
+					/>
+				) }
+			{ modalContent === modalContentMap.customGenericTemplate && (
+				<AddCustomGenericTemplateModalContent
+					createTemplate={ createTemplate }
+					onBack={ () =>
+						setModalContent( modalContentMap.templatesList )
+					}
+				/>
+			) }
+		</Modal>
+	);
+}
+
+function NewTemplate() {
+	const [ showModal, setShowModal ] = useState( false );
+
+	const { postType } = useSelect( ( select ) => {
+		const { getPostType } = select( coreStore );
+
+		return {
+			postType: getPostType( TEMPLATE_POST_TYPE ),
+		};
+	}, [] );
+
+	if ( ! postType ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Button
+				variant="primary"
+				onClick={ () => setShowModal( true ) }
+				label={ postType.labels.add_new_item }
+				__next40pxDefaultSize
+			>
+				{ postType.labels.add_new_item }
+			</Button>
+			{ showModal && (
+				<NewTemplateModal onClose={ () => setShowModal( false ) } />
+			) }
+		</>
+	);
+}
+
+interface MissingTemplate extends TemplateData {
+	onClick?: ( template: MissingTemplate ) => void;
+}
+
+function useMissingTemplates(
+	setEntityForSuggestions: ( entity: EntityForSuggestions ) => void,
+	onClick?: () => void
+): MissingTemplate[] {
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	const missingDefaultTemplates = ( defaultTemplateTypes || [] ).filter(
+		( template: any ) => DEFAULT_TEMPLATE_SLUGS.includes( template.slug )
+	);
+	const onClickMenuItem = ( _entityForSuggestions: EntityForSuggestions ) => {
+		onClick?.();
+		setEntityForSuggestions( _entityForSuggestions );
+	};
+	// We need to replace existing default template types with
+	// the create specific template functionality. The original
+	// info (title, description, etc.) is preserved in the
+	// used hooks.
+	const enhancedMissingDefaultTemplateTypes: MissingTemplate[] = [
+		...missingDefaultTemplates,
+	];
+	const { defaultTaxonomiesMenuItems, taxonomiesMenuItems } =
+		useTaxonomiesMenuItems( onClickMenuItem );
+	const { defaultPostTypesMenuItems, postTypesMenuItems } =
+		usePostTypeMenuItems( onClickMenuItem );
+
+	const authorMenuItem = useAuthorMenuItem( onClickMenuItem );
+	[
+		...defaultTaxonomiesMenuItems,
+		...defaultPostTypesMenuItems,
+		authorMenuItem,
+	].forEach( ( menuItem ) => {
+		if ( ! menuItem ) {
+			return;
+		}
+		const matchIndex = enhancedMissingDefaultTemplateTypes.findIndex(
+			( template ) => template.slug === menuItem.slug
+		);
+		// Some default template types might have been filtered above from
+		// `missingDefaultTemplates` because they only check for the general
+		// template. So here we either replace or append the item, augmented
+		// with the check if it has available specific item to create a
+		// template for.
+		if ( matchIndex > -1 ) {
+			enhancedMissingDefaultTemplateTypes[ matchIndex ] = menuItem;
+		} else {
+			enhancedMissingDefaultTemplateTypes.push( menuItem );
+		}
+	} );
+	// Update the sort order to match the DEFAULT_TEMPLATE_SLUGS order.
+	enhancedMissingDefaultTemplateTypes?.sort( ( template1, template2 ) => {
+		return (
+			DEFAULT_TEMPLATE_SLUGS.indexOf( template1.slug ) -
+			DEFAULT_TEMPLATE_SLUGS.indexOf( template2.slug )
+		);
+	} );
+	const missingTemplates = [
+		...enhancedMissingDefaultTemplateTypes,
+		...usePostTypeArchiveMenuItems(),
+		...postTypesMenuItems,
+		...taxonomiesMenuItems,
+	];
+	return missingTemplates;
+}
+
+export default memo( NewTemplate );

--- a/routes/template-list/add-new-template/style.scss
+++ b/routes/template-list/add-new-template/style.scss
@@ -1,0 +1,190 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.template-list-custom-template-modal {
+	&__contents-wrapper {
+		height: 100%;
+		justify-content: flex-start !important; // Required as topLeft alignment isn't working on VStack
+
+		> * {
+			width: 100%;
+		}
+
+		&__suggestions_list {
+			margin-left: - $grid-unit-15;
+			margin-right: - $grid-unit-15;
+			width: calc(100% + #{$grid-unit-15 * 2});
+		}
+	}
+
+	&__contents {
+		> .components-button {
+			height: auto;
+			justify-content: center;
+		}
+	}
+
+	@include break-medium() {
+		width: 456px;
+	}
+
+	.template-list-custom-template-modal__suggestions_list {
+		@include break-small() {
+			max-height: $grid-unit-70 * 4; // Height of four buttons
+			overflow-y: auto;
+		}
+
+		&__list-item {
+			display: block;
+			width: 100%;
+			text-align: left;
+			white-space: pre-wrap;
+			overflow-wrap: break-word;
+			height: auto;
+			padding: $grid-unit-10 $grid-unit-15;
+
+			mark {
+				font-weight: 700;
+				background: none;
+			}
+
+			&:hover {
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+
+				* {
+					color: var(--wp-admin-theme-color);
+				}
+
+				mark {
+					color: var(--wp-admin-theme-color);
+				}
+			}
+
+			&:focus {
+				background-color: $gray-100;
+			}
+
+			&:focus:not(:disabled) {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
+			}
+
+			&__title,
+			&__info {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: block;
+			}
+
+			&__info {
+				word-break: break-all;
+				color: $gray-700;
+			}
+		}
+	}
+}
+
+.template-list-custom-template-modal__no-results {
+	border: $border-width solid $gray-400;
+	border-radius: $radius-small;
+	padding: $grid-unit-20;
+}
+
+.template-list-custom-generic-template__modal {
+	.components-modal__header {
+		border-bottom: none;
+	}
+
+	.components-modal__content::before {
+		margin-bottom: $grid-unit-05;
+	}
+}
+
+.template-list-add-new-template__modal {
+
+	@include break-large() {
+		max-width: $grid-unit-80 * 13;
+		margin-top: $grid-unit-80;
+		width: calc(100% - #{$grid-unit-80 * 2});
+		max-height: calc(100% - #{$grid-unit-80 * 2});
+	}
+
+	.template-list-add-new-template__template-button,
+	.template-list-add-new-template__custom-template-button {
+		svg {
+			fill: var(--wp-admin-theme-color);
+		}
+	}
+
+	.template-list-add-new-template__custom-template-button {
+		.template-list-add-new-template__template-name {
+			flex-grow: 1;
+			align-items: flex-start;
+		}
+	}
+
+	.template-list-add-new-template__template-icon {
+		padding: $grid-unit-10;
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		border-radius: 100%;
+		max-height: $grid-unit-50;
+		max-width: $grid-unit-50;
+	}
+}
+
+.template-list-custom-template-modal__contents,
+.template-list-add-new-template__template-list__contents {
+	> .components-button {
+		padding: $grid-unit-40;
+		display: flex;
+		flex-direction: column;
+		border: $border-width solid $gray-300;
+		justify-content: center;
+
+		// Show the boundary of the button, in High Contrast Mode.
+		outline: 1px solid transparent;
+
+		span:first-child {
+			color: $gray-900;
+		}
+
+		span {
+			color: $gray-700;
+		}
+
+		&:hover {
+			color: var(--wp-admin-theme-color-darker-10);
+			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			border-color: transparent;
+
+			span {
+				color: var(--wp-admin-theme-color);
+			}
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			border-color: transparent;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 3px solid transparent;
+
+			span:first-child {
+				color: var(--wp-admin-theme-color);
+			}
+		}
+	}
+
+	.template-list-add-new-template__custom-template-button,
+	.template-list-add-new-template__template-list__prompt {
+		grid-column: 1 / -1;
+	}
+}
+
+.template-list-add-new-template__template-list__contents {
+	> .components-button {
+		height: 100%;
+		text-align: start;
+		align-items: flex-start;
+	}
+}

--- a/routes/template-list/package.json
+++ b/routes/template-list/package.json
@@ -26,7 +26,9 @@
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/url": "file:../../packages/url",
 		"@wordpress/views": "file:../../packages/views",
+		"change-case": "^4.1.2",
 		"clsx": "^2.1.1",
 		"dequal": "^2.0.3"
 	}

--- a/routes/template-list/stage.tsx
+++ b/routes/template-list/stage.tsx
@@ -35,6 +35,7 @@ import { activeField } from './fields/active';
 import { slugField } from './fields/slug';
 import { useTemplates } from './use-templates';
 import { useSetActiveTemplateAction } from './actions/set-active-template';
+import AddNewTemplate from './add-new-template';
 
 // Unlock WordPress private APIs
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
@@ -44,6 +45,7 @@ const { Tabs } = unlock( componentsPrivateApis );
  * Style dependencies
  */
 import './style.scss';
+import './add-new-template/style.scss';
 import type { Template } from './types';
 
 function getItemId( item: Template ) {
@@ -304,6 +306,7 @@ function TemplateList() {
 							{ __( 'Reset view' ) }
 						</Button>
 					) }
+					<AddNewTemplate />
 				</>
 			}
 			hasPadding={ false }


### PR DESCRIPTION
Related #70862 

This PR just brings to the "add new template" code from edit-site to the template route to reach feature parity. It also rewrites it as TS files.

## testing instructions

 - Open the template route: http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2Ftemplates%2Flist%2Factive
 - Try using the "add new template" button.