### PR TITLE
Preview Styles: Prevent leaked shadow due to blur

### DIFF
--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -20,6 +20,7 @@
 	max-width: 100%;
 	display: block;
 	width: 100%;
+	clip-path: border-box;
 }
 
 .global-styles-ui-typography-preview {


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73351

Prevents a shadowy blur from leaking beyond the bounds of the Preview Styles component.

## Why?

It's a subtle visual bug but these add up to detract from overall perceived quality.

## How?

Set `clip-path: border-box` on the preview component's wrapper.

## Testing Instructions

1. On trunk, activate TT5
2. Navigate to Editor > Styles
3. Note the faint shadow around the styles preview component when the default white variation is selected
4. Switch to this PR branch and repeat. The Shadow should be gone


## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <img width="736" height="734" alt="Image" src="https://github.com/user-attachments/assets/712afc53-5759-463c-b5bd-91b9687abf9e" /> | <img width="733" height="728" alt="Image" src="https://github.com/user-attachments/assets/aabeb7bb-2180-4262-bc1b-4844ba863b12" /> |
