### PR TITLE
Block Bindings: Remove caption from edit on `EditWithGeneratedProps`.

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -245,9 +245,8 @@ const EditWithGeneratedProps = ( props ) => {
 					! ( hasPatternOverrides && hasParentPattern ) &&
 					Object.keys( keptAttributes ).length
 				) {
-					// Don't update caption and href until they are supported.
+					// Don't update href until it is supported.
 					if ( hasPatternOverrides ) {
-						delete keptAttributes.caption;
 						delete keptAttributes.href;
 					}
 					setAttributes( keptAttributes );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -257,21 +257,10 @@ export function ImageEdit( {
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
-		// However, if caption is bound (e.g., with pattern overrides), we need
-		// to explicitly set it to clear the previous value.
-		const isCaptionBound =
-			metadata?.bindings?.caption ||
-			metadata?.bindings?.__default?.source === 'core/pattern-overrides';
 		if ( captionRef.current && ! mediaAttributes.caption ) {
-			if ( isCaptionBound ) {
-				// Explicitly set caption to undefined to clear it when bound.
-				mediaAttributes.caption = undefined;
-			} else {
-				// For non-bound captions, omit the caption key to preserve existing value.
-				const { caption: omittedCaption, ...restMediaAttributes } =
-					mediaAttributes;
-				mediaAttributes = restMediaAttributes;
-			}
+			const { caption: omittedCaption, ...restMediaAttributes } =
+				mediaAttributes;
+			mediaAttributes = restMediaAttributes;
 		}
 
 		let additionalAttributes;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -257,10 +257,21 @@ export function ImageEdit( {
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
+		// However, if caption is bound (e.g., with pattern overrides), we need
+		// to explicitly set it to clear the previous value.
+		const isCaptionBound =
+			metadata?.bindings?.caption ||
+			metadata?.bindings?.__default?.source === 'core/pattern-overrides';
 		if ( captionRef.current && ! mediaAttributes.caption ) {
-			const { caption: omittedCaption, ...restMediaAttributes } =
-				mediaAttributes;
-			mediaAttributes = restMediaAttributes;
+			if ( isCaptionBound ) {
+				// Explicitly set caption to undefined to clear it when bound.
+				mediaAttributes.caption = undefined;
+			} else {
+				// For non-bound captions, omit the caption key to preserve existing value.
+				const { caption: omittedCaption, ...restMediaAttributes } =
+					mediaAttributes;
+				mediaAttributes = restMediaAttributes;
+			}
 		}
 
 		let additionalAttributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Following the previous comment. Says that href and caption should be remove from that function.

This PR introduced it originally and has the testing instructions: [Pattern overrides: Fix aspect ratio not working in image with overrides](https://github.com/WordPress/gutenberg/pull/62828#top). It looks like when replacing images the code I linked above suppressed setting a caption (the image in the media library might have a caption). Perhaps it’s possible to delete that line and allow the caption to be set now.

The aspect ratio is still working as expected.

## Fixing the caption in pattern overrides

With this PR, the image caption attribute ( the one that is set on the media options ) will be the source of truth to show or not to show the caption when the override happens.

In order to test it, you can do two workflows:

 - Create a pattern override, with an image without caption. Set override as enabled.
 - In a post / page, add the pattern. The caption should not appear, but can be added.
 - Replace the image with one with caption. The caption should appear. And can be edited too.


https://github.com/user-attachments/assets/6d7d0e26-71f0-4ff0-ac4b-4c280dae0e24

 
 - Create a pattern override, with an image with a caption. Set override as enabled.
 - In a post / page, add the pattern. The caption should appear.
 - Replace the image with one without a caption. The caption should be empty, but still appear.


https://github.com/user-attachments/assets/81dbf9e5-9ed5-4f59-a566-e3c97c6bb5ea

I'm happy to add regression tests if you consider this is how it should be.
