### PR TITLE
PHP-only blocks: Pass all metadata from PHP registration to the client

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -334,11 +334,17 @@ export const registerCoreBlocks = (
 			const bootstrappedBlockType = unlock(
 				select( blocksStore )
 			).getBootstrappedBlockType( blockName );
-			const bootstrappedApiVersion = bootstrappedBlockType.apiVersion;
 
 			registerBlockType( blockName, {
-				title: blockName,
-				...( bootstrappedApiVersion < 3 && { apiVersion: 3 } ),
+				// Use all metadata from PHP registration,
+				// but fall back title to block name if not provided,
+				// ensure minimum apiVersion 3 for block wrapper support,
+				// and override with a ServerSideRender-based edit function.
+				...bootstrappedBlockType,
+				title: bootstrappedBlockType?.title || blockName,
+				...( ( bootstrappedBlockType?.apiVersion ?? 0 ) < 3 && {
+					apiVersion: 3,
+				} ),
 				edit: function Edit( { attributes } ) {
 					const blockProps = useBlockProps();
 					const { content, status, error } = useServerSideRender( {

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -48,6 +48,11 @@ add_action(
 		register_block_type(
 			'test/auto-register-block',
 			array(
+				'title'           => 'Auto Register Test Block',
+				'icon'            => 'admin-generic',
+				'category'        => 'widgets',
+				'description'     => 'A test block for auto-registration',
+				'keywords'        => array( 'serverblock', 'autotest' ),
 				'render_callback' => static function ( $attributes ) {
 					$wrapper_attributes = get_block_wrapper_attributes(
 						array(

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -149,6 +149,40 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		expect( blockExists ).toBe( false );
 	} );
 
+	test( 'should use PHP-defined metadata (title, icon, category, keywords) for auto-registered blocks', async ( {
+		page,
+	} ) => {
+		// Open the inserter
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+
+		// Search using the custom title defined in PHP
+		await page
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Auto Register Test Block' );
+
+		// Verify the block appears with the custom title
+		const blockOption = page.getByRole( 'option', {
+			name: 'Auto Register Test Block',
+		} );
+		await expect( blockOption ).toBeVisible();
+
+		// Verify block metadata is correctly set from PHP
+		const blockType = await page.evaluate( () => {
+			return window.wp.blocks.getBlockType( 'test/auto-register-block' );
+		} );
+
+		// These should match the PHP-defined values
+		// Icon is normalized to object format by WordPress
+		expect( blockType.title ).toBe( 'Auto Register Test Block' );
+		expect( blockType.icon.src ).toBe( 'admin-generic' );
+		expect( blockType.category ).toBe( 'widgets' );
+		expect( blockType.description ).toBe(
+			'A test block for auto-registration'
+		);
+		expect( blockType.keywords ).toContain( 'serverblock' );
+		expect( blockType.keywords ).toContain( 'autotest' );
+	} );
+
 	test( 'should render server-side content for auto-registered blocks with block supports', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What

Solves #73499: PHP-only blocks with `auto_register` support now pass all metadata from the PHP registration, like `title`.

## Why
When registering PHP-only blocks with `'supports' => array( 'auto_register' => true )`, the block name was used as the title instead of the PHP-defined `title`; other metadata (`icon`, `category`, `description`, etc.) was completely ignored. This made it impossible for developers to customize how their auto-registered blocks appear in the inserter

## How

- Spread all bootstrapped block type metadata when auto-registering blocks in JS
- Keep fallback to block name for `title` if not provided
- Add a set of tests to verify that metadata is successfully provided to the client registration

## Testing Instructions

1. Register a PHP-only block with custom metadata:
   ```php
   register_block_type( 'my/block', array(
       'title'       => 'My Custom Title',
       'icon'        => 'admin-generic',
       'category'    => 'widgets',
       'description' => 'My block description',
       'keywords'    => array( 'test' ),
       'render_callback' => fn() => '<p>Hello</p>',
       'supports'    => array( 'auto_register' => true ),
   ) );

2. Open the block inserter and search for "My Custom Title"
3. Verify the block appears with the custom title, icon, and in the correct category

| Before | After |
| - | - |
| <img width="335" height="266" alt="image" src="https://github.com/user-attachments/assets/9410ff93-f8db-49a5-bb22-9c677dd42e1f" /> | <img width="333" height="242" alt="image" src="https://github.com/user-attachments/assets/7134d98a-d67c-4dc3-bd35-e13e3839cf9a" /> |
