### PR TITLE
Editor: Add Block-Aware Revision Diff Viewer sidebar

### DIFF
--- a/lib/experimental/class-wp-rest-block-revision-diff-controller.php
+++ b/lib/experimental/class-wp-rest-block-revision-diff-controller.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * REST API: WP_REST_Block_Revision_Diff_Controller class
+ *
+ * Provides a REST endpoint for computing block-level diffs between revisions.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Controller for block-aware revision diff endpoint.
+ *
+ * @since 6.9.0
+ */
+class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'gutenberg/v1';
+		$this->rest_base = 'posts/(?P<parent_id>[\d]+)/revisions/diff';
+	}
+
+	/**
+	 * Registers the routes for the controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_diff' ),
+					'permission_callback' => array( $this, 'get_diff_permissions_check' ),
+					'args'                => array(
+						'parent_id' => array(
+							'description' => __( 'The ID of the post.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+						'from'      => array(
+							'description' => __( 'Source revision ID.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+						'to'        => array(
+							'description' => __( 'Target revision ID.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read the diff.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_diff_permissions_check( $request ) {
+		$parent_id = $request['parent_id'];
+		$post      = get_post( $parent_id );
+
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_post', $parent_id ) ) {
+			return new WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view revisions of this post.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the block-level diff between two revisions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function get_diff( $request ) {
+		$parent_id    = $request['parent_id'];
+		$from_id      = $request['from'];
+		$to_id        = $request['to'];
+
+		// Validate revisions belong to the parent post.
+		$from_revision = $this->get_revision( $from_id, $parent_id );
+		if ( is_wp_error( $from_revision ) ) {
+			return $from_revision;
+		}
+
+		$to_revision = $this->get_revision( $to_id, $parent_id );
+		if ( is_wp_error( $to_revision ) ) {
+			return $to_revision;
+		}
+
+		// Parse blocks from both revisions.
+		$from_blocks = parse_blocks( $from_revision->post_content );
+		$to_blocks   = parse_blocks( $to_revision->post_content );
+
+		// Compute the diff.
+		$diff_items = $this->compute_block_diff( $from_blocks, $to_blocks );
+
+		// Count changes.
+		$summary = $this->compute_summary( $diff_items );
+
+		// Get author information.
+		$from_author = get_userdata( $from_revision->post_author );
+		$to_author   = get_userdata( $to_revision->post_author );
+
+		$response = array(
+			'oldRevisionId' => $from_id,
+			'newRevisionId' => $to_id,
+			'oldDate'       => $from_revision->post_date,
+			'newDate'       => $to_revision->post_date,
+			'oldAuthor'     => $from_author ? $from_author->display_name : __( 'Unknown', 'gutenberg' ),
+			'newAuthor'     => $to_author ? $to_author->display_name : __( 'Unknown', 'gutenberg' ),
+			'summary'       => $summary,
+			'blocks'        => $diff_items,
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Gets a revision and validates it belongs to the parent post.
+	 *
+	 * @param int $revision_id The revision ID.
+	 * @param int $parent_id   The parent post ID.
+	 * @return WP_Post|WP_Error The revision post or error.
+	 */
+	private function get_revision( $revision_id, $parent_id ) {
+		$revision = get_post( $revision_id );
+
+		if ( ! $revision ) {
+			return new WP_Error(
+				'rest_revision_invalid_id',
+				__( 'Invalid revision ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'revision' !== $revision->post_type ) {
+			return new WP_Error(
+				'rest_revision_invalid_type',
+				__( 'The specified ID is not a revision.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( (int) $revision->post_parent !== (int) $parent_id ) {
+			return new WP_Error(
+				'rest_revision_parent_mismatch',
+				__( 'The revision does not belong to the specified post.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return $revision;
+	}
+
+	/**
+	 * Computes the block-level diff between two arrays of parsed blocks.
+	 *
+	 * @param array $old_blocks Blocks from older revision.
+	 * @param array $new_blocks Blocks from newer revision.
+	 * @return array Array of diff items.
+	 */
+	private function compute_block_diff( $old_blocks, $new_blocks ) {
+		$diff = array();
+
+		// Filter out empty blocks (whitespace-only).
+		$old_blocks = $this->filter_empty_blocks( $old_blocks );
+		$new_blocks = $this->filter_empty_blocks( $new_blocks );
+
+		// Index blocks by signature for comparison.
+		$old_index = $this->index_blocks( $old_blocks );
+		$new_index = $this->index_blocks( $new_blocks );
+
+		$processed_new = array();
+
+		// Process old blocks - find removed and modified.
+		foreach ( $old_index as $i => $old_block ) {
+			$signature = $this->get_block_signature( $old_block );
+			$found     = false;
+
+			foreach ( $new_index as $j => $new_block ) {
+				if ( isset( $processed_new[ $j ] ) ) {
+					continue;
+				}
+
+				$new_signature = $this->get_block_signature( $new_block );
+
+				// Same block type at similar position.
+				if ( $old_block['blockName'] === $new_block['blockName'] ) {
+					$processed_new[ $j ] = true;
+					$found               = true;
+
+					// Check if content/attributes changed.
+					$attribute_changes = $this->compare_attributes(
+						$old_block['attrs'] ?? array(),
+						$new_block['attrs'] ?? array()
+					);
+
+					$content_changed = $this->normalize_content( $old_block['innerHTML'] ?? '' ) !==
+									   $this->normalize_content( $new_block['innerHTML'] ?? '' );
+
+					if ( $content_changed || ! empty( $attribute_changes ) ) {
+						$diff[] = array(
+							'id'               => 'diff-' . wp_generate_uuid4(),
+							'type'             => 'modified',
+							'blockName'        => $old_block['blockName'],
+							'oldBlock'         => $this->prepare_block_for_response( $old_block ),
+							'newBlock'         => $this->prepare_block_for_response( $new_block ),
+							'attributeChanges' => $attribute_changes,
+							'innerBlocksDiff'  => $this->compute_block_diff(
+								$old_block['innerBlocks'] ?? array(),
+								$new_block['innerBlocks'] ?? array()
+							),
+						);
+					} else {
+						$diff[] = array(
+							'id'              => 'diff-' . wp_generate_uuid4(),
+							'type'            => 'unchanged',
+							'blockName'       => $old_block['blockName'],
+							'oldBlock'        => $this->prepare_block_for_response( $old_block ),
+							'newBlock'        => $this->prepare_block_for_response( $new_block ),
+							'innerBlocksDiff' => $this->compute_block_diff(
+								$old_block['innerBlocks'] ?? array(),
+								$new_block['innerBlocks'] ?? array()
+							),
+						);
+					}
+					break;
+				}
+			}
+
+			if ( ! $found ) {
+				$diff[] = array(
+					'id'        => 'diff-' . wp_generate_uuid4(),
+					'type'      => 'removed',
+					'blockName' => $old_block['blockName'],
+					'oldBlock'  => $this->prepare_block_for_response( $old_block ),
+				);
+			}
+		}
+
+		// Find added blocks (in new but not processed).
+		foreach ( $new_index as $j => $new_block ) {
+			if ( ! isset( $processed_new[ $j ] ) ) {
+				$diff[] = array(
+					'id'        => 'diff-' . wp_generate_uuid4(),
+					'type'      => 'added',
+					'blockName' => $new_block['blockName'],
+					'newBlock'  => $this->prepare_block_for_response( $new_block ),
+				);
+			}
+		}
+
+		return $diff;
+	}
+
+	/**
+	 * Filters out empty/whitespace-only blocks.
+	 *
+	 * @param array $blocks Array of blocks.
+	 * @return array Filtered blocks.
+	 */
+	private function filter_empty_blocks( $blocks ) {
+		return array_values(
+			array_filter(
+				$blocks,
+				function ( $block ) {
+					// Keep blocks that have a name (not just whitespace).
+					return ! empty( $block['blockName'] );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Creates an indexed array of blocks.
+	 *
+	 * @param array $blocks Array of blocks.
+	 * @return array Indexed blocks.
+	 */
+	private function index_blocks( $blocks ) {
+		$indexed = array();
+		foreach ( $blocks as $i => $block ) {
+			$indexed[ $i ] = $block;
+		}
+		return $indexed;
+	}
+
+	/**
+	 * Generates a signature for a block for comparison purposes.
+	 *
+	 * @param array $block The block to generate signature for.
+	 * @return string The block signature.
+	 */
+	private function get_block_signature( $block ) {
+		return $block['blockName'] . ':' . md5( wp_json_encode( $block['attrs'] ?? array() ) . ( $block['innerHTML'] ?? '' ) );
+	}
+
+	/**
+	 * Normalizes block content for comparison.
+	 *
+	 * @param string $content The content to normalize.
+	 * @return string Normalized content.
+	 */
+	private function normalize_content( $content ) {
+		// Remove extra whitespace and normalize line endings.
+		$content = preg_replace( '/\s+/', ' ', $content );
+		return trim( $content );
+	}
+
+	/**
+	 * Compares two attribute arrays and returns the differences.
+	 *
+	 * @param array $old_attrs Old attributes.
+	 * @param array $new_attrs New attributes.
+	 * @return array Array of attribute changes.
+	 */
+	private function compare_attributes( $old_attrs, $new_attrs ) {
+		$changes = array();
+
+		$all_keys = array_unique( array_merge( array_keys( $old_attrs ), array_keys( $new_attrs ) ) );
+
+		foreach ( $all_keys as $key ) {
+			$old_value = $old_attrs[ $key ] ?? null;
+			$new_value = $new_attrs[ $key ] ?? null;
+
+			if ( $old_value !== $new_value ) {
+				$changes[] = array(
+					'attribute' => $key,
+					'oldValue'  => $old_value,
+					'newValue'  => $new_value,
+				);
+			}
+		}
+
+		return $changes;
+	}
+
+	/**
+	 * Prepares a block for the REST response.
+	 *
+	 * @param array $block The block to prepare.
+	 * @return array Prepared block data.
+	 */
+	private function prepare_block_for_response( $block ) {
+		return array(
+			'blockName'   => $block['blockName'],
+			'attrs'       => $block['attrs'] ?? array(),
+			'innerHTML'   => $block['innerHTML'] ?? '',
+			'innerBlocks' => array_map(
+				array( $this, 'prepare_block_for_response' ),
+				$block['innerBlocks'] ?? array()
+			),
+		);
+	}
+
+	/**
+	 * Computes summary counts from diff items.
+	 *
+	 * @param array $diff_items Array of diff items.
+	 * @return array Summary counts.
+	 */
+	private function compute_summary( $diff_items ) {
+		$summary = array(
+			'added'     => 0,
+			'removed'   => 0,
+			'modified'  => 0,
+			'unchanged' => 0,
+		);
+
+		foreach ( $diff_items as $item ) {
+			if ( isset( $summary[ $item['type'] ] ) ) {
+				++$summary[ $item['type'] ];
+			}
+
+			// Count nested changes.
+			if ( ! empty( $item['innerBlocksDiff'] ) ) {
+				$nested = $this->compute_summary( $item['innerBlocksDiff'] );
+				$summary['added']     += $nested['added'];
+				$summary['removed']   += $nested['removed'];
+				$summary['modified']  += $nested['modified'];
+				$summary['unchanged'] += $nested['unchanged'];
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Retrieves the item's schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'revision-diff',
+			'type'       => 'object',
+			'properties' => array(
+				'oldRevisionId' => array(
+					'description' => __( 'The ID of the source revision.', 'gutenberg' ),
+					'type'        => 'integer',
+				),
+				'newRevisionId' => array(
+					'description' => __( 'The ID of the target revision.', 'gutenberg' ),
+					'type'        => 'integer',
+				),
+				'oldDate'       => array(
+					'description' => __( 'The date of the source revision.', 'gutenberg' ),
+					'type'        => 'string',
+				),
+				'newDate'       => array(
+					'description' => __( 'The date of the target revision.', 'gutenberg' ),
+					'type'        => 'string',
+				),
+				'oldAuthor'     => array(
+					'description' => __( 'The author of the source revision.', 'gutenberg' ),
+					'type'        => 'string',
+				),
+				'newAuthor'     => array(
+					'description' => __( 'The author of the target revision.', 'gutenberg' ),
+					'type'        => 'string',
+				),
+				'summary'       => array(
+					'description' => __( 'Summary of changes.', 'gutenberg' ),
+					'type'        => 'object',
+					'properties'  => array(
+						'added'     => array( 'type' => 'integer' ),
+						'removed'   => array( 'type' => 'integer' ),
+						'modified'  => array( 'type' => 'integer' ),
+						'unchanged' => array( 'type' => 'integer' ),
+					),
+				),
+				'blocks'        => array(
+					'description' => __( 'Array of block diff items.', 'gutenberg' ),
+					'type'        => 'array',
+				),
+			),
+		);
+	}
+}
+

--- a/lib/experimental/class-wp-rest-block-revision-diff-controller.php
+++ b/lib/experimental/class-wp-rest-block-revision-diff-controller.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+if ( class_exists( 'WP_REST_Block_Revision_Diff_Controller' ) ) {
+	return;
+}
+
 /**
  * Controller for block-aware revision diff endpoint.
  *
@@ -97,9 +101,9 @@ class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
 	 */
 	public function get_diff( $request ) {
-		$parent_id    = $request['parent_id'];
-		$from_id      = $request['from'];
-		$to_id        = $request['to'];
+		$parent_id = $request['parent_id'];
+		$from_id   = $request['from'];
+		$to_id     = $request['to'];
 
 		// Validate revisions belong to the parent post.
 		$from_revision = $this->get_revision( $from_id, $parent_id );
@@ -198,16 +202,13 @@ class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 		$processed_new = array();
 
 		// Process old blocks - find removed and modified.
-		foreach ( $old_index as $i => $old_block ) {
-			$signature = $this->get_block_signature( $old_block );
-			$found     = false;
+		foreach ( $old_index as $old_block ) {
+			$found = false;
 
 			foreach ( $new_index as $j => $new_block ) {
 				if ( isset( $processed_new[ $j ] ) ) {
 					continue;
 				}
-
-				$new_signature = $this->get_block_signature( $new_block );
 
 				// Same block type at similar position.
 				if ( $old_block['blockName'] === $new_block['blockName'] ) {
@@ -220,8 +221,9 @@ class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 						$new_block['attrs'] ?? array()
 					);
 
-					$content_changed = $this->normalize_content( $old_block['innerHTML'] ?? '' ) !==
-									   $this->normalize_content( $new_block['innerHTML'] ?? '' );
+					$old_content     = $this->normalize_content( $old_block['innerHTML'] ?? '' );
+					$new_content     = $this->normalize_content( $new_block['innerHTML'] ?? '' );
+					$content_changed = $old_content !== $new_content;
 
 					if ( $content_changed || ! empty( $attribute_changes ) ) {
 						$diff[] = array(
@@ -399,7 +401,7 @@ class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 
 			// Count nested changes.
 			if ( ! empty( $item['innerBlocksDiff'] ) ) {
-				$nested = $this->compute_summary( $item['innerBlocksDiff'] );
+				$nested               = $this->compute_summary( $item['innerBlocksDiff'] );
 				$summary['added']     += $nested['added'];
 				$summary['removed']   += $nested['removed'];
 				$summary['modified']  += $nested['modified'];
@@ -463,4 +465,3 @@ class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 		);
 	}
 }
-

--- a/lib/experimental/class-wp-rest-block-revision-diff-controller.php
+++ b/lib/experimental/class-wp-rest-block-revision-diff-controller.php
@@ -11,457 +11,456 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-if ( class_exists( 'WP_REST_Block_Revision_Diff_Controller' ) ) {
-	return;
-}
-
-/**
- * Controller for block-aware revision diff endpoint.
- *
- * @since 6.9.0
- */
-class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
-
+if ( ! class_exists( 'WP_REST_Block_Revision_Diff_Controller' ) ) {
 	/**
-	 * Constructor.
+	 * Controller for block-aware revision diff endpoint.
+	 *
+	 * @since 6.9.0
 	 */
-	public function __construct() {
-		$this->namespace = 'gutenberg/v1';
-		$this->rest_base = 'posts/(?P<parent_id>[\d]+)/revisions/diff';
-	}
+	class WP_REST_Block_Revision_Diff_Controller extends WP_REST_Controller {
 
-	/**
-	 * Registers the routes for the controller.
-	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->namespace = 'gutenberg/v1';
+			$this->rest_base = 'posts/(?P<parent_id>[\d]+)/revisions/diff';
+		}
+
+		/**
+		 * Registers the routes for the controller.
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_diff' ),
-					'permission_callback' => array( $this, 'get_diff_permissions_check' ),
-					'args'                => array(
-						'parent_id' => array(
-							'description' => __( 'The ID of the post.', 'gutenberg' ),
-							'type'        => 'integer',
-							'required'    => true,
-						),
-						'from'      => array(
-							'description' => __( 'Source revision ID.', 'gutenberg' ),
-							'type'        => 'integer',
-							'required'    => true,
-						),
-						'to'        => array(
-							'description' => __( 'Target revision ID.', 'gutenberg' ),
-							'type'        => 'integer',
-							'required'    => true,
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_diff' ),
+						'permission_callback' => array( $this, 'get_diff_permissions_check' ),
+						'args'                => array(
+							'parent_id' => array(
+								'description' => __( 'The ID of the post.', 'gutenberg' ),
+								'type'        => 'integer',
+								'required'    => true,
+							),
+							'from'      => array(
+								'description' => __( 'Source revision ID.', 'gutenberg' ),
+								'type'        => 'integer',
+								'required'    => true,
+							),
+							'to'        => array(
+								'description' => __( 'Target revision ID.', 'gutenberg' ),
+								'type'        => 'integer',
+								'required'    => true,
+							),
 						),
 					),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
-
-	/**
-	 * Checks if a given request has access to read the diff.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
-	 */
-	public function get_diff_permissions_check( $request ) {
-		$parent_id = $request['parent_id'];
-		$post      = get_post( $parent_id );
-
-		if ( ! $post ) {
-			return new WP_Error(
-				'rest_post_invalid_id',
-				__( 'Invalid post ID.', 'gutenberg' ),
-				array( 'status' => 404 )
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
 			);
 		}
 
-		if ( ! current_user_can( 'edit_post', $parent_id ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to view revisions of this post.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
+		/**
+		 * Checks if a given request has access to read the diff.
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+		 */
+		public function get_diff_permissions_check( $request ) {
+			$parent_id = $request['parent_id'];
+			$post      = get_post( $parent_id );
+
+			if ( ! $post ) {
+				return new WP_Error(
+					'rest_post_invalid_id',
+					__( 'Invalid post ID.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			if ( ! current_user_can( 'edit_post', $parent_id ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to view revisions of this post.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
+		}
+
+		/**
+		 * Retrieves the block-level diff between two revisions.
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+		 */
+		public function get_diff( $request ) {
+			$parent_id = $request['parent_id'];
+			$from_id   = $request['from'];
+			$to_id     = $request['to'];
+
+			// Validate revisions belong to the parent post.
+			$from_revision = $this->get_revision( $from_id, $parent_id );
+			if ( is_wp_error( $from_revision ) ) {
+				return $from_revision;
+			}
+
+			$to_revision = $this->get_revision( $to_id, $parent_id );
+			if ( is_wp_error( $to_revision ) ) {
+				return $to_revision;
+			}
+
+			// Parse blocks from both revisions.
+			$from_blocks = parse_blocks( $from_revision->post_content );
+			$to_blocks   = parse_blocks( $to_revision->post_content );
+
+			// Compute the diff.
+			$diff_items = $this->compute_block_diff( $from_blocks, $to_blocks );
+
+			// Count changes.
+			$summary = $this->compute_summary( $diff_items );
+
+			// Get author information.
+			$from_author = get_userdata( $from_revision->post_author );
+			$to_author   = get_userdata( $to_revision->post_author );
+
+			$response = array(
+				'oldRevisionId' => $from_id,
+				'newRevisionId' => $to_id,
+				'oldDate'       => $from_revision->post_date,
+				'newDate'       => $to_revision->post_date,
+				'oldAuthor'     => $from_author ? $from_author->display_name : __( 'Unknown', 'gutenberg' ),
+				'newAuthor'     => $to_author ? $to_author->display_name : __( 'Unknown', 'gutenberg' ),
+				'summary'       => $summary,
+				'blocks'        => $diff_items,
 			);
+
+			return rest_ensure_response( $response );
 		}
 
-		return true;
-	}
+		/**
+		 * Gets a revision and validates it belongs to the parent post.
+		 *
+		 * @param int $revision_id The revision ID.
+		 * @param int $parent_id   The parent post ID.
+		 * @return WP_Post|WP_Error The revision post or error.
+		 */
+		private function get_revision( $revision_id, $parent_id ) {
+			$revision = get_post( $revision_id );
 
-	/**
-	 * Retrieves the block-level diff between two revisions.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
-	 */
-	public function get_diff( $request ) {
-		$parent_id = $request['parent_id'];
-		$from_id   = $request['from'];
-		$to_id     = $request['to'];
+			if ( ! $revision ) {
+				return new WP_Error(
+					'rest_revision_invalid_id',
+					__( 'Invalid revision ID.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
 
-		// Validate revisions belong to the parent post.
-		$from_revision = $this->get_revision( $from_id, $parent_id );
-		if ( is_wp_error( $from_revision ) ) {
-			return $from_revision;
+			if ( 'revision' !== $revision->post_type ) {
+				return new WP_Error(
+					'rest_revision_invalid_type',
+					__( 'The specified ID is not a revision.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			if ( (int) $revision->post_parent !== (int) $parent_id ) {
+				return new WP_Error(
+					'rest_revision_parent_mismatch',
+					__( 'The revision does not belong to the specified post.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			return $revision;
 		}
 
-		$to_revision = $this->get_revision( $to_id, $parent_id );
-		if ( is_wp_error( $to_revision ) ) {
-			return $to_revision;
-		}
+		/**
+		 * Computes the block-level diff between two arrays of parsed blocks.
+		 *
+		 * @param array $old_blocks Blocks from older revision.
+		 * @param array $new_blocks Blocks from newer revision.
+		 * @return array Array of diff items.
+		 */
+		private function compute_block_diff( $old_blocks, $new_blocks ) {
+			$diff = array();
 
-		// Parse blocks from both revisions.
-		$from_blocks = parse_blocks( $from_revision->post_content );
-		$to_blocks   = parse_blocks( $to_revision->post_content );
+			// Filter out empty blocks (whitespace-only).
+			$old_blocks = $this->filter_empty_blocks( $old_blocks );
+			$new_blocks = $this->filter_empty_blocks( $new_blocks );
 
-		// Compute the diff.
-		$diff_items = $this->compute_block_diff( $from_blocks, $to_blocks );
+			// Index blocks by signature for comparison.
+			$old_index = $this->index_blocks( $old_blocks );
+			$new_index = $this->index_blocks( $new_blocks );
 
-		// Count changes.
-		$summary = $this->compute_summary( $diff_items );
+			$processed_new = array();
 
-		// Get author information.
-		$from_author = get_userdata( $from_revision->post_author );
-		$to_author   = get_userdata( $to_revision->post_author );
+			// Process old blocks - find removed and modified.
+			foreach ( $old_index as $old_block ) {
+				$found = false;
 
-		$response = array(
-			'oldRevisionId' => $from_id,
-			'newRevisionId' => $to_id,
-			'oldDate'       => $from_revision->post_date,
-			'newDate'       => $to_revision->post_date,
-			'oldAuthor'     => $from_author ? $from_author->display_name : __( 'Unknown', 'gutenberg' ),
-			'newAuthor'     => $to_author ? $to_author->display_name : __( 'Unknown', 'gutenberg' ),
-			'summary'       => $summary,
-			'blocks'        => $diff_items,
-		);
-
-		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Gets a revision and validates it belongs to the parent post.
-	 *
-	 * @param int $revision_id The revision ID.
-	 * @param int $parent_id   The parent post ID.
-	 * @return WP_Post|WP_Error The revision post or error.
-	 */
-	private function get_revision( $revision_id, $parent_id ) {
-		$revision = get_post( $revision_id );
-
-		if ( ! $revision ) {
-			return new WP_Error(
-				'rest_revision_invalid_id',
-				__( 'Invalid revision ID.', 'gutenberg' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		if ( 'revision' !== $revision->post_type ) {
-			return new WP_Error(
-				'rest_revision_invalid_type',
-				__( 'The specified ID is not a revision.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( (int) $revision->post_parent !== (int) $parent_id ) {
-			return new WP_Error(
-				'rest_revision_parent_mismatch',
-				__( 'The revision does not belong to the specified post.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return $revision;
-	}
-
-	/**
-	 * Computes the block-level diff between two arrays of parsed blocks.
-	 *
-	 * @param array $old_blocks Blocks from older revision.
-	 * @param array $new_blocks Blocks from newer revision.
-	 * @return array Array of diff items.
-	 */
-	private function compute_block_diff( $old_blocks, $new_blocks ) {
-		$diff = array();
-
-		// Filter out empty blocks (whitespace-only).
-		$old_blocks = $this->filter_empty_blocks( $old_blocks );
-		$new_blocks = $this->filter_empty_blocks( $new_blocks );
-
-		// Index blocks by signature for comparison.
-		$old_index = $this->index_blocks( $old_blocks );
-		$new_index = $this->index_blocks( $new_blocks );
-
-		$processed_new = array();
-
-		// Process old blocks - find removed and modified.
-		foreach ( $old_index as $old_block ) {
-			$found = false;
-
-			foreach ( $new_index as $j => $new_block ) {
-				if ( isset( $processed_new[ $j ] ) ) {
-					continue;
-				}
-
-				// Same block type at similar position.
-				if ( $old_block['blockName'] === $new_block['blockName'] ) {
-					$processed_new[ $j ] = true;
-					$found               = true;
-
-					// Check if content/attributes changed.
-					$attribute_changes = $this->compare_attributes(
-						$old_block['attrs'] ?? array(),
-						$new_block['attrs'] ?? array()
-					);
-
-					$old_content     = $this->normalize_content( $old_block['innerHTML'] ?? '' );
-					$new_content     = $this->normalize_content( $new_block['innerHTML'] ?? '' );
-					$content_changed = $old_content !== $new_content;
-
-					if ( $content_changed || ! empty( $attribute_changes ) ) {
-						$diff[] = array(
-							'id'               => 'diff-' . wp_generate_uuid4(),
-							'type'             => 'modified',
-							'blockName'        => $old_block['blockName'],
-							'oldBlock'         => $this->prepare_block_for_response( $old_block ),
-							'newBlock'         => $this->prepare_block_for_response( $new_block ),
-							'attributeChanges' => $attribute_changes,
-							'innerBlocksDiff'  => $this->compute_block_diff(
-								$old_block['innerBlocks'] ?? array(),
-								$new_block['innerBlocks'] ?? array()
-							),
-						);
-					} else {
-						$diff[] = array(
-							'id'              => 'diff-' . wp_generate_uuid4(),
-							'type'            => 'unchanged',
-							'blockName'       => $old_block['blockName'],
-							'oldBlock'        => $this->prepare_block_for_response( $old_block ),
-							'newBlock'        => $this->prepare_block_for_response( $new_block ),
-							'innerBlocksDiff' => $this->compute_block_diff(
-								$old_block['innerBlocks'] ?? array(),
-								$new_block['innerBlocks'] ?? array()
-							),
-						);
+				foreach ( $new_index as $j => $new_block ) {
+					if ( isset( $processed_new[ $j ] ) ) {
+						continue;
 					}
-					break;
+
+					// Same block type at similar position.
+					if ( $old_block['blockName'] === $new_block['blockName'] ) {
+						$processed_new[ $j ] = true;
+						$found               = true;
+
+						// Check if content/attributes changed.
+						$attribute_changes = $this->compare_attributes(
+							$old_block['attrs'] ?? array(),
+							$new_block['attrs'] ?? array()
+						);
+
+						$old_content     = $this->normalize_content( $old_block['innerHTML'] ?? '' );
+						$new_content     = $this->normalize_content( $new_block['innerHTML'] ?? '' );
+						$content_changed = $old_content !== $new_content;
+
+						if ( $content_changed || ! empty( $attribute_changes ) ) {
+							$diff[] = array(
+								'id'               => 'diff-' . wp_generate_uuid4(),
+								'type'             => 'modified',
+								'blockName'        => $old_block['blockName'],
+								'oldBlock'         => $this->prepare_block_for_response( $old_block ),
+								'newBlock'         => $this->prepare_block_for_response( $new_block ),
+								'attributeChanges' => $attribute_changes,
+								'innerBlocksDiff'  => $this->compute_block_diff(
+									$old_block['innerBlocks'] ?? array(),
+									$new_block['innerBlocks'] ?? array()
+								),
+							);
+						} else {
+							$diff[] = array(
+								'id'              => 'diff-' . wp_generate_uuid4(),
+								'type'            => 'unchanged',
+								'blockName'       => $old_block['blockName'],
+								'oldBlock'        => $this->prepare_block_for_response( $old_block ),
+								'newBlock'        => $this->prepare_block_for_response( $new_block ),
+								'innerBlocksDiff' => $this->compute_block_diff(
+									$old_block['innerBlocks'] ?? array(),
+									$new_block['innerBlocks'] ?? array()
+								),
+							);
+						}
+						break;
+					}
+				}
+
+				if ( ! $found ) {
+					$diff[] = array(
+						'id'        => 'diff-' . wp_generate_uuid4(),
+						'type'      => 'removed',
+						'blockName' => $old_block['blockName'],
+						'oldBlock'  => $this->prepare_block_for_response( $old_block ),
+					);
 				}
 			}
 
-			if ( ! $found ) {
-				$diff[] = array(
-					'id'        => 'diff-' . wp_generate_uuid4(),
-					'type'      => 'removed',
-					'blockName' => $old_block['blockName'],
-					'oldBlock'  => $this->prepare_block_for_response( $old_block ),
-				);
-			}
-		}
-
-		// Find added blocks (in new but not processed).
-		foreach ( $new_index as $j => $new_block ) {
-			if ( ! isset( $processed_new[ $j ] ) ) {
-				$diff[] = array(
-					'id'        => 'diff-' . wp_generate_uuid4(),
-					'type'      => 'added',
-					'blockName' => $new_block['blockName'],
-					'newBlock'  => $this->prepare_block_for_response( $new_block ),
-				);
-			}
-		}
-
-		return $diff;
-	}
-
-	/**
-	 * Filters out empty/whitespace-only blocks.
-	 *
-	 * @param array $blocks Array of blocks.
-	 * @return array Filtered blocks.
-	 */
-	private function filter_empty_blocks( $blocks ) {
-		return array_values(
-			array_filter(
-				$blocks,
-				function ( $block ) {
-					// Keep blocks that have a name (not just whitespace).
-					return ! empty( $block['blockName'] );
+			// Find added blocks (in new but not processed).
+			foreach ( $new_index as $j => $new_block ) {
+				if ( ! isset( $processed_new[ $j ] ) ) {
+					$diff[] = array(
+						'id'        => 'diff-' . wp_generate_uuid4(),
+						'type'      => 'added',
+						'blockName' => $new_block['blockName'],
+						'newBlock'  => $this->prepare_block_for_response( $new_block ),
+					);
 				}
-			)
-		);
-	}
-
-	/**
-	 * Creates an indexed array of blocks.
-	 *
-	 * @param array $blocks Array of blocks.
-	 * @return array Indexed blocks.
-	 */
-	private function index_blocks( $blocks ) {
-		$indexed = array();
-		foreach ( $blocks as $i => $block ) {
-			$indexed[ $i ] = $block;
-		}
-		return $indexed;
-	}
-
-	/**
-	 * Generates a signature for a block for comparison purposes.
-	 *
-	 * @param array $block The block to generate signature for.
-	 * @return string The block signature.
-	 */
-	private function get_block_signature( $block ) {
-		return $block['blockName'] . ':' . md5( wp_json_encode( $block['attrs'] ?? array() ) . ( $block['innerHTML'] ?? '' ) );
-	}
-
-	/**
-	 * Normalizes block content for comparison.
-	 *
-	 * @param string $content The content to normalize.
-	 * @return string Normalized content.
-	 */
-	private function normalize_content( $content ) {
-		// Remove extra whitespace and normalize line endings.
-		$content = preg_replace( '/\s+/', ' ', $content );
-		return trim( $content );
-	}
-
-	/**
-	 * Compares two attribute arrays and returns the differences.
-	 *
-	 * @param array $old_attrs Old attributes.
-	 * @param array $new_attrs New attributes.
-	 * @return array Array of attribute changes.
-	 */
-	private function compare_attributes( $old_attrs, $new_attrs ) {
-		$changes = array();
-
-		$all_keys = array_unique( array_merge( array_keys( $old_attrs ), array_keys( $new_attrs ) ) );
-
-		foreach ( $all_keys as $key ) {
-			$old_value = $old_attrs[ $key ] ?? null;
-			$new_value = $new_attrs[ $key ] ?? null;
-
-			if ( $old_value !== $new_value ) {
-				$changes[] = array(
-					'attribute' => $key,
-					'oldValue'  => $old_value,
-					'newValue'  => $new_value,
-				);
-			}
-		}
-
-		return $changes;
-	}
-
-	/**
-	 * Prepares a block for the REST response.
-	 *
-	 * @param array $block The block to prepare.
-	 * @return array Prepared block data.
-	 */
-	private function prepare_block_for_response( $block ) {
-		return array(
-			'blockName'   => $block['blockName'],
-			'attrs'       => $block['attrs'] ?? array(),
-			'innerHTML'   => $block['innerHTML'] ?? '',
-			'innerBlocks' => array_map(
-				array( $this, 'prepare_block_for_response' ),
-				$block['innerBlocks'] ?? array()
-			),
-		);
-	}
-
-	/**
-	 * Computes summary counts from diff items.
-	 *
-	 * @param array $diff_items Array of diff items.
-	 * @return array Summary counts.
-	 */
-	private function compute_summary( $diff_items ) {
-		$summary = array(
-			'added'     => 0,
-			'removed'   => 0,
-			'modified'  => 0,
-			'unchanged' => 0,
-		);
-
-		foreach ( $diff_items as $item ) {
-			if ( isset( $summary[ $item['type'] ] ) ) {
-				++$summary[ $item['type'] ];
 			}
 
-			// Count nested changes.
-			if ( ! empty( $item['innerBlocksDiff'] ) ) {
-				$nested               = $this->compute_summary( $item['innerBlocksDiff'] );
-				$summary['added']     += $nested['added'];
-				$summary['removed']   += $nested['removed'];
-				$summary['modified']  += $nested['modified'];
-				$summary['unchanged'] += $nested['unchanged'];
-			}
+			return $diff;
 		}
 
-		return $summary;
-	}
+		/**
+		 * Filters out empty/whitespace-only blocks.
+		 *
+		 * @param array $blocks Array of blocks.
+		 * @return array Filtered blocks.
+		 */
+		private function filter_empty_blocks( $blocks ) {
+			return array_values(
+				array_filter(
+					$blocks,
+					function ( $block ) {
+						// Keep blocks that have a name (not just whitespace).
+						return ! empty( $block['blockName'] );
+					}
+				)
+			);
+		}
 
-	/**
-	 * Retrieves the item's schema, conforming to JSON Schema.
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'revision-diff',
-			'type'       => 'object',
-			'properties' => array(
-				'oldRevisionId' => array(
-					'description' => __( 'The ID of the source revision.', 'gutenberg' ),
-					'type'        => 'integer',
+		/**
+		 * Creates an indexed array of blocks.
+		 *
+		 * @param array $blocks Array of blocks.
+		 * @return array Indexed blocks.
+		 */
+		private function index_blocks( $blocks ) {
+			$indexed = array();
+			foreach ( $blocks as $i => $block ) {
+				$indexed[ $i ] = $block;
+			}
+			return $indexed;
+		}
+
+		/**
+		 * Generates a signature for a block for comparison purposes.
+		 *
+		 * @param array $block The block to generate signature for.
+		 * @return string The block signature.
+		 */
+		private function get_block_signature( $block ) {
+			return $block['blockName'] . ':' . md5( wp_json_encode( $block['attrs'] ?? array() ) . ( $block['innerHTML'] ?? '' ) );
+		}
+
+		/**
+		 * Normalizes block content for comparison.
+		 *
+		 * @param string $content The content to normalize.
+		 * @return string Normalized content.
+		 */
+		private function normalize_content( $content ) {
+			// Remove extra whitespace and normalize line endings.
+			$content = preg_replace( '/\s+/', ' ', $content );
+			return trim( $content );
+		}
+
+		/**
+		 * Compares two attribute arrays and returns the differences.
+		 *
+		 * @param array $old_attrs Old attributes.
+		 * @param array $new_attrs New attributes.
+		 * @return array Array of attribute changes.
+		 */
+		private function compare_attributes( $old_attrs, $new_attrs ) {
+			$changes = array();
+
+			$all_keys = array_unique( array_merge( array_keys( $old_attrs ), array_keys( $new_attrs ) ) );
+
+			foreach ( $all_keys as $key ) {
+				$old_value = $old_attrs[ $key ] ?? null;
+				$new_value = $new_attrs[ $key ] ?? null;
+
+				if ( $old_value !== $new_value ) {
+					$changes[] = array(
+						'attribute' => $key,
+						'oldValue'  => $old_value,
+						'newValue'  => $new_value,
+					);
+				}
+			}
+
+			return $changes;
+		}
+
+		/**
+		 * Prepares a block for the REST response.
+		 *
+		 * @param array $block The block to prepare.
+		 * @return array Prepared block data.
+		 */
+		private function prepare_block_for_response( $block ) {
+			return array(
+				'blockName'   => $block['blockName'],
+				'attrs'       => $block['attrs'] ?? array(),
+				'innerHTML'   => $block['innerHTML'] ?? '',
+				'innerBlocks' => array_map(
+					array( $this, 'prepare_block_for_response' ),
+					$block['innerBlocks'] ?? array()
 				),
-				'newRevisionId' => array(
-					'description' => __( 'The ID of the target revision.', 'gutenberg' ),
-					'type'        => 'integer',
-				),
-				'oldDate'       => array(
-					'description' => __( 'The date of the source revision.', 'gutenberg' ),
-					'type'        => 'string',
-				),
-				'newDate'       => array(
-					'description' => __( 'The date of the target revision.', 'gutenberg' ),
-					'type'        => 'string',
-				),
-				'oldAuthor'     => array(
-					'description' => __( 'The author of the source revision.', 'gutenberg' ),
-					'type'        => 'string',
-				),
-				'newAuthor'     => array(
-					'description' => __( 'The author of the target revision.', 'gutenberg' ),
-					'type'        => 'string',
-				),
-				'summary'       => array(
-					'description' => __( 'Summary of changes.', 'gutenberg' ),
-					'type'        => 'object',
-					'properties'  => array(
-						'added'     => array( 'type' => 'integer' ),
-						'removed'   => array( 'type' => 'integer' ),
-						'modified'  => array( 'type' => 'integer' ),
-						'unchanged' => array( 'type' => 'integer' ),
+			);
+		}
+
+		/**
+		 * Computes summary counts from diff items.
+		 *
+		 * @param array $diff_items Array of diff items.
+		 * @return array Summary counts.
+		 */
+		private function compute_summary( $diff_items ) {
+			$summary = array(
+				'added'     => 0,
+				'removed'   => 0,
+				'modified'  => 0,
+				'unchanged' => 0,
+			);
+
+			foreach ( $diff_items as $item ) {
+				if ( isset( $summary[ $item['type'] ] ) ) {
+					++$summary[ $item['type'] ];
+				}
+
+				// Count nested changes.
+				if ( ! empty( $item['innerBlocksDiff'] ) ) {
+					$nested_summary = $this->compute_summary( $item['innerBlocksDiff'] );
+
+					$summary['added']     += $nested_summary['added'];
+					$summary['removed']   += $nested_summary['removed'];
+					$summary['modified']  += $nested_summary['modified'];
+					$summary['unchanged'] += $nested_summary['unchanged'];
+				}
+			}
+
+			return $summary;
+		}
+
+		/**
+		 * Retrieves the item's schema, conforming to JSON Schema.
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			return array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'revision-diff',
+				'type'       => 'object',
+				'properties' => array(
+					'oldRevisionId' => array(
+						'description' => __( 'The ID of the source revision.', 'gutenberg' ),
+						'type'        => 'integer',
+					),
+					'newRevisionId' => array(
+						'description' => __( 'The ID of the target revision.', 'gutenberg' ),
+						'type'        => 'integer',
+					),
+					'oldDate'       => array(
+						'description' => __( 'The date of the source revision.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+					'newDate'       => array(
+						'description' => __( 'The date of the target revision.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+					'oldAuthor'     => array(
+						'description' => __( 'The author of the source revision.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+					'newAuthor'     => array(
+						'description' => __( 'The author of the target revision.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+					'summary'       => array(
+						'description' => __( 'Summary of changes.', 'gutenberg' ),
+						'type'        => 'object',
+						'properties'  => array(
+							'added'     => array( 'type' => 'integer' ),
+							'removed'   => array( 'type' => 'integer' ),
+							'modified'  => array( 'type' => 'integer' ),
+							'unchanged' => array( 'type' => 'integer' ),
+						),
+					),
+					'blocks'        => array(
+						'description' => __( 'Array of block diff items.', 'gutenberg' ),
+						'type'        => 'array',
 					),
 				),
-				'blocks'        => array(
-					'description' => __( 'Array of block diff items.', 'gutenberg' ),
-					'type'        => 'array',
-				),
-			),
-		);
+			);
+		}
 	}
 }

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -19,6 +19,15 @@ function gutenberg_register_block_editor_settings() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_block_editor_settings' );
 
+/**
+ * Registers the Block Revision Diff REST API routes.
+ */
+function gutenberg_register_block_revision_diff_routes() {
+	$controller = new WP_REST_Block_Revision_Diff_Controller();
+	$controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_block_revision_diff_routes' );
+
 
 /**
  * Shim for get_sample_permalink() to add support for auto-draft status.

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-block-editor-settings-controller.php';
 	}
 
+	// Block Revision Diff Controller.
+	require_once __DIR__ . '/experimental/class-wp-rest-block-revision-diff-controller.php';
+
 	// WordPress 6.8 compat.
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -140,7 +140,7 @@ There are two caveats:
 _Usage_
 
 ```jsx
-<AutosaveMonitor interval={ 30000 } />
+<AutosaveMonitor interval={30000} />
 ```
 
 _Parameters_
@@ -365,11 +365,11 @@ _Usage_
 
 ```jsx
 <EditorProvider
-	post={ post }
-	settings={ settings }
-	__unstableTemplate={ template }
+  post={ post }
+  settings={ settings }
+  __unstableTemplate={ template }
 >
-	{ children }
+  { children }
 </EditorProvider>
 ```
 
@@ -585,17 +585,20 @@ _Usage_
 var __ = wp.i18n.__;
 var PluginBlockSettingsMenuItem = wp.editor.PluginBlockSettingsMenuItem;
 
-function doOnClick() {
+function doOnClick(){
 	// To be called when the user clicks the menu item.
 }
 
 function MyPluginBlockSettingsMenuItem() {
-	return React.createElement( PluginBlockSettingsMenuItem, {
-		allowedBlocks: [ 'core/paragraph' ],
-		icon: 'dashicon-name',
-		label: __( 'Menu item text' ),
-		onClick: doOnClick,
-	} );
+	return React.createElement(
+		PluginBlockSettingsMenuItem,
+		{
+			allowedBlocks: [ 'core/paragraph' ],
+			icon: 'dashicon-name',
+			label: __( 'Menu item text' ),
+			onClick: doOnClick,
+		}
+	);
 }
 ```
 
@@ -604,17 +607,16 @@ function MyPluginBlockSettingsMenuItem() {
 import { __ } from '@wordpress/i18n';
 import { PluginBlockSettingsMenuItem } from '@wordpress/editor';
 
-const doOnClick = () => {
-	// To be called when the user clicks the menu item.
+const doOnClick = ( ) => {
+    // To be called when the user clicks the menu item.
 };
 
 const MyPluginBlockSettingsMenuItem = () => (
-	<PluginBlockSettingsMenuItem
+    <PluginBlockSettingsMenuItem
 		allowedBlocks={ [ 'core/paragraph' ] }
-		icon="dashicon-name"
+		icon='dashicon-name'
 		label={ __( 'Menu item text' ) }
-		onClick={ doOnClick }
-	/>
+		onClick={ doOnClick } />
 );
 ```
 
@@ -658,7 +660,7 @@ function MyDocumentSettingPlugin() {
 }
 
 registerPlugin( 'my-document-setting-plugin', {
-	render: MyDocumentSettingPlugin,
+		render: MyDocumentSettingPlugin
 } );
 ```
 
@@ -668,16 +670,12 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 const MyDocumentSettingTest = () => (
-	<PluginDocumentSettingPanel
-		className="my-document-setting-plugin"
-		title="My Panel"
-		name="my-panel"
-	>
+		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel" name="my-panel">
 		<p>My Document Setting Panel</p>
 	</PluginDocumentSettingPanel>
 );
 
-registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
+ registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
 ```
 
 _Parameters_
@@ -732,7 +730,10 @@ function onButtonClick() {
 }
 
 const MyButtonMoreMenuItem = () => (
-	<PluginMoreMenuItem icon={ more } onClick={ onButtonClick }>
+	<PluginMoreMenuItem
+		icon={ more }
+		onClick={ onButtonClick }
+	>
 		{ __( 'My button title' ) }
 	</PluginMoreMenuItem>
 );
@@ -768,7 +769,7 @@ const MyPluginPostPublishPanel = () => (
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
-		{ __( 'My panel content' ) }
+        { __( 'My panel content' ) }
 	</PluginPostPublishPanel>
 );
 ```
@@ -804,7 +805,7 @@ function MyPluginPostStatusInfo() {
 			className: 'my-plugin-post-status-info',
 		},
 		__( 'My post status info' )
-	);
+	)
 }
 ```
 
@@ -814,7 +815,9 @@ import { __ } from '@wordpress/i18n';
 import { PluginPostStatusInfo } from '@wordpress/editor';
 
 const MyPluginPostStatusInfo = () => (
-	<PluginPostStatusInfo className="my-plugin-post-status-info">
+	<PluginPostStatusInfo
+		className="my-plugin-post-status-info"
+	>
 		{ __( 'My post status info' ) }
 	</PluginPostStatusInfo>
 );
@@ -847,7 +850,7 @@ const MyPluginPrePublishPanel = () => (
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
-		{ __( 'My panel content' ) }
+	    { __( 'My panel content' ) }
 	</PluginPrePublishPanel>
 );
 ```
@@ -877,16 +880,19 @@ import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { external } from '@wordpress/icons';
 
 function onPreviewClick() {
-	// Handle preview action
+  // Handle preview action
 }
 
 const ExternalPreviewMenuItem = () => (
-	<PluginPreviewMenuItem icon={ external } onClick={ onPreviewClick }>
-		{ __( 'Preview in new tab' ) }
-	</PluginPreviewMenuItem>
+  <PluginPreviewMenuItem
+    icon={ external }
+    onClick={ onPreviewClick }
+  >
+    { __( 'Preview in new tab' ) }
+  </PluginPreviewMenuItem>
 );
 registerPlugin( 'external-preview-menu-item', {
-	render: ExternalPreviewMenuItem,
+    render: ExternalPreviewMenuItem,
 } );
 ```
 
@@ -908,9 +914,7 @@ _Returns_
 Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar. It also automatically renders a corresponding `PluginSidebarMenuItem` component when `isPinnable` flag is set to `true`. If you wish to display the sidebar, you can with use the `PluginSidebarMoreMenuItem` component or the `wp.data.dispatch` API:
 
 ```js
-wp.data
-	.dispatch( 'core/edit-post' )
-	.openGeneralSidebar( 'plugin-name/sidebar-name' );
+wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( 'plugin-name/sidebar-name' );
 ```
 
 _Related_
@@ -929,13 +933,17 @@ var moreIcon = React.createElement( 'svg' ); //... svg element.
 
 function MyPluginSidebar() {
 	return el(
-		PluginSidebar,
-		{
-			name: 'my-sidebar',
-			title: 'My sidebar title',
-			icon: moreIcon,
-		},
-		el( PanelBody, {}, __( 'My sidebar content' ) )
+			PluginSidebar,
+			{
+				name: 'my-sidebar',
+				title: 'My sidebar title',
+				icon: moreIcon,
+			},
+			el(
+				PanelBody,
+				{},
+				__( 'My sidebar content' )
+			)
 	);
 }
 ```
@@ -948,8 +956,14 @@ import { PluginSidebar } from '@wordpress/editor';
 import { more } from '@wordpress/icons';
 
 const MyPluginSidebar = () => (
-	<PluginSidebar name="my-sidebar" title="My sidebar title" icon={ more }>
-		<PanelBody>{ __( 'My sidebar content' ) }</PanelBody>
+	<PluginSidebar
+		name="my-sidebar"
+		title="My sidebar title"
+		icon={ more }
+	>
+		<PanelBody>
+			{ __( 'My sidebar content' ) }
+		</PanelBody>
 	</PluginSidebar>
 );
 ```
@@ -984,7 +998,7 @@ function MySidebarMoreMenuItem() {
 			icon: moreIcon,
 		},
 		__( 'My sidebar title' )
-	);
+	)
 }
 ```
 
@@ -995,7 +1009,10 @@ import { PluginSidebarMoreMenuItem } from '@wordpress/editor';
 import { more } from '@wordpress/icons';
 
 const MySidebarMoreMenuItem = () => (
-	<PluginSidebarMoreMenuItem target="my-sidebar" icon={ more }>
+	<PluginSidebarMoreMenuItem
+		target="my-sidebar"
+		icon={ more }
+	>
 		{ __( 'My sidebar title' ) }
 	</PluginSidebarMoreMenuItem>
 );
@@ -1435,7 +1452,7 @@ Renders the `PostTitle` component.
 
 _Parameters_
 
--   \_\_\_ `Object`: Unused parameter.
+-   _\__ `Object`: Unused parameter.
 -   _forwardedRef_ `Element`: Forwarded ref for the component.
 
 _Returns_
@@ -1594,6 +1611,24 @@ _Parameters_
 -   _kind_ `string`: Entity kind.
 -   _name_ `string`: Entity name.
 -   _config_ `Field`: Field configuration.
+
+### RevisionDiffPanel
+
+Main revision diff viewer panel component.
+
+_Returns_
+
+-   `JSX.Element`: The rendered component
+
+### RevisionDiffViewerSidebar
+
+Revision Diff Viewer Sidebar container component.
+
+Renders the block-aware revision diff viewer in the editor sidebar.
+
+_Returns_
+
+-   `JSX.Element|null`: The sidebar component or null
 
 ### RichText
 
@@ -1800,6 +1835,7 @@ _Returns_
 ### WritingFlow
 
 > **Deprecated** since 5.3, use `wp.blockEditor.WritingFlow` instead.
+
 
 <!-- END TOKEN(Autogenerated API docs) -->
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -140,7 +140,7 @@ There are two caveats:
 _Usage_
 
 ```jsx
-<AutosaveMonitor interval={30000} />
+<AutosaveMonitor interval={ 30000 } />
 ```
 
 _Parameters_
@@ -365,11 +365,11 @@ _Usage_
 
 ```jsx
 <EditorProvider
-  post={ post }
-  settings={ settings }
-  __unstableTemplate={ template }
+	post={ post }
+	settings={ settings }
+	__unstableTemplate={ template }
 >
-  { children }
+	{ children }
 </EditorProvider>
 ```
 
@@ -585,20 +585,17 @@ _Usage_
 var __ = wp.i18n.__;
 var PluginBlockSettingsMenuItem = wp.editor.PluginBlockSettingsMenuItem;
 
-function doOnClick(){
+function doOnClick() {
 	// To be called when the user clicks the menu item.
 }
 
 function MyPluginBlockSettingsMenuItem() {
-	return React.createElement(
-		PluginBlockSettingsMenuItem,
-		{
-			allowedBlocks: [ 'core/paragraph' ],
-			icon: 'dashicon-name',
-			label: __( 'Menu item text' ),
-			onClick: doOnClick,
-		}
-	);
+	return React.createElement( PluginBlockSettingsMenuItem, {
+		allowedBlocks: [ 'core/paragraph' ],
+		icon: 'dashicon-name',
+		label: __( 'Menu item text' ),
+		onClick: doOnClick,
+	} );
 }
 ```
 
@@ -607,16 +604,17 @@ function MyPluginBlockSettingsMenuItem() {
 import { __ } from '@wordpress/i18n';
 import { PluginBlockSettingsMenuItem } from '@wordpress/editor';
 
-const doOnClick = ( ) => {
-    // To be called when the user clicks the menu item.
+const doOnClick = () => {
+	// To be called when the user clicks the menu item.
 };
 
 const MyPluginBlockSettingsMenuItem = () => (
-    <PluginBlockSettingsMenuItem
+	<PluginBlockSettingsMenuItem
 		allowedBlocks={ [ 'core/paragraph' ] }
-		icon='dashicon-name'
+		icon="dashicon-name"
 		label={ __( 'Menu item text' ) }
-		onClick={ doOnClick } />
+		onClick={ doOnClick }
+	/>
 );
 ```
 
@@ -660,7 +658,7 @@ function MyDocumentSettingPlugin() {
 }
 
 registerPlugin( 'my-document-setting-plugin', {
-		render: MyDocumentSettingPlugin
+	render: MyDocumentSettingPlugin,
 } );
 ```
 
@@ -670,12 +668,16 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 const MyDocumentSettingTest = () => (
-		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel" name="my-panel">
+	<PluginDocumentSettingPanel
+		className="my-document-setting-plugin"
+		title="My Panel"
+		name="my-panel"
+	>
 		<p>My Document Setting Panel</p>
 	</PluginDocumentSettingPanel>
 );
 
- registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
+registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
 ```
 
 _Parameters_
@@ -730,10 +732,7 @@ function onButtonClick() {
 }
 
 const MyButtonMoreMenuItem = () => (
-	<PluginMoreMenuItem
-		icon={ more }
-		onClick={ onButtonClick }
-	>
+	<PluginMoreMenuItem icon={ more } onClick={ onButtonClick }>
 		{ __( 'My button title' ) }
 	</PluginMoreMenuItem>
 );
@@ -769,7 +768,7 @@ const MyPluginPostPublishPanel = () => (
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
-        { __( 'My panel content' ) }
+		{ __( 'My panel content' ) }
 	</PluginPostPublishPanel>
 );
 ```
@@ -805,7 +804,7 @@ function MyPluginPostStatusInfo() {
 			className: 'my-plugin-post-status-info',
 		},
 		__( 'My post status info' )
-	)
+	);
 }
 ```
 
@@ -815,9 +814,7 @@ import { __ } from '@wordpress/i18n';
 import { PluginPostStatusInfo } from '@wordpress/editor';
 
 const MyPluginPostStatusInfo = () => (
-	<PluginPostStatusInfo
-		className="my-plugin-post-status-info"
-	>
+	<PluginPostStatusInfo className="my-plugin-post-status-info">
 		{ __( 'My post status info' ) }
 	</PluginPostStatusInfo>
 );
@@ -850,7 +847,7 @@ const MyPluginPrePublishPanel = () => (
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
-	    { __( 'My panel content' ) }
+		{ __( 'My panel content' ) }
 	</PluginPrePublishPanel>
 );
 ```
@@ -880,19 +877,16 @@ import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { external } from '@wordpress/icons';
 
 function onPreviewClick() {
-  // Handle preview action
+	// Handle preview action
 }
 
 const ExternalPreviewMenuItem = () => (
-  <PluginPreviewMenuItem
-    icon={ external }
-    onClick={ onPreviewClick }
-  >
-    { __( 'Preview in new tab' ) }
-  </PluginPreviewMenuItem>
+	<PluginPreviewMenuItem icon={ external } onClick={ onPreviewClick }>
+		{ __( 'Preview in new tab' ) }
+	</PluginPreviewMenuItem>
 );
 registerPlugin( 'external-preview-menu-item', {
-    render: ExternalPreviewMenuItem,
+	render: ExternalPreviewMenuItem,
 } );
 ```
 
@@ -914,7 +908,9 @@ _Returns_
 Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar. It also automatically renders a corresponding `PluginSidebarMenuItem` component when `isPinnable` flag is set to `true`. If you wish to display the sidebar, you can with use the `PluginSidebarMoreMenuItem` component or the `wp.data.dispatch` API:
 
 ```js
-wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( 'plugin-name/sidebar-name' );
+wp.data
+	.dispatch( 'core/edit-post' )
+	.openGeneralSidebar( 'plugin-name/sidebar-name' );
 ```
 
 _Related_
@@ -933,17 +929,13 @@ var moreIcon = React.createElement( 'svg' ); //... svg element.
 
 function MyPluginSidebar() {
 	return el(
-			PluginSidebar,
-			{
-				name: 'my-sidebar',
-				title: 'My sidebar title',
-				icon: moreIcon,
-			},
-			el(
-				PanelBody,
-				{},
-				__( 'My sidebar content' )
-			)
+		PluginSidebar,
+		{
+			name: 'my-sidebar',
+			title: 'My sidebar title',
+			icon: moreIcon,
+		},
+		el( PanelBody, {}, __( 'My sidebar content' ) )
 	);
 }
 ```
@@ -956,14 +948,8 @@ import { PluginSidebar } from '@wordpress/editor';
 import { more } from '@wordpress/icons';
 
 const MyPluginSidebar = () => (
-	<PluginSidebar
-		name="my-sidebar"
-		title="My sidebar title"
-		icon={ more }
-	>
-		<PanelBody>
-			{ __( 'My sidebar content' ) }
-		</PanelBody>
+	<PluginSidebar name="my-sidebar" title="My sidebar title" icon={ more }>
+		<PanelBody>{ __( 'My sidebar content' ) }</PanelBody>
 	</PluginSidebar>
 );
 ```
@@ -998,7 +984,7 @@ function MySidebarMoreMenuItem() {
 			icon: moreIcon,
 		},
 		__( 'My sidebar title' )
-	)
+	);
 }
 ```
 
@@ -1009,10 +995,7 @@ import { PluginSidebarMoreMenuItem } from '@wordpress/editor';
 import { more } from '@wordpress/icons';
 
 const MySidebarMoreMenuItem = () => (
-	<PluginSidebarMoreMenuItem
-		target="my-sidebar"
-		icon={ more }
-	>
+	<PluginSidebarMoreMenuItem target="my-sidebar" icon={ more }>
 		{ __( 'My sidebar title' ) }
 	</PluginSidebarMoreMenuItem>
 );
@@ -1452,7 +1435,7 @@ Renders the `PostTitle` component.
 
 _Parameters_
 
--   _\__ `Object`: Unused parameter.
+-   \_\_\_ `Object`: Unused parameter.
 -   _forwardedRef_ `Element`: Forwarded ref for the component.
 
 _Returns_
@@ -1835,7 +1818,6 @@ _Returns_
 ### WritingFlow
 
 > **Deprecated** since 5.3, use `wp.blockEditor.WritingFlow` instead.
-
 
 <!-- END TOKEN(Autogenerated API docs) -->
 

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -17,6 +17,7 @@ import Sidebar from '../sidebar';
 import NotesSidebar from '../collab-sidebar';
 import GlobalStylesSidebar from '../global-styles-sidebar';
 import { GlobalStylesRenderer } from '../global-styles-renderer';
+import { RevisionDiffViewerSidebar } from '../revision-diff-viewer';
 
 function Editor( {
 	postType,
@@ -125,6 +126,7 @@ function Editor( {
 						extraPanels={ extraSidebarPanels }
 					/>
 					<NotesSidebar />
+					<RevisionDiffViewerSidebar />
 					{ isBlockTheme && <GlobalStylesRenderer /> }
 					{ showGlobalStyles && <GlobalStylesSidebar /> }
 				</ExperimentalEditorProvider>

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -101,7 +101,10 @@ export { default as TimeToRead } from './time-to-read';
 export { default as CharacterCount } from './character-count';
 
 // Revision Diff Viewer.
-export { RevisionDiffViewerSidebar, RevisionDiffPanel } from './revision-diff-viewer';
+export {
+	RevisionDiffViewerSidebar,
+	RevisionDiffPanel,
+} from './revision-diff-viewer';
 
 // State Related Components.
 export { default as EditorProvider } from './provider';

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -100,6 +100,9 @@ export { default as WordCount } from './word-count';
 export { default as TimeToRead } from './time-to-read';
 export { default as CharacterCount } from './character-count';
 
+// Revision Diff Viewer.
+export { RevisionDiffViewerSidebar, RevisionDiffPanel } from './revision-diff-viewer';
+
 // State Related Components.
 export { default as EditorProvider } from './provider';
 

--- a/packages/editor/src/components/revision-diff-viewer/block-diff-item.js
+++ b/packages/editor/src/components/revision-diff-viewer/block-diff-item.js
@@ -1,0 +1,179 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, Button } from '@wordpress/components';
+import { plus, trash, update, check } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+
+/**
+ * @typedef {import('./utils/types').BlockDiffItem} BlockDiffItem
+ */
+
+/**
+ * Gets the icon for a diff type.
+ *
+ * @param {string} type - The diff type
+ * @return {Object} The icon component
+ */
+function getDiffIcon( type ) {
+	switch ( type ) {
+		case 'added':
+			return plus;
+		case 'removed':
+			return trash;
+		case 'modified':
+			return update;
+		case 'unchanged':
+		default:
+			return check;
+	}
+}
+
+/**
+ * Gets a human-readable block name.
+ *
+ * @param {string} blockName - The block type name
+ * @return {string} Human-readable name
+ */
+function getBlockLabel( blockName ) {
+	if ( ! blockName ) {
+		return __( 'Unknown Block' );
+	}
+
+	// Remove namespace and capitalize.
+	const name = blockName.replace( /^core\//, '' );
+	return name
+		.split( '-' )
+		.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );
+}
+
+/**
+ * Extracts a preview of block content.
+ *
+ * @param {Object} block - The block data
+ * @return {string} Content preview
+ */
+function getContentPreview( block ) {
+	if ( ! block || ! block.innerHTML ) {
+		return '';
+	}
+
+	// Strip HTML tags and get first 100 characters.
+	const text = block.innerHTML.replace( /<[^>]*>/g, '' ).trim();
+	if ( text.length > 100 ) {
+		return text.substring( 0, 100 ) + '...';
+	}
+	return text;
+}
+
+/**
+ * Renders attribute changes for a modified block.
+ *
+ * @param {Object}   props                  - Component props
+ * @param {Object[]} props.attributeChanges - Array of attribute changes
+ * @return {JSX.Element|null} The rendered changes or null
+ */
+function AttributeChanges( { attributeChanges } ) {
+	if ( ! attributeChanges || attributeChanges.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="revision-diff-viewer__attribute-changes">
+			<h5>{ __( 'Changed attributes:' ) }</h5>
+			<ul>
+				{ attributeChanges.map( ( change, index ) => (
+					<li key={ index }>
+						<strong>{ change.attribute }:</strong>
+						<span className="revision-diff-viewer__old-value">
+							{ JSON.stringify( change.oldValue ) }
+						</span>
+						<span className="revision-diff-viewer__arrow">→</span>
+						<span className="revision-diff-viewer__new-value">
+							{ JSON.stringify( change.newValue ) }
+						</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}
+
+/**
+ * Individual block diff item component.
+ *
+ * @param {Object}        props      - Component props
+ * @param {BlockDiffItem} props.item - The block diff item to display
+ * @return {JSX.Element} The rendered component
+ */
+export function BlockDiffItem( { item } ) {
+	const [ isExpanded, setIsExpanded ] = useState( false );
+
+	const icon = getDiffIcon( item.type );
+	const label = getBlockLabel( item.blockName );
+	const preview =
+		getContentPreview( item.newBlock ) ||
+		getContentPreview( item.oldBlock );
+
+	const hasDetails =
+		( item.attributeChanges && item.attributeChanges.length > 0 ) ||
+		( item.innerBlocksDiff && item.innerBlocksDiff.length > 0 );
+
+	const typeClass = `revision-diff-viewer__item--${ item.type }`;
+
+	return (
+		<div className={ `revision-diff-viewer__item ${ typeClass }` }>
+			<div className="revision-diff-viewer__item-header">
+				<Icon
+					icon={ icon }
+					className="revision-diff-viewer__item-icon"
+				/>
+				<span className="revision-diff-viewer__item-label">
+					{ label }
+				</span>
+				<span className="revision-diff-viewer__item-type">
+					{ item.type }
+				</span>
+				{ hasDetails && (
+					<Button
+						variant="tertiary"
+						onClick={ () => setIsExpanded( ! isExpanded ) }
+						className="revision-diff-viewer__expand-button"
+						__next40pxDefaultSize
+					>
+						{ isExpanded ? __( 'Collapse' ) : __( 'Details' ) }
+					</Button>
+				) }
+			</div>
+
+			{ preview && (
+				<div className="revision-diff-viewer__item-preview">
+					{ preview }
+				</div>
+			) }
+
+			{ isExpanded && (
+				<div className="revision-diff-viewer__item-details">
+					<AttributeChanges
+						attributeChanges={ item.attributeChanges }
+					/>
+
+					{ item.innerBlocksDiff &&
+						item.innerBlocksDiff.length > 0 && (
+							<div className="revision-diff-viewer__nested-blocks">
+								<h5>{ __( 'Nested block changes:' ) }</h5>
+								{ item.innerBlocksDiff.map( ( nested ) => (
+									<BlockDiffItem
+										key={ nested.id }
+										item={ nested }
+									/>
+								) ) }
+							</div>
+						) }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/packages/editor/src/components/revision-diff-viewer/diff-summary.js
+++ b/packages/editor/src/components/revision-diff-viewer/diff-summary.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * @typedef {import('./utils/types').DiffSummary} DiffSummary
+ */
+
+/**
+ * Summary component showing change counts.
+ *
+ * @param {Object}      props         - Component props
+ * @param {DiffSummary} props.summary - The diff summary counts
+ * @return {JSX.Element} The rendered component
+ */
+export function DiffSummary( { summary } ) {
+	const { added, removed, modified } = summary;
+	const totalChanges = added + removed + modified;
+
+	if ( totalChanges === 0 ) {
+		return (
+			<div className="revision-diff-viewer__summary revision-diff-viewer__summary--no-changes">
+				{ __( 'No changes between these revisions.' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="revision-diff-viewer__summary">
+			<span className="revision-diff-viewer__summary-total">
+				{ sprintf(
+					/* translators: %d: total number of changes */
+					__( '%d changes' ),
+					totalChanges
+				) }
+			</span>
+			<div className="revision-diff-viewer__summary-counts">
+				{ added > 0 && (
+					<span className="revision-diff-viewer__count revision-diff-viewer__count--added">
+						{ sprintf(
+							/* translators: %d: number of blocks added */
+							__( '+%d added' ),
+							added
+						) }
+					</span>
+				) }
+				{ removed > 0 && (
+					<span className="revision-diff-viewer__count revision-diff-viewer__count--removed">
+						{ sprintf(
+							/* translators: %d: number of blocks removed */
+							__( '-%d removed' ),
+							removed
+						) }
+					</span>
+				) }
+				{ modified > 0 && (
+					<span className="revision-diff-viewer__count revision-diff-viewer__count--modified">
+						{ sprintf(
+							/* translators: %d: number of blocks modified */
+							__( '~%d modified' ),
+							modified
+						) }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/packages/editor/src/components/revision-diff-viewer/index.js
+++ b/packages/editor/src/components/revision-diff-viewer/index.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { backup } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import PluginSidebar from '../plugin-sidebar';
+import { RevisionDiffPanel } from './panel';
+import { store as editorStore } from '../../store';
+
+/**
+ * Sidebar identifier for the revision diff viewer.
+ */
+export const REVISION_DIFF_VIEWER_SIDEBAR_NAME =
+	'edit-post/revision-diff-viewer';
+
+/**
+ * Revision Diff Viewer Sidebar container component.
+ *
+ * Renders the block-aware revision diff viewer in the editor sidebar.
+ *
+ * @return {JSX.Element|null} The sidebar component or null
+ */
+function RevisionDiffViewerSidebar() {
+	const { editorMode } = useSelect( ( select ) => {
+		const { getEditorMode } = select( editorStore );
+		return {
+			editorMode: getEditorMode?.() || 'visual',
+		};
+	}, [] );
+
+	// Only show in visual mode.
+	if ( editorMode !== 'visual' ) {
+		return null;
+	}
+
+	return (
+		<PluginSidebar
+			name={ REVISION_DIFF_VIEWER_SIDEBAR_NAME }
+			title={ __( 'Revision Diff Viewer' ) }
+			icon={ backup }
+		>
+			<RevisionDiffPanel />
+		</PluginSidebar>
+	);
+}
+
+export { RevisionDiffViewerSidebar, RevisionDiffPanel };

--- a/packages/editor/src/components/revision-diff-viewer/panel.js
+++ b/packages/editor/src/components/revision-diff-viewer/panel.js
@@ -1,0 +1,196 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { Spinner, Notice, Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { fetchRevisionDiff, fetchRevisions } from './utils/api';
+import { RevisionSelector } from './revision-selector';
+import { DiffSummary } from './diff-summary';
+import { BlockDiffItem } from './block-diff-item';
+import { store as editorStore } from '../../store';
+
+/**
+ * @typedef {import('./utils/types').RevisionDiff} RevisionDiff
+ */
+
+/**
+ * Main revision diff viewer panel component.
+ *
+ * @return {JSX.Element} The rendered component
+ */
+export function RevisionDiffPanel() {
+	const [ revisions, setRevisions ] = useState( [] );
+	const [ fromId, setFromId ] = useState( null );
+	const [ toId, setToId ] = useState( null );
+	const [ diff, setDiff ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const [ showUnchanged, setShowUnchanged ] = useState( false );
+
+	// Get the current post ID.
+	const postId = useSelect(
+		( select ) => select( editorStore ).getCurrentPostId(),
+		[]
+	);
+
+	// Load revisions when post ID is available.
+	useEffect( () => {
+		if ( ! postId ) {
+			return;
+		}
+
+		setIsLoading( true );
+		setError( null );
+
+		fetchRevisions( postId )
+			.then( ( data ) => {
+				setRevisions( data );
+				// Auto-select first two revisions if available.
+				if ( data.length >= 2 ) {
+					setFromId( data[ 1 ].id ); // Older.
+					setToId( data[ 0 ].id ); // Newer.
+				}
+			} )
+			.catch( ( err ) => {
+				setError( err.message || __( 'Failed to load revisions.' ) );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ postId ] );
+
+	// Load diff when revisions are selected.
+	const loadDiff = useCallback( () => {
+		if ( ! postId || ! fromId || ! toId || fromId === toId ) {
+			setDiff( null );
+			return;
+		}
+
+		setIsLoading( true );
+		setError( null );
+
+		fetchRevisionDiff( postId, fromId, toId )
+			.then( ( data ) => {
+				setDiff( data );
+			} )
+			.catch( ( err ) => {
+				setError( err.message || __( 'Failed to load diff.' ) );
+				setDiff( null );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ postId, fromId, toId ] );
+
+	// Load diff when selections change.
+	useEffect( () => {
+		loadDiff();
+	}, [ loadDiff ] );
+
+	// Filter blocks based on showUnchanged setting.
+	const filteredBlocks = diff?.blocks?.filter(
+		( block ) => showUnchanged || block.type !== 'unchanged'
+	);
+
+	if ( ! postId ) {
+		return (
+			<div className="revision-diff-viewer__panel">
+				<Notice status="warning" isDismissible={ false }>
+					{ __( 'No post selected.' ) }
+				</Notice>
+			</div>
+		);
+	}
+
+	return (
+		<div className="revision-diff-viewer__panel">
+			<div className="revision-diff-viewer__header">
+				<p className="revision-diff-viewer__description">
+					{ __(
+						'Compare revisions to see what blocks changed between versions.'
+					) }
+				</p>
+			</div>
+
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
+
+			{ isLoading && ! diff && (
+				<div className="revision-diff-viewer__loading">
+					<Spinner />
+					<span>{ __( 'Loading…' ) }</span>
+				</div>
+			) }
+
+			{ ! isLoading && revisions.length > 0 && (
+				<RevisionSelector
+					revisions={ revisions }
+					fromId={ fromId }
+					toId={ toId }
+					onFromChange={ setFromId }
+					onToChange={ setToId }
+				/>
+			) }
+
+			{ fromId === toId && fromId !== null && (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'Please select two different revisions to compare.'
+					) }
+				</Notice>
+			) }
+
+			{ diff && (
+				<>
+					<DiffSummary summary={ diff.summary } />
+
+					<div className="revision-diff-viewer__controls">
+						<Button
+							variant="tertiary"
+							onClick={ () =>
+								setShowUnchanged( ! showUnchanged )
+							}
+							__next40pxDefaultSize
+						>
+							{ showUnchanged
+								? __( 'Hide unchanged blocks' )
+								: __( 'Show unchanged blocks' ) }
+						</Button>
+					</div>
+
+					<div className="revision-diff-viewer__blocks">
+						{ filteredBlocks && filteredBlocks.length > 0 ? (
+							filteredBlocks.map( ( block ) => (
+								<BlockDiffItem
+									key={ block.id }
+									item={ block }
+								/>
+							) )
+						) : (
+							<p className="revision-diff-viewer__no-changes">
+								{ __( 'No visible changes.' ) }
+							</p>
+						) }
+					</div>
+				</>
+			) }
+
+			{ ! isLoading && revisions.length < 2 && (
+				<Notice status="info" isDismissible={ false }>
+					{ __(
+						'This post needs at least two revisions to compare. Make some changes and save to create revisions.'
+					) }
+				</Notice>
+			) }
+		</div>
+	);
+}

--- a/packages/editor/src/components/revision-diff-viewer/revision-selector.js
+++ b/packages/editor/src/components/revision-diff-viewer/revision-selector.js
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { dateI18n, getSettings } from '@wordpress/date';
+
+/**
+ * @typedef {import('./utils/types').Revision} Revision
+ */
+
+/**
+ * Formats a revision for display in the dropdown.
+ *
+ * @param {Object} revision - The revision object
+ * @return {string} Formatted label
+ */
+function formatRevisionLabel( revision ) {
+	const dateFormat = getSettings().formats.datetime;
+	const formattedDate = dateI18n( dateFormat, revision.date );
+	const authorName =
+		revision.author_name || revision.author || __( 'Unknown' );
+
+	return sprintf(
+		/* translators: 1: revision date, 2: author name */
+		__( '%1$s by %2$s' ),
+		formattedDate,
+		authorName
+	);
+}
+
+/**
+ * Revision selector component.
+ *
+ * @param {Object}   props              - Component props
+ * @param {Array}    props.revisions    - Array of revision objects
+ * @param {number}   props.fromId       - Selected source revision ID
+ * @param {number}   props.toId         - Selected target revision ID
+ * @param {Function} props.onFromChange - Callback when source changes
+ * @param {Function} props.onToChange   - Callback when target changes
+ * @return {JSX.Element} The rendered component
+ */
+export function RevisionSelector( {
+	revisions,
+	fromId,
+	toId,
+	onFromChange,
+	onToChange,
+} ) {
+	if ( ! revisions || revisions.length < 2 ) {
+		return (
+			<div className="revision-diff-viewer__selector-empty">
+				{ __( 'Not enough revisions to compare.' ) }
+			</div>
+		);
+	}
+
+	const options = revisions.map( ( revision ) => ( {
+		value: revision.id.toString(),
+		label: formatRevisionLabel( revision ),
+	} ) );
+
+	return (
+		<div className="revision-diff-viewer__selector">
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'From revision' ) }
+				value={ fromId?.toString() || '' }
+				options={ options }
+				onChange={ ( value ) => onFromChange( parseInt( value, 10 ) ) }
+			/>
+			<span className="revision-diff-viewer__selector-arrow">→</span>
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'To revision' ) }
+				value={ toId?.toString() || '' }
+				options={ options }
+				onChange={ ( value ) => onToChange( parseInt( value, 10 ) ) }
+			/>
+		</div>
+	);
+}

--- a/packages/editor/src/components/revision-diff-viewer/style.scss
+++ b/packages/editor/src/components/revision-diff-viewer/style.scss
@@ -1,0 +1,272 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.revision-diff-viewer__panel {
+	padding: $grid-unit-15;
+}
+
+.revision-diff-viewer__header {
+	margin-bottom: $grid-unit-20;
+}
+
+.revision-diff-viewer__description {
+	color: $gray-700;
+	font-size: $default-font-size;
+	margin: 0 0 $grid-unit-15;
+}
+
+.revision-diff-viewer__loading {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	padding: $grid-unit-20;
+	justify-content: center;
+}
+
+// Revision selector styles.
+.revision-diff-viewer__selector {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+	margin-bottom: $grid-unit-20;
+	padding: $grid-unit-15;
+	background: $gray-100;
+	border-radius: $radius-small;
+}
+
+.revision-diff-viewer__selector-arrow {
+	text-align: center;
+	color: $gray-700;
+	font-size: 18px;
+}
+
+.revision-diff-viewer__selector-empty {
+	color: $gray-700;
+	text-align: center;
+	padding: $grid-unit-20;
+}
+
+// Summary styles.
+.revision-diff-viewer__summary {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-05;
+	padding: $grid-unit-15;
+	background: $gray-100;
+	border-radius: $radius-small;
+	margin-bottom: $grid-unit-15;
+}
+
+.revision-diff-viewer__summary--no-changes {
+	color: $gray-700;
+	text-align: center;
+}
+
+.revision-diff-viewer__summary-total {
+	font-weight: 600;
+	font-size: $default-font-size;
+}
+
+.revision-diff-viewer__summary-counts {
+	display: flex;
+	gap: $grid-unit-15;
+	flex-wrap: wrap;
+}
+
+.revision-diff-viewer__count {
+	font-size: $default-font-size;
+	padding: 2px $grid-unit-10;
+	border-radius: $radius-small;
+
+	&--added {
+		background: rgba(0, 135, 90, 0.1);
+		color: #00875a;
+	}
+
+	&--removed {
+		background: rgba(204, 24, 30, 0.1);
+		color: #cc181e;
+	}
+
+	&--modified {
+		background: rgba(255, 171, 0, 0.2);
+		color: #996600;
+	}
+}
+
+// Controls.
+.revision-diff-viewer__controls {
+	margin-bottom: $grid-unit-15;
+}
+
+// Block diff item styles.
+.revision-diff-viewer__blocks {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+}
+
+.revision-diff-viewer__item {
+	border: 1px solid $gray-300;
+	border-radius: $radius-small;
+	overflow: hidden;
+
+	&--added {
+		border-left: 4px solid #00875a;
+		background: rgba(0, 135, 90, 0.05);
+	}
+
+	&--removed {
+		border-left: 4px solid #cc181e;
+		background: rgba(204, 24, 30, 0.05);
+	}
+
+	&--modified {
+		border-left: 4px solid #ffab00;
+		background: rgba(255, 171, 0, 0.05);
+	}
+
+	&--unchanged {
+		border-left: 4px solid $gray-400;
+		background: $gray-100;
+		opacity: 0.7;
+	}
+}
+
+.revision-diff-viewer__item-header {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	padding: $grid-unit-10 $grid-unit-15;
+	background: rgba(255, 255, 255, 0.5);
+}
+
+.revision-diff-viewer__item-icon {
+	flex-shrink: 0;
+
+	.revision-diff-viewer__item--added & {
+		fill: #00875a;
+	}
+
+	.revision-diff-viewer__item--removed & {
+		fill: #cc181e;
+	}
+
+	.revision-diff-viewer__item--modified & {
+		fill: #996600;
+	}
+
+	.revision-diff-viewer__item--unchanged & {
+		fill: $gray-600;
+	}
+}
+
+.revision-diff-viewer__item-label {
+	font-weight: 500;
+	flex-grow: 1;
+}
+
+.revision-diff-viewer__item-type {
+	font-size: 11px;
+	text-transform: uppercase;
+	color: $gray-700;
+	padding: 2px 6px;
+	background: rgba(0, 0, 0, 0.05);
+	border-radius: 3px;
+}
+
+.revision-diff-viewer__expand-button {
+	flex-shrink: 0;
+}
+
+.revision-diff-viewer__item-preview {
+	padding: $grid-unit-10 $grid-unit-15;
+	font-size: $default-font-size - 1px;
+	color: $gray-700;
+	border-top: 1px solid $gray-200;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.revision-diff-viewer__item-details {
+	padding: $grid-unit-15;
+	border-top: 1px solid $gray-200;
+	background: rgba(255, 255, 255, 0.5);
+}
+
+// Attribute changes.
+.revision-diff-viewer__attribute-changes {
+	h5 {
+		margin: 0 0 $grid-unit-10;
+		font-size: $default-font-size - 1px;
+		font-weight: 600;
+	}
+
+	ul {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	li {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		flex-wrap: wrap;
+		margin-bottom: $grid-unit-05;
+		font-size: $default-font-size - 1px;
+
+		strong {
+			color: $gray-900;
+		}
+	}
+}
+
+.revision-diff-viewer__old-value {
+	background: rgba(204, 24, 30, 0.1);
+	padding: 2px 4px;
+	border-radius: 2px;
+	color: #cc181e;
+	word-break: break-all;
+	max-width: 150px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.revision-diff-viewer__new-value {
+	background: rgba(0, 135, 90, 0.1);
+	padding: 2px 4px;
+	border-radius: 2px;
+	color: #00875a;
+	word-break: break-all;
+	max-width: 150px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.revision-diff-viewer__arrow {
+	color: $gray-600;
+}
+
+// Nested blocks.
+.revision-diff-viewer__nested-blocks {
+	margin-top: $grid-unit-15;
+
+	h5 {
+		margin: 0 0 $grid-unit-10;
+		font-size: $default-font-size - 1px;
+		font-weight: 600;
+	}
+
+	.revision-diff-viewer__item {
+		margin-left: $grid-unit-15;
+	}
+}
+
+.revision-diff-viewer__no-changes {
+	color: $gray-700;
+	text-align: center;
+	padding: $grid-unit-20;
+}
+

--- a/packages/editor/src/components/revision-diff-viewer/style.scss
+++ b/packages/editor/src/components/revision-diff-viewer/style.scss
@@ -90,7 +90,7 @@
 
 	&--modified {
 		background: rgba(255, 171, 0, 0.2);
-		color: #996600;
+		color: #960;
 	}
 }
 
@@ -153,7 +153,7 @@
 	}
 
 	.revision-diff-viewer__item--modified & {
-		fill: #996600;
+		fill: #960;
 	}
 
 	.revision-diff-viewer__item--unchanged & {

--- a/packages/editor/src/components/revision-diff-viewer/utils/api.js
+++ b/packages/editor/src/components/revision-diff-viewer/utils/api.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * @typedef {import('./types').RevisionDiff} RevisionDiff
+ */
+
+/**
+ * Fetches the block-level diff between two revisions.
+ *
+ * @param {number} postId - The ID of the post
+ * @param {number} fromId - The source revision ID
+ * @param {number} toId   - The target revision ID
+ * @return {Promise<RevisionDiff>} The revision diff data
+ */
+export async function fetchRevisionDiff( postId, fromId, toId ) {
+	const path = `/gutenberg/v1/posts/${ postId }/revisions/diff?from=${ fromId }&to=${ toId }`;
+
+	return apiFetch( { path } );
+}
+
+/**
+ * Fetches the list of revisions for a post.
+ *
+ * @param {number} postId - The ID of the post
+ * @return {Promise<Array>} Array of revision objects
+ */
+export async function fetchRevisions( postId ) {
+	const path = `/wp/v2/posts/${ postId }/revisions`;
+
+	return apiFetch( { path } );
+}

--- a/packages/editor/src/components/revision-diff-viewer/utils/types.js
+++ b/packages/editor/src/components/revision-diff-viewer/utils/types.js
@@ -1,0 +1,71 @@
+/**
+ * Revision Diff Viewer - Type Definitions
+ *
+ * This file contains JSDoc type definitions for the revision diff system.
+ */
+
+/**
+ * @typedef {'added' | 'removed' | 'modified' | 'unchanged'} DiffType
+ * The type of change detected for a block.
+ */
+
+/**
+ * @typedef {Object} AttributeChange
+ * Represents a change to a single block attribute.
+ * @property {string} attribute - The attribute name that changed
+ * @property {*}      oldValue  - The previous value
+ * @property {*}      newValue  - The new value
+ */
+
+/**
+ * @typedef {Object} BlockData
+ * Represents a parsed block's data.
+ * @property {string}      blockName   - The block type name (e.g., 'core/paragraph')
+ * @property {Object}      attrs       - Block attributes
+ * @property {string}      innerHTML   - The block's inner HTML content
+ * @property {BlockData[]} innerBlocks - Nested child blocks
+ */
+
+/**
+ * @typedef {Object} BlockDiffItem
+ * Represents a single block diff item.
+ * @property {string}            id                 - Unique identifier for the diff item
+ * @property {DiffType}          type               - The type of change
+ * @property {string}            blockName          - The block type name
+ * @property {BlockData}         [oldBlock]         - Block data from the older revision
+ * @property {BlockData}         [newBlock]         - Block data from the newer revision
+ * @property {AttributeChange[]} [attributeChanges] - Specific attribute differences
+ * @property {BlockDiffItem[]}   [innerBlocksDiff]  - Diff of nested blocks
+ */
+
+/**
+ * @typedef {Object} DiffSummary
+ * Summary counts of changes between revisions.
+ * @property {number} added     - Number of blocks added
+ * @property {number} removed   - Number of blocks removed
+ * @property {number} modified  - Number of blocks modified
+ * @property {number} unchanged - Number of unchanged blocks
+ */
+
+/**
+ * @typedef {Object} RevisionDiff
+ * The complete revision diff response from the API.
+ * @property {number}          oldRevisionId - ID of the source revision
+ * @property {number}          newRevisionId - ID of the target revision
+ * @property {string}          oldDate       - Date of the source revision
+ * @property {string}          newDate       - Date of the target revision
+ * @property {string}          oldAuthor     - Author of the source revision
+ * @property {string}          newAuthor     - Author of the target revision
+ * @property {DiffSummary}     summary       - Summary of changes
+ * @property {BlockDiffItem[]} blocks        - Array of block diff items
+ */
+
+/**
+ * @typedef {Object} Revision
+ * Represents a WordPress revision.
+ * @property {number} id     - The revision ID
+ * @property {string} date   - The revision date
+ * @property {string} author - The revision author display name
+ */
+
+export {};

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -59,5 +59,6 @@
 @use "./components/table-of-contents/style.scss" as *;
 @use "./components/text-editor/style.scss" as *;
 @use "./components/visual-editor/style.scss" as *;
+@use "./components/revision-diff-viewer/style.scss" as *;
 @use "./dataviews/fields/content-preview/style.scss" as *;
 @use "./hooks/push-changes-to-global-styles/style.scss" as *;


### PR DESCRIPTION
## What?

This PR introduces a new sidebar panel that allows users to compare post revisions at the block level, showing what blocks were added, removed, or modified between versions.

## Why?

Currently, WordPress shows revision diffs as raw HTML text, which is confusing for non-technical users. This feature presents changes in a user-friendly, block-aware format that content creators can easily understand.

## How?

### Backend (PHP)
- New REST API endpoint: `GET /gutenberg/v1/posts/{id}/revisions/diff?from={fromId}&to={toId}`
- Block diff algorithm using `parse_blocks()` to compare revision content
- Returns structured diff data with change types (added, removed, modified, unchanged)

### Frontend (React)
- New `RevisionDiffViewerPanel` component in the editor sidebar
- Revision selector dropdowns to pick two versions to compare
- Color-coded block changes:
  - 🟢 Green = Added blocks
  - 🔴 Red = Removed blocks  
  - 🟡 Yellow = Modified blocks
- Summary counts showing total changes
- Toggle to show/hide unchanged blocks

## Testing Instructions

1. Open a post in the editor
2. Click the "Revision Diff Viewer" button in the top toolbar (clock icon)
3. Create at least 2 revisions by saving the post multiple times with different content
4. Select two revisions from the dropdowns to see the block-level diff

## Screenshots

The sidebar displays:
- Revision selector dropdowns
- Change summary (e.g., "+2 added, -1 removed, ~3 modified")
- Individual block diff items with expand/collapse

## Files Changed

**New files:**
- `lib/experimental/class-wp-rest-block-revision-diff-controller.php`
- `packages/editor/src/components/revision-diff-viewer/*`

**Modified files:**
- `lib/experimental/rest-api.php`
- `lib/load.php`
- `packages/editor/src/components/editor/index.js`
- `packages/editor/src/components/index.js`
- `packages/editor/src/style.scss`