### PR TITLE
Block Editor: Filter file input accept attribute based on upload_mimes

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -29,6 +29,7 @@ import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { store as blockEditorStore } from '../../store';
 import { parseDropEvent } from '../use-on-block-drop';
+import { getComputedAcceptAttribute } from './utils';
 
 const noop = () => {};
 
@@ -166,68 +167,11 @@ export function MediaPlaceholder( {
 		setSrc( value?.src ?? '' );
 	}, [ value?.src ] );
 
-	/**
-	 * Computes the accept attribute for file inputs based on allowed types
-	 * and server-supported MIME types.
-	 *
-	 * This ensures users can only select file types that the server can handle,
-	 * preventing upload failures (e.g., HEIC files when server lacks support).
-	 *
-	 * @return {string} Computed accept attribute value.
-	 */
-	const getComputedAcceptAttribute = () => {
-		// If accept prop is explicitly provided, use it as is.
-		if ( accept ) {
-			return accept;
-		}
-
-		// If allowedMimeTypes is not available, fall back to wildcard.
-		if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
-			if ( allowedTypes && allowedTypes.length > 0 ) {
-				return allowedTypes
-					.map( ( type ) => `${ type }/*` )
-					.join( ',' );
-			}
-			return undefined;
-		}
-
-		// If no allowedTypes specified, we can't filter, so return undefined.
-		if ( ! allowedTypes || allowedTypes.length === 0 ) {
-			return undefined;
-		}
-
-		// Build a list of specific MIME types based on allowedTypes.
-		const acceptedMimeTypes = [];
-
-		for ( const [ , mimeType ] of Object.entries( allowedMimeTypes ) ) {
-			// Check if this MIME type matches any of the allowedTypes.
-			const isAllowed = allowedTypes.some( ( allowedType ) => {
-				// Support both 'image' and 'image/jpeg' formats.
-				if ( allowedType.includes( '/' ) ) {
-					return mimeType === allowedType;
-				}
-				return mimeType.startsWith( `${ allowedType }/` );
-			} );
-
-			if ( isAllowed ) {
-				acceptedMimeTypes.push( mimeType );
-			}
-		}
-
-		// If we found specific MIME types, use them. Otherwise fall back to wildcard.
-		if ( acceptedMimeTypes.length > 0 ) {
-			return acceptedMimeTypes.join( ',' );
-		}
-
-		// Fallback to wildcard if no specific types were found.
-		if ( allowedTypes && allowedTypes.length > 0 ) {
-			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
-		}
-
-		return undefined;
-	};
-
-	const computedAccept = getComputedAcceptAttribute();
+	const computedAccept = getComputedAcceptAttribute(
+		allowedTypes,
+		allowedMimeTypes,
+		accept
+	);
 
 	const onlyAllowsImages = () => {
 		if ( ! allowedTypes || allowedTypes.length === 0 ) {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -16,7 +16,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { keyboardReturn } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
@@ -165,10 +165,14 @@ export function MediaPlaceholder( {
 		setSrc( value?.src ?? '' );
 	}, [ value?.src ] );
 
-	const computedAccept = getComputedAcceptAttribute(
-		allowedTypes,
-		allowedMimeTypes,
-		accept
+	const computedAccept = useMemo(
+		() =>
+			getComputedAcceptAttribute(
+				allowedTypes,
+				allowedMimeTypes,
+				accept
+			),
+		[ allowedTypes, allowedMimeTypes, accept ]
 	);
 
 	const onlyAllowsImages = () => {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -151,16 +151,14 @@ export function MediaPlaceholder( {
 		} );
 	}
 
-	const { mediaUpload: mediaUploadFromSettings, allowedMimeTypes } =
-		useSelect( ( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const settings = getSettings();
-			return {
-				mediaUpload: settings.mediaUpload,
-				allowedMimeTypes: settings.allowedMimeTypes,
-			};
-		}, [] );
-	const mediaUpload = mediaUploadFromSettings;
+	const { mediaUpload, allowedMimeTypes } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			mediaUpload: settings.mediaUpload,
+			allowedMimeTypes: settings.allowedMimeTypes,
+		};
+	}, [] );
 	const [ src, setSrc ] = useState( '' );
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -150,15 +150,84 @@ export function MediaPlaceholder( {
 		} );
 	}
 
-	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings().mediaUpload;
-	}, [] );
+	const { mediaUpload: mediaUploadFromSettings, allowedMimeTypes } =
+		useSelect( ( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const settings = getSettings();
+			return {
+				mediaUpload: settings.mediaUpload,
+				allowedMimeTypes: settings.allowedMimeTypes,
+			};
+		}, [] );
+	const mediaUpload = mediaUploadFromSettings;
 	const [ src, setSrc ] = useState( '' );
 
 	useEffect( () => {
 		setSrc( value?.src ?? '' );
 	}, [ value?.src ] );
+
+	/**
+	 * Computes the accept attribute for file inputs based on allowed types
+	 * and server-supported MIME types.
+	 *
+	 * This ensures users can only select file types that the server can handle,
+	 * preventing upload failures (e.g., HEIC files when server lacks support).
+	 *
+	 * @return {string} Computed accept attribute value.
+	 */
+	const getComputedAcceptAttribute = () => {
+		// If accept prop is explicitly provided, use it as is.
+		if ( accept ) {
+			return accept;
+		}
+
+		// If allowedMimeTypes is not available, fall back to wildcard.
+		if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
+			if ( allowedTypes && allowedTypes.length > 0 ) {
+				return allowedTypes
+					.map( ( type ) => `${ type }/*` )
+					.join( ',' );
+			}
+			return undefined;
+		}
+
+		// If no allowedTypes specified, we can't filter, so return undefined.
+		if ( ! allowedTypes || allowedTypes.length === 0 ) {
+			return undefined;
+		}
+
+		// Build a list of specific MIME types based on allowedTypes.
+		const acceptedMimeTypes = [];
+
+		for ( const [ , mimeType ] of Object.entries( allowedMimeTypes ) ) {
+			// Check if this MIME type matches any of the allowedTypes.
+			const isAllowed = allowedTypes.some( ( allowedType ) => {
+				// Support both 'image' and 'image/jpeg' formats.
+				if ( allowedType.includes( '/' ) ) {
+					return mimeType === allowedType;
+				}
+				return mimeType.startsWith( `${ allowedType }/` );
+			} );
+
+			if ( isAllowed ) {
+				acceptedMimeTypes.push( mimeType );
+			}
+		}
+
+		// If we found specific MIME types, use them. Otherwise fall back to wildcard.
+		if ( acceptedMimeTypes.length > 0 ) {
+			return acceptedMimeTypes.join( ',' );
+		}
+
+		// Fallback to wildcard if no specific types were found.
+		if ( allowedTypes && allowedTypes.length > 0 ) {
+			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
+		}
+
+		return undefined;
+	};
+
+	const computedAccept = getComputedAcceptAttribute();
 
 	const onlyAllowsImages = () => {
 		if ( ! allowedTypes || allowedTypes.length === 0 ) {
@@ -470,7 +539,7 @@ export function MediaPlaceholder( {
 					{ renderDropZone() }
 					<FormFileUpload
 						onChange={ onUpload }
-						accept={ accept }
+						accept={ computedAccept }
 						multiple={ !! multiple }
 						render={ ( { openFileDialog } ) => {
 							const content = (
@@ -518,7 +587,7 @@ export function MediaPlaceholder( {
 							</Button>
 						) }
 						onChange={ onUpload }
-						accept={ accept }
+						accept={ computedAccept }
 						multiple={ !! multiple }
 					/>
 					{ uploadMediaLibraryButton }

--- a/packages/block-editor/src/components/media-placeholder/test/get-computed-accept-attribute.js
+++ b/packages/block-editor/src/components/media-placeholder/test/get-computed-accept-attribute.js
@@ -1,0 +1,164 @@
+/**
+ * Internal dependencies
+ */
+import { getComputedAcceptAttribute } from '../utils';
+
+describe( 'getComputedAcceptAttribute', () => {
+	it( 'returns the accept prop as-is when explicitly provided', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			{ 'jpg|jpeg': 'image/jpeg', png: 'image/png' },
+			'image/png,image/jpeg'
+		);
+		expect( result ).toBe( 'image/png,image/jpeg' );
+	} );
+
+	it( 'returns undefined when no allowedTypes are specified', () => {
+		const result = getComputedAcceptAttribute(
+			[],
+			{ 'jpg|jpeg': 'image/jpeg', png: 'image/png' },
+			undefined
+		);
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when allowedTypes is null or undefined', () => {
+		const result = getComputedAcceptAttribute(
+			null,
+			{ 'jpg|jpeg': 'image/jpeg', png: 'image/png' },
+			undefined
+		);
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'returns wildcard format when allowedMimeTypes is not available', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image', 'video' ],
+			undefined,
+			undefined
+		);
+		expect( result ).toBe( 'image/*,video/*' );
+	} );
+
+	it( 'returns wildcard format when allowedMimeTypes is not an object', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			'not-an-object',
+			undefined
+		);
+		expect( result ).toBe( 'image/*' );
+	} );
+
+	it( 'returns specific MIME types when they match allowedTypes', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			{
+				'jpg|jpeg': 'image/jpeg',
+				png: 'image/png',
+				mp4: 'video/mp4',
+			},
+			undefined
+		);
+		expect( result ).toBe( 'image/jpeg,image/png' );
+	} );
+
+	it( 'supports allowedTypes with full MIME type format', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image/png', 'video/mp4' ],
+			{
+				png: 'image/png',
+				'jpg|jpeg': 'image/jpeg',
+				mp4: 'video/mp4',
+			},
+			undefined
+		);
+		expect( result ).toBe( 'image/png,video/mp4' );
+	} );
+
+	it( 'falls back to wildcard when specific MIME types are not found', () => {
+		const result = getComputedAcceptAttribute( [ 'image' ], {}, undefined );
+		expect( result ).toBe( 'image/*' );
+	} );
+
+	it( 'filters MIME types correctly when mixed with other types', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image', 'audio' ],
+			{
+				'jpg|jpeg': 'image/jpeg',
+				png: 'image/png',
+				mp4: 'video/mp4',
+				mp3: 'audio/mp3',
+				wav: 'audio/wav',
+			},
+			undefined
+		);
+		expect( result ).toBe( 'image/jpeg,image/png,audio/mp3,audio/wav' );
+	} );
+
+	it( 'returns undefined when allowedMimeTypes is invalid and allowedTypes is empty', () => {
+		const result = getComputedAcceptAttribute( [], null, undefined );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'handles empty allowedMimeTypes object', () => {
+		const result = getComputedAcceptAttribute( [ 'image' ], {}, undefined );
+		expect( result ).toBe( 'image/*' );
+	} );
+
+	it( 'preserves MIME type order from allowedMimeTypes', () => {
+		const mimeTypes = {
+			'jpg|jpeg': 'image/jpeg',
+			png: 'image/png',
+			gif: 'image/gif',
+		};
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			mimeTypes,
+			undefined
+		);
+		// The exact order depends on Object.entries, which preserves insertion order in modern JS
+		expect( result ).toContain( 'image/jpeg' );
+		expect( result ).toContain( 'image/png' );
+		expect( result ).toContain( 'image/gif' );
+	} );
+
+	it( 'handles mixed allowedTypes with and without MIME type format', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image', 'video/mp4' ],
+			{
+				png: 'image/png',
+				'jpg|jpeg': 'image/jpeg',
+				mp4: 'video/mp4',
+				webm: 'video/webm',
+			},
+			undefined
+		);
+		// 'image' matches image/* types and 'video/mp4' matches exact MIME type
+		expect( result ).toBe( 'image/png,image/jpeg,video/mp4' );
+	} );
+
+	it( 'returns single MIME type without comma', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			{
+				png: 'image/png',
+			},
+			undefined
+		);
+		expect( result ).toBe( 'image/png' );
+	} );
+
+	it( 'prioritizes specific MIME types over wildcard', () => {
+		const result = getComputedAcceptAttribute(
+			[ 'image' ],
+			{
+				'jpg|jpeg': 'image/jpeg',
+				png: 'image/png',
+			},
+			undefined
+		);
+		// Should return specific types, not 'image/*'
+		expect( result ).not.toBe( 'image/*' );
+		expect( result ).toBe( 'image/jpeg,image/png' );
+	} );
+} );

--- a/packages/block-editor/src/components/media-placeholder/utils.js
+++ b/packages/block-editor/src/components/media-placeholder/utils.js
@@ -1,0 +1,66 @@
+/**
+ * Computes the accept attribute for file inputs based on allowed types
+ * and server-supported MIME types.
+ *
+ * This ensures users can only select file types that the server can handle,
+ * preventing upload failures (e.g., HEIC files when server lacks support).
+ *
+ * @param {Array}  allowedTypes     - List of allowed media types (e.g., ['image', 'video']).
+ * @param {Object} allowedMimeTypes - Map of allowed MIME types from server settings.
+ * @param {string} accept           - Optional explicit accept attribute to use.
+ *
+ * @return {string|undefined} Computed accept attribute value, or undefined if no restrictions apply.
+ */
+export function getComputedAcceptAttribute(
+	allowedTypes,
+	allowedMimeTypes,
+	accept
+) {
+	// If accept prop is explicitly provided, use it as is.
+	if ( accept ) {
+		return accept;
+	}
+
+	// If allowedMimeTypes is not available, fall back to wildcard.
+	if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
+		if ( allowedTypes && allowedTypes.length > 0 ) {
+			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
+		}
+		return undefined;
+	}
+
+	// If no allowedTypes specified, we can't filter, so return undefined.
+	if ( ! allowedTypes || allowedTypes.length === 0 ) {
+		return undefined;
+	}
+
+	// Build a list of specific MIME types based on allowedTypes.
+	const acceptedMimeTypes = [];
+
+	for ( const [ , mimeType ] of Object.entries( allowedMimeTypes ) ) {
+		// Check if this MIME type matches any of the allowedTypes.
+		const isAllowed = allowedTypes.some( ( allowedType ) => {
+			// Support both 'image' and 'image/jpeg' formats.
+			if ( allowedType.includes( '/' ) ) {
+				return mimeType === allowedType;
+			}
+			return mimeType.startsWith( `${ allowedType }/` );
+		} );
+
+		if ( isAllowed ) {
+			acceptedMimeTypes.push( mimeType );
+		}
+	}
+
+	// If we found specific MIME types, use them. Otherwise fall back to wildcard.
+	if ( acceptedMimeTypes.length > 0 ) {
+		return acceptedMimeTypes.join( ',' );
+	}
+
+	// Fallback to wildcard if no specific types were found.
+	if ( allowedTypes && allowedTypes.length > 0 ) {
+		return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
+	}
+
+	return undefined;
+}

--- a/packages/block-editor/src/components/media-placeholder/utils.js
+++ b/packages/block-editor/src/components/media-placeholder/utils.js
@@ -22,7 +22,11 @@ export function getComputedAcceptAttribute(
 	}
 
 	// If allowedMimeTypes is not available, fall back to wildcard.
-	if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
+	if (
+		! allowedMimeTypes ||
+		typeof allowedMimeTypes !== 'object' ||
+		Object.keys( allowedMimeTypes ).length === 0
+	) {
 		if ( allowedTypes && allowedTypes.length > 0 ) {
 			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
 		}
@@ -57,10 +61,5 @@ export function getComputedAcceptAttribute(
 		return acceptedMimeTypes.join( ',' );
 	}
 
-	// Fallback to wildcard if no specific types were found.
-	if ( allowedTypes && allowedTypes.length > 0 ) {
-		return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
-	}
-
-	return undefined;
+	return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
 }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -57,8 +57,78 @@ const MediaReplaceFlow = ( {
 	renderToggle,
 	className,
 } ) => {
-	const { getSettings } = useSelect( blockEditorStore );
+	const { mediaUpload, allowedMimeTypes } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			mediaUpload: settings.mediaUpload,
+			allowedMimeTypes: settings.allowedMimeTypes,
+		};
+	}, [] );
 	const errorNoticeID = `block-editor/media-replace-flow/error-notice/${ ++uniqueId }`;
+
+	/**
+	 * Computes the accept attribute for file inputs based on allowed types
+	 * and server-supported MIME types.
+	 *
+	 * This ensures users can only select file types that the server can handle,
+	 * preventing upload failures (e.g., HEIC files when server lacks support).
+	 *
+	 * @return {string} Computed accept attribute value.
+	 */
+	const getComputedAcceptAttribute = () => {
+		// If accept prop is explicitly provided, use it as is.
+		if ( accept ) {
+			return accept;
+		}
+
+		// If allowedMimeTypes is not available, fall back to wildcard.
+		if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
+			if ( allowedTypes && allowedTypes.length > 0 ) {
+				return allowedTypes
+					.map( ( type ) => `${ type }/*` )
+					.join( ',' );
+			}
+			return undefined;
+		}
+
+		// If no allowedTypes specified, we can't filter, so return undefined.
+		if ( ! allowedTypes || allowedTypes.length === 0 ) {
+			return undefined;
+		}
+
+		// Build a list of specific MIME types based on allowedTypes.
+		const acceptedMimeTypes = [];
+
+		for ( const [ , mimeType ] of Object.entries( allowedMimeTypes ) ) {
+			// Check if this MIME type matches any of the allowedTypes.
+			const isAllowed = allowedTypes.some( ( allowedType ) => {
+				// Support both 'image' and 'image/jpeg' formats.
+				if ( allowedType.includes( '/' ) ) {
+					return mimeType === allowedType;
+				}
+				return mimeType.startsWith( `${ allowedType }/` );
+			} );
+
+			if ( isAllowed ) {
+				acceptedMimeTypes.push( mimeType );
+			}
+		}
+
+		// If we found specific MIME types, use them. Otherwise fall back to wildcard.
+		if ( acceptedMimeTypes.length > 0 ) {
+			return acceptedMimeTypes.join( ',' );
+		}
+
+		// Fallback to wildcard if no specific types were found.
+		if ( allowedTypes && allowedTypes.length > 0 ) {
+			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
+		}
+
+		return undefined;
+	};
+
+	const computedAccept = getComputedAcceptAttribute();
 
 	const onUploadError = ( message ) => {
 		const safeMessage = stripHTML( message );
@@ -99,7 +169,7 @@ const MediaReplaceFlow = ( {
 			return onSelect( files );
 		}
 		onFilesUpload( files );
-		getSettings().mediaUpload( {
+		mediaUpload( {
 			allowedTypes,
 			filesList: files,
 			onFileChange: ( [ media ] ) => {
@@ -181,7 +251,7 @@ const MediaReplaceFlow = ( {
 								onChange={ ( event ) => {
 									uploadFiles( event, onClose );
 								} }
-								accept={ accept }
+								accept={ computedAccept }
 								multiple={ !! multiple }
 								render={ ( { openFileDialog } ) => {
 									return (

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -21,6 +21,7 @@ import {
 import { compose } from '@wordpress/compose';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { store as noticesStore } from '@wordpress/notices';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -68,10 +69,14 @@ const MediaReplaceFlow = ( {
 	}, [] );
 	const errorNoticeID = `block-editor/media-replace-flow/error-notice/${ ++uniqueId }`;
 
-	const computedAccept = getComputedAcceptAttribute(
-		allowedTypes,
-		allowedMimeTypes,
-		accept
+	const computedAccept = useMemo(
+		() =>
+			getComputedAcceptAttribute(
+				allowedTypes,
+				allowedMimeTypes,
+				accept
+			),
+		[ allowedTypes, allowedMimeTypes, accept ]
 	);
 
 	const onUploadError = ( message ) => {

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -29,6 +29,7 @@ import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import LinkControl from '../link-control';
 import { store as blockEditorStore } from '../../store';
+import { getComputedAcceptAttribute } from '../media-placeholder/utils';
 
 const noop = () => {};
 let uniqueId = 0;
@@ -67,68 +68,11 @@ const MediaReplaceFlow = ( {
 	}, [] );
 	const errorNoticeID = `block-editor/media-replace-flow/error-notice/${ ++uniqueId }`;
 
-	/**
-	 * Computes the accept attribute for file inputs based on allowed types
-	 * and server-supported MIME types.
-	 *
-	 * This ensures users can only select file types that the server can handle,
-	 * preventing upload failures (e.g., HEIC files when server lacks support).
-	 *
-	 * @return {string} Computed accept attribute value.
-	 */
-	const getComputedAcceptAttribute = () => {
-		// If accept prop is explicitly provided, use it as is.
-		if ( accept ) {
-			return accept;
-		}
-
-		// If allowedMimeTypes is not available, fall back to wildcard.
-		if ( ! allowedMimeTypes || typeof allowedMimeTypes !== 'object' ) {
-			if ( allowedTypes && allowedTypes.length > 0 ) {
-				return allowedTypes
-					.map( ( type ) => `${ type }/*` )
-					.join( ',' );
-			}
-			return undefined;
-		}
-
-		// If no allowedTypes specified, we can't filter, so return undefined.
-		if ( ! allowedTypes || allowedTypes.length === 0 ) {
-			return undefined;
-		}
-
-		// Build a list of specific MIME types based on allowedTypes.
-		const acceptedMimeTypes = [];
-
-		for ( const [ , mimeType ] of Object.entries( allowedMimeTypes ) ) {
-			// Check if this MIME type matches any of the allowedTypes.
-			const isAllowed = allowedTypes.some( ( allowedType ) => {
-				// Support both 'image' and 'image/jpeg' formats.
-				if ( allowedType.includes( '/' ) ) {
-					return mimeType === allowedType;
-				}
-				return mimeType.startsWith( `${ allowedType }/` );
-			} );
-
-			if ( isAllowed ) {
-				acceptedMimeTypes.push( mimeType );
-			}
-		}
-
-		// If we found specific MIME types, use them. Otherwise fall back to wildcard.
-		if ( acceptedMimeTypes.length > 0 ) {
-			return acceptedMimeTypes.join( ',' );
-		}
-
-		// Fallback to wildcard if no specific types were found.
-		if ( allowedTypes && allowedTypes.length > 0 ) {
-			return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
-		}
-
-		return undefined;
-	};
-
-	const computedAccept = getComputedAcceptAttribute();
+	const computedAccept = getComputedAcceptAttribute(
+		allowedTypes,
+		allowedMimeTypes,
+		accept
+	);
 
 	const onUploadError = ( message ) => {
 		const safeMessage = stripHTML( message );

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -107,7 +107,6 @@ export default function CoverBlockControls( {
 					mediaId={ id }
 					mediaURL={ url }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="image/*,video/*"
 					onSelect={ onSelectMedia }
 					onToggleFeaturedImage={ toggleUseFeaturedImage }
 					useFeaturedImage={ useFeaturedImage }

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -25,7 +25,6 @@ export default function CoverPlaceholder( {
 				title: __( 'Cover' ),
 			} }
 			onSelect={ onSelectMedia }
-			accept="image/*,video/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -596,7 +596,6 @@ export default function GalleryEdit( props ) {
 				instructions: PLACEHOLDER_TEXT,
 			} }
 			onSelect={ updateImages }
-			accept="image/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			multiple
 			onError={ onUploadError }
@@ -910,7 +909,6 @@ export default function GalleryEdit( props ) {
 						<BlockControls group="other">
 							<MediaReplaceFlow
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								accept="image/*"
 								handleUpload={ false }
 								onSelect={ updateImages }
 								name={ __( 'Add' ) }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -464,7 +464,6 @@ export function ImageEdit( {
 					onSelectURL={ onSelectURL }
 					onError={ onUploadError }
 					placeholder={ placeholder }
-					accept="image/*"
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					handleUpload={ ( files ) => files.length === 1 }
 					value={ { id, src } }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -718,7 +718,6 @@ export default function Image( {
 					mediaId={ id }
 					mediaURL={ url }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="image/*"
 					onSelect={ onSelectImage }
 					onSelectURL={ onSelectURL }
 					onError={ onUploadError }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -61,7 +61,6 @@ function ToolbarEditButton( {
 				mediaId={ mediaId }
 				mediaURL={ mediaUrl }
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				accept="image/*,video/*"
 				onSelect={ onSelectMedia }
 				onToggleFeaturedImage={ toggleUseFeaturedImage }
 				useFeaturedImage={ useFeaturedImage }
@@ -91,7 +90,6 @@ function PlaceholderContainer( {
 			} }
 			className={ className }
 			onSelect={ onSelectMedia }
-			accept="image/*,video/*"
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			onError={ onUploadError }


### PR DESCRIPTION
## What?

Dynamically computes the file input `accept` attribute based on WordPress's `allowedMimeTypes` (from the `upload_mimes` filter) to prevent users from selecting unsupported file types.

## Why?

Fixes #73558 

Users could select HEIC files for upload even when the server doesn't support them (lacks Imagick with HEIC support), leading to confusing upload failures. The file picker would show all image types as selectable, but HEIC uploads would fail.

## How?

### Changes:

1. **MediaPlaceholder**: Retrieves `allowedMimeTypes` from editor settings and computes specific MIME type list for the accept attribute
2. **MediaReplaceFlow**: Applies same logic for media replacement flow  
3. **Image Block**: Removes hardcoded `accept="image/*"` to allow dynamic computation based on server capabilities
4. **Fallback**: Falls back to wildcard (e.g., `"image/*"`) when `allowedMimeTypes` is unavailable

### Implementation Details:

- Uses WordPress's existing `get_allowed_mime_types()` which applies the `upload_mimes` filter
- This data is already exposed via `getSettings().allowedMimeTypes` in the block editor
- Dynamically builds the accept attribute by filtering MIME types based on `allowedTypes` prop
- Example: When HEIC is not supported, `accept="image/jpeg,image/png,image/gif,image/webp,image/avif"` instead of `accept="image/*"`

## Testing Instructions

### Setup

1. Apply this filter to simulate a server without HEIC support:
```php
add_filter( 'upload_mimes', function( $mimes ) {
    unset( $mimes['heic'] );
    return $mimes;
} );
```

### Test

2. Create a new post
3. Add an Image block
4. Click "Upload"
5. **Expected:** HEIC files should be grayed out/not selectable in the file picker (like how .mov files are grayed out when uploading images)
6. **Before:** All image files including HEIC were selectable, but upload would fail
7. **After:** Only server-supported image types are selectable
8. Also, test the other main image-based blocks: Gallery, Cover, and Media & Text

### Verify in DevTools

9. Inspect the `<input type="file">` element
10. **Before:** `accept="image/*"`
11. **After:** `accept="image/jpeg,image/png,image/gif,image/webp,image/avif,..."` (without image/heic)

## Screencast

Before this PR:

https://github.com/user-attachments/assets/b9aa6d32-19bb-4acb-84eb-d47efd8ae233

After this PR:

https://github.com/user-attachments/assets/16cb930f-205a-47c6-956f-8c9bac416729

## Note

As mentioned in the original issue, this only affects the file picker dialog. Drag-and-drop will still allow selecting HEIC files, but they will fail to upload with an appropriate error message (existing WordPress behavior).