### PR TITLE
Patterns: check for prevent default on event to enable media placeholder button

### DIFF
--- a/packages/editor/src/components/visual-editor/use-edit-content-only-section-exit.js
+++ b/packages/editor/src/components/visual-editor/use-edit-content-only-section-exit.js
@@ -30,17 +30,16 @@ export function useEditContentOnlySectionExit() {
 					return;
 				}
 
-				if ( ! event.defaultPrevented ) {
-					event.preventDefault();
+				// Check if the click is outside the edited block first.
+				const isClickOutside = ! event.target.closest(
+					`[data-block="${ editedContentOnlySection }"]`
+				);
 
-					// If the user clicks outside the edited block, stop editing.
-					if (
-						! event.target.closest(
-							`[data-block="${ editedContentOnlySection }"]`
-						)
-					) {
-						stopEditingContentOnlySection();
-					}
+				// Only prevent default and stop editing if clicking outside.
+				// This allows default behavior (e.g., file dialogs) to work when clicking inside.
+				if ( isClickOutside && ! event.defaultPrevented ) {
+					event.preventDefault();
+					stopEditingContentOnlySection();
 				}
 			}
 


### PR DESCRIPTION

## What?
Fixes https://github.com/WordPress/gutenberg/issues/73563

Modifies use-edit-content-only-section-exit.js to only call `preventDefault()` when clicking outside the edited section. Clicks inside the section now allow default behavior, so the file dialog opens.



<!-- In a few words, what is the PR actually doing? -->

## Why?

In content-only mode, clicking the "Upload" button in the media placeholder didn't open the file dialog because `event.preventDefault()` was called for all clicks, even inside the edited section.


## Testing Instructions

1. Activate the content only experiment
2. Insert a pattern in a post
3. Click on "Edit section" in the RHS inspector bar
4. Add an image block, or media/text block or any with a media placeholder
5. Try to upload an image using the button

Try for other media/file blocks:

<img width="648" height="383" alt="Screenshot 2025-11-26 at 12 50 49 pm" src="https://github.com/user-attachments/assets/455b4b6c-c0ad-4ec9-8dc6-0b50382f58a1" />


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/67070525-4088-4e6e-8920-3acd333f6c83


