### PR TITLE
WP_Theme_JSON: use self:: for class private static methods

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3821,10 +3821,10 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array $input  Input settings to process.
-	 * @param array $output Output settings array (passed by reference).
-	 * @param array $schema Schema to validate against (typically VALID_SETTINGS).
-	 * @param array $path   Current path in the schema (for recursive calls).
+	 * @param array             $input  Input settings to process.
+	 * @param array             $output Output settings array (passed by reference).
+	 * @param array             $schema Schema to validate against (typically VALID_SETTINGS).
+	 * @param array<string|int> $path   Current path in the schema (for recursive calls).
 	 */
 	private static function preserve_valid_typed_settings( $input, &$output, $schema, $path = array() ) {
 		foreach ( $schema as $key => $schema_value ) {
@@ -3837,7 +3837,7 @@ class WP_Theme_JSON_Gutenberg {
 					_wp_array_set( $output, $current_path, $value ); // Preserve boolean value.
 				}
 			} elseif ( is_array( $schema_value ) ) {
-				static::preserve_valid_typed_settings( $input, $output, $schema_value, $current_path ); // Recurse into nested structure.
+				self::preserve_valid_typed_settings( $input, $output, $schema_value, $current_path ); // Recurse into nested structure.
 			}
 		}
 	}
@@ -3902,7 +3902,7 @@ class WP_Theme_JSON_Gutenberg {
 		static::remove_indirect_properties( $input, $output );
 
 		// Preserve all valid settings that have type markers in VALID_SETTINGS.
-		static::preserve_valid_typed_settings( $input, $output, static::VALID_SETTINGS );
+		self::preserve_valid_typed_settings( $input, $output, static::VALID_SETTINGS );
 
 		return $output;
 	}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1292,6 +1292,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * It is recursive and modifies the input in-place.
 	 *
 	 * @since 5.8.0
+	 * @since 7.0.0 Added type validation for boolean values.
 	 *
 	 * @param array $tree   Input to process.
 	 * @param array $schema Schema to adhere to.


### PR DESCRIPTION

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/73452

Implements feedback from Core patch https://github.com/WordPress/wordpress-develop/pull/10534

Refactor `preserve_valid_typed_settings` method to use 'self' instead of 'static'.

## Why?

Use `self::` for private methods (they can't be overridden). Use `static::` for protected/public methods or constants when you want child classes to potentially override them.



## Testing Instructions
Tests should pass. There should be no regressions in behaviour.
