### PR TITLE
Patterns: resolve_pattern_blocks sync with Core patch 

### DIFF
--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -52,20 +52,20 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 				$blocks_to_insert = parse_blocks( trim( $pattern['content'] ) );
 
 				/*
-				* For single-root patterns, add the pattern name to make this a pattern instance in the editor.
-				* If the pattern has metadata, merge it with the existing metadata.
-				*/
+				 * For single-root patterns, add the pattern name to make this a pattern instance in the editor.
+				 * If the pattern has metadata, merge it with the existing metadata.
+				 */
 				if ( count( $blocks_to_insert ) === 1 ) {
 					$block_metadata                = $blocks_to_insert[0]['attrs']['metadata'] ?? array();
 					$block_metadata['patternName'] = $slug;
 
 					/*
-					* Merge pattern metadata with existing block metadata.
-					* Pattern metadata takes precedence, but existing block metadata
-					* is preserved as a fallback when the pattern doesn't define that field.
-					* Only the defined fields (name, description, categories) are updated;
-					* other metadata keys are preserved.
-					*/
+					 * Merge pattern metadata with existing block metadata.
+					 * Pattern metadata takes precedence, but existing block metadata
+					 * is preserved as a fallback when the pattern doesn't define that field.
+					 * Only the defined fields (name, description, categories) are updated;
+					 * other metadata keys are preserved.
+					 */
 					foreach ( array(
 						'name'        => 'title', // 'title' is the field in the pattern object 'name' is the field in the block metadata.
 						'description' => 'description',
@@ -73,7 +73,7 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 					) as $key => $pattern_key ) {
 						$value = $pattern[ $pattern_key ] ?? $block_metadata[ $key ] ?? null;
 						if ( $value ) {
-							$block_metadata[ $key ] = 'categories' === $key && is_array( $value )
+							$block_metadata[ $key ] = is_array( $value )
 								? array_map( 'sanitize_text_field', $value )
 								: sanitize_text_field( $value );
 						}


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Sync with feedback from https://github.com/WordPress/wordpress-develop/pull/10248

PHP doc alignment and remove unnecessary condition.



## Testing Instructions

PHP unit tests exist. They should pass as expected