### PR TITLE
Edit This: Try an Edit This button overlaid on the site frontend

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -404,3 +404,55 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_latex_to_mathml_lo
 function gutenberg_enqueue_latex_to_mathml_loader() {
 	wp_enqueue_script_module( '@wordpress/latex-to-mathml/loader' );
 }
+
+/**
+ * Enqueue the frontend edit overlay script and styles.
+ *
+ * Only enqueues for logged-in users with edit capabilities when the experiment is enabled.
+ */
+function gutenberg_enqueue_frontend_edit_overlay() {
+	// Only enqueue for logged-in users.
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
+	// Only enqueue for users who can edit posts.
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		return;
+	}
+
+	// Only enqueue when the experiment is enabled.
+	if ( ! function_exists( 'gutenberg_is_experiment_enabled' ) || ! gutenberg_is_experiment_enabled( 'gutenberg-frontend-edit-overlay' ) ) {
+		return;
+	}
+
+	$version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
+
+	// Enqueue the stylesheet.
+	wp_enqueue_style(
+		'wp-frontend-edit-overlay',
+		gutenberg_url( 'lib/frontend-edit-overlay/style.css' ),
+		array(),
+		$version
+	);
+
+	// Enqueue the script.
+	wp_enqueue_script(
+		'wp-frontend-edit-overlay',
+		gutenberg_url( 'lib/frontend-edit-overlay/view.js' ),
+		array(),
+		$version,
+		array(
+			'in_footer' => true,
+		)
+	);
+
+	// Inline the experiment flag.
+	wp_add_inline_script(
+		'wp-frontend-edit-overlay',
+		'window.__experimentalFrontendEditOverlay = true;',
+		'before'
+	);
+}
+
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_frontend_edit_overlay' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -233,6 +233,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-frontend-edit-overlay',
+		__( 'Frontend: "Edit this" overlay', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables hover-over "Edit this" buttons on the site frontend for template parts and post content when logged in as an admin user.', 'gutenberg' ),
+			'id'    => 'gutenberg-frontend-edit-overlay',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/frontend-edit-overlay.php
+++ b/lib/frontend-edit-overlay.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Frontend Edit Overlay
+ *
+ * Adds "Edit this" hover-over buttons on the site frontend for template parts and post content.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'gutenberg_is_experiment_enabled' ) ) {
+	return;
+}
+
+if ( ! gutenberg_is_experiment_enabled( 'gutenberg-frontend-edit-overlay' ) ) {
+	return;
+}
+
+// Only enable for block themes.
+if ( ! wp_is_block_theme() ) {
+	return;
+}
+
+/**
+ * Generate the edit URL for a template part.
+ *
+ * @param string $template_part_id The template part ID in the format {theme}//{slug}.
+ * @return string The edit URL for the site editor in edit mode.
+ */
+function gutenberg_get_frontend_edit_overlay_template_part_url( $template_part_id ) {
+	return add_query_arg(
+		array(
+			'p'      => '/wp_template_part/' . $template_part_id,
+			'canvas' => 'edit',
+		),
+		admin_url( 'site-editor.php' )
+	);
+}
+
+/**
+ * Generate the edit URL for a post.
+ *
+ * @param int $post_id The post ID.
+ * @return string The edit URL for the post editor.
+ */
+function gutenberg_get_frontend_edit_overlay_post_url( $post_id ) {
+	return add_query_arg(
+		array(
+			'post'   => $post_id,
+			'action' => 'edit',
+		),
+		admin_url( 'post.php' )
+	);
+}
+
+/**
+ * Add edit overlay data attributes to rendered blocks.
+ *
+ * Hooks into the render_block filter to add data attributes to template parts
+ * when the user has appropriate permissions.
+ *
+ * @param string $block_content The rendered block content.
+ * @param array  $block         The parsed block array.
+ * @return string The modified block content with data attributes.
+ */
+function gutenberg_add_frontend_edit_overlay_to_block( $block_content, $block ) {
+	// Handle template part blocks.
+	if ( 'core/template-part' === $block['blockName'] ) {
+		// Check if user can edit theme options (required for site editor).
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return $block_content;
+		}
+
+		if ( empty( $block['attrs']['slug'] ) ) {
+			return $block_content;
+		}
+
+		$template_part_slug = $block['attrs']['slug'];
+		$theme              = isset( $block['attrs']['theme'] ) ? $block['attrs']['theme'] : wp_get_theme()->get_stylesheet();
+		$full_template_id   = $theme . '//' . $template_part_slug;
+
+		// Get the edit URL.
+		$edit_url = gutenberg_get_frontend_edit_overlay_template_part_url( $full_template_id );
+
+		// Use WP_HTML_Tag_Processor to add data attributes to the wrapper element.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the first tag (should be the wrapper element).
+		if ( $processor->next_tag() ) {
+			$processor->set_attribute( 'data-wp-edit-overlay-target', 'template-part' );
+			$processor->set_attribute( 'data-wp-edit-template-part-id', $full_template_id );
+			$processor->set_attribute( 'data-wp-edit-url', $edit_url );
+
+			return $processor->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	// Handle post title blocks.
+	if ( 'core/post-title' === $block['blockName'] ) {
+		// Get post ID from block context.
+		if ( empty( $block['context']['postId'] ) ) {
+			return $block_content;
+		}
+
+		$post_id = (int) $block['context']['postId'];
+
+		// Check if user can edit this post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return $block_content;
+		}
+
+		// Get the edit URL.
+		$edit_url = gutenberg_get_frontend_edit_overlay_post_url( $post_id );
+
+		// Use WP_HTML_Tag_Processor to add data attributes to the wrapper element.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the first tag (should be the wrapper element).
+		if ( $processor->next_tag() ) {
+			$processor->set_attribute( 'data-wp-edit-overlay-target', 'post-title' );
+			$processor->set_attribute( 'data-wp-edit-post-id', $post_id );
+			$processor->set_attribute( 'data-wp-edit-url', $edit_url );
+
+			return $processor->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	// Handle post content blocks.
+	if ( 'core/post-content' === $block['blockName'] ) {
+		// Get post ID from block context, or fall back to the current post from the main query loop.
+		$post_id = ! empty( $block['context']['postId'] ) ? (int) $block['context']['postId'] : get_the_ID();
+
+		if ( ! $post_id ) {
+			return $block_content;
+		}
+
+		// Check if user can edit this post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return $block_content;
+		}
+
+		// Get the edit URL.
+		$edit_url = gutenberg_get_frontend_edit_overlay_post_url( $post_id );
+
+		// Use WP_HTML_Tag_Processor to add data attributes to the wrapper element.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the first tag (should be the wrapper element).
+		if ( $processor->next_tag() ) {
+			$processor->set_attribute( 'data-wp-edit-overlay-target', 'post-content' );
+			$processor->set_attribute( 'data-wp-edit-post-id', $post_id );
+			$processor->set_attribute( 'data-wp-edit-url', $edit_url );
+
+			return $processor->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	return $block_content;
+}
+
+// Hook into the render_block filter to catch rendered template parts.
+add_filter( 'render_block', 'gutenberg_add_frontend_edit_overlay_to_block', 10, 2 );

--- a/lib/frontend-edit-overlay/PLAN.md
+++ b/lib/frontend-edit-overlay/PLAN.md
@@ -1,0 +1,209 @@
+# "Edit This" Frontend Hover-Overlay Feature - Implementation Plan
+
+## Overview
+Add frontend "Edit this" hover-overlay buttons on the site frontend for logged-in admins. When hovering over template parts (header, footer, sidebars) or post content, an overlay button appears that links to the appropriate editor (site editor for template parts, post editor for post content). Feature is guarded behind a Gutenberg experiment flag.
+
+## Requirements Summary
+- **Scope**: Template parts + post content
+- **Detection**: HTML data attributes with namespace (`data-wp-edit-overlay-*`)
+- **Actions**: Navigate to appropriate editor (site editor or post editor)
+- **Page coverage**: All public pages (home, single posts, archives, search, etc.)
+- **Approach**: Lightweight overlay using vanilla JavaScript initially, can migrate to Interactivity API later
+
+## Architecture: Three-Layer Implementation
+
+### Layer 1: Experiment Registration (PHP)
+**File**: `/lib/experiments-page.php`
+- Register new experiment flag: `gutenberg-frontend-edit-overlay`
+- Uses existing checkbox field UI pattern
+- Accessed via: `gutenberg_is_experiment_enabled( 'gutenberg-frontend-edit-overlay' )`
+
+### Layer 2: Server-Side Markup (PHP)
+**File**: `/lib/frontend-edit-overlay.php` (IMPLEMENTED)
+- Hook into `render_block` filter to catch final rendered HTML with wrapper elements
+- Handles three block types:
+  - `core/template-part`: Requires `edit_theme_options` capability
+  - `core/post-title`: Requires `edit_post` capability
+  - `core/post-content`: Requires `edit_post` capability, uses `get_the_ID()` fallback for post ID detection
+- Use `WP_HTML_Tag_Processor` to add identifying data attributes:
+  - All blocks: `data-wp-edit-overlay-target`, `data-wp-edit-url`
+  - Template parts: `data-wp-edit-template-part-id`
+  - Posts: `data-wp-edit-post-id`
+- Generate edit URLs with appropriate parameters:
+  - Template parts: Site editor with `canvas=edit` parameter
+  - Posts: Post editor with `post` and `action=edit` parameters
+- Block theme guard: Feature only enabled for block themes via `wp_is_block_theme()` check
+
+### Layer 3: Frontend Overlay UI (JavaScript)
+**File**: `/lib/frontend-edit-overlay/view.js` (IMPLEMENTED)
+- Query all elements with `[data-wp-edit-overlay-target]`
+- Button creation and management:
+  - Create one button per element (stored in WeakMap for automatic cleanup)
+  - Position as fixed element relative to element's bounding client rect
+  - Position at bottom-right corner of element using `getBoundingClientRect()`
+- Event handling:
+  - Hover on element: Show button with 50ms debounce
+  - Mouse enter button: Keep visible (prevent flickering)
+  - Mouse leave button: Hide only if element not hovered
+  - Scroll/Resize: Update button positions via debounced `updateButtonPositions()`
+  - Focus: Show overlay for keyboard navigation support
+  - Escape key: Hide all overlays
+- State tracking:
+  - `hoveredElements` Set: Track which elements are currently hovered
+  - `overlayButtons` WeakMap: Associate buttons with elements
+  - Proper focus management to prevent flickering
+- Click handler: Navigate to edit URL from `data-wp-edit-url` attribute
+
+**Design philosophy**: Keep styling flexible and customizable. Use CSS variables for colors, sizes, positioning to allow themes/experiments to customize appearance easily.
+
+**Button behavior**: Buttons float over their associated elements at the bottom-right corner, with fixed positioning that updates during scroll/resize events to stay properly positioned relative to the element they're editing.
+
+## Implementation Files
+
+### New Files Created ✓
+1. **`/lib/frontend-edit-overlay.php`** (~160 lines)
+   - `gutenberg_get_frontend_edit_overlay_template_part_url()`: Generates site editor URLs
+   - `gutenberg_get_frontend_edit_overlay_post_url()`: Generates post editor URLs
+   - `gutenberg_add_frontend_edit_overlay_to_block()`: Main filter callback handling template-part, post-title, and post-content blocks
+   - Hooked to `render_block` filter at priority 10
+   - All debug logging removed for production
+
+2. **`/lib/frontend-edit-overlay/view.js`** (~260 lines)
+   - DOM query for marked elements with event delegation
+   - Hover event handling with 50ms debounce
+   - Overlay button creation and positioning logic
+   - WeakMap for button lifecycle management
+   - Set for tracking hovered elements to prevent flickering
+   - Scroll and resize event listeners (debounced 10ms) to update button positions
+   - Click handler for navigation
+   - Keyboard support (focus, blur, escape)
+
+3. **`/lib/frontend-edit-overlay/style.css`** (~56 lines)
+   - Vanilla CSS (no build step required)
+   - Button styling with CSS variables for customization
+   - States: default (hidden), visible, hover, focus, active
+   - Minimal CSS, no layout shifts
+   - Variables: `--wp-edit-overlay-button-bg`, `--wp-edit-overlay-button-color`, `--wp-edit-overlay-button-border-color`, `--wp-edit-overlay-z-index`, `--wp-edit-overlay-button-padding`, `--wp-edit-overlay-button-font-size`, `--wp-edit-overlay-button-border-radius`
+
+### Files Modified ✓
+1. **`/lib/experiments-page.php`** (~10 lines added)
+   - Registered `gutenberg-frontend-edit-overlay` experiment field
+   - Added to experiments list with user-friendly description
+
+2. **`/lib/client-assets.php`** (~50 lines added)
+   - Added `gutenberg_enqueue_frontend_edit_overlay()` function
+   - Conditional loading: only for logged-in users with `edit_posts` capability and experiment enabled
+   - Enqueues both script and stylesheet with proper dependencies
+   - Hooked to `wp_enqueue_scripts`
+   - Uses `gutenberg_url()` for asset paths
+
+3. **`/lib/load.php`** (~2 lines added)
+   - Conditionally requires `/lib/frontend-edit-overlay.php` when experiment is enabled
+
+## Key Design Decisions
+
+### Hook Strategy for Detecting Areas
+- **Unified approach**: All blocks use `render_block` filter at priority 10
+- **Why this approach**:
+  - `render_block` filter receives the **final rendered HTML with wrapper elements**, unlike action hooks which fire before wrapper creation
+  - Single filter is simpler than multiple block-specific hooks
+  - Works for template-part, post-title, and post-content blocks
+  - Allows checking block context and capabilities in one place
+- **Lesson learned**: Initially tried specific action hooks (`render_block_core_template_part_post`, etc.) but these fire before wrapper HTML is created, making attribute injection impossible. Switched to `render_block` which has the complete rendered output.
+
+### Frontend Script Loading
+- Conditional loading only for authorized users (checked in PHP)
+- No script loaded for:
+  - Non-logged-in users
+  - Users without `edit_posts` capability
+  - When experiment is disabled
+- Reduces unnecessary JavaScript for non-admin users
+
+### Edit URL Generation
+- Template parts: `/wp-admin/site-editor.php?p=/wp_template_part/{ID}`
+- Post content: `/wp-admin/post.php?post={ID}&action=edit`
+- URLs generated server-side and stored in data attributes
+
+## Testing Strategy
+
+### PHP Unit Tests
+- Experiment flag registration
+- Attribute injection for template parts and post content
+- Capability checks (non-admin users don't get attributes)
+- Behavior when experiment is disabled
+
+### E2E Tests (Playwright)
+- Overlay appears on hover for logged-in admin users
+- Clicking navigates to correct editor (verified by URL)
+- Overlay doesn't appear for non-admin users
+- Different template part types work (header, footer, sidebar)
+- Works on different page types (single posts, archives, home)
+
+### Manual Testing
+- Enable experiment in wp-admin > Tools > Experiments
+- Visit frontend as logged-in admin
+- Verify overlay on hover, correct editor navigation
+
+## Implementation Order (Completed)
+
+1. ✓ **Phase 1 - Infrastructure**: Registered experiment in `/lib/experiments-page.php`, created `/lib/frontend-edit-overlay.php`
+2. ✓ **Phase 2 - Template Parts**: Added `render_block` filter for template-part blocks with data attributes
+3. ✓ **Phase 3 - Post Content**: Added filter handling for post-title and post-content blocks with fallback post ID detection
+4. ✓ **Phase 4 - Frontend JS**: Created view.js with hover overlay logic, button positioning, and event handling
+5. ✓ **Phase 5 - Frontend Styles**: Created style.css with CSS variables and state styling
+6. ✓ **Phase 6 - Script Integration**: Registered and conditionally loaded frontend script in `/lib/client-assets.php`
+7. ✓ **Phase 7 - Refinements**:
+   - Fixed flickering issues with proper focus and hover state tracking
+   - Implemented element-relative button positioning at bottom-right corner
+   - Added scroll/resize event listeners to update button positions
+   - Removed all debug logging
+   - Added post-content fallback using `get_the_ID()`
+   - Added block theme guard
+
+## Performance Considerations
+
+- One button per element stored in WeakMap (automatic garbage collection when elements removed)
+- Lazy button creation (only on hover, not page load)
+- Debounced hover events (50ms delay to reduce event processing)
+- Debounced scroll/resize position updates (10ms delay to reduce reflow/repaint)
+- Minimal CSS (no animation libraries, simple opacity transitions)
+- Passive event listeners for scroll and resize (non-blocking)
+- Script only loaded for authorized users and when experiment enabled
+- Total frontend bundle size: ~7 KB (view.js + style.css)
+
+## Accessibility
+- Overlay button is focusable (keyboard navigation via Tab)
+- Button remains visible when focused (not hidden on blur)
+- Proper ARIA labels and semantic HTML (`<button>` tag)
+- Keyboard support: Tab to focus, Enter to activate, Escape to close
+- Works for screen readers
+- Focus management: When element or button is focused, overlay stays visible
+- Hidden state: Only hidden when mouse leaves AND nothing is focused
+
+## Current Status: IMPLEMENTATION COMPLETE ✓
+
+### What Works
+- ✓ Experiment registration and gating
+- ✓ Template part overlay detection and edit links
+- ✓ Post title overlay detection and edit links
+- ✓ Post content overlay detection and edit links (with fallback post ID detection)
+- ✓ Floating button positioned at bottom-right of element
+- ✓ Button positioning updates on scroll/resize
+- ✓ Proper show/hide behavior without flickering
+- ✓ Keyboard navigation and focus management
+- ✓ Escape key to close all overlays
+- ✓ Block theme guard
+- ✓ Capability checks for authorized users only
+- ✓ All debug logging removed
+
+### Known Limitations
+- Buttons are created per element (not a single global button)
+- Positioning uses fixed viewport coordinates, requires scroll/resize listeners to track element movement
+- CSS variables for customization are available but not extensively documented
+
+### Testing Recommendations
+- Manual testing on various page types (single posts, archives, home page)
+- Test with long pages (post-content scrolling behavior)
+- Test on narrow viewports (button visibility at element edges)
+- Verify capability checks prevent non-admin access
+- Test with experiment disabled to ensure feature is gated properly

--- a/lib/frontend-edit-overlay/style.css
+++ b/lib/frontend-edit-overlay/style.css
@@ -1,0 +1,55 @@
+/**
+ * Frontend Edit Overlay Styles
+ *
+ * Styles for the "Edit this" hover button overlay.
+ */
+
+:root {
+	--wp-edit-overlay-button-bg: #000;
+	--wp-edit-overlay-button-color: #fff;
+	--wp-edit-overlay-button-border-color: #fff;
+	--wp-edit-overlay-z-index: 999999;
+	--wp-edit-overlay-button-padding: 0.5rem 1rem;
+	--wp-edit-overlay-button-font-size: 0.875rem;
+	--wp-edit-overlay-button-border-radius: 3px;
+}
+
+.wp-edit-overlay__button {
+	padding: var(--wp-edit-overlay-button-padding);
+	background-color: var(--wp-edit-overlay-button-bg);
+	color: var(--wp-edit-overlay-button-color);
+	border: 2px solid #fff;
+	border-radius: var(--wp-edit-overlay-button-border-radius);
+	font-size: var(--wp-edit-overlay-button-font-size);
+	font-weight: 500;
+	cursor: pointer;
+	transition: all 0.15s ease-in-out;
+	white-space: nowrap;
+	z-index: var(--wp-edit-overlay-z-index);
+	opacity: 0;
+	pointer-events: none;
+}
+
+.wp-edit-overlay__button.wp-edit-overlay--visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.wp-edit-overlay__button:hover {
+	background-color: #333;
+	border-color: #fff;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	transform: translateY(-2px);
+}
+
+.wp-edit-overlay__button:focus {
+	outline: 2px solid #0073aa;
+	outline-offset: 2px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.wp-edit-overlay__button:active {
+	background-color: #1a1a1a;
+	border-color: #1a1a1a;
+	transform: translateY(0);
+}

--- a/lib/frontend-edit-overlay/view.js
+++ b/lib/frontend-edit-overlay/view.js
@@ -1,0 +1,279 @@
+/**
+ * Frontend Edit Overlay
+ *
+ * Displays "Edit this" hover buttons on the site frontend for template parts and post content.
+ */
+
+( function () {
+	// Configuration
+	const OVERLAY_BUTTON_CLASS = 'wp-edit-overlay__button';
+	const OVERLAY_VISIBLE_CLASS = 'wp-edit-overlay--visible';
+	const DEBOUNCE_DELAY = 50;
+	const ATTRIBUTE_TARGET = 'data-wp-edit-overlay-target';
+	const ATTRIBUTE_URL = 'data-wp-edit-url';
+
+	let debounceTimer = null;
+	let scrollTimer = null;
+	const overlayButtons = new WeakMap(); // Store overlay button for each element
+	const hoveredElements = new Set(); // Track which elements are currently hovered
+	let editableElements = [];
+
+	/**
+	 * Create the overlay button element positioned as a floating action button.
+	 *
+	 * @return {HTMLElement} The overlay button element.
+	 */
+	function createOverlayButton() {
+		const button = document.createElement( 'button' );
+		button.className = OVERLAY_BUTTON_CLASS;
+		button.setAttribute( 'type', 'button' );
+		button.setAttribute( 'aria-label', 'Edit this' );
+		button.textContent = 'Edit This';
+
+		// Position as fixed so it floats and scrolls with the page
+		button.style.position = 'fixed';
+		button.style.zIndex = '999999';
+
+		return button;
+	}
+
+	/**
+	 * Show the overlay button for a given element.
+	 *
+	 * @param {HTMLElement} element The element to show the overlay for.
+	 */
+	function showOverlay( element ) {
+		// Get the bounding rect of the element
+		const rect = element.getBoundingClientRect();
+
+		// Check if element is in viewport
+		if ( rect.bottom < 0 || rect.top > window.innerHeight ) {
+			return;
+		}
+
+		// Reuse existing button if available, otherwise create new one
+		let button = overlayButtons.get( element );
+		if ( ! button ) {
+			button = createOverlayButton();
+			document.body.appendChild( button );
+			overlayButtons.set( element, button );
+
+			// Get edit URL from data attribute and set up click handler
+			const editUrl = element.getAttribute( ATTRIBUTE_URL );
+			if ( editUrl ) {
+				button.addEventListener( 'click', () => {
+					window.location.href = editUrl;
+				} );
+			}
+
+			// Add mouseenter/mouseleave handlers to prevent flickering
+			button.addEventListener( 'mouseenter', () => {
+				handleButtonMouseEnter( element );
+			} );
+			button.addEventListener( 'mouseleave', () => {
+				handleButtonMouseLeave( element );
+			} );
+
+			// Show the button
+			button.classList.add( OVERLAY_VISIBLE_CLASS );
+		} else if ( ! button.classList.contains( OVERLAY_VISIBLE_CLASS ) ) {
+			// Show the button if not already visible
+			button.classList.add( OVERLAY_VISIBLE_CLASS );
+		}
+
+		// Position the button at the bottom-right corner of the element using viewport coordinates
+		// Fixed positioning uses viewport coordinates, so we use rect directly
+		button.style.top = rect.bottom - button.offsetHeight + 'px';
+		button.style.left = rect.right - button.offsetWidth + 'px';
+		button.style.right = 'auto';
+		button.style.bottom = 'auto';
+	}
+
+	/**
+	 * Hide the overlay button for a given element.
+	 *
+	 * @param {HTMLElement} element The element to hide the overlay for.
+	 */
+	function hideOverlay( element ) {
+		const button = overlayButtons.get( element );
+		if ( button ) {
+			button.classList.remove( OVERLAY_VISIBLE_CLASS );
+		}
+	}
+
+	/**
+	 * Check if a button is currently focused.
+	 *
+	 * @param {HTMLElement} element The element the button belongs to.
+	 * @return {boolean} True if the button is focused.
+	 */
+	function isButtonFocused( element ) {
+		const button = overlayButtons.get( element );
+		return button && button === button.ownerDocument.activeElement;
+	}
+
+	/**
+	 * Handle mouse enter on an editable element.
+	 *
+	 * @param {HTMLElement} element The element that was entered.
+	 */
+	function handleMouseEnter( element ) {
+		hoveredElements.add( element );
+		clearTimeout( debounceTimer );
+		debounceTimer = setTimeout( () => {
+			showOverlay( element );
+		}, DEBOUNCE_DELAY );
+	}
+
+	/**
+	 * Handle mouse leave on an editable element.
+	 *
+	 * @param {HTMLElement} element The element that was left.
+	 */
+	function handleMouseLeave( element ) {
+		hoveredElements.delete( element );
+		clearTimeout( debounceTimer );
+		debounceTimer = setTimeout( () => {
+			// Only hide if the button is not focused and not being hovered
+			const button = overlayButtons.get( element );
+			if (
+				! isButtonFocused( element ) &&
+				! ( button && button.matches( ':hover' ) )
+			) {
+				hideOverlay( element );
+			}
+		}, DEBOUNCE_DELAY );
+	}
+
+	/**
+	 * Handle mouse enter on the overlay button.
+	 */
+	function handleButtonMouseEnter() {
+		// Keep overlay visible
+		clearTimeout( debounceTimer );
+	}
+
+	/**
+	 * Handle mouse leave on the overlay button.
+	 *
+	 * @param {HTMLElement} element The element the button belongs to.
+	 */
+	function handleButtonMouseLeave( element ) {
+		// Check if element is still hovered, if not, hide overlay
+		if (
+			! hoveredElements.has( element ) &&
+			! isButtonFocused( element )
+		) {
+			clearTimeout( debounceTimer );
+			debounceTimer = setTimeout( () => {
+				hideOverlay( element );
+			}, DEBOUNCE_DELAY );
+		}
+	}
+
+	/**
+	 * Update the position of buttons for all currently hovered elements.
+	 */
+	function updateButtonPositions() {
+		hoveredElements.forEach( ( element ) => {
+			const button = overlayButtons.get( element );
+			if (
+				button &&
+				button.classList.contains( OVERLAY_VISIBLE_CLASS )
+			) {
+				const rect = element.getBoundingClientRect();
+
+				// Check if element is still in viewport
+				if ( rect.bottom < 0 || rect.top > window.innerHeight ) {
+					hideOverlay( element );
+					return;
+				}
+
+				// Update button position
+				button.style.top = rect.bottom - button.offsetHeight + 'px';
+				button.style.left = rect.right - button.offsetWidth + 'px';
+			}
+		} );
+	}
+
+	/**
+	 * Initialize the frontend edit overlay.
+	 */
+	function initialize() {
+		// Find all elements marked with edit overlay target
+		editableElements = Array.from(
+			document.querySelectorAll( '[' + ATTRIBUTE_TARGET + ']' )
+		);
+
+		if ( editableElements.length === 0 ) {
+			return;
+		}
+
+		// Add event listeners to each editable element
+		editableElements.forEach( ( element ) => {
+			element.addEventListener( 'mouseenter', () => {
+				handleMouseEnter( element );
+			} );
+
+			element.addEventListener( 'mouseleave', () => {
+				handleMouseLeave( element );
+			} );
+
+			// Handle focus on the element itself (for keyboard navigation to overlay)
+			element.addEventListener(
+				'focus',
+				() => {
+					showOverlay( element );
+				},
+				true
+			);
+
+			// Handle blur
+			element.addEventListener(
+				'blur',
+				() => {
+					if ( ! isButtonFocused( element ) ) {
+						hideOverlay( element );
+					}
+				},
+				true
+			);
+		} );
+
+		// Handle scroll to update button positions
+		window.addEventListener(
+			'scroll',
+			() => {
+				clearTimeout( scrollTimer );
+				scrollTimer = setTimeout( updateButtonPositions, 10 );
+			},
+			{ passive: true }
+		);
+
+		// Handle window resize to update button positions
+		window.addEventListener(
+			'resize',
+			() => {
+				clearTimeout( scrollTimer );
+				scrollTimer = setTimeout( updateButtonPositions, 10 );
+			},
+			{ passive: true }
+		);
+
+		// Handle escape key to hide all overlays
+		document.addEventListener( 'keydown', ( event ) => {
+			if ( event.key === 'Escape' ) {
+				editableElements.forEach( ( element ) => {
+					hideOverlay( element );
+				} );
+			}
+		} );
+	}
+
+	// Initialize when DOM is ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initialize );
+	} else {
+		initialize();
+	}
+} )();

--- a/lib/load.php
+++ b/lib/load.php
@@ -125,6 +125,11 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 	require __DIR__ . '/experimental/disable-tinymce.php';
 }
 
+// Frontend Edit Overlay experiment.
+if ( gutenberg_is_experiment_enabled( 'gutenberg-frontend-edit-overlay' ) ) {
+	require __DIR__ . '/frontend-edit-overlay.php';
+}
+
 // Load the BC Layer to avoid fatal errors of extenders using the Fonts API.
 // @core-merge: do not merge the BC layer files into WordPress Core.
 require __DIR__ . '/experimental/font-face/bc-layer/class-wp-fonts-provider.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

🚧 🚧 🚧 Note: this is a vibe coded proof of concept, and I've barely looked at the code — it is just for demonstration purposes only 🚧 🚧 🚧 

A demo for #73568

Try adding an Edit This button on the logged-in site frontend, that allows folks to click to edit a template part or post content.

This _really_ is just a demo to show how it might look. If it's a viable idea, then it would need to handle all kinds of different edge cases (edit the template, archive pages, how do we handle lists of posts, etc, etc)

I really put this up to gauge interest

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Dynamically inject some HTML attributes after blocks are rendered, and enqueue some JS to hook into those attributes to render the right buttons.

## Testing Instructions

1. Switch on the experiment in the Gutenberg experiment page:

<img width="1071" height="77" alt="image" src="https://github.com/user-attachments/assets/9ae093a2-409c-43ef-ac3b-51d9b0183e7e" />

2. Load a page on your site frontend, and there should be Edit This buttons on hover, over the header, footer, and somewhere around post content

Did I mention this is very buggy? It's just here to gauge how it might feel as an idea.

## Screenshots or screencast <!-- if applicable -->

<img width="1720" height="534" alt="image" src="https://github.com/user-attachments/assets/14a27a70-3fc5-4732-ac33-24bcf7d49b8a" />
