### PR TITLE
Only log paste debug info when SCRIPT_DEBUG is enabled

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -42,8 +42,10 @@ export default ( props ) => ( element ) => {
 		event.preventDefault();
 
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', html );
-		window.console.log( 'Received plain text:\n\n', plainText );
+		if ( globalThis.SCRIPT_DEBUG ) {
+			window.console.log( 'Received HTML:\n\n', html );
+			window.console.log( 'Received plain text:\n\n', plainText );
+		}
 
 		if ( disableFormats ) {
 			onChange( insert( value, plainText ) );

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -35,7 +35,11 @@ import slackParagraphCorrector from './slack-paragraph-corrector';
 import isLatexMathMode from './latex-to-math';
 import { createBlock } from '../factory';
 
-const log = ( ...args ) => window?.console?.log?.( ...args );
+const log = ( ...args ) => {
+	if ( globalThis.SCRIPT_DEBUG ) {
+		window?.console?.log?.( ...args );
+	}
+};
 
 /**
  * Filters HTML to only contain phrasing content.

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -129,8 +129,10 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		}
 
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', html );
-		window.console.log( 'Received plain text:\n\n', plainText );
+		if ( globalThis.SCRIPT_DEBUG ) {
+			window.console.log( 'Received HTML:\n\n', html );
+			window.console.log( 'Received plain text:\n\n', plainText );
+		}
 
 		const content = pasteHandler( {
 			HTML: html,

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -249,7 +249,9 @@ export const link = {
 		}
 
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Created link:\n\n', pastedText );
+		if ( globalThis.SCRIPT_DEBUG ) {
+			window.console.log( 'Created link:\n\n', pastedText );
+		}
 
 		const format = {
 			type: name,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Wraps `console.log` statements for paste operations in a `SCRIPT_DEBUG` conditional check to prevent unnecessary logging in production environments.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

By gating these logs behind `SCRIPT_DEBUG`, we ensure debug logging only appears in development environments where it's actually useful.

## Testing Instructions

Without SCRIPT_DEBUG (default):

1. Ensure `SCRIPT_DEBUG` is not enabled (or set to false) in your `wp-config.php`
2. Open the block editor (new post) and open your browser's developer console
3. Copy some content and paste it into the post title
4. Verify that the paste console logs do NOT appear

With SCRIPT_DEBUG enabled:

1. Add `define( 'SCRIPT_DEBUG', true );` to your `wp-config.php`
2. Open the block editor (new post) and open your browser's developer console
3. Copy some content and paste it into the post title
4. Verify that you see the "Received HTML:" and "Received plain text:" console logs


