### PR TITLE
Annotations: maintain active formats after applying

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
+++ b/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
@@ -3,88 +3,115 @@
 	const PanelBody = wp.components.PanelBody;
 	const select = wp.data.select;
 	const dispatch = wp.data.dispatch;
+	const useSelect = wp.data.useSelect;
+	const useDispatch = wp.data.useDispatch;
 	const Fragment = wp.element.Fragment;
 	const el = wp.element.createElement;
-	const Component = wp.element.Component;
+	const useState = wp.element.useState;
+	const useEffect = wp.element.useEffect;
 	const __ = wp.i18n.__;
 	const registerPlugin = wp.plugins.registerPlugin;
 	const PluginSidebar = wp.editor.PluginSidebar;
 	const PluginSidebarMoreMenuItem = wp.editor.PluginSidebarMoreMenuItem;
 
-	class SidebarContents extends Component {
-		constructor( props ) {
-			super( props );
+	function SidebarContents() {
+		const [ range, setRange ] = useState( { start: 0, end: 0 } );
 
-			this.state = {
-				start: 0,
-				end: 0,
-			};
-		}
+		const blocks = useSelect( ( sel ) => {
+			return sel( 'core/block-editor' ).getBlocks();
+		} );
 
-		render() {
-			return el(
-				PanelBody,
-				{},
-				el( 'input', {
-					type: 'number',
-					id: 'annotations-tests-range-start',
-					onChange: ( reactEvent ) => {
-						this.setState( {
-							start: reactEvent.target.value,
+		const { __experimentalAddAnnotation: addAnnotation } =
+			useDispatch( 'core/annotations' );
+
+		const allBlocks = blocks
+			.filter( ( block ) => block.name === 'core/paragraph' )
+			.map( ( block ) => [
+				block.clientId,
+				block.attributes.content.text,
+			] );
+
+		useEffect( () => {
+			allBlocks.forEach( ( [ clientId, content ] ) => {
+				const applePosition = content.indexOf( 'apple' );
+				if ( applePosition !== -1 ) {
+					addAnnotation( {
+						source: 'test-annotation',
+						blockClientId: clientId,
+						richTextIdentifier: 'content',
+						range: {
+							start: applePosition,
+							end: applePosition + 5,
+						},
+					} );
+				}
+			} );
+		} );
+
+		return el(
+			PanelBody,
+			{},
+			el( 'input', {
+				type: 'number',
+				id: 'annotations-tests-range-start',
+				onChange: ( reactEvent ) => {
+					setRange( {
+						...range,
+						start: reactEvent.target.value,
+					} );
+				},
+				value: range.start,
+			} ),
+			el( 'input', {
+				type: 'number',
+				id: 'annotations-tests-range-end',
+				onChange: ( reactEvent ) => {
+					setRange( {
+						...range,
+						end: reactEvent.target.value,
+					} );
+				},
+				value: range.end,
+			} ),
+			el(
+				Button,
+				{
+					variant: 'primary',
+					onClick: () => {
+						dispatch(
+							'core/annotations'
+						).__experimentalAddAnnotation( {
+							source: 'e2e-tests',
+							blockClientId:
+								select(
+									'core/block-editor'
+								).getBlockOrder()[ 0 ],
+							richTextIdentifier: 'content',
+							range: {
+								start: parseInt( range.start, 10 ),
+								end: parseInt( range.end, 10 ),
+							},
 						} );
 					},
-					value: this.state.start,
-				} ),
-				el( 'input', {
-					type: 'number',
-					id: 'annotations-tests-range-end',
-					onChange: ( reactEvent ) => {
-						this.setState( {
-							end: reactEvent.target.value,
-						} );
+				},
+				__( 'Add annotation' )
+			),
+			el(
+				Button,
+				{
+					variant: 'primary',
+					onClick: () => {
+						dispatch(
+							'core/annotations'
+						).__experimentalRemoveAnnotationsBySource(
+							'e2e-tests'
+						);
 					},
-					value: this.state.end,
-				} ),
-				el(
-					Button,
-					{
-						variant: 'primary',
-						onClick: () => {
-							dispatch(
-								'core/annotations'
-							).__experimentalAddAnnotation( {
-								source: 'e2e-tests',
-								blockClientId:
-									select(
-										'core/block-editor'
-									).getBlockOrder()[ 0 ],
-								richTextIdentifier: 'content',
-								range: {
-									start: parseInt( this.state.start, 10 ),
-									end: parseInt( this.state.end, 10 ),
-								},
-							} );
-						},
-					},
-					__( 'Add annotation' )
-				),
-				el(
-					Button,
-					{
-						variant: 'primary',
-						onClick: () => {
-							dispatch(
-								'core/annotations'
-							).__experimentalRemoveAnnotationsBySource(
-								'e2e-tests'
-							);
-						},
-					},
+				},
 
-					__( 'Remove annotations' )
-				)
-			);
-		}
+				__( 'Remove annotations' )
+			)
+		);
 	}
 
 	function AnnotationsSidebar() {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -64,6 +64,7 @@ export function useRichText( {
 	const recordRef = useRef();
 
 	function setRecordFromProps() {
+		const activeFormats = recordRef.current?.activeFormats;
 		_valueRef.current = value;
 		recordRef.current = value;
 		if ( ! ( value instanceof RichTextData ) ) {
@@ -76,6 +77,7 @@ export function useRichText( {
 			text: recordRef.current.text,
 			formats: recordRef.current.formats,
 			replacements: recordRef.current.replacements,
+			activeFormats,
 		};
 		if ( disableFormats ) {
 			recordRef.current.formats = Array( value.length );

--- a/test/e2e/specs/editor/plugins/annotations.spec.js
+++ b/test/e2e/specs/editor/plugins/annotations.spec.js
@@ -159,6 +159,68 @@ test.describe( 'Annotations', () => {
 			},
 		] );
 	} );
+
+	test( 'automatically annotates the word "apple"', async ( {
+		editor,
+		page,
+		annotations,
+	} ) => {
+		await annotations.openAnnotationsSidebar();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Title' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'I love apple pie' );
+
+		const block = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const blockAnnotation = block.locator(
+			'.annotation-text-test-annotation'
+		);
+
+		await expect( blockAnnotation ).toBeVisible();
+		await expect( blockAnnotation ).toHaveText( 'apple' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'I love apple pie' },
+			},
+		] );
+	} );
+
+	test( 'automatically annotates the word "apple" (bold)', async ( {
+		editor,
+		page,
+		annotations,
+		pageUtils,
+	} ) => {
+		await annotations.openAnnotationsSidebar();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Title' );
+		await page.keyboard.press( 'Enter' );
+		await pageUtils.pressKeys( 'primary+b' );
+		await page.keyboard.type( 'I love apple pie' );
+
+		const block = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const blockAnnotation = block.locator(
+			'.annotation-text-test-annotation'
+		);
+
+		await expect( blockAnnotation ).toBeVisible();
+		await expect( blockAnnotation ).toHaveText( 'apple' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '<strong>I love apple pie</strong>' },
+			},
+		] );
+	} );
 } );
 
 class AnnotationsUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Alternative to #73371.

When applying an annotation, or generally, when a value is set from outside RichText, maintain the active formats. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/71698

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Preserve active formats when a new value is set from outside RichText.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I've added an e2e test, but also see #73371.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
