### PR TITLE
Paragraph block: Backward compatibility support for align attribute

### DIFF
--- a/packages/block-library/src/paragraph/deprecated-attributes.js
+++ b/packages/block-library/src/paragraph/deprecated-attributes.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useEvent } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * If a plugin is still using the old align attribute, we need to migrate its value
+ * to the new style.typography.textAlign attribute.
+ *
+ * @param {string?}          align         Align attribute value.
+ * @param {Object?}          style         Style attribute value.
+ * @param {(Object) => void} setAttributes Updater function for block attributes.
+ */
+export default function useDeprecatedAlign( align, style, setAttributes ) {
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+	const updateStyleWithAlign = useEvent( () => {
+		deprecated( 'align attribute in paragraph block', {
+			alternative: 'style.typography.textAlign',
+			since: '7.0',
+		} );
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( {
+			style: {
+				...style,
+				typography: {
+					...style?.typography,
+					textAlign: align,
+				},
+			},
+		} );
+	} );
+	const lastUpdatedAlignRef = useRef();
+	useEffect( () => {
+		if ( align === lastUpdatedAlignRef.current ) {
+			return;
+		}
+		lastUpdatedAlignRef.current = align;
+		updateStyleWithAlign();
+	}, [ align, updateStyleWithAlign ] );
+}

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -26,6 +26,7 @@ import { formatLtr } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useOnEnter } from './use-enter';
+import useDeprecatedAlign from './deprecated-attributes';
 
 function ParagraphRTLControl( { direction, setDirection } ) {
 	return (
@@ -110,6 +111,7 @@ function ParagraphBlock( {
 } ) {
 	const { content, direction, dropCap, placeholder, style } = attributes;
 	const textAlign = style?.typography?.textAlign;
+	useDeprecatedAlign( attributes.align, style, setAttributes );
 	const blockProps = useBlockProps( {
 		ref: useOnEnter( { clientId, content } ),
 		className: clsx( {


### PR DESCRIPTION
## What?

In #73111 We remove the align attribute from the paragraph block. The issue though is that we didn't take into consideration plugins that might still be updating this attribute programmatically, like plugins adding "justify" buttons.

This PR adds a shim for these plugins while throwing a deprecation message.

## Testing Instructions

1- Insert a paragraph block
2- Open the browser console
3- Update the align attribute programmatically, something like

```
const id = wp.data.select('core/block-editor').getBlocks()[0].clientId;
wp.data.dispatch('core/block-editor').updateBlockAttributes( id, { align: "right" } );
```

Notice that the alignment of the paragraph changes as you call the updateBlockAttribute function. Also a deprecation is printed in the console the first time you do it.