### PR TITLE
Gutenberg plugin: Override core classic theme styles

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -238,6 +238,16 @@ function gutenberg_register_packages_styles( $styles ) {
 		$version
 	);
 	$styles->add_data( 'wp-block-library-theme', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'classic-theme-styles',
+		gutenberg_url( 'build/styles/block-library/classic.css' ),
+		array(),
+		$version
+	);
+	$styles->add_data( 'classic-theme-styles', 'rtl', 'replace' );
+	$styles->add_data( 'classic-theme-styles', 'path', gutenberg_dir_path() . 'build/styles/block-library/classic.css' );
 }
 add_action( 'wp_default_styles', 'gutenberg_register_packages_styles', 15 );
 


### PR DESCRIPTION
Found while investigating the approach suggested in https://github.com/WordPress/gutenberg/issues/73454#issuecomment-3574747802

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

There is a style called `classic-theme-styles` that is only enqueued when the classic theme is active. I found that the Gutenberg plugin was missing the code to override this. This PR overrides this core style so that the Gutenberg plugin can test styles for the new classic theme.

## Testing Instructions

- Activate any of the classic themes
- Open `packages/block-library/src/classic.scss` and add some changes
- Confirm that the style is applied correctly on both the editor and the front-end

## Screenshots or screencast <!-- if applicable -->

<img width="1228" height="494" alt="classic-style" src="https://github.com/user-attachments/assets/bd211621-ffcf-4cda-9c48-e065d7dd869e" />


