### PR TITLE
Template Activation: Rename gutenberg_get_block_template

### DIFF
--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -589,6 +589,16 @@ add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////
 function gutenberg_get_block_template( $output, $id, $template_type ) {
+	function gutenberg_get_block_template( $output = null, $id = null, $template_type = null ) {
+	// get_block_template() expects 2 arguments: $template_type and $id.
+	// This allows gutenberg_get_block_template() to also be called with 2 arguments,
+	// and treat them as $template_type and $id.
+	$arg_count = func_num_args();
+	if ( 2 === $arg_count ) {
+		$template_type = $output;
+		$id            = $id;
+		$output        = null;
+	}
 	// Check active_templates experiment status.
 	if ( ! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		return $output;

--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -583,12 +583,12 @@ function gutenberg_maybe_update_active_templates( $post_id ) {
 	update_option( 'active_templates', $active_templates );
 }
 
-add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
+add_action( 'pre_get_block_template', 'gutenberg_filter_pre_get_block_template', 10, 3 );
 
 ///////////////////////////////////////////////////////////////////////
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////
-function gutenberg_get_block_template( $output = null, $id = null, $template_type = null ) {
+function gutenberg_filter_pre_get_block_template( $output, $id, $template_type ) {
 	// Check active_templates experiment status.
 	if ( ! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		return $output;

--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -588,8 +588,7 @@ add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
 ///////////////////////////////////////////////////////////////////////
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////
-function gutenberg_get_block_template( $output, $id, $template_type ) {
-	function gutenberg_get_block_template( $output = null, $id = null, $template_type = null ) {
+function gutenberg_get_block_template( $output = null, $id = null, $template_type = null ) {
 	// get_block_template() expects 2 arguments: $template_type and $id.
 	// This allows gutenberg_get_block_template() to also be called with 2 arguments,
 	// and treat them as $template_type and $id.

--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -589,15 +589,6 @@ add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////
 function gutenberg_get_block_template( $output = null, $id = null, $template_type = null ) {
-	// get_block_template() expects 2 arguments: $template_type and $id.
-	// This allows gutenberg_get_block_template() to also be called with 2 arguments,
-	// and treat them as $template_type and $id.
-	$arg_count = func_num_args();
-	if ( 2 === $arg_count ) {
-		$template_type = $output;
-		$id            = $id;
-		$output        = null;
-	}
 	// Check active_templates experiment status.
 	if ( ! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		return $output;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This fixes the following error, which can be triggered by plugins calling the old `gutenberg_get_block_template` function with two arguments when the Template Activation experiment is enabled:

`Fatal error: Uncaught ArgumentCountError: Too few arguments to function gutenberg_get_block_template(), 2 passed in /wp-content/plugins/directorist/blocks/includes/class-block-templates-controller.php on line 93 and exactly 3 expected in /wordpress/plugins/gutenberg/22.1.2/lib/compat/wordpress-6.9/template-activate.php:591`

This example is from the Directorist plugin, but this would happen for any plugin using this function with two args.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prevents fatal errors from `gutenberg_get_block_template()`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Allows all three args to be `null`, and if there are only two passed, treat them as `get_block_template()` would treat two args.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the Template Activation experiment in Gutenberg - Experiments
2. Install any plugin that calls the `gutenberg_get_block_template` function with 2 args, e.g. Directorist
3. Visit the front end of your site
4. Ensure there are no errors


