### PR TITLE
Asset Loader: load all scripts in body (footer)

### DIFF
--- a/packages/asset-loader/src/index.ts
+++ b/packages/asset-loader/src/index.ts
@@ -276,15 +276,9 @@ async function loadAssets(
 	}
 
 	// Load scripts in dependency order
-	const scriptElementsHead: HTMLScriptElement[] = [];
-	const scriptElementsBody: HTMLScriptElement[] = [];
+	const scriptElements: HTMLScriptElement[] = [];
 
 	for ( const handle of orderedScripts ) {
-		const inFooter = scriptsData[ handle ].in_footer || false;
-		const scriptElements = inFooter
-			? scriptElementsBody
-			: scriptElementsHead;
-
 		const beforeInline = inlineScripts.before?.[ handle ];
 		if ( beforeInline ) {
 			scriptElements.push(
@@ -302,10 +296,7 @@ async function loadAssets(
 		}
 	}
 
-	const scriptsPromise = ( async () => {
-		await performScriptLoad( scriptElementsHead, document.head );
-		await performScriptLoad( scriptElementsBody, document.body );
-	} )();
+	const scriptsPromise = performScriptLoad( scriptElements, document.body );
 
 	await Promise.all( [ Promise.all( stylePromises ), scriptsPromise ] );
 


### PR DESCRIPTION
Improves the asset loader so that it loads all scripts in footer. Two reasons:
- fixes a bug when a header script depends on a footer (`in_footer=true`) script. Then the dependent could be loaded before the dependency and fail. We didn't implement a logic similar to Core's `WP_Dependencies::all_deps` where such footer scripts would get moved to header automatically.
- when loading scripts dynamically at runtime, after the HTML parsing is finished and the DOM is initialized, it doesn't matter any more whether a script is in header or footer. It has the same loading behavior in both. Respecting the `in_footer` flag and splitting scripts to two groups was redundant.
