### PR TITLE
Routing: Add view transitions to the new routing infrastructure

### DIFF
--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -18,9 +18,8 @@ import {
  * Internal dependencies
  */
 import Root from '../root';
-import type { CanvasData, Route, RouteLoaderContext } from '../../store/types';
+import type { Route, RouteLoaderContext } from '../../store/types';
 import { unlock } from '../../lock-unlock';
-import Canvas from '../canvas';
 
 const {
 	createLazyRoute,
@@ -30,7 +29,6 @@ const {
 	RouterProvider,
 	createBrowserHistory,
 	parseHref,
-	useMatches,
 } = unlock( routePrivateApis );
 
 // Not found component
@@ -47,20 +45,10 @@ function NotFoundComponent() {
 function RouteComponent( {
 	stage: Stage,
 	inspector: Inspector,
-	canvas: CustomCanvas,
 }: {
 	stage?: ComponentType;
 	inspector?: ComponentType;
-	canvas?: ComponentType;
 } ) {
-	// Get canvas data from the current route's loader
-	const matches = useMatches();
-	const currentMatch = matches[ matches.length - 1 ];
-	const canvasData = ( currentMatch?.loaderData as any )?.canvas as
-		| CanvasData
-		| null
-		| undefined;
-
 	return (
 		<>
 			{ Stage && (
@@ -71,18 +59,6 @@ function RouteComponent( {
 			{ Inspector && (
 				<div className="boot-layout__inspector">
 					<Inspector />
-				</div>
-			) }
-			{ /* Render custom canvas when canvas() returns null */ }
-			{ canvasData === null && CustomCanvas && (
-				<div className="boot-layout__canvas">
-					<CustomCanvas />
-				</div>
-			) }
-			{ /* Render default canvas when canvas() returns CanvasData */ }
-			{ canvasData && (
-				<div className="boot-layout__canvas">
-					<Canvas canvas={ canvasData } />
 				</div>
 			) }
 		</>
@@ -142,6 +118,8 @@ async function createRouteFromDefinition(
 			return {
 				...( loaderData as any ),
 				canvas: canvasData,
+				// Include content module path so Root can load custom canvas
+				routeContentModule: route.content_module,
 			};
 		},
 		loaderDeps: ( opts: any ) => opts.search,
@@ -159,7 +137,6 @@ async function createRouteFromDefinition(
 					<RouteComponent
 						stage={ module.stage }
 						inspector={ module.inspector }
-						canvas={ module.canvas }
 					/>
 				);
 			},

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -234,6 +234,7 @@ export default function Router( {
 					routeTree,
 					defaultPreload: 'intent',
 					defaultNotFoundComponent: NotFoundComponent,
+					defaultViewTransition: true,
 				} );
 				setRouter( newRouter );
 			}

--- a/packages/boot/src/components/canvas-renderer/index.tsx
+++ b/packages/boot/src/components/canvas-renderer/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Canvas from '../canvas';
+import type { CanvasData } from '../../store/types';
+
+interface CanvasRendererProps {
+	canvas: CanvasData | null | undefined;
+	routeContentModule?: string;
+}
+
+/**
+ * CanvasRenderer handles rendering of both default and custom canvas components.
+ * The logic here would have been way simpler if we just render the canvas within
+ * the RouteComponent like the other surfaces.
+ * The issue is that doing so forces the canvas to remount on every route change,
+ * which is not desirable for smooth transitions.
+ *
+ * - When canvas is undefined: No canvas is rendered
+ * - When canvas is null: Loads and renders custom canvas from contentModulePath
+ * - When canvas is CanvasData: Renders default Canvas component with editor
+ *
+ * This component is designed to be rendered at the Root level to prevent
+ * remounting when navigating between routes.
+ *
+ * @param props                    Component props
+ * @param props.canvas             Canvas data from route loader
+ * @param props.routeContentModule Path to content module for custom canvas
+ * @return Canvas renderer
+ */
+export default function CanvasRenderer( {
+	canvas,
+	routeContentModule,
+}: CanvasRendererProps ) {
+	const [ CustomCanvas, setCustomCanvas ] = useState< any >( null );
+
+	useEffect( () => {
+		if ( canvas === null && routeContentModule ) {
+			import( routeContentModule )
+				.then( ( module ) => {
+					setCustomCanvas( () => module.canvas );
+				} )
+				.catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to load custom canvas:', error );
+				} );
+		} else {
+			setCustomCanvas( null );
+		}
+	}, [ canvas, routeContentModule ] );
+
+	// No canvas
+	if ( canvas === undefined ) {
+		return null;
+	}
+
+	// Custom canvas
+	if ( canvas === null ) {
+		if ( ! CustomCanvas ) {
+			return null; // Still loading
+		}
+		return <CustomCanvas />;
+	}
+
+	// Default canvas
+	return <Canvas canvas={ canvas } />;
+}

--- a/packages/boot/src/components/canvas/back-button.scss
+++ b/packages/boot/src/components/canvas/back-button.scss
@@ -60,3 +60,8 @@
 		backdrop-filter: saturate(180%) blur(15px);
 	}
 }
+
+// Remove the header slide-in animation so the back logo does not move.
+.interface-interface-skeleton__header {
+	margin-top: 0 !important;
+}

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -17,6 +17,7 @@ import { EditorSnackbars } from '@wordpress/editor';
  */
 import Sidebar from '../sidebar';
 import SavePanel from '../save-panel';
+import CanvasRenderer from '../canvas-renderer';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -31,6 +32,8 @@ export default function Root() {
 		| CanvasData
 		| null
 		| undefined;
+	const routeContentModule = ( currentMatch?.loaderData as any )
+		?.routeContentModule as string | undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
 
 	return (
@@ -56,6 +59,15 @@ export default function Root() {
 						>
 							<Outlet />
 						</ThemeProvider>
+						{ /* Render Canvas in Root to prevent remounting on route changes */ }
+						{ ( canvas || canvas === null ) && (
+							<div className="boot-layout__canvas">
+								<CanvasRenderer
+									canvas={ canvas }
+									routeContentModule={ routeContentModule }
+								/>
+							</div>
+						) }
 					</div>
 				</div>
 			</ThemeProvider>

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -16,6 +16,7 @@ import { EditorSnackbars } from '@wordpress/editor';
  * Internal dependencies
  */
 import SavePanel from '../save-panel';
+import CanvasRenderer from '../canvas-renderer';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -34,6 +35,8 @@ export default function RootSinglePage() {
 		| CanvasData
 		| null
 		| undefined;
+	const routeContentModule = ( currentMatch?.loaderData as any )
+		?.routeContentModule as string | undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
 
 	return (
@@ -54,6 +57,15 @@ export default function RootSinglePage() {
 						>
 							<Outlet />
 						</ThemeProvider>
+						{ /* Render Canvas in Root to prevent remounting on route changes */ }
+						{ ( canvas || canvas === null ) && (
+							<div className="boot-layout__canvas">
+								<CanvasRenderer
+									canvas={ canvas }
+									routeContentModule={ routeContentModule }
+								/>
+							</div>
+						) }
 					</div>
 				</div>
 			</ThemeProvider>

--- a/packages/boot/src/index.tsx
+++ b/packages/boot/src/index.tsx
@@ -2,5 +2,6 @@
  * Internal dependencies
  */
 import './style.scss';
+import './view-transitions.scss';
 export { init, initSinglePage } from './components/app';
 export { store } from './store';

--- a/packages/boot/src/view-transitions.scss
+++ b/packages/boot/src/view-transitions.scss
@@ -1,0 +1,239 @@
+@use "@wordpress/base-styles/colors";
+
+// Disable view transitions on mobile devices
+// to avoid conflicts with sidebar navigation.
+@media (max-width: 782px) {
+	* {
+		view-transition-name: none !important;
+	}
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation-duration: 250ms;
+}
+
+@media not (prefers-reduced-motion: reduce) {
+	.boot-layout__canvas .interface-interface-skeleton__header {
+		view-transition-name: boot--canvas-header;
+	}
+
+	.boot-layout__canvas .interface-interface-skeleton__sidebar {
+		view-transition-name: boot--canvas-sidebar;
+	}
+
+	.boot-layout.has-full-canvas
+	.boot-layout__canvas
+	.boot-site-icon-link,
+	.boot-layout:not(.has-full-canvas)
+	.boot-site-hub
+	.boot-site-icon-link {
+		view-transition-name: boot--site-icon-link;
+	}
+
+	// Default (non-Safari) view transition names
+	.boot-layout__stage {
+		view-transition-name: boot--stage;
+	}
+
+	.boot-layout__inspector {
+		view-transition-name: boot--inspector;
+	}
+
+	.boot-layout__canvas:not(.is-full-canvas),
+	.boot-layout__canvas.is-full-canvas
+	.interface-interface-skeleton__content {
+		view-transition-name: boot--canvas;
+	}
+
+	// Safari-specific view transition names
+	// Uses CSS feature detection instead of .is-safari class
+	@supports (-webkit-hyphens:none) and (not (-moz-appearance:none)) {
+		.boot-layout__stage {
+			view-transition-name: boot-safari--stage;
+		}
+
+		.boot-layout__inspector {
+			view-transition-name: boot-safari--inspector;
+		}
+
+		.boot-layout__canvas:not(.is-full-canvas),
+		.boot-layout__canvas.is-full-canvas
+		.interface-interface-skeleton__content {
+			view-transition-name: boot-safari--canvas;
+		}
+	}
+
+	// For any popover that stays open across a query change.
+	// Naming it avoids the stage overlaying it.
+	.components-popover:first-of-type {
+		view-transition-name: boot--components-popover;
+	}
+}
+
+::view-transition-group(boot--canvas-header),
+::view-transition-group(boot--canvas-sidebar),
+::view-transition-group(boot-safari--canvas),
+::view-transition-group(boot--canvas) {
+	z-index: 1;
+}
+
+::view-transition-group(boot--site-icon-link) {
+	z-index: 2;
+}
+
+::view-transition-new(boot--site-icon-link),
+::view-transition-old(boot--site-icon-link) {
+	animation: none;
+}
+
+// Safari-specific pseudo-element styles with width: auto fix
+::view-transition-new(boot-safari--canvas),
+::view-transition-old(boot-safari--canvas),
+::view-transition-new(boot-safari--stage),
+::view-transition-old(boot-safari--stage),
+::view-transition-old(boot-safari--inspector),
+::view-transition-new(boot-safari--inspector) {
+	width: auto;
+}
+
+// Safari trips up with using object fit on the pseudo images and filling out
+// background.
+::view-transition-new(boot--canvas),
+::view-transition-old(boot--canvas),
+::view-transition-new(boot--stage),
+::view-transition-old(boot--stage),
+::view-transition-new(boot--inspector),
+::view-transition-old(boot--inspector) {
+	background: colors.$white;
+	border-radius: 8px;
+	width: 100%;
+	height: 100%;
+	object-fit: none;
+	object-position: left top;
+	overflow: hidden;
+}
+
+::view-transition-new(boot--canvas),
+::view-transition-old(boot--canvas) {
+	object-position: center top;
+}
+
+::view-transition-old(boot-safari--inspector):only-child,
+::view-transition-old(boot--inspector):only-child,
+::view-transition-old(boot-safari--stage):only-child,
+::view-transition-old(boot--stage):only-child {
+	animation-name: zoomOut;
+	will-change: transform, opacity;
+}
+
+::view-transition-new(boot-safari--inspector):only-child,
+::view-transition-new(boot--inspector):only-child,
+::view-transition-new(boot-safari--stage):only-child,
+::view-transition-new(boot--stage):only-child {
+	animation-name: zoomIn;
+	will-change: transform, opacity;
+}
+
+@keyframes zoomOut {
+	from {
+		transform: scale(1);
+		opacity: 1;
+	}
+
+	to {
+		transform: scale(0.9);
+		opacity: 0;
+	}
+}
+
+@keyframes zoomIn {
+	from {
+		transform: scale(0.95);
+		opacity: 0;
+	}
+
+	to {
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+
+::view-transition-new(boot-safari--canvas):only-child,
+::view-transition-new(boot--canvas):only-child {
+	animation-name: slideFromRight;
+	will-change: transform;
+}
+
+::view-transition-old(boot-safari--canvas):only-child,
+::view-transition-old(boot--canvas):only-child {
+	animation-name: slideToRight;
+	will-change: transform;
+}
+
+@keyframes slideFromRight {
+	from {
+		// Should ideally be 100% + 16px, but we also need to take into account
+		// that the canvas can be the editor-interface-skeleton__content, which
+		// not placed on the right side.
+		transform: translateX(100vw);
+	}
+
+	to {
+		transform: translateX(0);
+	}
+}
+
+@keyframes slideToRight {
+	from {
+		transform: translateX(0);
+	}
+
+	to {
+		transform: translateX(100vw);
+	}
+}
+
+::view-transition-new(boot--canvas-header):only-child {
+	animation-name: slideHeaderFromTop;
+	will-change: transform;
+}
+
+::view-transition-old(boot--canvas-header):only-child {
+	animation-name: slideHeaderToTop;
+	will-change: transform;
+}
+
+@keyframes slideHeaderFromTop {
+	from {
+		transform: translateY(-100%);
+	}
+}
+
+@keyframes slideHeaderToTop {
+	to {
+		transform: translateY(-100%);
+	}
+}
+
+::view-transition-new(boot--canvas-sidebar):only-child {
+	animation-name: slideSidebarFromRight;
+	will-change: transform;
+}
+
+::view-transition-old(boot--canvas-sidebar):only-child {
+	animation-name: slideSidebarToRight;
+	will-change: transform;
+}
+
+@keyframes slideSidebarFromRight {
+	from {
+		transform: translateX(100%);
+	}
+}
+
+@keyframes slideSidebarToRight {
+	to {
+		transform: translateX(100%);
+	}
+}


### PR DESCRIPTION
Related #70862 

## What?

Enables view transitions in the boot package with smooth animations for route navigation.

This is not entirely smooth but maybe it's a start.

## Testing Instructions

You can test using this URL http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot

  1. Navigate between different routes in the boot package
  2. Observe transitions (zoom/slide animations)
  4. Verify transitions are disabled on mobile viewports (<782px)
  5. Check that transitions respect reduced motion preferences