### PR TITLE
Site Hub: Use optional chaining on currentTheme

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -134,7 +134,7 @@ export const SiteHubMobile = memo(
 			const currentTheme = getCurrentTheme();
 			const settings = getSettings();
 			const supportsEditorStyles =
-				currentTheme.theme_supports[ 'editor-styles' ];
+				currentTheme?.theme_supports[ 'editor-styles' ];
 			// This is a temp solution until the has_theme_json value is available for the current theme.
 			const hasThemeJson = settings.supportsLayout;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This fixes a console error when visiting the Site Editor on a mobile viewport: `TypeError: Cannot read properties of null (reading 'theme_supports')`

<img width="562" height="158" alt="image" src="https://github.com/user-attachments/assets/65996252-3dd1-41c5-b9b0-1313a0f86370" />


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Allows the Site Editor to load in a mobile viewport.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds optional chaining to `currentTheme`, as we usually do when using `getCurrentTheme()`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Visit the Site Editor in a mobile viewport (less than 480px wide)
2. Ensure the editor loads with no console errors
