### PR TITLE
Prototype: Enhance Link Editing and Management in Navigation Block Sidebar

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -103,6 +103,19 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
+	const { blockName } = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return { blockName: null };
+			}
+			const { getBlockName } = select( blockEditorStore );
+			return {
+				blockName: getBlockName( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
 	const parentNavBlockClientId = useSelect(
 		( select ) => {
 			if ( parentClientId || isChild || ! allowParentNavigation ) {
@@ -176,10 +189,16 @@ function BlockCard( {
 							<Badge>{ title }</Badge>
 						) }
 					</TitleElement>
-					{ ! parentClientId && ! isChild && description && (
-						<Text className="block-editor-block-card__description">
-							{ description }
-						</Text>
+					{ ! parentClientId &&
+					! isChild &&
+					blockName === 'core/navigation-link' ? (
+						<Badge intent="success">{ __( 'Active' ) }</Badge>
+					) : (
+						description && (
+							<Text className="block-editor-block-card__description">
+								{ description }
+							</Text>
+						)
 					) }
 					{ children }
 				</VStack>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -155,6 +155,7 @@ function LinkControl( {
 	handleEntities = false,
 	hasCopyControl = true,
 	useDropdownMode = false,
+	className,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -589,7 +590,7 @@ function LinkControl( {
 			<div
 				tabIndex={ -1 }
 				ref={ wrapperNode }
-				className="block-editor-link-control"
+				className={ clsx( 'block-editor-link-control', className ) }
 			>
 				{ isCreatingPage && (
 					<div className="block-editor-link-control__loading">
@@ -657,7 +658,7 @@ function LinkControl( {
 		<div
 			tabIndex={ -1 }
 			ref={ wrapperNode }
-			className="block-editor-link-control"
+			className={ clsx( 'block-editor-link-control', className ) }
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -8,9 +8,11 @@ import clsx from 'clsx';
  */
 import {
 	Button,
+	Dropdown,
 	Spinner,
 	Notice,
 	TextControl,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	__experimentalHStack as HStack,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
@@ -115,6 +117,14 @@ const noop = () => {};
 const PREFERENCE_SCOPE = 'core/block-editor';
 const PREFERENCE_KEY = 'linkControlSettingsDrawer';
 
+const popoverProps = {
+	placement: 'left-start',
+	offset: 36,
+	shift: true,
+	flip: true,
+	resize: false,
+};
+
 /**
  * Renders a link control. A link control is a controlled input which maintains
  * a value associated with a link (HTML anchor element) and relevant settings
@@ -144,12 +154,15 @@ function LinkControl( {
 	renderControlBottom = null,
 	handleEntities = false,
 	hasCopyControl = true,
+	useDropdownMode = false,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
 	}
 
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
+	const dropdownToggleRef = useRef( null );
 
 	const { advancedSettingsPreference } = useSelect( ( select ) => {
 		const prefsStore = select( preferencesStore );
@@ -235,6 +248,16 @@ function LinkControl( {
 		setIsEditingLink( forceIsEditingLink );
 	}, [ forceIsEditingLink ] );
 
+	// Handle dropdown toggle - sync with editing state
+	const handleDropdownToggle = ( isOpen ) => {
+		setIsDropdownOpen( isOpen );
+		if ( isOpen ) {
+			setIsEditingLink( true );
+		} else if ( hasLinkValue ) {
+			setIsEditingLink( false );
+		}
+	};
+
 	useEffect( () => {
 		// We don't auto focus into the Link UI on mount
 		// because otherwise using the keyboard to select text
@@ -303,6 +326,9 @@ function LinkControl( {
 		} );
 
 		stopEditing();
+		if ( useDropdownMode && dropdownToggleRef.current ) {
+			dropdownToggleRef.current();
+		}
 	};
 
 	const handleSubmit = () => {
@@ -316,6 +342,9 @@ function LinkControl( {
 			} );
 		}
 		stopEditing();
+		if ( useDropdownMode && dropdownToggleRef.current ) {
+			dropdownToggleRef.current();
+		}
 	};
 
 	const handleSubmitWithEnter = ( event ) => {
@@ -347,6 +376,10 @@ function LinkControl( {
 		} else {
 			// If there is no link value, then remove the link entirely.
 			onRemove?.();
+		}
+
+		if ( useDropdownMode && dropdownToggleRef.current ) {
+			dropdownToggleRef.current();
 		}
 
 		onCancel?.();
@@ -421,6 +454,205 @@ function LinkControl( {
 		return value;
 	}, [ value ] );
 
+	/**
+	 * Renders the editing content for LinkControl.
+	 * This includes the search input, text control, settings, and action buttons.
+	 */
+	const renderEditingContent = () => {
+		return (
+			<>
+				<div
+					className={ clsx( {
+						'block-editor-link-control__search-input-wrapper': true,
+						'has-text-control': showTextControl,
+						'has-actions': showActions,
+					} ) }
+				>
+					{ showTextControl && (
+						<TextControl
+							__nextHasNoMarginBottom
+							ref={ textInputRef }
+							className="block-editor-link-control__field block-editor-link-control__text-content"
+							label={ __( 'Text' ) }
+							value={ internalControlValue?.title }
+							onChange={ setInternalTextInputValue }
+							onKeyDown={ handleSubmitWithEnter }
+							__next40pxDefaultSize
+						/>
+					) }
+					<LinkControlSearchInput
+						ref={ searchInputRef }
+						currentLink={ value }
+						className="block-editor-link-control__field block-editor-link-control__search-input"
+						placeholder={ searchInputPlaceholder }
+						value={ currentUrlInputValue }
+						withCreateSuggestion={ withCreateSuggestion }
+						onCreateSuggestion={ createPage }
+						onChange={ setInternalURLInputValue }
+						onSelect={ handleSelectSuggestion }
+						showInitialSuggestions={ showInitialSuggestions }
+						allowDirectEntry={ ! noDirectEntry }
+						showSuggestions={ showSuggestions }
+						suggestionsQuery={ suggestionsQuery }
+						withURLSuggestion={ ! noURLSuggestion }
+						createSuggestionButtonText={
+							createSuggestionButtonText
+						}
+						hideLabelFromVision={ ! showTextControl }
+						isEntity={ isEntity }
+						suffix={
+							<SearchSuffixControl
+								isEntity={ isEntity }
+								showActions={ showActions }
+								isDisabled={ isDisabled }
+								onUnlink={ handleUnlink }
+								onSubmit={ handleSubmit }
+								helpTextId={ helpTextId }
+							/>
+						}
+					/>
+					{ isEntity && helpTextId && (
+						<p
+							id={ helpTextId }
+							className="block-editor-link-control__help"
+						>
+							{ sprintf(
+								/* translators: %s: entity type (e.g., page, post) */
+								__( 'Synced with the selected %s.' ),
+								internalControlValue?.type || 'item'
+							) }
+						</p>
+					) }
+				</div>
+				{ errorMessage && (
+					<Notice
+						className="block-editor-link-control__search-error"
+						status="error"
+						isDismissible={ false }
+					>
+						{ errorMessage }
+					</Notice>
+				) }
+				{ showSettings && (
+					<div className="block-editor-link-control__tools">
+						{ ! currentInputIsEmpty && (
+							<LinkControlSettingsDrawer
+								settingsOpen={ isSettingsOpen }
+								setSettingsOpen={
+									setSettingsOpenWithPreference
+								}
+							>
+								<LinkSettings
+									value={ internalControlValue }
+									settings={ settings }
+									onChange={ createSetInternalSettingValueHandler(
+										settingsKeys
+									) }
+								/>
+							</LinkControlSettingsDrawer>
+						) }
+					</div>
+				) }
+				{ showActions && (
+					<HStack
+						justify="right"
+						className="block-editor-link-control__search-actions"
+					>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ handleCancel }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ isDisabled ? noop : handleSubmit }
+							className="block-editor-link-control__search-submit"
+							aria-disabled={ isDisabled }
+						>
+							{ __( 'Apply' ) }
+						</Button>
+					</HStack>
+				) }
+			</>
+		);
+	};
+
+	// When in dropdown mode, wrap everything in a Dropdown
+	if ( useDropdownMode ) {
+		// If there's no value, show editing content directly (dropdown opens automatically)
+		const shouldShowEditing = isEditing || ! value || ! value.url;
+
+		return (
+			<div
+				tabIndex={ -1 }
+				ref={ wrapperNode }
+				className="block-editor-link-control"
+			>
+				{ isCreatingPage && (
+					<div className="block-editor-link-control__loading">
+						<Spinner /> { __( 'Creating' ) }…
+					</div>
+				) }
+
+				{ shouldShowEditing && ! value && (
+					// Show editing content directly when there's no value
+					<DropdownContentWrapper paddingSize="none">
+						<div className="block-editor-link-control__dropdown-content">
+							{ renderEditingContent() }
+						</div>
+					</DropdownContentWrapper>
+				) }
+
+				{ value && ! isCreatingPage && (
+					<Dropdown
+						popoverProps={ popoverProps }
+						className="block-editor-link-control__dropdown"
+						renderToggle={ ( { onToggle, isOpen } ) => {
+							// Store the toggle function so actions can close the dropdown
+							dropdownToggleRef.current = onToggle;
+
+							// Sync dropdown state with our internal state
+							if ( isOpen !== isDropdownOpen ) {
+								handleDropdownToggle( isOpen );
+							}
+
+							return (
+								<LinkPreview
+									key={ previewValue?.url }
+									value={ previewValue }
+									onToggle={ onToggle }
+									isOpen={ isOpen }
+									hasRichPreviews={ hasRichPreviews }
+									hasUnlinkControl={ shownUnlinkControl }
+									hasCopyControl={ hasCopyControl }
+									onRemove={ () => {
+										onRemove();
+										onToggle();
+									} }
+								/>
+							);
+						} }
+						renderContent={ () => (
+							<DropdownContentWrapper paddingSize="none">
+								<div className="block-editor-link-control__dropdown-content">
+									{ renderEditingContent() }
+								</div>
+							</DropdownContentWrapper>
+						) }
+					/>
+				) }
+
+				{ ! isCreatingPage &&
+					renderControlBottom &&
+					renderControlBottom() }
+			</div>
+		);
+	}
+
+	// Original non-dropdown mode
 	return (
 		<div
 			tabIndex={ -1 }
@@ -433,82 +665,7 @@ function LinkControl( {
 				</div>
 			) }
 
-			{ isEditing && (
-				<>
-					<div
-						className={ clsx( {
-							'block-editor-link-control__search-input-wrapper': true,
-							'has-text-control': showTextControl,
-							'has-actions': showActions,
-						} ) }
-					>
-						{ showTextControl && (
-							<TextControl
-								__nextHasNoMarginBottom
-								ref={ textInputRef }
-								className="block-editor-link-control__field block-editor-link-control__text-content"
-								label={ __( 'Text' ) }
-								value={ internalControlValue?.title }
-								onChange={ setInternalTextInputValue }
-								onKeyDown={ handleSubmitWithEnter }
-								__next40pxDefaultSize
-							/>
-						) }
-						<LinkControlSearchInput
-							ref={ searchInputRef }
-							currentLink={ value }
-							className="block-editor-link-control__field block-editor-link-control__search-input"
-							placeholder={ searchInputPlaceholder }
-							value={ currentUrlInputValue }
-							withCreateSuggestion={ withCreateSuggestion }
-							onCreateSuggestion={ createPage }
-							onChange={ setInternalURLInputValue }
-							onSelect={ handleSelectSuggestion }
-							showInitialSuggestions={ showInitialSuggestions }
-							allowDirectEntry={ ! noDirectEntry }
-							showSuggestions={ showSuggestions }
-							suggestionsQuery={ suggestionsQuery }
-							withURLSuggestion={ ! noURLSuggestion }
-							createSuggestionButtonText={
-								createSuggestionButtonText
-							}
-							hideLabelFromVision={ ! showTextControl }
-							isEntity={ isEntity }
-							suffix={
-								<SearchSuffixControl
-									isEntity={ isEntity }
-									showActions={ showActions }
-									isDisabled={ isDisabled }
-									onUnlink={ handleUnlink }
-									onSubmit={ handleSubmit }
-									helpTextId={ helpTextId }
-								/>
-							}
-						/>
-						{ isEntity && helpTextId && (
-							<p
-								id={ helpTextId }
-								className="block-editor-link-control__help"
-							>
-								{ sprintf(
-									/* translators: %s: entity type (e.g., page, post) */
-									__( 'Synced with the selected %s.' ),
-									internalControlValue?.type || 'item'
-								) }
-							</p>
-						) }
-					</div>
-					{ errorMessage && (
-						<Notice
-							className="block-editor-link-control__search-error"
-							status="error"
-							isDismissible={ false }
-						>
-							{ errorMessage }
-						</Notice>
-					) }
-				</>
-			) }
+			{ isEditing && renderEditingContent() }
 
 			{ value && ! isEditingLink && ! isCreatingPage && (
 				<LinkPreview
@@ -523,49 +680,6 @@ function LinkControl( {
 						setIsEditingLink( true );
 					} }
 				/>
-			) }
-
-			{ showSettings && (
-				<div className="block-editor-link-control__tools">
-					{ ! currentInputIsEmpty && (
-						<LinkControlSettingsDrawer
-							settingsOpen={ isSettingsOpen }
-							setSettingsOpen={ setSettingsOpenWithPreference }
-						>
-							<LinkSettings
-								value={ internalControlValue }
-								settings={ settings }
-								onChange={ createSetInternalSettingValueHandler(
-									settingsKeys
-								) }
-							/>
-						</LinkControlSettingsDrawer>
-					) }
-				</div>
-			) }
-
-			{ showActions && (
-				<HStack
-					justify="right"
-					className="block-editor-link-control__search-actions"
-				>
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ handleCancel }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						onClick={ isDisabled ? noop : handleSubmit }
-						className="block-editor-link-control__search-submit"
-						aria-disabled={ isDisabled }
-					>
-						{ __( 'Apply' ) }
-					</Button>
-				</HStack>
 			) }
 
 			{ ! isCreatingPage && renderControlBottom && renderControlBottom() }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -143,6 +143,7 @@ function LinkControl( {
 	hasTextControl = false,
 	renderControlBottom = null,
 	handleEntities = false,
+	hasCopyControl = true,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -516,6 +517,7 @@ function LinkControl( {
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
+					hasCopyControl={ hasCopyControl }
 					onRemove={ () => {
 						onRemove();
 						setIsEditingLink( true );

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -55,6 +55,8 @@ export default function LinkPreview( {
 	hasUnlinkControl = false,
 	hasCopyControl = true,
 	onRemove,
+	onToggle,
+	isOpen,
 } ) {
 	const showIconLabels = useSelect(
 		( select ) =>
@@ -102,19 +104,45 @@ export default function LinkPreview( {
 		} );
 	} );
 
+	const containerProps = onToggle
+		? {
+				role: 'button',
+				'aria-label': __( 'Edit link' ),
+				'aria-expanded': isOpen,
+				onClick: onToggle,
+				onKeyDown: ( event ) => {
+					if ( event.key === 'Enter' || event.key === ' ' ) {
+						event.preventDefault();
+						onToggle();
+					}
+				},
+				tabIndex: 0,
+				className: clsx( 'block-editor-link-control__search-item', {
+					'is-current': true,
+					'is-rich': hasRichData,
+					'is-fetching': !! isFetching,
+					'is-preview': true,
+					'is-error': isEmptyURL,
+					'is-url-title': displayTitle === displayURL,
+					'is-dropdown-toggle': true,
+					'is-open': isOpen,
+				} ),
+		  }
+		: {
+				role: 'group',
+				'aria-label': __( 'Manage link' ),
+				className: clsx( 'block-editor-link-control__search-item', {
+					'is-current': true,
+					'is-rich': hasRichData,
+					'is-fetching': !! isFetching,
+					'is-preview': true,
+					'is-error': isEmptyURL,
+					'is-url-title': displayTitle === displayURL,
+				} ),
+		  };
+
 	return (
-		<div
-			role="group"
-			aria-label={ __( 'Manage link' ) }
-			className={ clsx( 'block-editor-link-control__search-item', {
-				'is-current': true,
-				'is-rich': hasRichData,
-				'is-fetching': !! isFetching,
-				'is-preview': true,
-				'is-error': isEmptyURL,
-				'is-url-title': displayTitle === displayURL,
-			} ) }
-		>
+		<div { ...containerProps }>
 			<div className="block-editor-link-control__search-item-top">
 				<span
 					className="block-editor-link-control__search-item-header"
@@ -163,7 +191,7 @@ export default function LinkPreview( {
 				<Button
 					icon={ pencil }
 					label={ __( 'Edit link' ) }
-					onClick={ onEditClick }
+					onClick={ onToggle || onEditClick }
 					size="compact"
 					showTooltip={ ! showIconLabels }
 				/>

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -167,7 +167,12 @@ export default function LinkPreview( {
 							<>
 								<ExternalLink
 									className="block-editor-link-control__search-item-title"
-									href={ value.url }
+									href={ onToggle ? undefined : value.url }
+									onClick={
+										onToggle
+											? ( e ) => e.preventDefault()
+											: undefined
+									}
 								>
 									<Truncate numberOfLines={ 1 }>
 										{ displayTitle }
@@ -188,14 +193,16 @@ export default function LinkPreview( {
 						) }
 					</span>
 				</span>
-				<Button
-					icon={ pencil }
-					label={ __( 'Edit link' ) }
-					onClick={ onToggle || onEditClick }
-					size="compact"
-					showTooltip={ ! showIconLabels }
-				/>
-				{ hasUnlinkControl && (
+				{ ! onToggle && (
+					<Button
+						icon={ pencil }
+						label={ __( 'Edit link' ) }
+						onClick={ onEditClick }
+						size="compact"
+						showTooltip={ ! showIconLabels }
+					/>
+				) }
+				{ ! onToggle && hasUnlinkControl && (
 					<Button
 						icon={ linkOff }
 						label={ __( 'Remove link' ) }

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -64,6 +64,85 @@ export default function LinkPreview( {
 		[]
 	);
 
+	// Get entity type name and status from value props (for entity links)
+	const getEntityDisplayInfo = () => {
+		// Only process if we have an entity ID
+		if ( ! value?.id || ! value?.kind || ! value?.type ) {
+			return { entityTypeName: null, entityStatus: null };
+		}
+
+		const isPostType = value.kind === 'post-type';
+		const isTaxonomy = value.kind === 'taxonomy';
+
+		if ( ! isPostType && ! isTaxonomy ) {
+			return { entityTypeName: null, entityStatus: null };
+		}
+
+		// Get entity type name
+		let typeName = value.type;
+		if ( isPostType ) {
+			switch ( value.type ) {
+				case 'post':
+					typeName = __( 'Post' );
+					break;
+				case 'page':
+					typeName = __( 'Page' );
+					break;
+				default:
+					typeName = value.type;
+			}
+		} else {
+			switch ( value.type ) {
+				case 'category':
+					typeName = __( 'Category' );
+					break;
+				case 'tag':
+					typeName = __( 'Tag' );
+					break;
+				default:
+					typeName = __( 'Term' );
+			}
+		}
+
+		// Get status from value.status if provided, otherwise default
+		// For taxonomies, always show "Published"
+		let status = null;
+		if ( isTaxonomy ) {
+			status = __( 'Published' );
+		} else if ( value.status ) {
+			// Status can be passed in the value prop
+			switch ( value.status ) {
+				case 'publish':
+					status = __( 'Published' );
+					break;
+				case 'draft':
+					status = __( 'Draft' );
+					break;
+				case 'pending':
+					status = __( 'Pending' );
+					break;
+				case 'private':
+					status = __( 'Private' );
+					break;
+				case 'future':
+					status = __( 'Scheduled' );
+					break;
+				default:
+					status = value.status;
+			}
+		} else {
+			// Default to Published if no status provided
+			status = __( 'Published' );
+		}
+
+		return {
+			entityTypeName: typeName,
+			entityStatus: status,
+		};
+	};
+
+	const { entityTypeName, entityStatus } = getEntityDisplayInfo();
+
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
@@ -72,9 +151,13 @@ export default function LinkPreview( {
 	// Rich data may be an empty object so test for that.
 	const hasRichData = richData && Object.keys( richData ).length;
 
+	// For entity links, show entity type and status instead of URL
 	const displayURL =
-		( value && filterURLForDisplay( safeDecodeURI( value.url ), 24 ) ) ||
-		'';
+		entityTypeName && entityStatus
+			? `${ entityTypeName } - ${ entityStatus }`
+			: ( value &&
+					filterURLForDisplay( safeDecodeURI( value.url ), 24 ) ) ||
+			  '';
 
 	// url can be undefined if the href attribute is unset
 	const isEmptyURL = ! value?.url?.length;

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -53,6 +53,7 @@ export default function LinkPreview( {
 	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
+	hasCopyControl = true,
 	onRemove,
 } ) {
 	const showIconLabels = useSelect(
@@ -175,15 +176,17 @@ export default function LinkPreview( {
 						showTooltip={ ! showIconLabels }
 					/>
 				) }
-				<Button
-					icon={ copySmall }
-					label={ __( 'Copy link' ) }
-					ref={ ref }
-					accessibleWhenDisabled
-					disabled={ isEmptyURL }
-					size="compact"
-					showTooltip={ ! showIconLabels }
-				/>
+				{ hasCopyControl && (
+					<Button
+						icon={ copySmall }
+						label={ __( 'Copy link' ) }
+						ref={ ref }
+						accessibleWhenDisabled
+						disabled={ isEmptyURL }
+						size="compact"
+						showTooltip={ ! showIconLabels }
+					/>
+				) }
 				<ViewerSlot fillProps={ value } />
 			</div>
 		</div>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -18,9 +18,10 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control {
 	position: relative;
+	min-width: auto;
 
 	.components-popover__content & {
-		min-width: auto;
+
 		width: 90vw;
 		max-width: $modal-min-width;
 		min-width: $modal-min-width;
@@ -423,9 +424,9 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
-.block-editor-link-control__search-input {
-	min-width: auto !important;
-}
+// .block-editor-link-control__search-input {
+// 	min-width: auto !important;
+// }
 
 .block-editor-link-control .block-editor-link-control__search-input .components-spinner {
 	display: block;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -174,6 +174,10 @@ $block-editor-link-control-number-of-actions: 1;
 		padding: $grid-unit-20;
 	}
 
+	&.is-dropdown-toggle {
+		border: 1px solid var(--wp-components-color-gray-600, #949494);
+	}
+
 	.block-editor-link-control__search-item-header {
 		display: block;
 		flex-direction: row;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -473,3 +473,7 @@ $block-editor-link-control-number-of-actions: 1;
 	top: calc(50% + #{$spinner-size} / 4); // Add top spacing because this input has a visual label.
 	right: $grid-unit-15;
 }
+
+.block-editor-link-control__dropdown{
+	display: block;
+}

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -176,6 +176,31 @@ $block-editor-link-control-number-of-actions: 1;
 
 	&.is-dropdown-toggle {
 		border: 1px solid var(--wp-components-color-gray-600, #949494);
+		cursor: pointer !important;
+		transition: background-color 0.1s ease, border-color 0.1s ease;
+
+		&:hover {
+			background-color: var(--wp-components-color-gray-100, #f0f0f0);
+			border-color: var(--wp-components-color-gray-700, #757575);
+		}
+
+		&:focus {
+			outline: 2px solid transparent;
+			box-shadow: 0 0 0 1px var(--wp-components-color-accent, var(--wp-admin-theme-color, #2271b1));
+		}
+
+		&.is-open {
+			background-color: var(--wp-components-color-gray-50, #fafafa);
+		}
+
+		.block-editor-link-control__search-item-title {
+			cursor: pointer;
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: none;
+			}
+		}
 	}
 
 	.block-editor-link-control__search-item-header {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -18,12 +18,12 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control {
 	position: relative;
-	min-width: $modal-min-width;
 
 	.components-popover__content & {
 		min-width: auto;
 		width: 90vw;
 		max-width: $modal-min-width;
+		min-width: $modal-min-width;
 	}
 
 	.show-icon-labels & {
@@ -421,6 +421,10 @@ $block-editor-link-control-number-of-actions: 1;
 			}
 		}
 	}
+}
+
+.block-editor-link-control__search-input {
+	min-width: auto !important;
 }
 
 .block-editor-link-control .block-editor-link-control__search-input .components-spinner {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -540,6 +540,7 @@ export default function NavigationLinkEdit( {
 						hasTextControl
 						hasRichPreviews
 						hasCopyControl={ false }
+						useDropdownMode={ true }
 						className="wp-block-navigation-link__inline-link-input"
 						value={ testLink }
 						showInitialSuggestions={ true }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -23,7 +23,11 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 	useInnerBlocksProps,
+<<<<<<< HEAD
 	useBlockEditingMode,
+=======
+	__experimentalLinkControl as LinkControl,
+>>>>>>> 9fd8fde7cfa (Implement proof of concept)
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
@@ -35,6 +39,12 @@ import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+<<<<<<< HEAD
+=======
+import { name } from './block.json';
+import { LinkUI, getSuggestionsQuery } from './link-ui';
+import { updateAttributes } from './update-attributes';
+>>>>>>> 9fd8fde7cfa (Implement proof of concept)
 import { getColors } from '../navigation/edit/utils';
 import {
 	Controls,
@@ -497,6 +507,12 @@ export default function NavigationLinkEdit( {
 		isInvalid ? __( 'Invalid' ) : __( 'Draft' )
 	})`;
 
+	const testLink = {
+		url,
+		opensInNewTab: attributes?.opensInNewTab,
+		title: label && stripHTML( label ),
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -521,11 +537,93 @@ export default function NavigationLinkEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
+<<<<<<< HEAD
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					clientId={ clientId }
 				/>
+=======
+				{ /* className="wp-block-navigation-link__inline-link-input"
+				clientId={ clientId }
+				link={ attributes }
+				onClose={ () => setIsLinkOpen( false ) }
+				anchor={ popoverAnchor }
+				hasCreateSuggestion={ userCanCreate }
+				onRemove={ removeLink }
+				onChange=
+				{ ( updatedValue ) => {
+					updateAttributes( updatedValue, setAttributes, attributes );
+				} } */ }
+
+				<PanelBody title={ __( 'Link settings' ) }>
+					<LinkControl
+						hasTextControl
+						hasRichPreviews
+						className="wp-block-navigation-link__inline-link-input"
+						value={ testLink }
+						showInitialSuggestions={ true }
+						noDirectEntry={ !! type }
+						noURLSuggestion={ !! type }
+						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
+						onChange={ ( updatedValue ) => {
+							updateAttributes(
+								updatedValue,
+								setAttributes,
+								attributes
+							);
+						} }
+						onRemove={ removeLink }
+					/>
+					<TextControl
+						value={ label ? stripHTML( label ) : '' }
+						onChange={ ( labelValue ) => {
+							setAttributes( { label: labelValue } );
+						} }
+						label={ __( 'Label' ) }
+						autoComplete="off"
+					/>
+					<TextControl
+						value={ url || '' }
+						onChange={ ( urlValue ) => {
+							updateAttributes(
+								{ url: urlValue },
+								setAttributes,
+								attributes
+							);
+						} }
+						label={ __( 'URL' ) }
+						autoComplete="off"
+					/>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						value={ description || '' }
+						onChange={ ( descriptionValue ) => {
+							setAttributes( { description: descriptionValue } );
+						} }
+						label={ __( 'Description' ) }
+						help={ __(
+							'The description will be displayed in the menu if the current theme supports it.'
+						) }
+					/>
+					<TextControl
+						value={ title || '' }
+						onChange={ ( titleValue ) => {
+							setAttributes( { title: titleValue } );
+						} }
+						label={ __( 'Link title' ) }
+						autoComplete="off"
+					/>
+					<TextControl
+						value={ rel || '' }
+						onChange={ ( relValue ) => {
+							setAttributes( { rel: relValue } );
+						} }
+						label={ __( 'Link rel' ) }
+						autoComplete="off"
+					/>
+				</PanelBody>
+>>>>>>> 9fd8fde7cfa (Implement proof of concept)
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ hasMissingEntity && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -9,6 +9,9 @@ import clsx from 'clsx';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	PanelBody,
+	TextControl,
+	TextareaControl,
 	ToolbarButton,
 	ToolbarGroup,
 	VisuallyHidden,
@@ -23,15 +26,13 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 	useInnerBlocksProps,
-<<<<<<< HEAD
 	useBlockEditingMode,
-=======
 	__experimentalLinkControl as LinkControl,
->>>>>>> 9fd8fde7cfa (Implement proof of concept)
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useInstanceId } from '@wordpress/compose';
@@ -39,12 +40,8 @@ import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-<<<<<<< HEAD
-=======
 import { name } from './block.json';
-import { LinkUI, getSuggestionsQuery } from './link-ui';
-import { updateAttributes } from './update-attributes';
->>>>>>> 9fd8fde7cfa (Implement proof of concept)
+import { getSuggestionsQuery } from './link-ui';
 import { getColors } from '../navigation/edit/utils';
 import {
 	Controls,
@@ -205,7 +202,8 @@ export default function NavigationLinkEdit( {
 	context,
 	clientId,
 } ) {
-	const { id, label, type, url, description, kind, metadata } = attributes;
+	const { id, label, type, url, description, kind, metadata, title, rel } =
+		attributes;
 	const { maxNestingLevel } = context;
 
 	const {
@@ -537,25 +535,6 @@ export default function NavigationLinkEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
-<<<<<<< HEAD
-				<Controls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-				/>
-=======
-				{ /* className="wp-block-navigation-link__inline-link-input"
-				clientId={ clientId }
-				link={ attributes }
-				onClose={ () => setIsLinkOpen( false ) }
-				anchor={ popoverAnchor }
-				hasCreateSuggestion={ userCanCreate }
-				onRemove={ removeLink }
-				onChange=
-				{ ( updatedValue ) => {
-					updateAttributes( updatedValue, setAttributes, attributes );
-				} } */ }
-
 				<PanelBody title={ __( 'Link settings' ) }>
 					<LinkControl
 						hasTextControl
@@ -575,37 +554,7 @@ export default function NavigationLinkEdit( {
 						} }
 						onRemove={ removeLink }
 					/>
-					<TextControl
-						value={ label ? stripHTML( label ) : '' }
-						onChange={ ( labelValue ) => {
-							setAttributes( { label: labelValue } );
-						} }
-						label={ __( 'Label' ) }
-						autoComplete="off"
-					/>
-					<TextControl
-						value={ url || '' }
-						onChange={ ( urlValue ) => {
-							updateAttributes(
-								{ url: urlValue },
-								setAttributes,
-								attributes
-							);
-						} }
-						label={ __( 'URL' ) }
-						autoComplete="off"
-					/>
-					<TextareaControl
-						__nextHasNoMarginBottom
-						value={ description || '' }
-						onChange={ ( descriptionValue ) => {
-							setAttributes( { description: descriptionValue } );
-						} }
-						label={ __( 'Description' ) }
-						help={ __(
-							'The description will be displayed in the menu if the current theme supports it.'
-						) }
-					/>
+
 					<TextControl
 						value={ title || '' }
 						onChange={ ( titleValue ) => {
@@ -623,7 +572,6 @@ export default function NavigationLinkEdit( {
 						autoComplete="off"
 					/>
 				</PanelBody>
->>>>>>> 9fd8fde7cfa (Implement proof of concept)
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ hasMissingEntity && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	BaseControl,
 	PanelBody,
 	TextControl,
 	TextareaControl,
@@ -580,27 +581,35 @@ export default function NavigationLinkEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
-					<LinkControl
-						hasTextControl={ false }
-						hasRichPreviews
-						hasCopyControl={ false }
-						useDropdownMode={ true }
-						handleEntities={ isBoundEntityAvailable }
-						className="wp-block-navigation-link__inline-link-input"
-						value={ testLink }
-						showInitialSuggestions={ true }
-						noDirectEntry={ !! type }
-						noURLSuggestion={ !! type }
-						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
-						onChange={ ( updatedValue ) => {
-							updateAttributes(
-								updatedValue,
-								setAttributes,
-								attributes
-							);
-						} }
-						onRemove={ removeLink }
-					/>
+					<BaseControl __nextHasNoMarginBottom>
+						<BaseControl.VisualLabel>
+							{ __( 'Link' ) }
+						</BaseControl.VisualLabel>
+						<LinkControl
+							hasTextControl={ false }
+							hasRichPreviews
+							hasCopyControl={ false }
+							useDropdownMode={ true }
+							handleEntities={ isBoundEntityAvailable }
+							className="wp-block-navigation-link__inline-link-input"
+							value={ testLink }
+							showInitialSuggestions={ true }
+							noDirectEntry={ !! type }
+							noURLSuggestion={ !! type }
+							suggestionsQuery={ getSuggestionsQuery(
+								type,
+								kind
+							) }
+							onChange={ ( updatedValue ) => {
+								updateAttributes(
+									updatedValue,
+									setAttributes,
+									attributes
+								);
+							} }
+							onRemove={ removeLink }
+						/>
+					</BaseControl>
 
 					<TextControl
 						value={ title || '' }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -304,6 +304,46 @@ export default function NavigationLinkEdit( {
 		validateLinkStatus
 	);
 
+	// Fetch entity title for entity links
+	const entityTitle = useSelect(
+		( select ) => {
+			// Only fetch if we have an entity ID
+			if ( ! id || ! kind || ! type ) {
+				return null;
+			}
+
+			const { getEntityRecord } = select( coreStore );
+			const isPostType = kind === 'post-type';
+			const isTaxonomy = kind === 'taxonomy';
+
+			if ( ! isPostType && ! isTaxonomy ) {
+				return null;
+			}
+
+			try {
+				const entityType = isTaxonomy ? 'taxonomy' : 'postType';
+				const typeForAPI = type === 'tag' ? 'post_tag' : type;
+				const entityRecord = getEntityRecord(
+					entityType,
+					typeForAPI,
+					id
+				);
+
+				if ( ! entityRecord ) {
+					return null;
+				}
+
+				// For posts, use title.rendered; for taxonomies, use name
+				return isPostType
+					? entityRecord.title?.rendered || entityRecord.title
+					: entityRecord.name;
+			} catch {
+				return null;
+			}
+		},
+		[ id, kind, type ]
+	);
+
 	/**
 	 * Transform to submenu block.
 	 */
@@ -508,7 +548,11 @@ export default function NavigationLinkEdit( {
 	const testLink = {
 		url,
 		opensInNewTab: attributes?.opensInNewTab,
-		title: label && stripHTML( label ),
+		// Use entity title if available (for entity links), otherwise use label
+		title: entityTitle || ( label && stripHTML( label ) ),
+		kind,
+		type,
+		id,
 	};
 
 	return (
@@ -541,6 +585,7 @@ export default function NavigationLinkEdit( {
 						hasRichPreviews
 						hasCopyControl={ false }
 						useDropdownMode={ true }
+						handleEntities={ isBoundEntityAvailable }
 						className="wp-block-navigation-link__inline-link-input"
 						value={ testLink }
 						showInitialSuggestions={ true }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -53,8 +53,6 @@ import {
 } from './shared';
 import { unlock } from '../lock-unlock';
 
-const { Badge } = unlock( componentsPrivateApis );
-
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
 	'core/navigation-link',
@@ -308,12 +306,12 @@ export default function NavigationLinkEdit( {
 		validateLinkStatus
 	);
 
-	// Fetch entity title for entity links
-	const entityTitle = useSelect(
+	// Fetch entity title and status for entity links
+	const { entityTitle, entityStatus } = useSelect(
 		( select ) => {
 			// Only fetch if we have an entity ID
 			if ( ! id || ! kind || ! type ) {
-				return null;
+				return { entityTitle: null, entityStatus: null };
 			}
 
 			const { getEntityRecord } = select( coreStore );
@@ -321,7 +319,7 @@ export default function NavigationLinkEdit( {
 			const isTaxonomy = kind === 'taxonomy';
 
 			if ( ! isPostType && ! isTaxonomy ) {
-				return null;
+				return { entityTitle: null, entityStatus: null };
 			}
 
 			try {
@@ -334,15 +332,25 @@ export default function NavigationLinkEdit( {
 				);
 
 				if ( ! entityRecord ) {
-					return null;
+					return { entityTitle: null, entityStatus: null };
 				}
 
 				// For posts, use title.rendered; for taxonomies, use name
-				return isPostType
+				const title = isPostType
 					? entityRecord.title?.rendered || entityRecord.title
 					: entityRecord.name;
+
+				// Get status (for post types) or use 'publish' for taxonomies
+				const status = isTaxonomy
+					? 'publish'
+					: entityRecord.status || 'draft';
+
+				return {
+					entityTitle: title,
+					entityStatus: status,
+				};
 			} catch {
-				return null;
+				return { entityTitle: null, entityStatus: null };
 			}
 		},
 		[ id, kind, type ]
@@ -557,6 +565,8 @@ export default function NavigationLinkEdit( {
 		kind,
 		type,
 		id,
+		// Pass status for entity links so LinkPreview can display it
+		status: entityStatus,
 	};
 
 	return (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -539,6 +539,7 @@ export default function NavigationLinkEdit( {
 					<LinkControl
 						hasTextControl
 						hasRichPreviews
+						hasCopyControl={ false }
 						className="wp-block-navigation-link__inline-link-input"
 						value={ testLink }
 						showInitialSuggestions={ true }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -581,7 +581,7 @@ export default function NavigationLinkEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<LinkControl
-						hasTextControl
+						hasTextControl={ false }
 						hasRichPreviews
 						hasCopyControl={ false }
 						useDropdownMode={ true }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -626,6 +626,14 @@ export default function NavigationLinkEdit( {
 					</BaseControl>
 
 					<TextControl
+						value={ label || '' }
+						onChange={ ( labelValue ) => {
+							setAttributes( { label: labelValue } );
+						} }
+						label={ __( 'Label' ) }
+						autoComplete="off"
+					/>
+					<TextControl
 						value={ title || '' }
 						onChange={ ( titleValue ) => {
 							setAttributes( { title: titleValue } );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -12,10 +12,10 @@ import {
 	BaseControl,
 	PanelBody,
 	TextControl,
-	TextareaControl,
 	ToolbarButton,
 	ToolbarGroup,
 	VisuallyHidden,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
@@ -51,6 +51,9 @@ import {
 	useEntityBinding,
 	MissingEntityHelpText,
 } from './shared';
+import { unlock } from '../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
@@ -585,6 +588,7 @@ export default function NavigationLinkEdit( {
 						<BaseControl.VisualLabel>
 							{ __( 'Link' ) }
 						</BaseControl.VisualLabel>
+
 						<LinkControl
 							hasTextControl={ false }
 							hasRichPreviews

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -151,6 +151,3 @@
 	color: $alert-red;
 }
 
-.wp-block-navigation-link__inline-link-input {
-	margin-bottom: 16px;
-}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -150,3 +150,7 @@
 .navigation-link-control__error-text {
 	color: $alert-red;
 }
+
+.wp-block-navigation-link__inline-link-input {
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
## Description

This is a prototype PR implementing enhanced link editing and management in the Navigation Block sidebar, addressing the requirements outlined in #73043.

## Changes

- Added LinkControl to Navigation Link block sidebar using a dropdown pattern
- LinkPreview acts as the toggle button for the dropdown
- Entity type and post status are displayed instead of URL for entity links
- Added Label TextControl above Link title field
- Implemented handleEntities support for entity-bound links
- Added visual styling for dropdown toggle behavior

## Related Issue

Fixes #73043

## Testing

- Test link creation and editing in Navigation sidebar
- Verify entity links show type and status correctly
- Test dropdown toggle behavior
- Verify label field updates correctly