### PR TITLE
Block Editor: Restore ToolSelector component for backward compatibility

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -847,6 +847,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#registerStore>
 
+### ToolSelector
+
+This component has been deprecated and no longer renders anything.
+
 ### transformStyles
 
 Applies a series of CSS rule transforms to wrap selectors inside a given class and/or rewrite URLs depending on the parameters passed.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -172,3 +172,7 @@ export { useBlockEditingMode } from './block-editing-mode';
 export { default as BlockEditorProvider } from './provider';
 export { useSettings, useSetting } from './use-settings';
 export { useBlockCommands } from './use-block-commands';
+
+// This component is no longer used in Gutenberg,
+// but kept for backwards compatibility.
+export { default as ToolSelector } from './tool-selector';

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+import { forwardRef } from '@wordpress/element';
+
+function ToolSelector() {
+	deprecated( 'wp.blockEditor.ToolSelector', {
+		since: '6.9',
+		hint: 'The ToolSelector component no longer renders anything.',
+	} );
+
+	return null;
+}
+
+/**
+ * This component has been deprecated and no longer renders anything.
+ */
+export default forwardRef( ToolSelector );


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/72193#issuecomment-3580522952

## What?

This PR restores the `ToolsSelector` component, which renders nothing for backward compatibility.

## Why?

This component is probably not widely used by consumers, but since it is a public component, it cannot simply be removed. In fact, it caused problems in the pattern directory. See https://github.com/WordPress/pattern-directory/pull/730

## How?
Restore the component with a deprecation message.

## Testing Instructions

For example, use the component as follows:

```diff
diff --git a/packages/editor/src/components/document-tools/index.js b/packages/editor/src/components/document-tools/index.js
index 0a24373ab36..955c70a13cc 100644
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
-import { NavigableToolbar } from '@wordpress/block-editor';
+import { NavigableToolbar, ToolSelector } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
@@ -126,6 +126,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
                                ) }
                                { ( isWideViewport || ! showIconLabels ) && (
                                        <>
+                                               <ToolbarItem as={ ToolSelector } size="compact" />
                                                <ToolbarItem
                                                        as={ EditorHistoryUndo }
                                                        showTooltip={ ! showIconLabels }
```

- Open the editor.
- Confirm that your browser console show the following wargnin message:
  ```
  wp.blockEditor.ToolSelector is deprecated since version 6.9. Note: ToolSelector has been removed and no longer renders anything.
  ```