### PR TITLE
Docs: Clarify asset filename behavior for DependencyExtractionWebpackPlugin

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -137,10 +137,28 @@ For example:
 // Source file entrypoint.js
 import { store, getContext } from '@wordpress/interactivity';
 
-// Webpack will produce the output output/entrypoint.js
-/* bundled JavaScript output */
+/*
+ * Depending on your webpack configuration, the output filename used for the
+ * bundled script may differ from the entry point name. The Dependency
+ * Extraction Webpack Plugin will always generate the corresponding asset
+ * metadata file based on the final output filename.
+ *
+ * Examples:
+ * - With @wordpress/scripts default config:
+ *     build/main.js
+ *     build/main.asset.php
+ *
+ * - With a custom filename:
+ *     output/bunny-plugin-entrypoint.min.js
+ *     output/bunny-plugin-entrypoint.min.asset.php
+ *
+ * In all cases, the asset file is named:
+ *
+ *     <output-filename>.asset.php
+ *
+ * and contains the dependency list and a version hash.
+ */
 
-// Webpack will also produce output/entrypoint.asset.php declaring script dependencies
 <?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => 'dd4c2dc50d046ed9d4c063a7ca95702f');
 ```
 


### PR DESCRIPTION
## What?

This PR updates the documentation for `@wordpress/dependency-extraction-webpack-plugin` to clarify how the asset filename is determined.

The previous example suggested that the asset file is always named after the entry point (e.g. `entrypoint.asset.php`), which can be misleading.

This update explains the correct behavior:

- The asset filename is based on the **final webpack output filename**, not the entry point name.
- New examples demonstrate both default `@wordpress/scripts` output and custom `output.filename` usage.

## Why?

Developers using custom webpack output filenames were confused when the documentation implied that asset files always follow the entry point name. This resulted in mismatches between expected and actual generated `.asset.php` files.

Clarifying that the plugin derives the asset filename from the **final output filename** removes this ambiguity and reflects the actual behavior.

## How?

Documentation-only changes:

- Replaced the old example referencing `output/entrypoint.js` and `output/entrypoint.asset.php`.
- Added a clearer explanation using `<output-filename>.asset.php`.
- Added accurate examples for different webpack configurations.

No runtime or behavioral changes are included.

## Testing Instructions

1. Review the updated README section.
2. Confirm that the examples correctly reflect how webpack generates output filenames.
3. Verify that the asset file name matches the final output filename in real builds.

## Screenshots

N/A — documentation change only.