### PR TITLE
Fix: Align Document Outline padding in List View sidebar to match surrounding panels (#73576)

### DIFF
--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -2,8 +2,6 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .document-outline {
-	margin: 0;
-
 	ul {
 		margin: 0;
 		padding: 0;

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .document-outline {
-	margin: 20px 0;
+	margin: 0;
 
 	ul {
 		margin: 0;

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -22,9 +22,22 @@
 	// This allows items in the list view to have equidistant padding left and right
 	// right up until a scrollbar is present.
 	scrollbar-gutter: auto;
+}
 
-	// The table cells use an extra pixels of space left and right. We compensate for that here.
+// The table cells use an extra pixels of space left and right. We compensate for that here.
+.editor-list-view-sidebar__list-view-panel-content {
+	// Keep the original padding for the List View panel so its spacing matches trunk.
 	padding: $grid-unit-05;
+}
+
+// Apply the new padding only to the Document Outline panel.
+.editor-list-view-sidebar__list-view-container > .document-outline {
+	padding: $grid-unit-20;
+
+	// Reset the top margin to avoid stacking margin + padding (previously 36px total).
+	.document-outline__summary {
+		margin-top: 0;
+	}
 }
 
 .editor-list-view-sidebar__list-view-container {

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -24,16 +24,14 @@
 	scrollbar-gutter: auto;
 }
 
-// The table cells use an extra pixels of space left and right. We compensate for that here.
+// The table cells use a few extra pixels of horizontal space.
+// Apply compensating padding for the List View panel.
 .editor-list-view-sidebar__list-view-panel-content {
-	// Keep the original padding for the List View panel so its spacing matches trunk.
 	padding: $grid-unit-05;
 }
 
-// Apply the new padding only to the Document Outline panel.
+// Match the Outline panel’s padding with the surrounding panels.
 .editor-list-view-sidebar__list-view-container > .document-outline {
-	// Override the global top margin (20px) so it doesn’t stack with the new padding.
-	margin-top: 0;
 	padding: $grid-unit-20;
 }
 

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -24,19 +24,19 @@
 	scrollbar-gutter: auto;
 }
 
+// The table cells use an extra pixels of space left and right. We compensate for that here.
 .editor-list-view-sidebar__list-view-panel-content {
 	padding: $grid-unit-05;
-}
-
-// Match the Outline panel’s padding with the surrounding panels.
-.editor-list-view-sidebar__list-view-container > .document-outline {
-	padding: $grid-unit-20;
 }
 
 .editor-list-view-sidebar__list-view-container {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+
+	> .document-outline {
+		padding: $grid-unit-20;
+	}
 }
 
 .editor-list-view-sidebar__tab-panel {

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -24,8 +24,6 @@
 	scrollbar-gutter: auto;
 }
 
-// The table cells use a few extra pixels of horizontal space.
-// Apply compensating padding for the List View panel.
 .editor-list-view-sidebar__list-view-panel-content {
 	padding: $grid-unit-05;
 }

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -32,12 +32,9 @@
 
 // Apply the new padding only to the Document Outline panel.
 .editor-list-view-sidebar__list-view-container > .document-outline {
+	// Override the global top margin (20px) so it doesn’t stack with the new padding.
+	margin-top: 0;
 	padding: $grid-unit-20;
-
-	// Reset the top margin to avoid stacking margin + padding (previously 36px total).
-	.document-outline__summary {
-		margin-top: 0;
-	}
 }
 
 .editor-list-view-sidebar__list-view-container {


### PR DESCRIPTION
## What?

This PR fixes inconsistent padding inside the Outline panel in the List View sidebar.  
Closes: #73576

Previously, the `.document-outline` area had no padding, causing the content to touch the left/right edges while the statistics block above (“Characters / Words / Time to read”) had proper spacing. This created a visual imbalance.

## Why?

To improve UI consistency and readability.  
The Outline panel is part of the same sidebar group, so its spacing should visually match the panels above it.

## How?

Updated SCSS in:

`packages/editor/src/components/list-view-sidebar/style.scss`

Changes include:

- Restored the original List View panel padding (`$grid-unit-05`) so its spacing matches trunk.
- Applied the new padding (`$grid-unit-20`) only to `.document-outline`.
- Overrode the global top margin on `.document-outline` (`margin-top: 0`) so it doesn’t stack with the new padding.

This ensures consistent spacing in the Outline panel without affecting the List View panel layout.


## Testing Instructions

1. Open the block editor.
2. Open List View → Outline tab.
3. Check that:
   - The Outline list has padding on all sides.
   - It visually aligns with the “Characters / Words / Time to read” stats panel.
4. Scroll inside the Outline panel to confirm scrollbar behavior remains correct.
5. Resize the editor window and ensure no layout shift or regression.

## Keyboard Testing

1. Use Tab to move focus into List View.
2. Navigate into the Outline panel with arrow keys.
3. Ensure:
   - The focus outline is fully visible (not clipped).
   - Navigation order is unchanged.
   - Padding does not interfere with focus movement.

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/38d87ae2-fb95-4442-b627-04c5638eb539) | ![After](https://github.com/user-attachments/assets/6cd4b87f-fee6-4d8f-ae3e-69e40a32b626) |