### PR TITLE
@wordpress/data: migrate `index.js` to `index.ts`

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -516,10 +516,6 @@ _Related_
 
 -   [use](#use)
 
-_Type_
-
--   `Object`
-
 ### register
 
 Registers a standard `@wordpress/data` store descriptor.

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,11 +1,21 @@
 /**
  * Internal dependencies
  */
-import defaultRegistry from './default-registry';
+import defaultRegistryUntyped from './default-registry';
 import * as plugins from './plugins';
 import { combineReducers as combineReducersModule } from './redux-store';
 
-/** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
+import type {
+	StoreDescriptor,
+	ReduxStoreConfig,
+	combineReducers as CombineReducers,
+} from './types';
+
+// The runtime registry is created from the JavaScript implementation in `registry.js`.
+// Its JSDoc type (`WPDataRegistry`) doesn't include some newer methods like
+// `resolveSelect` or `suspendSelect`, so we widen the type here for the typed
+// exports in this module.
+const defaultRegistry: any = defaultRegistryUntyped;
 
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
@@ -29,12 +39,12 @@ export { default as createReduxStore } from './redux-store';
 export { dispatch } from './dispatch';
 export { select } from './select';
 
+export * from './types';
+
 /**
  * Object of available plugins to use with a registry.
  *
  * @see [use](#use)
- *
- * @type {Object}
  */
 export { plugins };
 
@@ -77,12 +87,14 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
-export const combineReducers = combineReducersModule;
+export const combineReducers =
+	combineReducersModule as unknown as CombineReducers;
 
 /**
- * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
- * so that you only need to supply additional arguments, and modified so that they return promises
- * that resolve to their eventual values, after any resolvers have ran.
+ * Given a store descriptor, returns an object containing the store's selectors
+ * pre-bound to state so that you only need to supply additional arguments, and
+ * modified so that they return promises that resolve to their eventual values,
+ * after any resolvers have ran.
  *
  * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
  *                                                       convention of passing the store name is
@@ -98,7 +110,11 @@ export const combineReducers = combineReducersModule;
  *
  * @return {Object} Object containing the store's promise-wrapped selectors.
  */
-export const resolveSelect = defaultRegistry.resolveSelect;
+export const resolveSelect = (
+	storeNameOrDescriptor:
+		| string
+		| StoreDescriptor< ReduxStoreConfig< any, any, any > >
+): any => defaultRegistry.resolveSelect( storeNameOrDescriptor );
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
@@ -111,7 +127,11 @@ export const resolveSelect = defaultRegistry.resolveSelect;
  *
  * @return {Object} Object containing the store's suspense-wrapped selectors.
  */
-export const suspendSelect = defaultRegistry.suspendSelect;
+export const suspendSelect = (
+	storeNameOrDescriptor:
+		| string
+		| StoreDescriptor< ReduxStoreConfig< any, any, any > >
+): any => defaultRegistry.suspendSelect( storeNameOrDescriptor );
 
 /**
  * Given a listener function, the function will be called any time the state value
@@ -137,7 +157,13 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  * unsubscribe();
  * ```
  */
-export const subscribe = defaultRegistry.subscribe;
+export const subscribe = (
+	listener: () => void,
+	storeNameOrDescriptor?:
+		| string
+		| StoreDescriptor< ReduxStoreConfig< any, any, any > >
+): ( () => void ) =>
+	defaultRegistry.subscribe( listener, storeNameOrDescriptor );
 
 /**
  * Registers a generic store instance.
@@ -147,7 +173,8 @@ export const subscribe = defaultRegistry.subscribe;
  * @param {string} name  Store registry name.
  * @param {Object} store Store instance (`{ getSelectors, getActions, subscribe }`).
  */
-export const registerGenericStore = defaultRegistry.registerGenericStore;
+export const registerGenericStore: Function =
+	defaultRegistry.registerGenericStore;
 
 /**
  * Registers a standard `@wordpress/data` store.
@@ -159,7 +186,7 @@ export const registerGenericStore = defaultRegistry.registerGenericStore;
  *
  * @return {Object} Registered store object.
  */
-export const registerStore = defaultRegistry.registerStore;
+export const registerStore: Function = defaultRegistry.registerStore;
 
 /**
  * Extends a registry to inherit functionality provided by a given plugin. A
@@ -168,7 +195,7 @@ export const registerStore = defaultRegistry.registerStore;
  *
  * @param {Object} plugin Plugin object.
  */
-export const use = defaultRegistry.use;
+export const use: any = defaultRegistry.use;
 
 /**
  * Registers a standard `@wordpress/data` store descriptor.
@@ -188,4 +215,6 @@ export const use = defaultRegistry.use;
  *
  * @param {StoreDescriptor} store Store descriptor.
  */
-export const register = defaultRegistry.register;
+export const register = (
+	store: StoreDescriptor< ReduxStoreConfig< any, any, any > >
+): void => defaultRegistry.register( store );

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -18,7 +18,7 @@ export interface StoreInstance< Config extends AnyConfig > {
 	subscribe: ( listener: () => void ) => () => void;
 }
 
-export interface StoreDescriptor< Config extends AnyConfig > {
+export interface StoreDescriptor< Config extends AnyConfig = AnyConfig > {
 	/**
 	 * Store Name
 	 */

--- a/typings/wordpress__data.d.ts
+++ b/typings/wordpress__data.d.ts
@@ -1,3 +1,0 @@
-declare module '@wordpress/data' {
-	export * from '@wordpress/data/build-types/index';
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:

https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

This PR exports `@wordpress/data`’s TypeScript types from its root entrypoint and tighten the public API typings so that downstream packages (like `@wordpress/core-data` and routes) get stable, correct types without relying on internal `build-types/*` paths.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously, the core generics for `@wordpress/data` (such as `StoreDescriptor` and `ReduxStoreConfig`) were defined in `src/types.ts` and emitted to `build-types/types.d.ts`. When `@wordpress/core-data`’s declarations were generated, the `store` export ended up typed via `import("@wordpress/data/build-types/types")…`. In the monorepo and in external projects, TypeScript often couldn’t resolve that internal subpath, leading to:

> Cannot find module '@wordpress/data/build-types/types' or its corresponding type declarations.

This forced consumers to add ad‑hoc `declare module '@wordpress/data'` shims under `typings/` just to get proper type information. The goal of this PR is to make the *published* root module, `@wordpress/data`, the single canonical place to import both runtime functions and types, so that downstream `.d.ts` files no longer need to reference private internal paths.

## How?

This PR converts the .js + jsdoc approach to define types to a `.ts` fie. This allows us to export `StoreDescriptor and `ReduxStoreConfig` in the index.ts.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->


1. From `trunk`, run `npm run build`
2. Check the `packages/core-data/build-types/index.d.ts` 
3. See `export const store: import("@wordpress/data/build-types/types").StoreDescriptor<import("@wordpress/data/build-types/types").ReduxStoreConfig<any, {`

<img width="1185" height="580" alt="image" src="https://github.com/user-attachments/assets/c5f59280-4fd7-48d2-9170-3f4f51c0baf8" />

4. This import works due `typings/wordpress__data.d.ts`:

https://github.com/WordPress/gutenberg/blob/9d9dce0d9a3e9582eaaa054a50a600bee20b8cc9/typings/wordpress__data.d.ts#L1-L4

5. Checkout this branch.
6. Run `npm run build`.
7. Check the `packages/core-data/build-types/index.d.ts` 
8. See  `export const store: import("@wordpress/data").StoreDescriptor<
     import("@wordpress/data").ReduxStoreConfig<...>`
