### PR TITLE
Content only and patterns: detach edit fields from the content only experience

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -33,6 +33,10 @@ function gutenberg_enable_experiments() {
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
+		// Only enable inspector fields if both parent and sub-experiment are enabled
+		if ( array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
+			wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
+		}
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -259,31 +259,14 @@ add_action( 'admin_init', 'gutenberg_initialize_experiments_settings' );
  *
  * @since 6.3.0
  *
- * @param array $args ( $label, $id, $requires ).
+ * @param array $args ( $label, $id ).
  */
 function gutenberg_display_experiment_field( $args ) {
 	$options = get_option( 'gutenberg-experiments' );
 	$value   = isset( $options[ $args['id'] ] ) ? 1 : 0;
-
-	// Check if this experiment requires another experiment to be enabled
-	$is_disabled = false;
-	if ( isset( $args['requires'] ) ) {
-		$is_disabled = ! isset( $options[ $args['requires'] ] );
-		// If the required experiment is disabled, also disable this one
-		if ( $is_disabled && $value ) {
-			$value = 0;
-		}
-	}
 	?>
 		<label for="<?php echo $args['id']; ?>">
-			<input 
-				type="checkbox" 
-				name="<?php echo 'gutenberg-experiments[' . $args['id'] . ']'; ?>" 
-				id="<?php echo $args['id']; ?>" 
-				value="1" 
-				<?php checked( 1, $value ); ?>
-				<?php disabled( $is_disabled ); ?>
-			/>
+			<input type="checkbox" name="<?php echo 'gutenberg-experiments[' . $args['id'] . ']'; ?>" id="<?php echo $args['id']; ?>" value="1" <?php checked( 1, $value ); ?> />
 			<?php echo $args['label']; ?>
 		</label>
 	<?php
@@ -301,59 +284,23 @@ function gutenberg_display_experiment_section() {
 	<?php
 }
 
-/**
- * Handles form submission for the Gutenberg experiments settings page.
- *
- * This function processes the experiments form submission and handles:
- * 1. Template activation setting (active_templates) - managed separately from regular experiments
- * 2. Experiment dependency management - ensures sub-experiments are automatically disabled
- *    when their parent experiments are disabled
- */
-add_action( 'admin_init', 'gutenberg_handle_experiments_setting_submission' );
-function gutenberg_handle_experiments_setting_submission() {
-	// Only process submissions for the gutenberg-experiments settings page.
+add_action( 'admin_init', 'gutenberg_handle_template_activate_setting_submission' );
+function gutenberg_handle_template_activate_setting_submission() {
 	if ( ! isset( $_POST['option_page'] ) || 'gutenberg-experiments' !== $_POST['option_page'] ) {
 		return;
 	}
 
-	// Verify nonce for security.
 	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'gutenberg-experiments-options' ) ) {
 		return;
 	}
 
-	// Check user capabilities.
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
-	// Handle template activation setting.
-	// This is managed separately from regular experiments as it uses a different option.
 	if ( isset( $_POST['active_templates'] ) && '1' === $_POST['active_templates'] ) {
 		update_option( 'active_templates', gutenberg_get_migrated_active_templates() );
 	} else {
 		delete_option( 'active_templates' );
-	}
-
-	// Handle experiment dependencies.
-	// If the parent experiment (gutenberg-content-only-pattern-insertion) is disabled,
-	// automatically disable the sub-experiment (gutenberg-content-only-inspector-fields).
-	// This ensures sub-experiments can never be enabled without their parent experiment.
-	// Only process this if gutenberg-experiments data was submitted in the form.
-	if ( isset( $_POST['gutenberg-experiments'] ) && is_array( $_POST['gutenberg-experiments'] ) ) {
-		$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-		// Ensure we have an array to work with (get_option can return false if option doesn't exist).
-		if ( ! is_array( $gutenberg_experiments ) ) {
-			$gutenberg_experiments = array();
-		}
-
-		// Check if the parent experiment is enabled in the form submission.
-		$parent_experiment_enabled = isset( $_POST['gutenberg-experiments']['gutenberg-content-only-pattern-insertion'] );
-
-		// If parent experiment is not enabled, disable the sub-experiment.
-		// Only update if the sub-experiment is currently enabled to avoid unnecessary option updates.
-		if ( ! $parent_experiment_enabled && isset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] ) ) {
-			unset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] );
-			update_option( 'gutenberg-experiments', $gutenberg_experiments );
-		}
 	}
 }

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -301,31 +301,59 @@ function gutenberg_display_experiment_section() {
 	<?php
 }
 
-add_action( 'admin_init', 'gutenberg_handle_template_activate_setting_submission' );
-function gutenberg_handle_template_activate_setting_submission() {
+/**
+ * Handles form submission for the Gutenberg experiments settings page.
+ *
+ * This function processes the experiments form submission and handles:
+ * 1. Template activation setting (active_templates) - managed separately from regular experiments
+ * 2. Experiment dependency management - ensures sub-experiments are automatically disabled
+ *    when their parent experiments are disabled
+ */
+add_action( 'admin_init', 'gutenberg_handle_experiments_setting_submission' );
+function gutenberg_handle_experiments_setting_submission() {
+	// Only process submissions for the gutenberg-experiments settings page.
 	if ( ! isset( $_POST['option_page'] ) || 'gutenberg-experiments' !== $_POST['option_page'] ) {
 		return;
 	}
 
+	// Verify nonce for security.
 	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'gutenberg-experiments-options' ) ) {
 		return;
 	}
 
+	// Check user capabilities.
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
+	// Handle template activation setting.
+	// This is managed separately from regular experiments as it uses a different option.
 	if ( isset( $_POST['active_templates'] ) && '1' === $_POST['active_templates'] ) {
 		update_option( 'active_templates', gutenberg_get_migrated_active_templates() );
 	} else {
 		delete_option( 'active_templates' );
 	}
 
+	// Handle experiment dependencies.
 	// If the parent experiment (gutenberg-content-only-pattern-insertion) is disabled,
 	// automatically disable the sub-experiment (gutenberg-content-only-inspector-fields).
-	$gutenberg_experiments = get_option( 'gutenberg-experiments', array() );
-	if ( ! isset( $_POST['gutenberg-experiments']['gutenberg-content-only-pattern-insertion'] ) ) {
-		unset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] );
-		update_option( 'gutenberg-experiments', $gutenberg_experiments );
+	// This ensures sub-experiments can never be enabled without their parent experiment.
+	// Only process this if gutenberg-experiments data was submitted in the form.
+	if ( isset( $_POST['gutenberg-experiments'] ) && is_array( $_POST['gutenberg-experiments'] ) ) {
+		$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+		// Ensure we have an array to work with (get_option can return false if option doesn't exist).
+		if ( ! is_array( $gutenberg_experiments ) ) {
+			$gutenberg_experiments = array();
+		}
+
+		// Check if the parent experiment is enabled in the form submission.
+		$parent_experiment_enabled = isset( $_POST['gutenberg-experiments']['gutenberg-content-only-pattern-insertion'] );
+
+		// If parent experiment is not enabled, disable the sub-experiment.
+		// Only update if the sub-experiment is currently enabled to avoid unnecessary option updates.
+		if ( ! $parent_experiment_enabled && isset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] ) ) {
+			unset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] );
+			update_option( 'gutenberg-experiments', $gutenberg_experiments );
+		}
 	}
 }

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -210,6 +210,19 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
+		'gutenberg-content-only-inspector-fields',
+		__( 'contentOnly: Enable editable inspector fields', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label'    => __( 'Enables editable inspector fields (media, links, alt text, etc.) in the content-only pattern editing interface. Requires "contentOnly: Make patterns contentOnly by default upon insertion" to be enabled.', 'gutenberg' ),
+			'id'       => 'gutenberg-content-only-inspector-fields',
+			'requires' => 'gutenberg-content-only-pattern-insertion',
+		)
+	);
+
+	add_settings_field(
 		'gutenberg-workflow-palette',
 		__( 'Workflow Palette', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
@@ -246,14 +259,31 @@ add_action( 'admin_init', 'gutenberg_initialize_experiments_settings' );
  *
  * @since 6.3.0
  *
- * @param array $args ( $label, $id ).
+ * @param array $args ( $label, $id, $requires ).
  */
 function gutenberg_display_experiment_field( $args ) {
 	$options = get_option( 'gutenberg-experiments' );
 	$value   = isset( $options[ $args['id'] ] ) ? 1 : 0;
+
+	// Check if this experiment requires another experiment to be enabled
+	$is_disabled = false;
+	if ( isset( $args['requires'] ) ) {
+		$is_disabled = ! isset( $options[ $args['requires'] ] );
+		// If the required experiment is disabled, also disable this one
+		if ( $is_disabled && $value ) {
+			$value = 0;
+		}
+	}
 	?>
 		<label for="<?php echo $args['id']; ?>">
-			<input type="checkbox" name="<?php echo 'gutenberg-experiments[' . $args['id'] . ']'; ?>" id="<?php echo $args['id']; ?>" value="1" <?php checked( 1, $value ); ?> />
+			<input 
+				type="checkbox" 
+				name="<?php echo 'gutenberg-experiments[' . $args['id'] . ']'; ?>" 
+				id="<?php echo $args['id']; ?>" 
+				value="1" 
+				<?php checked( 1, $value ); ?>
+				<?php disabled( $is_disabled ); ?>
+			/>
 			<?php echo $args['label']; ?>
 		</label>
 	<?php
@@ -289,5 +319,13 @@ function gutenberg_handle_template_activate_setting_submission() {
 		update_option( 'active_templates', gutenberg_get_migrated_active_templates() );
 	} else {
 		delete_option( 'active_templates' );
+	}
+
+	// If the parent experiment (gutenberg-content-only-pattern-insertion) is disabled,
+	// automatically disable the sub-experiment (gutenberg-content-only-inspector-fields).
+	$gutenberg_experiments = get_option( 'gutenberg-experiments', array() );
+	if ( ! isset( $_POST['gutenberg-experiments']['gutenberg-content-only-pattern-insertion'] ) ) {
+		unset( $gutenberg_experiments['gutenberg-content-only-inspector-fields'] );
+		update_option( 'gutenberg-experiments', $gutenberg_experiments );
 	}
 }

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -15,14 +15,18 @@ const ContentTab = ( { rootClientId, contentClientIds } ) => {
 		return null;
 	}
 
+	const shouldShowContentOnlyControls =
+		window?.__experimentalContentOnlyPatternInsertion &&
+		window?.__experimentalContentOnlyInspectorFields;
+
 	return (
 		<>
-			{ ! window?.__experimentalContentOnlyPatternInsertion && (
+			{ ! shouldShowContentOnlyControls && (
 				<PanelBody title={ __( 'Content' ) }>
 					<BlockQuickNavigation clientIds={ contentClientIds } />
 				</PanelBody>
 			) }
-			{ window?.__experimentalContentOnlyPatternInsertion && (
+			{ shouldShowContentOnlyControls && (
 				<ContentOnlyControls rootClientId={ rootClientId } />
 			) }
 		</>

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -36,7 +36,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'audio',

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -38,7 +38,7 @@ export const settings = {
 	} ),
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'text',

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -43,7 +43,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -56,7 +56,7 @@ export const settings = {
 	variations,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'background',

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -65,7 +65,7 @@ export const settings = {
 	transforms,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'summary',

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -36,7 +36,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'file',

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -73,7 +73,7 @@ export const settings = {
 	variations,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -66,7 +66,7 @@ export const settings = {
 	deprecated,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'image',

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -36,7 +36,7 @@ export const settings = {
 	[ unlock( privateApis ).requiresWrapperOnCopy ]: true,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -54,7 +54,7 @@ export const settings = {
 	deprecated,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'media',

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -40,7 +40,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'customText',

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -93,7 +93,7 @@ export const settings = {
 	transforms,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'label',

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -52,7 +52,7 @@ export const settings = {
 	transforms,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'label',

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -62,7 +62,7 @@ export const settings = {
 	variations,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -43,7 +43,7 @@ export const settings = {
 	},
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -40,7 +40,7 @@ export const settings = {
 	deprecated,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'value',

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -30,7 +30,7 @@ export const settings = {
 	edit,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'label',

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	variations,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'link',

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -45,7 +45,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -37,7 +37,7 @@ export const settings = {
 	save,
 };
 
-if ( window.__experimentalContentOnlyPatternInsertion ) {
+if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'video',


### PR DESCRIPTION


## What?

Resolves https://github.com/WordPress/gutenberg/issues/73532


Adds a sub-experiment `gutenberg-content-only-inspector-fields` that gates the editable inspector fields (from PR #73374). The sub-experiment is only available when `gutenberg-content-only-pattern-insertion` is enabled.

**Changes:**
- Adds new experiment checkbox in Gutenberg experiments page
- Sub-experiment checkbox is disabled when parent experiment is off
- Sub-experiment is automatically disabled when parent is turned off
- `ContentOnlyControls` with editable fields only shows when both experiments are enabled
- When parent is on but sub-experiment is off, shows `BlockQuickNavigation` (pre-PR #71730 behavior)

## Testing Instructions

1. Enable the `contentOnly: Make patterns contentOnly by default upon insertion` experiment
2. Verify the new `contentOnly: Enable editable inspector fields` checkbox appears and is enabled
3. Insert a pattern with various block types (Image, Cover, Media & Text, etc.)
4. With both experiments ON: Verify `ContentOnlyControls` shows with all editable fields (media, links, alt text, etc.)
5. Turn OFF the sub-experiment (keep parent ON): Verify `BlockQuickNavigation` is shown instead
6. Turn OFF the parent experiment: Verify sub-experiment is automatically disabled and both show `BlockQuickNavigation`
7. Verify sub-experiment checkbox is disabled when parent is off

<img width="1647" height="185" alt="Screenshot 2025-11-27 at 4 51 59 pm" src="https://github.com/user-attachments/assets/c882391f-0925-40d6-8241-b2f5b3d4f6b7" />

| With content only experiment only | With both experiments |
|--------|--------|
| <img width="1159" height="680" alt="Screenshot 2025-11-27 at 4 52 28 pm" src="https://github.com/user-attachments/assets/af37b376-b2c0-4276-9682-274a112cae10" /> | <img width="1172" height="671" alt="Screenshot 2025-11-27 at 4 52 19 pm" src="https://github.com/user-attachments/assets/fd59a0d6-1358-4785-84eb-2c142fd13f70" /> | 




