### PR TITLE
Accordion Heading: Add default style for classic themes

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,9 +1,3 @@
-.wp-block-accordion-heading {
-	// Some classic themes apply default margins to heading elements,
-	// so those styles need to be reset.
-	margin: 0;
-}
-
 .wp-block-accordion-heading__toggle {
 	font-family: inherit;
 	font-size: inherit;
@@ -14,7 +8,9 @@
 	text-decoration: inherit;
 	word-spacing: inherit;
 	font-style: inherit;
+	background: none;
 	border: none;
+	color: inherit;
 	padding: var(--wp--preset--spacing--20, 1em) 0;
 	cursor: pointer;
 	overflow: hidden;
@@ -23,32 +19,8 @@
 	text-align: inherit;
 	width: 100%;
 
-	// Some themes may apply colors to button elements with a particularly
-	// high CSS specificity. Since it's impossible to predict this specificity,
-	// we reset the colors using `!important`.
-	background-color: inherit !important;
-	color: inherit !important;
-
 	&:not(:focus-visible) {
 		outline: none;
-	}
-
-	&:hover,
-	&:focus {
-		// Some themes may apply styles when a button element is hovered
-		// over or focused. This is not intended for accordion toggle
-		// buttons, so we reset it here.
-		text-decoration: none;
-		background-color: inherit !important;
-		box-shadow: none;
-		color: inherit;
-		border: none;
-		padding: var(--wp--preset--spacing--20, 1em) 0;
-	}
-
-	&:focus-visible {
-		outline: auto;
-		outline-offset: 0;
 	}
 
 	&:hover .wp-block-accordion-heading__toggle-title {

--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -20,3 +20,41 @@
 	background: #32373c;
 	color: $white;
 }
+
+// These rules are needed to enforce the default styling of
+// the Accordion Heading block in the classic theme.
+.wp-block-accordion-heading {
+	// Heading elements may have default margins applied, so those
+	// styles need to be reset.
+	margin: 0;
+}
+
+.wp-block-accordion-heading__toggle {
+	// Button elements can have colors applied with high CSS specificity,
+	// and since this specificity is impossible to predict, we use
+	// `!important` to reset the color.
+	background-color: inherit !important;
+	color: inherit !important;
+
+	&:not(:focus-visible) {
+		outline: none;
+	}
+
+	&:hover,
+	&:focus {
+		// Sometimes styles are applied when the button element is
+		// hovered over or focused. This isn't expected for accordion
+		// toggle buttons, so reset those styles here.
+		text-decoration: none;
+		background-color: inherit !important;
+		box-shadow: none;
+		color: inherit;
+		border: none;
+		padding: var(--wp--preset--spacing--20, 1em) 0;
+	}
+
+	&:focus-visible {
+		outline-offset: 0;
+		outline: auto;
+	}
+}

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,
@@ -8,42 +8,12 @@
 			"wideSize": "1100px"
 		}
 	},
-	"styles": {
-		"blocks": {
-			"core/accordion-item": {
-				"border": {
-					"color": "#d5dae2",
-					"style": "solid",
-					"width": "1px",
-					"radius": "12px"
-				},
-				"color": {
-					"background": "#f6f7f9",
-					"text": "#343b46"
-				},
-				"shadow": "0 10px 15px -3px #80000080, 0 4px 6px -4px #80000080"
-			},
-			"core/accordion-heading": {
-				"css": "&__toggle { padding: var(--wp--preset--spacing--40) var(--wp--style--block-gap); }",
-				"typography": {
-					"fontFamily": "inherit",
-					"fontSize": "inherit",
-					"fontStyle": "inherit",
-					"fontWeight": "500",
-					"lineHeight": "inherit",
-					"textTransform": "inherit"
-				}
-			},
-			"core/accordion-panel": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--style--block-gap)",
-						"bottom": "var(--wp--style--block-gap)",
-						"left": "var(--wp--style--block-gap)",
-						"right": "var(--wp--style--block-gap)"
-					}
-				}
-			}
+	"customTemplates": [
+		{
+			"name": "custom-template",
+			"title": "Custom",
+			"postTypes": [ "post" ]
 		}
-	}
+	],
+	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../schemas/json/theme.json",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,
@@ -8,12 +8,42 @@
 			"wideSize": "1100px"
 		}
 	},
-	"customTemplates": [
-		{
-			"name": "custom-template",
-			"title": "Custom",
-			"postTypes": [ "post" ]
+	"styles": {
+		"blocks": {
+			"core/accordion-item": {
+				"border": {
+					"color": "#d5dae2",
+					"style": "solid",
+					"width": "1px",
+					"radius": "12px"
+				},
+				"color": {
+					"background": "#f6f7f9",
+					"text": "#343b46"
+				},
+				"shadow": "0 10px 15px -3px #80000080, 0 4px 6px -4px #80000080"
+			},
+			"core/accordion-heading": {
+				"css": "&__toggle { padding: var(--wp--preset--spacing--40) var(--wp--style--block-gap); }",
+				"typography": {
+					"fontFamily": "inherit",
+					"fontSize": "inherit",
+					"fontStyle": "inherit",
+					"fontWeight": "500",
+					"lineHeight": "inherit",
+					"textTransform": "inherit"
+				}
+			},
+			"core/accordion-panel": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--style--block-gap)",
+						"bottom": "var(--wp--style--block-gap)",
+						"left": "var(--wp--style--block-gap)",
+						"right": "var(--wp--style--block-gap)"
+					}
+				}
+			}
 		}
-	],
-	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
+	}
 }


### PR DESCRIPTION
Fixes #73454

## What?

This PR moves some styles for the Accordion Heading block to the `classic.scss` so that consumers can override the default styles via the global styles or theme.json

## Why?

In #73032, we added some styles with high CSS specificity to enforce default styles for many themes, especially classic themes. This requires theme developers to use higher CSS specificity selectors or import statements to override default styles, making it less extensible.

## How?

Move most of the styles we added for the classic theme into the `classic.scss` file. [This stylesheet is only enqueued when the classic theme (or more precisely, a theme without a theme.json) is active](https://github.com/WordPress/wordpress-develop/blob/6b7adc0159731f2dc23719d52b1add89d1cd1703/src/wp-includes/script-loader.php#L3420-L3424). This makes it easier to override the default styles via the global styles or theme.json.

## Testing Instructions

Activate the Emptytheme and update the theme.json with the following definitions. This code is based on [the Styling accordions in WordPress 6.9](https://developer.wordpress.org/news/2025/10/styling-accordions-in-wordpress-6-9/) documentation. All custom styles should now be applied correctly.

<details><summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/accordion-item": {
				"border": {
					"color": "#d5dae2",
					"style": "solid",
					"width": "1px",
					"radius": "12px"
				},
				"color": {
					"background": "#f6f7f9",
					"text": "#343b46"
				},
				"shadow": "0 10px 15px -3px #80000080, 0 4px 6px -4px #80000080"
			},
			"core/accordion-heading": {
				"css": "&__toggle { padding: var(--wp--preset--spacing--40) var(--wp--style--block-gap); }",
				"typography": {
					"fontFamily": "inherit",
					"fontSize": "inherit",
					"fontStyle": "inherit",
					"fontWeight": "500",
					"lineHeight": "inherit",
					"textTransform": "inherit"
				}
			},
			"core/accordion-panel": {
				"spacing": {
					"padding": {
						"top": "var(--wp--style--block-gap)",
						"bottom": "var(--wp--style--block-gap)",
						"left": "var(--wp--style--block-gap)",
						"right": "var(--wp--style--block-gap)"
					}
				}
			}
		}
	}
}
```

</details> 

Next, activate any of the default classic themes. Ensure the following styles are achieved:

- The toggle button inherits text and background color.
- The toggle button has no text-decoration style.
- When the toggle button is focused by the tab key, the outline should be visible.
- When the toggle button is hovered, the text-decoration style should be applied.