### PR TITLE
Site Editor Pages: add "notes count" field

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -184,7 +184,7 @@ export default function PostList( { postType } ) {
 		if ( processedRecords ) {
 			return processedRecords.map( ( record ) => ( {
 				...record,
-				_notesCount: notesCount[ record.id ] ?? 0,
+				notesCount: notesCount[ record.id ] ?? 0,
 			} ) );
 		}
 

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -33,6 +33,7 @@ import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import { defaultLayouts, getDefaultView } from './view-utils';
+import useNotesCount from './use-notes-count';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -162,18 +163,33 @@ export default function PostList( { postType } ) {
 		totalPages,
 	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
 
+	const postIds = useMemo(
+		() => records?.map( ( record ) => record.id ) ?? [],
+		[ records ]
+	);
+	const { notesCount } = useNotesCount( postIds );
+
 	// The REST API sort the authors by ID, but we want to sort them by name.
 	const data = useMemo( () => {
+		let processedRecords = records;
+
 		if ( view?.sort?.field === 'author' ) {
-			return filterSortAndPaginate(
+			processedRecords = filterSortAndPaginate(
 				records,
 				{ sort: { ...view.sort } },
 				fields
 			).data;
 		}
 
-		return records;
-	}, [ records, fields, view?.sort ] );
+		if ( processedRecords ) {
+			return processedRecords.map( ( record ) => ( {
+				...record,
+				_notesCount: notesCount[ record.id ] ?? 0,
+			} ) );
+		}
+
+		return processedRecords;
+	}, [ records, fields, view?.sort, notesCount ] );
 
 	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -167,7 +167,8 @@ export default function PostList( { postType } ) {
 		() => records?.map( ( record ) => record.id ) ?? [],
 		[ records ]
 	);
-	const { notesCount } = useNotesCount( postIds );
+	const { notesCount, isLoading: isLoadingNotesCount } =
+		useNotesCount( postIds );
 
 	// The REST API sort the authors by ID, but we want to sort them by name.
 	const data = useMemo( () => {
@@ -290,7 +291,7 @@ export default function PostList( { postType } ) {
 				fields={ fields }
 				actions={ actions }
 				data={ data || EMPTY_ARRAY }
-				isLoading={ isLoadingData }
+				isLoading={ isLoadingData || isLoadingNotesCount }
 				view={ view }
 				onChangeView={ onChangeView }
 				selection={ selection }

--- a/packages/edit-site/src/components/post-list/use-notes-count.js
+++ b/packages/edit-site/src/components/post-list/use-notes-count.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Hook to fetch notes counts for a list of post IDs.
+ *
+ * Notes are stored as comments with type 'note'.
+ * This hook fetches all notes for the given posts and returns
+ * a map of post ID to notes count.
+ *
+ * @param {number[]} postIds - Array of post IDs to fetch notes for.
+ * @return {{ notesCount: Object, isResolving: boolean }} Object with notesCount map and loading state.
+ */
+export default function useNotesCount( postIds ) {
+	const { records: notes, isResolving } = useEntityRecords(
+		'root',
+		'comment',
+		{
+			post: postIds,
+			type: 'note',
+			status: 'all',
+			per_page: -1,
+		},
+		{
+			enabled: postIds?.length > 0,
+		}
+	);
+
+	const notesCount = useMemo( () => {
+		if ( ! notes || notes.length === 0 ) {
+			return {};
+		}
+
+		const counts = {};
+		notes.forEach( ( note ) => {
+			const postId = note.post;
+			counts[ postId ] = ( counts[ postId ] || 0 ) + 1;
+		} );
+
+		return counts;
+	}, [ notes ] );
+
+	return { notesCount, isResolving };
+}

--- a/packages/edit-site/src/components/post-list/use-notes-count.js
+++ b/packages/edit-site/src/components/post-list/use-notes-count.js
@@ -23,6 +23,7 @@ export default function useNotesCount( postIds ) {
 			type: 'note',
 			status: 'all',
 			per_page: -1,
+			_fields: 'id,post',
 		},
 		{
 			enabled: postIds?.length > 0,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -52,30 +52,17 @@ declare global {
 }
 
 /**
- * Check if a post type supports a given feature key (e.g., 'editor.notes').
+ * Check if a post type supports editor notes.
  *
  * @param supports The post type supports object.
- * @param key      The support key to check (e.g., 'editor.notes').
- * @return Whether the feature is supported.
+ * @return Whether editor notes are supported.
  */
-function checkSupport(
-	supports: PostType[ 'supports' ] = {},
-	key: string
-): boolean {
-	// Check for top-level support keys.
-	if ( supports[ key as keyof typeof supports ] !== undefined ) {
-		return !! supports[ key as keyof typeof supports ];
+function hasEditorNotesSupport( supports?: PostType[ 'supports' ] ): boolean {
+	const editor = supports?.editor;
+	if ( Array.isArray( editor ) ) {
+		return !! editor[ 0 ]?.notes;
 	}
-
-	const [ topKey, subKey ] = key.split( '.' );
-	const topSupport = supports[ topKey as keyof typeof supports ];
-
-	// Try to unwrap sub-properties from the superfluous array.
-	const [ subProperties ] = Array.isArray( topSupport ) ? topSupport : [];
-
-	return Array.isArray( subProperties )
-		? subProperties.includes( subKey )
-		: !! ( subProperties as Record< string, boolean > )?.[ subKey ];
+	return false;
 }
 
 export function registerEntityAction< Item >(
@@ -238,8 +225,7 @@ export const registerPostTypeSchema =
 			postTypeConfig.supports?.editor &&
 				postTypeConfig.viewable &&
 				postPreviewField,
-			checkSupport( postTypeConfig.supports, 'editor.notes' ) &&
-				notesField,
+			hasEditorNotesSupport( postTypeConfig.supports ) && notesField,
 		].filter( Boolean );
 		if ( postTypeConfig.supports?.title ) {
 			let _titleField;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -34,6 +34,7 @@ import {
 	templateTitleField,
 	pageTitleField,
 	patternTitleField,
+	notesField,
 } from '@wordpress/fields';
 
 /**
@@ -48,6 +49,33 @@ declare global {
 	interface Window {
 		__experimentalTemplateActivate?: boolean;
 	}
+}
+
+/**
+ * Check if a post type supports a given feature key (e.g., 'editor.notes').
+ *
+ * @param supports The post type supports object.
+ * @param key      The support key to check (e.g., 'editor.notes').
+ * @return Whether the feature is supported.
+ */
+function checkSupport(
+	supports: PostType[ 'supports' ] = {},
+	key: string
+): boolean {
+	// Check for top-level support keys.
+	if ( supports[ key as keyof typeof supports ] !== undefined ) {
+		return !! supports[ key as keyof typeof supports ];
+	}
+
+	const [ topKey, subKey ] = key.split( '.' );
+	const topSupport = supports[ topKey as keyof typeof supports ];
+
+	// Try to unwrap sub-properties from the superfluous array.
+	const [ subProperties ] = Array.isArray( topSupport ) ? topSupport : [];
+
+	return Array.isArray( subProperties )
+		? subProperties.includes( subKey )
+		: !! ( subProperties as Record< string, boolean > )?.[ subKey ];
 }
 
 export function registerEntityAction< Item >(
@@ -210,6 +238,8 @@ export const registerPostTypeSchema =
 			postTypeConfig.supports?.editor &&
 				postTypeConfig.viewable &&
 				postPreviewField,
+			checkSupport( postTypeConfig.supports, 'editor.notes' ) &&
+				notesField,
 		].filter( Boolean );
 		if ( postTypeConfig.supports?.title ) {
 			let _titleField;

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -71,6 +71,10 @@ Export action as JSON for Pattern.
 
 Featured Image field for BasePostWithEmbeddedFeaturedMedia.
 
+### notesField
+
+Notes count field for post types that support editor.notes.
+
 ### orderField
 
 Order field for BasePost.

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -14,3 +14,4 @@ export { default as pingStatusField } from './ping-status';
 export { default as discussionField } from './discussion';
 export { default as dateField } from './date';
 export { default as authorField } from './author';
+export { default as notesField } from './notes';

--- a/packages/fields/src/fields/notes/index.tsx
+++ b/packages/fields/src/fields/notes/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+interface PostWithNotesCount extends BasePost {
+	_notesCount?: number;
+}
+
+const notesField: Field< PostWithNotesCount > = {
+	id: '_notesCount',
+	label: __( 'Notes' ),
+	type: 'integer',
+};
+
+/**
+ * Notes count field for post types that support editor.notes.
+ */
+export default notesField;

--- a/packages/fields/src/fields/notes/index.tsx
+++ b/packages/fields/src/fields/notes/index.tsx
@@ -17,6 +17,8 @@ const notesField: Field< PostWithNotesCount > = {
 	id: 'notesCount',
 	label: __( 'Notes' ),
 	type: 'integer',
+	enableSorting: false,
+	filterBy: false,
 };
 
 /**

--- a/packages/fields/src/fields/notes/index.tsx
+++ b/packages/fields/src/fields/notes/index.tsx
@@ -10,11 +10,11 @@ import { __ } from '@wordpress/i18n';
 import type { BasePost } from '../../types';
 
 interface PostWithNotesCount extends BasePost {
-	_notesCount?: number;
+	notesCount?: number;
 }
 
 const notesField: Field< PostWithNotesCount > = {
-	id: '_notesCount',
+	id: 'notesCount',
 	label: __( 'Notes' ),
 	type: 'integer',
 };

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -112,6 +112,10 @@ export type PostWithPermissions = Post & {
 	};
 };
 
+interface EditorSupport {
+	notes?: boolean;
+}
+
 export interface PostType {
 	slug: string;
 	viewable: boolean;
@@ -122,7 +126,7 @@ export interface PostType {
 		author?: string;
 		thumbnail?: string;
 		comments?: string;
-		editor?: boolean;
+		editor?: boolean | [ EditorSupport ];
 		trackbacks?: boolean;
 	};
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/73606

## What?

Adds a new note field in the Site Editor > Pages.

## Why?

See https://github.com/WordPress/gutenberg/issues/73606

## How?

- Creates a new `notesCount` fields.
- Registers it for post types that have support for `editor.notes`.
- Augment the pages post type screen to include the note counts.

## Testing Instructions

- Visit Site Editor > Pages.
- Enable the new `Notes` field (via cog/view config, or via right-click in the column header).