### PR TITLE
Private APIs: remove re-registration check

### DIFF
--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -43,12 +43,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/global-styles-ui',
 ];
 
-/**
- * A list of core modules that already opted-in to
- * the privateApis package.
- */
-const registeredPrivateApis: Array< string > = [];
-
 /*
  * Warning for theme and plugin developers.
  *
@@ -65,9 +59,6 @@ const registeredPrivateApis: Array< string > = [];
  */
 const requiredConsent =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
-
-// The safety measure is meant for WordPress core where IS_WORDPRESS_CORE is set to true.
-const allowReRegistration = globalThis.IS_WORDPRESS_CORE ? false : true;
 
 /**
  * Called by a @wordpress package wishing to opt-in to accessing or exposing
@@ -90,21 +81,6 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 				'your product will inevitably break on one of the next WordPress releases.'
 		);
 	}
-	if (
-		! allowReRegistration &&
-		registeredPrivateApis.includes( moduleName )
-	) {
-		// This check doesn't play well with Story Books / Hot Module Reloading
-		// and isn't included in the Gutenberg plugin. It only matters in the
-		// WordPress core release.
-		throw new Error(
-			`You tried to opt-in to unstable APIs as module "${ moduleName }" which is already registered. ` +
-				'This feature is only for JavaScript modules shipped with WordPress core. ' +
-				'Please do not use it in plugins and themes as the unstable APIs will be removed ' +
-				'without a warning. If you ignore this error and depend on unstable features, ' +
-				'your product will inevitably break on one of the next WordPress releases.'
-		);
-	}
 	if ( consent !== requiredConsent ) {
 		throw new Error(
 			`You tried to opt-in to unstable APIs without confirming you know the consequences. ` +
@@ -114,7 +90,6 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 				'your product will inevitably break on the next WordPress release.'
 		);
 	}
-	registeredPrivateApis.push( moduleName );
 
 	return {
 		lock,
@@ -223,14 +198,5 @@ export function allowCoreModule( name: string ) {
 export function resetAllowedCoreModules() {
 	while ( CORE_MODULES_USING_PRIVATE_APIS.length ) {
 		CORE_MODULES_USING_PRIVATE_APIS.pop();
-	}
-}
-/**
- * Private function to allow the unit tests to reset
- * the list of registered private apis.
- */
-export function resetRegisteredPrivateApis() {
-	while ( registeredPrivateApis.length ) {
-		registeredPrivateApis.pop();
 	}
 }

--- a/packages/private-apis/src/test/index.js
+++ b/packages/private-apis/src/test/index.js
@@ -32,18 +32,7 @@ describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 			/This feature is only for JavaScript modules shipped with WordPress core/
 		);
 	} );
-	it( 'Should not register the same module twice', () => {
-		expect( () => {
-			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-				requiredConsent,
-				'@privateApis/test'
-			);
-			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-				requiredConsent,
-				'@privateApis/test'
-			);
-		} ).toThrow( /is already registered/ );
-	} );
+
 	it( 'Should grant access to unstable APIs when passed both a consent string and a previously unregistered package name', () => {
 		const unstableAPIs = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 			requiredConsent,

--- a/packages/private-apis/src/test/index.js
+++ b/packages/private-apis/src/test/index.js
@@ -2,14 +2,9 @@
  * Internal dependencies
  */
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '../';
-import {
-	resetRegisteredPrivateApis,
-	resetAllowedCoreModules,
-	allowCoreModule,
-} from '../implementation';
+import { resetAllowedCoreModules, allowCoreModule } from '../implementation';
 
 beforeEach( () => {
-	resetRegisteredPrivateApis();
 	resetAllowedCoreModules();
 	allowCoreModule( '@privateApis/test' );
 	allowCoreModule( '@privateApis/test-consumer' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Remove the re-registration check from the private APIs package. This allows packages to opt-in to private APIs multiple times.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some of our packages like data views and global styles UI are bundled in other packages multiple times, which causes the private APIs registration to complain about multiple opt-ins, _except_ in Gutenberg itself. This means we have a behavior difference between Gutenberg and Core, which is [preventing package syncs from happening because the editors crash](https://github.com/WordPress/wordpress-develop/pull/10551).

First of all, the behavior should be the same for core and Gutenberg.

Secondly, the way that some modules like data views and global styles UI are being developed makes it hard to enable the re-registration check in the GB repo.

The fact that people have to go through a lot of effort to use private APIs (install private api packages, opt-in string, unlock...) should be enough to communicate that these APIs are private and there's to backwards compatibility. There's quite a few cases where people create workaround even around the re-registration, e.g. by npm package patches, which makes everything even more fragile. When packages are consumed through npm, there's also less concern because of the versioning and people should be able to use the private APIs if they really wanted to.

So I propose that we simply remove the check. 🙂

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Tests should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
