### PR TITLE
Block JSON schema: add visibility key to supports definition

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -1175,4 +1175,15 @@ the selection correctly and we know where to split.
 
 ## visibility
 
+_**Note:** Since WordPress 6.9._
+
+-   Type: `boolean`
+-   Default value: `true`
+
 By default, a block can be hidden by a user from the block 'Options' dropdown. To disable this behavior, set visibility to false.
+
+```js
+supports: {
+	visibility: false,
+}
+```

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -1172,3 +1172,7 @@ is only meant for simple text blocks such as paragraphs and headings with a
 single `RichText` field. RichText in the `edit` function _must_ have an
 `identifier` prop that matches the attribute key of the text, so that it updates
 the selection correctly and we know where to split.
+
+## visibility
+
+By default, a block can be hidden by a user from the block 'Options' dropdown. To disable this behavior, set visibility to false.

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -377,6 +377,11 @@
 					"type": "boolean",
 					"default": true
 				},
+				"visibility": {
+					"description": "By default, a block can be visibility by a user from the block 'Options' dropdown. To disable this behavior, set visibility to false.",
+					"type": "boolean",
+					"default": true
+				},
 				"layout": {
 					"description": "This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.",
 					"oneOf": [

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -378,7 +378,7 @@
 					"default": true
 				},
 				"visibility": {
-					"description": "By default, a block can be visibility by a user from the block 'Options' dropdown. To disable this behavior, set visibility to false.",
+					"description": "By default, a block can be hidden by a user from the block 'Options' dropdown. To disable this behavior, set visibility to false.",
 					"type": "boolean",
 					"default": true
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related #57373

This PR adds `visibility` key to supports definition in block.json schema.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
You should see the `visibility` key listed in the supports property.

<img width="671" height="134" alt="visibility" src="https://github.com/user-attachments/assets/33980bc7-966c-41a9-95d7-27dfadce4f01" />

