### PR TITLE
DataViews stories: update empty story

### DIFF
--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -189,14 +189,26 @@ const CustomEmptyComponent = () => (
 	</VStack>
 );
 
-const EmptyComponent = ( { customEmpty }: { customEmpty?: boolean } ) => {
+const EmptyComponent = ( {
+	customEmpty,
+	containerHeight,
+}: {
+	customEmpty?: boolean;
+	containerHeight?: 'auto' | '50vh' | '100vh';
+} ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],
 	} );
 
 	return (
-		<div style={ { height: 600 } }>
+		<div
+			style={ {
+				display: 'flex',
+				flexDirection: 'column',
+				height: containerHeight,
+			} }
+		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
 				paginationInfo={ { totalItems: 0, totalPages: 0 } }
@@ -216,11 +228,17 @@ export const Empty = {
 	render: EmptyComponent,
 	args: {
 		customEmpty: false,
+		containerHeight: '50vh',
 	},
 	argTypes: {
 		customEmpty: {
 			control: 'boolean',
 			description: 'Use custom empty state with planet illustration',
+		},
+		containerHeight: {
+			control: 'select',
+			options: [ 'auto', '50vh', '100vh' ],
+			description: 'Height of the container',
 		},
 	},
 };

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -196,17 +196,19 @@ const EmptyComponent = ( { customEmpty }: { customEmpty?: boolean } ) => {
 	} );
 
 	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ { totalItems: 0, totalPages: 0 } }
-			data={ [] }
-			view={ view }
-			fields={ fields }
-			onChangeView={ setView }
-			actions={ actions }
-			defaultLayouts={ defaultLayouts }
-			empty={ customEmpty ? <CustomEmptyComponent /> : undefined }
-		/>
+		<div style={ { height: 600 } }>
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ { totalItems: 0, totalPages: 0 } }
+				data={ [] }
+				view={ view }
+				fields={ fields }
+				onChangeView={ setView }
+				actions={ actions }
+				defaultLayouts={ defaultLayouts }
+				empty={ customEmpty ? <CustomEmptyComponent /> : undefined }
+			/>
+		</div>
 	);
 };
 

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -192,9 +192,11 @@ const CustomEmptyComponent = () => (
 const EmptyComponent = ( {
 	customEmpty,
 	containerHeight,
+	isLoading,
 }: {
 	customEmpty?: boolean;
 	containerHeight?: 'auto' | '50vh' | '100vh';
+	isLoading?: boolean;
 } ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
@@ -218,6 +220,7 @@ const EmptyComponent = ( {
 				onChangeView={ setView }
 				actions={ actions }
 				defaultLayouts={ defaultLayouts }
+				isLoading={ isLoading }
 				empty={ customEmpty ? <CustomEmptyComponent /> : undefined }
 			/>
 		</div>
@@ -229,6 +232,7 @@ export const Empty = {
 	args: {
 		customEmpty: false,
 		containerHeight: '50vh',
+		isLoading: false,
 	},
 	argTypes: {
 		customEmpty: {
@@ -239,6 +243,10 @@ export const Empty = {
 			control: 'select',
 			options: [ 'auto', '50vh', '100vh' ],
 			description: 'Height of the container',
+		},
+		isLoading: {
+			control: 'boolean',
+			description: 'Show loading state',
 		},
 	},
 };

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -161,7 +161,35 @@ Default.argTypes = {
 	},
 };
 
-export const Empty = () => {
+const PlanetIllustration = () => (
+	<svg
+		width="120"
+		height="120"
+		viewBox="0 0 120 120"
+		fill="none"
+		style={ { opacity: 0.6 } }
+	>
+		<circle cx="60" cy="60" r="35" fill="#9ca3af" />
+		<ellipse
+			cx="60"
+			cy="60"
+			rx="55"
+			ry="12"
+			stroke="#9ca3af"
+			strokeWidth="3"
+			fill="none"
+		/>
+	</svg>
+);
+
+const CustomEmptyComponent = () => (
+	<VStack alignment="center" justify="center" spacing={ 3 }>
+		<PlanetIllustration />
+		<Text>No celestial bodies found</Text>
+	</VStack>
+);
+
+const EmptyComponent = ( { customEmpty }: { customEmpty?: boolean } ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],
@@ -177,29 +205,22 @@ export const Empty = () => {
 			onChangeView={ setView }
 			actions={ actions }
 			defaultLayouts={ defaultLayouts }
+			empty={ customEmpty ? <CustomEmptyComponent /> : undefined }
 		/>
 	);
 };
 
-export const CustomEmpty = () => {
-	const [ view, setView ] = useState< View >( {
-		...DEFAULT_VIEW,
-		fields: [ 'title', 'description', 'categories' ],
-	} );
-
-	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ { totalItems: 0, totalPages: 0 } }
-			data={ [] }
-			view={ view }
-			fields={ fields }
-			onChangeView={ setView }
-			actions={ actions }
-			defaultLayouts={ defaultLayouts }
-			empty={ <p>{ view.search ? 'No sites found' : 'No sites' }</p> }
-		/>
-	);
+export const Empty = {
+	render: EmptyComponent,
+	args: {
+		customEmpty: false,
+	},
+	argTypes: {
+		customEmpty: {
+			control: 'boolean',
+			description: 'Use custom empty state with planet illustration',
+		},
+	},
 };
 
 const MinimalUIComponent = ( {


### PR DESCRIPTION
## What?

This PR improves the existing DataViews stories:

- Remove "custom empty" story and merge into the "empty" one.
- Add controls for:
  - boolean: customEmpty. Whether to display a custom empty component.
  - boolean: isLoading. Displays the loading state.
  - select: container height.
    - auto: no height defined for the container, so height is the content (empty or loading state)
    - 50vh: half of viewport
    - 100vh: full viewport, the empty and loading states are vertical aligned in the screen

https://github.com/user-attachments/assets/0ffff935-9c33-4ff6-bb7b-9969959e06e2

## Why?

To provide a better curation of what the component can do, and better demonstrate different states.

## Testing Instructions

- Visit "DataViews > Empty" story in local storybook (`npm run storybook:dev`).
- Play with the controls.