### PR TITLE
Routing Boot package: Add mobile rendering

### DIFF
--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -7,12 +7,18 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { SidebarToggleSlot } from './sidebar-toggle-slot';
+
 export default function Header( {
 	breadcrumbs,
 	badges,
 	title,
 	subTitle,
 	actions,
+	showSidebarToggle = true,
 }: {
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
@@ -28,7 +34,13 @@ export default function Header( {
 				justify="space-between"
 				spacing={ 2 }
 			>
-				<HStack spacing={ 2 }>
+				<HStack spacing={ 2 } justify="flex-start">
+					{ showSidebarToggle && (
+						<SidebarToggleSlot
+							bubblesVirtually
+							className="admin-ui-page__sidebar-toggle-slot"
+						/>
+					) }
 					{ title && (
 						<Heading as="h2" level={ 3 } weight={ 500 } truncate>
 							{ title }

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import Header from './header';
 import NavigableRegion from '../navigable-region';
+import { SidebarToggleFill } from './sidebar-toggle-slot';
 
 function Page( {
 	breadcrumbs,
@@ -18,6 +19,7 @@ function Page( {
 	className,
 	actions,
 	hasPadding = false,
+	showSidebarToggle = true,
 }: {
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
@@ -27,6 +29,7 @@ function Page( {
 	className?: string;
 	actions?: React.ReactNode;
 	hasPadding?: boolean;
+	showSidebarToggle?: boolean;
 } ) {
 	const classes = clsx( 'admin-ui-page', className );
 
@@ -39,6 +42,7 @@ function Page( {
 					title={ title }
 					subTitle={ subTitle }
 					actions={ actions }
+					showSidebarToggle={ showSidebarToggle }
 				/>
 			) }
 			{ hasPadding ? (
@@ -51,5 +55,7 @@ function Page( {
 		</NavigableRegion>
 	);
 }
+
+Page.SidebarToggleFill = SidebarToggleFill;
 
 export default Page;

--- a/packages/admin-ui/src/page/sidebar-toggle-slot.tsx
+++ b/packages/admin-ui/src/page/sidebar-toggle-slot.tsx
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: SidebarToggleFill, Slot: SidebarToggleSlot } =
+	createSlotFill( 'SidebarToggle' );
+
+export { SidebarToggleFill, SidebarToggleSlot };

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -11,6 +11,17 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 import { CommandMenu } from '@wordpress/commands';
 import { privateApis as themePrivateApis } from '@wordpress/theme';
 import { EditorSnackbars } from '@wordpress/editor';
+import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
+import {
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+	Button,
+	SlotFillProvider,
+} from '@wordpress/components';
+import { menu } from '@wordpress/icons';
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Page } from '@wordpress/admin-ui';
 
 /**
  * Internal dependencies
@@ -23,10 +34,11 @@ import type { CanvasData } from '../../store/types';
 import './style.scss';
 
 const { ThemeProvider } = unlock( themePrivateApis );
-const { useMatches, Outlet } = unlock( routePrivateApis );
+const { useLocation, useMatches, Outlet } = unlock( routePrivateApis );
 
 export default function Root() {
 	const matches = useMatches();
+	const location = useLocation();
 	const currentMatch = matches[ matches.length - 1 ];
 	const canvas = ( currentMatch?.loaderData as any )?.canvas as
 		| CanvasData
@@ -36,41 +48,143 @@ export default function Root() {
 		?.routeContentModule as string | undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
 
+	// Mobile sidebar state
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const [ isMobileSidebarOpen, setIsMobileSidebarOpen ] = useState( false );
+	const disableMotion = useReducedMotion();
+	// Close mobile sidebar on viewport resize and path change
+	useEffect( () => {
+		setIsMobileSidebarOpen( false );
+	}, [ location.pathname, isMobileViewport ] );
+
 	return (
-		<ThemeProvider isRoot color={ { bg: '#f8f8f8', primary: '#3858e9' } }>
-			<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
-				<div
-					className={ clsx( 'boot-layout', {
-						'has-canvas': !! canvas || canvas === null,
-						'has-full-canvas': isFullScreen,
-					} ) }
-				>
-					<CommandMenu />
-					<SavePanel />
-					<EditorSnackbars />
-					{ ! isFullScreen && (
-						<div className="boot-layout__sidebar">
-							<Sidebar />
-						</div>
-					) }
-					<div className="boot-layout__surfaces">
-						<ThemeProvider
-							color={ { bg: '#ffffff', primary: '#3858e9' } }
-						>
-							<Outlet />
-						</ThemeProvider>
-						{ /* Render Canvas in Root to prevent remounting on route changes */ }
-						{ ( canvas || canvas === null ) && (
-							<div className="boot-layout__canvas">
-								<CanvasRenderer
-									canvas={ canvas }
-									routeContentModule={ routeContentModule }
+		<SlotFillProvider>
+			<ThemeProvider
+				isRoot
+				color={ { bg: '#f8f8f8', primary: '#3858e9' } }
+			>
+				<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
+					<div
+						className={ clsx( 'boot-layout', {
+							'has-canvas': !! canvas || canvas === null,
+							'has-full-canvas': isFullScreen,
+						} ) }
+					>
+						<CommandMenu />
+						<SavePanel />
+						<EditorSnackbars />
+						{ isMobileViewport && (
+							<Page.SidebarToggleFill>
+								<Button
+									icon={ menu }
+									onClick={ () =>
+										setIsMobileSidebarOpen( true )
+									}
+									label={ __( 'Open navigation panel' ) }
+									size="compact"
 								/>
+							</Page.SidebarToggleFill>
+						) }
+						{ /* Mobile Sidebar Backdrop */ }
+						<AnimatePresence>
+							{ isMobileViewport &&
+								isMobileSidebarOpen &&
+								! isFullScreen && (
+									<motion.div
+										initial={ { opacity: 0 } }
+										animate={ { opacity: 1 } }
+										exit={ { opacity: 0 } }
+										transition={ {
+											type: 'tween',
+											duration: disableMotion ? 0 : 0.2,
+											ease: 'easeOut',
+										} }
+										className="boot-layout__sidebar-backdrop"
+										onClick={ () =>
+											setIsMobileSidebarOpen( false )
+										}
+										onKeyDown={ ( event ) => {
+											if ( event.key === 'Escape' ) {
+												setIsMobileSidebarOpen( false );
+											}
+										} }
+										role="button"
+										tabIndex={ -1 }
+										aria-label={ __(
+											'Close navigation panel'
+										) }
+									/>
+								) }
+						</AnimatePresence>
+						{ /* Mobile Sidebar */ }
+						<AnimatePresence>
+							{ isMobileViewport &&
+								isMobileSidebarOpen &&
+								! isFullScreen && (
+									<motion.div
+										initial={ { x: '-100%' } }
+										animate={ { x: 0 } }
+										exit={ { x: '-100%' } }
+										transition={ {
+											type: 'tween',
+											duration: disableMotion ? 0 : 0.2,
+											ease: 'easeOut',
+										} }
+										className="boot-layout__sidebar is-mobile"
+									>
+										<Sidebar />
+									</motion.div>
+								) }
+						</AnimatePresence>
+						{ /* Desktop Sidebar */ }
+						{ ! isMobileViewport && ! isFullScreen && (
+							<div className="boot-layout__sidebar">
+								<Sidebar />
 							</div>
 						) }
+						<div className="boot-layout__surfaces">
+							<ThemeProvider
+								color={ { bg: '#ffffff', primary: '#3858e9' } }
+							>
+								<Outlet />
+							</ThemeProvider>
+							{ /* Render Canvas in Root to prevent remounting on route changes */ }
+							{ ( canvas || canvas === null ) && (
+								<div
+									className={ clsx( 'boot-layout__canvas', {
+										'has-mobile-drawer':
+											canvas?.isPreview &&
+											isMobileViewport,
+									} ) }
+								>
+									{ canvas?.isPreview && isMobileViewport && (
+										<div className="boot-layout__mobile-sidebar-drawer">
+											<Button
+												icon={ menu }
+												onClick={ () =>
+													setIsMobileSidebarOpen(
+														true
+													)
+												}
+												label={ __(
+													'Open navigation panel'
+												) }
+												size="compact"
+											/>
+										</div>
+									) }
+									<CanvasRenderer
+										canvas={ canvas }
+										routeContentModule={
+											routeContentModule
+										}
+									/>
+								</div>
+							) }
+						</div>
 					</div>
-				</div>
+				</ThemeProvider>
 			</ThemeProvider>
-		</ThemeProvider>
+		</SlotFillProvider>
 	);
 }

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables";
+@use "@wordpress/base-styles/mixins";
 
 .boot-layout {
 	height: 100%;
@@ -10,37 +11,150 @@
 	background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
 }
 
+.boot-layout__sidebar-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 100002;
+	cursor: pointer;
+}
+
 .boot-layout__sidebar {
 	height: 100%;
 	flex-shrink: 0;
 	width: 240px;
 	position: relative;
 	overflow: hidden;
+
+	&.is-mobile {
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: 300px;
+		max-width: 85vw;
+		background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+		z-index: 100003;
+		box-shadow: 2px 0 8px rgba(0, 0, 0, 0.2);
+	}
+}
+
+.boot-layout__mobile-sidebar-drawer {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 3;
+	background: var(--wpds-color-bg-surface-neutral, #fff);
+	padding: variables.$grid-unit-20;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+}
+
+.boot-layout__canvas.has-mobile-drawer {
+	position: relative;
+	padding-top: 65px;
 }
 
 .boot-layout__surfaces {
 	display: flex;
 	flex-grow: 1;
-	margin: variables.$grid-unit-10;
+	margin: 0;
 	gap: variables.$grid-unit-10;
+
+	@include mixins.break-medium {
+		margin: variables.$grid-unit-10;
+	}
 }
 
 .boot-layout__stage,
-.boot-layout__inspector,
+.boot-layout__inspector {
+	flex: 1;
+	overflow-y: auto;
+	background: var(--wpds-color-bg-surface-neutral, #fff);
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	position: relative;
+
+	// Mobile-first: surfaces take full screen with fixed positioning
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: 100vw;
+	height: 100vh;
+	border-radius: 0;
+	margin: 0;
+
+	// Desktop: restore original styles
+	@include mixins.break-medium {
+		position: static;
+		width: auto;
+		height: auto;
+		border-radius: 8px;
+		margin: 0;
+	}
+}
+
+.boot-layout__stage {
+	z-index: 2; // Highest surface priority on mobile
+
+	@include mixins.break-medium {
+		z-index: auto;
+	}
+}
+
+.boot-layout__inspector {
+	z-index: 3; // Medium surface priority on mobile
+
+	@include mixins.break-medium {
+		z-index: auto;
+	}
+}
+
 .boot-layout__canvas {
 	flex: 1;
 	overflow-y: auto;
 	background: var(--wpds-color-bg-surface-neutral, #fff);
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
-	border-radius: 8px;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
 	position: relative;
+
+	// Mobile-first: full screen with lowest priority
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: 100vw;
+	height: 100vh;
+	z-index: 1; // Lowest surface priority
+	border-radius: 0;
+	margin: 0;
+
+	// Desktop: restore original styles
+	@include mixins.break-medium {
+		position: static;
+		width: auto;
+		height: auto;
+		border-radius: 8px;
+		z-index: auto;
+	}
 }
 
 .boot-layout.has-canvas .boot-layout__stage,
 .boot-layout__inspector {
-	max-width: 400px;
+	@include mixins.break-medium {
+		max-width: 400px;
+	}
 }
 
 .boot-layout__canvas .interface-interface-skeleton {

--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -13,6 +13,7 @@ import {
 	redirect,
 	RouterProvider,
 	useCanGoBack,
+	useLocation,
 	useMatches,
 	useRouter,
 } from '@tanstack/react-router';
@@ -44,6 +45,7 @@ lock( privateApis, {
 	redirect,
 	createLink,
 	useCanGoBack,
+	useLocation,
 	useMatches,
 	useRouter,
 


### PR DESCRIPTION
Related #70862

## What?

Adds responsive mobile sidebar drawer to the boot package.

## Why?

The sidebar was always visible on desktop but inaccessible on mobile viewports, making navigation difficult on smaller screens.

## Testing Instructions

Check this url http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot&p=%2F

  1. Resize browser to mobile width (< 782px)
  2. Click hamburger menu icon in page header to open sidebar
  3. Verify sidebar slides in from left with backdrop
  4. Click backdrop or press Escape to close
  5. Navigate to different route - sidebar should auto-close
  6. Resize to desktop width - sidebar should display normally