### PR TITLE
Commenting scaling feature

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -39,6 +39,7 @@ import { noop } from './utils';
 const { useBlockElementRef, cleanEmptyObject } = unlock(
 	blockEditorPrivateApis
 );
+const { RECEIVE_INTERMEDIATE_RESULTS } = unlock( coreStore );
 
 export function useBlockComments( postId ) {
 	const [ commentLastUpdated, reflowComments ] = useReducer(
@@ -46,18 +47,44 @@ export function useBlockComments( postId ) {
 		0
 	);
 
+	// Initial query to fetch top-level notes only.
 	const queryArgs = {
 		post: postId,
 		type: 'note',
 		status: 'all',
+		parent: 0,
+		per_page: 100,
+	};
+
+	const { records: topLevelThreads } = useEntityRecords(
+		'root',
+		'comment',
+		queryArgs,
+		{
+			enabled: !! postId && typeof postId === 'number',
+		}
+	);
+
+	// Background query: fetch all notes.
+	const allCommentsQueryArgs = {
+		post: postId,
+		type: 'note',
+		status: 'all',
 		per_page: -1,
+		[ RECEIVE_INTERMEDIATE_RESULTS ]: true,
 	};
 
 	const { records: threads } = useEntityRecords(
 		'root',
 		'comment',
-		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
+		allCommentsQueryArgs,
+		{
+			enabled:
+				!! postId &&
+				typeof postId === 'number' &&
+				topLevelThreads &&
+				topLevelThreads.length > 0,
+		}
 	);
 
 	const { getBlockAttributes } = useSelect( blockEditorStore );


### PR DESCRIPTION
Closes #71668

This PR updates the useBlockComments hook to load comments in two stages:

Initial request: Fetch only top-level note comments.

Background request: Fetch all note comments (with intermediate results enabled).

## Why?

The current commenting implementation may not scale well when there are many (hundreds or thousands) comments (or comment replies) on a post.

## How

- Load only top-level comments first to render the sidebar immediately.
- Then fetch all remaining comments in the background using intermediate results.
- Enable the background fetch only after top-level data is ready, preventing sidebar flicker and scaling to large comment sets.

## Testing Instructions

- Open a post with many comments (or create >100 notes).
- Open the collab sidebar.
- The sidebar loads quickly with top-level comments.
- Replies load gradually in the background.

**Note:** This is an initial workaround to improve loading behavior for large comment sets. The approach may evolve as we gather more community feedback, validate performance, and explore more robust long-term solutions.


## Video 


https://github.com/user-attachments/assets/23efe683-b105-47d5-9707-2976177ecd1e

