### PR TITLE
Blocks: Add new attribute types; use for block bindings

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -118,11 +118,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
-	hasSupport( name ) {
-		return ! [
-			'core/post-date',
-			'core/navigation-link',
-			'core/navigation-submenu',
-		].includes( name );
+	hasSupport() {
+		return true;
 	},
 };

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -34,7 +34,7 @@
 			"default": false
 		},
 		"url": {
-			"type": "string",
+			"type": "url",
 			"role": "content"
 		},
 		"title": {

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -29,7 +29,7 @@
 			"default": false
 		},
 		"url": {
-			"type": "string",
+			"type": "url",
 			"role": "content"
 		},
 		"title": {

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -8,7 +8,7 @@
 	"textdomain": "default",
 	"attributes": {
 		"datetime": {
-			"type": "string",
+			"type": "datetime",
 			"role": "content"
 		},
 		"textAlign": {

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -15,17 +15,17 @@ const postDataFields = [
 	{
 		label: __( 'Post Date' ),
 		args: { field: 'date' },
-		type: 'string',
+		type: 'datetime',
 	},
 	{
 		label: __( 'Post Modified Date' ),
 		args: { field: 'modified' },
-		type: 'string',
+		type: 'datetime',
 	},
 	{
 		label: __( 'Post Link' ),
 		args: { field: 'link' },
-		type: 'string',
+		type: 'url',
 	},
 ];
 

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -162,17 +162,17 @@ describe( 'post-data bindings', () => {
 				{
 					label: 'Post Date',
 					args: { field: 'date' },
-					type: 'string',
+					type: 'datetime',
 				},
 				{
 					label: 'Post Modified Date',
 					args: { field: 'modified' },
-					type: 'string',
+					type: 'datetime',
 				},
 				{
 					label: 'Post Link',
 					args: { field: 'link' },
-					type: 'string',
+					type: 'url',
 				},
 			] );
 		} );

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -123,7 +123,9 @@
 										"string",
 										"rich-text",
 										"integer",
-										"number"
+										"number",
+										"datetime",
+										"url"
 									]
 								},
 								{

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -52,7 +52,7 @@ test.describe( 'Post Data source', () => {
 			// Check the fields registered by other sources are there.
 		} );
 
-		test( 'should not render Attributes panel for date blocks', async ( {
+		test( 'should include post data fields in UI to connect attributes on date blocks', async ( {
 			editor,
 			page,
 		} ) => {
@@ -69,9 +69,15 @@ test.describe( 'Post Data source', () => {
 					},
 				},
 			} );
-			await expect(
-				page.getByLabel( 'Attributes options' )
-			).toBeHidden();
+			await page
+				.getByRole( 'button', {
+					name: 'datetime',
+				} )
+				.click();
+			const postDataMenuItem = page.getByRole( 'menuitem', {
+				name: 'Post Data',
+			} );
+			await expect( postDataMenuItem ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
* Add two new block attribute types, `datetime` and `url`.
* Use them as types for the eponymous attributes in the Date, Navigation Link, and Navigation Submenu blocks, respectively.
* Furthermore, use them in the `core/post-data` block bindings source, in order to only display fields that match a given attribute type.

Fixes https://github.com/WordPress/gutenberg/issues/72446. Reverts https://github.com/WordPress/gutenberg/pull/72712.

An alternative approach was discussed in https://github.com/WordPress/gutenberg/pull/72716.

## Why?
To remove incompatible source items from the block bindings UI for a given block bindings source.

For example, when we show the available items from the `core/post-data` list for the Date block's `datetime` attribute, we only want to show the `date` and `modified` source items, but not `link` (which is an `url` and thus incompatible with a `datetime` field).

## How
By extending the list of allowed block attribute types, and changing some block attribute types to those newly added types.

## Testing Instructions
- In the editor, insert a Date block.
- In the block inspector, open the "Attributes" panel.
- Click on the `datetime` attribute to expand the dropdown menu. It should contain the "Post Data" source.
- Verify that there are two items available from that source: Post Date and Modified Date.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="700" height="240" alt="image" src="https://github.com/user-attachments/assets/0ff48979-e403-497b-92c4-b58e5f6ee53c" /> | <img width="657" height="188" alt="image" src="https://github.com/user-attachments/assets/91f32b42-84a5-49ef-9b83-dca315c3e825" /> |
