### PR TITLE
Attachments Controller: Allow strings as media_type

### DIFF
--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-attachments-controller-6-9.php
@@ -36,13 +36,13 @@ class Gutenberg_REST_Attachments_Controller_6_9 extends WP_REST_Attachments_Cont
 		$media_type_array = null;
 		$mime_type_array  = null;
 
-		if ( ! empty( $request['media_type'] ) && is_array( $request['media_type'] ) ) {
-			$media_type_array = $request['media_type'];
+		if ( ! empty( $request['media_type'] ) ) {
+			$media_type_array = is_array( $request['media_type'] ) ? $request['media_type'] : array( $request['media_type'] );
 			unset( $request['media_type'] );
 		}
 
-		if ( ! empty( $request['mime_type'] ) && is_array( $request['mime_type'] ) ) {
-			$mime_type_array = $request['mime_type'];
+		if ( ! empty( $request['mime_type'] ) ) {
+			$mime_type_array = is_array( $request['mime_type'] ) ? $request['mime_type'] : array( $request['mime_type'] );
 			unset( $request['mime_type'] );
 		}
 
@@ -110,19 +110,34 @@ class Gutenberg_REST_Attachments_Controller_6_9 extends WP_REST_Attachments_Cont
 		$params['media_type'] = array(
 			'default'     => null,
 			'description' => __( 'Limit result set to attachments of a particular media type or media types.' ),
-			'type'        => 'array',
-			'items'       => array(
-				'type' => 'string',
-				'enum' => $media_types,
+			'oneOf'       => array(
+				array(
+					'type' => 'string',
+					'enum' => $media_types,
+				),
+				array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+						'enum' => $media_types,
+					),
+				),
 			),
 		);
 
 		$params['mime_type'] = array(
 			'default'     => null,
 			'description' => __( 'Limit result set to attachments of a particular MIME type or MIME types.' ),
-			'type'        => 'array',
-			'items'       => array(
-				'type' => 'string',
+			'oneOf'       => array(
+				array(
+					'type' => 'string',
+				),
+				array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
 			),
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
In https://github.com/WordPress/gutenberg/pull/73029, we introduced `array` as a `media_type`. This is a breaking change, as previously these were only allowed as a `string`, breaking any existing implementations. This PR allows both `string` and `array` for `media_type`.

Do we need to make any changes elsewhere to support this? Also, I assume this will need to be backported to WP 6.9.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Allow backwards compatibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Allow for both arrays and strings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


