### PR TITLE
Zoom-out: add page 'carousel'

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1579,6 +1579,14 @@ _Returns_
 
 -   `Object`: Action object.
 
+### resetBlockEditingModes
+
+Clears all block editing modes.
+
+_Returns_
+
+-   `Object`: Action object.
+
 ### resetBlocks
 
 Action that resets blocks state to the specified array of blocks, taking precedence over any other content reflected as an edit in state.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2135,3 +2135,14 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * Clears all block editing modes.
+ *
+ * @return {Object} Action object.
+ */
+export function resetBlockEditingModes() {
+	return {
+		type: 'RESET_BLOCK_EDITING_MODES',
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2005,6 +2005,9 @@ export function blockEditingModes( state = new Map(), action ) {
 				? new Map().set( '', state.get( '' ) )
 				: state;
 		}
+		case 'RESET_BLOCK_EDITING_MODES': {
+			return new Map();
+		}
 	}
 	return state;
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -46,6 +46,7 @@ import {
 	useSyncDeprecatedEntityIntoState,
 } from './use-resolve-edited-entity';
 import SitePreview from './site-preview';
+import ZoomOutPageNavigation from '../zoom-out-page-navigation';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -235,6 +236,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 							<PluginTemplateSettingPanel.Slot />
 						)
 					}
+					extraContent={ <ZoomOutPageNavigation /> }
 				>
 					{ isEditMode && (
 						<BackButton>

--- a/packages/edit-site/src/components/zoom-out-page-navigation/index.js
+++ b/packages/edit-site/src/components/zoom-out-page-navigation/index.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useHistory } = unlock( routerPrivateApis );
+
+export default function ZoomOutPageNavigation() {
+	const history = useHistory();
+
+	const { isZoomedOut, currentPostId, currentPostType, pages } = useSelect(
+		( select ) => {
+			const { isZoomOut } = unlock( select( blockEditorStore ) );
+			const { getCurrentPostId, getCurrentPostType } =
+				select( editorStore );
+			const { getEntityRecords } = select( coreStore );
+
+			return {
+				isZoomedOut: isZoomOut(),
+				currentPostId: getCurrentPostId(),
+				currentPostType: getCurrentPostType(),
+				pages: getEntityRecords( 'postType', 'page', {
+					per_page: -1,
+					status: 'publish',
+					orderby: 'menu_order',
+					order: 'asc',
+				} ),
+			};
+		}
+	);
+
+	// Sort pages by menu_order, then by title (matching Page List block behavior)
+	const sortedPages = useMemo( () => {
+		if ( ! pages ) {
+			return [];
+		}
+		return [ ...pages ].sort( ( a, b ) => {
+			if ( a.menu_order === b.menu_order ) {
+				return a.title.rendered.localeCompare( b.title.rendered );
+			}
+			return a.menu_order - b.menu_order;
+		} );
+	}, [ pages ] );
+
+	// Only render for pages in zoom-out mode
+	if ( ! isZoomedOut || currentPostType !== 'page' || ! sortedPages.length ) {
+		return null;
+	}
+
+	// Find current page index and determine prev/next
+	const currentIndex = sortedPages.findIndex(
+		( p ) => p.id === currentPostId
+	);
+	const prevPage = currentIndex > 0 ? sortedPages[ currentIndex - 1 ] : null;
+	const nextPage =
+		currentIndex >= 0 && currentIndex < sortedPages.length - 1
+			? sortedPages[ currentIndex + 1 ]
+			: null;
+
+	const navigateToPage = ( pageId ) => {
+		history.navigate( `/page/${ pageId }?canvas=edit` );
+	};
+
+	return (
+		<>
+			{ prevPage && (
+				<Button
+					className="edit-site-zoom-out-page-navigation__prev"
+					icon={ chevronLeft }
+					label={ __( 'Previous page' ) }
+					onClick={ () => navigateToPage( prevPage.id ) }
+					__next40pxDefaultSize
+				/>
+			) }
+			{ nextPage && (
+				<Button
+					className="edit-site-zoom-out-page-navigation__next"
+					icon={ chevronRight }
+					label={ __( 'Next page' ) }
+					onClick={ () => navigateToPage( nextPage.id ) }
+					__next40pxDefaultSize
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/zoom-out-page-navigation/style.scss
+++ b/packages/edit-site/src/components/zoom-out-page-navigation/style.scss
@@ -1,0 +1,15 @@
+.edit-site-zoom-out-page-navigation__prev,
+.edit-site-zoom-out-page-navigation__next {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	z-index: 1000;
+}
+
+.edit-site-zoom-out-page-navigation__prev {
+	left: 0;
+}
+
+.edit-site-zoom-out-page-navigation__next {
+	right: 0;
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -33,6 +33,7 @@
 @use "./components/resizable-frame/style.scss" as *;
 @use "./components/pagination/style.scss" as *;
 @use "./components/sidebar-global-styles/style.scss" as *;
+@use "./components/zoom-out-page-navigation/style.scss" as *;
 
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 ::view-transition-image-pair(root) {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -13,6 +13,7 @@ import {
 	BlockEditorProvider,
 	BlockContextProvider,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
@@ -283,6 +284,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		} = unlock( useDispatch( editorStore ) );
 		const { createWarningNotice, removeNotice } =
 			useDispatch( noticesStore );
+		const { resetBlockEditingModes } = useDispatch( blockEditorStore );
 
 		// Ideally this should be synced on each change and not just something you do once.
 		useLayoutEffect( () => {
@@ -326,6 +328,12 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				removeNotice( 'template-activate-notice' );
 			}
 		}, [ post.type, post.id, setEditedPost, removeNotice ] );
+
+		// Reset block editing modes when switching posts to ensure
+		// stale modes from the previous post don't persist.
+		useEffect( () => {
+			resetBlockEditingModes();
+		}, [ post.id, resetBlockEditingModes ] );
 
 		// Synchronize the editor settings as they change.
 		useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

🚨 Vibe code alert: 99% Claude, 1% me (100% my good instructions 😛) 🚨

Adds prev/next buttons to Zoom-out mode:

* In Site Editor only for now (to take advantage of the router)
* For pages only for now (we could maybe do something similar for templates)
* For Pages appearing in the navigation only. I'm not sure what the right call is here. But also this makes it _very_ dependent on the Navigation block (we need to make sure the order matches).

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's lots of room, and it could be an interesting way to easily navigate between pages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It's pretty straightforward, just adds two buttons and queries for menu pages (that part might need polish to match the Navigation block more closely).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to the Site Editor. Make sure you have multiple pages in the Navigation block. Enter Zoom-out.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/e94935f0-9703-4c40-9502-29ab9b356357

https://github.com/user-attachments/assets/85abfc79-1a2b-4fde-a81d-e2c4788e3f51

