### PR TITLE
Template Activation: Update template ID format test

### DIFF
--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -75,34 +75,24 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
-		await page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save' } )
-			.click();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty:
+				! experiments.includes( 'active_templates' ),
+		} );
 
 		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		// Make a second edit to the template to ensure wp_id is not 0.
-		const secondEditText = `Second edit - ${ contentText }`;
+		const secondEditText = `Second edit: ${ contentText }`;
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: secondEditText },
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		const saveButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save' } );
-		await saveButton.click();
-
-		if ( experiments.includes( 'active_templates' ) ) {
-			const secondSaveButton = page
-				.getByRole( 'region', { name: 'Editor publish' } )
-				.getByRole( 'button', { name: 'Save' } );
-			await secondSaveButton.click();
-		} else {
-			await expect( saveButton ).toBeDisabled( { timeout: 5000 } );
-		}
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await expect( page.locator( 'body' ) ).not.toContainText(
 			'No templates exist with that id.'

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -93,10 +93,6 @@ test.describe( 'Template ID Format', () => {
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
 		} );
-
-		await expect( page.locator( 'body' ) ).not.toContainText(
-			'No templates exist with that id.'
-		);
 	};
 
 	test( 'should open and edit templates correctly when active_templates experiment is enabled', async ( {

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -3,6 +3,39 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
+	// Navigate directly to the page editor using the page ID.
+	await admin.editPost( pageId );
+
+	// Wait for the editor to be ready.
+	await expect(
+		page.locator( 'iframe[name="editor-canvas"]' )
+	).toBeVisible();
+
+	// Close pattern chooser dialog if visible.
+	const patternDialog = page.getByRole( 'dialog', {
+		name: 'Choose a pattern',
+	} );
+	await expect( patternDialog ).toBeVisible( { timeout: 2000 } );
+	await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
+
+	await editor.openDocumentSettingsSidebar();
+	const settingsPanel = page.getByRole( 'region', {
+		name: 'Editor settings',
+	} );
+	await settingsPanel.getByRole( 'tab', { name: 'Page' } ).click();
+	await settingsPanel
+		.getByRole( 'button', { name: 'Template options' } )
+		.click();
+	await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
+	await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
+
+	// Set preferences for the site editor context.
+	await editor.setPreferences( 'core/edit-post', {
+		welcomeGuideTemplate: false,
+	} );
+}
+
 test.describe( 'Template ID Format', () => {
 	let pageId;
 
@@ -34,36 +67,7 @@ test.describe( 'Template ID Format', () => {
 	) => {
 		await requestUtils.setGutenbergExperiments( experiments );
 
-		// Navigate directly to the page editor using the page ID.
-		await admin.editPost( pageId );
-
-		// Wait for the editor to be ready.
-		await expect(
-			page.locator( 'iframe[name="editor-canvas"]' )
-		).toBeVisible();
-
-		// Close pattern chooser dialog if visible.
-		const patternDialog = page.getByRole( 'dialog', {
-			name: 'Choose a pattern',
-		} );
-		await expect( patternDialog ).toBeVisible( { timeout: 2000 } );
-		await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
-
-		await editor.openDocumentSettingsSidebar();
-		const settingsPanel = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await settingsPanel.getByRole( 'tab', { name: 'Page' } ).click();
-		await settingsPanel
-			.getByRole( 'button', { name: 'Template options' } )
-			.click();
-		await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
-		await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
-
-		// Set preferences for the site editor context.
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuideTemplate: false,
-		} );
+		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		await editor.insertBlock( {
 			name: 'core/paragraph',
@@ -75,6 +79,30 @@ test.describe( 'Template ID Format', () => {
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Save' } )
 			.click();
+
+		await navigateToTemplateEditor( { admin, editor, page }, pageId );
+
+		// Make a second edit to the template to ensure wp_id is not 0.
+		const secondEditText = `Second edit - ${ contentText }`;
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: secondEditText },
+		} );
+		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
+
+		const saveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } );
+		await saveButton.click();
+
+		if ( experiments.includes( 'active_templates' ) ) {
+			const secondSaveButton = page
+				.getByRole( 'region', { name: 'Editor publish' } )
+				.getByRole( 'button', { name: 'Save' } );
+			await secondSaveButton.click();
+		} else {
+			await expect( saveButton ).toBeDisabled( { timeout: 5000 } );
+		}
 
 		await expect( page.locator( 'body' ) ).not.toContainText(
 			'No templates exist with that id.'

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -4,15 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
-	// Navigate directly to the page editor using the page ID.
 	await admin.editPost( pageId );
-
-	// Wait for the editor to be ready.
 	await expect(
 		page.locator( 'iframe[name="editor-canvas"]' )
 	).toBeVisible();
 
-	// Close pattern chooser dialog if visible.
+	// Close pattern chooser dialog.
 	const patternDialog = page.getByRole( 'dialog', {
 		name: 'Choose a pattern',
 	} );
@@ -30,7 +27,6 @@ async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
 	await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
 	await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
 
-	// Set preferences for the site editor context.
 	await editor.setPreferences( 'core/edit-post', {
 		welcomeGuideTemplate: false,
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Updates the template ID format test to include two edits to the template, as this is what was causing the original bug.

<!-- In a few words, what is the PR actually doing? -->

## Why? / How?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure test covers regression by including two edits to the template.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. This test should fail if the fix in https://github.com/WordPress/gutenberg/pull/73585 is removed
2. All tests should pass otherwise
