### PR TITLE
Command Palette: add pages to initial view for page editor

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -13,6 +13,7 @@ import Layout from '../layout';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import { useCommonCommands } from '../../hooks/commands/use-common-commands';
+import { usePageNavigationCommands } from '../../hooks/commands/use-page-navigation-commands';
 import useSetCommandContext from '../../hooks/commands/use-set-command-context';
 import { useRegisterSiteEditorRoutes } from '../site-editor-routes';
 import {
@@ -24,6 +25,7 @@ const { RouterProvider } = unlock( routerPrivateApis );
 
 function AppLayout() {
 	useCommonCommands();
+	usePageNavigationCommands();
 	useSetCommandContext();
 
 	return <Layout />;

--- a/packages/edit-site/src/hooks/commands/use-page-navigation-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-page-navigation-commands.js
@@ -1,0 +1,95 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { page as pageIcon } from '@wordpress/icons';
+import { useCommandLoader } from '@wordpress/commands';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useHistory } = unlock( routerPrivateApis );
+
+const getPageNavigationCommandLoader = () =>
+	function usePageNavigationCommandLoader( { search } ) {
+		const history = useHistory();
+
+		const { currentPostType, pages, isLoading } = useSelect(
+			( select ) => {
+				const { getCurrentPostType } = select( editorStore );
+				const postType = getCurrentPostType();
+
+				// Only load pages when editing a page and no search query
+				// (the existing search-based loader handles searches)
+				if ( postType !== 'page' || search ) {
+					return {
+						currentPostType: postType,
+						pages: [],
+						isLoading: false,
+					};
+				}
+
+				const query = {
+					per_page: -1,
+					status: 'publish',
+					orderby: 'menu_order',
+					order: 'asc',
+				};
+
+				return {
+					currentPostType: postType,
+					pages:
+						select( coreStore ).getEntityRecords(
+							'postType',
+							'page',
+							query
+						) ?? [],
+					isLoading: ! select( coreStore ).hasFinishedResolution(
+						'getEntityRecords',
+						[ 'postType', 'page', query ]
+					),
+				};
+			},
+			[ search ]
+		);
+
+		const commands = useMemo( () => {
+			// Don't show commands if not editing a page or if searching
+			if ( currentPostType !== 'page' || search ) {
+				return [];
+			}
+
+			return pages.map( ( pageRecord ) => ( {
+				name: 'core/edit-site/navigate-to-page-' + pageRecord.id,
+				label: pageRecord.title?.rendered
+					? decodeEntities( pageRecord.title.rendered )
+					: __( '(no title)' ),
+				icon: pageIcon,
+				callback: ( { close } ) => {
+					history.navigate( `/page/${ pageRecord.id }?canvas=edit` );
+					close();
+				},
+			} ) );
+		}, [ currentPostType, pages, history, search ] );
+
+		return {
+			commands,
+			isLoading,
+		};
+	};
+
+export function usePageNavigationCommands() {
+	useCommandLoader( {
+		name: 'core/edit-site/page-navigation',
+		hook: getPageNavigationCommandLoader(),
+		context: 'entity-edit', // Shows by default when in edit mode
+	} );
+}

--- a/packages/edit-site/src/hooks/commands/use-page-navigation-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-page-navigation-commands.js
@@ -61,13 +61,25 @@ const getPageNavigationCommandLoader = () =>
 			[ search ]
 		);
 
+		const sortedPages = useMemo( () => {
+			if ( ! pages ) {
+				return [];
+			}
+			return [ ...pages ].sort( ( a, b ) => {
+				if ( a.menu_order === b.menu_order ) {
+					return a.title.rendered.localeCompare( b.title.rendered );
+				}
+				return a.menu_order - b.menu_order;
+			} );
+		}, [ pages ] );
+
 		const commands = useMemo( () => {
 			// Don't show commands if not editing a page or if searching
 			if ( currentPostType !== 'page' || search ) {
 				return [];
 			}
 
-			return pages.map( ( pageRecord ) => ( {
+			return sortedPages.map( ( pageRecord ) => ( {
 				name: 'core/edit-site/navigate-to-page-' + pageRecord.id,
 				label: pageRecord.title?.rendered
 					? decodeEntities( pageRecord.title.rendered )
@@ -78,7 +90,7 @@ const getPageNavigationCommandLoader = () =>
 					close();
 				},
 			} ) );
-		}, [ currentPostType, pages, history, search ] );
+		}, [ currentPostType, sortedPages, history, search ] );
 
 		return {
 			commands,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Related: #73628.

🚨 Vibe code alert: 100% Claude 🚨

Adds the pages that appear in the Navigation block to the initial command palette list.

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/34f548b7-ee64-4fc3-b9c5-33805929e3ea" />

Test in the Site Editor. Perhaps we should also add this to templates? I'm not sure.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's hard to discover how to navigate between pages, so this simple addition could help a little. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the Site Editor. Go to a page. Make sure you have multiple pages in the Navigation block. Click the document toolbar to open the command palette.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

