### PR TITLE
Docs: update package docs with general guidelines

### DIFF
--- a/docs/reference-guides/packages.md
+++ b/docs/reference-guides/packages.md
@@ -2,6 +2,40 @@
 
 WordPress exposes a list of JavaScript packages and tools for WordPress development.
 
+For information on creating and managing packages in Gutenberg, see the [packages README](../../packages/README.md). For details on the build system and package configuration, see the [@wordpress/build README](../../packages/wp-build/README.md).
+
+## Package Guidelines
+
+Packages are the first layer of architecture and organization in Gutenberg. They exist to separate concerns, provide clarity, and establish a shared mental model across teams. To maintain good package hygiene, follow these guidelines when creating new packages or iterating on existing ones:
+
+1. **Each package should have a single, clear purpose.**
+
+   It should be immediately obvious why the package exists.
+
+2. **Every package must include a README.**
+
+   This is the first place contributors look to understand scope and usage.
+
+3. **Any prerequisites must be documented.**
+
+   Generic packages without prerequisites are better, but packages with some prerequisites are acceptable. Examples of prerequisites: API endpoints that must exist, authentication assumptions, environment dependencies. These should be clearly stated in the README.
+
+4. **Public APIs should have documentation.**
+
+   Either inline in the README or linked to external docs.
+
+5. **Avoid utility and kitchen-sink packages.**
+
+   They tend to grow without a coherent domain and become junk drawers.
+
+6. **Avoid broad, catch-all scopes.**
+
+   For example: "Reusable components for the WooCommerce plugin." This creates unclear ownership and encourages uncontrolled growth.
+
+7. **Default to bundled packages (no globals, no modules) unless necessary.**
+
+   In Gutenberg, we should default to "bundled" packages unless there's a specific need for globals or modules. See the [@wordpress/build README](../../packages/wp-build/README.md) for more information on package configuration.
+
 ## Using the packages via WordPress global
 
 JavaScript packages are available as a registered script in WordPress and can be accessed using the `wp` global variable.

--- a/docs/reference-guides/packages.md
+++ b/docs/reference-guides/packages.md
@@ -6,35 +6,9 @@ For information on creating and managing packages in Gutenberg, see the [package
 
 ## Package Guidelines
 
-Packages are the first layer of architecture and organization in Gutenberg. They exist to separate concerns, provide clarity, and establish a shared mental model across teams. To maintain good package hygiene, follow these guidelines when creating new packages or iterating on existing ones:
+Packages are the first layer of architecture in Gutenberg. Each package should have a single, clear purpose, include a README, document prerequisites and public APIs, and avoid utility/kitchen-sink patterns. Default to bundled packages unless globals or modules are necessary.
 
-1. **Each package should have a single, clear purpose.**
-
-   It should be immediately obvious why the package exists.
-
-2. **Every package must include a README.**
-
-   This is the first place contributors look to understand scope and usage.
-
-3. **Any prerequisites must be documented.**
-
-   Generic packages without prerequisites are better, but packages with some prerequisites are acceptable. Examples of prerequisites: API endpoints that must exist, authentication assumptions, environment dependencies. These should be clearly stated in the README.
-
-4. **Public APIs should have documentation.**
-
-   Either inline in the README or linked to external docs.
-
-5. **Avoid utility and kitchen-sink packages.**
-
-   They tend to grow without a coherent domain and become junk drawers.
-
-6. **Avoid broad, catch-all scopes.**
-
-   For example: "Reusable components for the WooCommerce plugin." This creates unclear ownership and encourages uncontrolled growth.
-
-7. **Default to bundled packages (no globals, no modules) unless necessary.**
-
-   In Gutenberg, we should default to "bundled" packages unless there's a specific need for globals or modules. See the [@wordpress/build README](../../packages/wp-build/README.md) for more information on package configuration.
+For complete guidelines, see the [package guidelines](../../packages/README.md#package-guidelines) in the packages README.
 
 ## Using the packages via WordPress global
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -28,7 +28,7 @@ Packages are the first layer of architecture and organization in Gutenberg. They
 
 6. **Avoid broad, catch-all scopes.**
 
-   For example: "Reusable components for the WooCommerce plugin." This creates unclear ownership and encourages uncontrolled growth.
+   For example: "Reusable WordPress components" or "Utilities for different use cases." These create unclear ownership and encourage uncontrolled growth. Instead, define a specific domain or purpose.
 
 7. **Default to bundled packages (no globals, no modules) unless necessary.**
 
@@ -127,6 +127,21 @@ When creating a new package, you need to provide at least the following. Package
     ```
 
 To ensure your package is recognized in npm workspaces, you should run `npm install` to update the package lock file.
+
+## Making a Package Private
+
+If a package is only used internally within Gutenberg (or WordPress core) and should not be published to npm, mark it as private by adding the following to the package's `package.json`:
+
+```json
+{
+	"private": true,
+	"wpScript": false
+}
+```
+
+Private packages will be excluded from npm publication but will still work within the monorepo as dependencies for other packages. Setting `wpScript` to `false` ensures the package is not exposed as a WordPress script.
+
+Note: You can safely include the `publishConfig` field in private packages—it will be ignored by npm since the `private` flag takes precedence.
 
 ## Managing Dependencies
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,6 +2,40 @@
 
 This repository uses [npm workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) to manage WordPress packages and [lerna](https://lerna.js.org/) to publish them with to [npm](https://www.npmjs.com/).
 
+## Package Guidelines
+
+Packages are the first layer of architecture and organization in Gutenberg. They exist to separate concerns, provide clarity, and establish a shared mental model across teams. To maintain good package hygiene, follow these guidelines when creating new packages or iterating on existing ones:
+
+1. **Each package should have a single, clear purpose.**
+
+   It should be immediately obvious why the package exists.
+
+2. **Every package must include a README.**
+
+   This is the first place contributors look to understand scope and usage.
+
+3. **Any prerequisites must be documented.**
+
+   Generic packages without prerequisites are better, but packages with some prerequisites are acceptable. Examples of prerequisites: API endpoints that must exist, authentication assumptions, environment dependencies. These should be clearly stated in the README.
+
+4. **Public APIs should have documentation.**
+
+   Either inline in the README or linked to external docs.
+
+5. **Avoid utility and kitchen-sink packages.**
+
+   They tend to grow without a coherent domain and become junk drawers.
+
+6. **Avoid broad, catch-all scopes.**
+
+   For example: "Reusable components for the WooCommerce plugin." This creates unclear ownership and encourages uncontrolled growth.
+
+7. **Default to bundled packages (no globals, no modules) unless necessary.**
+
+   In Gutenberg, we should default to "bundled" packages unless there's a specific need for globals or modules. See the [@wordpress/build README](../wp-build/README.md) for more information on package configuration.
+
+For more information on the build system and package configuration, see the [@wordpress/build README](../wp-build/README.md).
+
 ## Creating a New Package
 
 When creating a new package, you need to provide at least the following. Packages bundled in Gutenberg or WordPress must include a `wpScript` and or `wpScriptModuleExports` field in their `package.json` file. See the details below.
@@ -71,6 +105,8 @@ When creating a new package, you need to provide at least the following. Package
     ```
 
     Both `wpScript` and `wpScriptModuleExports` may be included if the package exposes both a script and a script module. These fields are also essential when performing a license check for all their dependencies, because they trigger strict validation against compatibility with GPL v2. All remaining dependencies WordPress doesn't distribute but uses for development purposes can contain also a few other OSS compatible licenses.
+
+    For more details on package configuration options, see the [@wordpress/build README](../wp-build/README.md).
 
 1. `README.md` file containing at least:
     - Package name

--- a/packages/README.md
+++ b/packages/README.md
@@ -128,9 +128,31 @@ When creating a new package, you need to provide at least the following. Package
 
 To ensure your package is recognized in npm workspaces, you should run `npm install` to update the package lock file.
 
-## Making a Package Private
+## When to Omit or Set `wpScript` to `false`
 
-If a package is only used internally within Gutenberg (or WordPress core) and should not be published to npm, mark it as private by adding the following to the package's `package.json`:
+By default, packages do not expose as WordPress scripts/modules (not accessible via the `wp` global). Only packages that should be directly available in WordPress should set `wpScript: true`.
+
+Omit `wpScript` (or explicitly set to `false`) for packages designed solely as dependencies for other packages:
+
+```json
+{
+	"wpScript": false
+}
+```
+
+**Examples of packages that should not expose to the `wp` global:**
+- Utility packages used internally by other packages
+- Shared logic or helpers without a direct WordPress use case
+- Intermediate packages intended only as dependencies of other `@wordpress/*` packages
+
+When a package omits `wpScript` or sets it to `false`, it:
+- Will not be exposed as a WordPress script (not available via the `wp` global)
+- Can still be used as a dependency by other packages (via npm imports)
+- Should still be published to npm to support backporting to WordPress core releases
+
+### Truly Private Packages
+
+In rare cases, if a package is only used internally within Gutenberg and should never be published to npm, mark it as private:
 
 ```json
 {
@@ -139,7 +161,7 @@ If a package is only used internally within Gutenberg (or WordPress core) and sh
 }
 ```
 
-Private packages will be excluded from npm publication but will still work within the monorepo as dependencies for other packages. Setting `wpScript` to `false` ensures the package is not exposed as a WordPress script.
+Private packages will be excluded from npm publication and should only be used for development-only utilities (such as build tools or internal development helpers). They should not be used as dependencies for other packages, as this could break the backporting process to WordPress core.
 
 Note: You can safely include the `publishConfig` field in private packages—it will be ignored by npm since the `private` flag takes precedence.
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -58,13 +58,19 @@ Configure your `package.json` with the following optional fields:
 
 ### `wpScript`
 
-Set to `true` to bundle the package as a WordPress script/module:
+Controls whether the package is exposed as a bundled WordPress script/module and accessible via the configured global variable.
+
+- **`true`**: The package will be bundled and exposed as a WordPress script. It will be available in WordPress as part of the configured global (e.g., `wp.blockEditor`, `wp.data`, or a custom global name if configured differently).
+
+- **Omitted or `false` (default)**: The package will not be exposed as a WordPress script. Use this for packages designed solely as dependencies for other packages. The package can still be used as a dependency via npm imports by other packages.
 
 ```json
 {
 	"wpScript": true
 }
 ```
+
+For more details on when to omit or set this to `false`, see the [package guidelines](../README.md#when-to-omit-or-set-wpscript-to-false).
 
 ### `wpScriptModuleExports`
 


### PR DESCRIPTION



## What?

Adds package guidelines to `packages/README.md` and `docs/reference-guides/packages.md`, covering purpose, documentation, prerequisites, and avoiding utility/kitchen-sink packages. 

Also adds links to `packages/wp-build/README.md` for build system details.
