### PR TITLE
Attachments controller: use 6.7 compat method

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
@@ -150,7 +150,15 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Don't prepare the response body for HEAD requests.
-		if ( $request->is_method( 'HEAD' ) ) {
+		/*
+		 * Gutenberg only. Do not backport this change to core. 
+		 * Using the get_method() method to check the request method
+		 * to satisfy the minimum `GUTENBERG_MINIMUM_WP_VERSION` version requirement for WordPress 6.7 and above.
+		 * Once 6.9 is released, we can make Gutenberg's minimum version
+		 * requirement 6.8 and then use the is_method() method instead.
+		 * See: https://core.trac.wordpress.org/changeset/59899
+		 */ 
+		if ( 'HEAD' === $request->get_method() ) {
 			return new WP_REST_Response( array() );
 		}
 

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
@@ -151,13 +151,13 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 	public function prepare_item_for_response( $item, $request ) {
 		// Don't prepare the response body for HEAD requests.
 		/*
-		 * Gutenberg only. Do not backport this change to core. 
+		 * Gutenberg only. Do not backport this change to core.
 		 * Using the get_method() method to check the request method
 		 * to satisfy the minimum `GUTENBERG_MINIMUM_WP_VERSION` version requirement for WordPress 6.7 and above.
 		 * Once 6.9 is released, we can make Gutenberg's minimum version
 		 * requirement 6.8 and then use the is_method() method instead.
 		 * See: https://core.trac.wordpress.org/changeset/59899
-		 */ 
+		 */
 		if ( 'HEAD' === $request->get_method() ) {
 			return new WP_REST_Response( array() );
 		}


### PR DESCRIPTION

## What?

Update Gutenberg REST Templates Controller: Change request method check from `is_method()` to `get_method()` for HEAD requests to comply with minimum WordPress version requirements. 

The use of `is_method()` was committed in https://github.com/WordPress/gutenberg/pull/73477, since it matched Core. 
Unit tests passed locally on the branch, but appear to break things on the trunk CI.

> [!IMPORTANT]
> This adjustment is specific to Gutenberg and should not be backported to Core.

## Why

The tests were failing because they were running against WP 6.7, and in that version there is no such method as `is_method()`

`Call to undefined method WP_REST_Request::is_method() in the file: wp-content/plugins/gutenberg/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php at line 153.`

For now, and until WP 6.8 becomes the minimum version after the release of 6.9, let's make the extension class compatible with 6.7.

Once 6.9 is released, we can make Gutenberg's minimum version 6.8 and revert this change.

See: https://core.trac.wordpress.org/changeset/59899

## Testing

Tests should pass.


