### PR TITLE
Font Library: Move Font Collection fetching to core-data entities

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -211,6 +211,15 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/registered-templates',
 		key: 'id',
 	},
+	{
+		label: __( 'Font Collections' ),
+		name: 'fontCollection',
+		kind: 'root',
+		baseURL: '/wp/v2/font-collections',
+		baseURLParams: { context: 'view' },
+		plural: 'fontCollections',
+		key: 'slug',
+	},
 ];
 
 export const deprecatedEntities = {

--- a/packages/core-data/src/entity-types/font-collection.ts
+++ b/packages/core-data/src/entity-types/font-collection.ts
@@ -1,0 +1,62 @@
+/**
+ * Internal dependencies
+ */
+import type { Context } from './helpers';
+import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+
+declare module './base-entity-records' {
+	export namespace BaseEntityRecords {
+		/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+		export interface FontCollection< C extends Context > {
+			/**
+			 * The collection's slug. This uniquely identifies the collection.
+			 */
+			slug: string;
+			/**
+			 * The name of the collection.
+			 */
+			name: string;
+			/**
+			 * A description of the collection.
+			 */
+			description?: string;
+			/**
+			 * List of font families in this collection.
+			 */
+			font_families?: CollectionFontFamily[];
+			/**
+			 * Categories for organizing fonts.
+			 */
+			categories?: Array< {
+				slug: string;
+				name: string;
+			} >;
+		}
+	}
+}
+
+interface CollectionFontFamily {
+	id: string;
+	font_family_settings: Record<
+		string,
+		{
+			name: string;
+			fontFamily: string;
+			slug: string;
+			fontFace: {
+				src: string;
+				fontWeight?: string;
+				fontStyle?: string;
+				fontFamily?: string;
+				preview?: string;
+			}[];
+			preview: string;
+		}
+	>;
+	categories?: string[];
+}
+
+export type FontCollection< C extends Context = 'edit' > =
+	_BaseEntityRecords.FontCollection< C >;
+
+export type { _BaseEntityRecords as BaseEntityRecords };

--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -5,6 +5,7 @@ import type { Context, Updatable } from './helpers';
 import type { Attachment } from './attachment';
 import type { Base, TemplatePartArea, TemplateType } from './base';
 import type { Comment } from './comment';
+import type { FontCollection } from './font-collection';
 import type { GlobalStylesRevision } from './global-styles-revision';
 import type { MenuLocation } from './menu-location';
 import type { NavMenu } from './nav-menu';
@@ -33,6 +34,7 @@ export type {
 	Base as UnstableBase,
 	Comment,
 	Context,
+	FontCollection,
 	GlobalStylesRevision,
 	MenuLocation,
 	NavMenu,
@@ -95,6 +97,7 @@ export interface PerPackageEntityRecords< C extends Context > {
 		| Base< C >
 		| Attachment< C >
 		| Comment< C >
+		| FontCollection< C >
 		| GlobalStylesRevision< C >
 		| MenuLocation< C >
 		| NavMenu< C >

--- a/packages/global-styles-ui/src/font-library-modal/context.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/context.tsx
@@ -21,8 +21,6 @@ import {
 	fetchGetFontFamilyBySlug,
 	fetchInstallFontFamily,
 	fetchUninstallFontFamily,
-	fetchFontCollections,
-	fetchFontCollection,
 } from './resolvers';
 import {
 	setUIValuesNeeded,
@@ -39,7 +37,6 @@ import { setImmutably } from './utils/set-immutably';
 import { toggleFont } from './utils/toggleFont';
 import type {
 	CollectionFontFamily,
-	FontCollection,
 	FontFace,
 	FontFamily,
 	FontLibraryState,
@@ -525,40 +522,6 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		loadedFontUrls.add( src );
 	};
 
-	// Font Collections
-	const [ collections, setFontCollections ] = useState< FontCollection[] >(
-		[]
-	);
-	const getFontCollections = async () => {
-		const response = await fetchFontCollections();
-		setFontCollections( response );
-	};
-	const getFontCollection = async ( slug: string ) => {
-		try {
-			const hasData = !! collections.find(
-				( collection ) => collection.slug === slug
-			)?.font_families;
-			if ( hasData ) {
-				return;
-			}
-			const response = await fetchFontCollection( slug );
-			const updatedCollections = collections.map( ( collection ) =>
-				collection.slug === slug
-					? { ...collection, ...response }
-					: collection
-			);
-			setFontCollections( updatedCollections );
-		} catch ( e ) {
-			// eslint-disable-next-line no-console
-			console.error( e );
-			throw e;
-		}
-	};
-
-	useEffect( () => {
-		getFontCollections();
-	}, [] );
-
 	return (
 		<FontLibraryContext.Provider
 			value={ {
@@ -579,8 +542,6 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 				saveFontFamilies,
 				isResolvingLibrary,
 				isInstalling,
-				collections,
-				getFontCollection,
 			} }
 		>
 			{ children }

--- a/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
@@ -89,7 +89,7 @@ function FontCollection( { slug }: { slug: string } ) {
 		requiresPermission && ! getGoogleFontsPermissionFromStorage()
 	);
 	const { installFonts, isInstalling } = useContext( FontLibraryContext );
-	const { record: selectedCollection } =
+	const { record: selectedCollection, isResolving: isLoading } =
 		useEntityRecord< FontCollectionType >( 'root', 'fontCollection', slug );
 
 	useEffect( () => {
@@ -132,8 +132,6 @@ function FontCollection( { slug }: { slug: string } ) {
 		() => filterFonts( collectionFonts, filters ),
 		[ collectionFonts, filters ]
 	);
-
-	const isLoading = ! selectedCollection?.font_families && ! notice;
 
 	// NOTE: The height of the font library modal unavailable to use for rendering font family items is roughly 417px
 	// The height of each font family item is 61px.

--- a/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
@@ -33,6 +33,10 @@ import {
 	chevronLeft,
 	chevronRight,
 } from '@wordpress/icons';
+import {
+	useEntityRecord,
+	type FontCollection as FontCollectionType,
+} from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -49,7 +53,7 @@ import GoogleFontsConfirmDialog from './google-fonts-confirm-dialog';
 import { downloadFontFaceAssets } from './utils';
 import { sortFontFaces } from './utils/sort-font-faces';
 import CollectionFontVariant from './collection-font-variant';
-import type { FontFace, FontFamily } from './types';
+import type { FontFace, FontFamily, CollectionFontFamily } from './types';
 
 const DEFAULT_CATEGORY = {
 	slug: 'all',
@@ -84,11 +88,9 @@ function FontCollection( { slug }: { slug: string } ) {
 	const [ renderConfirmDialog, setRenderConfirmDialog ] = useState(
 		requiresPermission && ! getGoogleFontsPermissionFromStorage()
 	);
-	const { collections, getFontCollection, installFonts, isInstalling } =
-		useContext( FontLibraryContext );
-	const selectedCollection = collections.find(
-		( collection ) => collection.slug === slug
-	);
+	const { installFonts, isInstalling } = useContext( FontLibraryContext );
+	const { record: selectedCollection } =
+		useEntityRecord< FontCollectionType >( 'root', 'fontCollection', slug );
 
 	useEffect( () => {
 		const handleStorage = () => {
@@ -107,23 +109,6 @@ function FontCollection( { slug }: { slug: string } ) {
 	};
 
 	useEffect( () => {
-		const fetchFontCollection = async () => {
-			try {
-				await getFontCollection( slug );
-				resetFilters();
-			} catch ( e ) {
-				if ( ! notice ) {
-					setNotice( {
-						type: 'error',
-						message: ( e as Error )?.message,
-					} );
-				}
-			}
-		};
-		fetchFontCollection();
-	}, [ slug, getFontCollection, setNotice, notice ] );
-
-	useEffect( () => {
 		setSelectedFont( null );
 	}, [ slug ] );
 
@@ -133,7 +118,10 @@ function FontCollection( { slug }: { slug: string } ) {
 	}, [ selectedFont ] );
 
 	const collectionFonts = useMemo(
-		() => selectedCollection?.font_families ?? [],
+		() =>
+			( selectedCollection?.font_families as
+				| CollectionFontFamily[]
+				| undefined ) ?? [],
 		[ selectedCollection ]
 	);
 	const collectionCategories = selectedCollection?.categories ?? [];
@@ -168,11 +156,6 @@ function FontCollection( { slug }: { slug: string } ) {
 
 	// @ts-expect-error
 	const debouncedUpdateSearchInput = debounce( handleUpdateSearchInput, 300 );
-
-	const resetFilters = () => {
-		setFilters( {} );
-		setPage( 1 );
-	};
 
 	const handleToggleVariant = ( font: FontFamily, face?: FontFace ) => {
 		const newFontsToInstall = toggleFont( font, face, fontsToInstall );

--- a/packages/global-styles-ui/src/font-library-modal/index.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/index.tsx
@@ -6,9 +6,9 @@ import {
 	Modal,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useContext } from '@wordpress/element';
+import type { FontCollection as FontCollectionType } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -16,8 +16,6 @@ import { useContext } from '@wordpress/element';
 import InstalledFonts from './installed-fonts';
 import FontCollection from './font-collection';
 import UploadFonts from './upload-fonts';
-import { FontLibraryContext } from './context';
-import type { FontCollection as FontCollectionType } from './types';
 import { unlock } from '../lock-unlock';
 
 const { Tabs } = unlock( componentsPrivateApis );
@@ -48,7 +46,10 @@ function FontLibraryModal( {
 	onRequestClose: () => void;
 	defaultTabId?: string;
 } ) {
-	const { collections } = useContext( FontLibraryContext );
+	const { records: collections = [] } =
+		useEntityRecords< FontCollectionType >( 'root', 'fontCollection', {
+			_fields: 'slug,name,description',
+		} );
 	const canUserCreate = useSelect( ( select ) => {
 		return select( coreStore ).canUser( 'create', {
 			kind: 'postType',

--- a/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/resolvers.tsx
@@ -9,12 +9,10 @@ import apiFetch from '@wordpress/api-fetch';
 import type {
 	CollectionFontFace,
 	CollectionFontFamily,
-	FontCollection,
 	FontFace,
 } from './types';
 
 const FONT_FAMILIES_URL = '/wp/v2/font-families';
-const FONT_COLLECTIONS_URL = '/wp/v2/font-collections';
 
 export async function fetchInstallFontFamily( data: FormData ) {
 	const config = {
@@ -78,20 +76,4 @@ export async function fetchUninstallFontFamily(
 		method: 'DELETE',
 	};
 	return await apiFetch( config );
-}
-
-export async function fetchFontCollections() {
-	const config = {
-		path: `${ FONT_COLLECTIONS_URL }?_fields=slug,name,description`,
-		method: 'GET',
-	};
-	return ( await apiFetch( config ) ) as FontCollection[];
-}
-
-export async function fetchFontCollection( id: string ) {
-	const config = {
-		path: `${ FONT_COLLECTIONS_URL }/${ id }`,
-		method: 'GET',
-	};
-	return ( await apiFetch( config ) ) as FontCollection;
 }

--- a/packages/global-styles-ui/src/font-library-modal/types.ts
+++ b/packages/global-styles-ui/src/font-library-modal/types.ts
@@ -51,18 +51,6 @@ export interface FontFamily {
 	category?: string;
 }
 
-export interface FontCollection {
-	id: string;
-	slug: string;
-	name: string;
-	description?: string;
-	font_families?: CollectionFontFamily[];
-	categories?: {
-		slug: string;
-		name: string;
-	}[];
-}
-
 export interface FontLibraryState {
 	isInstalling: boolean;
 	fontFamilies: Record< string, FontFamilyPreset[] >;
@@ -100,8 +88,6 @@ export interface FontLibraryState {
 			| undefined
 	) => Promise< void >;
 	isResolvingLibrary: boolean;
-	collections: FontCollection[];
-	getFontCollection: ( slug: string ) => Promise< FontCollection | void >;
 }
 
 export interface FontDemoProps {


### PR DESCRIPTION
## What

This PR updates the code to fetch font collections to use core-data entities instead of adhoc api-fetch calls within random packages.

## Why

 - All the benefits core-data provides in terms of caching...
 - A lot simpler architecture
 - Consistency

## Testing instructions

 - Open the font library modal from global styles
 - Install fonts...