### PR TITLE
Font Library: Move font family fetching and types to core-data

### DIFF
--- a/packages/core-data/src/entity-types/font-collection.ts
+++ b/packages/core-data/src/entity-types/font-collection.ts
@@ -3,6 +3,7 @@
  */
 import type { Context } from './helpers';
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { FontFace, FontFamily } from './font-family';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -35,25 +36,24 @@ declare module './base-entity-records' {
 	}
 }
 
-interface CollectionFontFamily {
+/**
+ * Collection wrapper for REST API font family responses.
+ */
+export interface CollectionFontFamily {
 	id: string;
-	font_family_settings: Record<
-		string,
-		{
-			name: string;
-			fontFamily: string;
-			slug: string;
-			fontFace: {
-				src: string;
-				fontWeight?: string;
-				fontStyle?: string;
-				fontFamily?: string;
-				preview?: string;
-			}[];
-			preview: string;
-		}
-	>;
+	font_family_settings: FontFamily;
 	categories?: string[];
+	_embedded?: {
+		font_faces?: CollectionFontFace[];
+	};
+}
+
+/**
+ * Collection wrapper for REST API font face responses.
+ */
+export interface CollectionFontFace {
+	id: string;
+	font_face_settings: FontFace;
 }
 
 export type FontCollection< C extends Context = 'edit' > =

--- a/packages/core-data/src/entity-types/font-family.ts
+++ b/packages/core-data/src/entity-types/font-family.ts
@@ -1,0 +1,94 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	Context,
+	ContextualField,
+	RenderedText,
+	OmitNevers,
+} from './helpers';
+import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+
+declare module './base-entity-records' {
+	export namespace BaseEntityRecords {
+		/**
+		 * Font Family post type (wp_font_family)
+		 */
+		export interface WpFontFamily< C extends Context > {
+			/**
+			 * Unique identifier for the font family.
+			 */
+			id: number | string;
+			/**
+			 * An alphanumeric identifier for the font family unique to its type.
+			 */
+			slug: string;
+			/**
+			 * The name of the font family (rendered).
+			 */
+			name: RenderedText< C >;
+			/**
+			 * Font family settings as a JSON object (camelCase properties).
+			 */
+			font_family_settings: FontFamily;
+			/**
+			 * Embedded font faces (when using _embed parameter).
+			 */
+			_embedded?: ContextualField<
+				{
+					font_faces?: Array< {
+						id: string;
+						font_face_settings: FontFace;
+					} >;
+				},
+				'view' | 'edit',
+				C
+			>;
+		}
+	}
+}
+
+/**
+ * Font family type in Theme.JSON format.
+ */
+export interface FontFamily {
+	name: string;
+	slug: string;
+	fontFamily: string;
+	fontFace?: FontFace[];
+	preview?: string;
+	id?: string;
+	source?: string;
+	version?: string;
+	author?: string;
+	license?: string;
+	description?: string;
+	tags?: string[];
+	variants?: FontFace[];
+	category?: string;
+}
+
+/**
+ * Font face type for use in components.
+ * This matches the shape in font_face_settings.
+ */
+export interface FontFace {
+	fontFamily: string;
+	fontStyle?: string;
+	fontWeight?: string | number;
+	src?: string | string[];
+	preview?: string;
+	id?: string;
+	fontDisplay?: string;
+	fontStretch?: string;
+	fontVariant?: string;
+	fontFeatureSettings?: string;
+	fontVariationSettings?: string;
+	unicodeRange?: string;
+}
+
+export type WpFontFamily< C extends Context = 'edit' > = OmitNevers<
+	_BaseEntityRecords.WpFontFamily< C >
+>;
+
+export type { _BaseEntityRecords as BaseEntityRecords };

--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -5,7 +5,12 @@ import type { Context, Updatable } from './helpers';
 import type { Attachment } from './attachment';
 import type { Base, TemplatePartArea, TemplateType } from './base';
 import type { Comment } from './comment';
-import type { FontCollection } from './font-collection';
+import type {
+	FontCollection,
+	CollectionFontFamily,
+	CollectionFontFace,
+} from './font-collection';
+import type { FontFamily, FontFace, WpFontFamily } from './font-family';
 import type { GlobalStylesRevision } from './global-styles-revision';
 import type { MenuLocation } from './menu-location';
 import type { NavMenu } from './nav-menu';
@@ -32,9 +37,13 @@ export type { BaseEntityRecords } from './base-entity-records';
 export type {
 	Attachment,
 	Base as UnstableBase,
+	CollectionFontFace,
+	CollectionFontFamily,
 	Comment,
 	Context,
 	FontCollection,
+	FontFace,
+	FontFamily,
 	GlobalStylesRevision,
 	MenuLocation,
 	NavMenu,
@@ -56,6 +65,7 @@ export type {
 	User,
 	Widget,
 	WidgetType,
+	WpFontFamily,
 	WpTemplate,
 	WpTemplatePart,
 };
@@ -116,6 +126,7 @@ export interface PerPackageEntityRecords< C extends Context > {
 		| Type< C >
 		| Widget< C >
 		| WidgetType< C >
+		| WpFontFamily< C >
 		| WpTemplate< C >
 		| WpTemplatePart< C >;
 }

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -772,7 +772,7 @@ const ParentProvidingRegistry = ( props ) => {
 
 _Returns_
 
--   `Function`: A custom react hook exposing the registry context value.
+-   `import('../../types').DataRegistry`: A custom react hook exposing the registry context value.
 
 ### useSelect
 

--- a/packages/data/src/components/registry-provider/use-registry.js
+++ b/packages/data/src/components/registry-provider/use-registry.js
@@ -45,7 +45,7 @@ import { Context } from './context';
  * };
  * ```
  *
- * @return {Function}  A custom react hook exposing the registry context value.
+ * @return {import('../../types').DataRegistry} A custom react hook exposing the registry context value.
  */
 export default function useRegistry() {
 	return useContext( Context );

--- a/packages/global-styles-ui/src/font-family-item.tsx
+++ b/packages/global-styles-ui/src/font-family-item.tsx
@@ -8,13 +8,13 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import type { FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { FontLibraryContext } from './font-library-modal/context';
 import { getFamilyPreviewStyle } from './font-library-modal/utils/preview-styles';
-import type { FontFamily } from './font-library-modal/types';
 
 interface FontFamilyItemProps {
 	font: FontFamily;

--- a/packages/global-styles-ui/src/font-library-modal/api.ts
+++ b/packages/global-styles-ui/src/font-library-modal/api.ts
@@ -2,15 +2,11 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
 import type {
 	CollectionFontFace,
 	CollectionFontFamily,
 	FontFace,
-} from './types';
+} from '@wordpress/core-data';
 
 const FONT_FAMILIES_URL = '/wp/v2/font-families';
 
@@ -42,38 +38,4 @@ export async function fetchInstallFontFace(
 		id: response.id,
 		...response.font_face_settings,
 	};
-}
-
-export async function fetchGetFontFamilyBySlug( slug: string ) {
-	const config = {
-		path: `${ FONT_FAMILIES_URL }?slug=${ slug }&_embed=true`,
-		method: 'GET',
-	};
-	const response = ( await apiFetch( config ) ) as
-		| CollectionFontFamily[]
-		| undefined;
-	if ( ! response || response.length === 0 ) {
-		return null;
-	}
-	const fontFamilyPost = response[ 0 ];
-	return {
-		id: fontFamilyPost.id,
-		...fontFamilyPost.font_family_settings,
-		fontFace:
-			( fontFamilyPost?._embedded?.font_faces ?? [] ).map(
-				( face ) => face.font_face_settings
-			) || [],
-	};
-}
-
-export async function fetchUninstallFontFamily(
-	fontFamilyId: string
-): Promise< {
-	deleted: boolean;
-} > {
-	const config = {
-		path: `${ FONT_FAMILIES_URL }/${ fontFamilyId }?force=true`,
-		method: 'DELETE',
-	};
-	return await apiFetch( config );
 }

--- a/packages/global-styles-ui/src/font-library-modal/font-card.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-card.tsx
@@ -10,12 +10,12 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import type { FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import FontDemo from './font-demo';
-import type { FontFamily } from './types';
 
 function FontCard( {
 	font,

--- a/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-collection.tsx
@@ -33,9 +33,12 @@ import {
 	chevronLeft,
 	chevronRight,
 } from '@wordpress/icons';
-import {
-	useEntityRecord,
-	type FontCollection as FontCollectionType,
+import { useEntityRecord } from '@wordpress/core-data';
+import type {
+	FontCollection as FontCollectionType,
+	FontFace,
+	FontFamily,
+	CollectionFontFamily,
 } from '@wordpress/core-data';
 
 /**
@@ -53,7 +56,7 @@ import GoogleFontsConfirmDialog from './google-fonts-confirm-dialog';
 import { downloadFontFaceAssets } from './utils';
 import { sortFontFaces } from './utils/sort-font-faces';
 import CollectionFontVariant from './collection-font-variant';
-import type { FontFace, FontFamily, CollectionFontFamily } from './types';
+import type { FontFamilyToUpload } from './types';
 
 const DEFAULT_CATEGORY = {
 	slug: 'all',
@@ -193,7 +196,7 @@ function FontCollection( { slug }: { slug: string } ) {
 	const handleInstall = async () => {
 		setNotice( null );
 
-		const fontFamily = fontsToInstall[ 0 ];
+		const fontFamily: FontFamilyToUpload = fontsToInstall[ 0 ];
 
 		try {
 			if ( fontFamily?.fontFace ) {

--- a/packages/global-styles-ui/src/font-library-modal/font-demo.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/font-demo.tsx
@@ -3,6 +3,7 @@
  */
 import { __experimentalText as Text } from '@wordpress/components';
 import { useContext, useEffect, useState, useRef } from '@wordpress/element';
+import type { FontFamily, FontFace } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import {
 	getFacePreviewStyle,
 	getFamilyPreviewStyle,
 } from './utils/preview-styles';
-import type { FontFamily, FontFace, FontDemoProps } from './types';
+import type { FontDemoProps } from './types';
 
 function getPreviewUrl( fontFace: FontFace ): string | undefined {
 	if ( fontFace.preview ) {
@@ -48,7 +49,6 @@ function getDisplayFontFace( font: FontFamily | FontFace ): FontFace {
 		fontStyle: 'normal',
 		fontWeight: '400',
 		fontFamily: font.fontFamily,
-		fake: true,
 	};
 }
 

--- a/packages/global-styles-ui/src/font-library-modal/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/installed-fonts.tsx
@@ -25,6 +25,7 @@ import type {
 	FontFamilyPreset,
 	GlobalStylesConfig,
 } from '@wordpress/global-styles-engine';
+import type { FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -40,7 +41,6 @@ import {
 	getDisplaySrcFromFontFace,
 } from './utils';
 import { useSetting } from '../hooks';
-import type { FontFamily } from './types';
 
 function InstalledFonts() {
 	const {

--- a/packages/global-styles-ui/src/font-library-modal/library-font-details.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/library-font-details.tsx
@@ -5,13 +5,13 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
+import type { FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import LibraryFontVariant from './library-font-variant';
 import { sortFontFaces } from './utils/sort-font-faces';
-import type { FontFamily } from './types';
 
 function LibraryFontDetails( { font }: { font: FontFamily } ) {
 	const fontFaces =

--- a/packages/global-styles-ui/src/font-library-modal/library-font-variant.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/library-font-variant.tsx
@@ -3,6 +3,7 @@
  */
 import { useContext, useId } from '@wordpress/element';
 import { CheckboxControl, Flex } from '@wordpress/components';
+import type { FontFace, FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -10,7 +11,6 @@ import { CheckboxControl, Flex } from '@wordpress/components';
 import { getFontFaceVariantName } from './utils';
 import { FontLibraryContext } from './context';
 import FontDemo from './font-demo';
-import type { FontFace, FontFamily } from './types';
 
 function LibraryFontVariant( {
 	face,

--- a/packages/global-styles-ui/src/font-library-modal/types.ts
+++ b/packages/global-styles-ui/src/font-library-modal/types.ts
@@ -2,54 +2,15 @@
  * WordPress dependencies
  */
 import type { FontFamilyPreset } from '@wordpress/global-styles-engine';
+import type { FontFamily, FontFace } from '@wordpress/core-data';
 
-export interface CollectionFontFace {
-	id: string;
-	font_face_settings: FontFace;
-}
-
-export interface FontFace {
-	fontFamily: string;
-	fontStyle?: string;
-	fontWeight?: string | number;
-	src?: string | string[];
-	preview?: string;
+export type FontFaceToUpload = FontFace & {
 	file?: File | File[];
-	fake?: boolean;
-	id?: string;
-	fontDisplay?: string;
-	fontStretch?: string;
-	fontVariant?: string;
-	fontFeatureSettings?: string;
-	fontVariationSettings?: string;
-	unicodeRange?: string;
-}
+};
 
-export interface CollectionFontFamily {
-	id: string;
-	font_family_settings: FontFamily;
-	categories?: string[];
-	_embedded?: {
-		font_faces?: CollectionFontFace[];
-	};
-}
-
-export interface FontFamily {
-	name: string;
-	slug: string;
-	fontFamily: string;
-	fontFace?: FontFace[];
-	preview?: string;
-	id?: string;
-	source?: string;
-	version?: string;
-	author?: string;
-	license?: string;
-	description?: string;
-	tags?: string[];
-	variants?: FontFace[];
-	category?: string;
-}
+export type FontFamilyToUpload = Omit< FontFamily, 'fontFace' > & {
+	fontFace?: FontFaceToUpload[];
+};
 
 export interface FontLibraryState {
 	isInstalling: boolean;

--- a/packages/global-styles-ui/src/font-library-modal/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/upload-fonts.tsx
@@ -14,6 +14,7 @@ import {
 	ProgressBar,
 } from '@wordpress/components';
 import { useContext, useState } from '@wordpress/element';
+import type { FontFace } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -23,7 +24,6 @@ import { FontLibraryContext } from './context';
 import { Font } from './lib/lib-font.browser';
 import makeFamiliesFromFaces from './utils/make-families-from-faces';
 import { loadFontFaceInBrowser } from './utils';
-import type { FontFace } from './types';
 
 function UploadFonts() {
 	const { installFonts } = useContext( FontLibraryContext );

--- a/packages/global-styles-ui/src/font-library-modal/utils/filter-fonts.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/filter-fonts.ts
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import type { CollectionFontFamily } from '../types';
+import type { CollectionFontFamily } from '@wordpress/core-data';
 
 /**
  * Filters a list of fonts based on the specified filters.

--- a/packages/global-styles-ui/src/font-library-modal/utils/fonts-outline.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/fonts-outline.ts
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import type { FontFace, FontFamily } from '../types';
+import type { FontFace, FontFamily } from '@wordpress/core-data';
 
 export function getFontsOutline(
 	fonts: FontFamily[]

--- a/packages/global-styles-ui/src/font-library-modal/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/index.ts
@@ -2,14 +2,15 @@
  * WordPress dependencies
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import type { FontFamily, FontFace } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
-import { fetchInstallFontFace } from '../resolvers';
+import { fetchInstallFontFace } from '../api';
 import { formatFontFaceName } from './preview-styles';
-import type { FontFamily, FontFace, FontUploadResult } from '../types';
+import type { FontFamilyToUpload, FontUploadResult } from '../types';
 import { unlock } from '../../lock-unlock';
 
 /**
@@ -221,7 +222,7 @@ export function makeFontFamilyFormData( fontFamily: FontFamily ): FormData {
 	return formData;
 }
 
-export function makeFontFacesFormData( font: FontFamily ): FormData[] {
+export function makeFontFacesFormData( font: FontFamilyToUpload ): FormData[] {
 	const fontFacesFormData = ( font?.fontFace ?? [] ).map(
 		( item, faceIndex ) => {
 			const face = { ...item };

--- a/packages/global-styles-ui/src/font-library-modal/utils/make-families-from-faces.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/make-families-from-faces.ts
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import type { FontFamily, FontFace } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import type { FontFamily, FontFace } from '../types';
 import { unlock } from '../../lock-unlock';
 
 const { kebabCase } = unlock( componentsPrivateApis );

--- a/packages/global-styles-ui/src/font-library-modal/utils/preview-styles.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/preview-styles.ts
@@ -4,9 +4,9 @@
 import type { CSSProperties } from 'react';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import type { FontFace, FontFamily } from '../types';
+import type { FontFace, FontFamily } from '@wordpress/core-data';
 
 function findNearest( input: number, numbers: number[] ) {
 	// If the numbers array is empty, return null

--- a/packages/global-styles-ui/src/font-library-modal/utils/sort-font-faces.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/sort-font-faces.ts
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import type { FontFace } from '../types';
+import type { FontFace } from '@wordpress/core-data';
 
 function getNumericFontWeight( value: string ): number {
 	switch ( value ) {

--- a/packages/global-styles-ui/src/font-library-modal/utils/toggleFont.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/toggleFont.ts
@@ -31,9 +31,9 @@
  * // This will add the specified face to 'roboto' in customFonts
  */
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import type { FontFamily, FontFace } from '../types';
+import type { FontFamily, FontFace } from '@wordpress/core-data';
 
 export function toggleFont(
 	font: FontFamily,


### PR DESCRIPTION
Similar to #73635 
Preparation for more font library related work.

## What

This PR updates the code to fetch font families to always rely on core-data and moves all the related types to core-data like the other post types.

## Why

 - Consistency and cleanup.

## Testing instructions

 - Open the font library modal from global styles
 - Install fonts...