### PR TITLE
Font Library: Simplify cache invalidation

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -88,10 +88,10 @@ export function receiveEntityRecords(
 	kind,
 	name,
 	records,
-	query,
+	query = undefined,
 	invalidateCache = false,
-	edits,
-	meta
+	edits = undefined,
+	meta = undefined
 ) {
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -159,6 +159,9 @@ export interface SelectorWithCustomCurrySignature {
 
 export interface DataRegistry {
 	register: ( store: StoreDescriptor< any > ) => void;
+	dispatch: < S extends StoreDescriptor< any > >(
+		store: S
+	) => ActionCreatorsOf< ConfigOf< S > >;
 }
 
 // Type Helpers.

--- a/packages/global-styles-ui/src/font-library-modal/api.ts
+++ b/packages/global-styles-ui/src/font-library-modal/api.ts
@@ -2,21 +2,50 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { store as coreDataStore } from '@wordpress/core-data';
 import type {
 	CollectionFontFace,
 	CollectionFontFamily,
 	FontFace,
 } from '@wordpress/core-data';
+import type { DataRegistry } from '@wordpress/data';
 
 const FONT_FAMILIES_URL = '/wp/v2/font-families';
 
-export async function fetchInstallFontFamily( data: FormData ) {
+/**
+ * Invalidates the cache for font family queries.
+ * This should be called after installing fonts
+ * to ensure the UI reflects the latest state.
+ *
+ * @param registry The data registry to use for dispatching actions.
+ */
+function invalidateFontFamilyCache( registry: DataRegistry ) {
+	const { receiveEntityRecords } = registry.dispatch( coreDataStore );
+
+	// Invalidate all font family queries
+	// Ideally there should be a dedicated action to do this
+	// "invalide all cacches for this entity type"
+	receiveEntityRecords(
+		'postType',
+		'wp_font_family',
+		[],
+		undefined,
+		true // invalidateCache
+	);
+}
+
+export async function fetchInstallFontFamily(
+	data: FormData,
+	registry: DataRegistry
+) {
 	const config = {
 		path: FONT_FAMILIES_URL,
 		method: 'POST',
 		body: data,
 	};
 	const response: CollectionFontFamily = await apiFetch( config );
+	invalidateFontFamilyCache( registry );
+
 	return {
 		id: response.id as string,
 		...response.font_family_settings,
@@ -26,7 +55,8 @@ export async function fetchInstallFontFamily( data: FormData ) {
 
 export async function fetchInstallFontFace(
 	fontFamilyId: string,
-	data: FormData
+	data: FormData,
+	registry: DataRegistry
 ): Promise< FontFace > {
 	const config = {
 		path: `${ FONT_FAMILIES_URL }/${ fontFamilyId }/font-faces`,
@@ -34,6 +64,7 @@ export async function fetchInstallFontFace(
 		body: data,
 	};
 	const response = ( await apiFetch( config ) ) as CollectionFontFace;
+	invalidateFontFamilyCache( registry );
 	return {
 		id: response.id,
 		...response.font_face_settings,

--- a/packages/global-styles-ui/src/font-library-modal/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library-modal/installed-fonts.tsx
@@ -47,7 +47,6 @@ function InstalledFonts() {
 		baseCustomFonts,
 		libraryFontSelected,
 		handleSetLibraryFontSelected,
-		refreshLibrary,
 		uninstallFontFamily,
 		isResolvingLibrary,
 		isInstalling,
@@ -176,7 +175,6 @@ function InstalledFonts() {
 
 	useEffect( () => {
 		handleSetLibraryFontSelected( libraryFontSelected );
-		refreshLibrary();
 	}, [] );
 
 	// Get activated fonts count.

--- a/packages/global-styles-ui/src/font-library-modal/types.ts
+++ b/packages/global-styles-ui/src/font-library-modal/types.ts
@@ -24,7 +24,6 @@ export interface FontLibraryState {
 	uninstallFontFamily: ( fontFamily: FontFamily ) => Promise< {
 		deleted: boolean;
 	} >;
-	refreshLibrary: () => void;
 	// Additional properties found in the codebase
 	baseCustomFonts: FontFamily[];
 	modalTabOpen: string;

--- a/packages/global-styles-ui/src/font-library-modal/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library-modal/utils/index.ts
@@ -3,6 +3,7 @@
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import type { FontFamily, FontFace } from '@wordpress/core-data';
+import type { DataRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -258,7 +259,8 @@ export function makeFontFacesFormData( font: FontFamilyToUpload ): FormData[] {
 
 export async function batchInstallFontFaces(
 	fontFamilyId: string,
-	fontFacesData: FormData[]
+	fontFacesData: FormData[],
+	registry: DataRegistry
 ): Promise< FontUploadResult > {
 	const responses: {
 		status: 'fulfilled' | 'rejected';
@@ -274,7 +276,8 @@ export async function batchInstallFontFaces(
 		try {
 			const response = await fetchInstallFontFace(
 				fontFamilyId,
-				faceData
+				faceData,
+				registry
 			);
 			responses.push( { status: 'fulfilled', value: response } );
 		} catch ( error ) {


### PR DESCRIPTION
Preparation PR for more font library work.

## What

Since we're using core-data for fetching font families, we should't use an adhoc way to clear cache, we can just invalidate the query cache in core-data instead. 

This PR uses a similar approach to attachments to do the same for font families.

## Testing instructions

 - you can try installing/uninstalling fonts.