### PR TITLE
Notes: Ensure notes never show on the comments page

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -115,3 +115,17 @@ function gutenberg_filter_comment_count_query_exclude_block_comments( $query ) {
 	return $query;
 }
 add_filter( 'query', 'gutenberg_filter_comment_count_query_exclude_block_comments' );
+
+/**
+ * Adjusts the comments list table query so `comment_type=note` never displays.
+ *
+ * @param array $args An array of get_comments() arguments.
+ * @return array Possibly modified arguments for get_comments().
+ */
+function gutenberg_hide_note_from_comment_list_table( $args ) {
+	if ( ! empty( $_REQUEST['comment_type'] ) && 'note' === $_REQUEST['comment_type'] ) {
+		unset( $args['type'] );
+	}
+	return $args;
+}
+add_filter( 'comments_list_table_query_args', 'gutenberg_hide_note_from_comment_list_table' );


### PR DESCRIPTION
- Part of #73141
- backport this core changeset to Gutenberg: https://core.trac.wordpress.org/changeset/61183

## What?

This PR ensures notes never show on the comment list page.

## Why?

See: https://core.trac.wordpress.org/ticket/64198

## How?
To mimic [this process](https://github.com/WordPress/wordpress-develop/blob/785e61f9474a42ba1771b112cc8356d2df347763/src/wp-admin/includes/class-wp-comments-list-table.php#L104-L106) in the Gutenberg plugin, we do the opposite: if `comment_type` is set to `note`, we unset the `type` field.

## Testing Instructions

Note: This issue has been resolved in the latest WordPress core, so don't forget to downgrade the WordPress version to 6.8 and test it.

1. Add a note.
2. Access: http://localhost:8888/wp-admin/edit-comments.php?comment_type=note.
3. The notes should not be visible.