### PR TITLE
Fix Page List block button HTML rendering to escape at output

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -192,8 +192,7 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 			$css_class .= ' menu-item-home';
 		}
 
-		$title = wp_kses_post( $page['title'] );
-		$title = $title ? $title : __( '(no title)' );
+		$title = $page['title'] ? $page['title'] : __( '(no title)' );
 
 		$aria_label = sprintf(
 			/* translators: Accessibility text. %s: Parent page title. */
@@ -204,10 +203,10 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 		$markup .= '<li class="wp-block-pages-list__item' . esc_attr( $css_class ) . '"' . $style_attribute . '>';
 
 		if ( isset( $page['children'] ) && $is_navigation_child && $open_submenus_on_click ) {
-			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . esc_html( $title ) .
+			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . wp_kses_post( $title ) .
 			'</button><span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
 		} else {
-			$markup .= '<a class="wp-block-pages-list__item__link' . esc_attr( $navigation_child_content_class ) . '" href="' . esc_url( $page['link'] ) . '"' . $aria_current . '>' . $title . '</a>';
+			$markup .= '<a class="wp-block-pages-list__item__link' . esc_attr( $navigation_child_content_class ) . '" href="' . esc_url( $page['link'] ) . '"' . $aria_current . '>' . wp_kses_post( $title ) . '</a>';
 		}
 
 		if ( isset( $page['children'] ) ) {


### PR DESCRIPTION
## What

This is a follow-up to https://github.com/WordPress/gutenberg/pull/73614. Fixes inconsistency in the Page List block frontend rendering where buttons were escaping HTML (showing raw markup) while links rendered HTML correctly. Both buttons and links now render HTML formatting consistently.

## Why

After #73614 fixed the editor rendering, there remained an inconsistency in the frontend PHP code:
- Buttons used `esc_html( $title )` which escaped HTML, showing raw markup
- Links output `$title` directly (after early sanitization), rendering HTML correctly

Additionally, the code was sanitizing early (using `wp_kses_post()` on line 195) rather than at the point of output, which reduces resilience and clarity.

## How

- Removed early sanitization of `$title` variable
- Applied `wp_kses_post()` at the point of output for both buttons (line 206) and links (line 209)
- This ensures HTML is sanitized just before rendering, making the code more resilient to accidental variable modification and clearer to review

Escaping at the point of output is preferred because:
- It's more resilient: if the variable is accidentally modified before output, it's still properly sanitized
- It's clearer: reviewers can immediately see that output is sanitized without tracing through the code
- It's more maintainable: future code changes are less likely to introduce security issues

## Testing Instructions

1. Create a page with HTML in the title (e.g., `<strong>Bold Title</strong>`)
2. Insert a Page List block in a Navigation block with `openSubmenusOnClick` enabled
3. Verify the button displays with formatting rendered (bold text, not raw `<strong>` tags)
4. Verify links also display with formatting rendered
5. Compare with editor preview to ensure they match