### PR TITLE
Add i18n support for math block error messages

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
@@ -113,7 +113,11 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										intent="error"
 										className="wp-block-math__error"
 									>
-										{ error }
+										{ sprintf(
+											/* translators: %s: error message returned when parsing LaTeX. */
+											__( 'Error: %s' ),
+											error
+										) }
 									</Badge>
 									<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
 								</>

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -98,7 +98,15 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 										setError( null );
 									} catch ( err ) {
 										setError( err.message );
-										speak( err.message );
+										speak(
+											sprintf(
+												/* translators: %s: error message returned when parsing LaTeX. */
+												__(
+													'Error parsing mathematical expression: %s'
+												),
+												err.message
+											)
+										);
 									}
 									setAttributes( {
 										mathML: newMathML,

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { insertObject, useAnchor } from '@wordpress/rich-text';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
@@ -100,7 +100,11 @@ function InlineUI( {
 								intent="error"
 								className="wp-block-math__error"
 							>
-								{ error }
+								{ sprintf(
+									/* translators: %s: error message returned when parsing LaTeX. */
+									__( 'Error: %s' ),
+									error
+								) }
 							</Badge>
 							<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
 						</>

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -53,7 +53,13 @@ function InlineUI( {
 				setError( null );
 			} catch ( err ) {
 				setError( err.message );
-				speak( err.message );
+				speak(
+					sprintf(
+						/* translators: %s: error message returned when parsing LaTeX. */
+						__( 'Error parsing mathematical expression: %s' ),
+						err.message
+					)
+				);
 				return;
 			}
 		}

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Math Block', () => {
 		] );
 
 		await expect( page.locator( '[aria-live="polite"]' ) ).toHaveText(
-			`Expected 'EOF', got '&' at position 1: &̲x^2`
+			`Error: Expected 'EOF', got '&' at position 1: &̲x^2`
 		);
 
 		// Can delete the math block.

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Math Block', () => {
 		] );
 
 		await expect( page.locator( '[aria-live="polite"]' ) ).toHaveText(
-			`Error: Expected 'EOF', got '&' at position 1: &̲x^2`
+			`Error parsing mathematical expression: Expected 'EOF', got '&' at position 1: &̲x^2`
 		);
 
 		// Can delete the math block.


### PR DESCRIPTION
## What?
Closes #73615

Include a localized prefix `Error: ` before error messages in math blocks.

## Why?
When parsing mathematical expressions fails in a Math block or Math format, the error message comes from the `Temml` library and lacks localization. Adding a localized `Error: ` prefix clearly indicates to users that it's an error message.

## How?
Implement by prepending a localized `Error: ` prefix to the existing error message.

## Testing Instructions

1. Add a Math Block or Format in block editor.
2. Put any invalid mathematical expression like `&x^2`
3. Error message should start with `Error: ` and it should be localized.

## Screenshots

|Before|After|
|-|-|
| <img width="341" height="186" alt="Screenshot 2025-11-28 at 3 18 08 PM" src="https://github.com/user-attachments/assets/9cfa81f7-d924-4908-850e-d4bf2d9bfeb1" /> | <img width="341" height="186" alt="Screenshot 2025-11-28 at 3 17 14 PM" src="https://github.com/user-attachments/assets/f178c11e-733f-4050-94b8-cd4e7dfb27e8" /> |
| <img width="341" height="186" alt="Screenshot 2025-11-28 at 3 18 50 PM" src="https://github.com/user-attachments/assets/bd5f9ba2-b844-4e1e-ae81-68a5da36272a" /> | <img width="341" height="186" alt="Screenshot 2025-11-28 at 3 19 46 PM" src="https://github.com/user-attachments/assets/409b76e3-f1ed-4ce1-906d-df6951b5d34e" /> |
