### PR TITLE
Field API: display formats for `number` and `integer` types

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
+- Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1857,10 +1857,12 @@ Valid operators per field type:
 
 ### `format`
 
-Display format configuration for fields. Currently supported for date fields. This configuration affects how the field is displayed in the `render` method, the `Edit` control, and filter controls.
+Display format configuration for fields. Supported for date, number, and integer fields. This configuration affects how the field is displayed in the `render` method, the `Edit` control, and filter controls.
 
 -   Type: `object`.
 -   Optional.
+
+For `date` fields:
 -   Properties:
     -   `date`: The format string using PHP date format (e.g., 'F j, Y' for 'March 10, 2023'). Optional, defaults to WordPress "Date Format" setting.
     -   `weekStartsOn`: Specifies the first day of the week for calendar controls. One of 0, 1, 2, 3, 4, 5, 6. Optional, defaults to WordPress "Week Starts On" setting, whose value is 0 (Sunday).
@@ -1875,6 +1877,46 @@ Example:
 	format: {
 		date: 'F j, Y',
 		weekStartsOn: 1,
+	},
+}
+```
+
+For `number` fields:
+
+-   Properties:
+    -   `separatorThousand`: The character used as thousand separator (e.g., ',' for '1,234'). Optional, defaults to ','.
+    -   `separatorDecimal`: The character used as decimal separator (e.g., '.' for '1.23'). Optional, defaults to '.'.
+    -   `decimals`: Number of decimal places to display (0-100). Optional, defaults to 2.
+
+Example:
+
+```js
+{
+	id: 'price',
+	type: 'number',
+	label: 'Price',
+	format: {
+		separatorThousand: ',',
+		separatorDecimal: '.',
+		decimals: 2,
+	},
+}
+```
+
+For `integer` fields:
+
+-   Properties:
+    -   `separatorThousand`: The character used as thousand separator (e.g., ',' for '1,234'). Optional, defaults to ','.
+
+Example:
+
+```js
+{
+	id: 'quantity',
+	type: 'integer',
+	label: 'Quantity',
+	format: {
+		separatorThousand: ',',
 	},
 }
 ```

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -55,6 +55,8 @@ import type {
 	Filter,
 	NormalizedField,
 	NormalizedFieldDate,
+	NormalizedFieldNumber,
+	NormalizedFieldInteger,
 	NormalizedFilter,
 	Operator,
 	Option,
@@ -62,6 +64,8 @@ import type {
 } from '../../types';
 import useElements from '../../hooks/use-elements';
 import parseDateTime from '../../field-types/utils/parse-date-time';
+import { formatNumber } from '../../field-types/number';
+import { formatInteger } from '../../field-types/integer';
 
 const ENTER = 'Enter';
 const SPACE = ' ';
@@ -521,6 +525,12 @@ export default function Filter( {
 			} catch ( e ) {
 				label = filterInView.value;
 			}
+		} else if ( field?.type === 'number' && typeof label === 'number' ) {
+			const numberField = field as NormalizedFieldNumber< any >;
+			label = formatNumber( label, numberField.format );
+		} else if ( field?.type === 'integer' && typeof label === 'number' ) {
+			const integerField = field as NormalizedFieldInteger< any >;
+			label = formatInteger( label, integerField.format );
 		}
 
 		activeElements = [

--- a/packages/dataviews/src/dataform-controls/number.tsx
+++ b/packages/dataviews/src/dataform-controls/number.tsx
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import type { DataFormControlProps } from '../types';
+import type { DataFormControlProps, FormatNumber } from '../types';
 import ValidatedNumber from './utils/validated-number';
 
 export default function Number< Item >( props: DataFormControlProps< Item > ) {
-	// TODO: remove this hardcoded value when the decimal number is configurable
-	return <ValidatedNumber { ...props } decimals={ 2 } />;
+	const decimals = ( props.field.format as FormatNumber )?.decimals ?? 2;
+	return <ValidatedNumber { ...props } decimals={ decimals } />;
 }

--- a/packages/dataviews/src/field-types/date.tsx
+++ b/packages/dataviews/src/field-types/date.tsx
@@ -28,16 +28,17 @@ import {
 } from '../constants';
 
 function getFormat< Item >( field: Field< Item > ): Required< FormatDate > {
+	const fieldFormat = field.format as FormatDate | undefined;
 	return {
 		date:
-			field.format?.date !== undefined &&
-			typeof field.format.date === 'string'
-				? field.format.date
+			fieldFormat?.date !== undefined &&
+			typeof fieldFormat.date === 'string'
+				? fieldFormat.date
 				: getSettings().formats.date,
 		weekStartsOn:
-			field.format?.weekStartsOn !== undefined &&
-			DAYS_OF_WEEK.includes( field.format?.weekStartsOn )
-				? field.format.weekStartsOn
+			fieldFormat?.weekStartsOn !== undefined &&
+			DAYS_OF_WEEK.includes( fieldFormat?.weekStartsOn )
+				? fieldFormat.weekStartsOn
 				: getSettings().l10n.startOfWeek,
 	};
 }

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -48,7 +48,7 @@ export function formatInteger(
 		return String( value );
 	}
 	const { separatorThousand } = format;
-	const integerValue = Math.floor( value );
+	const integerValue = Math.trunc( value );
 	if ( ! separatorThousand ) {
 		return String( integerValue );
 	}

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -6,7 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { Rules } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	Field,
+	FormatInteger,
+	Rules,
+} from '../types';
 import type { FieldType } from '../types/private';
 import {
 	OPERATOR_IS,
@@ -21,8 +26,63 @@ import {
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_BETWEEN,
 } from '../constants';
-import render from './utils/render-default';
+import RenderFromElements from './utils/render-from-elements';
 import sort from './utils/sort-number';
+
+function getFormat< Item >( field: Field< Item > ): Required< FormatInteger > {
+	const fieldFormat = field.format as FormatInteger | undefined;
+	return {
+		separatorThousand:
+			fieldFormat?.separatorThousand !== undefined &&
+			typeof fieldFormat.separatorThousand === 'string'
+				? fieldFormat.separatorThousand
+				: ',',
+	};
+}
+
+export function formatInteger(
+	value: number,
+	format: Required< FormatInteger >
+): string {
+	if ( ! Number.isFinite( value ) ) {
+		return String( value );
+	}
+	const { separatorThousand } = format;
+	const integerValue = Math.floor( value );
+	if ( ! separatorThousand ) {
+		return String( integerValue );
+	}
+	// Add thousand separators.
+	return String( integerValue ).replace(
+		/\B(?=(\d{3})+(?!\d))/g,
+		separatorThousand
+	);
+}
+
+function render( { item, field }: DataViewRenderFieldProps< any > ) {
+	if ( field.hasElements ) {
+		return <RenderFromElements item={ item } field={ field } />;
+	}
+
+	const value = field.getValue( { item } );
+	if ( [ null, undefined ].includes( value ) ) {
+		return '';
+	}
+
+	// If the field type is integer, we've already normalized the format,
+	// and so it's safe to tell TypeScript to trust us ("as Required<FormatInteger>").
+	//
+	// There're no runtime paths where this render function is called with a non-integer field,
+	// but TypeScript is unable to infer this, hence the type assertion.
+	let format: Required< FormatInteger >;
+	if ( field.type !== 'integer' ) {
+		format = getFormat( field as Field< any > );
+	} else {
+		format = field.format as Required< FormatInteger >;
+	}
+
+	return formatInteger( Number( value ), format );
+}
 
 const isValid: Rules< any > = {
 	elements: true,
@@ -71,5 +131,5 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	getFormat,
 } satisfies FieldType< any >;

--- a/packages/dataviews/src/field-types/number.tsx
+++ b/packages/dataviews/src/field-types/number.tsx
@@ -6,7 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { DataViewRenderFieldProps, Rules } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	Field,
+	FormatNumber,
+	Rules,
+} from '../types';
 import type { FieldType } from '../types/private';
 import {
 	OPERATOR_IS,
@@ -24,6 +29,49 @@ import {
 import RenderFromElements from './utils/render-from-elements';
 import sort from './utils/sort-number';
 
+function getFormat< Item >( field: Field< Item > ): Required< FormatNumber > {
+	const fieldFormat = field.format as FormatNumber | undefined;
+	return {
+		separatorThousand:
+			fieldFormat?.separatorThousand !== undefined &&
+			typeof fieldFormat.separatorThousand === 'string'
+				? fieldFormat.separatorThousand
+				: ',',
+		separatorDecimal:
+			fieldFormat?.separatorDecimal !== undefined &&
+			typeof fieldFormat.separatorDecimal === 'string'
+				? fieldFormat.separatorDecimal
+				: '.',
+		decimals:
+			fieldFormat?.decimals !== undefined &&
+			typeof fieldFormat.decimals === 'number' &&
+			fieldFormat.decimals >= 0 &&
+			fieldFormat.decimals <= 100 &&
+			Number.isInteger( fieldFormat.decimals )
+				? fieldFormat.decimals
+				: 2,
+	};
+}
+
+export function formatNumber(
+	value: number,
+	format: Required< FormatNumber >
+): string {
+	if ( ! Number.isFinite( value ) ) {
+		return String( value );
+	}
+	const { separatorThousand, separatorDecimal, decimals } = format;
+	const fixedValue = value.toFixed( decimals );
+	const [ integerPart, decimalPart ] = fixedValue.split( '.' );
+	const formattedInteger = integerPart.replace(
+		/\B(?=(\d{3})+(?!\d))/g,
+		separatorThousand
+	);
+	return decimals === 0
+		? formattedInteger
+		: formattedInteger + separatorDecimal + decimalPart;
+}
+
 function isEmpty( value: unknown ): value is '' | undefined | null {
 	return value === '' || value === undefined || value === null;
 }
@@ -34,11 +82,23 @@ function render( { item, field }: DataViewRenderFieldProps< any > ) {
 	}
 
 	const value = field.getValue( { item } );
-	if ( ! [ null, undefined ].includes( value ) ) {
-		return Number( value ).toFixed( 2 );
+	if ( [ null, undefined ].includes( value ) ) {
+		return '';
 	}
 
-	return null;
+	// If the field type is number, we've already normalized the format,
+	// and so it's safe to tell TypeScript to trust us ("as Required<FormatNumber>").
+	//
+	// There're no runtime paths where this render function is called with a non-number field,
+	// but TypeScript is unable to infer this, hence the type assertion.
+	let format: Required< FormatNumber >;
+	if ( field.type !== 'number' ) {
+		format = getFormat( field as Field< any > );
+	} else {
+		format = field.format as Required< FormatNumber >;
+	}
+
+	return formatNumber( Number( value ), format );
 }
 
 const isValid: Rules< any > = {
@@ -86,5 +146,5 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	getFormat,
 } satisfies FieldType< any >;

--- a/packages/dataviews/src/field-types/number.tsx
+++ b/packages/dataviews/src/field-types/number.tsx
@@ -63,10 +63,9 @@ export function formatNumber(
 	const { separatorThousand, separatorDecimal, decimals } = format;
 	const fixedValue = value.toFixed( decimals );
 	const [ integerPart, decimalPart ] = fixedValue.split( '.' );
-	const formattedInteger = integerPart.replace(
-		/\B(?=(\d{3})+(?!\d))/g,
-		separatorThousand
-	);
+	const formattedInteger = separatorThousand
+		? integerPart.replace( /\B(?=(\d{3})+(?!\d))/g, separatorThousand )
+		: integerPart;
 	return decimals === 0
 		? formattedInteger
 		: formattedInteger + separatorDecimal + decimalPart;

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -733,14 +733,29 @@ export const IntegerComponent = ( {
 	type,
 	Edit,
 	asyncElements,
+	formatSeparatorThousand,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
+	formatSeparatorThousand?: string;
 } ) => {
 	const integerFields = useMemo(
-		() => fields.filter( ( field ) => field.type === 'integer' ),
-		[]
+		() =>
+			fields
+				.filter( ( field ) => field.type === 'integer' )
+				.map( ( field ) => {
+					if ( formatSeparatorThousand !== undefined ) {
+						return {
+							...field,
+							format: {
+								separatorThousand: formatSeparatorThousand,
+							},
+						};
+					}
+					return field;
+				} ),
+		[ formatSeparatorThousand ]
 	);
 
 	return (
@@ -753,19 +768,64 @@ export const IntegerComponent = ( {
 	);
 };
 IntegerComponent.storyName = 'integer';
+IntegerComponent.args = {
+	formatSeparatorThousand: ',',
+};
+IntegerComponent.argTypes = {
+	formatSeparatorThousand: {
+		control: 'text',
+		description:
+			'Character used as thousand separator (e.g., "," for "1,234"). Default is ",".',
+	},
+};
 
 export const NumberComponent = ( {
 	type,
 	Edit,
 	asyncElements,
+	formatSeparatorThousand,
+	formatSeparatorDecimal,
+	formatDecimals,
 }: {
 	type: PanelTypes;
 	Edit: ControlTypes;
 	asyncElements: boolean;
+	formatSeparatorThousand?: string;
+	formatSeparatorDecimal?: string;
+	formatDecimals?: number;
 } ) => {
 	const numberFields = useMemo(
-		() => fields.filter( ( field ) => field.type === 'number' ),
-		[]
+		() =>
+			fields
+				.filter( ( field ) => field.type === 'number' )
+				.map( ( field ) => {
+					if (
+						formatSeparatorThousand !== undefined ||
+						formatSeparatorDecimal !== undefined ||
+						formatDecimals !== undefined
+					) {
+						const format: {
+							separatorThousand?: string;
+							separatorDecimal?: string;
+							decimals?: number;
+						} = {};
+						if ( formatSeparatorThousand !== undefined ) {
+							format.separatorThousand = formatSeparatorThousand;
+						}
+						if ( formatSeparatorDecimal !== undefined ) {
+							format.separatorDecimal = formatSeparatorDecimal;
+						}
+						if ( formatDecimals !== undefined ) {
+							format.decimals = formatDecimals;
+						}
+						return {
+							...field,
+							format,
+						};
+					}
+					return field;
+				} ),
+		[ formatSeparatorThousand, formatSeparatorDecimal, formatDecimals ]
 	);
 
 	return (
@@ -778,6 +838,28 @@ export const NumberComponent = ( {
 	);
 };
 NumberComponent.storyName = 'number';
+NumberComponent.args = {
+	formatSeparatorThousand: ',',
+	formatSeparatorDecimal: '.',
+	formatDecimals: 2,
+};
+NumberComponent.argTypes = {
+	formatSeparatorThousand: {
+		control: 'text',
+		description:
+			'Character used as thousand separator (e.g., "," for "1,234"). Default is ",".',
+	},
+	formatSeparatorDecimal: {
+		control: 'text',
+		description:
+			'Character used as decimal separator (e.g., "." for "1.23"). Default is ".".',
+	},
+	formatDecimals: {
+		control: { type: 'number', min: 0, max: 100, step: 1 },
+		description:
+			'Number of decimal places to display (0-100). Default is 2.',
+	},
+};
 
 export const BooleanComponent = ( {
 	type,

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -348,13 +348,10 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format ).toBeDefined();
-			expect( normalizedFields[ 0 ].format.date ).toBeDefined();
-			expect( typeof normalizedFields[ 0 ].format.date ).toBe( 'string' );
-			expect( normalizedFields[ 0 ].format.weekStartsOn ).toBeDefined();
-			expect( typeof normalizedFields[ 0 ].format.weekStartsOn ).toBe(
-				'number'
-			);
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				date: expect.any( String ),
+				weekStartsOn: expect.any( Number ),
+			} );
 		} );
 
 		it( 'preserves custom format when provided', () => {
@@ -369,8 +366,10 @@ describe( 'normalizeFields: default getValue', () => {
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format.date ).toBe( 'F j, Y' );
-			expect( normalizedFields[ 0 ].format.weekStartsOn ).toBe( 1 );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				date: 'F j, Y',
+				weekStartsOn: 1,
+			} );
 		} );
 
 		it( 'adds empty format for non-date field types', () => {
@@ -379,14 +378,91 @@ describe( 'normalizeFields: default getValue', () => {
 					id: 'title',
 					type: 'text',
 				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toEqual( {} );
+		} );
+
+		it( 'applies default format for number fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'price',
+					type: 'number',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				separatorThousand: ',',
+				separatorDecimal: '.',
+				decimals: 2,
+			} );
+		} );
+
+		it( 'preserves custom format for number fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'price',
+					type: 'number',
+					format: {
+						separatorThousand: ' ',
+						separatorDecimal: ',',
+						decimals: 3,
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				separatorThousand: ' ',
+				separatorDecimal: ',',
+				decimals: 3,
+			} );
+		} );
+
+		it( 'applies partial custom format for number fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'price',
+					type: 'number',
+					format: {
+						decimals: 0,
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				separatorThousand: ',',
+				separatorDecimal: '.',
+				decimals: 0,
+			} );
+		} );
+
+		it( 'applies default format for integer fields', () => {
+			const fields: Field< {} >[] = [
 				{
 					id: 'count',
 					type: 'integer',
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
-			expect( normalizedFields[ 0 ].format ).toEqual( {} );
-			expect( normalizedFields[ 1 ].format ).toEqual( {} );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				separatorThousand: ',',
+			} );
+		} );
+
+		it( 'preserves custom format for integer fields', () => {
+			const fields: Field< {} >[] = [
+				{
+					id: 'count',
+					type: 'integer',
+					format: {
+						separatorThousand: '.',
+					},
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			expect( normalizedFields[ 0 ].format ).toEqual( {
+				separatorThousand: '.',
+			} );
 		} );
 	} );
 } );

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -245,7 +245,7 @@ export type Field< Item > = {
 	/**
 	 * Display format configuration for fields.
 	 */
-	format?: FormatDate;
+	format?: FormatDate | FormatNumber | FormatInteger;
 };
 
 /**
@@ -261,6 +261,32 @@ export type FormatDate = {
 	weekStartsOn?: DayNumber;
 };
 export type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * Format for number fields:
+ *
+ * - separatorThousand: character to use for thousand separators (e.g., ',')
+ * - separatorDecimal: character to use for decimal point (e.g., '.')
+ * - decimals: number of decimal places to display (e.g., 2)
+ *
+ * If not provided, defaults to ',' for thousands, '.' for decimal, 2 decimals.
+ */
+export type FormatNumber = {
+	separatorThousand?: string;
+	separatorDecimal?: string;
+	decimals?: number;
+};
+
+/**
+ * Format for integer fields:
+ *
+ * - separatorThousand: character to use for thousand separators (e.g., ',')
+ *
+ * If not provided, defaults to ',' for thousands.
+ */
+export type FormatInteger = {
+	separatorThousand?: string;
+};
 
 type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' > & {
 	label: string;
@@ -284,9 +310,21 @@ export type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
 	format: Required< FormatDate >;
 };
 
+export type NormalizedFieldNumber< Item > = NormalizedFieldBase< Item > & {
+	type: 'number';
+	format: Required< FormatNumber >;
+};
+
+export type NormalizedFieldInteger< Item > = NormalizedFieldBase< Item > & {
+	type: 'integer';
+	format: Required< FormatInteger >;
+};
+
 export type NormalizedField< Item > =
 	| NormalizedFieldBase< Item >
-	| NormalizedFieldDate< Item >;
+	| NormalizedFieldDate< Item >
+	| NormalizedFieldNumber< Item >
+	| NormalizedFieldInteger< Item >;
 
 /**
  * A collection of dataview fields for a data type.

--- a/packages/dataviews/src/types/private.ts
+++ b/packages/dataviews/src/types/private.ts
@@ -1,7 +1,14 @@
 /**
  * Internal dependencies
  */
-import type { Field, FormatDate, NormalizedField, Operator } from './field-api';
+import type {
+	Field,
+	FormatDate,
+	FormatInteger,
+	FormatNumber,
+	NormalizedField,
+	Operator,
+} from './field-api';
 
 export type SelectionOrUpdater = string[] | ( ( prev: string[] ) => string[] );
 export type SetSelection = ( selection: SelectionOrUpdater ) => void;
@@ -19,5 +26,9 @@ export type FieldType< Item > = Pick<
 	defaultOperators: Operator[];
 	getFormat: (
 		field: Field< Item >
-	) => Record< string, any > | Required< FormatDate >;
+	) =>
+		| Record< string, any >
+		| Required< FormatDate >
+		| Required< FormatNumber >
+		| Required< FormatInteger >;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/73154

This PR adds `format` for `integer` and `number` field types.

Format properties by type:
  - number: `separatorThousand, `separatorDecimal`, `decimals`
  - integer: `separatorThousand`

## Testing Instructions
1. In storybook (`npm run storybook:dev`) test `number` (?path=/story/dataviews-fieldtypes--number-component) and `integer` (?path=/story/dataviews-fieldtypes--integer-component). There are controls for inserting the available format options
2. Also check the filters that respect the current format

