### PR TITLE
Introduce a Toolbar-Based [+] Inserter for the Navigation Block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -46,7 +46,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { close, Icon, page } from '@wordpress/icons';
+import { close, Icon, plus } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -107,15 +107,18 @@ function NavigationAddPageButton( { clientId } ) {
 	}, [ clientId, insertBlock, getBlockCount ] );
 
 	return (
-		<BlockControls>
+		<BlockControls group="other">
 			<ToolbarGroup>
-				<ToolbarButton
-					name="add-page"
-					icon={ page }
-					onClick={ onAddPage }
-				>
-					{ __( 'Add page' ) }
-				</ToolbarButton>
+				<VStack alignment="center">
+					<ToolbarButton
+						name="add-page"
+						icon={ plus }
+						onClick={ onAddPage }
+						label={ __( 'Add page' ) }
+						showTooltip
+						className="wp-block-navigation__toolbar-inserter-button"
+					/>
+				</VStack>
 			</ToolbarGroup>
 		</BlockControls>
 	);
@@ -982,7 +985,7 @@ function Navigation( {
 					blockEditingMode={ blockEditingMode }
 				/>
 				{ blockEditingMode === 'default' && stylingInspectorControls }
-				{ blockEditingMode === 'contentOnly' && isEntityAvailable && (
+				{ isEntityAvailable && (
 					<NavigationAddPageButton clientId={ clientId } />
 				) }
 				{ blockEditingMode === 'default' && isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -47,7 +47,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { close, Icon, plus } from '@wordpress/icons';
+import { close, Icon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -100,23 +100,20 @@ function NavigationAddPageButton( { clientId } ) {
 
 	return (
 		<BlockControls group="other">
-			<ToolbarGroup>
+			<ToolbarGroup className="wp-block-navigation__toolbar-inserter-group">
 				<VStack alignment="center">
 					<Inserter
 						rootClientId={ clientId }
 						directInsertBlock={ directInsertBlock }
 						isAppender
-						renderToggle={ ( { onToggle, disabled } ) => (
-							<ToolbarButton
-								name="add-page"
-								icon={ plus }
-								onClick={ onToggle }
-								label={ __( 'Add page' ) }
-								showTooltip
-								className="wp-block-navigation__toolbar-inserter-button"
-								disabled={ disabled }
-							/>
-						) }
+						toggleProps={ {
+							as: ToolbarButton,
+							name: 'add-page',
+							label: __( 'Add page' ),
+							showTooltip: true,
+							className:
+								'wp-block-navigation__toolbar-inserter-button',
+						} }
 					/>
 				</VStack>
 			</ToolbarGroup>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -27,6 +27,7 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
 	BlockControls,
+	Inserter,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
@@ -47,7 +48,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon, plus } from '@wordpress/icons';
-import { createBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -89,34 +89,34 @@ import { DEFAULT_BLOCK } from '../constants';
  * @return {JSX.Element|null} The Add page button component or null if not applicable.
  */
 function NavigationAddPageButton( { clientId } ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
-	const { getBlockCount } = useSelect( blockEditorStore );
-
-	const onAddPage = useCallback( () => {
-		// Get the current number of blocks to insert at the end
-		const blockCount = getBlockCount( clientId );
-
-		// Create a new navigation link block (default block)
-		const newBlock = createBlock( DEFAULT_BLOCK.name, {
+	// Hardcode directInsertBlock for simplicity
+	const directInsertBlock = {
+		name: DEFAULT_BLOCK.name,
+		attributes: {
 			kind: DEFAULT_BLOCK.attributes.kind,
 			type: DEFAULT_BLOCK.attributes.type,
-		} );
-
-		// Insert the block at the end of the navigation
-		insertBlock( newBlock, blockCount, clientId );
-	}, [ clientId, insertBlock, getBlockCount ] );
+		},
+	};
 
 	return (
 		<BlockControls group="other">
 			<ToolbarGroup>
 				<VStack alignment="center">
-					<ToolbarButton
-						name="add-page"
-						icon={ plus }
-						onClick={ onAddPage }
-						label={ __( 'Add page' ) }
-						showTooltip
-						className="wp-block-navigation__toolbar-inserter-button"
+					<Inserter
+						rootClientId={ clientId }
+						directInsertBlock={ directInsertBlock }
+						isAppender
+						renderToggle={ ( { onToggle, disabled } ) => (
+							<ToolbarButton
+								name="add-page"
+								icon={ plus }
+								onClick={ onToggle }
+								label={ __( 'Add page' ) }
+								showTooltip
+								className="wp-block-navigation__toolbar-inserter-button"
+								disabled={ disabled }
+							/>
+						) }
 					/>
 				</VStack>
 			</ToolbarGroup>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -26,8 +26,8 @@ import {
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
-	BlockControls,
 	Inserter,
+	__unstableBlockToolbarLastItem as BlockToolbarLastItem,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
@@ -45,7 +45,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -99,7 +99,7 @@ function NavigationAddPageButton( { clientId } ) {
 	};
 
 	return (
-		<BlockControls group="other">
+		<BlockToolbarLastItem>
 			<ToolbarGroup className="wp-block-navigation__toolbar-inserter-group">
 				<VStack alignment="center">
 					<Inserter
@@ -108,8 +108,12 @@ function NavigationAddPageButton( { clientId } ) {
 						isAppender
 						toggleProps={ {
 							as: ToolbarButton,
-							name: 'add-page',
-							label: __( 'Add page' ),
+							name: 'add-block',
+							label: sprintf(
+								// translators: %s: The type of navigation link (e.g., "page", "post")
+								__( 'Add %s' ),
+								DEFAULT_BLOCK.attributes.type
+							),
 							showTooltip: true,
 							className:
 								'wp-block-navigation__toolbar-inserter-button',
@@ -117,7 +121,7 @@ function NavigationAddPageButton( { clientId } ) {
 					/>
 				</VStack>
 			</ToolbarGroup>
-		</BlockControls>
+		</BlockToolbarLastItem>
 	);
 }
 

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -4,7 +4,6 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
-	InnerBlocks,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -22,30 +21,14 @@ export default function NavigationInnerBlocks( {
 	orientation,
 	templateLock,
 } ) {
-	const {
-		isImmediateParentOfSelectedBlock,
-		selectedBlockHasChildren,
-		isSelected,
-		hasSelectedDescendant,
-	} = useSelect(
+	const { isSelected } = useSelect(
 		( select ) => {
-			const {
-				getBlockCount,
-				hasSelectedInnerBlock,
-				getSelectedBlockClientId,
-			} = select( blockEditorStore );
+			const { getSelectedBlockClientId } = select( blockEditorStore );
 			const selectedBlockId = getSelectedBlockClientId();
 
 			return {
-				isImmediateParentOfSelectedBlock: hasSelectedInnerBlock(
-					clientId,
-					false
-				),
-				selectedBlockHasChildren: !! getBlockCount( selectedBlockId ),
-				hasSelectedDescendant: hasSelectedInnerBlock( clientId, true ),
-
 				// This prop is already available but computing it here ensures it's
-				// fresh compared to isImmediateParentOfSelectedBlock.
+				// fresh compared to other selectors.
 				isSelected: selectedBlockId === clientId,
 			};
 		},
@@ -68,14 +51,6 @@ export default function NavigationInnerBlocks( {
 	const showPlaceholder =
 		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
 
-	// Hide the in-canvas appender when the Navigation block itself is selected,
-	// since the toolbar-based [+] button will be available instead.
-	// Show the appender when child blocks are selected to allow inserting between items.
-	const shouldShowAppender =
-		! isSelected &&
-		( ( isImmediateParentOfSelectedBlock && ! selectedBlockHasChildren ) ||
-			hasSelectedDescendant );
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -89,17 +64,7 @@ export default function NavigationInnerBlocks( {
 			directInsert: true,
 			orientation,
 			templateLock,
-
-			// As an exception to other blocks which feature nesting, show
-			// the block appender even when a child block is selected.
-			// This should be a temporary fix, to be replaced by improvements to
-			// the sibling inserter.
-			// See https://github.com/WordPress/gutenberg/issues/37572.
-			// Hide the appender when the Navigation block itself is selected,
-			// as the toolbar-based inserter will be available instead.
-			renderAppender: shouldShowAppender
-				? InnerBlocks.ButtonBlockAppender
-				: false,
+			renderAppender: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -57,13 +57,6 @@ export default function NavigationInnerBlocks( {
 		'wp_navigation'
 	);
 
-	// When the block is selected itself or has a top level item selected that
-	// doesn't itself have children, show the standard appender. Else show no
-	// appender.
-	const parentOrChildHasSelection =
-		isSelected ||
-		( isImmediateParentOfSelectedBlock && ! selectedBlockHasChildren );
-
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
 	const hasMenuItems = !! blocks?.length;
@@ -74,6 +67,14 @@ export default function NavigationInnerBlocks( {
 	// alongside the appender.
 	const showPlaceholder =
 		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
+
+	// Hide the in-canvas appender when the Navigation block itself is selected,
+	// since the toolbar-based [+] button will be available instead.
+	// Show the appender when child blocks are selected to allow inserting between items.
+	const shouldShowAppender =
+		! isSelected &&
+		( ( isImmediateParentOfSelectedBlock && ! selectedBlockHasChildren ) ||
+			hasSelectedDescendant );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
@@ -94,15 +95,11 @@ export default function NavigationInnerBlocks( {
 			// This should be a temporary fix, to be replaced by improvements to
 			// the sibling inserter.
 			// See https://github.com/WordPress/gutenberg/issues/37572.
-			renderAppender:
-				isSelected ||
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasChildren ) ||
-				hasSelectedDescendant ||
-				// Show the appender while dragging to allow inserting element between item and the appender.
-				parentOrChildHasSelection
-					? InnerBlocks.ButtonBlockAppender
-					: false,
+			// Hide the appender when the Navigation block itself is selected,
+			// as the toolbar-based inserter will be available instead.
+			renderAppender: shouldShowAppender
+				? InnerBlocks.ButtonBlockAppender
+				: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -649,3 +649,59 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 .wp-block-navigation__submenu-accessibility-notice {
 	grid-column: span 2;
 }
+
+/**
+ * Toolbar inserter button
+ * Black square with white plus icon, matching the mockup design
+ */
+.block-editor-block-toolbar .wp-block-navigation__toolbar-inserter-button.components-button,
+.block-editor-block-toolbar .components-toolbar__control.wp-block-navigation__toolbar-inserter-button,
+.components-toolbar-group .wp-block-navigation__toolbar-inserter-button.components-button {
+	// Black square with white plus icon
+	background: $gray-900 !important;
+	color: $white !important;
+	padding: 0 !important;
+	min-width: $button-size-small !important;
+	width: $button-size-small !important;
+	height: $button-size-small !important;
+	border-radius: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	// Override default toolbar button padding and sizing
+	&.has-icon,
+	&.has-icon.has-icon {
+		padding-left: 0 !important;
+		padding-right: 0 !important;
+		min-width: $button-size-small !important;
+		width: $button-size-small !important;
+		height: $button-size-small !important;
+	}
+
+	// Hide the default focus ::before pseudo-element
+	&::before {
+		display: none !important;
+	}
+
+	&:hover {
+		color: $white !important;
+		background: var(--wp-admin-theme-color) !important;
+	}
+
+	&:focus {
+		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color) !important;
+		outline: none;
+
+		&::before {
+			display: none !important;
+		}
+	}
+
+	// Ensure the icon is centered
+	svg {
+		margin: 0;
+		width: 20px;
+		height: 20px;
+	}
+}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -652,56 +652,29 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 /**
  * Toolbar inserter button
- * Black square with white plus icon, matching the mockup design
+ * Black square with rounded corners and white plus icon, matching the standard block inserter
  */
-.block-editor-block-toolbar .wp-block-navigation__toolbar-inserter-button.components-button,
-.block-editor-block-toolbar .components-toolbar__control.wp-block-navigation__toolbar-inserter-button,
-.components-toolbar-group .wp-block-navigation__toolbar-inserter-button.components-button {
-	// Black square with white plus icon
-	background: $gray-900 !important;
-	color: $white !important;
-	padding: 0 !important;
-	min-width: $button-size-small !important;
-	width: $button-size-small !important;
-	height: $button-size-small !important;
-	border-radius: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-
-	// Override default toolbar button padding and sizing
-	&.has-icon,
-	&.has-icon.has-icon {
-		padding-left: 0 !important;
-		padding-right: 0 !important;
-		min-width: $button-size-small !important;
-		width: $button-size-small !important;
-		height: $button-size-small !important;
-	}
+.wp-block-navigation__toolbar-inserter-group .wp-block-navigation__toolbar-inserter-button.components-button.has-icon.has-icon {
+	// Match standard inserter toggle styles
+	background: $gray-900;
+	color: $white;
+	padding: 0;
+	min-width: auto;
+	width: $button-size-small;
+	height: $button-size-small;
 
 	// Hide the default focus ::before pseudo-element
 	&::before {
-		display: none !important;
+		display: none;
 	}
 
 	&:hover {
-		color: $white !important;
-		background: var(--wp-admin-theme-color) !important;
+		color: $white;
+		background: var(--wp-admin-theme-color);
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color) !important;
+		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
 		outline: none;
-
-		&::before {
-			display: none !important;
-		}
-	}
-
-	// Ensure the icon is centered
-	svg {
-		margin: 0;
-		width: 20px;
-		height: 20px;
 	}
 }


### PR DESCRIPTION
## What

Introduce a toolbar-based [+] inserter for the Navigation block, replacing the in-canvas inserter.

Closes #73647

## Why

The inline inserter inside the Navigation block often leads to:
- Layout shifts as it appears/disappears within the menu
- Ambiguity about which part of the menu it relates to
- Extra complexity in an already nested editing experience

A toolbar-based inserter provides:
- A stable, predictable insertion point
- Clearer association with the Navigation block itself
- A cleaner canvas with fewer shifting elements

## How

- Updated the existing "Add page" control to use a [+] icon and moved it to the end of the block toolbar using `BlockToolbarLastItem`
- Reused the standard `Inserter` component with `toggleProps` for consistency
- Removed the in-canvas inserter for the Navigation block when the toolbar version is available
- Styled the button to match the standard block inserter (black square with rounded corners, white plus icon)

## Known Caveats

⚠️ **Design discrepancy**: The implementation doesn't fully match [the design](https://github.com/WordPress/gutenberg/issues/73647#issue-3674460150) in that the [+] button has a border between it and the options menu ("3 dots"). This is due to how `ToolbarGroup` renders separators.

⚠️ **Scope**: The implementation is locally scoped to the Navigation block but reuses existing components where possible for maintainability.

⚠️ **Child block selection behavior**: There's an open question about the behavior when Navigation menu items (links) are selected. The Navigation block was previously configured to always show the parent "appender" even if a child was selected, making it easy to continue adding links after a newly added block becomes selected. We need to decide whether to:

1. **Option A**: Show the toolbar [+] inserter when child blocks are selected (would require additional implementation)
2. **Option B**: Continue to show the standard appender in the canvas when menu items are selected

Currently, the toolbar inserter is only visible when the Navigation block itself is selected. When child menu items are selected, there is no inserter available (the in-canvas appender was removed). This may need adjustment based on UX testing and feedback.

## Screenshot

<img width="428" height="175" alt="Screenshot 2025-11-28 at 12 19 09" src="https://github.com/user-attachments/assets/2279b2fa-004c-437e-be62-d55f85e3710b" />


