### PR TITLE
Fix Dragging scroll thread collapse

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -164,10 +164,14 @@ export function Comments( {
 
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
-		// Fallback to 'new-note-thread' when showing the comment board for a new note.
-		setSelectedThread(
-			newNoteFormState === 'open' ? 'new-note-thread' : blockCommentId
-		);
+		if ( newNoteFormState === 'open' ) {
+			setSelectedThread( 'new-note-thread' );
+			return;
+		}
+
+		if ( blockCommentId ) {
+			setSelectedThread( blockCommentId );
+		}
 	}, [ blockCommentId, newNoteFormState ] );
 
 	const setBlockRef = useCallback( ( id, blockRef ) => {


### PR DESCRIPTION
##  What?

Closes #73547.

This PR fixes an issue where dragging the Notes sidebar scrollbar caused expanded note threads to collapse. The fix adjusts the thread-selection effect in Comments so the component stops collapsing threads when blockCommentId becomes temporarily null during sidebar scrolling.

## Why?

Dragging the sidebar scrollbar caused the sidebar to collapse the currently open thread, even though the user was only scrolling.

This made long note threads very difficult to navigate using the scrollbar.


## Testing Instructions

1. Open a post and ensure the Notes sidebar has long threads.
2. Expand a thread with multiple replies.
3. Scroll using:
4. mouse wheel → should remain open
5. sidebar scrollbar drag → should remain open (previously collapsed)

## Video 

https://github.com/user-attachments/assets/46c22c6e-43e6-4cf1-9885-f8d308791201

