### PR TITLE
Search and File Blocks: Fix client navigation support on WordPress 6.8

### DIFF
--- a/lib/compat/wordpress-6.9/client-assets.php
+++ b/lib/compat/wordpress-6.9/client-assets.php
@@ -19,9 +19,11 @@ if ( ! method_exists( 'WP_Interactivity_API', 'add_client_navigation_support_to_
 	 */
 	function gutenberg_interactive_script_modules_registry( $script_module_id = null ) {
 		static $interactive_script_modules = array(
+			'@wordpress/block-library/file/view-js-module'       => true,
+			'@wordpress/block-library/image/view-js-module'      => true,
 			'@wordpress/block-library/navigation/view-js-module' => true,
 			'@wordpress/block-library/query/view-js-module'      => true,
-			'@wordpress/block-library/image/view-js-module'      => true,
+			'@wordpress/block-library/search/view-js-module'     => true,
 		);
 		if ( null !== $script_module_id ) {
 			$interactive_script_modules[ $script_module_id . '-js-module' ] = true;

--- a/lib/compat/wordpress-6.9/client-assets.php
+++ b/lib/compat/wordpress-6.9/client-assets.php
@@ -19,11 +19,11 @@ if ( ! method_exists( 'WP_Interactivity_API', 'add_client_navigation_support_to_
 	 */
 	function gutenberg_interactive_script_modules_registry( $script_module_id = null ) {
 		static $interactive_script_modules = array(
-			'@wordpress/block-library/file/view-js-module'       => true,
-			'@wordpress/block-library/image/view-js-module'      => true,
+			'@wordpress/block-library/file/view-js-module' => true,
+			'@wordpress/block-library/image/view-js-module' => true,
 			'@wordpress/block-library/navigation/view-js-module' => true,
-			'@wordpress/block-library/query/view-js-module'      => true,
-			'@wordpress/block-library/search/view-js-module'     => true,
+			'@wordpress/block-library/query/view-js-module' => true,
+			'@wordpress/block-library/search/view-js-module' => true,
 		);
 		if ( null !== $script_module_id ) {
 			$interactive_script_modules[ $script_module_id . '-js-module' ] = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes client navigation compatibility of some interactive blocks when Gutenberg is installed in WordPress 6.8. In particular, the File and the Search blocks. These blocks are interactive blocks that support client-side navigation, but they lack a `viewScriptModule` entry in their `block.json` files, so the necessary `data-wp-router-options` directive is not injected for their script modules.

## Why?

These blocks should work with client-side navigation as they do in WordPress 6.9.

## How?

Just hardcoding the module IDs inside the `gutenberg_interactive_script_modules_registry` function that is included inside Gutenberg's `wordpress-6.9` compat folder. 

## Testing Instructions

1. Ensure the WordPress version you're using is 6.8.
2. Create a post with the following interactive blocks:
   - A Search block with the "button position" option set to "Button only".
   - A File block showing an uploaded .pdf file.
3. Create another post without interactive blocks.
4. Go to the site editor and, in the Blog Home template, modify the Query block so:
   - The "Reload full page" advanced setting is disabled.
   - It only displays one post per page.
   - The Post Content block is included in the Post Template block.
5. Visit the homepage.
6. The current page should display the post without interactive blocks.
7. Navigate to the next page.
8. The current page should display the post with the Search and File blocks.
9. Ensure both blocks work as expected.