### PR TITLE
Docs: add JSDoc for getUserLabel in users autocompleter

### DIFF
--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -6,11 +6,10 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
- * Returns the user label.
+ * Renders a user label for the autocompleter.
  *
  * @param {Object} user User object.
- *
- * @return {Object} User label component.
+ * @return {JSX.Element} User label component.
  */
 export function getUserLabel( user ) {
 	const avatar =

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -5,6 +5,13 @@ import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
+/**
+ * Returns the user label.
+ *
+ * @param {Object} user User object.
+ *
+ * @return {Object} User label component.
+ */
 export function getUserLabel( user ) {
 	const avatar =
 		user.avatar_urls && user.avatar_urls[ 24 ] ? (


### PR DESCRIPTION
Adds a JSDoc comment block for the `getUserLabel` helper function in the users autocompleter. This documents the `user` parameter and clarifies the returned React component for better maintainability and IDE support.

### Why
Improves code readability and provides better tooling support (hover documentation, type hints) without changing any runtime behavior.

### Changes
- Added JSDoc documentation above `getUserLabel` in `packages/editor/src/components/autocompleters/user.js`

### Files Changed
- `packages/editor/src/components/autocompleters/user.js`
