### PR TITLE
Fix: Stretchy text issue when nested on flex containers.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -18,18 +18,23 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	let bestSize = minSize;
 
 	const computedStyle = window.getComputedStyle( textElement );
-	const paddingLeft = parseFloat( computedStyle.paddingLeft ) || 0;
-	const paddingRight = parseFloat( computedStyle.paddingRight ) || 0;
+	let paddingLeft = parseFloat( computedStyle.paddingLeft ) || 0;
+	let paddingRight = parseFloat( computedStyle.paddingRight ) || 0;
 	const range = document.createRange();
 	range.selectNodeContents( textElement );
 
 	let referenceElement = textElement;
 	const parentElement = textElement.parentElement;
-	if (
-		parentElement &&
-		window?.getComputedStyle( parentElement )?.display === 'flex'
-	) {
+	if ( parentElement ) {
+		const parentElementComputedStyle =
+			window.getComputedStyle( parentElement );
+		if ( parentElementComputedStyle?.display === 'flex' ) {
 		referenceElement = parentElement;
+			paddingLeft +=
+				parseFloat( parentElementComputedStyle.paddingLeft ) || 0;
+			paddingRight +=
+				parseFloat( parentElementComputedStyle.paddingRight ) || 0;
+		}
 	}
 	let maxclientHeight = referenceElement.clientHeight;
 

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -23,12 +23,13 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	const range = document.createRange();
 	range.selectNodeContents( textElement );
 
-	const parentElement = textElement.parentElement;
 	let referenceElement = textElement;
-	if ( parentElement ) {
-		if ( window?.getComputedStyle( parentElement )?.display === 'flex' ) {
-			referenceElement = parentElement;
-		}
+	const parentElement = textElement.parentElement;
+	if (
+		parentElement &&
+		window?.getComputedStyle( parentElement )?.display === 'flex'
+	) {
+		referenceElement = parentElement;
 	}
 	let maxclientHeight = referenceElement.clientHeight;
 

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -24,9 +24,12 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	range.selectNodeContents( textElement );
 
 	const parentElement = textElement.parentElement;
-	const parentIsFlex =
-		window.getComputedStyle( parentElement ).display === 'flex';
-	const referenceElement = parentIsFlex ? parentElement : textElement;
+	let referenceElement = textElement;
+	if ( parentElement ) {
+		if ( window?.getComputedStyle( parentElement )?.display === 'flex' ) {
+			referenceElement = parentElement;
+		}
+	}
 	let maxclientHeight = referenceElement.clientHeight;
 
 	while ( minSize <= maxSize ) {

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -29,7 +29,7 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 		const parentElementComputedStyle =
 			window.getComputedStyle( parentElement );
 		if ( parentElementComputedStyle?.display === 'flex' ) {
-		referenceElement = parentElement;
+			referenceElement = parentElement;
 			paddingLeft +=
 				parseFloat( parentElementComputedStyle.paddingLeft ) || 0;
 			paddingRight +=

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -22,7 +22,13 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	const paddingRight = parseFloat( computedStyle.paddingRight ) || 0;
 	const range = document.createRange();
 	range.selectNodeContents( textElement );
-	let maxclientHeight = textElement.clientHeight;
+
+	const parentElement = textElement.parentElement;
+	const parentIsFlex =
+		window.getComputedStyle( parentElement ).display === 'flex';
+	const referenceElement = parentIsFlex ? parentElement : textElement;
+	let maxclientHeight = referenceElement.clientHeight;
+
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
 		applyFontSize( midSize );
@@ -36,12 +42,14 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 		// Check if text fits within the element's width and is not
 		// overflowing into the padding area.
 		const fitsWidth =
-			textElement.scrollWidth <= textElement.clientWidth &&
-			textWidth <= textElement.clientWidth - paddingLeft - paddingRight;
+			textElement.scrollWidth <= referenceElement.clientWidth &&
+			// textWidth <= textElement.parentElement.clientWidth &&
+			textWidth <=
+				referenceElement.clientWidth - paddingLeft - paddingRight;
 		// Check if text fits within the element's height.
 		const fitsHeight =
 			alreadyHasScrollableHeight ||
-			textElement.scrollHeight <= textElement.clientHeight ||
+			textElement.scrollHeight <= referenceElement.clientHeight ||
 			textElement.scrollHeight <= maxclientHeight;
 
 		// When there are calculated line heights, text may jump in height
@@ -49,8 +57,8 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 		// making text not fit.
 		// We store a maximum reference height: the maximum reference element height that was observed
 		// during the loop to avoid issues with such jumps.
-		if ( textElement.clientHeight > maxclientHeight ) {
-			maxclientHeight = textElement.clientHeight;
+		if ( referenceElement.clientHeight > maxclientHeight ) {
+			maxclientHeight = referenceElement.clientHeight;
 		}
 
 		if ( fitsWidth && fitsHeight ) {

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -52,7 +52,6 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 		// overflowing into the padding area.
 		const fitsWidth =
 			textElement.scrollWidth <= referenceElement.clientWidth &&
-			// textWidth <= textElement.parentElement.clientWidth &&
 			textWidth <=
 				referenceElement.clientWidth - paddingLeft - paddingRight;
 		// Check if text fits within the element's height.


### PR DESCRIPTION
Fixes an issue where Stretch text does not works well if nested inside flex based layouts like a stack whose width is limited for example by a column.

To fix the issue, we verify if the parent is a flex element, if yes, we use the parent width to constraint fit text (still taking into account padding) as for flex layouts the the descent could in theory grow indefinitely. For all other cases the previous logic is the same. 

cc: @henriqueiamarino

## Screenshots

### Before
<img width="1419" height="759" alt="Screenshot 2025-11-28 at 19 31 05" src="https://github.com/user-attachments/assets/c73f4472-09bf-4c4f-8534-62b06cf60d6d" />


### After
<img width="1424" height="430" alt="Screenshot 2025-11-28 at 19 30 53" src="https://github.com/user-attachments/assets/35af7cd5-edd9-425b-8266-a0eeb3d9b8af" />


## Testing Instructions
Open the editor past the following markup in the code editor:
```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>col 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fitText":true} -->
<p class="has-fit-text">Stretch</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>col 2</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
Verify the "Stretch" behavior is the expected one.
