### PR TITLE
fix css selector for list-item block for block style variation

### DIFF
--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -63,7 +63,7 @@
 		}
 	},
 	"selectors": {
-		"root": ".wp-block-list > li",
-		"border": ".wp-block-list:not(.wp-block-list .wp-block-list) > li"
+		"root": ".wp-block-list-item",
+		"border": ".wp-block-list-item:not(.wp-block-list .wp-block-list > .wp-block-list-item)"
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. --><!-- #ISSUE-NUMBER or URL -->
I fixed the block style variation for the List Item block by correcting the CSS selectors defined in its block.json. The original selectors were pointing to invalid or overly broad targets, which caused block style variations not to apply correctly. I updated the root and border selectors to use the proper .wp-block-list-item class reference.

Closes #73527
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
wordpress consume the selector and put the hashed class in the parent class `wp-block-list` instead of `wp-block-list-item` leading to make css selector
```
.wp-block-list.is-style-my-theme-tag-9077feea-6a9a-4a70-8d76-aba025da8519 >li
```
the right selector should be look like 
```
.wp-block-list-item.is-style-my-theme-tag-9077feea-6a9a-4a70-8d76-aba025da8519
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
change the css selector to be
`.wp-block-list-item` instead of `.wp-block-list > li`
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1- make file in your-theme/styles/blocks/tag.json
2- copy and paste the json file
```
{
    "$schema": "https://schemas.wp.org/wp/6.8/theme.json",
    "version": 3,
    "title": "Tag",
    "slug": "my-theme-tag",
    "blockTypes":
                    [
                    "core/list-item"
                    ],
    "styles": {
        "spacing": {
            "padding": {
                "top": "0.5em",
                "right": "1em",
                "bottom": "0.5em",
                "left": "1em"
            }
        },
        "color": {
            "background": "var:preset|color|secondary",
           "text": "var:preset|color|white"
        }
    }
}
```
3- open block editor 
4- add list
5- select the list-item block
6- in sidebar panel select styles option tag

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="1755" height="903" alt="image" src="https://github.com/user-attachments/assets/dfddbc53-8dd6-4a9b-b321-67485919b41c" />

### After
<img width="1755" height="903" alt="image" src="https://github.com/user-attachments/assets/be2ef6fe-13dc-4009-badb-b93f39188398" />
<!-- Before screenshot here --><!-- After screenshot here -->
