### PR TITLE
Documentation: fix a typo in the documentation

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -283,7 +283,6 @@ This directive adds or removes inline style to an HTML element, depending on its
 	</button>
 	<p data-wp-style--color="context.color">Hello World!</p>
 </div>
->
 ```
 
 <details>


### PR DESCRIPTION
In the #wp-style there is an additional symbol

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing the documentation error in `api-reference.md`, removing an extra `<` symbol.
Closes  #73657 

<!-- In a few words, what is the PR actually doing? -->

## Why?
We want to improve the documentation.

## Testing Instructions
This is documentation, you cannot directly test it.