### PR TITLE
Update the useCommandLoader example to fix the syntax error and add missing imports.

### DIFF
--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -122,7 +122,8 @@ Attach a command loader to the command palette. Used for dynamic commands.
 _Usage_
 
 ```js
-import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useCommandLoader } from '@wordpress/commands';
 import { page } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
@@ -161,16 +162,15 @@ function usePageSearchCommandLoader( { search } ) {
 				icon: page,
 				callback: ( { close } ) => {
 					const args = {
-						postType,
+						p: '/page',
 						postId: record.id,
-						...extraArgs,
 					};
 					document.location = addQueryArgs( 'site-editor.php', args );
 					close();
 				},
 			};
 		} );
-	}, [ records, history ] );
+	}, [ records ] );
 
 	return {
 		commands,

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -122,65 +122,65 @@ Attach a command loader to the command palette. Used for dynamic commands.
 _Usage_
 
 ```js
+import { registerPlugin } from '@wordpress/plugins';
 import { useCommandLoader } from '@wordpress/commands';
-import { post, page, layout, symbolFilled } from '@wordpress/icons';
-
-const icons = {
-    post,
-    page,
-    wp_template: layout,
-    wp_template_part: symbolFilled,
-};
+import { page } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
 
 function usePageSearchCommandLoader( { search } ) {
-    // Retrieve the pages for the "search" term.
-    const { records, isLoading } = useSelect( ( select ) => {
-        const { getEntityRecords } = select( coreStore );
-        const query = {
-            search: !! search ? search : undefined,
-            per_page: 10,
-            orderby: search ? 'relevance' : 'date',
-        };
-        return {
-            records: getEntityRecords( 'postType', 'page', query ),
-            isLoading: ! select( coreStore ).hasFinishedResolution(
-                'getEntityRecords',
-                'postType', 'page', query ]
-            ),
-        };
-    }, [ search ] );
+	// Retrieve the pages for the "search" term.
+	const { records, isLoading } = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const query = {
+				search: !! search ? search : undefined,
+				per_page: 10,
+				orderby: search ? 'relevance' : 'date',
+			};
+			return {
+				records: getEntityRecords( 'postType', 'page', query ),
+				isLoading: ! select( coreStore ).hasFinishedResolution(
+					'getEntityRecords',
+					[ 'postType', 'page', query ]
+				),
+			};
+		},
+		[ search ]
+	);
 
-    // Create the commands.
-    const commands = useMemo( () => {
-        return ( records ?? [] ).slice( 0, 10 ).map( ( record ) => {
-            return {
-                name: record.title?.rendered + ' ' + record.id,
-                label: record.title?.rendered
-                    ? record.title?.rendered
-                    : __( '(no title)' ),
-                icon: icons[ postType ],
-                callback: ( { close } ) => {
-                    const args = {
-                        postType,
-                        postId: record.id,
-                        ...extraArgs,
-                    };
-                    document.location = addQueryArgs( 'site-editor.php', args );
-                    close();
-                },
-            };
-        } );
-    }, [ records, history ] );
+	// Create the commands.
+	const commands = useMemo( () => {
+		return ( records ?? [] ).slice( 0, 10 ).map( ( record ) => {
+			return {
+				name: record.title?.rendered + ' ' + record.id,
+				label: record.title?.rendered
+					? record.title?.rendered
+					: __( '(no title)' ),
+				icon: page,
+				callback: ( { close } ) => {
+					const args = {
+						postType,
+						postId: record.id,
+						...extraArgs,
+					};
+					document.location = addQueryArgs( 'site-editor.php', args );
+					close();
+				},
+			};
+		} );
+	}, [ records, history ] );
 
-    return {
-        commands,
-        isLoading,
-    };
+	return {
+		commands,
+		isLoading,
+	};
 }
 
 useCommandLoader( {
-    name: 'myplugin/page-search',
-    hook: usePageSearchCommandLoader,
+	name: 'myplugin/page-search',
+	hook: usePageSearchCommandLoader,
 } );
 ```
 

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -16,33 +16,33 @@ import { store as commandsStore } from '../store';
  *
  * @example
  * ```js
+ * import { registerPlugin } from '@wordpress/plugins';
  * import { useCommandLoader } from '@wordpress/commands';
- * import { post, page, layout, symbolFilled } from '@wordpress/icons';
- *
- * const icons = {
- *     post,
- *     page,
- *     wp_template: layout,
- *     wp_template_part: symbolFilled,
- * };
+ * import { page } from '@wordpress/icons';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as coreStore } from '@wordpress/core-data';
+ * import { useMemo } from '@wordpress/element';
  *
  * function usePageSearchCommandLoader( { search } ) {
  *     // Retrieve the pages for the "search" term.
- *     const { records, isLoading } = useSelect( ( select ) => {
- *         const { getEntityRecords } = select( coreStore );
- *         const query = {
- *             search: !! search ? search : undefined,
- *             per_page: 10,
- *             orderby: search ? 'relevance' : 'date',
- *         };
- *         return {
- *             records: getEntityRecords( 'postType', 'page', query ),
- *             isLoading: ! select( coreStore ).hasFinishedResolution(
- *                 'getEntityRecords',
- *                 'postType', 'page', query ]
- *             ),
- *         };
- *     }, [ search ] );
+ *     const { records, isLoading } = useSelect(
+ *         ( select ) => {
+ *             const { getEntityRecords } = select( coreStore );
+ *             const query = {
+ *                 search: !! search ? search : undefined,
+ *                 per_page: 10,
+ *                 orderby: search ? 'relevance' : 'date',
+ *             };
+ *             return {
+ *                 records: getEntityRecords( 'postType', 'page', query ),
+ *                 isLoading: ! select( coreStore ).hasFinishedResolution(
+ *                     'getEntityRecords',
+ *                     [ 'postType', 'page', query ]
+ *                 ),
+ *             };
+ *         },
+ *         [ search ]
+ *     );
  *
  *     // Create the commands.
  *     const commands = useMemo( () => {
@@ -52,7 +52,7 @@ import { store as commandsStore } from '../store';
  *                 label: record.title?.rendered
  *                     ? record.title?.rendered
  *                     : __( '(no title)' ),
- *                 icon: icons[ postType ],
+ *                 icon: page,
  *                 callback: ( { close } ) => {
  *                     const args = {
  *                         postType,

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -16,7 +16,8 @@ import { store as commandsStore } from '../store';
  *
  * @example
  * ```js
- * import { registerPlugin } from '@wordpress/plugins';
+ * import { __ } from '@wordpress/i18n';
+ * import { addQueryArgs } from '@wordpress/url';
  * import { useCommandLoader } from '@wordpress/commands';
  * import { page } from '@wordpress/icons';
  * import { useSelect } from '@wordpress/data';
@@ -55,16 +56,15 @@ import { store as commandsStore } from '../store';
  *                 icon: page,
  *                 callback: ( { close } ) => {
  *                     const args = {
- *                         postType,
- *                         postId: record.id,
- *                         ...extraArgs,
+ * 							p: '/page',
+ * 							postId: record.id,
  *                     };
  *                     document.location = addQueryArgs( 'site-editor.php', args );
  *                     close();
  *                 },
  *             };
  *         } );
- *     }, [ records, history ] );
+ *     }, [ records ] );
  *
  *     return {
  *         commands,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The `useCommandLoader` example contained a syntax error and was missing imports. This caused anyone using the example to run into issues. 

## Why?
Examples should be complete and not cause errors.

## How?
I fixed the syntax error, added the imports, and removed some unneeded code.
