### PR TITLE
Fix sticky footer in dataviews grid view

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)
+
 ### Enhancements
 
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -10,6 +10,7 @@
 	flex-direction: column;
 	gap: $grid-unit-40;
 	container-type: inline-size;
+	margin-bottom: auto;
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up to #72997. Adds back the margin-bottom that got lost when that PR removed the GridItems component from the grid layout.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor, navigate to a dataview that doesn't have enough content to fill the screen, and switch to the grid layout. The footer should stick to the bottom of the screen.


|Before|After|
|-|-|
| <img width="995" height="901" alt="Screenshot 2025-12-01 at 2 08 45 pm" src="https://github.com/user-attachments/assets/f3ac330b-ddec-48ed-b9b8-164d513a026c" /> | <img width="1000" height="860" alt="Screenshot 2025-12-01 at 2 16 49 pm" src="https://github.com/user-attachments/assets/08c833e8-748f-46d7-8681-699ec5e036b2" /> |
