### PR TITLE
Enable grid block to be responsive when columns are set

### DIFF
--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -243,7 +243,7 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 	return (
 		<fieldset className="block-editor-hooks__grid-layout-minimum-width-control">
 			<BaseControl.VisualLabel as="legend">
-				{ __( 'Minimum column width' ) }
+				{ __( 'Min. column width' ) }
 			</BaseControl.VisualLabel>
 			<Flex gap={ 4 }>
 				<FlexItem isBlock>
@@ -278,6 +278,11 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 					/>
 				</FlexItem>
 			</Flex>
+			<p className="components-base-control__help">
+				{ __(
+					'Columns will wrap to fewer per row when they can no longer maintain the minimum width.'
+				) }
+			</p>
 		</fieldset>
 	);
 }
@@ -301,7 +306,7 @@ function GridLayoutColumnsAndRowsControl( {
 			<fieldset className="block-editor-hooks__grid-layout-columns-and-rows-controls">
 				{ ! isManualPlacement && (
 					<BaseControl.VisualLabel as="legend">
-						{ __( 'Columns' ) }
+						{ __( 'Max. columns' ) }
 					</BaseControl.VisualLabel>
 				) }
 				<Flex gap={ 4 }>

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -72,20 +72,20 @@ export default {
 	} ) {
 		const { allowSizingOnChildren = false } = layoutBlockSupport;
 
-		// In the experiment we want to also show column control in Auto mode, and
-		// the minimum width control in Manual mode.
-		const showColumnsControl =
-			window.__experimentalEnableGridInteractivity ||
-			!! layout?.columnCount;
+		// Always show both column and minimum width controls in Auto mode.
+		// Manual mode (with isManualPlacement) is only available behind the experiment flag.
+		const showColumnsControl = true;
 		const showMinWidthControl =
-			window.__experimentalEnableGridInteractivity ||
-			! layout?.columnCount;
+			! layout?.isManualPlacement ||
+			window.__experimentalEnableGridInteractivity;
 		return (
 			<>
-				<GridLayoutTypeControl
-					layout={ layout }
-					onChange={ onChange }
-				/>
+				{ window.__experimentalEnableGridInteractivity && (
+					<GridLayoutTypeControl
+						layout={ layout }
+						onChange={ onChange }
+					/>
+				) }
 				<VStack spacing={ 4 }>
 					{ showColumnsControl && (
 						<GridLayoutColumnsAndRowsControl
@@ -288,10 +288,8 @@ function GridLayoutColumnsAndRowsControl( {
 	onChange,
 	allowSizingOnChildren,
 } ) {
-	// If the grid interactivity experiment is enabled, allow unsetting the column count.
-	const defaultColumnCount = window.__experimentalEnableGridInteractivity
-		? undefined
-		: 3;
+	// Allow unsetting the column count in Auto mode.
+	const defaultColumnCount = undefined;
 	const {
 		columnCount = defaultColumnCount,
 		rowCount,
@@ -301,8 +299,7 @@ function GridLayoutColumnsAndRowsControl( {
 	return (
 		<>
 			<fieldset className="block-editor-hooks__grid-layout-columns-and-rows-controls">
-				{ ( ! window.__experimentalEnableGridInteractivity ||
-					! isManualPlacement ) && (
+				{ ! isManualPlacement && (
 					<BaseControl.VisualLabel as="legend">
 						{ __( 'Columns' ) }
 					</BaseControl.VisualLabel>
@@ -312,46 +309,28 @@ function GridLayoutColumnsAndRowsControl( {
 						<NumberControl
 							size="__unstable-large"
 							onChange={ ( value ) => {
-								if (
-									window.__experimentalEnableGridInteractivity
-								) {
-									// Allow unsetting the column count when in auto mode.
-									const defaultNewColumnCount =
-										isManualPlacement ? 1 : undefined;
-									const newColumnCount =
-										value === '' || value === '0'
-											? defaultNewColumnCount
-											: parseInt( value, 10 );
-									onChange( {
-										...layout,
-										columnCount: newColumnCount,
-									} );
-								} else {
-									// Don't allow unsetting the column count.
-									const newColumnCount =
-										value === '' || value === '0'
-											? 1
-											: parseInt( value, 10 );
-									onChange( {
-										...layout,
-										columnCount: newColumnCount,
-									} );
-								}
+								// Allow unsetting the column count when in auto mode.
+								const defaultNewColumnCount = isManualPlacement
+									? 1
+									: undefined;
+								const newColumnCount =
+									value === '' || value === '0'
+										? defaultNewColumnCount
+										: parseInt( value, 10 );
+								onChange( {
+									...layout,
+									columnCount: newColumnCount,
+								} );
 							} }
 							value={ columnCount }
 							min={ 1 }
 							label={ __( 'Columns' ) }
-							hideLabelFromVision={
-								! window.__experimentalEnableGridInteractivity ||
-								! isManualPlacement
-							}
+							hideLabelFromVision={ ! isManualPlacement }
 						/>
 					</FlexItem>
 
 					<FlexItem isBlock>
-						{ window.__experimentalEnableGridInteractivity &&
-						allowSizingOnChildren &&
-						isManualPlacement ? (
+						{ allowSizingOnChildren && isManualPlacement ? (
 							<NumberControl
 								size="__unstable-large"
 								onChange={ ( value ) => {
@@ -414,11 +393,7 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 		minimumColumnWidth || '12rem'
 	);
 
-	const gridPlacement =
-		isManualPlacement ||
-		( !! columnCount && ! window.__experimentalEnableGridInteractivity )
-			? 'manual'
-			: 'auto';
+	const gridPlacement = isManualPlacement ? 'manual' : 'auto';
 
 	const onChangeType = ( value ) => {
 		if ( value === 'manual' ) {
@@ -429,17 +404,9 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 		}
 		onChange( {
 			...layout,
-			columnCount: value === 'manual' ? tempColumnCount : null,
-			rowCount:
-				value === 'manual' &&
-				window.__experimentalEnableGridInteractivity
-					? tempRowCount
-					: undefined,
-			isManualPlacement:
-				value === 'manual' &&
-				window.__experimentalEnableGridInteractivity
-					? true
-					: undefined,
+			columnCount: value === 'manual' ? tempColumnCount : tempColumnCount,
+			rowCount: value === 'manual' ? tempRowCount : undefined,
+			isManualPlacement: value === 'manual' ? true : undefined,
 			minimumColumnWidth:
 				value === 'auto' ? tempMinimumColumnWidth : null,
 		} );
@@ -462,11 +429,7 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 			value={ gridPlacement }
 			onChange={ onChangeType }
 			isBlock
-			help={
-				window.__experimentalEnableGridInteractivity
-					? helpText
-					: undefined
-			}
+			help={ helpText }
 		>
 			<ToggleGroupControlOption
 				key="auto"

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -32,4 +32,18 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
+	it( 'should return `grid-template-columns` with max() function if both minimumColumnWidth and columnCount are provided', () => {
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(12rem, ( 100% - (1.2rem*2) ) / 3), 1fr)); container-type: inline-size; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { minimumColumnWidth: '12rem', columnCount: 3 },
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: false,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

A minimal iteration on [#57478](https://github.com/WordPress/gutenberg/issues/57478).

This PR allows both "minimum column width" and "columns" controls to be used simultaneously and removes the toggle between Auto and Manual modes.

Currently in trunk users have to choose between setting a minimum column width, which allows the grid to be responsive, or a number of columns, which stays fixed. 

In this branch, that behaviour is maintained if users set only one of the controls. However, if they choose to set both, "columns" will now behave as "max columns", and will become responsive according to the minimum column width set.

The UI is also simplified by removing the Auto/Manual toggle.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block to a post, and add some blocks inside it.
2. Play with the min width and columns controls, trying various combinations.


The below video shows the difference between setting only a min width, and setting both min width and columns.


https://github.com/user-attachments/assets/da9b1328-b8ab-47bf-add9-483a7fdf68ff


