### PR TITLE
Block notes: "All notes" button visible when show template is on, even when there are no notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -131,7 +131,7 @@ function NotesSidebar( { postId, mode } ) {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 	const showAllNotesSidebar =
-		resultComments.length > 0 || ! showFloatingSidebar;
+		resultComments.length > 0 || newNoteFormState !== 'closed';
 
 	async function openTheSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73659

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR addresses notes sidebar button to show only when adding new note or notes length is greater than 0.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Updates, showAllNotesSidebar to use notes length and state of note to add the new note.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post/page.
2. Check notes button in plugin sidebar, should not be visibile if no notes.
3. Change to show template mode, it should not show button if no notes.
4. Add notes with both mode, post-only and template-locked, it should show notes panel and when added it should show button to see notes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screencast <!-- if applicable -->


https://github.com/user-attachments/assets/baf2a036-1ff7-47b4-be5e-29543ca6ed29

