### PR TITLE
DataViews: Remove extra wrapper for GridItem

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+- DataViews: Remove extra wrapper for GridItem. [#73665](https://github.com/WordPress/gutenberg/pull/73665)
+
 ### Bug Fixes
 
 - Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/72997 

@tellthemachines' comment:

>Just curious, is there any reason why we had to nest GridItem inside a div here?


So this PR removes the extra div wrapper and makes the GridItem [open for extension](https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension) to be used properly from the Ariakit Composite.Item.

## Testing Instructions
1. Grid keyboard navigation should work exactly as before. 