### PR TITLE
Docs: Add missing periods to example descriptions in block-attributes.md

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -48,7 +48,7 @@ Attributes without a `source` will be automatically saved in the block [comment 
 
 For example, using the above attributes definition you would need to ensure that your `save` function has a corresponding img tag for the `url` attribute. The `title` and `size` attributes will be saved in the comment delimiter.
 
-_Example_: Example `save` function that contains the `url` attribute
+_Example_: Example `save` function that contains the `url` attribute.
 
 ```js
 function YourBlockSave( { attributes } ) {
@@ -469,7 +469,7 @@ The `role` property designates an attribute as being of a particular conceptual 
 Use `content` to designate the attribute as user-editable content. Blocks with attributes marked as `content` may be enabled for privileged editing in special circumstances such as content only locking.
 Use `local` to mark the attribute as temporary and non-persistable. Attributes marked as `local` are ignored by the Block Serializer and never saved to post content.
 
-_Example_: `content` role used by the paragraph block
+_Example_: `content` role used by the paragraph block.
 
 ```js
 {


### PR DESCRIPTION
This PR fixes two minor punctuation issues in the block attribute documentation.

## What was changed
- Added missing periods at the end of two example descriptions:
  - Example: Example `save` function that contains the `url` attribute.
  - Example: `content` role used by the paragraph block.

## Why this matters
These changes improve consistency and follow the documentation style used across the Gutenberg project. This helps maintain clarity and professionalism in the reference guides.

No functional or content behavior changes — documentation update only.