### PR TITLE
Remove duplicate hidden post from Query Loop block

### DIFF
--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
-import { memo, useMemo, useEffect, useId, useState } from '@wordpress/element';
+import { memo, useMemo, useEffect, useId } from '@wordpress/element';
 import { useDispatch, useRegistry } from '@wordpress/data';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
@@ -570,105 +570,80 @@ export function createBlockEditFilter( features ) {
 	addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );
 }
 
-function BlockProps( {
-	index,
-	useBlockProps: hook,
-	setAllWrapperProps,
-	...props
-} ) {
-	const wrapperProps = hook( props );
-	const setWrapperProps = ( next ) =>
-		setAllWrapperProps( ( prev ) => {
-			const nextAll = [ ...prev ];
-			nextAll[ index ] = next;
-			return nextAll;
-		} );
-	// Setting state after every render is fine because this component is
-	// pure and will only re-render when needed props change.
-	useEffect( () => {
-		// We could shallow compare the props, but since this component only
-		// changes when needed attributes change, the benefit is probably small.
-		setWrapperProps( wrapperProps );
-		return () => {
-			setWrapperProps( undefined );
-		};
+function getFeatureWrapperProps( feature, props ) {
+	const { hasSupport, attributeKeys = [], useBlockProps, isMatch } = feature;
+
+	const neededProps = {};
+	for ( const key of attributeKeys ) {
+		if ( props.attributes[ key ] ) {
+			neededProps[ key ] = props.attributes[ key ];
+		}
+	}
+
+	if (
+		// Skip if none of the needed attributes are set.
+		! hasSupport( props.name )
+	) {
+		return null;
+	}
+
+	// Call the hook directly to get wrapper props
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const wrapperProps = useBlockProps( {
+		name: props.name,
+		clientId: props.clientId,
+		...( neededProps ?? {} ),
 	} );
-	return null;
+
+	if (
+		// Skip if none of the needed attributes are set.
+		! Object.keys( neededProps ).length ||
+		( isMatch && ! isMatch( neededProps ) )
+	) {
+		return null;
+	}
+
+	return wrapperProps;
 }
 
-const BlockPropsPure = memo( BlockProps );
+export function useBlockPropsWithHooks( features, props ) {
+	// Collect all wrapper props by calling hooks directly in a loop
+	const allWrapperProps = [];
+
+	for ( let i = 0; i < features.length; i++ ) {
+		const wrapperProps = getFeatureWrapperProps( features[ i ], props );
+		allWrapperProps.push( wrapperProps );
+	}
+
+	// Merge all wrapper props
+	return allWrapperProps.filter( Boolean ).reduce( ( acc, wrapperProps ) => {
+		return {
+			...acc,
+			...wrapperProps,
+			className: clsx( acc.className, wrapperProps.className ),
+			style: {
+				...acc.style,
+				...wrapperProps.style,
+			},
+		};
+	}, props.wrapperProps || {} );
+}
 
 export function createBlockListBlockFilter( features ) {
 	const withBlockListBlockHooks = createHigherOrderComponent(
 		( BlockListBlock ) => ( props ) => {
-			const [ allWrapperProps, setAllWrapperProps ] = useState(
-				Array( features.length ).fill( undefined )
+			const mergedWrapperProps = useBlockPropsWithHooks(
+				features,
+				props
 			);
-			return [
-				...features.map( ( feature, i ) => {
-					const {
-						hasSupport,
-						attributeKeys = [],
-						useBlockProps,
-						isMatch,
-					} = feature;
 
-					const neededProps = {};
-					for ( const key of attributeKeys ) {
-						if ( props.attributes[ key ] ) {
-							neededProps[ key ] = props.attributes[ key ];
-						}
-					}
-
-					if (
-						// Skip rendering if none of the needed attributes are
-						// set.
-						! Object.keys( neededProps ).length ||
-						! hasSupport( props.name ) ||
-						( isMatch && ! isMatch( neededProps ) )
-					) {
-						return null;
-					}
-
-					return (
-						<BlockPropsPure
-							// We can use the index because the array length
-							// is fixed per page load right now.
-							key={ i }
-							index={ i }
-							useBlockProps={ useBlockProps }
-							// This component is pure, so we must pass a stable
-							// function reference.
-							setAllWrapperProps={ setAllWrapperProps }
-							name={ props.name }
-							clientId={ props.clientId }
-							// This component is pure, so only pass needed
-							// props!!!
-							{ ...neededProps }
-						/>
-					);
-				} ),
+			return (
 				<BlockListBlock
 					key="edit"
 					{ ...props }
-					wrapperProps={ allWrapperProps
-						.filter( Boolean )
-						.reduce( ( acc, wrapperProps ) => {
-							return {
-								...acc,
-								...wrapperProps,
-								className: clsx(
-									acc.className,
-									wrapperProps.className
-								),
-								style: {
-									...acc.style,
-									...wrapperProps.style,
-								},
-							};
-						}, props.wrapperProps || {} ) }
-				/>,
-			];
+					wrapperProps={ mergedWrapperProps }
+				/>
+			);
 		},
 		'withBlockListBlockHooks'
 	);

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -51,7 +51,6 @@ function PostTemplateBlockPreview( {
 	blocks,
 	blockContextId,
 	classList,
-	isHidden,
 	setActiveBlockContextId,
 } ) {
 	const blockPreviewProps = useBlockPreview( {
@@ -65,10 +64,6 @@ function PostTemplateBlockPreview( {
 		setActiveBlockContextId( blockContextId );
 	};
 
-	const style = {
-		display: isHidden ? 'none' : undefined,
-	};
-
 	return (
 		<li
 			{ ...blockPreviewProps }
@@ -77,7 +72,6 @@ function PostTemplateBlockPreview( {
 			role="button"
 			onClick={ handleOnClick }
 			onKeyPress={ handleOnClick }
-			style={ style }
 		/>
 	);
 }
@@ -309,10 +303,6 @@ export default function PostTemplateEdit( {
 		},
 	];
 
-	// To avoid flicker when switching active block contexts, a preview is rendered
-	// for each block context, but the preview for the active block context is hidden.
-	// This ensures that when it is displayed again, the cached rendering of the
-	// block preview is used, instead of having to re-render the preview from scratch.
 	return (
 		<>
 			<BlockControls>
@@ -332,20 +322,16 @@ export default function PostTemplateEdit( {
 								<PostTemplateInnerBlocks
 									classList={ blockContext.classList }
 								/>
-							) : null }
-							<MemoizedPostTemplateBlockPreview
-								blocks={ blocks }
-								blockContextId={ blockContext.postId }
-								classList={ blockContext.classList }
-								setActiveBlockContextId={
-									setActiveBlockContextId
-								}
-								isHidden={
-									blockContext.postId ===
-									( activeBlockContextId ||
-										blockContexts[ 0 ]?.postId )
-								}
-							/>
+							) : (
+								<MemoizedPostTemplateBlockPreview
+									blocks={ blocks }
+									blockContextId={ blockContext.postId }
+									classList={ blockContext.classList }
+									setActiveBlockContextId={
+										setActiveBlockContextId
+									}
+								/>
+							) }
 						</BlockContextProvider>
 					) ) }
 			</ul>


### PR DESCRIPTION
## What?
Closes #58889

Remove duplicate hidden post from Query Loop block in block editor to keep same post order as frontend. Check #58889 for more details.

## Why?
Address the CSS selector issue and ensure consistent UI across both the Block Editor and the Frontend. 

## How?
Conditionally rendering block or preview based on active block context instead of always rendering preview.

## Testing Instructions
1. Add the `Query Loop` block.
2. Inspect the loop list in Chrome DevTools. It should contain a number of items that matches the number of visible posts.
3. The Frontend and the Block Editor should display the same UI.
4. Ensure that the UI doesn't flicker when selecting a post with a position greater than 1. (Refer #33248).
