### PR TITLE
Breadcrumbs: Support paged comments

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -136,7 +136,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		}
 
 		// Add post title: linked when viewing a paginated page, plain text otherwise.
-		$is_paged = (int) get_query_var( 'page' ) > 1;
+		$is_paged = (int) get_query_var( 'page' ) > 1 || (int) get_query_var( 'cpage' ) > 1;
 		$title    = block_core_breadcrumbs_get_post_title( $post );
 
 		if ( $is_paged ) {
@@ -145,8 +145,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 				'url'        => get_permalink( $post ),
 				'allow_html' => true,
 			);
-
-			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item( 'page' );
+			$breadcrumb_items[] = block_core_breadcrumbs_create_page_number_item( (int) get_query_var( 'cpage' ) > 1 ? 'cpage' : 'page' );
 		} else {
 			$breadcrumb_items[] = array(
 				'label'      => $title,
@@ -213,6 +212,16 @@ function block_core_breadcrumbs_is_paged() {
  */
 function block_core_breadcrumbs_create_page_number_item( $query_var = 'paged' ) {
 	$paged = (int) get_query_var( $query_var );
+
+	if ( 'cpage' === $query_var ) {
+		return array(
+			'label' => sprintf(
+				/* translators: %s: comment page number */
+				__( 'Comments Page %s' ),
+				number_format_i18n( $paged )
+			),
+		);
+	}
 
 	return array(
 		'label' => sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498

This PR add support for paged comments on singular views (ex Posts).


## Testing Instructions
1. Enable GB experimental blocks.
2. For easier testing I'm adding this [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in theme's header and test various cases in the front end.
3. Add a couple of comments in a post
4. Go to `Discussion` settings and enable `Comment Pagination` and set `Top level comments per page` to `1`.
5. Visit the post in the front end and navigate to the second page of comments.

## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added x3p0-breadcrumbs plugin and the core block in the main header.
Above is x3p0-breadcrumbs and below is the core block.

<img width="679" height="125" alt="Screenshot 2025-12-01 at 2 27 22 PM" src="https://github.com/user-attachments/assets/1d6059f3-e639-4359-bb7d-72e89659dfb9" />
