### PR TITLE
Fix block toolbar icon CSS when using show icon label preference

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -193,18 +193,18 @@
 				font-size: $helptext-font-size;
 			}
 		}
+
+		.block-editor-block-icon {
+			width: 0 !important;
+			height: 0 !important;
+			min-width: 0 !important;
+		}
 	}
 
 	// Padding overrides.
 	.components-accessible-toolbar .components-toolbar-group > div:first-child:last-child > .components-button.has-icon {
 		padding-left: 6px;
 		padding-right: 6px;
-	}
-
-	.block-editor-block-icon {
-		width: 0 !important;
-		height: 0 !important;
-		min-width: 0 !important;
 	}
 
 	// Parent selector overrides


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes [issue reported in comment by](https://github.com/WordPress/gutenberg/pull/72935/files#r2558583348) @tellthemachines 

The block switcher was refactored to not handle the default block icon of the toolbar in https://github.com/WordPress/gutenberg/pull/72935/. This refactor caused a minor regression in the styles for the show icon label preference. The CSS should have been scoped to the block toolbar, but was instead scoped to any instance of the block icon. This fix applies the correct scope.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix the layout of the slash inserter and global styles blocks when using the show icon labels preference

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Scope the CSS to the block toolbar instead of all block icons (as it was before).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open two windows of the site editor
- In one, turn on the Show Icon Labels option (Options -> Preferences -> Accessibility -> Show button text labels
- In the canvas on an empty block, type "/" to bring up the slash inserter. Both your editor windows should have the same layout of the block icon and labels
- In the header, select Styles -> Blocks
- Compare the layout in both your windows. They should look the same.
- In the window with the Show button text labels, make sure sure the toolbar icon is hidden and instead shows the icon text (i.e. a Heading block will show the text "Heading" where the block icon would be

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Style Block Panel**

|Before|After|
|---|---|
|<img width="395" height="672" alt="518449370-29f0799b-43df-466e-b609-4e4505ce589c" src="https://github.com/user-attachments/assets/eadb1d9f-7303-40a4-90a9-86aedbc6cd6b" />|<img width="282" height="654" alt="Screenshot 2025-12-01 at 11 30 42 AM" src="https://github.com/user-attachments/assets/8af2a438-6beb-4dcb-96a1-e8b7de7c0aa2" />|

**Slash Inserter**

|Before|After|
|---|---|
|<img width="265" height="425" alt="518449421-fef4cecd-0a7f-4519-81f9-24570105cd29" src="https://github.com/user-attachments/assets/0ab3c00a-2575-4d7f-9dc7-b1c5666061bb" />|<img width="304" height="414" alt="Screenshot 2025-12-01 at 11 30 25 AM" src="https://github.com/user-attachments/assets/453b0e53-0dfe-42ca-abda-37ea4ebc1390" />|




