### PR TITLE
fixing css selector for list-item block for block style variation v2

### DIFF
--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -63,7 +63,7 @@
 		}
 	},
 	"selectors": {
-		"root": ".wp-block-list > li",
-		"border": ".wp-block-list:not(.wp-block-list .wp-block-list) > li"
+		"root": ".wp-block-list>li",
+		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)>li"
 	}
 }


### PR DESCRIPTION
What?
I fixed the block style variation for the List Item block _**and make it appear for front end either**_ by correcting the CSS selectors defined in its block.json. The original selectors were pointing to invalid or overly broad targets, which caused block style variations not to apply correctly. I updated the root and border selectors to be .wp-block-list>li without spaces.

the problem happen with the space when remove it, it will work fine

Closes #73527

Why?
When WordPress processes the selector, it applies the hashed class to the parent .wp-block-list element instead of the individual <li> tag. This causes the generated CSS selectors to target the list container rather than the list items, which breaks the intended block style variation.

`.wp-block-list.is-style-my-theme-tag-9077feea-6a9a-4a70-8d76-aba025da8519 >li` in the editor and
`.wp-block-list.is-style-my-theme-tag--3 > li` in the frontend

the right selector should be look like:
`.wp-block-list>li.is-style-my-theme-tag-9077feea-6a9a-4a70-8d76-aba025da8519` in the editor
`.wp-block-list>li.is-style-my-theme-tag--3` in the frontend
How?
change the css selector to be without space
`.wp-block-list>li` instead of `.wp-block-list > li`

Testing Instructions
1- make file in your-theme/styles/blocks/tag.json
2- copy and paste the json file
```json
{
    "$schema": "https://schemas.wp.org/wp/6.8/theme.json",
    "version": 3,
    "title": "Tag",
    "slug": "my-theme-tag",
    "blockTypes":
                    [
                    "core/list-item"
                    ],
    "styles": {
        "spacing": {
            "padding": {
                "top": "0.5em",
                "right": "1em",
                "bottom": "0.5em",
                "left": "1em"
            }
        },
        "color": {
            "background": "var:preset|color|black",
           "text": "var:preset|color|white"
        }
    }
}
```
3- open block editor
4- add list
5- select the list-item block
6- in sidebar panel select styles option tag

Testing Instructions for Keyboard
Screenshots or screencast

# Frontend
## Before
![Screenshot_1-12-2025_13814_localhost](https://github.com/user-attachments/assets/ef43fbd1-f68a-4e71-892a-5095ace65674)

## after

![Screenshot_1-12-2025_12318_localhost](https://github.com/user-attachments/assets/da15416b-6a85-4a16-90bb-e27f0bf4b869)

# Editor
## Before
![Screenshot_1-12-2025_125413_localhost](https://github.com/user-attachments/assets/b294f7ba-5e59-49d6-a960-d864a03b9087)


## After
![Screenshot_1-12-2025_13419_localhost](https://github.com/user-attachments/assets/1f8b0f37-1fd7-47cb-8c34-40ed559dbf49)

|<!-- Before screenshot here -->|<!-- After screenshot here -->|
