### PR TITLE
wp-build: Fix invalid package references for peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54304,26 +54304,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"packages/image-cropper/node_modules/@wordpress/element": {
-			"version": "6.31.1-next.233ccab9b.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.1-next.233ccab9b.0.tgz",
-			"integrity": "sha512-WfIJFgz3ajYE4OEaH99vaqKQ5Lije9Yup1qXYBYs8ubvLQ1hUpbKs34x8v3oHKCNcFIttG0oMUFLuWaCx62D6A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.31.1-next.233ccab9b.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"packages/interactivity": {
 			"name": "@wordpress/interactivity",
 			"version": "6.36.0",
@@ -55657,10 +55637,10 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
-				"@wordpress/boot": "^0.2.0",
+				"@wordpress/boot": "^0.3.0",
 				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/route": "^1.0.0",
-				"@wordpress/theme": "^1.0.0"
+				"@wordpress/route": "^0.2.0",
+				"@wordpress/theme": "^0.3.0"
 			},
 			"peerDependenciesMeta": {
 				"@wordpress/boot": {

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -52,10 +52,10 @@
 		"toposort": "2.0.2"
 	},
 	"peerDependencies": {
-		"@wordpress/boot": "^0.2.0",
+		"@wordpress/boot": "^0.3.0",
 		"@wordpress/private-apis": "^1.0.0",
-		"@wordpress/route": "^1.0.0",
-		"@wordpress/theme": "^1.0.0"
+		"@wordpress/route": "^0.2.0",
+		"@wordpress/theme": "^0.3.0"
 	},
 	"peerDependenciesMeta": {
 		"@wordpress/boot": {


### PR DESCRIPTION
## What?

Updates `@wordpress/wp-build`'s `package.json` to resolve invalid package references.

Notably, `@wordpress/route` and `@wordpress/theme` are specified as requiring `^1.0.0`, but there are only 0.x versions of these packages available.

It also removes an entry from `package-lock.json` related to `@wordpress/image-cropper` that was also causing "invalid" errors with `npm ls`.

## Why?

- Avoid errors in npm operations like `npm ls`
- Ensure that downstream consumers can install valid peer dependencies

## Testing Instructions

`npm ls` should exit without errors.

`npm install` should not produce any local changes to commit.