### PR TITLE
ContentOnlyControls: Refactor ad hoc fields to use setValue instead of updateBlockAttributes

### DIFF
--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -295,19 +295,13 @@ function BlockFields( { clientId } ) {
 				field.Edit = createConfiguredControl( {
 					control: fieldDef.type,
 					clientId,
-					updateBlockAttributes,
 					fieldDef,
 				} );
 			}
 
 			return field;
 		} );
-	}, [
-		blockTypeFields,
-		blockType?.attributes,
-		clientId,
-		updateBlockAttributes,
-	] );
+	}, [ blockTypeFields, blockType?.attributes, clientId ] );
 
 	const handleToggleField = ( fieldId ) => {
 		setForm( ( prev ) => {
@@ -351,26 +345,7 @@ function BlockFields( { clientId } ) {
 				fields={ dataFormFields }
 				form={ form }
 				onChange={ ( changes ) => {
-					// Map field values to block attributes using field.setValue
-					const mappedChanges = {};
-					Object.entries( changes ).forEach(
-						( [ fieldId, fieldValue ] ) => {
-							const field = dataFormFields.find(
-								( f ) => f.id === fieldId
-							);
-							if ( field && field.setValue ) {
-								const updates = field.setValue( {
-									item: attributes,
-									value: fieldValue,
-								} );
-								Object.assign( mappedChanges, updates );
-							} else {
-								// For fields without setValue, use the value directly
-								mappedChanges[ fieldId ] = fieldValue;
-							}
-						}
-					);
-					updateBlockAttributes( clientId, mappedChanges );
+					updateBlockAttributes( clientId, changes );
 				} }
 			/>
 		</div>

--- a/packages/block-editor/src/components/content-only-controls/link/index.js
+++ b/packages/block-editor/src/components/content-only-controls/link/index.js
@@ -67,15 +67,15 @@ export function getUpdatedLinkAttributes( {
 	};
 }
 
-export default function Link( { data, field, config = {} } ) {
+export default function Link( { data, field, onChange, config = {} } ) {
 	const [ isLinkControlOpen, setIsLinkControlOpen ] = useState( false );
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
 	} );
-	const { clientId, updateBlockAttributes, fieldDef } = config;
+	const { fieldDef } = config;
 	const updateAttributes = ( newValue ) => {
 		const mappedChanges = field.setValue( { item: data, value: newValue } );
-		updateBlockAttributes( clientId, mappedChanges );
+		onChange( mappedChanges );
 	};
 
 	const value = field.getValue( { item: data } );

--- a/packages/block-editor/src/components/content-only-controls/media/index.js
+++ b/packages/block-editor/src/components/content-only-controls/media/index.js
@@ -83,19 +83,19 @@ function MediaThumbnail( { data, field, attachment } ) {
 	return <Icon icon={ mediaIcon } size={ 24 } />;
 }
 
-export default function Media( { data, field, config = {} } ) {
+export default function Media( { data, field, onChange, config = {} } ) {
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
 	} );
 	const value = field.getValue( { item: data } );
 	const { allowedTypes = [], multiple = false } = field.config || {};
-	const { clientId, updateBlockAttributes, fieldDef } = config;
+	const { fieldDef } = config;
 	const updateAttributes = ( newFieldValue ) => {
 		const mappedChanges = field.setValue( {
 			item: data,
 			value: newFieldValue,
 		} );
-		updateBlockAttributes( clientId, mappedChanges );
+		onChange( mappedChanges );
 	};
 
 	// Check if featured image is supported by checking if it's in the mapping

--- a/packages/block-editor/src/components/content-only-controls/rich-text/index.js
+++ b/packages/block-editor/src/components/content-only-controls/rich-text/index.js
@@ -23,15 +23,16 @@ export default function RichTextControl( {
 	data,
 	field,
 	hideLabelFromVision,
+	onChange,
 	config = {},
 } ) {
 	const registry = useRegistry();
 	const attrValue = field.getValue( { item: data } );
 	const fieldConfig = field.config || {};
-	const { clientId, updateBlockAttributes } = config;
+	const { clientId } = config;
 	const updateAttributes = ( html ) => {
 		const mappedChanges = field.setValue( { item: data, value: html } );
-		updateBlockAttributes( clientId, mappedChanges );
+		onChange( mappedChanges );
 	};
 	const [ selection, setSelection ] = useState( {
 		start: undefined,

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -78,7 +78,7 @@ if ( window.__experimentalContentOnlyPatternInsertion ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'content' ],
+		fields: [ 'background' ],
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of https://github.com/WordPress/gutenberg/issues/73261

Follow up to:
* https://github.com/WordPress/gutenberg/pull/73374

One step of refactoring ad hoc ContentOnlyControls to better align with the Fields / DataForms API: don't pass in `updateBlockAttributes` to the Edit component's config, and instead use the `setValue` method to provide mapping, and defer to the DataForm to make the `updateBlockAttributes` call.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #73261, the current implementation doesn't conform to the Fields API and adds some not-quite-random-but-inappropriate values to the `config` object for the Edit component. Ideally, we want to get these ad hoc ContentOnlyControls (media, link, richtext) closer to a state where they could become canonical parts of the DataForm / controls APIs — or at the very least, they should be as close as possible to that structure.

Note: this PR just looks at `updateBlockAttributes`. There are other things to be refactored in separate PRs, e.g. `clientId` which is a bit tangled up with how rich text currently works. My hope is to look into other refactors in follow-ups and keep these changes fairly small.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the mapping logic from the `onChange` callback passed to `DataForm` as this is already handled in `setValue`
* In the ad hoc controls, call the passed in `onChange` to handle the `updateBlockAttributes` calls
* Remove the `updateBlockAttributes` function from being passed in to the Edit config
* Also, while unrelated, I noticed that the Cover block was specifying the wrong id for the fields to be shown by default. I've updated this to `background`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the ContentOnly experiment in the Gutenberg experiments page
2. Go to edit a template containing a pattern using blocks like Cover, Image, Media & Text, Buttons, and Heading
3. Try replacing and clearing images, adding a link, and updating rich text, and ensure it others works as on `trunk`

## Screenshots or screencast <!-- if applicable -->

The only visual change is that the Cover block's background control will be shown by default now, instead of there being an empty Cover block area:

<img width="1277" height="881" alt="image" src="https://github.com/user-attachments/assets/36a4d383-df3c-46cf-a607-f0e441476b65" />
