### PR TITLE
Pattern insertion: drag chip when multiple blocks of the same type in a pattern are dragged

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -57,13 +57,23 @@ const InserterDraggableBlocks = ( {
 			transferData={ { type: 'inserter', blocks: draggableBlocks } }
 			onDragStart={ ( event ) => {
 				startDragging();
+				const addedTypes = new Set();
 				for ( const block of draggableBlocks ) {
 					const type = `wp-block:${ block.name }`;
-					// This will fill in the dataTransfer.types array so that
-					// the drop zone can check if the draggable is eligible.
-					// Unfortuantely, on drag start, we don't have access to the
-					// actual data, only the data keys/types.
-					event.dataTransfer.items.add( '', type );
+					/*
+					 * Only add each block type once to avoid DataTransferItemList::add `NotSupportedError`
+					 * when patterns contain multiple blocks of the same type.
+					 */
+					if ( ! addedTypes.has( type ) ) {
+						/*
+						 * This will fill in the dataTransfer.types array so that
+						 * the drop zone can check if the draggable is eligible.
+						 * Unfortuantely, on drag start, we don't have access to the
+						 * actual data, only the data keys/types.
+						 */
+						event.dataTransfer.items.add( '', type );
+						addedTypes.add( type );
+					}
 				}
 			} }
 			onDragEnd={ () => {


### PR DESCRIPTION


Closes https://github.com/WordPress/gutenberg/issues/73338

## Description

Fixes a bug where dragging patterns with multiple blocks of the same type throws a `NotSupportedError` and leaves the drag chip visible after drop.

**Root cause:** The code added duplicate block types to `dataTransfer.items`, which the browser disallows. This error prevented the drag from completing, so `stopDragging()` wasn't called.

**Solution:** Track unique block types with a `Set` and add each type only once.

Fixes #73338

## Testing Instructions

1. Open the block inserter and go to the Patterns tab
2. Find a pattern that contains multiple blocks of the same type (e.g., multiple Group blocks). **In TT5 try the "Business homepage" pattern under "Starter content"**
3. Drag the pattern into the canvas
4. **Expected:** The pattern drops correctly and the drag chip disappears immediately
5. **Before fix:** The drag chip would linger and a console error would appear: `NotSupportedError: Failed to execute 'add' on 'DataTransferItemList'`

**Additional test cases:**
- Drag patterns with single block types (should still work)
- Drag patterns with mixed block types (should still work)
- Drag patterns and drop them in different locations (chip should always disappear)

## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/0fb0f3af-46a8-4d36-bb5b-9e63ac30e5f5

