### PR TITLE
Docs: add JSDoc for BlockRemovalWarnings, BlockVisibility, and BlogTitle

### DIFF
--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -63,6 +63,12 @@ const BLOCK_REMOVAL_RULES = [
 	},
 ];
 
+/**
+ * Renders a warning modal when certain blocks are deleted
+ * in templates, template parts, or patterns.
+ *
+ * @return {JSX.Element|null} Block removal warning modal component, or null.
+ */
 export default function BlockRemovalWarnings() {
 	const currentPostType = useSelect(
 		( select ) => select( editorStore ).getCurrentPostType(),

--- a/packages/editor/src/components/block-visibility/index.js
+++ b/packages/editor/src/components/block-visibility/index.js
@@ -18,6 +18,11 @@ import { unlock } from '../../lock-unlock';
 const { BlockManager } = unlock( blockEditorPrivateApis );
 const EMPTY_ARRAY = [];
 
+/**
+ * Renders controls for hiding or showing editor blocks.
+ *
+ * @return {JSX.Element} Block visibility settings component.
+ */
 export default function BlockVisibility() {
 	const { showBlockTypes, hideBlockTypes } = unlock(
 		useDispatch( editorStore )

--- a/packages/editor/src/components/blog-title/index.js
+++ b/packages/editor/src/components/blog-title/index.js
@@ -23,6 +23,11 @@ import { store as editorStore } from '../../store';
 
 const EMPTY_OBJECT = {};
 
+/**
+ * Renders controls for editing the blog posts page title.
+ *
+ * @return {JSX.Element|null} Blog title settings component, or null.
+ */
 export default function BlogTitle() {
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { postsPageTitle, postsPageId, isTemplate, postSlug } = useSelect(


### PR DESCRIPTION
## What

Adds JSDoc comment blocks for three editor components:

- `BlockRemovalWarnings` – shows a confirmation modal when removing certain template or pattern blocks.
- `BlockVisibility` – controls which blocks are visible in the inserter.
- `BlogTitle` – exposes controls for editing the posts page (blog) title in the template editor.

These components are now documented with a short description and `@return` type annotations.

## Why

- Improves code readability for contributors who are unfamiliar with these components.
- Provides better IDE and tooling support (hover docs, type hints, quick navigation).
- Aligns these components with other documented helpers and components in the editor codebase.

This PR is documentation-only and does not change editor behavior.

## Changes

- Added JSDoc documentation above the `BlockRemovalWarnings` component.
- Added JSDoc documentation above the `BlockVisibility` component.
- Added JSDoc documentation above the `BlogTitle` component.
