### PR TITLE
Tests: Update assertion for 'Global styles sidebar' e2e test

### DIFF
--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -35,15 +35,13 @@ test.describe( 'Global styles sidebar', () => {
 			.getByRole( 'searchbox', { name: 'Search' } )
 			.fill( 'heading' );
 
-		// Matches both Heading and Table of Contents blocks.
+		// Matches both Heading and Accordion Item blocks.
 		// The latter contains "heading" in its description.
 		await expect(
 			page.getByRole( 'button', { name: 'Heading', exact: true } )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'button', {
-				name: 'Table of Contents',
-			} )
+			page.getByRole( 'button', { name: 'Accordion Item' } )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/55045#discussion_r2545638791.

PR replaces the assertion for the experimental ToC block with a stable `Accordion Item` block.

## Why?
> The Table of Contents block is not in core, so this test will fail when it's run without GB active.

## Testing Instructions
CI checks are passing.

```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/global-styles-sidebar.spec.js
```
