### PR TITLE
Upgrade Playwright to v1.57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.56.1",
+				"@playwright/test": "1.57.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -9209,13 +9209,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+			"integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.56.1"
+				"playwright": "1.57.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -40318,13 +40318,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+			"integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.56.1"
+				"playwright-core": "1.57.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -40337,9 +40337,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+			"integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -55163,7 +55163,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.56.1",
+				"@playwright/test": "^1.57.0",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.56.1",
+		"@playwright/test": "1.57.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -94,7 +94,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.56.1",
+		"@playwright/test": "^1.57.0",
 		"@wordpress/env": "^10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -516,69 +516,6 @@ test.describe( 'Image', () => {
 		}, 'should replace the original image with the second image' ).toPass();
 	} );
 
-	test( 'should allow dragging and dropping HTML to media placeholder', async ( {
-		page,
-		editor,
-	} ) => {
-		await editor.insertBlock( { name: 'core/image' } );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-
-		await page.evaluate( () => {
-			const { createBlock } = window.wp.blocks;
-			const block = createBlock( 'core/image', {
-				url: 'https://live.staticflickr.com/3894/14962688165_04759a8b03_b.jpg',
-				alt: 'Cat',
-				caption: `"Cat" by tomhouslay is licensed under <a href="https://creativecommons.org/licenses/by-nc/2.0/?ref=openverse">CC BY-NC 2.0</a>.`,
-			} );
-			const dummy = document.createElement( 'div' );
-			dummy.style.width = '10px';
-			dummy.style.height = '10px';
-			dummy.style.zIndex = 99999;
-			dummy.style.position = 'fixed';
-			dummy.style.top = 0;
-			dummy.style.left = 0;
-			dummy.draggable = 'true';
-			dummy.addEventListener( 'dragstart', ( event ) => {
-				event.dataTransfer.setData(
-					'wp-blocks',
-					JSON.stringify( { blocks: [ block ] } )
-				);
-				event.dataTransfer.setData( 'wp-block:core/image', '' );
-				setTimeout( () => {
-					dummy.remove();
-				}, 0 );
-			} );
-			document.body.appendChild( dummy );
-		} );
-
-		await page.mouse.move( 0, 0 );
-		await page.mouse.down();
-		await imageBlock.hover();
-		await page.mouse.up();
-
-		const host = new URL( page.url() ).host;
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/image',
-				attributes: {
-					link: expect.stringContaining( host ),
-					url: expect.stringContaining( host ),
-					id: expect.any( Number ),
-					alt: 'Cat',
-					caption: `"Cat" by tomhouslay is licensed under <a href="https://creativecommons.org/licenses/by-nc/2.0/?ref=openverse">CC BY-NC 2.0</a>.`,
-				},
-			},
-		] );
-		const url = ( await editor.getBlocks() )[ 0 ].attributes.url;
-		await expect( imageBlock.getByRole( 'img' ) ).toHaveAttribute(
-			'src',
-			url
-		);
-	} );
-
 	test( 'image inserted via upload should appear in the frontend published post content', async ( {
 		editor,
 		imageBlockUtils,

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -460,7 +460,7 @@ test.describe( 'Image', () => {
 			.getByRole( 'listbox', { name: 'Media List' } )
 			.getByRole( 'option' )
 			.first()
-			.dragTo( imageBlock );
+			.dragTo( imageBlock, { steps: 3 } );
 
 		await expect( async () => {
 			const blocks = await editor.getBlocks();
@@ -493,7 +493,7 @@ test.describe( 'Image', () => {
 			.getByRole( 'listbox', { name: 'Media List' } )
 			.getByRole( 'option' )
 			.nth( 1 )
-			.dragTo( imageBlock );
+			.dragTo( imageBlock, { steps: 3 } );
 
 		await expect( async () => {
 			const blocks = await editor.getBlocks();

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Child Blocks', () => {
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();
-		expect( blockLibrary.getByRole( 'option' ) ).not.toContain( [
+		await expect( blockLibrary.getByRole( 'option' ) ).not.toContainText( [
 			'Child Blocks Child',
 		] );
 	} );


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.57.

## What's new?
https://playwright.dev/docs/release-notes#version-157

### Notes

* The new HTML reported "Speedboard" seems like a fantastic edition for debugging our slow tests.
* [testConfig.webServer](https://playwright.dev/docs/api/class-testconfig#test-config-web-server) added a `wait` field, which could also be useful for our env.

## Testing Instructions

- Run any e2e test locally; the command should download new browsers and run the test successfully.
- CI checks are green.
