### PR TITLE
Block Editor: Simplify 'useSelect' deps in 'InserterDraggableBlocks'

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -21,14 +21,15 @@ const InserterDraggableBlocks = ( {
 	children,
 	pattern,
 } ) => {
+	const blockName = blocks.length === 1 ? blocks[ 0 ].name : undefined;
 	const blockTypeIcon = useSelect(
 		( select ) => {
-			const { getBlockType } = select( blocksStore );
 			return (
-				blocks.length === 1 && getBlockType( blocks[ 0 ].name )?.icon
+				blockName &&
+				select( blocksStore ).getBlockType( blockName )?.icon
 			);
 		},
-		[ blocks ]
+		[ blockName ]
 	);
 
 	const { startDragging, stopDragging } = unlock(


### PR DESCRIPTION
## What?
A minor code quality improvement for the `InserterDraggableBlocks` component.

It simplifies the dependency used for selecting the block icon. It is always preferable to pass primitives as dependencies when possible.

Noticed while reviewing code for #73681.

## Testing Instructions
1. Open a post.
2. Open the global inserter.
3. Try dragging different blocks.
4. Confirm that the drag chip icon matches the block type icon.

### Testing Instructions for Keyboard
Same.