### PR TITLE
Notes: Avoid incrementing comment_count when notes are resolved or reopened

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -129,3 +129,22 @@ function gutenberg_hide_note_from_comment_list_table( $args ) {
 	return $args;
 }
 add_filter( 'comments_list_table_query_args', 'gutenberg_hide_note_from_comment_list_table' );
+
+/**
+ * Override comment_count to exclude notes from the comment count.
+ *
+ * @param int|null $new     The new comment count. Default null.
+ * @param int      $old     The old comment count.
+ * @param int      $post_id Post ID.
+ * @return int|null The modified comment count.
+ */
+function gutenberg_exclude_notes_from_comment_count( $new_count, $old_count, $post_id ) {
+	global $wpdb;
+	// If another filter already set a count, respect it.
+	if ( null !== $new_count ) {
+		return $new_count;
+	}
+	$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type != 'note'", $post_id ) );
+	return $new_count;
+}
+add_filter( 'pre_wp_update_comment_count_now', 'gutenberg_exclude_notes_from_comment_count', 10, 3 );


### PR DESCRIPTION
- Part of https://github.com/WordPress/gutenberg/issues/73141
- Backport these core changesets to Gutenberg: https://core.trac.wordpress.org/changeset/61336

## What?

This PR fixes incrementing comment_count when notes are resolved or reopened, which has been fixed in core.

<!-- In a few words, what is the PR actually doing? -->

## Why?

Backward compatibility.

## Testing Instructions

Note: This problem has already been fixed in the latest WordPress core, so don't forget to downgrade the WordPress version to 6.8 and test it.

- Create and publish a new post.
- Open the post on the front-end and add a normal comment to the post.
- The comment section says `One response to “{post_title}”.
- Add a block, add a note to it, resolve the note, and save the post.
- Open the post on the front-end.
- The comment section says `One response to “Test”`.
- Access http://localhost:8888/wp-admin/edit-comments.php
- The "In response to" column shows the number of comments as 1.