### PR TITLE
BlockBreadcrumb: Show custom block name

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -103,6 +103,7 @@ function BlockBreadcrumb( { rootLabelText } ) {
 						<BlockTitle
 							clientId={ parentClientId }
 							maximumLength={ 35 }
+							context="breadcrumb"
 						/>
 					</Button>
 					<Icon
@@ -116,7 +117,11 @@ function BlockBreadcrumb( { rootLabelText } ) {
 					className="block-editor-block-breadcrumb__current"
 					aria-current="true"
 				>
-					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
+					<BlockTitle
+						clientId={ clientId }
+						maximumLength={ 35 }
+						context="breadcrumb"
+					/>
 				</li>
 			) }
 		</ul>

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -28,8 +28,11 @@ export function addLabelCallback( settings ) {
 		settings.__experimentalLabel = ( attributes, { context } ) => {
 			const { metadata } = attributes;
 
-			// In the list view, use the block's name attribute as the label.
-			if ( context === 'list-view' && metadata?.name ) {
+			// In the list view and breadcrumb, use the block's name attribute as the label.
+			if (
+				( context === 'list-view' || context === 'breadcrumb' ) &&
+				metadata?.name
+			) {
 				return metadata.name;
 			}
 		};

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -47,6 +47,10 @@ export const settings = {
 		if ( context === 'list-view' && ( customName || hasContent ) ) {
 			return customName || text;
 		}
+
+		if ( context === 'breadcrumb' && customName ) {
+			return customName;
+		}
 	},
 };
 

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -50,6 +50,10 @@ export const settings = {
 			return customName || summary;
 		}
 
+		if ( context === 'breadcrumb' && customName ) {
+			return customName;
+		}
+
 		if ( context === 'accessibility' ) {
 			return ! hasSummary
 				? __( 'Details. Empty.' )

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -48,6 +48,10 @@ export const settings = {
 			return customName || content;
 		}
 
+		if ( context === 'breadcrumb' && customName ) {
+			return customName;
+		}
+
 		if ( context === 'accessibility' ) {
 			return ! hasContent
 				? sprintf(

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -35,7 +35,10 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		const customName = attributes?.metadata?.name;
 
-		if ( context === 'list-view' && customName ) {
+		if (
+			( context === 'list-view' || context === 'breadcrumb' ) &&
+			customName
+		) {
 			return customName;
 		}
 

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -45,6 +45,10 @@ export const settings = {
 		if ( context === 'list-view' && ( customName || hasContent ) ) {
 			return customName || content;
 		}
+
+		if ( context === 'breadcrumb' && customName ) {
+			return customName;
+		}
 	},
 };
 

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -27,7 +27,10 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		const customName = attributes?.metadata?.name;
 
-		if ( context === 'list-view' && customName ) {
+		if (
+			( context === 'list-view' || context === 'breadcrumb' ) &&
+			customName
+		) {
 			return customName;
 		}
 

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -33,6 +33,7 @@ export const settings = {
 
 		const customName = attributes?.metadata?.name;
 
+		// In the list view and breadcrumb, use the block's menu label as the label.
 		// If the menu label is empty, fall back to the default label.
 		if (
 			( context === 'list-view' || context === 'breadcrumb' ) &&

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -37,9 +37,9 @@ export const settings = {
 		// If the menu label is empty, fall back to the default label.
 		if (
 			( context === 'list-view' || context === 'breadcrumb' ) &&
-			( customName || label )
+			customName
 		) {
-			return customName || label;
+			return customName;
 		}
 
 		return label;

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -33,10 +33,12 @@ export const settings = {
 
 		const customName = attributes?.metadata?.name;
 
-		// In the list view, use the block's menu label as the label.
 		// If the menu label is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || label ) ) {
-			return attributes?.metadata?.name || label;
+		if (
+			( context === 'list-view' || context === 'breadcrumb' ) &&
+			( customName || label )
+		) {
+			return customName || label;
 		}
 
 		return label;

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -34,7 +34,10 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		const customName = attributes?.metadata?.name;
 
-		if ( context === 'list-view' && customName ) {
+		if (
+			( context === 'list-view' || context === 'breadcrumb' ) &&
+			customName
+		) {
 			return customName;
 		}
 


### PR DESCRIPTION
Fixes #56523 (I think)
See: https://github.com/WordPress/gutenberg/issues/56523#issuecomment-3199071804

## What? Why?

I think breadcrumbs should display custom block names just like the List View.

## How?

For breadcrumbs, I add a dedicated `breadcrumb` context. The `breadcrumb` context respects custom name, just like the `list-view` context, but with a few differences in some blocks:

- Details block:
  - `list-view`: Custom name or summary content
  - `breadcrumb`: Custom name
- Heading block:
  - `list-view`: Custom name or content
  - `breadcrumb`: Custom name

Breadcrumbs don't have block icons, so I avoided using content for breadcrumbs because it's hard to tell what a block is just from its content.

## Testing Instructions

Use the following markup to confirm various blocks with custom names and contents.

```html
<!-- wp:group {"metadata":{"name":"My Group Block"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group">
	<!-- wp:details {"metadata":{"name":"My Details Block"}} -->
	<details class="wp-block-details">
		<summary>Summary Text</summary>
		<!-- wp:heading -->
		<h2 class="wp-block-heading">This is a heading.</h2>
		<!-- /wp:heading -->
	</details>
	<!-- /wp:details -->
</div>
<!-- /wp:group -->
```

## Screenshots or screencast

### Before

<img width="797" height="511" alt="image" src="https://github.com/user-attachments/assets/a10f7d07-1dc4-413b-a58d-30550b7484af" />

### After

<img width="802" height="513" alt="image" src="https://github.com/user-attachments/assets/167992ec-8dc2-4151-b782-52af3d6819e0" />
