### PR TITLE
Global styles: add `:placeholder` pseudo-element support for textInput

### DIFF
--- a/docs/how-to-guides/themes/global-settings-and-styles.md
+++ b/docs/how-to-guides/themes/global-settings-and-styles.md
@@ -1036,7 +1036,7 @@ h3 {
 {% end %}
 ##### Element pseudo selectors
 
-Pseudo selectors `:hover`, `:focus`, `:focus-visible`, `:visited`, `:active`, `:link`, `:any-link` are supported by Gutenberg.
+Pseudo selectors `:hover`, `:focus`, `:focus-visible`, `:visited`, `:active`, `:link`, `:any-link`, `:placeholder` are supported by Gutenberg.
 
 ```json
 "elements": {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -590,12 +590,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0
 	 * @since 6.2.0 Added support for `:link` and `:any-link`.
 	 * @since 6.8.0 Added support for `:focus-visible`.
-	 * @since #.#.# Added support for `:placeholder`.
+	 * @since #.#.# Added support for `::placeholder`.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link'   => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
 		'button' => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
-		'textInput' => array( ':hover', ':focus', ':focus-visible', ':placeholder' ),
+		'textInput' => array( ':hover', ':focus', ':focus-visible', '::placeholder' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -590,10 +590,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0
 	 * @since 6.2.0 Added support for `:link` and `:any-link`.
 	 * @since 6.8.0 Added support for `:focus-visible`.
+	 * @since #.#.# Added support for `:placeholder`.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link'   => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
 		'button' => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
+		'textInput' => array( ':hover', ':focus', ':focus-visible', ':placeholder' ),
 	);
 
 	/**

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1789,7 +1789,7 @@
 				":visited": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
-				":placeholder": {
+				"::placeholder": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			}
@@ -1820,7 +1820,7 @@
 				":hover",
 				":link",
 				":visited",
-				":placeholder"
+				"::placeholder"
 			]
 		},
 		"stylesElementsPropertiesComplete": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1788,6 +1788,9 @@
 				},
 				":visited": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":placeholder": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			}
 		},
@@ -1816,7 +1819,8 @@
 				":focus-visible",
 				":hover",
 				":link",
-				":visited"
+				":visited",
+				":placeholder"
 			]
 		},
 		"stylesElementsPropertiesComplete": {


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/71382

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Adds support for styling `:placeholder` in `textInput` elements (added in https://github.com/WordPress/gutenberg/pull/70378)

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the [`:placeholder` pseudo element](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::placeholder) cannot be set via `theme.json` because it is not included in the `VALID_ELEMENT_PSEUDO_SELECTORS` list. This limitation makes it difficult to implement consistent styles for form inputs in plugins across the theme, and themers need to rely on custom CSS.

Later on, it would be good to add UI for allowing modification of the style directly in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PR updates the `VALID_ELEMENT_PSEUDO_SELECTORS` array in `class-wp-theme-json-gutenberg.php` by adding `:placeholder`. This change allows the `:placeholder` pseudo-class to be used directly within `theme.json` files.  

## Testing Instructions
1. Apply this PR.  
2. Create or edit a theme that uses `theme.json`.  
3. Add a style using the `:focus-visible` pseudo-class in `theme.json`. For example:  
```json
{
	"styles": {
		"elements": {
			"textInput": {
				":placeholder": {
					"color": {
						"text": "red"
					}
				}
			},
		}
	}
}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
