### PR TITLE
Update LayoutCard story in DataForm to use card layout

### DIFF
--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1575,6 +1575,7 @@ const LayoutCardComponent = ( {
 
 	const form: Form = useMemo(
 		() => ( {
+			layout: { type: 'card' },
 			fields: [
 				{
 					id: 'customerCard',


### PR DESCRIPTION
I'm not sure how this got overlooked, but this PR is a small follow-up to https://github.com/WordPress/gutenberg/pull/72249 which ensures the "LayoutCard" DataForm story uses the `card` layout to ensure correct spacing between cards.

### Testing
Compare http://localhost:50240/?path=/story/dataviews-dataform--layout-card with https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataform--layout-card and note that the gap between cards in the former is `24px` compared to `16px` in the latter. 