### PR TITLE
Notes: Simplify editing mode change position tracking

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -70,28 +70,22 @@ export function Comments( {
 		useDispatch( blockEditorStore )
 	);
 
-	const {
-		blockCommentId,
-		selectedBlockClientId,
-		orderedBlockIds,
-		blockMode,
-	} = useSelect( ( select ) => {
-		const {
-			getBlockAttributes,
-			getSelectedBlockClientId,
-			getClientIdsWithDescendants,
-			getBlockMode,
-		} = select( blockEditorStore );
-		const clientId = getSelectedBlockClientId();
-		return {
-			blockCommentId: clientId
-				? getBlockAttributes( clientId )?.metadata?.noteId
-				: null,
-			selectedBlockClientId: clientId,
-			orderedBlockIds: getClientIdsWithDescendants(),
-			blockMode: clientId ? getBlockMode( clientId ) : null,
-		};
-	}, [] );
+	const { blockCommentId, selectedBlockClientId, orderedBlockIds } =
+		useSelect( ( select ) => {
+			const {
+				getBlockAttributes,
+				getSelectedBlockClientId,
+				getClientIdsWithDescendants,
+			} = select( blockEditorStore );
+			const clientId = getSelectedBlockClientId();
+			return {
+				blockCommentId: clientId
+					? getBlockAttributes( clientId )?.metadata?.noteId
+					: null,
+				selectedBlockClientId: clientId,
+				orderedBlockIds: getClientIdsWithDescendants(),
+			};
+		}, [] );
 
 	const relatedBlockElement = useBlockElement( selectedBlockClientId );
 
@@ -318,7 +312,6 @@ export function Comments( {
 		threads,
 		selectedThread,
 		setCanvasMinHeight,
-		blockMode,
 	] );
 
 	const handleThreadNavigation = ( event, thread, isSelected ) => {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	useEffect,
 	useMemo,
-	useRef,
 	useCallback,
 	useReducer,
 } from '@wordpress/element';
@@ -36,9 +35,7 @@ import { collabSidebarName } from './constants';
 import { unlock } from '../../lock-unlock';
 import { noop } from './utils';
 
-const { useBlockElementRef, cleanEmptyObject } = unlock(
-	blockEditorPrivateApis
-);
+const { useBlockElement, cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 export function useBlockComments( postId ) {
 	const [ commentLastUpdated, reflowComments ] = useReducer(
@@ -369,20 +366,7 @@ export function useFloatingThread( {
 	setBlockRef,
 	commentLastUpdated,
 } ) {
-	const blockRef = useRef();
-	useBlockElementRef( thread.blockClientId, blockRef );
-
-	const blockMode = useSelect(
-		( select ) => {
-			return thread.blockClientId
-				? select( blockEditorStore ).getBlockMode(
-						thread.blockClientId
-				  )
-				: null;
-		},
-		[ thread.blockClientId ]
-	);
-
+	const blockElement = useBlockElement( thread.blockClientId );
 	const updateHeight = useCallback(
 		( id, newHeight ) => {
 			setHeights( ( prev ) => {
@@ -408,17 +392,17 @@ export function useFloatingThread( {
 
 	// Store the block reference for each thread.
 	useEffect( () => {
-		if ( blockRef.current ) {
-			refs.setReference( blockRef.current );
+		if ( blockElement ) {
+			refs.setReference( blockElement );
 		}
-	}, [ blockRef, refs, commentLastUpdated, blockMode ] );
+	}, [ blockElement, refs, commentLastUpdated ] );
 
 	// Track thread heights.
 	useEffect( () => {
 		if ( refs.floating?.current ) {
-			setBlockRef( thread.id, blockRef.current );
+			setBlockRef( thread.id, blockElement );
 		}
-	}, [ thread.id, refs.floating, setBlockRef ] );
+	}, [ blockElement, thread.id, refs.floating, setBlockRef ] );
 
 	// When the selected thread changes, update heights, triggering offset recalculation.
 	useEffect( () => {
@@ -435,7 +419,6 @@ export function useFloatingThread( {
 	] );
 
 	return {
-		blockRef,
 		y,
 		refs,
 	};


### PR DESCRIPTION
## What?
This is a follow-up to #73046.

PR refactors `useFloatingThread` hook and removes the need for keeping track of `blockMode`. This should be a simplified fix for https://github.com/WordPress/gutenberg/issues/72836.

## Why?
Fewer dependencies for effects to worry about is always better.

## How?
I basically replaced `useBlockElementRef` with `useBlockElement`. The latter reacts to DOM changes and triggers required recalculations.

The returned `blockRef` value from the hook was no longer used, which led me to this refactoring and alternative solution.

## Testing Instructions
Same as #73046. Confirm that there are no regressions.

1. Open the Post Editor.
2. Add a few blocks (e.g., Paragraph, Heading) and create Notes on them.
3. Select any block and choose “Edit as HTML” from the block toolbar.
4. The Notes remain properly aligned with their respective blocks.
5. No notes jump or overlap in the floating sidebar.
6. Switch back to Visual mode.
7. Confirm that the notes remain correctly aligned without requiring a page refresh.

### Testing Instructions for Keyboard
Same.