### PR TITLE
Explore Link Preview in Inspector Sidebar

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -50,11 +50,9 @@ function filterTitleForDisplay( title ) {
 
 export default function LinkPreview( {
 	value,
-	ariaLabel = __( 'Manage link' ),
 	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
-	hasCopyControl = true,
 	onRemove,
 } ) {
 	const showIconLabels = useSelect(
@@ -106,7 +104,7 @@ export default function LinkPreview( {
 	return (
 		<div
 			role="group"
-			aria-label={ ariaLabel }
+			aria-label={ __( 'Manage link' ) }
 			className={ clsx( 'block-editor-link-control__preview', {
 				'is-current': true,
 				'is-rich': hasRichData,
@@ -161,15 +159,13 @@ export default function LinkPreview( {
 						) }
 					</span>
 				</span>
-				{ typeof onEditClick === 'function' && (
-					<Button
-						icon={ pencil }
-						label={ __( 'Edit link' ) }
-						onClick={ onEditClick }
-						size="compact"
-						showTooltip={ ! showIconLabels }
-					/>
-				) }
+				<Button
+					icon={ pencil }
+					label={ __( 'Edit link' ) }
+					onClick={ onEditClick }
+					size="compact"
+					showTooltip={ ! showIconLabels }
+				/>
 				{ hasUnlinkControl && (
 					<Button
 						icon={ linkOff }
@@ -179,17 +175,15 @@ export default function LinkPreview( {
 						showTooltip={ ! showIconLabels }
 					/>
 				) }
-				{ hasCopyControl && (
-					<Button
-						icon={ copySmall }
-						label={ __( 'Copy link' ) }
-						ref={ ref }
-						accessibleWhenDisabled
-						disabled={ isEmptyURL }
-						size="compact"
-						showTooltip={ ! showIconLabels }
-					/>
-				) }
+				<Button
+					icon={ copySmall }
+					label={ __( 'Copy link' ) }
+					ref={ ref }
+					accessibleWhenDisabled
+					disabled={ isEmptyURL }
+					size="compact"
+					showTooltip={ ! showIconLabels }
+				/>
 				<ViewerSlot fillProps={ value } />
 			</div>
 		</div>

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -50,9 +50,11 @@ function filterTitleForDisplay( title ) {
 
 export default function LinkPreview( {
 	value,
+	ariaLabel = __( 'Manage link' ),
 	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
+	hasCopyControl = true,
 	onRemove,
 } ) {
 	const showIconLabels = useSelect(
@@ -104,8 +106,8 @@ export default function LinkPreview( {
 	return (
 		<div
 			role="group"
-			aria-label={ __( 'Manage link' ) }
-			className={ clsx( 'block-editor-link-control__search-item', {
+			aria-label={ ariaLabel }
+			className={ clsx( 'block-editor-link-control__preview', {
 				'is-current': true,
 				'is-rich': hasRichData,
 				'is-fetching': !! isFetching,
@@ -114,9 +116,9 @@ export default function LinkPreview( {
 				'is-url-title': displayTitle === displayURL,
 			} ) }
 		>
-			<div className="block-editor-link-control__search-item-top">
+			<div className="block-editor-link-control__preview-top">
 				<span
-					className="block-editor-link-control__search-item-header"
+					className="block-editor-link-control__preview-header"
 					role="figure"
 					aria-label={
 						/* translators: Accessibility text for the link preview when editing a link. */
@@ -125,7 +127,7 @@ export default function LinkPreview( {
 				>
 					<span
 						className={ clsx(
-							'block-editor-link-control__search-item-icon',
+							'block-editor-link-control__preview-icon',
 							{
 								'is-image': richData?.icon,
 							}
@@ -133,11 +135,11 @@ export default function LinkPreview( {
 					>
 						{ icon }
 					</span>
-					<span className="block-editor-link-control__search-item-details">
+					<span className="block-editor-link-control__preview-details">
 						{ ! isEmptyURL ? (
 							<>
 								<ExternalLink
-									className="block-editor-link-control__search-item-title"
+									className="block-editor-link-control__preview-title"
 									href={ value.url }
 								>
 									<Truncate numberOfLines={ 1 }>
@@ -145,7 +147,7 @@ export default function LinkPreview( {
 									</Truncate>
 								</ExternalLink>
 								{ ! isUrlRedundant && (
-									<span className="block-editor-link-control__search-item-info">
+									<span className="block-editor-link-control__preview-info">
 										<Truncate numberOfLines={ 1 }>
 											{ displayURL }
 										</Truncate>
@@ -153,19 +155,21 @@ export default function LinkPreview( {
 								) }
 							</>
 						) : (
-							<span className="block-editor-link-control__search-item-error-notice">
+							<span className="block-editor-link-control__preview-error-notice">
 								{ __( 'Link is empty' ) }
 							</span>
 						) }
 					</span>
 				</span>
-				<Button
-					icon={ pencil }
-					label={ __( 'Edit link' ) }
-					onClick={ onEditClick }
-					size="compact"
-					showTooltip={ ! showIconLabels }
-				/>
+				{ typeof onEditClick === 'function' && (
+					<Button
+						icon={ pencil }
+						label={ __( 'Edit link' ) }
+						onClick={ onEditClick }
+						size="compact"
+						showTooltip={ ! showIconLabels }
+					/>
+				) }
 				{ hasUnlinkControl && (
 					<Button
 						icon={ linkOff }
@@ -175,15 +179,17 @@ export default function LinkPreview( {
 						showTooltip={ ! showIconLabels }
 					/>
 				) }
-				<Button
-					icon={ copySmall }
-					label={ __( 'Copy link' ) }
-					ref={ ref }
-					accessibleWhenDisabled
-					disabled={ isEmptyURL }
-					size="compact"
-					showTooltip={ ! showIconLabels }
-				/>
+				{ hasCopyControl && (
+					<Button
+						icon={ copySmall }
+						label={ __( 'Copy link' ) }
+						ref={ ref }
+						accessibleWhenDisabled
+						disabled={ isEmptyURL }
+						size="compact"
+						showTooltip={ ! showIconLabels }
+					/>
+				) }
 				<ViewerSlot fillProps={ value } />
 			</div>
 		</div>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -39,7 +39,7 @@ $block-editor-link-control-number-of-actions: 1;
 			}
 		}
 
-		.block-editor-link-control__search-item-top {
+		.block-editor-link-control__preview-top {
 			gap: $grid-unit-05;
 			flex-wrap: wrap;
 
@@ -49,7 +49,7 @@ $block-editor-link-control-number-of-actions: 1;
 			}
 		}
 
-		.is-preview .block-editor-link-control__search-item-header {
+		.is-preview .block-editor-link-control_preview-header {
 			min-width: 100%;
 			margin-right: 0;
 		}
@@ -163,6 +163,9 @@ $block-editor-link-control-number-of-actions: 1;
 	&[aria-selected] {
 		background: $gray-100;
 	}
+}
+
+.block-editor-link-control__preview {
 
 	&.is-current {
 		flex-direction: column; // allow for stacking.
@@ -173,7 +176,7 @@ $block-editor-link-control-number-of-actions: 1;
 		padding: $grid-unit-20;
 	}
 
-	.block-editor-link-control__search-item-header {
+	.block-editor-link-control__preview-header {
 		display: block;
 		flex-direction: row;
 		align-items: center;
@@ -186,7 +189,7 @@ $block-editor-link-control-number-of-actions: 1;
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 
-		.block-editor-link-control__search-item-info {
+		.block-editor-link-control__preview-info {
 			color: $gray-700;
 			line-height: 1.1;
 			font-size: $helptext-font-size;
@@ -194,35 +197,35 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 	}
 
-	&.is-preview .block-editor-link-control__search-item-header {
+	&.is-preview .block-editor-link-control__preview-header {
 		display: flex;
 		flex: 1; // Fill available space.
 	}
 
-	&.is-error .block-editor-link-control__search-item-header {
+	&.is-error .block-editor-link-control__preview-header {
 		align-items: center;
 	}
 
-	&.is-url-title .block-editor-link-control__search-item-title {
+	&.is-url-title .block-editor-link-control__preview-title {
 		// To prevent overflow when the title is a URL
 		word-break: break-all;
 	}
 
-	.block-editor-link-control__search-item-details {
+	.block-editor-link-control__preview-details {
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
 		gap: $grid-unit-05;
 	}
 
-	.block-editor-link-control__search-item-header .block-editor-link-control__search-item-icon {
+	.block-editor-link-control__preview-header .block-editor-link-control__preview-icon {
 		background-color: $gray-100;
 		width: $grid-unit-40;
 		height: $grid-unit-40;
 		border-radius: $radius-small;
 	}
 
-	.block-editor-link-control__search-item-icon {
+	.block-editor-link-control__preview-icon {
 		position: relative;
 		flex-shrink: 0;
 		display: flex;
@@ -240,7 +243,7 @@ $block-editor-link-control-number-of-actions: 1;
 		max-height: 32px;
 	}
 
-	.block-editor-link-control__search-item-title {
+	.block-editor-link-control__preview-title {
 		line-height: 1.1;
 
 
@@ -276,16 +279,16 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
-.block-editor-link-control__search-item-top {
+.block-editor-link-control__preview-top {
 	display: flex;
 	flex-direction: row;
 	width: 100%; // clip.
 	align-items: center;
 }
 
-.block-editor-link-control__search-item.is-fetching {
+.block-editor-link-control__preview.is-fetching {
 
-	.block-editor-link-control__search-item-icon {
+	.block-editor-link-control__preview-icon {
 		svg,
 		img {
 			opacity: 0;
@@ -339,7 +342,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__search-create {
 	align-items: center; // align text with icon.
 
-	.block-editor-link-control__search-item-title {
+	.block-editor-link-control__preview-title {
 		margin-bottom: 0;
 	}
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2212,13 +2212,13 @@ describe( 'Rich link previews', () => {
 		// Todo: refactor to use user-facing queries.
 		// eslint-disable-next-line testing-library/no-node-access
 		const hasRichImagePreview = linkPreview.querySelector(
-			'.block-editor-link-control__search-item-image'
+			'.block-editor-link-control__preview-image'
 		);
 
 		// Todo: refactor to use user-facing queries.
 		// eslint-disable-next-line testing-library/no-node-access
 		const hasRichDescriptionPreview = linkPreview.querySelector(
-			'.block-editor-link-control__search-item-description'
+			'.block-editor-link-control__preview-description'
 		);
 
 		expect( hasRichImagePreview ).not.toBeInTheDocument();
@@ -2247,7 +2247,7 @@ describe( 'Rich link previews', () => {
 
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( titlePreview.parentElement.parentElement ).toHaveClass(
-			'block-editor-link-control__search-item-title'
+			'block-editor-link-control__preview-title'
 		);
 	} );
 
@@ -2271,7 +2271,7 @@ describe( 'Rich link previews', () => {
 
 		// eslint-disable-next-line testing-library/no-node-access
 		const iconPreview = linkPreview.querySelector(
-			`.block-editor-link-control__search-item-icon`
+			`.block-editor-link-control__preview-icon`
 		);
 
 		// eslint-disable-next-line testing-library/no-node-access
@@ -2310,7 +2310,7 @@ describe( 'Rich link previews', () => {
 
 			// eslint-disable-next-line testing-library/no-node-access
 			const missingDataItem = linkPreview.querySelector(
-				`.block-editor-link-control__search-item-${ dataItem }`
+				`.block-editor-link-control__preview-${ dataItem }`
 			);
 
 			expect( missingDataItem ).not.toBeInTheDocument();


### PR DESCRIPTION
This work is part of [explorations on the Link Preview](https://github.com/WordPress/gutenberg/issues/73043). 
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
