### PR TITLE
Add: Panel form layout validation

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
 - DataViews: Simplify list layout field color styles. [#73884](https://github.com/WordPress/gutenberg/pull/73884)
+- DataViews: Add panel form layout validation. [#73700](https://github.com/WordPress/gutenberg/pull/73700)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -69,6 +69,7 @@ function PanelDropdown< Item >( {
 	summaryFields,
 	fieldDefinition,
 	popoverAnchor,
+	onOpen,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -78,6 +79,7 @@ function PanelDropdown< Item >( {
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	popoverAnchor: HTMLElement | null;
+	onOpen?: () => void;
 } ) {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
@@ -135,7 +137,12 @@ function PanelDropdown< Item >( {
 					labelPosition={ labelPosition }
 					fieldLabel={ fieldLabel }
 					disabled={ fieldDefinition.readOnly === true }
-					onClick={ onToggle }
+					onClick={ () => {
+						if ( ! isOpen && onOpen ) {
+							onOpen();
+						}
+						onToggle();
+					} }
 					aria-expanded={ isOpen }
 				/>
 			) }

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -70,8 +70,6 @@ function PanelDropdown< Item >( {
 	fieldDefinition,
 	popoverAnchor,
 	onOpen,
-	showError,
-	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -82,8 +80,6 @@ function PanelDropdown< Item >( {
 	fieldDefinition: NormalizedField< Item >;
 	popoverAnchor: HTMLElement | null;
 	onOpen?: () => void;
-	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
@@ -148,8 +144,6 @@ function PanelDropdown< Item >( {
 						onToggle();
 					} }
 					aria-expanded={ isOpen }
-					showError={ showError }
-					errorMessage={ errorMessage }
 				/>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -70,6 +70,8 @@ function PanelDropdown< Item >( {
 	fieldDefinition,
 	popoverAnchor,
 	onOpen,
+	showError,
+	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -80,6 +82,8 @@ function PanelDropdown< Item >( {
 	fieldDefinition: NormalizedField< Item >;
 	popoverAnchor: HTMLElement | null;
 	onOpen?: () => void;
+	showError?: boolean;
+	errorMessage?: string;
 } ) {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
@@ -144,6 +148,8 @@ function PanelDropdown< Item >( {
 						onToggle();
 					} }
 					aria-expanded={ isOpen }
+					showError={ showError }
+					errorMessage={ errorMessage }
 				/>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -56,7 +56,8 @@ function getFirstValidationError(
 				return validation.message || 'A required field is empty';
 			}
 			if ( validation.message ) {
-			return validation.message;
+				return validation.message;
+			}
 		}
 	}
 
@@ -193,12 +194,17 @@ export default function FormPanelField< Item >( {
 	);
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
-	const validationIndicator = hasError && (
+	const labelContent = hasError ? (
 		<Tooltip text={ errorMessage } placement="top">
-			<span className="dataforms-layouts-panel__field-error-indicator">
-				<Icon icon={ errorIcon } size={ 20 } />
+			<span className="dataforms-layouts-panel__field-label-content">
+				<span className="dataforms-layouts-panel__field-error-indicator">
+					<Icon icon={ errorIcon } size={ 20 } />
+				</span>
+				{ fieldLabel }
 			</span>
 		</Tooltip>
+	) : (
+		fieldLabel
 	);
 
 	const renderedControl =
@@ -231,8 +237,7 @@ export default function FormPanelField< Item >( {
 					className={ labelClassName }
 					style={ { paddingBottom: 0 } }
 				>
-					{ validationIndicator }
-					{ fieldLabel }
+					{ labelContent }
 				</div>
 				<div className="dataforms-layouts-panel__field-control">
 					{ renderedControl }
@@ -255,10 +260,7 @@ export default function FormPanelField< Item >( {
 			ref={ setPopoverAnchor }
 			className="dataforms-layouts-panel__field"
 		>
-			<div className={ labelClassName }>
-				{ validationIndicator }
-				{ fieldLabel }
-			</div>
+			<div className={ labelClassName }>{ labelContent }</div>
 			<div className="dataforms-layouts-panel__field-control">
 				{ renderedControl }
 			</div>

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -175,12 +175,13 @@ export default function FormPanelField< Item >( {
 
 	const labelContent = showError ? (
 		<Tooltip text={ errorMessage } placement="top">
-			<span className="dataforms-layouts-panel__field-label-content">
-				<span className="dataforms-layouts-panel__field-error-indicator">
-					<Icon icon={ errorIcon } size={ 16 } />
-				</span>
-				{ fieldLabel }
-			</span>
+			<HStack
+				className="dataforms-layouts-panel__field-label-error-content"
+				justify="flex-start"
+			>
+				<Icon icon={ errorIcon } size={ 16 } />
+				<>{ fieldLabel }</>
+			</HStack>
 		</Tooltip>
 	) : (
 		fieldLabel
@@ -232,9 +233,11 @@ export default function FormPanelField< Item >( {
 			<HStack className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none">
 				{ showError && (
 					<Tooltip text={ errorMessage } placement="top">
-						<span className="dataforms-layouts-panel__field-error-indicator">
-							<Icon icon={ errorIcon } size={ 20 } />
-						</span>
+						<Icon
+							className="dataforms-layouts-panel__field-label-error-content"
+							icon={ errorIcon }
+							size={ 20 }
+						/>
 					</Tooltip>
 				) }
 				<div className="dataforms-layouts-panel__field-control">

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -30,17 +30,6 @@ import PanelDropdown from './dropdown';
 import PanelModal from './modal';
 import { getSummaryFields } from '../get-summary-fields';
 
-const VALIDATION_TYPES = [
-	'required',
-	'pattern',
-	'min',
-	'max',
-	'minLength',
-	'maxLength',
-	'elements',
-	'custom',
-] as const;
-
 function getFirstValidationError(
 	validity: FieldValidity | undefined
 ): string | undefined {
@@ -48,11 +37,13 @@ function getFirstValidationError(
 		return undefined;
 	}
 
-	for ( const type of VALIDATION_TYPES ) {
-		const validation = validity[ type ];
+	for ( const [ key, validation ] of Object.entries( validity ) ) {
+		if ( key === 'children' ) {
+			continue;
+		}
 		if ( validation?.type === 'invalid' ) {
 			// Provide default message for required validation (message is optional)
-			if ( type === 'required' ) {
+			if ( key === 'required' ) {
 				return validation.message || 'A required field is empty';
 			}
 			if ( validation.message ) {
@@ -74,15 +65,15 @@ function getFirstValidationError(
 	return undefined;
 }
 
-function hasInvalidValidation(
-	validity: FieldValidity | undefined
-): boolean {
+function hasInvalidValidation( validity: FieldValidity | undefined ): boolean {
 	if ( ! validity ) {
 		return false;
 	}
 
-	for ( const type of VALIDATION_TYPES ) {
-		const validation = validity[ type ];
+	for ( const [ key, validation ] of Object.entries( validity ) ) {
+		if ( key === 'children' ) {
+			continue;
+		}
 		if ( validation?.type === 'invalid' ) {
 			return true;
 		}

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -236,7 +236,7 @@ export default function FormPanelField< Item >( {
 						<Icon
 							className="dataforms-layouts-panel__field-label-error-content"
 							icon={ errorIcon }
-							size={ 20 }
+							size={ 16 }
 						/>
 					</Tooltip>
 				) }

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -196,10 +196,6 @@ export default function FormPanelField< Item >( {
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				onOpen={ handleOpen }
-				showError={ labelPosition === 'none' ? showError : false }
-				errorMessage={
-					labelPosition === 'none' ? errorMessage : undefined
-				}
 			/>
 		) : (
 			<PanelDropdown
@@ -212,10 +208,6 @@ export default function FormPanelField< Item >( {
 				fieldDefinition={ fieldDefinition }
 				popoverAnchor={ popoverAnchor }
 				onOpen={ handleOpen }
-				showError={ labelPosition === 'none' ? showError : false }
-				errorMessage={
-					labelPosition === 'none' ? errorMessage : undefined
-				}
 			/>
 		);
 
@@ -237,11 +229,18 @@ export default function FormPanelField< Item >( {
 
 	if ( labelPosition === 'none' ) {
 		return (
-			<div className="dataforms-layouts-panel__field">
+			<HStack className="dataforms-layouts-panel__field">
+				{ showError && (
+					<Tooltip text={ errorMessage } placement="top">
+						<span className="dataforms-layouts-panel__field-error-indicator">
+							<Icon icon={ errorIcon } size={ 20 } />
+						</span>
+					</Tooltip>
+				) }
 				<div className="dataforms-layouts-panel__field-control">
 					{ renderedControl }
 				</div>
-			</div>
+			</HStack>
 		);
 	}
 

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -229,7 +229,7 @@ export default function FormPanelField< Item >( {
 
 	if ( labelPosition === 'none' ) {
 		return (
-			<HStack className="dataforms-layouts-panel__field">
+			<HStack className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none">
 				{ showError && (
 					<Tooltip text={ errorMessage } placement="top">
 						<span className="dataforms-layouts-panel__field-error-indicator">

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -41,13 +41,23 @@ function getFirstValidationError(
 		if ( key === 'children' ) {
 			continue;
 		}
-		if ( validation?.type === 'invalid' ) {
+		if (
+			validation &&
+			typeof validation === 'object' &&
+			'type' in validation &&
+			validation.type === 'invalid'
+		) {
 			// Provide default message for required validation (message is optional)
 			if ( key === 'required' ) {
-				return validation.message || 'A required field is empty';
+				return (
+					( 'message' in validation &&
+						typeof validation.message === 'string' &&
+						validation.message ) ||
+					'A required field is empty'
+				);
 			}
-			if ( validation.message ) {
-				return validation.message;
+			if ( 'message' in validation && validation.message ) {
+				return validation.message as string;
 			}
 		}
 	}

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -177,6 +177,10 @@ export default function FormPanelField< Item >( {
 		null
 	);
 
+	// Track if the panel has been opened (touched) to only show errors after interaction.
+	const [ touched, setTouched ] = useState( false );
+	const handleOpen = () => setTouched( true );
+
 	const { fieldDefinition, summaryFields } =
 		getFieldDefinitionAndSummaryFields( layout, field, fields );
 
@@ -187,14 +191,16 @@ export default function FormPanelField< Item >( {
 	const labelPosition = layout.labelPosition;
 	const hasError = hasInvalidValidation( validity );
 	const errorMessage = getFirstValidationError( validity );
+
+	const showError = touched && hasError;
 	const labelClassName = clsx(
 		'dataforms-layouts-panel__field-label',
 		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,
-		{ 'has-error': hasError }
+		{ 'has-error': showError }
 	);
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
-	const labelContent = hasError ? (
+	const labelContent = showError ? (
 		<Tooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-content">
 				<span className="dataforms-layouts-panel__field-error-indicator">
@@ -216,6 +222,7 @@ export default function FormPanelField< Item >( {
 				labelPosition={ labelPosition }
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
+				onOpen={ handleOpen }
 			/>
 		) : (
 			<PanelDropdown
@@ -227,6 +234,7 @@ export default function FormPanelField< Item >( {
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				popoverAnchor={ popoverAnchor }
+				onOpen={ handleOpen }
 			/>
 		);
 

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -196,6 +196,10 @@ export default function FormPanelField< Item >( {
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				onOpen={ handleOpen }
+				showError={ labelPosition === 'none' ? showError : false }
+				errorMessage={
+					labelPosition === 'none' ? errorMessage : undefined
+				}
 			/>
 		) : (
 			<PanelDropdown
@@ -208,6 +212,10 @@ export default function FormPanelField< Item >( {
 				fieldDefinition={ fieldDefinition }
 				popoverAnchor={ popoverAnchor }
 				onOpen={ handleOpen }
+				showError={ labelPosition === 'none' ? showError : false }
+				errorMessage={
+					labelPosition === 'none' ? errorMessage : undefined
+				}
 			/>
 		);
 
@@ -230,7 +238,9 @@ export default function FormPanelField< Item >( {
 	if ( labelPosition === 'none' ) {
 		return (
 			<div className="dataforms-layouts-panel__field">
-				{ renderedControl }
+				<div className="dataforms-layouts-panel__field-control">
+					{ renderedControl }
+				</div>
 			</div>
 		);
 	}

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -65,32 +65,6 @@ function getFirstValidationError(
 	return undefined;
 }
 
-function hasInvalidValidation( validity: FieldValidity | undefined ): boolean {
-	if ( ! validity ) {
-		return false;
-	}
-
-	for ( const [ key, validation ] of Object.entries( validity ) ) {
-		if ( key === 'children' ) {
-			continue;
-		}
-		if ( validation?.type === 'invalid' ) {
-			return true;
-		}
-	}
-
-	// Check children recursively
-	if ( validity.children ) {
-		for ( const childValidity of Object.values( validity.children ) ) {
-			if ( hasInvalidValidation( childValidity ) ) {
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
 const getFieldDefinition = < Item, >(
 	field: NormalizedFormField,
 	fields: NormalizedField< Item >[]
@@ -180,10 +154,8 @@ export default function FormPanelField< Item >( {
 	}
 
 	const labelPosition = layout.labelPosition;
-	const hasError = hasInvalidValidation( validity );
 	const errorMessage = getFirstValidationError( validity );
-
-	const showError = touched && hasError;
+	const showError = touched && !! errorMessage;
 	const labelClassName = clsx(
 		'dataforms-layouts-panel__field-label',
 		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -50,7 +50,12 @@ function getFirstValidationError(
 
 	for ( const type of VALIDATION_TYPES ) {
 		const validation = validity[ type ];
-		if ( validation?.type === 'invalid' && validation.message ) {
+		if ( validation?.type === 'invalid' ) {
+			// Provide default message for required validation (message is optional)
+			if ( type === 'required' ) {
+				return validation.message || 'A required field is empty';
+			}
+			if ( validation.message ) {
 			return validation.message;
 		}
 	}

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -177,7 +177,7 @@ export default function FormPanelField< Item >( {
 		<Tooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-content">
 				<span className="dataforms-layouts-panel__field-error-indicator">
-					<Icon icon={ errorIcon } size={ 20 } />
+					<Icon icon={ errorIcon } size={ 16 } />
 				</span>
 				{ fieldLabel }
 			</span>

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -37,28 +37,27 @@ function getFirstValidationError(
 		return undefined;
 	}
 
-	for ( const [ key, validation ] of Object.entries( validity ) ) {
-		if ( key === 'children' ) {
+	const validityRules = Object.keys( validity ).filter(
+		( key ) => key !== 'children'
+	);
+
+	for ( const key of validityRules ) {
+		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
+		if ( rule === undefined ) {
 			continue;
 		}
-		if (
-			validation &&
-			typeof validation === 'object' &&
-			'type' in validation &&
-			validation.type === 'invalid'
-		) {
+
+		if ( rule.type === 'invalid' ) {
+			if ( rule.message ) {
+				return rule.message;
+			}
+
 			// Provide default message for required validation (message is optional)
 			if ( key === 'required' ) {
-				return (
-					( 'message' in validation &&
-						typeof validation.message === 'string' &&
-						validation.message ) ||
-					'A required field is empty'
-				);
+				return 'A required field is empty';
 			}
-			if ( 'message' in validation && validation.message ) {
-				return validation.message as string;
-			}
+
+			return 'Unidentified validation error';
 		}
 	}
 

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -9,14 +9,18 @@ import clsx from 'clsx';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	Icon,
+	Tooltip,
 } from '@wordpress/components';
 import { useState, useContext } from '@wordpress/element';
+import { error as errorIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import type {
 	FieldLayoutProps,
+	FieldValidity,
 	NormalizedField,
 	NormalizedFormField,
 	NormalizedPanelLayout,
@@ -25,6 +29,70 @@ import DataFormContext from '../../components/dataform-context';
 import PanelDropdown from './dropdown';
 import PanelModal from './modal';
 import { getSummaryFields } from '../get-summary-fields';
+
+const VALIDATION_TYPES = [
+	'required',
+	'pattern',
+	'min',
+	'max',
+	'minLength',
+	'maxLength',
+	'elements',
+	'custom',
+] as const;
+
+function getFirstValidationError(
+	validity: FieldValidity | undefined
+): string | undefined {
+	if ( ! validity ) {
+		return undefined;
+	}
+
+	for ( const type of VALIDATION_TYPES ) {
+		const validation = validity[ type ];
+		if ( validation?.type === 'invalid' && validation.message ) {
+			return validation.message;
+		}
+	}
+
+	// Check children recursively
+	if ( validity.children ) {
+		for ( const childValidity of Object.values( validity.children ) ) {
+			const childError = getFirstValidationError( childValidity );
+			if ( childError ) {
+				return childError;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+function hasInvalidValidation(
+	validity: FieldValidity | undefined
+): boolean {
+	if ( ! validity ) {
+		return false;
+	}
+
+	for ( const type of VALIDATION_TYPES ) {
+		const validation = validity[ type ];
+		if ( validation?.type === 'invalid' ) {
+			return true;
+		}
+	}
+
+	// Check children recursively
+	if ( validity.children ) {
+		for ( const childValidity of Object.values( validity.children ) ) {
+			if ( hasInvalidValidation( childValidity ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
 
 const getFieldDefinition = < Item, >(
 	field: NormalizedFormField,
@@ -111,11 +179,22 @@ export default function FormPanelField< Item >( {
 	}
 
 	const labelPosition = layout.labelPosition;
+	const hasError = hasInvalidValidation( validity );
+	const errorMessage = getFirstValidationError( validity );
 	const labelClassName = clsx(
 		'dataforms-layouts-panel__field-label',
-		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`
+		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,
+		{ 'has-error': hasError }
 	);
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
+
+	const validationIndicator = hasError && (
+		<Tooltip text={ errorMessage } placement="top">
+			<span className="dataforms-layouts-panel__field-error-indicator">
+				<Icon icon={ errorIcon } size={ 20 } />
+			</span>
+		</Tooltip>
+	);
 
 	const renderedControl =
 		layout.openAs === 'modal' ? (
@@ -147,6 +226,7 @@ export default function FormPanelField< Item >( {
 					className={ labelClassName }
 					style={ { paddingBottom: 0 } }
 				>
+					{ validationIndicator }
 					{ fieldLabel }
 				</div>
 				<div className="dataforms-layouts-panel__field-control">
@@ -170,7 +250,10 @@ export default function FormPanelField< Item >( {
 			ref={ setPopoverAnchor }
 			className="dataforms-layouts-panel__field"
 		>
-			<div className={ labelClassName }>{ fieldLabel }</div>
+			<div className={ labelClassName }>
+				{ validationIndicator }
+				{ fieldLabel }
+			</div>
 			<div className="dataforms-layouts-panel__field-control">
 				{ renderedControl }
 			</div>

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -151,6 +151,7 @@ function PanelModal< Item >( {
 	labelPosition,
 	summaryFields,
 	fieldDefinition,
+	onOpen,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -158,6 +159,7 @@ function PanelModal< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
+	onOpen?: () => void;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -171,7 +173,12 @@ function PanelModal< Item >( {
 				labelPosition={ labelPosition }
 				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
-				onClick={ () => setIsOpen( true ) }
+				onClick={ () => {
+					if ( onOpen ) {
+						onOpen();
+					}
+					setIsOpen( true );
+				} }
 				aria-expanded={ isOpen }
 			/>
 			{ isOpen && (

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -152,6 +152,8 @@ function PanelModal< Item >( {
 	summaryFields,
 	fieldDefinition,
 	onOpen,
+	showError,
+	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -160,6 +162,8 @@ function PanelModal< Item >( {
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	onOpen?: () => void;
+	showError?: boolean;
+	errorMessage?: string;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -180,6 +184,8 @@ function PanelModal< Item >( {
 					setIsOpen( true );
 				} }
 				aria-expanded={ isOpen }
+				showError={ showError }
+				errorMessage={ errorMessage }
 			/>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -152,8 +152,6 @@ function PanelModal< Item >( {
 	summaryFields,
 	fieldDefinition,
 	onOpen,
-	showError,
-	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -162,8 +160,6 @@ function PanelModal< Item >( {
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	onOpen?: () => void;
-	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -184,8 +180,6 @@ function PanelModal< Item >( {
 					setIsOpen( true );
 				} }
 				aria-expanded={ isOpen }
-				showError={ showError }
-				errorMessage={ errorMessage }
 			/>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -7,6 +7,10 @@
 	min-height: $grid-unit-40;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
+
+	&--label-position-none {
+		align-items: center !important;
+	}
 }
 
 .dataforms-layouts-panel__field-label {

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
 .dataforms-layouts-panel__field {
@@ -19,6 +20,22 @@
 
 	&--label-position-side {
 		align-self: center;
+	}
+
+	&.has-error {
+		color: $alert-red;
+	}
+}
+
+.dataforms-layouts-panel__field-error-indicator {
+	display: inline-flex;
+	align-items: center;
+	color: $alert-red;
+	margin-right: $grid-unit-05;
+	cursor: help;
+
+	svg {
+		fill: currentColor;
 	}
 }
 

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -27,12 +27,17 @@
 	}
 }
 
+.dataforms-layouts-panel__field-label-content {
+	display: inline-flex;
+	align-items: center;
+	cursor: help;
+}
+
 .dataforms-layouts-panel__field-error-indicator {
 	display: inline-flex;
 	align-items: center;
 	color: $alert-red;
 	margin-right: $grid-unit-05;
-	cursor: help;
 
 	svg {
 		fill: currentColor;

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -31,20 +31,9 @@
 	}
 }
 
-.dataforms-layouts-panel__field-label-content {
-	display: inline-flex;
-	align-items: center;
+.dataforms-layouts-panel__field-label-error-content {
 	cursor: help;
-}
-
-.dataforms-layouts-panel__field-error-indicator {
-	display: inline-flex;
-	align-items: center;
-	flex-shrink: 0;
-	color: $alert-red;
-	margin-right: $grid-unit-05;
-	cursor: help;
-
+	fill: $alert-red;
 	svg {
 		fill: currentColor;
 	}

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -40,8 +40,10 @@
 .dataforms-layouts-panel__field-error-indicator {
 	display: inline-flex;
 	align-items: center;
+	flex-shrink: 0;
 	color: $alert-red;
 	margin-right: $grid-unit-05;
+	cursor: help;
 
 	svg {
 		fill: currentColor;

--- a/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Icon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
+import { error as errorIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,6 +18,8 @@ function SummaryButton< Item >( {
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
+	showError,
+	errorMessage,
 }: {
 	summaryFields: NormalizedField< Item >[];
 	data: Item;
@@ -25,6 +28,8 @@ function SummaryButton< Item >( {
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
+	showError?: boolean;
+	errorMessage?: string;
 } ) {
 	return (
 		<Button
@@ -54,6 +59,13 @@ function SummaryButton< Item >( {
 					: undefined
 			}
 		>
+			{ showError && (
+				<Tooltip text={ errorMessage } placement="top">
+					<span className="dataforms-layouts-panel__field-error-indicator">
+						<Icon icon={ errorIcon } size={ 20 } />
+					</span>
+				</Tooltip>
+			) }
 			{ summaryFields.length > 1 ? (
 				<div
 					style={ {

--- a/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Icon, Tooltip } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
-import { error as errorIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,8 +17,6 @@ function SummaryButton< Item >( {
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
-	showError,
-	errorMessage,
 }: {
 	summaryFields: NormalizedField< Item >[];
 	data: Item;
@@ -28,8 +25,6 @@ function SummaryButton< Item >( {
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
-	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	return (
 		<Button
@@ -59,13 +54,6 @@ function SummaryButton< Item >( {
 					: undefined
 			}
 		>
-			{ showError && (
-				<Tooltip text={ errorMessage } placement="top">
-					<span className="dataforms-layouts-panel__field-error-indicator">
-						<Icon icon={ errorIcon } size={ 20 } />
-					</span>
-				</Tooltip>
-			) }
 			{ summaryFields.length > 1 ? (
 				<div
 					style={ {

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1278,7 +1278,6 @@ const ValidationComponent = ( {
 	}, [ elements, custom, required, pattern, minMax, getElements ] );
 
 	const form = useMemo( () => {
-		// Regular layout with nested groupings for testing validation bubbling
 		if ( layout === 'regular' ) {
 			return {
 				fields: [

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1343,8 +1343,11 @@ const ValidationComponent = ( {
 
 		// Panel and card layouts share the same grouped structure
 		const groupedFields = [
-			{ id: 'text' },
-			{ id: 'customEdit' },
+			{
+				id: 'textFields',
+				label: 'Text Fields',
+				children: [ 'text', 'textarea', 'password', 'customEdit' ],
+			},
 			{
 				id: 'numberFields',
 				label: 'Number Fields',
@@ -1356,12 +1359,6 @@ const ValidationComponent = ( {
 				children: [ 'email', 'telephone', 'url' ],
 			},
 			{
-				id: 'styleFields',
-				label: 'Style Fields',
-				children: [ 'color', 'password' ],
-			},
-			{ id: 'textarea' },
-			{
 				id: 'selectFields',
 				label: 'Selection Fields',
 				children: [ 'select', 'textWithRadio' ],
@@ -1371,6 +1368,7 @@ const ValidationComponent = ( {
 				label: 'Boolean Fields',
 				children: [ 'boolean', 'toggle', 'toggleGroup' ],
 			},
+			{ id: 'color' },
 			{ id: 'array' },
 			{
 				id: 'dateFields',

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -554,12 +554,14 @@ const ValidationComponent = ( {
 	custom,
 	pattern,
 	minMax,
+	layout,
 }: {
 	required: boolean;
 	elements: 'sync' | 'async' | 'none';
 	custom: 'sync' | 'async' | 'none';
 	pattern: boolean;
 	minMax: boolean;
+	layout: 'regular' | 'panel' | 'card';
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -1275,68 +1277,120 @@ const ValidationComponent = ( {
 		];
 	}, [ elements, custom, required, pattern, minMax, getElements ] );
 
-	const form = useMemo(
-		() => ( {
-			fields: [
-				'text',
-				{ id: 'customEdit' },
-				{
-					id: 'level1Integer',
-					children: [ 'integer' ],
-				},
-				{
-					id: 'level1Number',
-					children: [
-						{ id: 'level2Number', children: [ 'number' ] },
-					],
-				},
-				{
-					id: 'level1Email',
-					children: [
-						{
-							id: 'level2Email',
-							children: [
-								{ id: 'level3Email', children: [ 'email' ] },
-							],
-						},
-					],
-				},
-				{
-					id: 'level1Telephone',
-					children: [
-						{
-							id: 'level2Telephone',
-							children: [
-								{
-									id: 'level3Telephone',
-									children: [
-										{
-											id: 'level4Telephone',
-											children: [ 'telephone' ],
-										},
-									],
-								},
-							],
-						},
-					],
-				},
-				'url',
-				'color',
-				'password',
-				'textarea',
-				'select',
-				'textWithRadio',
-				'boolean',
-				'toggle',
-				'toggleGroup',
-				'array',
-				'date',
-				'dateRange',
-				'datetime',
-			],
-		} ),
-		[]
-	);
+	const form = useMemo( () => {
+		// Regular layout with nested groupings for testing validation bubbling
+		if ( layout === 'regular' ) {
+			return {
+				fields: [
+					'text',
+					{ id: 'customEdit' },
+					{ id: 'level1Integer', children: [ 'integer' ] },
+					{
+						id: 'level1Number',
+						children: [
+							{ id: 'level2Number', children: [ 'number' ] },
+						],
+					},
+					{
+						id: 'level1Email',
+						children: [
+							{
+								id: 'level2Email',
+								children: [
+									{
+										id: 'level3Email',
+										children: [ 'email' ],
+									},
+								],
+							},
+						],
+					},
+					{
+						id: 'level1Telephone',
+						children: [
+							{
+								id: 'level2Telephone',
+								children: [
+									{
+										id: 'level3Telephone',
+										children: [
+											{
+												id: 'level4Telephone',
+												children: [ 'telephone' ],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+					'url',
+					'color',
+					'password',
+					'textarea',
+					'select',
+					'textWithRadio',
+					'boolean',
+					'toggle',
+					'toggleGroup',
+					'array',
+					'date',
+					'dateRange',
+					'datetime',
+				],
+			};
+		}
+
+		// Panel and card layouts share the same grouped structure
+		const groupedFields = [
+			{ id: 'text' },
+			{ id: 'customEdit' },
+			{
+				id: 'numberFields',
+				label: 'Number Fields',
+				children: [ 'integer', 'number' ],
+			},
+			{
+				id: 'contactFields',
+				label: 'Contact Fields',
+				children: [ 'email', 'telephone', 'url' ],
+			},
+			{
+				id: 'styleFields',
+				label: 'Style Fields',
+				children: [ 'color', 'password' ],
+			},
+			{ id: 'textarea' },
+			{
+				id: 'selectFields',
+				label: 'Selection Fields',
+				children: [ 'select', 'textWithRadio' ],
+			},
+			{
+				id: 'booleanFields',
+				label: 'Boolean Fields',
+				children: [ 'boolean', 'toggle', 'toggleGroup' ],
+			},
+			{ id: 'array' },
+			{
+				id: 'dateFields',
+				label: 'Date Fields',
+				children: [ 'date', 'dateRange', 'datetime' ],
+			},
+		];
+
+		if ( layout === 'panel' ) {
+			return {
+				layout: { type: 'panel' as const },
+				fields: groupedFields,
+			};
+		}
+
+		return {
+			layout: { type: 'card' as const },
+			fields: groupedFields,
+		};
+	}, [ layout ] );
 
 	const { validity, isValid } = useFormValidity( post, _fields, form );
 
@@ -1355,13 +1409,6 @@ const ValidationComponent = ( {
 						} ) )
 					}
 				/>
-				<PanelValidationSection
-					required={ required }
-					elements={ elements }
-					custom={ custom }
-					pattern={ pattern }
-					minMax={ minMax }
-				/>
 				<Button
 					__next40pxDefaultSize
 					accessibleWhenDisabled
@@ -1372,497 +1419,6 @@ const ValidationComponent = ( {
 				</Button>
 			</VStack>
 		</form>
-	);
-};
-
-const PanelValidationSection = ( {
-	required,
-	elements,
-	custom,
-	pattern,
-	minMax,
-}: {
-	required: boolean;
-	elements: 'sync' | 'async' | 'none';
-	custom: 'sync' | 'async' | 'none';
-	pattern: boolean;
-	minMax: boolean;
-} ) => {
-	type PanelItem = {
-		slug: string;
-		categories: string[];
-		tags: string[];
-		weight: number;
-		description: string;
-		email: string;
-		telephone: string;
-		url: string;
-		foregroundColor: string;
-		backgroundColor: string;
-		notes: string;
-	};
-
-	const [ data, setData ] = useState< PanelItem >( {
-		slug: 'pizza oven', // Has spaces - will trigger validation error
-		categories: [],
-		tags: [ 'Pizza', 'Oven', 'Baking' ],
-		weight: 18,
-		description: 'No assembly, no mess, no fuss.',
-		email: 'invalid-email',
-		telephone: '+1-555-1234',
-		url: 'https://example.com',
-		foregroundColor: '#ffffff',
-		backgroundColor: '#ff6600',
-		notes: 'Some notes here',
-	} );
-
-	const panelFields: Field< PanelItem >[] = useMemo( () => {
-		const customSlugRule = ( item: PanelItem ) => {
-			if ( item.slug.includes( ' ' ) ) {
-				return 'Slug cannot contain spaces';
-			}
-			return null;
-		};
-
-		const asyncCustomSlugRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customSlugRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const customDescriptionRule = ( item: PanelItem ) => {
-			if ( item.description.length < 20 ) {
-				return 'Description must be at least 20 characters';
-			}
-			return null;
-		};
-
-		const asyncCustomDescriptionRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customDescriptionRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const customEmailRule = ( item: PanelItem ) => {
-			if ( ! /^[a-zA-Z0-9._%+-]+@example\.com$/.test( item.email ) ) {
-				return 'Email address must be from @example.com domain.';
-			}
-			return null;
-		};
-
-		const asyncCustomEmailRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customEmailRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const customTelephoneRule = ( item: PanelItem ) => {
-			if ( ! /^\+30\d{10}$/.test( item.telephone ) ) {
-				return 'Telephone must start with +30 and have 10 digits after.';
-			}
-			return null;
-		};
-
-		const asyncCustomTelephoneRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customTelephoneRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const customUrlRule = ( item: PanelItem ) => {
-			if ( ! /^https:\/\/example\.com$/.test( item.url ) ) {
-				return 'URL must be https://example.com.';
-			}
-			return null;
-		};
-
-		const asyncCustomUrlRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customUrlRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const customColorRule = ( item: PanelItem, fieldId: string ) => {
-			const value =
-				fieldId === 'foregroundColor'
-					? item.foregroundColor
-					: item.backgroundColor;
-			if ( ! /^#[0-9A-Fa-f]{6}$/.test( value ) ) {
-				return 'Color must be a valid hex format (e.g., #ff6600).';
-			}
-			return null;
-		};
-
-		const customNotesRule = ( item: PanelItem ) => {
-			if ( item.notes && item.notes.startsWith( ' ' ) ) {
-				return 'Notes cannot start with a space.';
-			}
-			return null;
-		};
-
-		const asyncCustomNotesRule = async ( item: PanelItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					resolve( customNotesRule( item ) );
-				}, 2000 );
-			} );
-		};
-
-		const maybeCustomRule = < T, >(
-			rule: ( item: T ) => string | null,
-			asyncRule: ( item: T ) => Promise< string | null >
-		) => {
-			if ( custom === 'sync' ) {
-				return rule;
-			}
-			if ( custom === 'async' ) {
-				return asyncRule;
-			}
-			return undefined;
-		};
-
-		const getDescription = (
-			patternDesc: string,
-			minMaxDesc: string,
-			customDesc: string
-		) => {
-			const parts = [];
-			if ( pattern ) {
-				parts.push( patternDesc );
-			}
-			if ( minMax ) {
-				parts.push( minMaxDesc );
-			}
-			if ( custom !== 'none' ) {
-				parts.push( customDesc );
-			}
-			return parts.length > 0 ? parts.join( '. ' ) : undefined;
-		};
-
-		return [
-			{
-				id: 'slug',
-				label: 'Slug',
-				type: 'text',
-				description: getDescription(
-					'Only lowercase letters, numbers, and hyphens',
-					'',
-					'No spaces allowed'
-				),
-				isValid: {
-					required,
-					pattern: pattern ? '^[a-z0-9-]+$' : undefined, // No spaces allowed
-					custom: maybeCustomRule(
-						customSlugRule,
-						asyncCustomSlugRule
-					),
-				},
-			},
-			{
-				id: 'categories',
-				label: 'Categories',
-				type: 'array',
-				description: required
-					? 'Select at least one category'
-					: undefined,
-				elements:
-					elements === 'async'
-						? undefined
-						: [
-								{ value: 'pizza-ovens', label: 'Pizza Ovens' },
-								{ value: 'grills', label: 'Grills' },
-								{ value: 'accessories', label: 'Accessories' },
-						  ],
-				getElements:
-					elements === 'async'
-						? () =>
-								new Promise( ( resolve ) =>
-									setTimeout(
-										() =>
-											resolve( [
-												{
-													value: 'pizza-ovens',
-													label: 'Pizza Ovens',
-												},
-												{
-													value: 'grills',
-													label: 'Grills',
-												},
-												{
-													value: 'accessories',
-													label: 'Accessories',
-												},
-											] ),
-										2000
-									)
-								)
-						: undefined,
-				isValid: {
-					required,
-					elements: elements !== 'none',
-				},
-			},
-			{
-				id: 'tags',
-				label: 'Tags',
-				type: 'array',
-				description: 'Add relevant tags for the product',
-				elements: [
-					{ value: 'Pizza', label: 'Pizza' },
-					{ value: 'Oven', label: 'Oven' },
-					{ value: 'Baking', label: 'Baking' },
-				],
-				isValid: {
-					elements: elements !== 'none',
-				},
-			},
-			{
-				id: 'weight',
-				label: 'Weight',
-				type: 'integer',
-				description: minMax ? 'Weight in kg (1-100)' : 'Weight in kg',
-				isValid: {
-					required,
-					min: minMax ? 1 : undefined,
-					max: minMax ? 100 : undefined,
-				},
-			},
-			{
-				id: 'description',
-				label: 'Description',
-				type: 'text',
-				Edit: 'textarea',
-				description: getDescription(
-					'',
-					'Between 20 and 200 characters',
-					'Must be at least 20 characters'
-				),
-				isValid: {
-					required,
-					minLength: minMax ? 20 : undefined,
-					maxLength: minMax ? 200 : undefined,
-					custom: maybeCustomRule(
-						customDescriptionRule,
-						asyncCustomDescriptionRule
-					),
-				},
-			},
-			{
-				id: 'email',
-				label: 'Email',
-				type: 'email',
-				description: getDescription(
-					'Must be a @company.com email',
-					'Between 10 and 50 characters',
-					'Must be from @example.com domain'
-				),
-				isValid: {
-					required,
-					pattern: pattern
-						? '^[a-zA-Z0-9._%+-]+@company\\.com$'
-						: undefined,
-					minLength: minMax ? 10 : undefined,
-					maxLength: minMax ? 50 : undefined,
-					custom: maybeCustomRule(
-						customEmailRule,
-						asyncCustomEmailRule
-					),
-				},
-			},
-			{
-				id: 'telephone',
-				label: 'Telephone',
-				type: 'telephone',
-				description: getDescription(
-					'Must start with +30 followed by 10 digits',
-					'Between 10 and 20 characters',
-					'Greek phone format: +30XXXXXXXXXX'
-				),
-				isValid: {
-					required,
-					pattern: pattern ? '^\\+30\\d{10}$' : undefined,
-					minLength: minMax ? 10 : undefined,
-					maxLength: minMax ? 20 : undefined,
-					custom: maybeCustomRule(
-						customTelephoneRule,
-						asyncCustomTelephoneRule
-					),
-				},
-			},
-			{
-				id: 'url',
-				label: 'URL',
-				type: 'url',
-				description: getDescription(
-					'Must be an https://example.com URL',
-					'Between 10 and 100 characters',
-					'Must be from example.com domain'
-				),
-				isValid: {
-					required,
-					pattern: pattern
-						? '^https:\\/\\/example\\.com.*$'
-						: undefined,
-					minLength: minMax ? 10 : undefined,
-					maxLength: minMax ? 100 : undefined,
-					custom: maybeCustomRule(
-						customUrlRule,
-						asyncCustomUrlRule
-					),
-				},
-			},
-			{
-				id: 'foregroundColor',
-				label: 'Foreground Color',
-				type: 'color',
-				description:
-					custom !== 'none'
-						? 'Valid hex color format (e.g., #ff6600)'
-						: undefined,
-				render: ( { item } ) => (
-					<span
-						style={ {
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '8px',
-						} }
-					>
-						<span
-							style={ {
-								width: '16px',
-								height: '16px',
-								borderRadius: '2px',
-								backgroundColor: item.foregroundColor,
-								border: '1px solid #ccc',
-							} }
-						/>
-						{ item.foregroundColor }
-					</span>
-				),
-				isValid: {
-					required,
-					custom:
-						custom !== 'none'
-							? ( item: PanelItem ) =>
-									customColorRule( item, 'foregroundColor' )
-							: undefined,
-				},
-			},
-			{
-				id: 'backgroundColor',
-				label: 'Background Color',
-				type: 'color',
-				description:
-					custom !== 'none'
-						? 'Valid hex color format (e.g., #ff6600)'
-						: undefined,
-				render: ( { item } ) => (
-					<span
-						style={ {
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '8px',
-						} }
-					>
-						<span
-							style={ {
-								width: '16px',
-								height: '16px',
-								borderRadius: '2px',
-								backgroundColor: item.backgroundColor,
-								border: '1px solid #ccc',
-							} }
-						/>
-						{ item.backgroundColor }
-					</span>
-				),
-				isValid: {
-					required,
-					custom:
-						custom !== 'none'
-							? ( item: PanelItem ) =>
-									customColorRule( item, 'backgroundColor' )
-							: undefined,
-				},
-			},
-			{
-				id: 'notes',
-				label: 'Notes',
-				type: 'text',
-				description: getDescription(
-					'Only alphanumeric characters and spaces',
-					'Between 5 and 100 characters',
-					'Cannot start with a space'
-				),
-				isValid: {
-					required,
-					pattern: pattern ? '^[a-zA-Z0-9 ]+$' : undefined,
-					minLength: minMax ? 5 : undefined,
-					maxLength: minMax ? 100 : undefined,
-					custom: maybeCustomRule(
-						customNotesRule,
-						asyncCustomNotesRule
-					),
-				},
-			},
-		];
-	}, [ required, elements, custom, pattern, minMax ] );
-
-	const panelForm: Form = {
-		layout: { type: 'panel' },
-		fields: [
-			{ id: 'slug', layout: { type: 'panel' } },
-			{
-				id: 'moreInfo',
-				label: 'More info',
-				children: [ 'categories', 'tags', 'weight' ],
-				layout: { type: 'panel' },
-			},
-			{ id: 'description', layout: { type: 'panel' } },
-			{
-				id: 'profile',
-				label: 'Profile',
-				children: [ 'email', 'telephone', 'url' ],
-				layout: { type: 'panel' },
-			},
-			{
-				id: 'colors',
-				label: 'Colors',
-				children: [ 'foregroundColor', 'backgroundColor' ],
-				layout: {
-					type: 'panel',
-					summary: [ 'foregroundColor', 'backgroundColor' ],
-				},
-			},
-			{ id: 'notes', layout: { type: 'panel', labelPosition: 'none' } },
-		],
-	};
-
-	const { validity } = useFormValidity( data, panelFields, panelForm );
-
-	return (
-		<VStack spacing={ 4 }>
-			<h3>Panel Layout Validation</h3>
-			<DataForm< PanelItem >
-				data={ data }
-				fields={ panelFields }
-				form={ panelForm }
-				validity={ validity }
-				onChange={ ( edits ) =>
-					setData( ( prev ) => ( { ...prev, ...edits } ) )
-				}
-			/>
-		</VStack>
 	);
 };
 
@@ -2687,6 +2243,11 @@ export const LayoutMixed = {
 export const Validation = {
 	render: ValidationComponent,
 	argTypes: {
+		layout: {
+			control: { type: 'select' },
+			description: 'Choose the form layout type.',
+			options: [ 'regular', 'panel', 'card' ],
+		},
 		required: {
 			control: { type: 'boolean' },
 			description:
@@ -2715,6 +2276,7 @@ export const Validation = {
 		},
 	},
 	args: {
+		layout: 'regular',
 		required: true,
 		elements: 'sync',
 		custom: 'sync',

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1399,6 +1399,7 @@ const PanelValidationSection = ( {
 		url: string;
 		foregroundColor: string;
 		backgroundColor: string;
+		notes: string;
 	};
 
 	const [ data, setData ] = useState< PanelItem >( {
@@ -1412,6 +1413,7 @@ const PanelValidationSection = ( {
 		url: 'https://example.com',
 		foregroundColor: '#ffffff',
 		backgroundColor: '#ff6600',
+		notes: 'Some notes here',
 	} );
 
 	const panelFields: Field< PanelItem >[] = useMemo( () => {
@@ -1499,6 +1501,21 @@ const PanelValidationSection = ( {
 				return 'Color must be a valid hex format (e.g., #ff6600).';
 			}
 			return null;
+		};
+
+		const customNotesRule = ( item: PanelItem ) => {
+			if ( item.notes && item.notes.startsWith( ' ' ) ) {
+				return 'Notes cannot start with a space.';
+			}
+			return null;
+		};
+
+		const asyncCustomNotesRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customNotesRule( item ) );
+				}, 2000 );
+			} );
 		};
 
 		const maybeCustomRule = < T, >(
@@ -1778,6 +1795,26 @@ const PanelValidationSection = ( {
 							: undefined,
 				},
 			},
+			{
+				id: 'notes',
+				label: 'Notes',
+				type: 'text',
+				description: getDescription(
+					'Only alphanumeric characters and spaces',
+					'Between 5 and 100 characters',
+					'Cannot start with a space'
+				),
+				isValid: {
+					required,
+					pattern: pattern ? '^[a-zA-Z0-9 ]+$' : undefined,
+					minLength: minMax ? 5 : undefined,
+					maxLength: minMax ? 100 : undefined,
+					custom: maybeCustomRule(
+						customNotesRule,
+						asyncCustomNotesRule
+					),
+				},
+			},
 		];
 	}, [ required, elements, custom, pattern, minMax ] );
 
@@ -1807,6 +1844,7 @@ const PanelValidationSection = ( {
 					summary: [ 'foregroundColor', 'backgroundColor' ],
 				},
 			},
+			{ id: 'notes', layout: { type: 'panel', labelPosition: 'none' } },
 		],
 	};
 

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1342,7 +1342,7 @@ const ValidationComponent = ( {
 
 	return (
 		<form>
-			<VStack alignment="left">
+			<VStack alignment="left" spacing={ 8 }>
 				<DataForm< ValidatedItem >
 					data={ post }
 					fields={ _fields }
@@ -1355,6 +1355,13 @@ const ValidationComponent = ( {
 						} ) )
 					}
 				/>
+				<PanelValidationSection
+					required={ required }
+					elements={ elements }
+					custom={ custom }
+					pattern={ pattern }
+					minMax={ minMax }
+				/>
 				<Button
 					__next40pxDefaultSize
 					accessibleWhenDisabled
@@ -1365,6 +1372,459 @@ const ValidationComponent = ( {
 				</Button>
 			</VStack>
 		</form>
+	);
+};
+
+const PanelValidationSection = ( {
+	required,
+	elements,
+	custom,
+	pattern,
+	minMax,
+}: {
+	required: boolean;
+	elements: 'sync' | 'async' | 'none';
+	custom: 'sync' | 'async' | 'none';
+	pattern: boolean;
+	minMax: boolean;
+} ) => {
+	type PanelItem = {
+		slug: string;
+		categories: string[];
+		tags: string[];
+		weight: number;
+		description: string;
+		email: string;
+		telephone: string;
+		url: string;
+		foregroundColor: string;
+		backgroundColor: string;
+	};
+
+	const [ data, setData ] = useState< PanelItem >( {
+		slug: 'pizza oven', // Has spaces - will trigger validation error
+		categories: [],
+		tags: [ 'Pizza', 'Oven', 'Baking' ],
+		weight: 18,
+		description: 'No assembly, no mess, no fuss.',
+		email: 'invalid-email',
+		telephone: '+1-555-1234',
+		url: 'https://example.com',
+		foregroundColor: '#ffffff',
+		backgroundColor: '#ff6600',
+	} );
+
+	const panelFields: Field< PanelItem >[] = useMemo( () => {
+		const customSlugRule = ( item: PanelItem ) => {
+			if ( item.slug.includes( ' ' ) ) {
+				return 'Slug cannot contain spaces';
+			}
+			return null;
+		};
+
+		const asyncCustomSlugRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customSlugRule( item ) );
+				}, 2000 );
+			} );
+		};
+
+		const customDescriptionRule = ( item: PanelItem ) => {
+			if ( item.description.length < 20 ) {
+				return 'Description must be at least 20 characters';
+			}
+			return null;
+		};
+
+		const asyncCustomDescriptionRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customDescriptionRule( item ) );
+				}, 2000 );
+			} );
+		};
+
+		const customEmailRule = ( item: PanelItem ) => {
+			if ( ! /^[a-zA-Z0-9._%+-]+@example\.com$/.test( item.email ) ) {
+				return 'Email address must be from @example.com domain.';
+			}
+			return null;
+		};
+
+		const asyncCustomEmailRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customEmailRule( item ) );
+				}, 2000 );
+			} );
+		};
+
+		const customTelephoneRule = ( item: PanelItem ) => {
+			if ( ! /^\+30\d{10}$/.test( item.telephone ) ) {
+				return 'Telephone must start with +30 and have 10 digits after.';
+			}
+			return null;
+		};
+
+		const asyncCustomTelephoneRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customTelephoneRule( item ) );
+				}, 2000 );
+			} );
+		};
+
+		const customUrlRule = ( item: PanelItem ) => {
+			if ( ! /^https:\/\/example\.com$/.test( item.url ) ) {
+				return 'URL must be https://example.com.';
+			}
+			return null;
+		};
+
+		const asyncCustomUrlRule = async ( item: PanelItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					resolve( customUrlRule( item ) );
+				}, 2000 );
+			} );
+		};
+
+		const customColorRule = ( item: PanelItem, fieldId: string ) => {
+			const value =
+				fieldId === 'foregroundColor'
+					? item.foregroundColor
+					: item.backgroundColor;
+			if ( ! /^#[0-9A-Fa-f]{6}$/.test( value ) ) {
+				return 'Color must be a valid hex format (e.g., #ff6600).';
+			}
+			return null;
+		};
+
+		const maybeCustomRule = < T, >(
+			rule: ( item: T ) => string | null,
+			asyncRule: ( item: T ) => Promise< string | null >
+		) => {
+			if ( custom === 'sync' ) {
+				return rule;
+			}
+			if ( custom === 'async' ) {
+				return asyncRule;
+			}
+			return undefined;
+		};
+
+		const getDescription = (
+			patternDesc: string,
+			minMaxDesc: string,
+			customDesc: string
+		) => {
+			const parts = [];
+			if ( pattern ) {
+				parts.push( patternDesc );
+			}
+			if ( minMax ) {
+				parts.push( minMaxDesc );
+			}
+			if ( custom !== 'none' ) {
+				parts.push( customDesc );
+			}
+			return parts.length > 0 ? parts.join( '. ' ) : undefined;
+		};
+
+		return [
+			{
+				id: 'slug',
+				label: 'Slug',
+				type: 'text',
+				description: getDescription(
+					'Only lowercase letters, numbers, and hyphens',
+					'',
+					'No spaces allowed'
+				),
+				isValid: {
+					required,
+					pattern: pattern ? '^[a-z0-9-]+$' : undefined, // No spaces allowed
+					custom: maybeCustomRule(
+						customSlugRule,
+						asyncCustomSlugRule
+					),
+				},
+			},
+			{
+				id: 'categories',
+				label: 'Categories',
+				type: 'array',
+				description: required
+					? 'Select at least one category'
+					: undefined,
+				elements:
+					elements === 'async'
+						? undefined
+						: [
+								{ value: 'pizza-ovens', label: 'Pizza Ovens' },
+								{ value: 'grills', label: 'Grills' },
+								{ value: 'accessories', label: 'Accessories' },
+						  ],
+				getElements:
+					elements === 'async'
+						? () =>
+								new Promise( ( resolve ) =>
+									setTimeout(
+										() =>
+											resolve( [
+												{
+													value: 'pizza-ovens',
+													label: 'Pizza Ovens',
+												},
+												{
+													value: 'grills',
+													label: 'Grills',
+												},
+												{
+													value: 'accessories',
+													label: 'Accessories',
+												},
+											] ),
+										2000
+									)
+								)
+						: undefined,
+				isValid: {
+					required,
+					elements: elements !== 'none',
+				},
+			},
+			{
+				id: 'tags',
+				label: 'Tags',
+				type: 'array',
+				description: 'Add relevant tags for the product',
+				elements: [
+					{ value: 'Pizza', label: 'Pizza' },
+					{ value: 'Oven', label: 'Oven' },
+					{ value: 'Baking', label: 'Baking' },
+				],
+				isValid: {
+					elements: elements !== 'none',
+				},
+			},
+			{
+				id: 'weight',
+				label: 'Weight',
+				type: 'integer',
+				description: minMax ? 'Weight in kg (1-100)' : 'Weight in kg',
+				isValid: {
+					required,
+					min: minMax ? 1 : undefined,
+					max: minMax ? 100 : undefined,
+				},
+			},
+			{
+				id: 'description',
+				label: 'Description',
+				type: 'text',
+				Edit: 'textarea',
+				description: getDescription(
+					'',
+					'Between 20 and 200 characters',
+					'Must be at least 20 characters'
+				),
+				isValid: {
+					required,
+					minLength: minMax ? 20 : undefined,
+					maxLength: minMax ? 200 : undefined,
+					custom: maybeCustomRule(
+						customDescriptionRule,
+						asyncCustomDescriptionRule
+					),
+				},
+			},
+			{
+				id: 'email',
+				label: 'Email',
+				type: 'email',
+				description: getDescription(
+					'Must be a @company.com email',
+					'Between 10 and 50 characters',
+					'Must be from @example.com domain'
+				),
+				isValid: {
+					required,
+					pattern: pattern
+						? '^[a-zA-Z0-9._%+-]+@company\\.com$'
+						: undefined,
+					minLength: minMax ? 10 : undefined,
+					maxLength: minMax ? 50 : undefined,
+					custom: maybeCustomRule(
+						customEmailRule,
+						asyncCustomEmailRule
+					),
+				},
+			},
+			{
+				id: 'telephone',
+				label: 'Telephone',
+				type: 'telephone',
+				description: getDescription(
+					'Must start with +30 followed by 10 digits',
+					'Between 10 and 20 characters',
+					'Greek phone format: +30XXXXXXXXXX'
+				),
+				isValid: {
+					required,
+					pattern: pattern ? '^\\+30\\d{10}$' : undefined,
+					minLength: minMax ? 10 : undefined,
+					maxLength: minMax ? 20 : undefined,
+					custom: maybeCustomRule(
+						customTelephoneRule,
+						asyncCustomTelephoneRule
+					),
+				},
+			},
+			{
+				id: 'url',
+				label: 'URL',
+				type: 'url',
+				description: getDescription(
+					'Must be an https://example.com URL',
+					'Between 10 and 100 characters',
+					'Must be from example.com domain'
+				),
+				isValid: {
+					required,
+					pattern: pattern
+						? '^https:\\/\\/example\\.com.*$'
+						: undefined,
+					minLength: minMax ? 10 : undefined,
+					maxLength: minMax ? 100 : undefined,
+					custom: maybeCustomRule(
+						customUrlRule,
+						asyncCustomUrlRule
+					),
+				},
+			},
+			{
+				id: 'foregroundColor',
+				label: 'Foreground Color',
+				type: 'color',
+				description:
+					custom !== 'none'
+						? 'Valid hex color format (e.g., #ff6600)'
+						: undefined,
+				render: ( { item } ) => (
+					<span
+						style={ {
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '8px',
+						} }
+					>
+						<span
+							style={ {
+								width: '16px',
+								height: '16px',
+								borderRadius: '2px',
+								backgroundColor: item.foregroundColor,
+								border: '1px solid #ccc',
+							} }
+						/>
+						{ item.foregroundColor }
+					</span>
+				),
+				isValid: {
+					required,
+					custom:
+						custom !== 'none'
+							? ( item: PanelItem ) =>
+									customColorRule( item, 'foregroundColor' )
+							: undefined,
+				},
+			},
+			{
+				id: 'backgroundColor',
+				label: 'Background Color',
+				type: 'color',
+				description:
+					custom !== 'none'
+						? 'Valid hex color format (e.g., #ff6600)'
+						: undefined,
+				render: ( { item } ) => (
+					<span
+						style={ {
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '8px',
+						} }
+					>
+						<span
+							style={ {
+								width: '16px',
+								height: '16px',
+								borderRadius: '2px',
+								backgroundColor: item.backgroundColor,
+								border: '1px solid #ccc',
+							} }
+						/>
+						{ item.backgroundColor }
+					</span>
+				),
+				isValid: {
+					required,
+					custom:
+						custom !== 'none'
+							? ( item: PanelItem ) =>
+									customColorRule( item, 'backgroundColor' )
+							: undefined,
+				},
+			},
+		];
+	}, [ required, elements, custom, pattern, minMax ] );
+
+	const panelForm: Form = {
+		layout: { type: 'panel' },
+		fields: [
+			{ id: 'slug', layout: { type: 'panel' } },
+			{
+				id: 'moreInfo',
+				label: 'More info',
+				children: [ 'categories', 'tags', 'weight' ],
+				layout: { type: 'panel' },
+			},
+			{ id: 'description', layout: { type: 'panel' } },
+			{
+				id: 'profile',
+				label: 'Profile',
+				children: [ 'email', 'telephone', 'url' ],
+				layout: { type: 'panel' },
+			},
+			{
+				id: 'colors',
+				label: 'Colors',
+				children: [ 'foregroundColor', 'backgroundColor' ],
+				layout: {
+					type: 'panel',
+					summary: [ 'foregroundColor', 'backgroundColor' ],
+				},
+			},
+		],
+	};
+
+	const { validity } = useFormValidity( data, panelFields, panelForm );
+
+	return (
+		<VStack spacing={ 4 }>
+			<h3>Panel Layout Validation</h3>
+			<DataForm< PanelItem >
+				data={ data }
+				fields={ panelFields }
+				form={ panelForm }
+				validity={ validity }
+				onChange={ ( edits ) =>
+					setData( ( prev ) => ( { ...prev, ...edits } ) )
+				}
+			/>
+		</VStack>
 	);
 };
 


### PR DESCRIPTION
## Summary

Adds validation indicators to the panel layout in DataForm. When a field has validation errors, a red warning icon with tooltip appears next to the field label.

Part of: https://github.com/WordPress/gutenberg/issues/72321

### Details
- Shows error icon and red label text when validation fails
- Tooltip displays the error message on hover (over icon or label)
- Errors only appear after user interacts with the panel (opens it)
- Supports both dropdown and modal panel variants
- Recursively checks children validity for grouped panels

## Screenshot
<img width="326" height="366" alt="Screenshot 2025-12-02 at 18 20 16" src="https://github.com/user-attachments/assets/968f554b-7eda-4567-a3e7-f726a05c6413" />

cc: @oandregal, @jameskoster 

## Test plan

- [ ] Open Storybook DataForm Validation story http://localhost:50240/?path=/story/dataviews-dataform--validation
- [ ] Scrool to Panel Layout Validation section
- [ ] Verify no validation errors show initially on panel fields
- [ ] Click on a panel to open it, then close
- [ ] Verify validation errors now appear for invalid fields
- [ ] Hover over error icon or red label text to see tooltip message
- [ ] Verify grouped panels show errors when any child is invalid
