### PR TITLE
Block Styles: Avoid re-rendering when typing

### DIFF
--- a/packages/block-editor/src/components/block-styles/use-styles-for-block.js
+++ b/packages/block-editor/src/components/block-styles/use-styles-for-block.js
@@ -37,7 +37,7 @@ function useGenericPreviewBlock( block, type ) {
 		if ( block ) {
 			return cloneBlock( block );
 		}
-	}, [ type?.example ? block?.name : block, type ] );
+	}, [ block, type?.example, type?.name ] );
 }
 
 /**
@@ -63,7 +63,7 @@ export default function useStylesForBlocks( { clientId, onSwitch } ) {
 		const { getBlockStyles } = select( blocksStore );
 
 		return {
-			block,
+			block: ! blockType?.example ? block : null,
 			blockType,
 			styles: getBlockStyles( block.name ),
 			className: block.attributes.className || '',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A minor performance optimization for `useStylesForBlocks` and `BlockStyles`. Avoids rendering the block Styles panel on every attribute change when a static example is available for the block type.

## Testing Instructions
1. Open a post.
2. Insert a block with variation.
3. Confirm that style previews are displayed correctly.
4. Enabled "Highlight updates when components render" in React Dev Tools.
5. Change block attributes, confirm that Block Styles doesn't rerender on every change.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/3b715f7d-7a39-4be6-865c-b59593a67851

**After**

https://github.com/user-attachments/assets/5bdef61f-0d1a-43ae-9b72-abf8c628adbd


