### PR TITLE
fix the processing of variation class with css selector

### DIFF
--- a/packages/global-styles-engine/src/utils/common.ts
+++ b/packages/global-styles-engine/src/utils/common.ts
@@ -283,20 +283,22 @@ export function getBlockStyleVariationSelector(
 		return variationClass;
 	}
 
-	const ancestorRegex = /((?::\([^)]+\))?\s*)([^\s:]+)/;
-	const addVariationClass = (
-		_match: string,
-		group1: string,
-		group2: string
-	) => {
-		return group1 + group2 + variationClass;
-	};
+	const ancestorRegex = /((?::+:?[\w-]+(?:\([^)]+\))?)+)$/;
+	const result = blockSelector.split( ',' ).map( ( part: string ) => {
+		part = part.trim();
 
-	const result = blockSelector
-		.split( ',' )
-		.map( ( part ) => part.replace( ancestorRegex, addVariationClass ) );
-
-	return result.join( ',' );
+		// Check if the part ends with a pseudo-selector
+		if ( ancestorRegex.test( part ) ) {
+			// Case 1: It ends with :not(), :hover, etc.
+			// We replace the match (the pseudo part) with "variationClass + match"
+			// '$1' represents the captured pseudo-class text
+			return part.replace( ancestorRegex, variationClass + '$1' );
+		}
+		// Case 2: It ends with a standard element or class
+		// We simply append the variation class to the end
+		return part + variationClass;
+	} );
+	return result.join( ', ' );
 }
 
 /**


### PR DESCRIPTION
## What?
Normalize whitespace in block selectors before applying variation classes.

Closes #73527

## Why?
Extra spaces in CSS selectors (e.g., "div > span") previously broke variation class injection, causing styles not to apply.
in function `getBlockStyleVariationSelector` the regex select the first match of the string (selector from block.json) and the function return selector with class variation on class parent of li
<img width="742" height="54" alt="image" src="https://github.com/user-attachments/assets/98322f23-0597-4dcd-a453-cb90b3267f40" />


## How?
make the regex select the last part of the selector and append the variation class

<img width="724" height="64" alt="image" src="https://github.com/user-attachments/assets/08a4019a-fab2-47fe-b4c1-84d354609185" />

**it support pseudo classes :not(), :hover, etc.**
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. add tag.json to `your-theme/styles/blocks/`
```json
{
    "$schema": "https://schemas.wp.org/wp/6.8/theme.json",
    "version": 3,
    "title": "Tag",
    "slug": "my-theme-tag",
    "blockTypes": ["core/list-item", "core/paragraph"],
    "styles": {
        "spacing": {
            "padding": {
                "top": "0.5em",
                "right": "1em",
                "bottom": "0.5em",
                "left": "1em"
            }
        },
        "color": {
            "background": "var:preset|color|black",
           "text": "var:preset|color|white",
        }
    }
}
```
2. open page eidtor
3. add list and select list item
4. select style variation tag
<img width="1577" height="715" alt="image" src="https://github.com/user-attachments/assets/1a3b83ff-70ee-4430-afd6-a62cde6fbc53" />

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1362" height="802" alt="image" src="https://github.com/user-attachments/assets/b8eea628-b641-4494-a3ac-411d3814bcc6" />|<img width="1411" height="908" alt="image" src="https://github.com/user-attachments/assets/19937dd7-4f84-41ca-b259-f54d94e921ef" />|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
