### PR TITLE
Fields: Update "Trash" translation to provide verb context

### DIFF
--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -23,7 +23,7 @@ import type { CoreDataError, PostWithPermissions } from '../types';
 
 const trashPost: Action< PostWithPermissions > = {
 	id: 'move-to-trash',
-	label: __( 'Trash' ),
+	label: _x( 'Trash', 'verb' ),
 	isPrimary: true,
 	icon: trash,
 	isEligible( item ) {


### PR DESCRIPTION
## What?

Updates the translation of the word "Trash" to use `_x` to provide translator context that the word should be translated as a verb.

Follow-up to #72596 (see https://github.com/WordPress/gutenberg/pull/72596/files#r2481181750)

## Why?

- Since "Trash" can be either a verb or a noun, and may be translated differently as a result
- For consistency / reuse of the same translation [further down in the same component](https://github.com/WordPress/gutenberg/blob/48a6e8ae52d97441b0bbb593162124eb6c74dd46/packages/fields/src/actions/trash-post.tsx#L196)

## Testing Instructions

Repeat Testing Instructions from #72596