### PR TITLE
Tests: Emulate form blocks experiments in integration tests

### DIFF
--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -35,13 +35,6 @@ import {
 	writeBlockFixtureSerializedHTML,
 } from '../fixtures';
 
-/* eslint-disable no-restricted-syntax */
-import * as form from '@wordpress/block-library/src/form';
-import * as formInput from '@wordpress/block-library/src/form-input';
-import * as formSubmitButton from '@wordpress/block-library/src/form-submit-button';
-import * as formSubmissionNotification from '@wordpress/block-library/src/form-submission-notification';
-/* eslint-enable no-restricted-syntax */
-
 const blockBasenames = getAvailableBlockFixturesBasenames();
 
 /**
@@ -59,6 +52,7 @@ const normalizeParsedBlocks = ( blocks ) =>
 	} ) );
 
 describe( 'full post content fixture', () => {
+	let originalEnableFormBlocks;
 	beforeAll( () => {
 		const blockMetadataFiles = glob.sync(
 			'packages/block-library/src/*/block.json'
@@ -70,23 +64,21 @@ describe( 'full post content fixture', () => {
 			} )
 		);
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
-		registerCoreBlocks();
-
 		// Form-related blocks will not be registered unless they are opted
-		// in on the experimental settings page. Therefore, these blocks
-		// must be explicitly registered.
-		registerCoreBlocks( [
-			form,
-			formInput,
-			formSubmitButton,
-			formSubmissionNotification,
-		] );
+		// in on the experimental settings page.
+		originalEnableFormBlocks = window.__experimentalEnableFormBlocks;
+		window.__experimentalEnableFormBlocks = true;
+		registerCoreBlocks();
 
 		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 			__experimentalRegisterExperimentalCoreBlocks( {
 				enableFSEBlocks: true,
 			} );
 		}
+	} );
+
+	afterAll( () => {
+		window.__experimentalEnableFormBlocks = originalEnableFormBlocks;
 	} );
 
 	let spacer = 4;

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -52,7 +52,6 @@ const normalizeParsedBlocks = ( blocks ) =>
 	} ) );
 
 describe( 'full post content fixture', () => {
-	let originalEnableFormBlocks;
 	beforeAll( () => {
 		const blockMetadataFiles = glob.sync(
 			'packages/block-library/src/*/block.json'
@@ -66,7 +65,6 @@ describe( 'full post content fixture', () => {
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
 		// Form-related blocks will not be registered unless they are opted
 		// in on the experimental settings page.
-		originalEnableFormBlocks = window.__experimentalEnableFormBlocks;
 		window.__experimentalEnableFormBlocks = true;
 		registerCoreBlocks();
 
@@ -75,10 +73,6 @@ describe( 'full post content fixture', () => {
 				enableFSEBlocks: true,
 			} );
 		}
-	} );
-
-	afterAll( () => {
-		window.__experimentalEnableFormBlocks = originalEnableFormBlocks;
 	} );
 
 	let spacer = 4;


### PR DESCRIPTION
## What?

Updates "full content" integration tests to avoid explicitly registering form blocks, and instead sets up the environment that they would be registered as if the requisite experiment is enabled.

Related to #72978

## Why?

As discussed in #72978, the import subpaths for `@wordpress/block-library` as used in these tests are not [valid exports](https://github.com/WordPress/gutenberg/blob/48a6e8ae52d97441b0bbb593162124eb6c74dd46/packages/block-library/package.json#L27-L36) for the package, and only work because Jest presumably doesn't actually respect the exports API. This means it's likely to break in the future.

While we could update these imports to import from `build-module`, that means that the tests would only pass if the package were built ahead of time, which is not a requirement we should want to impose ([see related code](https://github.com/WordPress/gutenberg/blob/48a6e8ae52d97441b0bbb593162124eb6c74dd46/.github/workflows/unit-test.yml#L63-L65)).

## How?

Updates test to assign the `window` global that's evaluated when considering to register these blocks ([source](https://github.com/WordPress/gutenberg/blob/48a6e8ae52d97441b0bbb593162124eb6c74dd46/packages/block-library/src/index.js#L272)).

## Testing Instructions

`npm run test:unit test/integration/full-content/full-content.test.js`