### PR TITLE
Block Styles: Fix dynamic block previews

### DIFF
--- a/packages/block-editor/src/components/block-styles/preview-panel.js
+++ b/packages/block-editor/src/components/block-styles/preview-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -16,11 +15,10 @@ export default function BlockStylesPreviewPanel( {
 	className,
 	activeStyle,
 } ) {
-	const example = getBlockType( genericPreviewBlock.name )?.example;
 	const styleClassName = replaceActiveStyle( className, activeStyle, style );
 	const previewBlocks = useMemo( () => {
 		return {
-			...genericPreviewBlock,
+			name: genericPreviewBlock.name,
 			title: style.label || style.name,
 			description: style.description,
 			initialAttributes: {
@@ -29,9 +27,9 @@ export default function BlockStylesPreviewPanel( {
 					styleClassName +
 					' block-editor-block-styles__block-preview-container',
 			},
-			example,
+			example: genericPreviewBlock,
 		};
-	}, [ genericPreviewBlock, styleClassName ] );
+	}, [ genericPreviewBlock, style, styleClassName ] );
 
 	return <InserterPreviewPanel item={ previewBlocks } />;
 }


### PR DESCRIPTION
## What?
PR fixes a bug where block styles were not generating a preview without a static `blockType.example`.

Unlike the inserter, block styles can use user-provided content to generate previews. All this is already handled in the `useStylesForBlocks` hook, but it seems to regress at some point.

## Testing Instructions
1. Comment out the static example for Paragraph, Heading or any block.
2. Open a post.
3. Add the test block and enter the content.
4. Confirm that the preview is generated based on the content from the canvas.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/13d9ab23-9853-4780-a18e-c6f6ece29002

