### PR TITLE
PostPickerModal: Try a generalised post picker modal in the site editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -133,6 +133,7 @@ $z-layers: (
 	".edit-site-list__rename-modal": 1000001,
 	".dataviews-action-modal": 1000001,
 	".editor-action-modal": 1000001,
+	".editor-post-picker-modal": 1000001,
 	".editor-post-template__swap-template-modal": 1000001,
 	".editor-post-template__create-template-modal": 1000001,
 	".edit-site-template-panel__replace-template-modal": 1000001,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -42,6 +42,7 @@ import {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	postPickerKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
@@ -110,6 +111,7 @@ lock( privateApis, {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	postPickerKey,
 	useBlockElement,
 	useBlockElementRef,
 } );

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -6,3 +6,4 @@ export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );
 export const mediaEditKey = Symbol( 'mediaEditKey' );
 export const getMediaSelectKey = Symbol( 'getMediaSelect' );
 export const essentialFormatKey = Symbol( 'essentialFormat' );
+export const postPickerKey = Symbol( 'postPickerKey' );

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -47,7 +47,8 @@ import SaveHub from '../save-hub';
 import SavePanel from '../save-panel';
 
 const { useLocation } = unlock( routerPrivateApis );
-const { useStyle } = unlock( editorPrivateApis );
+const { useStyle, PostPickerProvider, PostPickerModal } =
+	unlock( editorPrivateApis );
 
 const ANIMATION_DURATION = 0.3;
 
@@ -273,10 +274,13 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 	}
 
 	return (
-		<SlotFillProvider>
-			{ /** This needs to be within the SlotFillProvider */ }
-			<PluginArea onError={ onPluginAreaError } />
-			<Layout { ...props } />
-		</SlotFillProvider>
+		<PostPickerProvider>
+			<SlotFillProvider>
+				{ /** This needs to be within the SlotFillProvider */ }
+				<PluginArea onError={ onPluginAreaError } />
+				<Layout { ...props } />
+				<PostPickerModal />
+			</SlotFillProvider>
+		</PostPickerProvider>
 	);
 }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -22,7 +22,11 @@ import { unlock } from '../../lock-unlock';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
-const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
+const { usePostFields, PostCardPanel, useOpenPostPicker } =
+	unlock( editorPrivateApis );
+const { ExperimentalBlockEditorProvider, postPickerKey } = unlock(
+	blockEditorPrivateApis
+);
 
 const fieldsWithBulkEditSupport = [
 	'title',
@@ -32,7 +36,7 @@ const fieldsWithBulkEditSupport = [
 	'discussion',
 ];
 
-function PostEditForm( { postType, postId } ) {
+function PostEditForm( { postType, postId, settings } ) {
 	const ids = useMemo( () => postId.split( ',' ), [ postId ] );
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -147,19 +151,14 @@ function PostEditForm( { postType, postId } ) {
 		setMultiEdits( {} );
 	}, [ ids ] );
 
-	const { ExperimentalBlockEditorProvider } = unlock(
-		blockEditorPrivateApis
-	);
-	const settings = usePatternSettings();
-
 	/**
-	 * The template field depends on the block editor settings.
+	 * The template field and parent field depend on the block editor settings.
 	 * This is a workaround to ensure that the block editor settings are available.
 	 * For more information, see: https://github.com/WordPress/gutenberg/issues/67521
 	 */
 	const fieldsWithDependency = useMemo( () => {
 		return fields.map( ( field ) => {
-			if ( field.id === 'template' ) {
+			if ( field.id === 'template' || field.id === 'parent' ) {
 				return {
 					...field,
 					Edit: ( data ) => (
@@ -189,17 +188,33 @@ function PostEditForm( { postType, postId } ) {
 }
 
 export function PostEdit( { postType, postId } ) {
+	const baseSettings = usePatternSettings();
+	const openPostPicker = useOpenPostPicker();
+
+	const settings = useMemo( () => {
+		return {
+			...baseSettings,
+			[ postPickerKey ]: openPostPicker,
+		};
+	}, [ baseSettings, openPostPicker ] );
+
 	return (
-		<Page
-			className={ clsx( 'edit-site-post-edit', {
-				'is-empty': ! postId,
-			} ) }
-			label={ __( 'Post Edit' ) }
-		>
-			{ postId && (
-				<PostEditForm postType={ postType } postId={ postId } />
-			) }
-			{ ! postId && <p>{ __( 'Select a page to edit' ) }</p> }
-		</Page>
+		<ExperimentalBlockEditorProvider settings={ settings }>
+			<Page
+				className={ clsx( 'edit-site-post-edit', {
+					'is-empty': ! postId,
+				} ) }
+				label={ __( 'Post Edit' ) }
+			>
+				{ postId && (
+					<PostEditForm
+						postType={ postType }
+						postId={ postId }
+						settings={ settings }
+					/>
+				) }
+				{ ! postId && <p>{ __( 'Select a page to edit' ) }</p> }
+			</Page>
+		</ExperimentalBlockEditorProvider>
 	);
 }

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -13,6 +13,8 @@ import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import EditorInterface from '../editor-interface';
 import { ExperimentalEditorProvider } from '../provider';
+import { PostPickerProvider } from '../post-picker-modal/context';
+import PostPickerModal from '../post-picker-modal';
 import Sidebar from '../sidebar';
 import NotesSidebar from '../collab-sidebar';
 import GlobalStylesSidebar from '../global-styles-sidebar';
@@ -109,25 +111,28 @@ function Editor( {
 				</Notice>
 			) }
 			{ !! post && (
-				<ExperimentalEditorProvider
-					post={ post }
-					__unstableTemplate={ template }
-					settings={ settings }
-					initialEdits={ initialEdits }
-					useSubRegistry={ false }
-				>
-					<EditorInterface { ...props }>
-						{ extraContent }
-					</EditorInterface>
-					{ children }
-					<Sidebar
-						onActionPerformed={ onActionPerformed }
-						extraPanels={ extraSidebarPanels }
-					/>
-					<NotesSidebar />
-					{ isBlockTheme && <GlobalStylesRenderer /> }
-					{ showGlobalStyles && <GlobalStylesSidebar /> }
-				</ExperimentalEditorProvider>
+				<PostPickerProvider>
+					<ExperimentalEditorProvider
+						post={ post }
+						__unstableTemplate={ template }
+						settings={ settings }
+						initialEdits={ initialEdits }
+						useSubRegistry={ false }
+					>
+						<EditorInterface { ...props }>
+							{ extraContent }
+						</EditorInterface>
+						{ children }
+						<Sidebar
+							onActionPerformed={ onActionPerformed }
+							extraPanels={ extraSidebarPanels }
+						/>
+						<NotesSidebar />
+						{ isBlockTheme && <GlobalStylesRenderer /> }
+						{ showGlobalStyles && <GlobalStylesSidebar /> }
+						<PostPickerModal />
+					</ExperimentalEditorProvider>
+				</PostPickerProvider>
 			) }
 		</>
 	);

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -22,7 +22,11 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
-import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import {
+	__experimentalInspectorPopoverHeader as InspectorPopoverHeader,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { filterURLForDisplay } from '@wordpress/url';
 
 /**
@@ -31,6 +35,9 @@ import { filterURLForDisplay } from '@wordpress/url';
 import PostPanelRow from '../post-panel-row';
 import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { postPickerKey } = unlock( blockEditorPrivateApis );
 
 function getTitle( post ) {
 	return post?.title?.rendered
@@ -67,6 +74,9 @@ export function PageAttributesParent() {
 		parentPostTitle,
 		pageItems,
 		isLoading,
+		postTypeSlug,
+		postId,
+		openPostPicker,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -77,15 +87,15 @@ export function PageAttributesParent() {
 			} = select( coreStore );
 			const { getCurrentPostId, getEditedPostAttribute } =
 				select( editorStore );
-			const postTypeSlug = getEditedPostAttribute( 'type' );
+			const postTypeSlugValue = getEditedPostAttribute( 'type' );
 			const pageId = getEditedPostAttribute( 'parent' );
-			const pType = getPostType( postTypeSlug );
-			const postId = getCurrentPostId();
+			const pType = getPostType( postTypeSlugValue );
+			const postIdValue = getCurrentPostId();
 			const postIsHierarchical = pType?.hierarchical ?? false;
 			const query = {
 				per_page: 100,
-				exclude: postId,
-				parent_exclude: postId,
+				exclude: postIdValue,
+				parent_exclude: postIdValue,
 				orderby: 'menu_order',
 				order: 'asc',
 				_fields: 'id,title,parent',
@@ -97,23 +107,36 @@ export function PageAttributesParent() {
 			}
 
 			const parentPost = pageId
-				? getEntityRecord( 'postType', postTypeSlug, pageId )
+				? getEntityRecord( 'postType', postTypeSlugValue, pageId )
 				: null;
+
+			// Get the openPostPicker function from block editor settings
+			let pickerFunction;
+			try {
+				const { getSettings } = select( blockEditorStore );
+				const blockEditorSettings = getSettings();
+				pickerFunction = blockEditorSettings?.[ postPickerKey ];
+			} catch ( e ) {
+				// blockEditorStore might not be available in all contexts
+			}
 
 			return {
 				isHierarchical: postIsHierarchical,
 				parentPostId: pageId,
 				parentPostTitle: parentPost ? getTitle( parentPost ) : '',
 				pageItems: postIsHierarchical
-					? getEntityRecords( 'postType', postTypeSlug, query )
+					? getEntityRecords( 'postType', postTypeSlugValue, query )
 					: null,
 				isLoading: postIsHierarchical
 					? isResolving( 'getEntityRecords', [
 							'postType',
-							postTypeSlug,
+							postTypeSlugValue,
 							query,
 					  ] )
 					: false,
+				postTypeSlug: postTypeSlugValue,
+				postId: postIdValue,
+				openPostPicker: pickerFunction,
 			};
 		},
 		[ fieldValue ]
@@ -191,20 +214,50 @@ export function PageAttributesParent() {
 		editPost( { parent: selectedPostId } );
 	};
 
+	const handlePostPickerSelect = ( selectedPostId ) => {
+		editPost( { parent: selectedPostId } );
+	};
+
+	// Use PostPicker with ComboBox if available, otherwise use ComboBox alone
 	return (
-		<ComboboxControl
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-			className="editor-page-attributes__parent"
-			label={ __( 'Parent' ) }
-			help={ __( 'Choose a parent page.' ) }
-			value={ parentPostId }
-			options={ parentOptions }
-			onFilterValueChange={ debounce( handleKeydown, 300 ) }
-			onChange={ handleChange }
-			hideLabelFromVision
-			isLoading={ isLoading }
-		/>
+		<div>
+			<ComboboxControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				className="editor-page-attributes__parent"
+				label={ __( 'Parent' ) }
+				help={ __( 'Choose a parent page.' ) }
+				value={ parentPostId }
+				options={ parentOptions }
+				onFilterValueChange={ debounce( handleKeydown, 300 ) }
+				onChange={ handleChange }
+				hideLabelFromVision
+				isLoading={ isLoading }
+			/>
+			{ openPostPicker && (
+				<Button
+					variant="secondary"
+					onClick={ () =>
+						openPostPicker( {
+							postType: postTypeSlug,
+							excludePostId: postId,
+							onSelect: handlePostPickerSelect,
+							title: sprintf(
+								/* translators: %s: post type name */
+								__( 'Select Parent %s' ),
+								postTypeSlug
+							),
+						} )
+					}
+					__next40pxDefaultSize
+					style={ { marginTop: '8px', width: '100%' } }
+				>
+					{ parentPostId
+						? __( 'Change Parent' )
+						: __( 'Select Parent' ) }
+				</Button>
+			) }
+		</div>
 	);
 }
 

--- a/packages/editor/src/components/post-picker-modal/IMPLEMENTATION.md
+++ b/packages/editor/src/components/post-picker-modal/IMPLEMENTATION.md
@@ -1,0 +1,138 @@
+# PostPicker Component Implementation
+
+## Overview
+The `PostPickerModal` is a generalized component that allows selecting a post (typically a page) from a modal dialog. It's accessed via the `postPickerKey` private symbol injected into block editor settings, similar to how `mediaUpload` is injected.
+
+This component is used primarily for selecting parent pages from the parent field in the `packages/fields` package, but is designed to be flexible enough to work with any hierarchical post type.
+
+## Architecture
+
+### Core Components
+
+#### 1. PostPickerModal Component (`index.tsx`)
+- **Main component** that renders a Modal with DataViewsPicker
+- Uses `@wordpress/dataviews` for the browsing/selection interface
+- Fetches posts via `@wordpress/core-data` using `useEntityRecordsWithPermissions`
+- Displays a flat list of posts with title, status, and date columns
+- Supports search across all fields
+- Single-selection only (modal stays open after selection)
+
+**Key Features:**
+- Flat list display (no hierarchy visualization)
+- Full search support
+- Pagination support
+- Excludes current post ID from results
+- TODO: Add parent_exclude logic for preventing circular hierarchies
+
+#### 2. Type Definitions (`types.ts`)
+```typescript
+interface PostPickerModalProps {
+  isOpen: boolean;                    // Controls modal visibility
+  onClose: () => void;                // Called when modal closes
+  onSelect: (postId: number) => void; // Called with selected post ID
+  postType: string;                   // e.g., 'page', 'post'
+  excludePostId?: number;             // Current post to exclude
+  title?: string;                     // Custom modal title
+}
+
+interface PostData {
+  id: number;
+  title: { raw?: string; rendered?: string };
+  status: 'publish' | 'draft' | ...;
+  // ... other post fields
+}
+```
+
+### Symbol Injection Flow
+
+```
+packages/block-editor/src/store/private-keys.ts
+  ↓ (exports postPickerKey symbol)
+packages/block-editor/src/private-apis.js
+  ↓ (locks symbol in private APIs)
+packages/editor/src/components/provider/use-block-editor-settings.js
+  ↓ (unlocks symbol and injects PostPickerModal wrapper)
+Block Editor Settings
+  ↓ (symbol becomes accessible via settings[postPickerKey])
+packages/fields/src/fields/parent/parent-edit.tsx
+  ↓ (accesses and uses PostPickerModal)
+User can select parent post
+```
+
+### Integration with Block Editor Settings
+
+The `PostPickerModal` component is injected into block editor settings as a wrapped component that:
+1. Manages modal open/close state
+2. Wraps post selection callback to update the parent field
+3. Is accessed via the `postPickerKey` symbol
+
+Usage pattern in parent field:
+```typescript
+const postPickerModal = blockEditorSettings[postPickerKey];
+// Returns a React component that can be rendered
+```
+
+## Design Decisions
+
+### 1. **Flat List Display**
+- No hierarchy visualization (indentation/breadcrumbs)
+- Simpler implementation
+- Consistent with Media modal pattern
+- Users can search to find specific pages
+
+### 2. **Modal Stays Open After Selection**
+- Allows users to adjust their selection without reopening
+- Users click X button or outside to close
+- Single-selection only (no multi-select)
+
+### 3. **Post Exclusion**
+- Excludes `excludePostId` from results
+- TODO: Implement `parent_exclude` to prevent selecting descendants
+- Prevents selecting current post as own parent
+
+### 4. **Search**
+- Full search across all post fields
+- Uses WordPress REST API search parameter
+- Case-insensitive
+
+### 5. **Single Selection**
+- Only single post selection (not multiple)
+- Returns single `number` (post ID), not array
+
+## File Structure
+
+```
+packages/editor/src/components/post-picker-modal/
+├── index.tsx              # Main component
+├── types.ts               # TypeScript type definitions
+└── IMPLEMENTATION.md      # This file
+```
+
+## Related Files
+
+**Block Editor Setup:**
+- `packages/block-editor/src/store/private-keys.ts` - Symbol definition
+- `packages/block-editor/src/private-apis.js` - Symbol export
+- `packages/editor/src/components/provider/use-block-editor-settings.js` - Symbol injection
+
+**Field Integration:**
+- `packages/fields/src/fields/parent/parent-edit.tsx` - Usage in parent field
+
+## Future Enhancements
+
+1. **Parent Exclusion**: Add `parent_exclude` query parameter to prevent circular hierarchies
+   - Requires querying descendants of `excludePostId` first
+   - Can be added as a TODO for future work
+
+2. **Custom Columns**: Make field columns configurable per use case
+
+3. **Default Layout**: Support configurable default layout (grid vs table)
+
+4. **Multi-Select**: Extend to support multiple selection if needed
+
+## Implementation Notes
+
+- Uses `useEntityRecordsWithPermissions` hook for efficient data fetching
+- Respects WordPress user permissions for post types
+- Defaults to showing published posts only
+- Results ordered by title ascending for consistency

--- a/packages/editor/src/components/post-picker-modal/context.tsx
+++ b/packages/editor/src/components/post-picker-modal/context.tsx
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useState,
+	useContext,
+	useCallback,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { PostPickerParams, PostPickerState } from './types';
+
+interface PostPickerContextType {
+	state: PostPickerState;
+	openPostPicker: ( params: PostPickerParams ) => void;
+	closePostPicker: () => void;
+}
+
+const PostPickerContext = createContext< PostPickerContextType | undefined >(
+	undefined
+);
+
+export function PostPickerProvider( {
+	children,
+}: {
+	children: JSX.Element | JSX.Element[];
+} ) {
+	const [ state, setState ] = useState< PostPickerState >( {
+		isOpen: false,
+		postType: 'page',
+		onSelect: () => {},
+		excludePostId: undefined,
+		title: undefined,
+	} );
+
+	const openPostPicker = useCallback( ( params: PostPickerParams ) => {
+		setState( {
+			...params,
+			isOpen: true,
+		} );
+	}, [] );
+
+	const closePostPicker = useCallback( () => {
+		setState( ( prevState ) => ( {
+			...prevState,
+			isOpen: false,
+		} ) );
+	}, [] );
+
+	return (
+		<PostPickerContext.Provider
+			value={ { state, openPostPicker, closePostPicker } }
+		>
+			{ children }
+		</PostPickerContext.Provider>
+	);
+}
+
+export function usePostPickerContext() {
+	const context = useContext( PostPickerContext );
+	if ( ! context ) {
+		throw new Error(
+			'usePostPickerContext must be used within a PostPickerProvider'
+		);
+	}
+	return context;
+}

--- a/packages/editor/src/components/post-picker-modal/hook.ts
+++ b/packages/editor/src/components/post-picker-modal/hook.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { usePostPickerContext } from './context';
+import type { OpenPostPicker } from './types';
+
+/**
+ * Hook to get the openPostPicker function from the PostPickerProvider context.
+ *
+ * @return The openPostPicker function that can be called to open the modal
+ */
+export function useOpenPostPicker(): OpenPostPicker {
+	const { openPostPicker } = usePostPickerContext();
+	return openPostPicker;
+}
+
+export default useOpenPostPicker;

--- a/packages/editor/src/components/post-picker-modal/index.tsx
+++ b/packages/editor/src/components/post-picker-modal/index.tsx
@@ -1,0 +1,274 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import { Modal } from '@wordpress/components';
+import { DataViewsPicker } from '@wordpress/dataviews';
+import type { View, Field, ActionButton } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { PostPickerModalProps, PostData } from './types';
+import { usePostPickerContext } from './context';
+import { unlock } from '../../lock-unlock';
+import usePostFields from '../post-fields';
+
+// @ts-ignore
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+
+// Layout constants - matching the picker layout types
+const LAYOUT_PICKER_GRID = 'pickerGrid';
+const LAYOUT_PICKER_TABLE = 'pickerTable';
+
+/**
+ * PostPickerModalUI component that uses Modal and DataViewsPicker for post selection.
+ *
+ * This is the internal UI component. Use the context-based PostPickerModal wrapper instead.
+ *
+ * @param props               Component props
+ * @param props.isOpen        Whether the modal is open
+ * @param props.onClose       Function called when modal is closed
+ * @param props.onSelect      Function called when a post is selected
+ * @param props.postType      The post type slug to filter (e.g., 'page')
+ * @param props.excludePostId Optional: Post ID to exclude from results
+ * @param props.title         Optional: Custom title for the modal
+ * @return JSX element or null
+ */
+function PostPickerModalUI( {
+	isOpen,
+	onClose,
+	onSelect,
+	postType,
+	excludePostId,
+	title,
+}: PostPickerModalProps ) {
+	const [ selection, setSelection ] = useState< string[] >( [] );
+	// Initialize view with fields to display and title field configuration
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_PICKER_TABLE,
+		fields: [ 'title', 'author', 'status', 'date' ],
+		titleField: 'title',
+	} );
+
+	// Get registered fields for the post type
+	const registeredFields = usePostFields( { postType } );
+
+	// Build query args for fetching posts based on view state (pagination, search, sorting)
+	const queryArgs = useMemo( () => {
+		const args: Record< string, unknown > = {
+			per_page: view.perPage || 20,
+			page: view.page || 1,
+			status: 'publish',
+			order: view.sort?.direction || 'asc',
+			orderby: view.sort?.field || 'title',
+			// Embed author data so we can display author names
+			_embed: 'author',
+		};
+
+		// Add search if present
+		if ( view.search ) {
+			args.search = view.search;
+		}
+
+		// Exclude the current post if provided
+		if ( excludePostId ) {
+			args.exclude = [ excludePostId ];
+		}
+
+		// TODO: Consider adding parent_exclude to prevent circular hierarchies
+		// This would require fetching descendants of excludePostId first
+
+		return args;
+	}, [ view, excludePostId ] );
+
+	// Fetch posts using WordPress core data
+	const {
+		records: posts,
+		isResolving: isLoading,
+		totalItems,
+		totalPages,
+	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
+
+	// Filter fields to display in DataViewsPicker - use registered fields when available
+	// Show useful fields for identifying and selecting items: title, author, status, date
+	const fields: Field< PostData >[] = useMemo( () => {
+		if ( ! registeredFields || registeredFields.length === 0 ) {
+			// Fallback to basic fields if registration hasn't completed
+			return [
+				{
+					id: 'title',
+					type: 'text' as const,
+					label: __( 'Title' ),
+					getValue: ( { item }: { item: PostData } ) => {
+						const titleValue =
+							item.title.raw || item.title.rendered;
+						return titleValue || __( '(no title)' );
+					},
+				},
+				{
+					id: 'author',
+					type: 'text' as const,
+					label: __( 'Author' ),
+					getValue: ( { item }: { item: PostData } ) => {
+						// Fallback author display if embedded data not available
+						return (
+							item._embedded?.author?.[ 0 ]?.name ||
+							__( 'Unknown' )
+						);
+					},
+				},
+				{
+					id: 'status',
+					type: 'text' as const,
+					label: __( 'Status' ),
+					getValue: ( { item }: { item: PostData } ) => {
+						const statusMap: Record< string, string > = {
+							publish: __( 'Published' ),
+							draft: __( 'Draft' ),
+							pending: __( 'Pending' ),
+							private: __( 'Private' ),
+							future: __( 'Scheduled' ),
+							trash: __( 'Trash' ),
+						};
+						return statusMap[ item.status ] || item.status;
+					},
+				},
+				{
+					id: 'date',
+					type: 'text' as const,
+					label: __( 'Date' ),
+					getValue: ( { item }: { item: PostData } ) => {
+						if ( ! item.modified ) {
+							return '';
+						}
+						const date = new Date( item.modified );
+						return date.toLocaleDateString();
+					},
+				},
+			];
+		}
+
+		// Use registered fields and display the ones that are most useful for selection
+		// Priority: title (always), author, status, date - matches the sidebar fields
+		const fieldIdsToDisplay = [ 'title', 'author', 'status', 'date' ];
+		return registeredFields
+			.filter( ( field ) => fieldIdsToDisplay.includes( field.id ) )
+			.map( ( field ) => ( {
+				...field,
+				// Cast to PostData to align types
+			} ) ) as Field< PostData >[];
+	}, [ registeredFields ] );
+
+	// Define actions available in DataViewsPicker
+	const actions: ActionButton< PostData >[] = useMemo(
+		() => [
+			{
+				id: 'select',
+				label: __( 'Select' ),
+				isPrimary: true,
+				async callback() {
+					if ( selection.length === 0 ) {
+						return;
+					}
+
+					// Get the first selected post ID
+					const selectedPostId = parseInt( selection[ 0 ], 10 );
+
+					// Call the onSelect callback with the post ID
+					onSelect( selectedPostId );
+
+					// Clear selection but keep modal open
+					setSelection( [] );
+				},
+			},
+		],
+		[ selection, onSelect ]
+	);
+
+	const handleModalClose = useCallback( () => {
+		onClose?.();
+	}, [ onClose ] );
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems,
+			totalPages,
+		} ),
+		[ totalItems, totalPages ]
+	);
+
+	const defaultLayouts = useMemo(
+		() => ( {
+			[ LAYOUT_PICKER_GRID ]: {},
+			[ LAYOUT_PICKER_TABLE ]: {},
+		} ),
+		[]
+	);
+
+	// Generate default title based on post type
+	const defaultTitle = useMemo( () => {
+		const typeNames: Record< string, string > = {
+			page: __( 'Select Page' ),
+			post: __( 'Select Post' ),
+		};
+		return typeNames[ postType ] || __( 'Select Item' );
+	}, [ postType ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ title || defaultTitle }
+			onRequestClose={ handleModalClose }
+			isDismissible
+			size="fill"
+			overlayClassName="editor-post-picker-modal"
+		>
+			<DataViewsPicker
+				data={ posts || [] }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ defaultLayouts }
+				getItemId={ ( item: PostData ) => String( item.id ) }
+				search
+				searchLabel={ __( 'Search posts' ) }
+				itemListLabel={ __( 'Posts' ) }
+			/>
+		</Modal>
+	);
+}
+
+/**
+ * PostPickerModal component that integrates with the PostPickerProvider context.
+ * This is the main export that should be rendered within the provider.
+ */
+export function PostPickerModal() {
+	const { state, closePostPicker } = usePostPickerContext();
+
+	return (
+		<PostPickerModalUI
+			isOpen={ state.isOpen }
+			postType={ state.postType }
+			excludePostId={ state.excludePostId }
+			onSelect={ ( postId: number ) => {
+				state.onSelect( postId );
+				closePostPicker();
+			} }
+			onClose={ closePostPicker }
+			title={ state.title }
+		/>
+	);
+}
+
+export default PostPickerModal;

--- a/packages/editor/src/components/post-picker-modal/style.scss
+++ b/packages/editor/src/components/post-picker-modal/style.scss
@@ -1,0 +1,7 @@
+@use "@wordpress/base-styles/z-index" as *;
+
+// When the post picker modal is open, increase the z-index of its screen overlay
+// so it appears above popovers (which have z-index of 1000000).
+.editor-post-picker-modal {
+	z-index: z-index(".editor-post-picker-modal");
+}

--- a/packages/editor/src/components/post-picker-modal/types.ts
+++ b/packages/editor/src/components/post-picker-modal/types.ts
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import type { ReactElement } from 'react';
+
+export interface PostPickerParams {
+	/** The post type slug to filter (e.g., 'page', 'post') */
+	postType: string;
+
+	/** Called when a post is selected with the post ID */
+	onSelect: ( postId: number ) => void;
+
+	/** Optional: Post ID to exclude from results (current post) */
+	excludePostId?: number;
+
+	/** Optional: Custom modal title. Defaults to "Select {PostType}" */
+	title?: string;
+}
+
+export interface PostPickerState extends PostPickerParams {
+	/** Whether the modal is currently open */
+	isOpen: boolean;
+}
+
+export interface PostPickerModalProps {
+	/** Controls whether the modal is visible */
+	isOpen: boolean;
+
+	/** Called when the modal is closed (X button or escape key) */
+	onClose: () => void;
+
+	/** Called when a post is selected with the post ID */
+	onSelect: ( postId: number ) => void;
+
+	/** The post type slug to filter (e.g., 'page', 'post') */
+	postType: string;
+
+	/** Optional: Post ID to exclude from results (current post) */
+	excludePostId?: number;
+
+	/** Optional: Custom modal title. Defaults to "Select {PostType}" */
+	title?: string;
+}
+
+export interface PostData {
+	id: number;
+	title: {
+		raw?: string;
+		rendered?: string;
+	};
+	status: 'publish' | 'draft' | 'pending' | 'private' | 'future' | 'trash';
+	parent?: number;
+	date?: string;
+	date_gmt?: string;
+	modified?: string;
+	modified_gmt?: string;
+	slug?: string;
+	type: string;
+	link?: string;
+	_embedded?: {
+		author?: Array< {
+			id: number;
+			name: string;
+			[ key: string ]: unknown;
+		} >;
+		[ key: string ]: unknown;
+	};
+	[ key: string ]: unknown;
+}
+
+export type PostPickerModalComponent = (
+	props: PostPickerModalProps
+) => ReactElement | null;
+
+export type OpenPostPicker = ( params: PostPickerParams ) => void;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -37,6 +37,8 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
+import { PostPickerProvider } from '../post-picker-modal/context';
+import PostPickerModal from '../post-picker-modal';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -429,12 +431,15 @@ export const ExperimentalEditorProvider = withRegistryProvider(
  */
 export function EditorProvider( props ) {
 	return (
-		<ExperimentalEditorProvider
-			{ ...props }
-			BlockEditorProviderComponent={ BlockEditorProvider }
-		>
-			{ props.children }
-		</ExperimentalEditorProvider>
+		<PostPickerProvider>
+			<ExperimentalEditorProvider
+				{ ...props }
+				BlockEditorProviderComponent={ BlockEditorProvider }
+			>
+				{ props.children }
+				<PostPickerModal />
+			</ExperimentalEditorProvider>
+		</PostPickerProvider>
 	);
 }
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -27,6 +27,7 @@ import { default as mediaSideload } from '../../utils/media-sideload';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useGlobalStylesContext } from '../global-styles-provider';
+import { useOpenPostPicker } from '../post-picker-modal/hook';
 
 const EMPTY_OBJECT = {};
 
@@ -97,6 +98,7 @@ const {
 	sectionRootClientIdKey,
 	mediaEditKey,
 	getMediaSelectKey,
+	postPickerKey,
 } = unlock( privateApis );
 
 /**
@@ -110,6 +112,7 @@ const {
  * @return {Object} Block Editor Settings.
  */
 function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
+	const openPostPicker = useOpenPostPicker();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const {
 		allowRightClickOverrides,
@@ -344,6 +347,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			[ sectionRootClientIdKey ]: sectionRootClientId,
+			[ postPickerKey ]: openPostPicker,
 			editorTool:
 				renderingMode === 'post-only' && postType !== 'wp_template'
 					? 'edit'
@@ -377,6 +381,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		globalStylesLinksData,
 		renderingMode,
 		editMediaEntity,
+		openPostPicker,
 	] );
 }
 

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -18,6 +18,9 @@ import usePostFields from './components/post-fields';
 import ToolsMoreMenuGroup from './components/more-menu/tools-more-menu-group';
 import ViewMoreMenuGroup from './components/more-menu/view-more-menu-group';
 import ResizableEditor from './components/resizable-editor';
+import PostPickerModal from './components/post-picker-modal';
+import { PostPickerProvider } from './components/post-picker-modal/context';
+import { useOpenPostPicker } from './components/post-picker-modal/hook';
 import {
 	CreateTemplatePartModal,
 	patternTitleField,
@@ -48,6 +51,9 @@ lock( privateApis, {
 	ToolsMoreMenuGroup,
 	ViewMoreMenuGroup,
 	ResizableEditor,
+	PostPickerModal,
+	PostPickerProvider,
+	useOpenPostPicker,
 	registerCoreBlockBindingsSources,
 	getTemplateInfo,
 	// Global Styles

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -33,6 +33,7 @@
 @use "./components/post-last-revision/style.scss" as *;
 @use "./components/post-locked-modal/style.scss" as *;
 @use "./components/post-panel-row/style.scss" as *;
+@use "./components/post-picker-modal/style.scss" as *;
 @use "./components/post-panel-section/style.scss" as *;
 @use "./components/post-publish-panel/style.scss" as *;
 @use "./components/post-saved-state/style.scss" as *;

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -6,7 +6,7 @@ import removeAccents from 'remove-accents';
 /**
  * WordPress dependencies
  */
-import { ComboboxControl, ExternalLink } from '@wordpress/components';
+import { ComboboxControl, ExternalLink, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
 	createInterpolateElement,
@@ -16,6 +16,11 @@ import {
 } from '@wordpress/element';
 // @ts-ignore
 import { store as coreStore } from '@wordpress/core-data';
+// @ts-ignore
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 import { debounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -27,6 +32,11 @@ import { filterURLForDisplay } from '@wordpress/url';
  */
 import type { BasePost } from '../../types';
 import { getTitleWithFallbackName } from './utils';
+// @ts-ignore
+import { unlock } from '../../lock-unlock';
+
+// Get the postPickerKey symbol from block editor private APIs
+const { postPickerKey } = unlock( blockEditorPrivateApis );
 
 type TreeBase = {
 	id: number;
@@ -119,6 +129,19 @@ export function PageAttributesParent( {
 	const pageId = data.parent;
 	const postId = data.id;
 	const postTypeSlug = data.type;
+
+	// Get the openPostPicker function from block editor settings
+	const openPostPicker = useSelect( ( select ) => {
+		try {
+			// Try to get from block editor store
+			const blockEditorSettings =
+				select( blockEditorStore ).getSettings();
+			return blockEditorSettings?.[ postPickerKey ];
+		} catch ( e ) {
+			// blockEditorStore might not be available in all contexts
+		}
+		return undefined;
+	}, [] );
 
 	const { parentPostTitle, pageItems, isHierarchical } = useSelect(
 		( select ) => {
@@ -236,10 +259,6 @@ export function PageAttributesParent( {
 		} ) );
 	}, [ pageItems, fieldValue, parentPostTitle, pageId ] );
 
-	if ( ! isHierarchical ) {
-		return null;
-	}
-
 	/**
 	 * Handle user input.
 	 *
@@ -262,21 +281,56 @@ export function PageAttributesParent( {
 		onChangeControl( 0 );
 	};
 
+	const handlePostPickerSelect = useCallback(
+		( selectedPostId: number ) => {
+			onChangeControl( selectedPostId );
+		},
+		[ onChangeControl ]
+	);
+
+	if ( ! isHierarchical ) {
+		return null;
+	}
+
+	// Use PostPicker with ComboBox if available, otherwise use ComboBox alone
 	return (
-		<ComboboxControl
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-			label={ __( 'Parent' ) }
-			help={ __( 'Choose a parent page.' ) }
-			value={ pageId?.toString() }
-			options={ parentOptions }
-			onFilterValueChange={ debounce(
-				( value: unknown ) => handleKeydown( value as string ),
-				300
+		<div>
+			<ComboboxControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Parent' ) }
+				help={ __( 'Choose a parent page.' ) }
+				value={ pageId?.toString() }
+				options={ parentOptions }
+				onFilterValueChange={ debounce(
+					( value: unknown ) => handleKeydown( value as string ),
+					300
+				) }
+				onChange={ handleChange }
+				hideLabelFromVision
+			/>
+			{ openPostPicker && (
+				<Button
+					variant="secondary"
+					onClick={ () =>
+						openPostPicker( {
+							postType: postTypeSlug,
+							excludePostId: postId,
+							onSelect: handlePostPickerSelect,
+							title: sprintf(
+								/* translators: %s: post type name */
+								__( 'Select Parent %s' ),
+								postTypeSlug
+							),
+						} )
+					}
+					__next40pxDefaultSize
+					style={ { marginTop: '8px', width: '100%' } }
+				>
+					{ pageId ? __( 'Change Parent' ) : __( 'Select Parent' ) }
+				</Button>
 			) }
-			onChange={ handleChange }
-			hideLabelFromVision
-		/>
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71128

🚧 🚧 🚧 Note: this is vibe-coded proof of concept — not ready for review 🚧 🚧 🚧 

Add a PostPickerModal to the `editor` package, and make it available for use within the `parent` field (used for selecting page parents) and within the site editor.

This PR is really just to explore _how_ it could work at this stage, where it would be injected, how it could be accessed.

## To-do

* [ ] Guard behind an experiment
* [ ] Build out the defaults for fields display, etc

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it can be difficult and fiddly to select a page parent, or select a post or page in different interfaces, and the main solution I see in Gutenberg at the moment is the ComboBox, which doesn't play nicely for larger sites.

This PR currently integrates the modal into the `parent` field's popover. But it could stand on its own.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add the modal to the `editor` package
* Expose it to consumers via an `openPostPicker` function that gets injected into block editor settings (using a `postPickerKey`)
* Fields or any area that doesn't have access to the `editor` package, but _does_ have access to the block editor settings, can call this to open a post picker modal
* The `openPostPicker` function can be called with `postType`, `excludePostId`, and an `onSelect` callback (and a title prop), but this could conceivably include any of the customisation we might need for the query within the modal

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Enable the Quick Edit experiment
* Create and publish a few pages
* Open up the site editor and navigate to pages
* Within the table view, click the sidebar button to enable quick edit, and select one of the pages
* You should be able to access the big page picking modal view the `parent` field
* You should be able to search and select pages
* After selecting, you should be able to clear the selection via the Combobox
* Go to edit a page within the site editor and use the right hand sidebar to edit the `parent` field
* It should also allow you to use the modal

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f8b3d41b-375e-46ed-9186-22515ce3dda7


