### PR TITLE
Fix: long unhyphenated text overflows the container

### DIFF
--- a/packages/editor/src/components/post-author/style.scss
+++ b/packages/editor/src/components/post-author/style.scss
@@ -13,3 +13,7 @@
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
 	margin: $grid-unit-10;
 }
+
+.editor-post-author__panel-toggle {
+	word-break: break-word;
+}

--- a/packages/editor/src/components/post-template/style.scss
+++ b/packages/editor/src/components/post-template/style.scss
@@ -61,3 +61,7 @@
 .editor-post-template__classic-theme-dropdown {
 	padding: $grid-unit-10;
 }
+
+.components-dropdown-menu__toggle {
+	word-break: break-word;
+}

--- a/packages/editor/src/components/site-discussion/style.scss
+++ b/packages/editor/src/components/site-discussion/style.scss
@@ -4,3 +4,7 @@
 	min-width: 320px;
 	padding: $grid-unit-20;
 }
+
+.editor-post-discussion__panel-toggle {
+	word-break: break-word;
+}


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73707

<!-- In a few words, what is the PR actually doing? -->

## Why?
This will help fix the issue where long, unhyphenated text overflows the container in the side panel where the author’s name appears.

## Testing Instructions
To test in the post editor:
- Create a new user for your test site with a really long username with no hyphens
- Go to create a post and assign this post to that username
- See how the username can overflow the container

## Screenshots or screencast 

|Before|After|
|-|-|
| <img width="275" height="109" alt="image" src="https://github.com/user-attachments/assets/8d8d3678-6c1d-4b4a-b44e-696ce729bb12" /> | <img width="280" height="118" alt="image" src="https://github.com/user-attachments/assets/0c07b0b0-2ea3-411c-ae41-1dfe71998c2e" /> |
