### PR TITLE
Commands: Restrict editor UI commands to entity-edit context

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -455,6 +455,7 @@ export default function useCommands() {
 	useCommandLoader( {
 		name: 'core/editor/edit-ui',
 		hook: getEditorCommandLoader(),
+		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/73716

## What?

This PR makes sure that editor-related commands are only available in a `entity-edit` context.

## Why?

Otherwise, the commands are listed in places where they don't trigger any action.

## How?

Add `entity-edit` as context in the command registration.

## Testing Instructions

- Go to Site Editor > Templates.
- Engage the command palette.
- Search for show/hide.

In trunk, two commands will be listed (show/hide the settings + show/hide the block settings). The expected result is that they aren't in this branch.
