### PR TITLE
Section Styles: Handle block style variation selectors for nested block elements

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1226,7 +1226,7 @@ class WP_Theme_JSON_Gutenberg {
 
 					foreach ( $registered_styles[ $block_name ] as $block_style ) {
 						if ( ! isset( $style_selectors[ $block_style['name'] ] ) ) {
-							$block_element = $block_metadata['blockElement'] ?? null;
+							$block_element                           = $block_metadata['blockElement'] ?? null;
 							$style_selectors[ $block_style['name'] ] = static::get_block_style_variation_selector( $block_style['name'], $block_metadata['selector'], $block_element );
 						}
 					}
@@ -1274,7 +1274,7 @@ class WP_Theme_JSON_Gutenberg {
 			$style_selectors = array();
 			if ( ! empty( $block_type->styles ) ) {
 				foreach ( $block_type->styles as $style ) {
-					$block_element = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
+					$block_element                     = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
 					$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'], $block_element );
 				}
 			}
@@ -1282,7 +1282,7 @@ class WP_Theme_JSON_Gutenberg {
 			// Block style variations can be registered through the WP_Block_Styles_Registry as well as block.json.
 			$registered_styles = $style_registry->get_registered_styles_for_block( $block_name );
 			foreach ( $registered_styles as $style ) {
-				$block_element = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
+				$block_element                     = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
 				$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'], $block_element );
 			}
 
@@ -4762,7 +4762,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		// Simple approach: find the target element and add variation class after it (but before pseudo-selectors)
-		$pattern = '/(?<![a-zA-Z0-9_-])' . preg_quote( $block_element, '/' ) . '((?:\.[a-zA-Z0-9_-]+|#[a-zA-Z0-9_-]+|\[[^\]]+\])*)/';
+		$pattern     = '/(?<![a-zA-Z0-9_-])' . preg_quote( $block_element, '/' ) . '((?:\.[a-zA-Z0-9_-]+|#[a-zA-Z0-9_-]+|\[[^\]]+\])*)/';
 		$replacement = $block_element . '$1' . $variation_class;
 
 		$result = preg_replace( $pattern, $replacement, $selector_part );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1226,7 +1226,8 @@ class WP_Theme_JSON_Gutenberg {
 
 					foreach ( $registered_styles[ $block_name ] as $block_style ) {
 						if ( ! isset( $style_selectors[ $block_style['name'] ] ) ) {
-							$style_selectors[ $block_style['name'] ] = static::get_block_style_variation_selector( $block_style['name'], $block_metadata['selector'] );
+							$block_element = $block_metadata['blockElement'] ?? null;
+							$style_selectors[ $block_style['name'] ] = static::get_block_style_variation_selector( $block_style['name'], $block_metadata['selector'], $block_element );
 						}
 					}
 
@@ -1241,6 +1242,11 @@ class WP_Theme_JSON_Gutenberg {
 
 			static::$blocks_metadata[ $block_name ]['selector']  = $root_selector;
 			static::$blocks_metadata[ $block_name ]['selectors'] = static::get_block_selectors( $block_type, $root_selector );
+
+			// Extract blockElement from block type's selectors configuration if available
+			if ( isset( $block_type->selectors['blockElement'] ) && is_string( $block_type->selectors['blockElement'] ) ) {
+				static::$blocks_metadata[ $block_name ]['blockElement'] = $block_type->selectors['blockElement'];
+			}
 
 			$elements = static::get_block_element_selectors( $root_selector );
 			if ( ! empty( $elements ) ) {
@@ -1268,14 +1274,16 @@ class WP_Theme_JSON_Gutenberg {
 			$style_selectors = array();
 			if ( ! empty( $block_type->styles ) ) {
 				foreach ( $block_type->styles as $style ) {
-					$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
+					$block_element = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
+					$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'], $block_element );
 				}
 			}
 
 			// Block style variations can be registered through the WP_Block_Styles_Registry as well as block.json.
 			$registered_styles = $style_registry->get_registered_styles_for_block( $block_name );
 			foreach ( $registered_styles as $style ) {
-				$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
+				$block_element = static::$blocks_metadata[ $block_name ]['blockElement'] ?? null;
+				$style_selectors[ $style['name'] ] = static::get_block_style_variation_selector( $style['name'], static::$blocks_metadata[ $block_name ]['selector'], $block_element );
 			}
 
 			if ( ! empty( $style_selectors ) ) {
@@ -4707,34 +4715,71 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Generates a selector for a block style variation.
 	 *
-	 * @param string $variation_name Name of the block style variation.
-	 * @param string $block_selector CSS selector for the block.
+	 * @param string      $variation_name Name of the block style variation.
+	 * @param string      $block_selector CSS selector for the block.
+	 * @param string|null $block_element  Optional. The specific element within the selector that represents the block.
+	 *                                    If provided, the variation class will be added to this element instead of the first element.
 	 *
 	 * @return string Block selector with block style variation selector added to it.
 	 */
-	protected static function get_block_style_variation_selector( $variation_name, $block_selector ) {
+	protected static function get_block_style_variation_selector( $variation_name, $block_selector, $block_element = null ) {
 		$variation_class = ".is-style-$variation_name";
 
 		if ( ! $block_selector ) {
 			return $variation_class;
 		}
 
-		$limit          = 1;
 		$selector_parts = explode( ',', $block_selector );
 		$result         = array();
 
 		foreach ( $selector_parts as $part ) {
-			$result[] = preg_replace_callback(
+			$result[] = static::apply_variation_to_selector_part( trim( $part ), $variation_class, $block_element );
+		}
+
+		return implode( ', ', $result );
+	}
+
+	/**
+	 * Applies a variation class to a specific part of a CSS selector.
+	 *
+	 * @param string      $selector_part   A single CSS selector part (no commas).
+	 * @param string      $variation_class The variation class to add (e.g., ".is-style-custom").
+	 * @param string|null $block_element   Optional. The specific element to target (e.g., "li").
+	 *
+	 * @return string The modified selector part with variation class applied.
+	 */
+	private static function apply_variation_to_selector_part( $selector_part, $variation_class, $block_element ) {
+		// If no specific block element is provided, use the original logic
+		if ( ! $block_element ) {
+			return preg_replace_callback(
 				'/((?::\([^)]+\))?\s*)([^\s:]+)/',
 				function ( $matches ) use ( $variation_class ) {
 					return $matches[1] . $matches[2] . $variation_class;
 				},
-				$part,
-				$limit
+				$selector_part,
+				1
 			);
 		}
 
-		return implode( ',', $result );
+		// Simple approach: find the target element and add variation class after it (but before pseudo-selectors)
+		$pattern = '/(?<![a-zA-Z0-9_-])' . preg_quote( $block_element, '/' ) . '((?:\.[a-zA-Z0-9_-]+|#[a-zA-Z0-9_-]+|\[[^\]]+\])*)/';
+		$replacement = $block_element . '$1' . $variation_class;
+
+		$result = preg_replace( $pattern, $replacement, $selector_part );
+
+		// If no replacement was made, fall back to the original logic
+		if ( $result === $selector_part ) {
+			return preg_replace_callback(
+				'/((?::\([^)]+\))?\s*)([^\s:]+)/',
+				function ( $matches ) use ( $variation_class ) {
+					return $matches[1] . $matches[2] . $variation_class;
+				},
+				$selector_part,
+				1
+			);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5771,27 +5771,30 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_get_block_style_variation_selector
 	 *
-	 * @param string $selector  CSS selector.
-	 * @param string $expected  Expected block style variation CSS selector.
+	 * @param string      $selector      CSS selector.
+	 * @param string      $expected      Expected block style variation CSS selector.
+	 * @param string|null $block_element Optional. The specific element to target (e.g., "li" or "> li").
 	 */
-	public function test_get_block_style_variation_selector( $selector, $expected ) {
+	public function test_get_block_style_variation_selector( $selector, $expected, $block_element = null ) {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_style_variation_selector' );
 		$func->setAccessible( true );
 
-		$actual = $func->invoke( null, 'custom', $selector );
+		$actual = $func->invoke( null, 'custom', $selector, $block_element );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
 	 * Data provider for generating block style variation selectors.
+	 * Tests both standard selectors (no blockElement) and blockElement targeting.
 	 *
 	 * @return array[]
 	 */
 	public function data_get_block_style_variation_selector() {
 		return array(
+			// Standard selector tests (no blockElement parameter)
 			'empty block selector'     => array(
 				'selector' => '',
 				'expected' => '.is-style-custom',
@@ -5847,6 +5850,102 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'complex'                  => array(
 				'selector' => '.wp:where(.something):is(.test:not(.nothing p)):has(div[style]) .content, .wp:where(.nothing):not(.test:is(.something div)):has(span[style]) .inner',
 				'expected' => '.wp.is-style-custom:where(.something):is(.test:not(.nothing p)):has(div[style]) .content, .wp.is-style-custom:where(.nothing):not(.test:is(.something div)):has(span[style]) .inner',
+			),
+			'child combinator selector' => array(
+				'selector' => '.wp-block-list > li',
+				'expected' => '.wp-block-list.is-style-custom > li',
+			),
+			':not with child combinator' => array(
+				'selector' => '.wp-block-list:not(.nested) > li',
+				'expected' => '.wp-block-list.is-style-custom:not(.nested) > li',
+			),
+			'complex :not selector'    => array(
+				'selector' => '.wp-block-list:not(.wp-block-list .wp-block-list) > li',
+				'expected' => '.wp-block-list.is-style-custom:not(.wp-block-list .wp-block-list) > li',
+			),
+
+			// Element-only blockElement tests (recommended)
+			'list item basic'          => array(
+				'selector'      => '.wp-block-list > li',
+				'expected'      => '.wp-block-list > li.is-style-custom',
+				'block_element' => 'li',
+			),
+			'list item with :not'      => array(
+				'selector'      => '.wp-block-list:not(.wp-block-list .wp-block-list) > li',
+				'expected'      => '.wp-block-list:not(.wp-block-list .wp-block-list) > li.is-style-custom',
+				'block_element' => 'li',
+			),
+			'list item with classes'   => array(
+				'selector'      => '.wp-block-list > li.some-class',
+				'expected'      => '.wp-block-list > li.some-class.is-style-custom',
+				'block_element' => 'li',
+			),
+			'descendant with element'  => array(
+				'selector'      => '.wp-block-container div.content',
+				'expected'      => '.wp-block-container div.content.is-style-custom',
+				'block_element' => 'div',
+			),
+			'comma separated with element' => array(
+				'selector'      => '.wp-block-list > li, .wp-block-list > li.alternative',
+				'expected'      => '.wp-block-list > li.is-style-custom, .wp-block-list > li.alternative.is-style-custom',
+				'block_element' => 'li',
+			),
+			'element not found fallback' => array(
+				'selector'      => '.wp-block-button',
+				'expected'      => '.wp-block-button.is-style-custom',
+				'block_element' => 'span',
+			),
+			'complex nested selectors' => array(
+				'selector'      => '.wp-block-group .wp-block-list:not(.nested) > li:first-child',
+				'expected'      => '.wp-block-group .wp-block-list:not(.nested) > li.is-style-custom:first-child',
+				'block_element' => 'li',
+			),
+
+			// Combinator syntax blockElement tests (works but less semantic)
+			'basic > li combinator'     => array(
+				'selector'      => '.wp-block-list > li',
+				'expected'      => '.wp-block-list > li.is-style-custom',
+				'block_element' => '> li',
+			),
+			'> li with pseudo-selector' => array(
+				'selector'      => '.wp-block-list > li:first-child',
+				'expected'      => '.wp-block-list > li.is-style-custom:first-child',
+				'block_element' => '> li',
+			),
+			'> li with existing class'  => array(
+				'selector'      => '.wp-block-list > li.existing',
+				'expected'      => '.wp-block-list > li.existing.is-style-custom',
+				'block_element' => '> li',
+			),
+			'> li with complex selector' => array(
+				'selector'      => '.wp-block-group .wp-block-list:not(.nested) > li:first-child',
+				'expected'      => '.wp-block-group .wp-block-list:not(.nested) > li.is-style-custom:first-child',
+				'block_element' => '> li',
+			),
+			'+ span combinator'         => array(
+				'selector'      => '.wp-block-wrapper + span',
+				'expected'      => '.wp-block-wrapper + span.is-style-custom',
+				'block_element' => '+ span',
+			),
+			'~ p combinator'            => array(
+				'selector'      => '.wp-block-header ~ p.content',
+				'expected'      => '.wp-block-header ~ p.content.is-style-custom',
+				'block_element' => '~ p',
+			),
+			'multiple selectors with >' => array(
+				'selector'      => '.wp-block-list > li, .wp-block-list > li.alternative',
+				'expected'      => '.wp-block-list > li.is-style-custom, .wp-block-list > li.alternative.is-style-custom',
+				'block_element' => '> li',
+			),
+			'combinator not found (fallback)' => array(
+				'selector'      => '.wp-block-button',
+				'expected'      => '.wp-block-button.is-style-custom',
+				'block_element' => '> li',
+			),
+			'no spaces combinator >li'  => array(
+				'selector'      => '.wp-block-list>li',
+				'expected'      => '.wp-block-list>li.is-style-custom',
+				'block_element' => '>li',
 			),
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5795,144 +5795,144 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	public function data_get_block_style_variation_selector() {
 		return array(
 			// Standard selector tests (no blockElement parameter)
-			'empty block selector'     => array(
+			'empty block selector'            => array(
 				'selector' => '',
 				'expected' => '.is-style-custom',
 			),
-			'class selector'           => array(
+			'class selector'                  => array(
 				'selector' => '.wp-block',
 				'expected' => '.wp-block.is-style-custom',
 			),
-			'id selector'              => array(
+			'id selector'                     => array(
 				'selector' => '#wp-block',
 				'expected' => '#wp-block.is-style-custom',
 			),
-			'element tag selector'     => array(
+			'element tag selector'            => array(
 				'selector' => 'p',
 				'expected' => 'p.is-style-custom',
 			),
-			'attribute selector'       => array(
+			'attribute selector'              => array(
 				'selector' => '[style*="color"]',
 				'expected' => '[style*="color"].is-style-custom',
 			),
-			'descendant selector'      => array(
+			'descendant selector'             => array(
 				'selector' => '.wp-block .inner',
 				'expected' => '.wp-block.is-style-custom .inner',
 			),
-			'comma separated selector' => array(
+			'comma separated selector'        => array(
 				'selector' => '.wp-block .inner, .wp-block .alternative',
 				'expected' => '.wp-block.is-style-custom .inner, .wp-block.is-style-custom .alternative',
 			),
-			'pseudo selector'          => array(
+			'pseudo selector'                 => array(
 				'selector' => 'div:first-child',
 				'expected' => 'div.is-style-custom:first-child',
 			),
-			':is selector'             => array(
+			':is selector'                    => array(
 				'selector' => '.wp-block:is(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:is(.outer .inner:first-child)',
 			),
-			':not selector'            => array(
+			':not selector'                   => array(
 				'selector' => '.wp-block:not(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:not(.outer .inner:first-child)',
 			),
-			':has selector'            => array(
+			':has selector'                   => array(
 				'selector' => '.wp-block:has(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:has(.outer .inner:first-child)',
 			),
-			':where selector'          => array(
+			':where selector'                 => array(
 				'selector' => '.wp-block:where(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:where(.outer .inner:first-child)',
 			),
-			'wrapping :where selector' => array(
+			'wrapping :where selector'        => array(
 				'selector' => ':where(.outer .inner:first-child)',
 				'expected' => ':where(.outer.is-style-custom .inner:first-child)',
 			),
-			'complex'                  => array(
+			'complex'                         => array(
 				'selector' => '.wp:where(.something):is(.test:not(.nothing p)):has(div[style]) .content, .wp:where(.nothing):not(.test:is(.something div)):has(span[style]) .inner',
 				'expected' => '.wp.is-style-custom:where(.something):is(.test:not(.nothing p)):has(div[style]) .content, .wp.is-style-custom:where(.nothing):not(.test:is(.something div)):has(span[style]) .inner',
 			),
-			'child combinator selector' => array(
+			'child combinator selector'       => array(
 				'selector' => '.wp-block-list > li',
 				'expected' => '.wp-block-list.is-style-custom > li',
 			),
-			':not with child combinator' => array(
+			':not with child combinator'      => array(
 				'selector' => '.wp-block-list:not(.nested) > li',
 				'expected' => '.wp-block-list.is-style-custom:not(.nested) > li',
 			),
-			'complex :not selector'    => array(
+			'complex :not selector'           => array(
 				'selector' => '.wp-block-list:not(.wp-block-list .wp-block-list) > li',
 				'expected' => '.wp-block-list.is-style-custom:not(.wp-block-list .wp-block-list) > li',
 			),
 
 			// Element-only blockElement tests (recommended)
-			'list item basic'          => array(
+			'list item basic'                 => array(
 				'selector'      => '.wp-block-list > li',
 				'expected'      => '.wp-block-list > li.is-style-custom',
 				'block_element' => 'li',
 			),
-			'list item with :not'      => array(
+			'list item with :not'             => array(
 				'selector'      => '.wp-block-list:not(.wp-block-list .wp-block-list) > li',
 				'expected'      => '.wp-block-list:not(.wp-block-list .wp-block-list) > li.is-style-custom',
 				'block_element' => 'li',
 			),
-			'list item with classes'   => array(
+			'list item with classes'          => array(
 				'selector'      => '.wp-block-list > li.some-class',
 				'expected'      => '.wp-block-list > li.some-class.is-style-custom',
 				'block_element' => 'li',
 			),
-			'descendant with element'  => array(
+			'descendant with element'         => array(
 				'selector'      => '.wp-block-container div.content',
 				'expected'      => '.wp-block-container div.content.is-style-custom',
 				'block_element' => 'div',
 			),
-			'comma separated with element' => array(
+			'comma separated with element'    => array(
 				'selector'      => '.wp-block-list > li, .wp-block-list > li.alternative',
 				'expected'      => '.wp-block-list > li.is-style-custom, .wp-block-list > li.alternative.is-style-custom',
 				'block_element' => 'li',
 			),
-			'element not found fallback' => array(
+			'element not found fallback'      => array(
 				'selector'      => '.wp-block-button',
 				'expected'      => '.wp-block-button.is-style-custom',
 				'block_element' => 'span',
 			),
-			'complex nested selectors' => array(
+			'complex nested selectors'        => array(
 				'selector'      => '.wp-block-group .wp-block-list:not(.nested) > li:first-child',
 				'expected'      => '.wp-block-group .wp-block-list:not(.nested) > li.is-style-custom:first-child',
 				'block_element' => 'li',
 			),
 
 			// Combinator syntax blockElement tests (works but less semantic)
-			'basic > li combinator'     => array(
+			'basic > li combinator'           => array(
 				'selector'      => '.wp-block-list > li',
 				'expected'      => '.wp-block-list > li.is-style-custom',
 				'block_element' => '> li',
 			),
-			'> li with pseudo-selector' => array(
+			'> li with pseudo-selector'       => array(
 				'selector'      => '.wp-block-list > li:first-child',
 				'expected'      => '.wp-block-list > li.is-style-custom:first-child',
 				'block_element' => '> li',
 			),
-			'> li with existing class'  => array(
+			'> li with existing class'        => array(
 				'selector'      => '.wp-block-list > li.existing',
 				'expected'      => '.wp-block-list > li.existing.is-style-custom',
 				'block_element' => '> li',
 			),
-			'> li with complex selector' => array(
+			'> li with complex selector'      => array(
 				'selector'      => '.wp-block-group .wp-block-list:not(.nested) > li:first-child',
 				'expected'      => '.wp-block-group .wp-block-list:not(.nested) > li.is-style-custom:first-child',
 				'block_element' => '> li',
 			),
-			'+ span combinator'         => array(
+			'+ span combinator'               => array(
 				'selector'      => '.wp-block-wrapper + span',
 				'expected'      => '.wp-block-wrapper + span.is-style-custom',
 				'block_element' => '+ span',
 			),
-			'~ p combinator'            => array(
+			'~ p combinator'                  => array(
 				'selector'      => '.wp-block-header ~ p.content',
 				'expected'      => '.wp-block-header ~ p.content.is-style-custom',
 				'block_element' => '~ p',
 			),
-			'multiple selectors with >' => array(
+			'multiple selectors with >'       => array(
 				'selector'      => '.wp-block-list > li, .wp-block-list > li.alternative',
 				'expected'      => '.wp-block-list > li.is-style-custom, .wp-block-list > li.alternative.is-style-custom',
 				'block_element' => '> li',
@@ -5942,7 +5942,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected'      => '.wp-block-button.is-style-custom',
 				'block_element' => '> li',
 			),
-			'no spaces combinator >li'  => array(
+			'no spaces combinator >li'        => array(
 				'selector'      => '.wp-block-list>li',
 				'expected'      => '.wp-block-list>li.is-style-custom',
 				'block_element' => '>li',


### PR DESCRIPTION
> [!CAUTION]
> This is a test branch to illustrate an idea mentioned in https://github.com/WordPress/gutenberg/issues/73527#issuecomment-3604653034



## What?

Closes https://github.com/WordPress/gutenberg/issues/73527

Fixes the block style variation selector generation for blocks using base selectors that target an element within a parent block rather than itself directly.

## Why?

Allows blocks like the ListItem block that use custom selectors involving a parent class and child combinator to create the correct block style variation class.

## How?

• Added optional `$block_element` parameter to `get_block_style_variation_selector()`
• New logic to apply variation classes to specific elements (e.g., `li` in `.wp-block-list > li`)
• Automatically extracts `blockElement` from block's selectors configuration
• Clean regex-based approach for element targeting with fallback to original behavior
• Modified all calls to pass `blockElement` from block metadata when available  
• Added test cases for element-only syntax (`"li"`) and combinator syntax (`"> li"`)
• Block style variations now correctly target `.wp-block-list > li.is-style-custom` instead of `.wp-block-list.is-style-custom > li`
• Existing blocks work unchanged, new functionality requires explicit `blockElement` configuration

## Testing Instructions

Use the instructions in https://github.com/WordPress/gutenberg/issues/73527 to test
