### PR TITLE
Font Library: Restore correct style

### DIFF
--- a/packages/global-styles-ui/src/font-library-modal/style.scss
+++ b/packages/global-styles-ui/src/font-library-modal/style.scss
@@ -68,10 +68,6 @@ $footer-height: 70px;
 	background-color: colors.$white;
 }
 
-.font-library-modal__category-select {
-	min-width: 40%;
-}
-
 .font-library-modal__page-selection {
 	font-size: 11px;
 	font-weight: variables.$font-weight-medium;
@@ -115,10 +111,12 @@ $footer-height: 70px;
 	padding: variables.$grid-unit-20;
 	margin-top: -1px; /* To collapse the margin with the previous element */
 
-	background-color: colors.$gray-100;
-
 	&:hover {
 		background-color: colors.$gray-100;
+	}
+
+	&:focus {
+		position: relative;
 	}
 
 	.font-library-modal__font-card__name {


### PR DESCRIPTION
- Follow-up #72599
- Part of #73715

## What?

This PR fixes the following two problems occurring in the Font Library:

- Font item button has a gray background
- The focus outline is cut off

## Why?

When the Font library was moved to the Global Styles UI package, some styles were incorrect.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
| <img width="894" height="852" alt="image" src="https://github.com/user-attachments/assets/4060fb16-bcf4-46eb-acf1-bc76fab3bc53" /> | <img width="914" height="854" alt="image" src="https://github.com/user-attachments/assets/863bb3dd-4f7b-4cf0-886f-eb37a8ceea99" /> |