### PR TITLE
Global Styles: Fix 'useSelect' warning

### DIFF
--- a/packages/global-styles-ui/src/screen-revisions/use-global-styles-revisions.tsx
+++ b/packages/global-styles-ui/src/screen-revisions/use-global-styles-revisions.tsx
@@ -41,7 +41,7 @@ const SITE_EDITOR_AUTHORS_QUERY = {
 	capabilities: [ 'edit_theme_options' ],
 };
 const DEFAULT_QUERY = { per_page: 100, page: 1 };
-const EMPTY_ARRAY: RawRevision[] = [];
+const EMPTY_ARRAY: [] = [];
 
 export default function useGlobalStylesRevisions( {
 	query,
@@ -96,7 +96,7 @@ export default function useGlobalStylesRevisions( {
 				: EMPTY_ARRAY;
 			// @ts-expect-error - getUsers is not fully typed
 			const _authors: User[] =
-				getUsers( SITE_EDITOR_AUTHORS_QUERY ) || [];
+				getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
 			const _isResolving = globalStylesId
 				? isResolving( 'getRevisions', [
 						'root',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a follow-up to #72599.

PR fixes the `useSelect` warning in `useGlobalStylesRevisions` hook.

## Testing Instructions
1. Navigate to Site Editor > Styles
2. Confirm that the mentioned warning is no longer displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="900" height="521" alt="CleanShot 2025-12-03 at 20 57 01" src="https://github.com/user-attachments/assets/88ce3b95-f381-4ceb-bc25-3510964112ad" />
