### PR TITLE
DataViews: Apply primary style to first column if there is no title field

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)
+- DataViews: Apply primary style to first column if there is no title field. [#73729](https://github.com/WordPress/gutenberg/pull/73729)
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -405,7 +405,7 @@ function ViewTable< Item >( {
 						<col className="dataviews-view-table__col-checkbox" />
 					) }
 					{ hasPrimaryColumn && (
-						<col className="dataviews-view-table__col-primary" />
+						<col className="dataviews-view-table__col-first-data" />
 					) }
 					{ columns.map( ( column, index ) => (
 						<col
@@ -413,7 +413,7 @@ function ViewTable< Item >( {
 							className={ clsx(
 								`dataviews-view-table__col-${ column }`,
 								{
-									'dataviews-view-table__col-primary':
+									'dataviews-view-table__col-first-data':
 										! hasPrimaryColumn && index === 0,
 								}
 							) }

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -407,10 +407,16 @@ function ViewTable< Item >( {
 					{ hasPrimaryColumn && (
 						<col className="dataviews-view-table__col-primary" />
 					) }
-					{ columns.map( ( column ) => (
+					{ columns.map( ( column, index ) => (
 						<col
 							key={ `col-${ column }` }
-							className={ `dataviews-view-table__col-${ column }` }
+							className={ clsx(
+								`dataviews-view-table__col-${ column }`,
+								{
+									'dataviews-view-table__col-primary':
+										! hasPrimaryColumn && index === 0,
+								}
+							) }
 						/>
 					) ) }
 					{ !! actions?.length && (

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -322,6 +322,6 @@
 }
 
 /* Column width intents via colgroup: make non-primary columns shrink-to-fit */
-.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-primary) {
+.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-first-data) {
 	width: 1%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73727 

Applies the `dataviews-view-table__col-primary` class to the first column when `hasPrimaryColumn` is false as fallback.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When there is no `titleField` all columns are spaced, leaving unintended gaps in the table as it is assumed that the title field will be there to expand.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By applying the same class of the title field to the first column if there is no title field, guaranteeing there will always be an expanding column.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Easiest way is to use Storybook.
1. Start Storybook with `npm run storybook:dev` (or, separately, `npm run dev`, wait until done and then `storybook dev -c ./storybook -p 50240 --ci` if there is any issue with spawning browsers)
2. Go to Dataviews > Default
3. Click on the gear icon to open the table options
4. Remove "Title", "Image" and "Description"
5. Check that spacing is correct

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1098" height="324" alt="Screenshot from 2025-12-03 16-30-12" src="https://github.com/user-attachments/assets/62123c48-4e3a-4e35-a47b-21d7f3c52a0b" />|<img width="1098" height="324" alt="Screenshot from 2025-12-03 16-31-09" src="https://github.com/user-attachments/assets/aa1197f1-aee7-4e95-bf28-302784345645" />|
