### PR TITLE
Button: Migrate to text-align block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -102,8 +102,8 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, type, url, width
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
 
 ## Buttons
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -18,9 +18,6 @@
 			"type": "string",
 			"default": "button"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"url": {
 			"type": "string",
 			"source": "attribute",
@@ -88,6 +85,7 @@
 			"__experimentalSkipSerialization": [
 				"fontSize",
 				"lineHeight",
+				"textAlign",
 				"fontFamily",
 				"fontWeight",
 				"fontStyle",
@@ -97,6 +95,7 @@
 			],
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -34,7 +34,6 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import {
-	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	RichText,
@@ -186,7 +185,6 @@ function ButtonEdit( props ) {
 	} = props;
 	const {
 		tagName,
-		textAlign,
 		linkTarget,
 		placeholder,
 		rel,
@@ -361,7 +359,6 @@ function ButtonEdit( props ) {
 						borderProps.className,
 						typographyProps.className,
 						{
-							[ `has-text-align-${ textAlign }` ]: textAlign,
 							// For backwards compatibility add style that isn't
 							// provided via block support.
 							'no-border-radius': style?.border?.radius === 0,
@@ -385,14 +382,6 @@ function ButtonEdit( props ) {
 			</div>
 			{ hasBlockControls && (
 				<BlockControls group="block">
-					{ hasNonContentControls && (
-						<AlignmentControl
-							value={ textAlign }
-							onChange={ ( nextAlign ) => {
-								setAttributes( { textAlign: nextAlign } );
-							} }
-						/>
-					) }
 					{ isLinkTag && ! lockUrlControls && (
 						<ToolbarButton
 							name="link"

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -11,6 +11,7 @@ import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { unlock } from '../lock-unlock';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 /**
  * WordPress dependencies
@@ -194,6 +195,7 @@ function ButtonEdit( props ) {
 		width,
 		metadata,
 	} = attributes;
+	useDeprecatedTextAlign( props );
 
 	const TagName = tagName || 'a';
 

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -21,7 +21,6 @@ export default function save( { attributes, className } ) {
 	const {
 		tagName,
 		type,
-		textAlign,
 		fontSize,
 		linkTarget,
 		rel,
@@ -46,7 +45,6 @@ export default function save( { attributes, className } ) {
 		borderProps.className,
 		typographyProps.className,
 		{
-			[ `has-text-align-${ textAlign }` ]: textAlign,
 			// For backwards compatibility add style that isn't provided via
 			// block support.
 			'no-border-radius': style?.border?.radius === 0,

--- a/packages/block-library/src/utils/deprecated-text-align-attributes.js
+++ b/packages/block-library/src/utils/deprecated-text-align-attributes.js
@@ -15,7 +15,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 export default function useDeprecatedTextAlign( props ) {
 	const { name, attributes, setAttributes } = props;
-	const { textAlign, style } = attributes;
+	const { textAlign } = attributes;
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const updateStyleWithAlign = useEvent( () => {
@@ -24,15 +24,15 @@ export default function useDeprecatedTextAlign( props ) {
 			since: '7.0',
 		} );
 		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( {
+		setAttributes( ( currentAttr ) => ( {
 			style: {
-				...style,
+				...currentAttr.style,
 				typography: {
-					...style?.typography,
+					...currentAttr.style?.typography,
 					textAlign,
 				},
 			},
-		} );
+		} ) );
 	} );
 	const lastUpdatedAlignRef = useRef();
 	useEffect( () => {

--- a/packages/block-library/src/utils/deprecated-text-align-attributes.js
+++ b/packages/block-library/src/utils/deprecated-text-align-attributes.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useEvent } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * If a plugin is still using the old textAlign attribute, we need to migrate its value
+ * to the new style.typography.textAlign attribute.
+ *
+ * @param {Object} props Block props.
+ */
+export default function useDeprecatedTextAlign( props ) {
+	const { name, attributes, setAttributes } = props;
+	const { textAlign, style } = attributes;
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+	const updateStyleWithAlign = useEvent( () => {
+		deprecated( `textAlign attribute in ${ name }`, {
+			alternative: 'style.typography.textAlign',
+			since: '7.0',
+		} );
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( {
+			style: {
+				...style,
+				typography: {
+					...style?.typography,
+					textAlign,
+				},
+			},
+		} );
+	} );
+	const lastUpdatedAlignRef = useRef();
+	useEffect( () => {
+		if ( textAlign === lastUpdatedAlignRef.current ) {
+			return;
+		}
+		lastUpdatedAlignRef.current = textAlign;
+		updateStyleWithAlign();
+	}, [ textAlign, updateStyleWithAlign ] );
+}

--- a/packages/block-library/src/utils/migrate-text-align.js
+++ b/packages/block-library/src/utils/migrate-text-align.js
@@ -1,0 +1,22 @@
+/**
+ * Migrates the current textAlign attribute,
+ *
+ * @param {Object} attributes The current attributes
+ * @return {Object} The updated attributes.
+ */
+export default function ( attributes ) {
+	const { textAlign, ...restAttributes } = attributes;
+	if ( ! textAlign ) {
+		return attributes;
+	}
+	return {
+		...restAttributes,
+		style: {
+			...attributes.style,
+			typography: {
+				...attributes.style?.typography,
+				textAlign,
+			},
+		},
+	};
+}

--- a/test/integration/fixtures/blocks/core__button__deprecated-v13.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v13.html
@@ -1,0 +1,11 @@
+<!-- wp:button {"textAlign":"left"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-left wp-element-button">My button 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"textAlign":"center"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button">My button 2</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"textAlign":"right"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-right wp-element-button">My button 3</a></div>
+<!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v13.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v13.json
@@ -1,0 +1,47 @@
+[
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 1",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 2",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 3",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v13.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v13.parsed.json
@@ -1,0 +1,49 @@
+[
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-left wp-element-button\">My button 1</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-left wp-element-button\">My button 1</a></div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-center wp-element-button\">My button 2</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-center wp-element-button\">My button 2</a></div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-right wp-element-button\">My button 3</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-text-align-right wp-element-button\">My button 3</a></div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v13.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v13.serialized.html
@@ -1,0 +1,11 @@
+<!-- wp:button {"style":{"typography":{"textAlign":"left"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-left wp-element-button">My button 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"textAlign":"center"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button">My button 2</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"textAlign":"right"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-text-align-right wp-element-button">My button 3</a></div>
+<!-- /wp:button -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763
Related to #73111

<!-- In a few words, what is the PR actually doing? -->
Migrates the Button block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the Button block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Button block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized Button block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

Just like `migrateFontFamily`, I created the `migrateTextAlign` function so that it can be used in other blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new Button block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing Button blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

