### PR TITLE
ContentOnly: For template parts and synced patterns, ensure 'Edit section' button goes to the isolated editor

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -3,11 +3,14 @@
  */
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
+import { store as blockEditorStore } from '../../store';
 
 export default function EditContents( { clientId } ) {
 	const {
@@ -18,9 +21,58 @@ export default function EditContents( { clientId } ) {
 		stopEditingContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
 
+	const { block, onNavigateToEntityRecord } = useSelect(
+		( select ) => {
+			const { getBlock, getSettings } = select( blockEditorStore );
+			return {
+				block: getBlock( clientId ),
+				onNavigateToEntityRecord:
+					getSettings().onNavigateToEntityRecord,
+			};
+		},
+		[ clientId ]
+	);
+
 	if ( ! isWithinSection && ! isWithinEditedSection ) {
 		return null;
 	}
+
+	const blockAttributes = block?.attributes || {};
+
+	// Synced patterns and template parts should navigate to the isolated editor
+	const isSyncedPattern = isReusableBlock( block );
+	const isTemplatePartBlock = isTemplatePart( block );
+	const shouldNavigateToIsolatedEditor =
+		( isSyncedPattern || isTemplatePartBlock ) && onNavigateToEntityRecord;
+
+	const handleClick = () => {
+		if ( ! editedContentOnlySection ) {
+			if ( shouldNavigateToIsolatedEditor ) {
+				// Navigate to isolated editor for synced patterns and template parts
+				if ( isSyncedPattern ) {
+					onNavigateToEntityRecord( {
+						postId: blockAttributes.ref,
+						postType: 'wp_block',
+					} );
+				} else if ( isTemplatePartBlock ) {
+					const { theme, slug } = blockAttributes;
+					const templatePartId =
+						theme && slug ? `${ theme }//${ slug }` : null;
+					if ( templatePartId ) {
+						onNavigateToEntityRecord( {
+							postId: templatePartId,
+							postType: 'wp_template_part',
+						} );
+					}
+				}
+			} else {
+				// Use spotlight mode for unsynced patterns
+				editContentOnlySection( clientId );
+			}
+		} else {
+			stopEditingContentOnlySection();
+		}
+	};
 
 	return (
 		<VStack className="block-editor-block-inspector-edit-contents" expanded>
@@ -28,13 +80,7 @@ export default function EditContents( { clientId } ) {
 				className="block-editor-block-inspector-edit-contents__button"
 				__next40pxDefaultSize
 				variant="secondary"
-				onClick={ () => {
-					if ( ! editedContentOnlySection ) {
-						editContentOnlySection( clientId );
-					} else {
-						stopEditingContentOnlySection();
-					}
-				} }
+				onClick={ handleClick }
 			>
 				{ editedContentOnlySection
 					? __( 'Exit section' )

--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -12,6 +12,77 @@ import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
 import { store as blockEditorStore } from '../../store';
 
+function IsolatedEditButton( {
+	block,
+	onNavigateToEntityRecord,
+	isSyncedPattern,
+	isTemplatePartBlock,
+} ) {
+	const blockAttributes = block?.attributes || {};
+
+	const handleClick = () => {
+		if ( isSyncedPattern ) {
+			onNavigateToEntityRecord( {
+				postId: blockAttributes.ref,
+				postType: 'wp_block',
+			} );
+		} else if ( isTemplatePartBlock ) {
+			const { theme, slug } = blockAttributes;
+			const templatePartId =
+				theme && slug ? `${ theme }//${ slug }` : null;
+			if ( templatePartId ) {
+				onNavigateToEntityRecord( {
+					postId: templatePartId,
+					postType: 'wp_template_part',
+				} );
+			}
+		}
+	};
+
+	return (
+		<VStack className="block-editor-block-inspector-edit-contents" expanded>
+			<Button
+				className="block-editor-block-inspector-edit-contents__button"
+				__next40pxDefaultSize
+				variant="secondary"
+				onClick={ handleClick }
+			>
+				{ __( 'Edit section' ) }
+			</Button>
+		</VStack>
+	);
+}
+
+function InlineEditButton( {
+	clientId,
+	editedContentOnlySection,
+	editContentOnlySection,
+	stopEditingContentOnlySection,
+} ) {
+	const handleClick = () => {
+		if ( ! editedContentOnlySection ) {
+			editContentOnlySection( clientId );
+		} else {
+			stopEditingContentOnlySection();
+		}
+	};
+
+	return (
+		<VStack className="block-editor-block-inspector-edit-contents" expanded>
+			<Button
+				className="block-editor-block-inspector-edit-contents__button"
+				__next40pxDefaultSize
+				variant="secondary"
+				onClick={ handleClick }
+			>
+				{ editedContentOnlySection
+					? __( 'Exit section' )
+					: __( 'Edit section' ) }
+			</Button>
+		</VStack>
+	);
+}
+
 export default function EditContents( { clientId } ) {
 	const {
 		isWithinSection,
@@ -37,55 +108,28 @@ export default function EditContents( { clientId } ) {
 		return null;
 	}
 
-	const blockAttributes = block?.attributes || {};
-
-	// Synced patterns and template parts should navigate to the isolated editor
 	const isSyncedPattern = isReusableBlock( block );
 	const isTemplatePartBlock = isTemplatePart( block );
-	const shouldNavigateToIsolatedEditor =
+	const shouldUseIsolatedEditor =
 		( isSyncedPattern || isTemplatePartBlock ) && onNavigateToEntityRecord;
 
-	const handleClick = () => {
-		if ( ! editedContentOnlySection ) {
-			if ( shouldNavigateToIsolatedEditor ) {
-				// Navigate to isolated editor for synced patterns and template parts
-				if ( isSyncedPattern ) {
-					onNavigateToEntityRecord( {
-						postId: blockAttributes.ref,
-						postType: 'wp_block',
-					} );
-				} else if ( isTemplatePartBlock ) {
-					const { theme, slug } = blockAttributes;
-					const templatePartId =
-						theme && slug ? `${ theme }//${ slug }` : null;
-					if ( templatePartId ) {
-						onNavigateToEntityRecord( {
-							postId: templatePartId,
-							postType: 'wp_template_part',
-						} );
-					}
-				}
-			} else {
-				// Use spotlight mode for unsynced patterns
-				editContentOnlySection( clientId );
-			}
-		} else {
-			stopEditingContentOnlySection();
-		}
-	};
+	if ( shouldUseIsolatedEditor ) {
+		return (
+			<IsolatedEditButton
+				block={ block }
+				onNavigateToEntityRecord={ onNavigateToEntityRecord }
+				isSyncedPattern={ isSyncedPattern }
+				isTemplatePartBlock={ isTemplatePartBlock }
+			/>
+		);
+	}
 
 	return (
-		<VStack className="block-editor-block-inspector-edit-contents" expanded>
-			<Button
-				className="block-editor-block-inspector-edit-contents__button"
-				__next40pxDefaultSize
-				variant="secondary"
-				onClick={ handleClick }
-			>
-				{ editedContentOnlySection
-					? __( 'Exit section' )
-					: __( 'Edit section' ) }
-			</Button>
-		</VStack>
+		<InlineEditButton
+			clientId={ clientId }
+			editedContentOnlySection={ editedContentOnlySection }
+			editContentOnlySection={ editContentOnlySection }
+			stopEditingContentOnlySection={ stopEditingContentOnlySection }
+		/>
 	);
 }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -320,6 +320,10 @@ const BlockInspectorSingleBlock = ( {
 	hasBlockStyles,
 	editedContentOnlySection,
 } ) => {
+	const selectedBlockClientId = useSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( blockEditorStore );
+		return getSelectedBlockClientId();
+	}, [] );
 	const hasMultipleTabs = availableTabs?.length > 1;
 	const hasParentChildBlockCards =
 		window?.__experimentalContentOnlyPatternInsertion &&
@@ -331,6 +335,9 @@ const BlockInspectorSingleBlock = ( {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const isBlockSynced = blockInformation.isSynced;
 	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
+	const isSectionBlockSelected =
+		window?.__experimentalContentOnlyPatternInsertion &&
+		selectedBlockClientId === clientId;
 
 	return (
 		<div className="block-editor-block-inspector">
@@ -377,13 +384,15 @@ const BlockInspectorSingleBlock = ( {
 							showListControls
 						/>
 					) }
-					{ isSectionBlock && isBlockSynced && (
-						<>
-							<InspectorControls.Slot />
-							{ /* Allow AdvancedControls so users can adjust local attributes (e.g. additional CSS classes, HTML element). */ }
-							<AdvancedControls />
-						</>
-					) }
+					{ isSectionBlock &&
+						isBlockSynced &&
+						isSectionBlockSelected && (
+							<>
+								<InspectorControls.Slot />
+								{ /* Allow AdvancedControls so users can adjust local attributes (e.g. additional CSS classes, HTML element). */ }
+								<AdvancedControls />
+							</>
+						) }
 				</>
 			) }
 			<SkipToSelectedBlock key="back" />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -377,6 +377,13 @@ const BlockInspectorSingleBlock = ( {
 							showListControls
 						/>
 					) }
+					{ isSectionBlock && isBlockSynced && (
+						<>
+							<InspectorControls.Slot />
+							{ /* Allow AdvancedControls so users can adjust local attributes (e.g. additional CSS classes, HTML element). */ }
+							<AdvancedControls />
+						</>
+					) }
 				</>
 			) }
 			<SkipToSelectedBlock key="back" />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -86,8 +86,9 @@ function StyleInspectorSlots( {
 function BlockInspector() {
 	const {
 		selectedBlockCount,
-		selectedBlockName,
 		selectedBlockClientId,
+		renderedBlockName,
+		renderedBlockClientId,
 		blockType,
 		isSectionBlock,
 		isSectionBlockInSelection,
@@ -109,29 +110,30 @@ function BlockInspector() {
 		const isWithinEditedSection = isWithinEditedContentOnlySection(
 			_selectedBlockClientId
 		);
-		const renderedBlockClientId = isWithinEditedSection
+		const _renderedBlockClientId = isWithinEditedSection
 			? _selectedBlockClientId
 			: getParentSectionBlock( _selectedBlockClientId ) ||
 			  _selectedBlockClientId;
-		const _selectedBlockName =
-			renderedBlockClientId && getBlockName( renderedBlockClientId );
+		const _renderedBlockName =
+			_renderedBlockClientId && getBlockName( _renderedBlockClientId );
 		const _blockType =
-			_selectedBlockName && getBlockType( _selectedBlockName );
+			_renderedBlockName && getBlockType( _renderedBlockName );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const _isSectionBlockInSelection = selectedBlockClientIds.some(
 			( id ) => _isSectionBlock( id )
 		);
 		const blockStyles =
-			_selectedBlockName && getBlockStyles( _selectedBlockName );
+			_renderedBlockName && getBlockStyles( _renderedBlockName );
 		const _hasBlockStyles = blockStyles && blockStyles.length > 0;
 
 		return {
 			selectedBlockCount: getSelectedBlockCount(),
-			selectedBlockClientId: renderedBlockClientId,
-			selectedBlockName: _selectedBlockName,
+			selectedBlockClientId: _selectedBlockClientId,
+			renderedBlockClientId: _renderedBlockClientId,
+			renderedBlockName: _renderedBlockName,
 			blockType: _blockType,
 			isSectionBlockInSelection: _isSectionBlockInSelection,
-			isSectionBlock: _isSectionBlock( renderedBlockClientId ),
+			isSectionBlock: _isSectionBlock( _renderedBlockClientId ),
 			hasBlockStyles: _hasBlockStyles,
 			editedContentOnlySection: getEditedContentOnlySection(),
 		};
@@ -140,7 +142,7 @@ function BlockInspector() {
 	// Separate useSelect for contentClientIds with proper dependencies
 	const contentClientIds = useSelect(
 		( select ) => {
-			if ( ! isSectionBlock || ! selectedBlockClientId ) {
+			if ( ! isSectionBlock || ! renderedBlockClientId ) {
 				return [];
 			}
 
@@ -151,7 +153,7 @@ function BlockInspector() {
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
-				selectedBlockClientId
+				renderedBlockClientId
 			);
 
 			// Temporary workaround for issue #71991
@@ -182,7 +184,7 @@ function BlockInspector() {
 				);
 			} );
 		},
-		[ isSectionBlock, selectedBlockClientId ]
+		[ isSectionBlock, renderedBlockClientId ]
 	);
 
 	const availableTabs = useInspectorControlsTabs(
@@ -212,7 +214,7 @@ function BlockInspector() {
 					<InspectorControlsTabs tabs={ availableTabs } />
 				) : (
 					<StyleInspectorSlots
-						blockName={ selectedBlockName }
+						blockName={ renderedBlockName }
 						showAdvancedControls={ false }
 						showPositionControls={ false }
 						showBindingsControls={ false }
@@ -230,15 +232,15 @@ function BlockInspector() {
 		);
 	}
 
-	const isSelectedBlockUnregistered =
-		selectedBlockName === getUnregisteredTypeHandlerName();
+	const isRenderedBlockUnregistered =
+		renderedBlockName === getUnregisteredTypeHandlerName();
 
 	/*
-	 * If the selected block is of an unregistered type, avoid showing it as an actual selection
+	 * If the rendered block is of an unregistered type, avoid showing it as an actual selection
 	 * because we want the user to focus on the unregistered block warning, not block settings.
 	 */
 	const shouldShowWarning =
-		! blockType || ! selectedBlockClientId || isSelectedBlockUnregistered;
+		! blockType || ! renderedBlockClientId || isRenderedBlockUnregistered;
 
 	if ( shouldShowWarning ) {
 		return (
@@ -256,14 +258,15 @@ function BlockInspector() {
 					blockInspectorAnimationSettings={
 						blockInspectorAnimationSettings
 					}
-					selectedBlockClientId={ selectedBlockClientId }
+					renderedBlockClientId={ renderedBlockClientId }
 				>
 					{ children }
 				</AnimatedContainer>
 			) }
 		>
 			<BlockInspectorSingleBlock
-				clientId={ selectedBlockClientId }
+				renderedBlockClientId={ renderedBlockClientId }
+				selectedBlockClientId={ selectedBlockClientId }
 				blockName={ blockType.name }
 				isSectionBlock={ isSectionBlock }
 				availableTabs={ availableTabs }
@@ -281,7 +284,7 @@ const BlockInspectorSingleBlockWrapper = ( { animate, wrapper, children } ) => {
 
 const AnimatedContainer = ( {
 	blockInspectorAnimationSettings,
-	selectedBlockClientId,
+	renderedBlockClientId,
 	children,
 } ) => {
 	const animationOrigin =
@@ -304,7 +307,7 @@ const AnimatedContainer = ( {
 				x: animationOrigin,
 				opacity: 0,
 			} }
-			key={ selectedBlockClientId }
+			key={ renderedBlockClientId }
 		>
 			{ children }
 		</motion.div>
@@ -312,7 +315,8 @@ const AnimatedContainer = ( {
 };
 
 const BlockInspectorSingleBlock = ( {
-	clientId,
+	renderedBlockClientId,
+	selectedBlockClientId,
 	blockName,
 	isSectionBlock,
 	availableTabs,
@@ -320,24 +324,22 @@ const BlockInspectorSingleBlock = ( {
 	hasBlockStyles,
 	editedContentOnlySection,
 } ) => {
-	const selectedBlockClientId = useSelect( ( select ) => {
-		const { getSelectedBlockClientId } = select( blockEditorStore );
-		return getSelectedBlockClientId();
-	}, [] );
 	const hasMultipleTabs = availableTabs?.length > 1;
 	const hasParentChildBlockCards =
 		window?.__experimentalContentOnlyPatternInsertion &&
 		editedContentOnlySection &&
-		editedContentOnlySection !== clientId;
+		editedContentOnlySection !== renderedBlockClientId;
 	const parentBlockInformation = useBlockDisplayInformation(
 		editedContentOnlySection
 	);
-	const blockInformation = useBlockDisplayInformation( clientId );
+	const blockInformation = useBlockDisplayInformation(
+		renderedBlockClientId
+	);
 	const isBlockSynced = blockInformation.isSynced;
 	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
 	const isSectionBlockSelected =
 		window?.__experimentalContentOnlyPatternInsertion &&
-		selectedBlockClientId === clientId;
+		selectedBlockClientId === renderedBlockClientId;
 
 	return (
 		<div className="block-editor-block-inspector">
@@ -353,16 +355,16 @@ const BlockInspectorSingleBlock = ( {
 				allowParentNavigation
 				className={ isBlockSynced && 'is-synced' }
 				isChild={ hasParentChildBlockCards }
-				clientId={ clientId }
+				clientId={ renderedBlockClientId }
 			/>
 			{ window?.__experimentalContentOnlyPatternInsertion && (
-				<EditContents clientId={ clientId } />
+				<EditContents clientId={ renderedBlockClientId } />
 			) }
-			<BlockVariationTransforms blockClientId={ clientId } />
+			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
 			{ shouldShowTabs && (
 				<InspectorControlsTabs
 					hasBlockStyles={ hasBlockStyles }
-					clientId={ clientId }
+					clientId={ renderedBlockClientId }
 					blockName={ blockName }
 					tabs={ availableTabs }
 					isSectionBlock={ isSectionBlock }
@@ -372,10 +374,10 @@ const BlockInspectorSingleBlock = ( {
 			{ ! shouldShowTabs && (
 				<>
 					{ hasBlockStyles && (
-						<BlockStylesPanel clientId={ clientId } />
+						<BlockStylesPanel clientId={ renderedBlockClientId } />
 					) }
 					<ContentTab
-						rootClientId={ clientId }
+						rootClientId={ renderedBlockClientId }
 						contentClientIds={ contentClientIds }
 					/>
 					{ ! isSectionBlock && (

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -315,7 +315,12 @@ const AnimatedContainer = ( {
 };
 
 const BlockInspectorSingleBlock = ( {
+	// The block that is displayed in the inspector. This is the block whose
+	// controls and information are shown to the user.
 	renderedBlockClientId,
+	// The actual block that is selected in the editor. This may or may not
+	// be the same as the rendered block (e.g., when a child block is selected
+	// but its parent section block is the main one rendered in the inspector).
 	selectedBlockClientId,
 	blockName,
 	isSectionBlock,

--- a/packages/block-editor/src/components/block-settings-menu-controls/edit-section-menu-item.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/edit-section-menu-item.js
@@ -3,11 +3,14 @@
  */
 import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit';
+import { store as blockEditorStore } from '../../store';
 
 export function EditSectionMenuItem( { clientId, onClose } ) {
 	const {
@@ -15,6 +18,18 @@ export function EditSectionMenuItem( { clientId, onClose } ) {
 		isEditingContentOnlySection,
 		editContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
+
+	const { block, onNavigateToEntityRecord } = useSelect(
+		( select ) => {
+			const { getBlock, getSettings } = select( blockEditorStore );
+			return {
+				block: getBlock( clientId ),
+				onNavigateToEntityRecord:
+					getSettings().onNavigateToEntityRecord,
+			};
+		},
+		[ clientId ]
+	);
 
 	// Only show when the experiment is enabled, the block is a section block,
 	// and we're not already editing it
@@ -26,13 +41,42 @@ export function EditSectionMenuItem( { clientId, onClose } ) {
 		return null;
 	}
 
+	const blockAttributes = block?.attributes || {};
+
+	// Synced patterns and template parts should navigate to the isolated editor
+	const isSyncedPattern = isReusableBlock( block );
+	const isTemplatePartBlock = isTemplatePart( block );
+	const shouldNavigateToIsolatedEditor =
+		( isSyncedPattern || isTemplatePartBlock ) && onNavigateToEntityRecord;
+
+	const handleClick = () => {
+		if ( shouldNavigateToIsolatedEditor ) {
+			// Navigate to isolated editor for synced patterns and template parts
+			if ( isSyncedPattern ) {
+				onNavigateToEntityRecord( {
+					postId: blockAttributes.ref,
+					postType: 'wp_block',
+				} );
+			} else if ( isTemplatePartBlock ) {
+				const { theme, slug } = blockAttributes;
+				const templatePartId =
+					theme && slug ? `${ theme }//${ slug }` : null;
+				if ( templatePartId ) {
+					onNavigateToEntityRecord( {
+						postId: templatePartId,
+						postType: 'wp_template_part',
+					} );
+				}
+			}
+		} else {
+			// Use spotlight mode for unsynced patterns
+			editContentOnlySection( clientId );
+		}
+		onClose();
+	};
+
 	return (
-		<MenuItem
-			onClick={ () => {
-				editContentOnlySection( clientId );
-				onClose();
-			} }
-		>
+		<MenuItem onClick={ handleClick }>
 			{ _x( 'Edit section', 'Editing a section in the Editor' ) }
 		</MenuItem>
 	);

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -42,6 +42,7 @@ import {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	isIsolatedEditorKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
@@ -110,6 +111,7 @@ lock( privateApis, {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	isIsolatedEditorKey,
 	useBlockElement,
 	useBlockElementRef,
 } );

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -6,3 +6,4 @@ export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );
 export const mediaEditKey = Symbol( 'mediaEditKey' );
 export const getMediaSelectKey = Symbol( 'getMediaSelect' );
 export const essentialFormatKey = Symbol( 'essentialFormat' );
+export const isIsolatedEditorKey = Symbol( 'isIsolatedEditor' );

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -35,6 +35,7 @@ import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
 	sectionRootClientIdKey,
+	isIsolatedEditorKey,
 } from './private-keys';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
@@ -524,9 +525,15 @@ export function isSectionBlock( state, clientId ) {
 
 	const attributes = getBlockAttributes( state, clientId );
 	const isTemplatePart = blockName === 'core/template-part';
+
+	// When in an isolated editing context (e.g., editing a template part or pattern directly),
+	// don't treat nested unsynced patterns as section blocks.
+	const isIsolatedEditor = state.settings?.[ isIsolatedEditorKey ];
+
 	if (
 		( attributes?.metadata?.patternName || isTemplatePart ) &&
-		!! window?.__experimentalContentOnlyPatternInsertion
+		!! window?.__experimentalContentOnlyPatternInsertion &&
+		! isIsolatedEditor
 	) {
 		return true;
 	}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2294,7 +2294,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	);
 
 	// When in an isolated editing context (e.g., editing a template part or pattern directly),
-	// don't apply contentOnly mode to nested unsynced patterns.
+	// don't apply contentOnly mode to nested unsynced patterns or template parts.
 	const isIsolatedEditor = state.settings?.[ isIsolatedEditorKey ];
 
 	// Use array.from for better back compat. Older versions of the iterator returned

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -19,7 +19,7 @@ import {
  */
 import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
-import { sectionRootClientIdKey } from './private-keys';
+import { sectionRootClientIdKey, isIsolatedEditorKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
@@ -2292,10 +2292,16 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 		( clientId ) =>
 			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
 	);
+
+	// When in an isolated editing context (e.g., editing a template part or pattern directly),
+	// don't apply contentOnly mode to nested unsynced patterns.
+	const isIsolatedEditor = state.settings?.[ isIsolatedEditorKey ];
+
 	// Use array.from for better back compat. Older versions of the iterator returned
 	// from `keys()` didn't have the `filter` method.
 	const unsyncedPatternClientIds =
-		!! window?.__experimentalContentOnlyPatternInsertion
+		!! window?.__experimentalContentOnlyPatternInsertion &&
+		! isIsolatedEditor
 			? Array.from( state.blocks.attributes.keys() ).filter(
 					( clientId ) =>
 						state.blocks.attributes.get( clientId )?.metadata
@@ -2305,7 +2311,8 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
-		...( window?.__experimentalContentOnlyPatternInsertion
+		...( window?.__experimentalContentOnlyPatternInsertion &&
+		! isIsolatedEditor
 			? templatePartClientIds
 			: [] ),
 	];

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -39,17 +39,6 @@ import {
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
 } from './utils/hooks';
-import { unlock } from '../../lock-unlock';
-
-function getTemplatePartEditButtonTitle( clientId, editedContentOnlySection ) {
-	if ( ! window?.__experimentalContentOnlyPatternInsertion ) {
-		return __( 'Edit' );
-	}
-
-	return editedContentOnlySection === clientId
-		? __( 'Exit section' )
-		: __( 'Edit section' );
-}
 
 function ReplaceButton( {
 	isEntityAvailable,
@@ -119,15 +108,8 @@ export default function TemplatePartEdit( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { currentTheme, editedContentOnlySection } = useSelect(
-		( select ) => {
-			return {
-				currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
-				editedContentOnlySection: unlock(
-					select( blockEditorStore )
-				).getEditedContentOnlySection(),
-			};
-		},
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
 	);
 	const { slug, theme = currentTheme, tagName, layout = {} } = attributes;
@@ -259,17 +241,15 @@ export default function TemplatePartEdit( {
 						<BlockControls group="other">
 							<ToolbarButton
 								onClick={ () => {
-									// Template parts always navigate to isolated editor
 									onNavigateToEntityRecord( {
 										postId: templatePartId,
 										postType: 'wp_template_part',
 									} );
 								} }
 							>
-								{ getTemplatePartEditButtonTitle(
-									clientId,
-									editedContentOnlySection
-								) }
+								{ window?.__experimentalContentOnlyPatternInsertion
+									? __( 'Edit section' )
+									: __( 'Edit' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -119,9 +119,6 @@ export default function TemplatePartEdit( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { editContentOnlySection, stopEditingContentOnlySection } = unlock(
-		useDispatch( blockEditorStore )
-	);
 	const { currentTheme, editedContentOnlySection } = useSelect(
 		( select ) => {
 			return {
@@ -262,20 +259,7 @@ export default function TemplatePartEdit( {
 						<BlockControls group="other">
 							<ToolbarButton
 								onClick={ () => {
-									if (
-										window?.__experimentalContentOnlyPatternInsertion
-									) {
-										if (
-											editedContentOnlySection !==
-											clientId
-										) {
-											editContentOnlySection( clientId );
-										} else {
-											stopEditingContentOnlySection();
-										}
-										return;
-									}
-
+									// Template parts always navigate to isolated editor
 									onNavigateToEntityRecord( {
 										postId: templatePartId,
 										postType: 'wp_template_part',

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -83,8 +83,16 @@ export function useAlternativeBlockPatterns( area, clientId ) {
 			const blockNameWithArea = area
 				? `core/template-part/${ area }`
 				: 'core/template-part';
-			const { getPatternsByBlockTypes } = select( blockEditorStore );
-			return getPatternsByBlockTypes( blockNameWithArea, clientId );
+			const { getBlockRootClientId, getPatternsByBlockTypes } =
+				select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			// Use rootClientId to determine which patterns can be used in the current context.
+			// If revisiting the idea of template parts being spotlighted when edited, it may
+			// be worth either passing null or the template part's clientId instead.
+			// See the following PRs for context:
+			// - https://github.com/WordPress/gutenberg/pull/73736
+			// - https://github.com/WordPress/gutenberg/pull/73419
+			return getPatternsByBlockTypes( blockNameWithArea, rootClientId );
 		},
 		[ area, clientId ]
 	);

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -6,7 +6,6 @@ import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { usePrevious } from '@wordpress/compose';
 import { store as editorStore } from '@wordpress/editor';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ import useNavigateToEntityRecord from './use-navigate-to-entity-record';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
-const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
@@ -36,7 +34,7 @@ function useNavigateToPreviousEntityRecord() {
 }
 
 export function useSpecificEditorSettings() {
-	const { query, params } = useLocation();
+	const { query } = useLocation();
 	const { canvas = 'view' } = query;
 	const onNavigateToEntityRecord = useNavigateToEntityRecord();
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
@@ -51,11 +49,6 @@ export function useSpecificEditorSettings() {
 
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
-
-	// When editing template parts, patterns, or navigation in the isolated editor,
-	// we're in an isolated editing context (focused on that entity alone).
-	const isIsolatedEditor =
-		params?.postId && FOCUSABLE_ENTITIES.includes( params?.postType );
 
 	const defaultEditorSettings = useMemo( () => {
 		return {
@@ -81,7 +74,6 @@ export function useSpecificEditorSettings() {
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			isPreviewMode: canvas === 'view',
-			[ isIsolatedEditorKey ]: isIsolatedEditor,
 		};
 	}, [
 		settings,
@@ -89,7 +81,6 @@ export function useSpecificEditorSettings() {
 		currentPostIsTrashed,
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,
-		isIsolatedEditor,
 	] );
 
 	return defaultEditorSettings;

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { usePrevious } from '@wordpress/compose';
 import { store as editorStore } from '@wordpress/editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import useNavigateToEntityRecord from './use-navigate-to-entity-record';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
@@ -34,7 +36,7 @@ function useNavigateToPreviousEntityRecord() {
 }
 
 export function useSpecificEditorSettings() {
-	const { query } = useLocation();
+	const { query, params } = useLocation();
 	const { canvas = 'view' } = query;
 	const onNavigateToEntityRecord = useNavigateToEntityRecord();
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
@@ -49,6 +51,12 @@ export function useSpecificEditorSettings() {
 
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
+
+	// When editing template parts, patterns, or navigation in the isolated editor,
+	// we're in an isolated editing context (focused on that entity alone).
+	const isIsolatedEditor =
+		params?.postId && FOCUSABLE_ENTITIES.includes( params?.postType );
+
 	const defaultEditorSettings = useMemo( () => {
 		return {
 			...settings,
@@ -73,6 +81,7 @@ export function useSpecificEditorSettings() {
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			isPreviewMode: canvas === 'view',
+			[ isIsolatedEditorKey ]: isIsolatedEditor,
 		};
 	}, [
 		settings,
@@ -80,6 +89,7 @@ export function useSpecificEditorSettings() {
 		currentPostIsTrashed,
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,
+		isIsolatedEditor,
 	] );
 
 	return defaultEditorSettings;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -97,6 +97,7 @@ const {
 	sectionRootClientIdKey,
 	mediaEditKey,
 	getMediaSelectKey,
+	isIsolatedEditorKey,
 } = unlock( privateApis );
 
 /**
@@ -349,6 +350,15 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					? 'edit'
 					: undefined,
 		};
+
+		// When editing template parts, patterns, or navigation directly,
+		// we're in an isolated editing context (focused on that entity alone).
+		const isIsolatedEditor = [
+			'wp_template_part',
+			'wp_block',
+			'wp_navigation',
+		].includes( postType );
+		blockEditorSettings[ isIsolatedEditorKey ] = isIsolatedEditor;
 
 		return blockEditorSettings;
 	}, [

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -349,16 +349,14 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				renderingMode === 'post-only' && postType !== 'wp_template'
 					? 'edit'
 					: undefined,
+			// When editing template parts, patterns, or navigation directly,
+			// we're in an isolated editing context (focused on that entity alone).
+			[ isIsolatedEditorKey ]: [
+				'wp_template_part',
+				'wp_block',
+				'wp_navigation',
+			].includes( postType ),
 		};
-
-		// When editing template parts, patterns, or navigation directly,
-		// we're in an isolated editing context (focused on that entity alone).
-		const isIsolatedEditor = [
-			'wp_template_part',
-			'wp_block',
-			'wp_navigation',
-		].includes( postType );
-		blockEditorSettings[ isIsolatedEditorKey ] = isIsolatedEditor;
 
 		return blockEditorSettings;
 	}, [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of:

* #73677 

Update the Edit Section button to be aware of whether a block is a synced pattern or template part. If so, clicking the button will redirect to the isolated editor.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in #73677 this ensures that items edited in situ (unsynced patterns) are clearly edited within their context, and symbols (template parts, synced patterns) are edited in their own location. This better indicates the scope of changes someone might make (i.e. am I just changing this part of one page, or all instances of this thing)

## ~A caveat / question ❓~ A decision

Note that this PR currently means that the controls for changing the template part design are no longer available. What could or should we do about that? I.e. before this PR, when we clicked the Edit Section button, we could access these:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bd66a380-8bf9-4cb5-9b22-f68071146e18" />

Update: see the comment in https://github.com/WordPress/gutenberg/pull/73736#issuecomment-3614958239 — I've gone for a kind of hybrid where we show the content buttons _and_ the Design and Advanced panels so that we prioritise the content only experience while also allowing local edits for template parts. I _think_ this might give us a compromise between the behaviours.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add checks for whether the block is a template part or synced pattern
* Update the Edit Section buttons to take users to the isolated editor or engage the editing content only section mode
* Update the logic that determines whether unsynced blocks are treated as contentOnly / sections so that it only does that if we're not in an isolated editor. This ensures that if someone goes directly to edit template parts or patterns, that they're not locked out of making changes. It also means that when someone goes to the isolated editor _from_ a template, they're immediately able to edit in greater detail, without getting stuck. See the comments below for more context on this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Enable the content only insertion experiment in Gutenberg experiment settings
* Ensure you've got at least one synced pattern in your site
* In the site editor, play around with Edit Section on a template part, on a synced pattern, and on an unsynced pattern
* For template parts and synced patterns, the button should take you to the isolated editor
* Check that when in this editor, if you're editing a template part that contains patterns (especially true in themes like TT4) that the contentOnly mode does _not_ occur in the isolated editor
* On unsynced patterns it should enable the spotlighted editing mode

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2e16f485-9e17-4183-ba0a-2dd7d319fd04


