### PR TITLE
Global Styles: Fix Navigator warning

### DIFF
--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -7,7 +7,7 @@ import { getBlockTypes, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 // @ts-expect-error: Not typed yet.
 import { BlockEditorProvider } from '@wordpress/block-editor';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, Fragment } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 import {
 	generateGlobalStyles,
@@ -235,24 +235,23 @@ export function GlobalStylesUI( {
 						<ScreenBlockList />
 					</GlobalStylesNavigationScreen>
 					{ blocks.map( ( block: BlockType ) => (
-						<GlobalStylesNavigationScreen
-							key={ 'menu-block-' + block.name }
-							path={
-								'/blocks/' + encodeURIComponent( block.name )
-							}
-						>
-							<ScreenBlock name={ block.name } />
-						</GlobalStylesNavigationScreen>
-					) ) }
-
-					{ blocks.map( ( block: BlockType ) => (
-						<ContextScreens
-							key={ 'screens-block-' + block.name }
-							name={ block.name }
-							parentMenu={
-								'/blocks/' + encodeURIComponent( block.name )
-							}
-						/>
+						<Fragment key={ block.name }>
+							<GlobalStylesNavigationScreen
+								path={
+									'/blocks/' +
+									encodeURIComponent( block.name )
+								}
+							>
+								<ScreenBlock name={ block.name } />
+							</GlobalStylesNavigationScreen>
+							<ContextScreens
+								name={ block.name }
+								parentMenu={
+									'/blocks/' +
+									encodeURIComponent( block.name )
+								}
+							/>
+						</Fragment>
 					) ) }
 				</Navigator>
 			</BlockEditorProvider>

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -245,8 +245,6 @@ export function GlobalStylesUI( {
 						</GlobalStylesNavigationScreen>
 					) ) }
 
-					<ContextScreens />
-
 					{ blocks.map( ( block: BlockType ) => (
 						<ContextScreens
 							key={ 'screens-block-' + block.name }


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/72599.

PR removes duplicate rendering of the general colors palette screen, which fixes the Navigator component warning. The screen is already rendered above.

https://github.com/WordPress/gutenberg/blob/7b61690325fcb779e3463f7623caaeac3923598e/packages/global-styles-ui/src/global-styles-ui.tsx#L198-L200

## Testing Instructions
1. Open the Site Editor.
2. Confirm you can navigate to Styles > Colors > Edit Palette.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

| Screen | Warning |
|--------|--------|
| <img width="699" height="768" alt="CleanShot 2025-12-04 at 07 39 59" src="https://github.com/user-attachments/assets/9e32f2c5-88a4-4755-8aa8-f009b0b84a37" /> | <img width="1096" height="428" alt="CleanShot 2025-12-03 at 21 07 58" src="https://github.com/user-attachments/assets/13b3b319-8a89-47d6-95bf-7e370132e763" /> | 


