### PR TITLE
Reduce modal style specificity so it can be overridden more easily

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Modal`: Fix vertical scroll issue by reducing style specificity to allow overrides. ([#73739](https://github.com/WordPress/gutenberg/pull/73739))
 -   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
 
 ## 30.9.0 (2025-11-26)

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -109,7 +109,7 @@
 
 	&.is-full-screen {
 		// When full screen, make sure the children container is full height.
-		.components-modal__content {
+		:where(.components-modal__content) {
 			display: flex;
 			// If this container is scrollable, bottom padding won't apply so we use margin instead.
 			margin-bottom: $grid-unit-40;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes vertical scroll issue reported in #73715 by slightly reducing the specificity of the styles added to the fullscreen modal in #73150.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Follow steps in #73715 to check the font library modal is scrollable to its bottom;
2. `npm run storybook:dev` and check the [datapicker with modal story](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataviewspicker--with-modal). The footer should still be sticky
3. An alternative to 2 if you don't want to check out the branch locally is to enable the dataviews media modal experiment, and check any media modal in the editor (e.g image block > media library).

<img width="738" height="812" alt="Screenshot 2025-12-04 at 3 44 07 pm" src="https://github.com/user-attachments/assets/cd5817d8-79b7-4952-bf38-1edae76f334a" />
