### PR TITLE
Site Editor: Fix 'useNavigateToPreviousEntityRecord' internal deps

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -19,21 +19,17 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
-	const previousLocation = usePrevious( location );
+	const previousCanvas = usePrevious( location.query.canvas );
 	const history = useHistory();
 	const goBack = useMemo( () => {
 		const isFocusMode =
 			location.query.focusMode ||
 			( location?.params?.postId &&
 				FOCUSABLE_ENTITIES.includes( location?.params?.postType ) );
-		const didComeFromEditorCanvas =
-			previousLocation?.query.canvas === 'edit';
+		const didComeFromEditorCanvas = previousCanvas === 'edit';
 		const showBackButton = isFocusMode && didComeFromEditorCanvas;
 		return showBackButton ? () => history.back() : undefined;
-		// `previousLocation` changes when the component updates for any reason, not
-		// just when location changes. Until this is fixed we can't add it to deps. See
-		// https://github.com/WordPress/gutenberg/pull/58710#discussion_r1479219465.
-	}, [ location, history ] );
+	}, [ location, history, previousCanvas ] );
 	return goBack;
 }
 


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/58710#discussion_r1479219465.

PR fixes `useMemo` dependencies that generate `goBack` callback via `useNavigateToPreviousEntityRecord` hook.

## How?
Store just the previous canvas value used for calculations, which should give us more stable value from `usePrevious`.

## Testing Instructions
1. Go to Appearance → Editor → Patterns and edit a pattern.
2. You should not see a "Back" button in the document tools.
3. Go to Appearance → Editor → Templates and edit a template.
4. Select a template part (e.g. Header) and click "Edit".
5. You should see a "Back" button in the document tools.
6. Go to Appearance → Editor → Pages and edit a page.
7. In the sidebar, edit the page's template.
8. You should see a "Back" button in the document tools

### Testing Instructions for Keyboard
Same.
