### PR TITLE
Global Styles UI: Restore borders for preview items

### DIFF
--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -20,7 +20,6 @@
 	max-width: 100%;
 	display: block;
 	width: 100%;
-	clip-path: border-box;
 }
 
 .global-styles-ui-typography-preview {
@@ -276,6 +275,10 @@
 	&#{&} .global-styles-ui-screen-root__active-style-tile-preview {
 		border-radius: 2px;
 	}
+}
+
+.global-styles-ui-screen-root__active-style-tile-preview {
+	clip-path: border-box;
 }
 
 .global-styles-ui-color-palette-panel,


### PR DESCRIPTION
## What? Why?

#73545 added the following style to fix the leaking shadow in the preview card:

```css
.global-styles-ui-preview__wrapper {
	clip-path: border-box;
}
```

However, the `.global-styles-ui-preview__wrapper` CSS class is also used in the theme variation preview, which unintentionally removed the border.

## How?

Applies `clip-path: border-box` to the element above. This element is not used anywhere else. Ideally, all preview items would be properly standardized and have the same CSS applied, but for now this fix feels fine.

## Testing Instructions

- Navigate to Appearance > Editor > Styles Browse styles.
- Confirm that all items have a gray border.
- Confirm that the issue reported in #issues has not reoccurred.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="349" height="1213" alt="before" src="https://github.com/user-attachments/assets/afd12e5d-0e19-46bc-9ad2-d8151ac85695" /> | <img width="348" height="1215" alt="after" src="https://github.com/user-attachments/assets/cc83d249-9bca-4243-a006-2f3eb7a8c2d7" /> |