### PR TITLE
Fix: Default color variations not showing in global styles

### DIFF
--- a/packages/global-styles-ui/src/variations/variation.tsx
+++ b/packages/global-styles-ui/src/variations/variation.tsx
@@ -10,7 +10,10 @@ import { Tooltip } from '@wordpress/components';
 import { useMemo, useContext, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { _x, sprintf } from '@wordpress/i18n';
-import { areGlobalStylesEqual } from '@wordpress/global-styles-engine';
+import {
+	areGlobalStylesEqual,
+	mergeGlobalStyles,
+} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -41,7 +44,7 @@ export default function Variation( {
 	} = useContext( GlobalStylesContext );
 
 	const context = useMemo( () => {
-		let merged = { ...base, ...variation };
+		let merged = mergeGlobalStyles( base, variation );
 		if ( properties ) {
 			merged = filterObjectByProperties( merged, properties );
 		}


### PR DESCRIPTION
Follow-up to #72599

## What?

This PR will correctly display the default variation color in the Color Variations section of the global styles.

## Why?

I think we should perform a deep merge, not a shallow merge here.

## Testing Instructions

Access Editor > Global Styles > Browse Styles > Color Variations

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="251" height="264" alt="image" src="https://github.com/user-attachments/assets/34b3cb83-3360-46e7-8e8a-dc0c6117aaeb" /> | <img width="251" height="265" alt="image" src="https://github.com/user-attachments/assets/25bea2da-6ae6-4ceb-b5c6-12472bc780b9" /> |