### PR TITLE
Gallery: Fix missing captions shortcode transform

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -290,7 +290,10 @@ export default function GalleryEdit( props ) {
 			...newLinkTarget,
 			className: newClassName,
 			sizeSlug,
-			caption: imageAttributes.caption || image.caption?.raw,
+			caption:
+				imageAttributes.caption.length > 0
+					? imageAttributes.caption
+					: image.caption?.raw,
 			alt: imageAttributes.alt || image.alt_text,
 			aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,
 		};


### PR DESCRIPTION
## What?
Closes #30698.
Alternative to #73744.

PR fixes the condition in `buildImageAttributes` so it correctly falls back to the image caption from the media library. This prevents captions from being lost when transforming the gallery shortcode into a block.

## Why?
The `imageAttributes.caption` has the `rich-text` type, which uses the `RichTextData` object internally; therefore, the previous fallback value was never used.

When working with `RichTextData`, it's better to use `value.length` check or other RichText data methods.

## Testing Instructions
1. Open a post or page.
2. Insert a classic block and add a gallery to it.
3. Ensure at least some images have captions.
4. Convert Classic to Blocks.
5. Confirm that images in the gallery block have captions.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/92586309-b405-49b6-b763-0dcda55f1d88


