### PR TITLE
Block Editor: Remove block selection clearer handling from iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -21,7 +21,6 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
 import { useScaleCanvas } from './use-scale-canvas';
@@ -119,7 +118,6 @@ function Iframe( {
 	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
-	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 
 	const setRef = useRefEffect( ( node ) => {
@@ -175,8 +173,6 @@ function Iframe( {
 			iFrameDocument = contentDocument;
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
-
-			clearerRef( documentElement );
 
 			contentDocument.dir = ownerDocument.dir;
 
@@ -243,7 +239,6 @@ function Iframe( {
 	const bodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),
 		contentRef,
-		clearerRef,
 		writingFlowRef,
 		disabledRef,
 	] );


### PR DESCRIPTION
## What?
Partially reverts #31385.
Closes #73547.

PR removes `useBlockSelectionClearer` to avoid clearing block selection when clicking on the canvas scrollbar in the iframed editor. This matches the behavior of non-iframed editors.

## Why?
* Losing selection when just trying to scroll can be annoying, which was highlighted by the new Notes feature.
* I can no longer reproduce the original issue (#31369) even with these changes. This could be due to the removal of the root appender - #60697.

## Testing Instructions
1. Open a post or page.
2. Add blocks so that the canvas scrollbar is displayed.
3. Select a block.
4. Click on the scrollbar and scroll.
5. Confirm that the selection remains on the block

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/370ea9e2-dbdd-4249-96f8-f4937847ef3c

