### PR TITLE
DataViews docs: Clarify filter operators enabled by default per field type

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1858,9 +1858,9 @@ Each type of data supports a default set of filter operators, depending on its n
 - url: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`, `isNotAll`.
 - fields with no type: any operator.
 
-#### Filter Operators by Field Type  
+#### Default Filter Operators by Field Type
   
-Different field types enable by default different filter operators based on the type of data they represent:  
+Some field types automatically enable the filter operators that make sense for the type of data they represent:  
   
 - **Fields with `type: 'integer'` or `type: 'number'`** provide numeric comparison operators:  `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1808,6 +1808,7 @@ Or multi-selection operators:
 	}
 }
 ```
+#### Available Operators
 
 The next table lists all available operators:
 
@@ -1838,7 +1839,9 @@ The next table lists all available operators:
 
 Some operators are single-selection: `is`, `isNot`, `on`, `notOn`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `before`, `after`, `beforeInc`, `afterInc`, `contains`, `notContains`, and `startsWith`. Others are multi-selection: `isAny`, `isNone`, `isAll`, and `isNotAll`. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
 
-Valid operators per field type:
+#### Valid operators per field type
+
+Each type of data supports a default set of filter operators, depending on its nature:
 
 - array: `isAny`, `isNone`, `isAll`, `isNotAll`.
 - boolean: `is`, `isNot`.
@@ -1854,6 +1857,24 @@ Valid operators per field type:
 - text: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`, `isNotAll`.
 - url: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`, `isNotAll`.
 - fields with no type: any operator.
+
+#### Filter Operators by Field Type  
+  
+Different field types enable by default different filter operators based on the type of data they represent:  
+  
+- **Fields with `type: 'integer'` or `type: 'number'`** provide numeric comparison operators:  `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`
+
+- **Fields with `type: 'date'` or `type: 'datetime'`** provide date-specific operators:  
+  `on`, `notOn`, `before`, `after`, `beforeInc`, `afterInc`, `inThePast`, `over`, `between`
+
+- **Fields with `type: 'text'`** provide text matching operators:  
+  `is`, `isNot`, `contains`, `startsWith`
+
+- **Fields that define an `elements` array** (for select/radio-style fields) support multi-selection operators:  
+  `is`, `isNot`, `isAny`, `isNone`, `isAll`, `isNotAll`
+  
+You can customize the available operators by specifying `filterBy.operators` on your field definition, or disable filtering entirely with `filterBy: false`.
+
 
 ### `format`
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- If there's no specific issue, you can remove this line -->

Enhances the DataViews README documentation by adding clearer sections for filter operators enabled by default by field type.

## Why?
The existing documentation listed available operators and valid operators per field type, but lacked a comprehensive explanation of how different field types enable different filter operators by default. 

## How?
- Created a new "Filter Operators by Field Type" section that:
  - Groups related field types together (e.g., integer/number, date/datetime)
  - Lists the specific operators available for each group in a more readable format
  - Adds a note about customization options via `filterBy.operators` or disabling with `filterBy: false`

This PR also adds "Available Operators" and "Valid operators per field type" subheadings to improve section structure  

## Testing Instructions
This is a documentation-only change. To verify:
1. Navigate to `packages/dataviews/README.md`
2. Review the enhanced filter operators documentation sections
3. Verify that the information accurately represents the available operators for each field type
4. Confirm the documentation is clear and well-structured
