### PR TITLE
Prototype: Add Static Link Preview to Navigation Link Sidebar

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -74,6 +74,7 @@ export {
 export { __experimentalLinkControlSearchInput } from './link-control/search-input';
 export { __experimentalLinkControlSearchResults } from './link-control/search-results';
 export { __experimentalLinkControlSearchItem } from './link-control/search-item';
+export { default as __experimentalUseRemoteUrlData } from './link-control/use-rich-url-data';
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
 export { default as MediaReplaceFlow } from './media-replace-flow';

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -185,3 +185,64 @@
 	}
 }
 
+
+// Link Preview Button
+.components-button.link-control-preview-button {
+	width: 100%;
+	height: auto;
+	padding: $grid-unit-15;
+	box-shadow: inset 0 0 0 1px $gray-600;
+	border-color: $gray-600;
+}
+
+.link-control-preview-button__image-container {
+	width: $grid-unit-30;
+	height: $grid-unit-30;
+	flex-shrink: 0;
+}
+
+.link-control-preview-button__image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	border-radius: $radius-small;
+}
+
+// Fix truncation in flex layout
+.link-control-preview-button__content {
+	min-width: 0;
+	flex: 1;
+}
+
+.link-control-preview-button__details {
+	min-width: 0;
+	flex: 1;
+}
+
+.link-control-preview-button__title,
+.link-control-preview-button__url {
+	min-width: 0;
+	display: block;
+	width: 100%;
+	text-align: left;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.link-control-preview-button__title {
+	margin-top: $grid-unit-05;
+	font-weight: 500;
+	color: $gray-900;
+	display: block;
+}
+
+.link-control-preview-button__url {
+	font-size: $helptext-font-size;
+	color: $gray-700;
+	font-weight: 400;
+}
+
+.link-control-preview-button__icon {
+	color: $gray-900;
+}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -201,21 +201,21 @@
 
 
 // Link Preview Button
-.components-button.link-control-preview-button {
+.navigation-link-control-preview {
 	width: 100%;
 	height: auto;
 	padding: $grid-unit-15;
 	box-shadow: inset 0 0 0 1px $gray-600;
-	border-color: $gray-600;
+	border-radius: $radius-small;
 }
 
-.link-control-preview-button__image-container {
+.navigation-link-control-preview__image-container {
 	width: $grid-unit-30;
 	height: $grid-unit-30;
 	flex-shrink: 0;
 }
 
-.link-control-preview-button__image {
+.navigation-link-control-preview__image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
@@ -223,18 +223,18 @@
 }
 
 // Fix truncation in flex layout
-.link-control-preview-button__content {
+.navigation-link-control-preview__content {
 	min-width: 0;
 	flex: 1;
 }
 
-.link-control-preview-button__details {
+.navigation-link-control-preview__details {
 	min-width: 0;
 	flex: 1;
 }
 
-.link-control-preview-button__title,
-.link-control-preview-button__url {
+.navigation-link-control-preview__title,
+.navigation-link-control-preview__url {
 	min-width: 0;
 	display: block;
 	width: 100%;
@@ -244,19 +244,19 @@
 	white-space: nowrap;
 }
 
-.link-control-preview-button__title {
+.navigation-link-control-preview__title {
 	margin-top: $grid-unit-05;
 	font-weight: 500;
 	color: $gray-900;
 	display: block;
 }
 
-.link-control-preview-button__url {
+.navigation-link-control-preview__url {
 	font-size: $helptext-font-size;
 	color: $gray-700;
 	font-weight: 400;
 }
 
-.link-control-preview-button__icon {
+.navigation-link-control-preview__icon {
 	color: $gray-900;
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
@@ -157,7 +158,7 @@
  * Target the correct container based on HTML structure.
  */
 .components-tools-panel-item .block-editor-link-control__search-input-container {
-	margin: 0;
+	margin: $grid-unit-05 0 0;
 	min-width: 0;
 
 	// Style the input itself
@@ -182,6 +183,19 @@
 		box-sizing: border-box;
 		// Ensure proper background
 		background: $white;
+	}
+
+	// Visually hide the label in the search input container when used in navigation link
+	label {
+		border: 0;
+		clip-path: inset(50%);
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px;
+		word-wrap: normal;
 	}
 }
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -150,3 +150,38 @@
 .navigation-link-control__error-text {
 	color: $alert-red;
 }
+
+/**
+ * Search input styling for inspector controls.
+ * Remove margins from LinkControl styles that don't apply in inspector.
+ * Target the correct container based on HTML structure.
+ */
+.components-tools-panel-item .block-editor-link-control__search-input-container {
+	margin: 0;
+	min-width: 0;
+
+	// Style the input itself
+	.navigation-link-control__search-input {
+		margin: 0;
+		min-width: 0;
+	}
+
+	// Style the suggestions dropdown (sibling to input)
+	.block-editor-link-control__search-results-wrapper {
+		// Add spacing between input and dropdown
+		margin: $grid-unit-20 0 0;
+		padding: 0;
+	}
+
+	// Style the suggestions container
+	.block-editor-link-control__search-results {
+		// Add border around options
+		border: $border-width solid $gray-300;
+		border-radius: $radius-block-ui;
+		// Match the width of the input
+		box-sizing: border-box;
+		// Ensure proper background
+		background: $white;
+	}
+}
+

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -11,10 +11,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useEffect, useState } from '@wordpress/element';
-import {
-	useInstanceId,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { __experimentalLinkControlSearchInput as LinkControlSearchInput } from '@wordpress/block-editor';
@@ -27,7 +24,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { updateAttributes } from './update-attributes';
 import { useEntityBinding } from './use-entity-binding';
-import { LinkPreviewButton } from './link-preview-button';
+import { NavigationLinkPreview } from './link-preview-button';
 
 /**
  * Given the Link block's type attribute, return the query params for link suggestions.
@@ -111,18 +108,6 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 
 	// Local state to control the input value
 	const [ inputValue, setInputValue ] = useState( url );
-
-	// Track editing state to toggle between preview button and input
-	const [ isEditing, setIsEditing ] = useState( ! url );
-	const previewButtonRef = useRef();
-
-	// Get dialog props for proper accessibility
-	const [ dialogRef, dialogProps ] = useDialog( {
-		focusOnMount: 'firstElement',
-		onClose: () => {
-			setIsEditing( false );
-		},
-	} );
 
 	// Sync local state when url prop changes (e.g., from undo/redo or external updates)
 	useEffect( () => {
@@ -226,85 +211,63 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						id={ `${ inputId }-button` }
 						__nextHasNoMarginBottom
 					>
-						<LinkPreviewButton
-							buttonRef={ previewButtonRef }
+						<NavigationLinkPreview
 							link={ attributes }
 							featuredImage={ featuredImage }
 							hasEntityBinding={ hasUrlBinding }
-							onClick={ () => {
-								// Open it
-								setInputValue( '' );
-								setIsEditing( true );
-							} }
-							aria-haspopup="dialog"
-							aria-expanded={ isEditing }
-							id={ `${ inputId }-button` }
 						/>
 					</BaseControl>
 				) }
-				{ isEditing && (
-					<div ref={ dialogRef } { ...dialogProps }>
-						<LinkControlSearchInput
-							className="navigation-link-control__search-input"
-							value={
-								inputValue ? safeDecodeURI( inputValue ) : ''
+				<LinkControlSearchInput
+					className="navigation-link-control__search-input"
+					value={ inputValue ? safeDecodeURI( inputValue ) : '' }
+					currentLink={ {
+						url,
+						title: label && stripHTML( label ),
+						kind: attributes.kind,
+						type: attributes.type,
+						id: attributes.id,
+					} }
+					suggestionsQuery={ getSuggestionsQuery(
+						attributes.type,
+						attributes.kind
+					) }
+					onChange={ ( newValue ) => {
+						// Update local input state when typing
+						setInputValue( newValue );
+					} }
+					onSelect={ ( suggestion ) => {
+						// When a suggestion is selected (or Enter pressed)
+						if ( suggestion ) {
+							const attrs = {
+								url: suggestion.url,
+								kind: suggestion.kind,
+								type: suggestion.type,
+								id: suggestion.id,
+								title: suggestion.title,
+							};
+							updateAttributes(
+								attrs,
+								setAttributes,
+								attributes
+							);
+							// Create entity binding if we have entity data
+							if ( suggestion.id ) {
+								createBinding( attrs );
+								shouldFocusUnsyncButtonRef.current = true;
 							}
-							currentLink={ {
-								url,
-								title: label && stripHTML( label ),
-								kind: attributes.kind,
-								type: attributes.type,
-								id: attributes.id,
-							} }
-							suggestionsQuery={ getSuggestionsQuery(
-								attributes.type,
-								attributes.kind
-							) }
-							onChange={ ( newValue ) => {
-								// Update local input state when typing
-								setInputValue( newValue );
-							} }
-							onSelect={ ( suggestion ) => {
-								// When a suggestion is selected (or Enter pressed)
-								if ( suggestion ) {
-									const attrs = {
-										url: suggestion.url,
-										kind: suggestion.kind,
-										type: suggestion.type,
-										id: suggestion.id,
-										title: suggestion.title,
-									};
-									updateAttributes(
-										attrs,
-										setAttributes,
-										attributes
-									);
-									// Create entity binding if we have entity data
-									if ( suggestion.id ) {
-										createBinding( attrs );
-										shouldFocusUnsyncButtonRef.current = true;
-									}
-									// Exit edit mode and focus preview button
-									setIsEditing( false );
-								} else if ( inputValue ) {
-									// Freeform URL entry
-									updateAttributes(
-										{ url: inputValue },
-										setAttributes,
-										attributes
-									);
-									// Exit edit mode and focus preview button
-									setIsEditing( false );
-								}
-
-								// focus the preview button
-								previewButtonRef.current?.focus();
-							} }
-							showInitialSuggestions
-							showSuggestions
-						/>
-					</div>
-				) }
+						} else if ( inputValue ) {
+							// Freeform URL entry
+							updateAttributes(
+								{ url: inputValue },
+								setAttributes,
+								attributes
+							);
+						}
+					} }
+					showInitialSuggestions
+					showSuggestions
+				/>
 				{ hasUrlBinding && ! isBoundEntityAvailable && (
 					<p id={ helpTextId }>
 						<MissingEntityHelpText

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -4,7 +4,6 @@
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalInputControl as InputControl,
 	Button,
 	CheckboxControl,
 	TextControl,
@@ -17,7 +16,10 @@ import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { linkOff as unlinkIcon } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	__experimentalLinkControlSearchInput as LinkControlSearchInput,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -25,6 +27,35 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { updateAttributes } from './update-attributes';
 import { useEntityBinding } from './use-entity-binding';
+
+/**
+ * Given the Link block's type attribute, return the query params for link suggestions.
+ *
+ * @param {string} type - Link block's type attribute
+ * @param {string} kind - Link block's entity kind (post-type|taxonomy)
+ * @return {Object} Search query params
+ */
+function getSuggestionsQuery( type, kind ) {
+	switch ( type ) {
+		case 'post':
+		case 'page':
+			return { type: 'post', subtype: type };
+		case 'category':
+			return { type: 'term', subtype: 'category' };
+		case 'tag':
+			return { type: 'term', subtype: 'post_tag' };
+		case 'post_format':
+			return { type: 'post-format' };
+		default:
+			if ( kind === 'taxonomy' ) {
+				return { type: 'term', subtype: type };
+			}
+			if ( kind === 'post-type' ) {
+				return { type: 'post', subtype: type };
+			}
+			return {};
+	}
+}
 
 /**
  * Get a human-readable entity type name.
@@ -72,8 +103,10 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const urlInputRef = useRef();
 	const shouldFocusURLInputRef = useRef( false );
+	const shouldFocusUnsyncButtonRef = useRef( false );
+	const linkContainerRef = useRef();
+	const unsyncButtonRef = useRef();
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
@@ -87,11 +120,15 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	}, [ url ] );
 
 	// Use the entity binding hook internally
-	const { hasUrlBinding, isBoundEntityAvailable, clearBinding } =
-		useEntityBinding( {
-			clientId,
-			attributes,
-		} );
+	const {
+		hasUrlBinding,
+		isBoundEntityAvailable,
+		clearBinding,
+		createBinding,
+	} = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
 
 	// Get direct store dispatch to bypass setBoundAttributes wrapper
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -111,14 +148,25 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		} );
 	};
 
+	// Focus the input field after unsyncing
 	useEffect( () => {
-		// Only want to focus the input if the url is not bound to an entity.
 		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
-			// focuses and highlights the url input value, giving the user
-			// the ability to delete the value quickly or edit it.
-			urlInputRef.current?.select();
+			// Query for the input within the link container since
+			// ref is not available on LinkControlSearchInput experimental export
+			const input =
+				linkContainerRef.current?.querySelector( 'input[type="text"]' );
+			input?.focus();
+			input?.select();
 		}
 		shouldFocusURLInputRef.current = false;
+	}, [ hasUrlBinding ] );
+
+	// Focus the unsync button after creating a binding
+	useEffect( () => {
+		if ( hasUrlBinding && shouldFocusUnsyncButtonRef.current ) {
+			unsyncButtonRef.current?.focus();
+		}
+		shouldFocusUnsyncButtonRef.current = false;
 	}, [ hasUrlBinding ] );
 
 	return (
@@ -154,95 +202,70 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
+				ref={ linkContainerRef }
 				hasValue={ () => !! url }
 				label={ __( 'Link' ) }
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<InputControl
-					ref={ urlInputRef }
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					id={ inputId }
-					label={ __( 'Link' ) }
-					value={ ( () => {
-						if ( hasUrlBinding && ! isBoundEntityAvailable ) {
-							return '';
-						}
-						return inputValue ? safeDecodeURI( inputValue ) : '';
-					} )() }
-					autoComplete="off"
-					type="url"
-					disabled={ hasUrlBinding }
-					aria-invalid={
-						hasUrlBinding && ! isBoundEntityAvailable
-							? 'true'
-							: undefined
-					}
-					aria-describedby={ helpTextId }
-					className={
-						hasUrlBinding && ! isBoundEntityAvailable
-							? 'navigation-link-control__input-with-error-suffix'
-							: undefined
-					}
+				<LinkControlSearchInput
+					className="navigation-link-control__search-input"
+					value={ inputValue ? safeDecodeURI( inputValue ) : '' }
+					currentLink={ {
+						url,
+						title: label && stripHTML( label ),
+						kind: attributes.kind,
+						type: attributes.type,
+						id: attributes.id,
+					} }
+					suggestionsQuery={ getSuggestionsQuery(
+						attributes.type,
+						attributes.kind
+					) }
 					onChange={ ( newValue ) => {
-						if ( isBoundEntityAvailable ) {
-							return;
-						}
-
-						// Defer updating the url attribute until onBlur to prevent the canvas from
-						// treating a temporary empty value as a committed value, which replaces the
-						// label with placeholder text.
+						// Update local input state when typing
 						setInputValue( newValue );
 					} }
-					onFocus={ () => {
-						if ( isBoundEntityAvailable ) {
-							return;
+					onSelect={ ( suggestion ) => {
+						// When a suggestion is selected (or Enter pressed)
+						if ( suggestion ) {
+							const attrs = {
+								url: suggestion.url,
+								kind: suggestion.kind,
+								type: suggestion.type,
+								id: suggestion.id,
+								title: suggestion.title,
+							};
+							updateAttributes(
+								attrs,
+								setAttributes,
+								attributes
+							);
+							// Create entity binding if we have entity data
+							if ( suggestion.id ) {
+								createBinding( attrs );
+								shouldFocusUnsyncButtonRef.current = true;
+							}
+						} else if ( inputValue ) {
+							// Freeform URL entry
+							updateAttributes(
+								{ url: inputValue },
+								setAttributes,
+								attributes
+							);
 						}
-						lastURLRef.current = url;
 					} }
-					onBlur={ () => {
-						if ( isBoundEntityAvailable ) {
-							return;
-						}
-
-						const finalValue = ! inputValue
-							? lastURLRef.current
-							: inputValue;
-
-						// Update local state immediately so input reflects the reverted value if the value was cleared
-						setInputValue( finalValue );
-
-						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
-						updateAttributes( { url: finalValue }, setAttributes, {
-							...attributes,
-							url: lastURLRef.current,
-						} );
-					} }
-					help={
-						hasUrlBinding && ! isBoundEntityAvailable ? (
-							<MissingEntityHelp
-								id={ helpTextId }
-								type={ attributes.type }
-								kind={ attributes.kind }
-							/>
-						) : (
-							isBoundEntityAvailable && (
-								<BindingHelpText
-									type={ attributes.type }
-									kind={ attributes.kind }
-								/>
-							)
-						)
-					}
+					allowDirectEntry={ ! hasUrlBinding }
+					showSuggestions
+					showInitialSuggestions
+					isEntity={ hasUrlBinding }
 					suffix={
 						hasUrlBinding && (
 							<Button
+								ref={ unsyncButtonRef }
 								icon={ unlinkIcon }
 								onClick={ () => {
 									unsyncBoundLink();
-									// Focus management to send focus to the URL input
-									// on next render after disabled state is removed.
 									shouldFocusURLInputRef.current = true;
 								} }
 								aria-describedby={ helpTextId }
@@ -258,6 +281,22 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						)
 					}
 				/>
+				{ hasUrlBinding && ! isBoundEntityAvailable && (
+					<p id={ helpTextId }>
+						<MissingEntityHelpText
+							type={ attributes.type }
+							kind={ attributes.kind }
+						/>
+					</p>
+				) }
+				{ isBoundEntityAvailable && (
+					<p>
+						<BindingHelpText
+							type={ attributes.type }
+							kind={ attributes.kind }
+						/>
+					</p>
+				) }
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
@@ -350,13 +389,5 @@ export function MissingEntityHelpText( { type, kind } ) {
 		/* translators: %s is the entity type (e.g., "page", "post", "category") */
 		__( 'Synced %s is missing. Please update or remove this link.' ),
 		entityType
-	);
-}
-
-function MissingEntityHelp( { id, type, kind } ) {
-	return (
-		<span id={ id } className="navigation-link-control__error-text">
-			<MissingEntityHelpText type={ type } kind={ kind } />
-		</span>
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -113,6 +113,10 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	// Local state to control the input value
 	const [ inputValue, setInputValue ] = useState( url );
 
+	// Track focus state to control suggestion visibility
+	const [ isInputFocused, setIsInputFocused ] = useState( false );
+	const blurTimeoutRef = useRef();
+
 	// Sync local state when url prop changes (e.g., from undo/redo or external updates)
 	useEffect( () => {
 		setInputValue( url );
@@ -169,6 +173,15 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		shouldFocusUnsyncButtonRef.current = false;
 	}, [ hasUrlBinding ] );
 
+	// Cleanup blur timeout on unmount
+	useEffect( () => {
+		return () => {
+			if ( blurTimeoutRef.current ) {
+				clearTimeout( blurTimeoutRef.current );
+			}
+		};
+	}, [] );
+
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
@@ -208,79 +221,110 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<LinkControlSearchInput
-					className="navigation-link-control__search-input"
-					value={ inputValue ? safeDecodeURI( inputValue ) : '' }
-					currentLink={ {
-						url,
-						title: label && stripHTML( label ),
-						kind: attributes.kind,
-						type: attributes.type,
-						id: attributes.id,
-					} }
-					suggestionsQuery={ getSuggestionsQuery(
-						attributes.type,
-						attributes.kind
-					) }
-					onChange={ ( newValue ) => {
-						// Update local input state when typing
-						setInputValue( newValue );
-					} }
-					onSelect={ ( suggestion ) => {
-						// When a suggestion is selected (or Enter pressed)
-						if ( suggestion ) {
-							const attrs = {
-								url: suggestion.url,
-								kind: suggestion.kind,
-								type: suggestion.type,
-								id: suggestion.id,
-								title: suggestion.title,
-							};
-							updateAttributes(
-								attrs,
-								setAttributes,
-								attributes
-							);
-							// Create entity binding if we have entity data
-							if ( suggestion.id ) {
-								createBinding( attrs );
-								shouldFocusUnsyncButtonRef.current = true;
-							}
-						} else if ( inputValue ) {
-							// Freeform URL entry
-							updateAttributes(
-								{ url: inputValue },
-								setAttributes,
-								attributes
-							);
+				<div
+					onFocus={ () => {
+						// Clear any pending blur timeout
+						if ( blurTimeoutRef.current ) {
+							clearTimeout( blurTimeoutRef.current );
 						}
+						setIsInputFocused( true );
 					} }
-					allowDirectEntry={ ! hasUrlBinding }
-					showSuggestions
-					showInitialSuggestions
-					isEntity={ hasUrlBinding }
-					suffix={
-						hasUrlBinding && (
-							<Button
-								ref={ unsyncButtonRef }
-								icon={ unlinkIcon }
-								onClick={ () => {
-									unsyncBoundLink();
-									shouldFocusURLInputRef.current = true;
-								} }
-								aria-describedby={ helpTextId }
-								showTooltip
-								label={ __( 'Unsync and edit' ) }
-								__next40pxDefaultSize
-								className={
-									hasUrlBinding && ! isBoundEntityAvailable
-										? 'navigation-link-control__error-suffix-button'
-										: undefined
+					onBlur={ () => {
+						// Delay hiding suggestions to allow clicking on them
+						blurTimeoutRef.current = setTimeout( () => {
+							setIsInputFocused( false );
+						}, 150 );
+					} }
+				>
+					<LinkControlSearchInput
+						className="navigation-link-control__search-input"
+						value={ inputValue ? safeDecodeURI( inputValue ) : '' }
+						currentLink={
+							// When not focused, set currentLink.url to match the decoded value
+							// to trigger disableSuggestions in URLInput
+							! isInputFocused
+								? {
+										url: inputValue
+											? safeDecodeURI( inputValue )
+											: '',
+										title: label && stripHTML( label ),
+										kind: attributes.kind,
+										type: attributes.type,
+										id: attributes.id,
+								  }
+								: {
+										url,
+										title: label && stripHTML( label ),
+										kind: attributes.kind,
+										type: attributes.type,
+										id: attributes.id,
+								  }
+						}
+						suggestionsQuery={ getSuggestionsQuery(
+							attributes.type,
+							attributes.kind
+						) }
+						onChange={ ( newValue ) => {
+							// Update local input state when typing
+							setInputValue( newValue );
+						} }
+						onSelect={ ( suggestion ) => {
+							// When a suggestion is selected (or Enter pressed)
+							if ( suggestion ) {
+								const attrs = {
+									url: suggestion.url,
+									kind: suggestion.kind,
+									type: suggestion.type,
+									id: suggestion.id,
+									title: suggestion.title,
+								};
+								updateAttributes(
+									attrs,
+									setAttributes,
+									attributes
+								);
+								// Create entity binding if we have entity data
+								if ( suggestion.id ) {
+									createBinding( attrs );
+									shouldFocusUnsyncButtonRef.current = true;
 								}
-							/>
-						)
-					}
-				/>
+							} else if ( inputValue ) {
+								// Freeform URL entry
+								updateAttributes(
+									{ url: inputValue },
+									setAttributes,
+									attributes
+								);
+							}
+						} }
+						allowDirectEntry={ ! hasUrlBinding }
+						showSuggestions={ isInputFocused }
+						showInitialSuggestions={ isInputFocused }
+						isEntity={ hasUrlBinding }
+						suffix={
+							hasUrlBinding && (
+								<Button
+									ref={ unsyncButtonRef }
+									icon={ unlinkIcon }
+									onClick={ () => {
+										unsyncBoundLink();
+										shouldFocusURLInputRef.current = true;
+									} }
+									aria-describedby={ helpTextId }
+									showTooltip
+									label={ __( 'Unsync and edit' ) }
+									__next40pxDefaultSize
+									className={
+										hasUrlBinding &&
+										! isBoundEntityAvailable
+											? 'navigation-link-control__error-suffix-button'
+											: undefined
+									}
+								/>
+							)
+						}
+					/>
+				</div>
 				{ hasUrlBinding && ! isBoundEntityAvailable && (
 					<p id={ helpTextId }>
 						<MissingEntityHelpText

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -230,7 +230,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 							buttonRef={ previewButtonRef }
 							link={ attributes }
 							featuredImage={ featuredImage }
+							hasEntityBinding={ hasUrlBinding }
 							onClick={ () => {
+								// Open it
 								setInputValue( '' );
 								setIsEditing( true );
 							} }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -4,22 +4,21 @@
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	Button,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useEffect, useState } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
+import {
+	useInstanceId,
+	__experimentalUseDialog as useDialog,
+} from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
-import { linkOff as unlinkIcon } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
-import {
-	store as blockEditorStore,
-	__experimentalLinkControlSearchInput as LinkControlSearchInput,
-} from '@wordpress/block-editor';
+import { __experimentalLinkControlSearchInput as LinkControlSearchInput } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -27,6 +26,7 @@ import {
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { updateAttributes } from './update-attributes';
 import { useEntityBinding } from './use-entity-binding';
+import { LinkPreviewButton } from './link-preview-button';
 
 /**
  * Given the Link block's type attribute, return the query params for link suggestions.
@@ -103,19 +103,25 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const shouldFocusURLInputRef = useRef( false );
 	const shouldFocusUnsyncButtonRef = useRef( false );
 	const linkContainerRef = useRef();
-	const unsyncButtonRef = useRef();
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
 	// Local state to control the input value
 	const [ inputValue, setInputValue ] = useState( url );
 
-	// Track focus state to control suggestion visibility
-	const [ isInputFocused, setIsInputFocused ] = useState( false );
-	const blurTimeoutRef = useRef();
+	// Track editing state to toggle between preview button and input
+	const [ isEditing, setIsEditing ] = useState( ! url );
+	const previewButtonRef = useRef();
+
+	// Get dialog props for proper accessibility
+	const [ dialogRef, dialogProps ] = useDialog( {
+		focusOnMount: 'firstElement',
+		onClose: () => {
+			setIsEditing( false );
+		},
+	} );
 
 	// Sync local state when url prop changes (e.g., from undo/redo or external updates)
 	useEffect( () => {
@@ -124,63 +130,55 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	}, [ url ] );
 
 	// Use the entity binding hook internally
-	const {
-		hasUrlBinding,
-		isBoundEntityAvailable,
-		clearBinding,
-		createBinding,
-	} = useEntityBinding( {
-		clientId,
-		attributes,
-	} );
-
-	// Get direct store dispatch to bypass setBoundAttributes wrapper
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-
-	const unsyncBoundLink = () => {
-		// Clear the binding first
-		clearBinding();
-
-		// Use direct store dispatch to bypass block bindings safeguards
-		// which prevent updates to bound attributes when calling setAttributes.
-		// setAttributes is actually setBoundAttributes, a wrapper function that
-		// processes attributes through the binding system.
-		// See: packages/block-editor/src/components/block-edit/edit.js
-		updateBlockAttributes( clientId, {
-			url: lastURLRef.current, // set the lastURLRef as the new editable value so we avoid bugs from empty link states
-			id: undefined,
+	const { hasUrlBinding, isBoundEntityAvailable, createBinding } =
+		useEntityBinding( {
+			clientId,
+			attributes,
 		} );
-	};
 
-	// Focus the input field after unsyncing
-	useEffect( () => {
-		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
-			// Query for the input within the link container since
-			// ref is not available on LinkControlSearchInput experimental export
-			const input =
-				linkContainerRef.current?.querySelector( 'input[type="text"]' );
-			input?.focus();
-			input?.select();
-		}
-		shouldFocusURLInputRef.current = false;
-	}, [ hasUrlBinding ] );
-
-	// Focus the unsync button after creating a binding
-	useEffect( () => {
-		if ( hasUrlBinding && shouldFocusUnsyncButtonRef.current ) {
-			unsyncButtonRef.current?.focus();
-		}
-		shouldFocusUnsyncButtonRef.current = false;
-	}, [ hasUrlBinding ] );
-
-	// Cleanup blur timeout on unmount
-	useEffect( () => {
-		return () => {
-			if ( blurTimeoutRef.current ) {
-				clearTimeout( blurTimeoutRef.current );
+	// Fetch featured image for post-type entities
+	const featuredImage = useSelect(
+		( select ) => {
+			// Only fetch for post-type entities with an ID
+			if (
+				! attributes.id ||
+				attributes.kind !== 'post-type' ||
+				! attributes.type
+			) {
+				return null;
 			}
-		};
-	}, [] );
+
+			const { getEntityRecord } = select( coreStore );
+
+			// Get the post/page entity
+			const entity = getEntityRecord(
+				'postType',
+				attributes.type,
+				attributes.id
+			);
+
+			// If no entity or no featured media, return null
+			if ( ! entity || ! entity.featured_media ) {
+				return null;
+			}
+
+			// Get the media entity to fetch the image URL
+			const media = getEntityRecord(
+				'postType',
+				'attachment',
+				entity.featured_media
+			);
+
+			// Return the thumbnail or medium size URL, fallback to source_url
+			return (
+				media?.media_details?.sizes?.thumbnail?.source_url ||
+				media?.media_details?.sizes?.medium?.source_url ||
+				media?.source_url ||
+				null
+			);
+		},
+		[ attributes.id, attributes.kind, attributes.type ]
+	);
 
 	return (
 		<ToolsPanel
@@ -217,125 +215,89 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			<ToolsPanelItem
 				ref={ linkContainerRef }
 				hasValue={ () => !! url }
-				label={ __( 'Link' ) }
+				label={ __( 'Link to' ) }
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<div
-					onFocus={ () => {
-						// Clear any pending blur timeout
-						if ( blurTimeoutRef.current ) {
-							clearTimeout( blurTimeoutRef.current );
-						}
-						setIsInputFocused( true );
-					} }
-					onBlur={ () => {
-						// Delay hiding suggestions to allow clicking on them
-						blurTimeoutRef.current = setTimeout( () => {
-							setIsInputFocused( false );
-						}, 150 );
-					} }
-				>
-					<LinkControlSearchInput
-						className="navigation-link-control__search-input"
-						value={ inputValue ? safeDecodeURI( inputValue ) : '' }
-						currentLink={
-							// When not focused, set currentLink.url to match the decoded value
-							// to trigger disableSuggestions in URLInput
-							! isInputFocused
-								? {
-										url: inputValue
-											? safeDecodeURI( inputValue )
-											: '',
-										title: label && stripHTML( label ),
-										kind: attributes.kind,
-										type: attributes.type,
-										id: attributes.id,
-								  }
-								: {
-										url,
-										title: label && stripHTML( label ),
-										kind: attributes.kind,
-										type: attributes.type,
-										id: attributes.id,
-								  }
-						}
-						suggestionsQuery={ getSuggestionsQuery(
-							attributes.type,
-							attributes.kind
-						) }
-						onChange={ ( newValue ) => {
-							// Update local input state when typing
-							setInputValue( newValue );
+				{ url && (
+					<LinkPreviewButton
+						buttonRef={ previewButtonRef }
+						link={ attributes }
+						featuredImage={ featuredImage }
+						onClick={ () => {
+							setInputValue( '' );
+							setIsEditing( true );
 						} }
-						onSelect={ ( suggestion ) => {
-							// When a suggestion is selected (or Enter pressed)
-							if ( suggestion ) {
-								const attrs = {
-									url: suggestion.url,
-									kind: suggestion.kind,
-									type: suggestion.type,
-									id: suggestion.id,
-									title: suggestion.title,
-								};
-								updateAttributes(
-									attrs,
-									setAttributes,
-									attributes
-								);
-								// Create entity binding if we have entity data
-								if ( suggestion.id ) {
-									createBinding( attrs );
-									shouldFocusUnsyncButtonRef.current = true;
-								}
-							} else if ( inputValue ) {
-								// Freeform URL entry
-								updateAttributes(
-									{ url: inputValue },
-									setAttributes,
-									attributes
-								);
-							}
-						} }
-						allowDirectEntry={ ! hasUrlBinding }
-						showSuggestions={ isInputFocused }
-						showInitialSuggestions={ isInputFocused }
-						isEntity={ hasUrlBinding }
-						suffix={
-							hasUrlBinding && (
-								<Button
-									ref={ unsyncButtonRef }
-									icon={ unlinkIcon }
-									onClick={ () => {
-										unsyncBoundLink();
-										shouldFocusURLInputRef.current = true;
-									} }
-									aria-describedby={ helpTextId }
-									showTooltip
-									label={ __( 'Unsync and edit' ) }
-									__next40pxDefaultSize
-									className={
-										hasUrlBinding &&
-										! isBoundEntityAvailable
-											? 'navigation-link-control__error-suffix-button'
-											: undefined
-									}
-								/>
-							)
-						}
+						aria-haspopup="dialog"
+						aria-expanded={ isEditing }
 					/>
-				</div>
+				) }
+				{ isEditing && (
+					<div ref={ dialogRef } { ...dialogProps }>
+						<LinkControlSearchInput
+							className="navigation-link-control__search-input"
+							value={
+								inputValue ? safeDecodeURI( inputValue ) : ''
+							}
+							currentLink={ {
+								url,
+								title: label && stripHTML( label ),
+								kind: attributes.kind,
+								type: attributes.type,
+								id: attributes.id,
+							} }
+							suggestionsQuery={ getSuggestionsQuery(
+								attributes.type,
+								attributes.kind
+							) }
+							onChange={ ( newValue ) => {
+								// Update local input state when typing
+								setInputValue( newValue );
+							} }
+							onSelect={ ( suggestion ) => {
+								// When a suggestion is selected (or Enter pressed)
+								if ( suggestion ) {
+									const attrs = {
+										url: suggestion.url,
+										kind: suggestion.kind,
+										type: suggestion.type,
+										id: suggestion.id,
+										title: suggestion.title,
+									};
+									updateAttributes(
+										attrs,
+										setAttributes,
+										attributes
+									);
+									// Create entity binding if we have entity data
+									if ( suggestion.id ) {
+										createBinding( attrs );
+										shouldFocusUnsyncButtonRef.current = true;
+									}
+									// Exit edit mode and focus preview button
+									setIsEditing( false );
+								} else if ( inputValue ) {
+									// Freeform URL entry
+									updateAttributes(
+										{ url: inputValue },
+										setAttributes,
+										attributes
+									);
+									// Exit edit mode and focus preview button
+									setIsEditing( false );
+								}
+
+								// focus the preview button
+								previewButtonRef.current?.focus();
+							} }
+							showInitialSuggestions
+							showSuggestions
+						/>
+					</div>
+				) }
 				{ hasUrlBinding && ! isBoundEntityAvailable && (
 					<p id={ helpTextId }>
 						<MissingEntityHelpText
-							type={ attributes.type }
-							kind={ attributes.kind }
-						/>
-					</p>
-				) }
-				{ isBoundEntityAvailable && (
-					<p>
-						<BindingHelpText
 							type={ attributes.type }
 							kind={ attributes.kind }
 						/>

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	BaseControl,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
@@ -220,17 +221,24 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				isShownByDefault
 			>
 				{ url && (
-					<LinkPreviewButton
-						buttonRef={ previewButtonRef }
-						link={ attributes }
-						featuredImage={ featuredImage }
-						onClick={ () => {
-							setInputValue( '' );
-							setIsEditing( true );
-						} }
-						aria-haspopup="dialog"
-						aria-expanded={ isEditing }
-					/>
+					<BaseControl
+						label={ __( 'Link to' ) }
+						id={ `${ inputId }-button` }
+						__nextHasNoMarginBottom
+					>
+						<LinkPreviewButton
+							buttonRef={ previewButtonRef }
+							link={ attributes }
+							featuredImage={ featuredImage }
+							onClick={ () => {
+								setInputValue( '' );
+								setIsEditing( true );
+							} }
+							aria-haspopup="dialog"
+							aria-expanded={ isEditing }
+							id={ `${ inputId }-button` }
+						/>
+					</BaseControl>
 				) }
 				{ isEditing && (
 					<div ref={ dialogRef } { ...dialogProps }>

--- a/packages/block-library/src/navigation-link/shared/link-preview-button.js
+++ b/packages/block-library/src/navigation-link/shared/link-preview-button.js
@@ -2,13 +2,11 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	__experimentalTruncate as Truncate,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	FlexItem,
 } from '@wordpress/components';
-import { Icon, chevronDown } from '@wordpress/icons';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { __experimentalUseRemoteUrlData as useRemoteUrlData } from '@wordpress/block-editor';
@@ -25,7 +23,7 @@ import { __experimentalUseRemoteUrlData as useRemoteUrlData } from '@wordpress/b
  * @param {Object}   props.buttonRef        - Ref to attach to button
  * @param {Object}   props.props            - Additional props to pass to the button
  */
-export function LinkPreviewButton( {
+export function NavigationLinkPreview( {
 	link,
 	featuredImage,
 	hasEntityBinding,
@@ -71,21 +69,20 @@ export function LinkPreviewButton( {
 	}
 
 	return (
-		<Button
+		<div
 			ref={ buttonRef }
-			className="link-control-preview-button"
-			onClick={ onClick }
+			className="navigation-link-control-preview"
 			variant="secondary"
 			__next40pxDefaultSize
 			{ ...props }
 		>
 			<HStack justify="space-between" alignment="top">
-				<FlexItem className="link-control-preview-button__content">
+				<FlexItem className="navigation-link-control-preview__content">
 					<HStack alignment="top">
 						{ imageUrl && (
-							<FlexItem className="link-control-preview-button__image-container">
+							<FlexItem className="navigation-link-control-preview__image-container">
 								<img
-									className="link-control-preview-button__image"
+									className="navigation-link-control-preview__image"
 									src={ imageUrl }
 									alt=""
 								/>
@@ -93,29 +90,25 @@ export function LinkPreviewButton( {
 						) }
 
 						<VStack
-							className="link-control-preview-button__details"
+							className="navigation-link-control-preview__details"
 							alignment="topLeft"
 						>
 							<Truncate
 								numberOfLines={ 1 }
-								className="link-control-preview-button__title"
+								className="navigation-link-control-preview__title"
 							>
-								{ title }
+								<a href={ url }>{ title }</a>
 							</Truncate>
 							<Truncate
 								numberOfLines={ 1 }
-								className="link-control-preview-button__url"
+								className="navigation-link-control-preview__url"
 							>
 								{ displayUrl }
 							</Truncate>
 						</VStack>
 					</HStack>
 				</FlexItem>
-				<Icon
-					icon={ chevronDown }
-					className="link-control-preview-button__icon"
-				/>
 			</HStack>
-		</Button>
+		</div>
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/link-preview-button.js
+++ b/packages/block-library/src/navigation-link/shared/link-preview-button.js
@@ -11,29 +11,45 @@ import {
 import { Icon, chevronDown } from '@wordpress/icons';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { __experimentalUseRemoteUrlData as useRemoteUrlData } from '@wordpress/block-editor';
 
 /**
  * Link preview button component that displays the current link information.
  * Clicking this button reveals the LinkControlSearchInput.
  *
- * @param {Object}   props               - Component props
- * @param {Object}   props.link          - Link object with label, url, type, kind
- * @param {string}   props.featuredImage - Featured image URL (optional)
- * @param {Function} props.onClick       - Click handler
- * @param {Object}   props.buttonRef     - Ref to attach to button
- * @param {Object}   props.props         - Additional props to pass to the button
+ * @param {Object}   props                  - Component props
+ * @param {Object}   props.link             - Link object with label, url, type, kind, id
+ * @param {string}   props.featuredImage    - Featured image URL (optional)
+ * @param {boolean}  props.hasEntityBinding - Whether the link has an entity binding
+ * @param {Function} props.onClick          - Click handler
+ * @param {Object}   props.buttonRef        - Ref to attach to button
+ * @param {Object}   props.props            - Additional props to pass to the button
  */
 export function LinkPreviewButton( {
 	link,
 	featuredImage,
+	hasEntityBinding,
 	onClick,
 	buttonRef,
 	...props
 } ) {
 	const { label, url } = link;
 
-	// Get display title
-	const title = label ? stripHTML( label ) : safeDecodeURI( url );
+	// Fetch rich URL data for custom/external URLs (only if not entity-bound)
+	const { richData } = useRemoteUrlData( hasEntityBinding ? null : url );
+
+	// Get display title - prioritize richData.title for custom URLs
+	let title;
+	if ( richData?.title ) {
+		title = richData.title;
+	} else if ( label ) {
+		title = stripHTML( label );
+	} else {
+		title = safeDecodeURI( url );
+	}
+
+	// Get image - use featuredImage for entities, richData.icon for custom URLs
+	const imageUrl = featuredImage || richData?.icon;
 
 	// Get display URL - strip site URL if it matches current site
 	let displayUrl = safeDecodeURI( url || '' );
@@ -66,11 +82,11 @@ export function LinkPreviewButton( {
 			<HStack justify="space-between" alignment="top">
 				<FlexItem className="link-control-preview-button__content">
 					<HStack alignment="top">
-						{ featuredImage && (
+						{ imageUrl && (
 							<FlexItem className="link-control-preview-button__image-container">
 								<img
 									className="link-control-preview-button__image"
-									src={ featuredImage }
+									src={ imageUrl }
 									alt=""
 								/>
 							</FlexItem>

--- a/packages/block-library/src/navigation-link/shared/link-preview-button.js
+++ b/packages/block-library/src/navigation-link/shared/link-preview-button.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalTruncate as Truncate,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	FlexItem,
+} from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
+import { safeDecodeURI } from '@wordpress/url';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+
+/**
+ * Link preview button component that displays the current link information.
+ * Clicking this button reveals the LinkControlSearchInput.
+ *
+ * @param {Object}   props               - Component props
+ * @param {Object}   props.link          - Link object with label, url, type, kind
+ * @param {string}   props.featuredImage - Featured image URL (optional)
+ * @param {Function} props.onClick       - Click handler
+ * @param {Object}   props.buttonRef     - Ref to attach to button
+ * @param {Object}   props.props         - Additional props to pass to the button
+ */
+export function LinkPreviewButton( {
+	link,
+	featuredImage,
+	onClick,
+	buttonRef,
+	...props
+} ) {
+	const { label, url } = link;
+
+	// Get display title
+	const title = label ? stripHTML( label ) : safeDecodeURI( url );
+
+	// Get display URL - strip site URL if it matches current site
+	let displayUrl = safeDecodeURI( url || '' );
+	try {
+		const linkUrl = new URL( url );
+		const siteUrl = window.location.origin;
+		if ( linkUrl.origin === siteUrl ) {
+			// Show only the pathname (and search/hash if present)
+			let path = linkUrl.pathname + linkUrl.search + linkUrl.hash;
+			// Remove trailing slash
+			if ( path.endsWith( '/' ) && path.length > 1 ) {
+				path = path.slice( 0, -1 );
+			}
+			displayUrl = path;
+		}
+	} catch ( e ) {
+		// If URL parsing fails, use the original URL
+		displayUrl = safeDecodeURI( url || '' );
+	}
+
+	return (
+		<Button
+			ref={ buttonRef }
+			className="link-control-preview-button"
+			onClick={ onClick }
+			variant="secondary"
+			__next40pxDefaultSize
+			{ ...props }
+		>
+			<HStack justify="space-between" alignment="top">
+				<FlexItem className="link-control-preview-button__content">
+					<HStack alignment="top">
+						{ featuredImage && (
+							<FlexItem className="link-control-preview-button__image-container">
+								<img
+									className="link-control-preview-button__image"
+									src={ featuredImage }
+									alt=""
+								/>
+							</FlexItem>
+						) }
+
+						<VStack
+							className="link-control-preview-button__details"
+							alignment="topLeft"
+						>
+							<Truncate
+								numberOfLines={ 1 }
+								className="link-control-preview-button__title"
+							>
+								{ title }
+							</Truncate>
+							<Truncate
+								numberOfLines={ 1 }
+								className="link-control-preview-button__url"
+							>
+								{ displayUrl }
+							</Truncate>
+						</VStack>
+					</HStack>
+				</FlexItem>
+				<Icon
+					icon={ chevronDown }
+					className="link-control-preview-button__icon"
+				/>
+			</HStack>
+		</Button>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Alternative to https://github.com/WordPress/gutenberg/pull/73731

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/73310

<!-- In a few words, what is the PR actually doing? -->
Adds a Link Preview to the navigation link sidebar above the link control input to give confidence for the link control value.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. Give confidence about where your navigation link is linking to
2. Use the link control for searching entities

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a navigation link preview to the sidebar that updates when the link control value updates

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/14688771-fef8-4548-a385-37a8b67d9edf



|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
