### PR TITLE
Add overlay template part selector to Navigation block (behind experiment)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -533,7 +533,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTemplatePart, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -533,7 +533,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTemplatePart, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -54,6 +54,9 @@
 			"type": "string",
 			"default": "mobile"
 		},
+		"overlayTemplatePart": {
+			"type": "string"
+		},
 		"icon": {
 			"type": "string",
 			"default": "handle"

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -54,7 +54,7 @@
 			"type": "string",
 			"default": "mobile"
 		},
-		"overlayTemplatePart": {
+		"overlay": {
 			"type": "string"
 		},
 		"icon": {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -64,6 +64,7 @@ import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 import useNavigationNotice from './use-navigation-notice';
 import OverlayMenuIcon from './overlay-menu-icon';
 import OverlayMenuPreview from './overlay-menu-preview';
+import OverlayPanel from './overlay-panel';
 import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_ERROR,
 	CLASSIC_MENU_CONVERSION_PENDING,
@@ -263,6 +264,7 @@ function Navigation( {
 	const {
 		openSubmenusOnClick,
 		overlayMenu,
+		overlayTemplatePart,
 		showSubmenuIcon,
 		templateLock,
 		layout: {
@@ -287,6 +289,21 @@ function Navigation( {
 	const hasAlreadyRendered = useHasRecursion( recursionId );
 
 	const blockEditingMode = useBlockEditingMode();
+
+	// Get onNavigateToEntityRecord from block editor settings
+	const { onNavigateToEntityRecord } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
+		};
+	}, [] );
+
+	// Check if the customizable navigation overlays experiment is enabled
+	// The experiment sets window.__experimentalNavigationOverlays = true
+	const isOverlayExperimentEnabled =
+		typeof window !== 'undefined' &&
+		window.__experimentalNavigationOverlays === true;
 
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
@@ -815,6 +832,16 @@ function Navigation( {
 					</ToolsPanel>
 				) }
 			</InspectorControls>
+			{ isOverlayExperimentEnabled && (
+				<InspectorControls>
+					<OverlayPanel
+						overlayMenu={ overlayMenu }
+						overlayTemplatePart={ overlayTemplatePart }
+						setAttributes={ setAttributes }
+						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+					/>
+				</InspectorControls>
+			) }
 			<InspectorControls group="color">
 				{ /*
 				 * Avoid useMultipleOriginColorsAndGradients and detectColors

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -261,7 +261,7 @@ function Navigation( {
 	const {
 		openSubmenusOnClick,
 		overlayMenu,
-		overlayTemplatePart,
+		overlay,
 		showSubmenuIcon,
 		templateLock,
 		layout: {
@@ -287,7 +287,6 @@ function Navigation( {
 
 	const blockEditingMode = useBlockEditingMode();
 
-	// Get onNavigateToEntityRecord from block editor settings
 	const { onNavigateToEntityRecord } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const settings = getSettings();
@@ -296,8 +295,6 @@ function Navigation( {
 		};
 	}, [] );
 
-	// Check if the customizable navigation overlays experiment is enabled
-	// The experiment sets window.__experimentalNavigationOverlays = true
 	const isOverlayExperimentEnabled =
 		typeof window !== 'undefined' &&
 		window.__experimentalNavigationOverlays === true;
@@ -794,7 +791,7 @@ function Navigation( {
 				<InspectorControls>
 					<OverlayPanel
 						overlayMenu={ overlayMenu }
-						overlayTemplatePart={ overlayTemplatePart }
+						overlay={ overlay }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 						overlayMenuPreview={ overlayMenuPreview }
@@ -872,7 +869,7 @@ function Navigation( {
 					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
-					overlayTemplatePart={ overlayTemplatePart }
+					overlay={ overlay }
 					onNavigateToEntityRecord={ onNavigateToEntityRecord }
 				>
 					<UnsavedInnerBlocks
@@ -1036,7 +1033,7 @@ function Navigation( {
 									overlayBackgroundColor
 								}
 								overlayTextColor={ overlayTextColor }
-								overlayTemplatePart={ overlayTemplatePart }
+								overlay={ overlay }
 								onNavigateToEntityRecord={
 									onNavigateToEntityRecord
 								}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -675,88 +675,114 @@ function Navigation( {
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ isResponsive && (
+						{ ! isOverlayExperimentEnabled && (
 							<>
-								<Button
-									__next40pxDefaultSize
-									className={ overlayMenuPreviewClasses }
-									onClick={ () => {
-										setOverlayMenuPreview(
-											! overlayMenuPreview
-										);
-									} }
-									aria-label={ __( 'Overlay menu controls' ) }
-									aria-controls={ overlayMenuPreviewId }
-									aria-expanded={ overlayMenuPreview }
-								>
-									{ hasIcon && (
-										<>
-											<OverlayMenuIcon icon={ icon } />
-											<Icon icon={ close } />
-										</>
-									) }
-									{ ! hasIcon && (
-										<>
-											<span>{ __( 'Menu' ) }</span>
-											<span>{ __( 'Close' ) }</span>
-										</>
-									) }
-								</Button>
-								{ overlayMenuPreview && (
-									<VStack
-										id={ overlayMenuPreviewId }
-										spacing={ 4 }
-										style={ {
-											gridColumn: 'span 2',
-										} }
-									>
-										<OverlayMenuPreview
-											setAttributes={ setAttributes }
-											hasIcon={ hasIcon }
-											icon={ icon }
-											hidden={ ! overlayMenuPreview }
-										/>
-									</VStack>
+								{ isResponsive && (
+									<>
+										<Button
+											__next40pxDefaultSize
+											className={
+												overlayMenuPreviewClasses
+											}
+											onClick={ () => {
+												setOverlayMenuPreview(
+													! overlayMenuPreview
+												);
+											} }
+											aria-label={ __(
+												'Overlay menu controls'
+											) }
+											aria-controls={
+												overlayMenuPreviewId
+											}
+											aria-expanded={ overlayMenuPreview }
+										>
+											{ hasIcon && (
+												<>
+													<OverlayMenuIcon
+														icon={ icon }
+													/>
+													<Icon icon={ close } />
+												</>
+											) }
+											{ ! hasIcon && (
+												<>
+													<span>
+														{ __( 'Menu' ) }
+													</span>
+													<span>
+														{ __( 'Close' ) }
+													</span>
+												</>
+											) }
+										</Button>
+										{ overlayMenuPreview && (
+											<VStack
+												id={ overlayMenuPreviewId }
+												spacing={ 4 }
+												style={ {
+													gridColumn: 'span 2',
+												} }
+											>
+												<OverlayMenuPreview
+													setAttributes={
+														setAttributes
+													}
+													hasIcon={ hasIcon }
+													icon={ icon }
+													hidden={
+														! overlayMenuPreview
+													}
+												/>
+											</VStack>
+										) }
+									</>
 								) }
+
+								<ToolsPanelItem
+									hasValue={ () => overlayMenu !== 'mobile' }
+									label={ __( 'Overlay Visibility' ) }
+									onDeselect={ () =>
+										setAttributes( {
+											overlayMenu: 'mobile',
+										} )
+									}
+									isShownByDefault
+								>
+									<ToggleGroupControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Overlay Visibility' ) }
+										aria-label={ __(
+											'Configure overlay visibility'
+										) }
+										value={ overlayMenu }
+										help={ __(
+											'Collapses the navigation options in a menu icon opening an overlay.'
+										) }
+										onChange={ ( value ) =>
+											setAttributes( {
+												overlayMenu: value,
+											} )
+										}
+										isBlock
+									>
+										<ToggleGroupControlOption
+											value="never"
+											label={ __( 'Off' ) }
+										/>
+										<ToggleGroupControlOption
+											value="mobile"
+											label={ __( 'Mobile' ) }
+										/>
+										<ToggleGroupControlOption
+											value="always"
+											label={ __( 'Always' ) }
+										/>
+									</ToggleGroupControl>
+								</ToolsPanelItem>
 							</>
 						) }
-
-						<ToolsPanelItem
-							hasValue={ () => overlayMenu !== 'mobile' }
-							label={ __( 'Overlay Menu' ) }
-							onDeselect={ () =>
-								setAttributes( { overlayMenu: 'mobile' } )
-							}
-							isShownByDefault
-						>
-							<ToggleGroupControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ __( 'Overlay Menu' ) }
-								aria-label={ __( 'Configure overlay menu' ) }
-								value={ overlayMenu }
-								help={ __(
-									'Collapses the navigation options in a menu icon opening an overlay.'
-								) }
-								onChange={ ( value ) =>
-									setAttributes( { overlayMenu: value } )
-								}
-								isBlock
-							>
-								<ToggleGroupControlOption
-									value="never"
-									label={ __( 'Off' ) }
-								/>
-								<ToggleGroupControlOption
-									value="mobile"
-									label={ __( 'Mobile' ) }
-								/>
-								<ToggleGroupControlOption
-									value="always"
-									label={ __( 'Always' ) }
-								/>
-							</ToggleGroupControl>
-						</ToolsPanelItem>
 
 						{ hasSubmenus && (
 							<>
@@ -839,6 +865,13 @@ function Navigation( {
 						overlayTemplatePart={ overlayTemplatePart }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+						overlayMenuPreview={ overlayMenuPreview }
+						setOverlayMenuPreview={ setOverlayMenuPreview }
+						hasIcon={ hasIcon }
+						icon={ icon }
+						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
+						overlayMenuPreviewId={ overlayMenuPreviewId }
+						isResponsive={ isResponsive }
 					/>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -34,11 +34,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	__experimentalVStack as VStack,
 	ToggleControl,
-	Button,
 	Spinner,
 	Notice,
 	ToolbarButton,
@@ -46,7 +42,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { close, Icon, page } from '@wordpress/icons';
+import { page } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -62,9 +62,10 @@ import NavigationMenuNameControl from './navigation-menu-name-control';
 import UnsavedInnerBlocks from './unsaved-inner-blocks';
 import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 import useNavigationNotice from './use-navigation-notice';
-import OverlayMenuIcon from './overlay-menu-icon';
 import OverlayMenuPreview from './overlay-menu-preview';
 import OverlayPanel from './overlay-panel';
+import OverlayVisibilityControl from './overlay-visibility-control';
+import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_ERROR,
 	CLASSIC_MENU_CONVERSION_PENDING,
@@ -678,65 +679,27 @@ function Navigation( {
 						{ ! isOverlayExperimentEnabled && (
 							<>
 								{ isResponsive && (
-									<>
-										<Button
-											__next40pxDefaultSize
-											className={
-												overlayMenuPreviewClasses
-											}
-											onClick={ () => {
-												setOverlayMenuPreview(
-													! overlayMenuPreview
-												);
-											} }
-											aria-label={ __(
-												'Overlay menu controls'
-											) }
-											aria-controls={
-												overlayMenuPreviewId
-											}
-											aria-expanded={ overlayMenuPreview }
-										>
-											{ hasIcon && (
-												<>
-													<OverlayMenuIcon
-														icon={ icon }
-													/>
-													<Icon icon={ close } />
-												</>
-											) }
-											{ ! hasIcon && (
-												<>
-													<span>
-														{ __( 'Menu' ) }
-													</span>
-													<span>
-														{ __( 'Close' ) }
-													</span>
-												</>
-											) }
-										</Button>
-										{ overlayMenuPreview && (
-											<VStack
-												id={ overlayMenuPreviewId }
-												spacing={ 4 }
-												style={ {
-													gridColumn: 'span 2',
-												} }
-											>
-												<OverlayMenuPreview
-													setAttributes={
-														setAttributes
-													}
-													hasIcon={ hasIcon }
-													icon={ icon }
-													hidden={
-														! overlayMenuPreview
-													}
-												/>
-											</VStack>
-										) }
-									</>
+									<OverlayMenuPreviewButton
+										isResponsive={ isResponsive }
+										overlayMenuPreview={
+											overlayMenuPreview
+										}
+										setOverlayMenuPreview={
+											setOverlayMenuPreview
+										}
+										hasIcon={ hasIcon }
+										icon={ icon }
+										setAttributes={ setAttributes }
+										overlayMenuPreviewClasses={
+											overlayMenuPreviewClasses
+										}
+										overlayMenuPreviewId={
+											overlayMenuPreviewId
+										}
+										containerStyle={ {
+											gridColumn: 'span 2',
+										} }
+									/>
 								) }
 
 								<ToolsPanelItem
@@ -749,37 +712,10 @@ function Navigation( {
 									}
 									isShownByDefault
 								>
-									<ToggleGroupControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										label={ __( 'Overlay Visibility' ) }
-										aria-label={ __(
-											'Configure overlay visibility'
-										) }
-										value={ overlayMenu }
-										help={ __(
-											'Collapses the navigation options in a menu icon opening an overlay.'
-										) }
-										onChange={ ( value ) =>
-											setAttributes( {
-												overlayMenu: value,
-											} )
-										}
-										isBlock
-									>
-										<ToggleGroupControlOption
-											value="never"
-											label={ __( 'Off' ) }
-										/>
-										<ToggleGroupControlOption
-											value="mobile"
-											label={ __( 'Mobile' ) }
-										/>
-										<ToggleGroupControlOption
-											value="always"
-											label={ __( 'Always' ) }
-										/>
-									</ToggleGroupControl>
+									<OverlayVisibilityControl
+										overlayMenu={ overlayMenu }
+										setAttributes={ setAttributes }
+									/>
 								</ToolsPanelItem>
 							</>
 						) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -940,6 +940,8 @@ function Navigation( {
 					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					overlayTemplatePart={ overlayTemplatePart }
+					onNavigateToEntityRecord={ onNavigateToEntityRecord }
 				>
 					<UnsavedInnerBlocks
 						createNavigationMenu={ createNavigationMenu }
@@ -1102,6 +1104,10 @@ function Navigation( {
 									overlayBackgroundColor
 								}
 								overlayTextColor={ overlayTextColor }
+								overlayTemplatePart={ overlayTemplatePart }
+								onNavigateToEntityRecord={
+									onNavigateToEntityRecord
+								}
 							>
 								{ isEntityAvailable && (
 									<NavigationInnerBlocks

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -71,9 +71,9 @@ export default function OverlayMenuPreviewButton( {
 					style={ containerStyle }
 				>
 					<OverlayMenuPreviewControls
-						setAttributes={ setAttributes }
 						hasIcon={ hasIcon }
 						icon={ icon }
+						setAttributes={ setAttributes }
 					/>
 				</VStack>
 			) }

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -14,17 +14,17 @@ import OverlayMenuPreviewControls from './overlay-menu-preview-controls';
 /**
  * Overlay Menu Preview Button component.
  *
- * @param {Object}   props                          Component props.
- * @param {boolean}  props.isResponsive             Whether overlay menu is responsive.
- * @param {boolean}  props.overlayMenuPreview       Whether overlay menu preview is open.
- * @param {Function} props.setOverlayMenuPreview    Function to toggle overlay menu preview.
- * @param {boolean}  props.hasIcon                  Whether the overlay menu has an icon.
- * @param {string}   props.icon                     Icon type for overlay menu.
- * @param {Function} props.setAttributes            Function to update block attributes.
+ * @param {Object}   props                           Component props.
+ * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
+ * @param {boolean}  props.overlayMenuPreview        Whether overlay menu preview is open.
+ * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
+ * @param {boolean}  props.hasIcon                   Whether the overlay menu has an icon.
+ * @param {string}   props.icon                      Icon type for overlay menu.
+ * @param {Function} props.setAttributes             Function to update block attributes.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
- * @param {string}   props.overlayMenuPreviewId     ID for overlay menu preview.
- * @param {string}   props.containerStyle           Optional style for the preview container.
- * @return {JSX.Element|null} The overlay menu preview button or null if not responsive.
+ * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
+ * @param {string}   props.containerStyle            Optional style for the preview container.
+ * @return {JSX.Element|null}                       The overlay menu preview button or null if not responsive.
  */
 export default function OverlayMenuPreviewButton( {
 	isResponsive,
@@ -80,4 +80,3 @@ export default function OverlayMenuPreviewButton( {
 		</>
 	);
 }
-

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, close } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import OverlayMenuIcon from './overlay-menu-icon';
+import OverlayMenuPreviewControls from './overlay-menu-preview-controls';
+
+/**
+ * Overlay Menu Preview Button component.
+ *
+ * @param {Object}   props                          Component props.
+ * @param {boolean}  props.isResponsive             Whether overlay menu is responsive.
+ * @param {boolean}  props.overlayMenuPreview       Whether overlay menu preview is open.
+ * @param {Function} props.setOverlayMenuPreview    Function to toggle overlay menu preview.
+ * @param {boolean}  props.hasIcon                  Whether the overlay menu has an icon.
+ * @param {string}   props.icon                     Icon type for overlay menu.
+ * @param {Function} props.setAttributes            Function to update block attributes.
+ * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
+ * @param {string}   props.overlayMenuPreviewId     ID for overlay menu preview.
+ * @param {string}   props.containerStyle           Optional style for the preview container.
+ * @return {JSX.Element|null} The overlay menu preview button or null if not responsive.
+ */
+export default function OverlayMenuPreviewButton( {
+	isResponsive,
+	overlayMenuPreview,
+	setOverlayMenuPreview,
+	hasIcon,
+	icon,
+	setAttributes,
+	overlayMenuPreviewClasses,
+	overlayMenuPreviewId,
+	containerStyle,
+} ) {
+	if ( ! isResponsive ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				className={ overlayMenuPreviewClasses }
+				onClick={ () => setOverlayMenuPreview( ! overlayMenuPreview ) }
+				aria-label={ __( 'Overlay menu controls' ) }
+				aria-controls={ overlayMenuPreviewId }
+				aria-expanded={ overlayMenuPreview }
+			>
+				{ hasIcon && (
+					<>
+						<OverlayMenuIcon icon={ icon } />
+						<Icon icon={ close } />
+					</>
+				) }
+				{ ! hasIcon && (
+					<>
+						<span>{ __( 'Menu' ) }</span>
+						<span>{ __( 'Close' ) }</span>
+					</>
+				) }
+			</Button>
+			{ overlayMenuPreview && (
+				<VStack
+					id={ overlayMenuPreviewId }
+					spacing={ 4 }
+					style={ containerStyle }
+				>
+					<OverlayMenuPreviewControls
+						setAttributes={ setAttributes }
+						hasIcon={ hasIcon }
+						icon={ icon }
+					/>
+				</VStack>
+			) }
+		</>
+	);
+}
+

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
@@ -18,11 +18,11 @@ import OverlayMenuIcon from './overlay-menu-icon';
  * Overlay Menu Preview Controls component.
  * Used within PanelBody context (not ToolsPanel).
  *
- * @param {Object}   props              Component props.
- * @param {boolean}  props.hasIcon      Whether the overlay menu has an icon.
- * @param {string}   props.icon         Icon type for overlay menu.
+ * @param {Object}   props               Component props.
+ * @param {boolean}  props.hasIcon       Whether the overlay menu has an icon.
+ * @param {string}   props.icon          Icon type for overlay menu.
  * @param {Function} props.setAttributes Function to update block attributes.
- * @return {JSX.Element} The overlay menu preview controls.
+ * @return {JSX.Element}                The overlay menu preview controls.
  */
 export default function OverlayMenuPreviewControls( {
 	hasIcon,
@@ -37,9 +37,7 @@ export default function OverlayMenuPreviewControls( {
 				help={ __(
 					'Configure the visual appearance of the button that toggles the overlay menu.'
 				) }
-				onChange={ ( value ) =>
-					setAttributes( { hasIcon: value } )
-				}
+				onChange={ ( value ) => setAttributes( { hasIcon: value } ) }
 				checked={ hasIcon }
 			/>
 			<ToggleGroupControl
@@ -65,4 +63,3 @@ export default function OverlayMenuPreviewControls( {
 		</VStack>
 	);
 }
-

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
@@ -18,9 +18,9 @@ import OverlayMenuIcon from './overlay-menu-icon';
  * Overlay Menu Preview Controls component.
  * Used within PanelBody context (not ToolsPanel).
  *
- * @param {Object}  props       Component props.
- * @param {boolean} props.hasIcon Whether the overlay menu has an icon.
- * @param {string}  props.icon  Icon type for overlay menu.
+ * @param {Object}   props              Component props.
+ * @param {boolean}  props.hasIcon      Whether the overlay menu has an icon.
+ * @param {string}   props.icon         Icon type for overlay menu.
  * @param {Function} props.setAttributes Function to update block attributes.
  * @return {JSX.Element} The overlay menu preview controls.
  */

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import OverlayMenuIcon from './overlay-menu-icon';
+
+/**
+ * Overlay Menu Preview Controls component.
+ * Used within PanelBody context (not ToolsPanel).
+ *
+ * @param {Object}  props       Component props.
+ * @param {boolean} props.hasIcon Whether the overlay menu has an icon.
+ * @param {string}  props.icon  Icon type for overlay menu.
+ * @param {Function} props.setAttributes Function to update block attributes.
+ * @return {JSX.Element} The overlay menu preview controls.
+ */
+export default function OverlayMenuPreviewControls( {
+	hasIcon,
+	icon,
+	setAttributes,
+} ) {
+	return (
+		<VStack spacing={ 4 }>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Show icon button' ) }
+				help={ __(
+					'Configure the visual appearance of the button that toggles the overlay menu.'
+				) }
+				onChange={ ( value ) =>
+					setAttributes( { hasIcon: value } )
+				}
+				checked={ hasIcon }
+			/>
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				className="wp-block-navigation__overlay-menu-icon-toggle-group"
+				label={ __( 'Icon' ) }
+				value={ icon }
+				onChange={ ( value ) => setAttributes( { icon: value } ) }
+				isBlock
+			>
+				<ToggleGroupControlOption
+					value="handle"
+					aria-label={ __( 'handle' ) }
+					label={ <OverlayMenuIcon icon="handle" /> }
+				/>
+				<ToggleGroupControlOption
+					value="menu"
+					aria-label={ __( 'menu' ) }
+					label={ <OverlayMenuIcon icon="menu" /> }
+				/>
+			</ToggleGroupControl>
+		</VStack>
+	);
+}
+

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -19,7 +19,7 @@ import OverlayMenuPreviewButton from './overlay-menu-preview-button';
  *
  * @param {Object}   props                           Component props.
  * @param {string}   props.overlayMenu               Overlay menu setting ('never', 'mobile', 'always').
- * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
+ * @param {string}   props.overlay                   Currently selected overlay template part ID.
  * @param {Function} props.setAttributes             Function to update block attributes.
  * @param {Function} props.onNavigateToEntityRecord  Function to navigate to template part editor.
  * @param {boolean}  props.overlayMenuPreview        Whether overlay menu preview is open.
@@ -33,7 +33,7 @@ import OverlayMenuPreviewButton from './overlay-menu-preview-button';
  */
 export default function OverlayPanel( {
 	overlayMenu,
-	overlayTemplatePart,
+	overlay,
 	setAttributes,
 	onNavigateToEntityRecord,
 	overlayMenuPreview,
@@ -67,7 +67,7 @@ export default function OverlayPanel( {
 
 				{ overlayMenu !== 'never' && (
 					<OverlayTemplatePartSelector
-						overlayTemplatePart={ overlayTemplatePart }
+						overlay={ overlay }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 					/>

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import OverlayTemplatePartSelector from './overlay-template-part-selector';
+
+/**
+ * Overlay Panel component for Navigation block.
+ *
+ * @param {Object}   props                          Component props.
+ * @param {string}   props.overlayMenu              Overlay menu setting ('never', 'mobile', 'always').
+ * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
+ * @param {Function} props.setAttributes            Function to update block attributes.
+ * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
+ * @return {JSX.Element|null} The overlay panel component or null if overlay is disabled.
+ */
+export default function OverlayPanel( {
+	overlayMenu,
+	overlayTemplatePart,
+	setAttributes,
+	onNavigateToEntityRecord,
+} ) {
+	// Only show panel when overlay is enabled
+	if ( overlayMenu === 'never' ) {
+		return null;
+	}
+
+	return (
+		<PanelBody title={ __( 'Overlay' ) } initialOpen>
+			<VStack spacing={ 4 }>
+				<OverlayTemplatePartSelector
+					overlayTemplatePart={ overlayTemplatePart }
+					setAttributes={ setAttributes }
+					onNavigateToEntityRecord={ onNavigateToEntityRecord }
+				/>
+			</VStack>
+		</PanelBody>
+	);
+}
+

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -17,19 +17,19 @@ import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 /**
  * Overlay Panel component for Navigation block.
  *
- * @param {Object}   props                          Component props.
- * @param {string}   props.overlayMenu              Overlay menu setting ('never', 'mobile', 'always').
- * @param {string}   props.overlayTemplatePart      Currently selected overlay template part ID.
- * @param {Function} props.setAttributes            Function to update block attributes.
- * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
- * @param {boolean}  props.overlayMenuPreview       Whether overlay menu preview is open.
- * @param {Function} props.setOverlayMenuPreview    Function to toggle overlay menu preview.
- * @param {boolean}  props.hasIcon                  Whether the overlay menu has an icon.
- * @param {string}   props.icon                     Icon type for overlay menu.
+ * @param {Object}   props                           Component props.
+ * @param {string}   props.overlayMenu               Overlay menu setting ('never', 'mobile', 'always').
+ * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
+ * @param {Function} props.setAttributes             Function to update block attributes.
+ * @param {Function} props.onNavigateToEntityRecord  Function to navigate to template part editor.
+ * @param {boolean}  props.overlayMenuPreview        Whether overlay menu preview is open.
+ * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
+ * @param {boolean}  props.hasIcon                   Whether the overlay menu has an icon.
+ * @param {string}   props.icon                      Icon type for overlay menu.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
- * @param {string}   props.overlayMenuPreviewId     ID for overlay menu preview.
- * @param {boolean}  props.isResponsive             Whether overlay menu is responsive.
- * @return {JSX.Element|null} The overlay panel component or null if overlay is disabled.
+ * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
+ * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
+ * @return {JSX.Element|null}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
 	overlayMenu,

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -4,19 +4,15 @@
 import {
 	PanelBody,
 	__experimentalVStack as VStack,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	ToggleControl,
-	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, close } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import OverlayTemplatePartSelector from './overlay-template-part-selector';
-import OverlayMenuIcon from './overlay-menu-icon';
+import OverlayVisibilityControl from './overlay-visibility-control';
+import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 
 /**
  * Overlay Panel component for Navigation block.
@@ -51,100 +47,22 @@ export default function OverlayPanel( {
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
 			<VStack spacing={ 4 }>
-				<ToggleGroupControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Overlay Visibility' ) }
-					aria-label={ __( 'Configure overlay visibility' ) }
-					value={ overlayMenu }
-					help={ __(
-						'Collapses the navigation options in a menu icon opening an overlay.'
-					) }
-					onChange={ ( value ) =>
-						setAttributes( { overlayMenu: value } )
-					}
-					isBlock
-				>
-					<ToggleGroupControlOption
-						value="never"
-						label={ __( 'Off' ) }
-					/>
-					<ToggleGroupControlOption
-						value="mobile"
-						label={ __( 'Mobile' ) }
-					/>
-					<ToggleGroupControlOption
-						value="always"
-						label={ __( 'Always' ) }
-					/>
-				</ToggleGroupControl>
+				<OverlayVisibilityControl
+					overlayMenu={ overlayMenu }
+					setAttributes={ setAttributes }
+				/>
 
-				{ isResponsive && overlayMenu !== 'never' && (
-					<>
-						<Button
-							__next40pxDefaultSize
-							className={ overlayMenuPreviewClasses }
-							onClick={ () => {
-								setOverlayMenuPreview( ! overlayMenuPreview );
-							} }
-							aria-label={ __( 'Overlay menu controls' ) }
-							aria-controls={ overlayMenuPreviewId }
-							aria-expanded={ overlayMenuPreview }
-						>
-							{ hasIcon && (
-								<>
-									<OverlayMenuIcon icon={ icon } />
-									<Icon icon={ close } />
-								</>
-							) }
-							{ ! hasIcon && (
-								<>
-									<span>{ __( 'Menu' ) }</span>
-									<span>{ __( 'Close' ) }</span>
-								</>
-							) }
-						</Button>
-						{ overlayMenuPreview && (
-							<VStack
-								id={ overlayMenuPreviewId }
-								spacing={ 4 }
-							>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show icon button' ) }
-									help={ __(
-										'Configure the visual appearance of the button that toggles the overlay menu.'
-									) }
-									onChange={ ( value ) =>
-										setAttributes( { hasIcon: value } )
-									}
-									checked={ hasIcon }
-								/>
-								<ToggleGroupControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									className="wp-block-navigation__overlay-menu-icon-toggle-group"
-									label={ __( 'Icon' ) }
-									value={ icon }
-									onChange={ ( value ) =>
-										setAttributes( { icon: value } )
-									}
-									isBlock
-								>
-									<ToggleGroupControlOption
-										value="handle"
-										aria-label={ __( 'handle' ) }
-										label={ <OverlayMenuIcon icon="handle" /> }
-									/>
-									<ToggleGroupControlOption
-										value="menu"
-										aria-label={ __( 'menu' ) }
-										label={ <OverlayMenuIcon icon="menu" /> }
-									/>
-								</ToggleGroupControl>
-							</VStack>
-						) }
-					</>
+				{ overlayMenu !== 'never' && (
+					<OverlayMenuPreviewButton
+						isResponsive={ isResponsive }
+						overlayMenuPreview={ overlayMenuPreview }
+						setOverlayMenuPreview={ setOverlayMenuPreview }
+						hasIcon={ hasIcon }
+						icon={ icon }
+						setAttributes={ setAttributes }
+						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
+						overlayMenuPreviewId={ overlayMenuPreviewId }
+					/>
 				) }
 
 				{ overlayMenu !== 'never' && (

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -1,22 +1,38 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	PanelBody,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	ToggleControl,
+	Button,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Icon, close } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import OverlayTemplatePartSelector from './overlay-template-part-selector';
+import OverlayMenuIcon from './overlay-menu-icon';
 
 /**
  * Overlay Panel component for Navigation block.
  *
  * @param {Object}   props                          Component props.
  * @param {string}   props.overlayMenu              Overlay menu setting ('never', 'mobile', 'always').
- * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
+ * @param {string}   props.overlayTemplatePart      Currently selected overlay template part ID.
  * @param {Function} props.setAttributes            Function to update block attributes.
  * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
+ * @param {boolean}  props.overlayMenuPreview       Whether overlay menu preview is open.
+ * @param {Function} props.setOverlayMenuPreview    Function to toggle overlay menu preview.
+ * @param {boolean}  props.hasIcon                  Whether the overlay menu has an icon.
+ * @param {string}   props.icon                     Icon type for overlay menu.
+ * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
+ * @param {string}   props.overlayMenuPreviewId     ID for overlay menu preview.
+ * @param {boolean}  props.isResponsive             Whether overlay menu is responsive.
  * @return {JSX.Element|null} The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -24,22 +40,121 @@ export default function OverlayPanel( {
 	overlayTemplatePart,
 	setAttributes,
 	onNavigateToEntityRecord,
+	overlayMenuPreview,
+	setOverlayMenuPreview,
+	hasIcon,
+	icon,
+	overlayMenuPreviewClasses,
+	overlayMenuPreviewId,
+	isResponsive,
 } ) {
-	// Only show panel when overlay is enabled
-	if ( overlayMenu === 'never' ) {
-		return null;
-	}
-
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
 			<VStack spacing={ 4 }>
-				<OverlayTemplatePartSelector
-					overlayTemplatePart={ overlayTemplatePart }
-					setAttributes={ setAttributes }
-					onNavigateToEntityRecord={ onNavigateToEntityRecord }
-				/>
+				<ToggleGroupControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Overlay Visibility' ) }
+					aria-label={ __( 'Configure overlay visibility' ) }
+					value={ overlayMenu }
+					help={ __(
+						'Collapses the navigation options in a menu icon opening an overlay.'
+					) }
+					onChange={ ( value ) =>
+						setAttributes( { overlayMenu: value } )
+					}
+					isBlock
+				>
+					<ToggleGroupControlOption
+						value="never"
+						label={ __( 'Off' ) }
+					/>
+					<ToggleGroupControlOption
+						value="mobile"
+						label={ __( 'Mobile' ) }
+					/>
+					<ToggleGroupControlOption
+						value="always"
+						label={ __( 'Always' ) }
+					/>
+				</ToggleGroupControl>
+
+				{ isResponsive && overlayMenu !== 'never' && (
+					<>
+						<Button
+							__next40pxDefaultSize
+							className={ overlayMenuPreviewClasses }
+							onClick={ () => {
+								setOverlayMenuPreview( ! overlayMenuPreview );
+							} }
+							aria-label={ __( 'Overlay menu controls' ) }
+							aria-controls={ overlayMenuPreviewId }
+							aria-expanded={ overlayMenuPreview }
+						>
+							{ hasIcon && (
+								<>
+									<OverlayMenuIcon icon={ icon } />
+									<Icon icon={ close } />
+								</>
+							) }
+							{ ! hasIcon && (
+								<>
+									<span>{ __( 'Menu' ) }</span>
+									<span>{ __( 'Close' ) }</span>
+								</>
+							) }
+						</Button>
+						{ overlayMenuPreview && (
+							<VStack
+								id={ overlayMenuPreviewId }
+								spacing={ 4 }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show icon button' ) }
+									help={ __(
+										'Configure the visual appearance of the button that toggles the overlay menu.'
+									) }
+									onChange={ ( value ) =>
+										setAttributes( { hasIcon: value } )
+									}
+									checked={ hasIcon }
+								/>
+								<ToggleGroupControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									className="wp-block-navigation__overlay-menu-icon-toggle-group"
+									label={ __( 'Icon' ) }
+									value={ icon }
+									onChange={ ( value ) =>
+										setAttributes( { icon: value } )
+									}
+									isBlock
+								>
+									<ToggleGroupControlOption
+										value="handle"
+										aria-label={ __( 'handle' ) }
+										label={ <OverlayMenuIcon icon="handle" /> }
+									/>
+									<ToggleGroupControlOption
+										value="menu"
+										aria-label={ __( 'menu' ) }
+										label={ <OverlayMenuIcon icon="menu" /> }
+									/>
+								</ToggleGroupControl>
+							</VStack>
+						) }
+					</>
+				) }
+
+				{ overlayMenu !== 'never' && (
+					<OverlayTemplatePartSelector
+						overlayTemplatePart={ overlayTemplatePart }
+						setAttributes={ setAttributes }
+						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+					/>
+				) }
 			</VStack>
 		</PanelBody>
 	);
 }
-

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -38,9 +38,9 @@ function parseTemplatePartId( templatePartId ) {
  * Overlay Template Part Selector component.
  *
  * @param {Object}   props                          Component props.
- * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
- * @param {Function} props.setAttributes             Function to update block attributes.
- * @param {Function} props.onNavigateToEntityRecord  Function to navigate to template part editor.
+ * @param {string}   props.overlayTemplatePart      Currently selected overlay template part ID.
+ * @param {Function} props.setAttributes            Function to update block attributes.
+ * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
  * @return {JSX.Element} The overlay template part selector component.
  */
 export default function OverlayTemplatePartSelector( {

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -104,6 +104,20 @@ export default function OverlayTemplatePartSelector( {
 		return parseTemplatePartId( overlay );
 	}, [ overlay ] );
 
+	// Find the selected template part to get its title
+	const selectedTemplatePart = useMemo( () => {
+		if ( ! overlay || ! overlayTemplateParts ) {
+			return null;
+		}
+		return overlayTemplateParts.find( ( templatePart ) => {
+			const templatePartId = createTemplatePartId(
+				templatePart.theme,
+				templatePart.slug
+			);
+			return templatePartId === overlay;
+		} );
+	}, [ overlay, overlayTemplateParts ] );
+
 	const handleSelectChange = ( value ) => {
 		setAttributes( {
 			overlay: value || undefined,
@@ -149,7 +163,7 @@ export default function OverlayTemplatePartSelector( {
 				accessibleWhenDisabled
 				help={
 					overlayTemplateParts.length === 0 && hasResolved
-						? __( 'No overlays found. Create one?' )
+						? __( 'No overlays found.' )
 						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>
@@ -161,11 +175,16 @@ export default function OverlayTemplatePartSelector( {
 					disabled={ isEditButtonDisabled }
 					accessibleWhenDisabled
 					aria-label={
-						parsedTemplatePart
+						selectedTemplatePart
 							? sprintf(
-									/* translators: %s: Overlay title or slug. */
+									/* translators: %s: Overlay title. */
 									__( 'Edit overlay: %s' ),
-									overlay
+									selectedTemplatePart.title?.rendered
+										? decodeEntities(
+												selectedTemplatePart.title
+													.rendered
+										  )
+										: selectedTemplatePart.slug
 							  )
 							: __( 'Edit overlay' )
 					}

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -111,14 +111,13 @@ export default function OverlayTemplatePartSelector( {
 	};
 
 	const handleEditClick = () => {
-		if ( ! parsedTemplatePart || ! onNavigateToEntityRecord ) {
+		if ( ! overlayTemplatePart || ! onNavigateToEntityRecord ) {
 			return;
 		}
 
 		onNavigateToEntityRecord( {
-			kind: 'postType',
-			name: 'wp_template_part',
 			postId: overlayTemplatePart,
+			postType: 'wp_template_part',
 		} );
 	};
 

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -156,25 +156,27 @@ export default function OverlayTemplatePartSelector( {
 						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				onClick={ handleEditClick }
-				disabled={ isEditButtonDisabled }
-				accessibleWhenDisabled
-				aria-label={
-					parsedTemplatePart
-						? sprintf(
-								/* translators: %s: Overlay title or slug. */
-								__( 'Edit overlay: %s' ),
-								overlayTemplatePart
-						  )
-						: __( 'Edit overlay' )
-				}
-				style={ { marginTop: '8px', width: '100%' } }
-			>
-				{ __( 'Edit' ) }
-			</Button>
+			{ overlayTemplatePart && (
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ handleEditClick }
+					disabled={ isEditButtonDisabled }
+					accessibleWhenDisabled
+					aria-label={
+						parsedTemplatePart
+							? sprintf(
+									/* translators: %s: Overlay title or slug. */
+									__( 'Edit overlay: %s' ),
+									overlayTemplatePart
+							  )
+							: __( 'Edit overlay' )
+					}
+					className="wp-block-navigation__overlay-edit-button"
+				>
+					{ __( 'Edit' ) }
+				</Button>
+			) }
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -1,0 +1,183 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { SelectControl, Spinner, Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
+
+/**
+ * Parses a template part ID into theme and slug components.
+ *
+ * @param {string} templatePartId Template part ID in format "theme//slug".
+ * @return {{theme: string, slug: string}|null} Parsed components or null if invalid.
+ */
+function parseTemplatePartId( templatePartId ) {
+	if ( ! templatePartId || typeof templatePartId !== 'string' ) {
+		return null;
+	}
+
+	const parts = templatePartId.split( '//' );
+	if ( parts.length !== 2 ) {
+		return null;
+	}
+
+	return {
+		theme: parts[ 0 ],
+		slug: parts[ 1 ],
+	};
+}
+
+/**
+ * Overlay Template Part Selector component.
+ *
+ * @param {Object}   props                          Component props.
+ * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
+ * @param {Function} props.setAttributes            Function to update block attributes.
+ * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
+ * @return {JSX.Element} The overlay template part selector component.
+ */
+export default function OverlayTemplatePartSelector( {
+	overlayTemplatePart,
+	setAttributes,
+	onNavigateToEntityRecord,
+} ) {
+	const {
+		records: templateParts,
+		isResolving,
+		hasResolved,
+	} = useEntityRecords( 'postType', 'wp_template_part', {
+		per_page: -1,
+	} );
+
+	// Filter template parts by overlay area
+	const overlayTemplateParts = useMemo( () => {
+		if ( ! templateParts ) {
+			return [];
+		}
+		return templateParts.filter(
+			( templatePart ) => templatePart.area === 'overlay'
+		);
+	}, [ templateParts ] );
+
+	// Build options for SelectControl
+	const options = useMemo( () => {
+		const baseOptions = [
+			{
+				label: __( 'None' ),
+				value: '',
+			},
+		];
+
+		if ( ! hasResolved || isResolving ) {
+			return baseOptions;
+		}
+
+		const templatePartOptions = overlayTemplateParts.map(
+			( templatePart ) => {
+				const templatePartId = createTemplatePartId(
+					templatePart.theme,
+					templatePart.slug
+				);
+				const label = templatePart.title?.rendered
+					? decodeEntities( templatePart.title.rendered )
+					: templatePart.slug;
+
+				return {
+					label,
+					value: templatePartId,
+				};
+			}
+		);
+
+		return [ ...baseOptions, ...templatePartOptions ];
+	}, [ overlayTemplateParts, hasResolved, isResolving ] );
+
+	// Parse selected template part for navigation
+	const parsedTemplatePart = useMemo( () => {
+		return parseTemplatePartId( overlayTemplatePart );
+	}, [ overlayTemplatePart ] );
+
+	const handleSelectChange = ( value ) => {
+		setAttributes( {
+			overlayTemplatePart: value || undefined,
+		} );
+	};
+
+	const handleEditClick = () => {
+		if ( ! parsedTemplatePart || ! onNavigateToEntityRecord ) {
+			return;
+		}
+
+		onNavigateToEntityRecord( {
+			kind: 'postType',
+			name: 'wp_template_part',
+			postId: overlayTemplatePart,
+		} );
+	};
+
+	const isEditButtonDisabled =
+		! overlayTemplatePart ||
+		! parsedTemplatePart ||
+		! onNavigateToEntityRecord ||
+		isResolving;
+
+	if ( isResolving && ! hasResolved ) {
+		return (
+			<div>
+				<Spinner />
+				<p>{ __( 'Loading overlay template parts…' ) }</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="wp-block-navigation__overlay-template-part-selector">
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Overlay Template Part' ) }
+				value={ overlayTemplatePart || '' }
+				options={ options }
+				onChange={ handleSelectChange }
+				disabled={ isResolving }
+				accessibleWhenDisabled
+				help={
+					overlayTemplateParts.length === 0 && hasResolved
+						? __(
+								'No overlay template parts available. Create one in the Site Editor.'
+						  )
+						: __(
+								'Select a template part to use as the navigation overlay.'
+						  )
+				}
+			/>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				onClick={ handleEditClick }
+				disabled={ isEditButtonDisabled }
+				accessibleWhenDisabled
+				aria-label={
+					parsedTemplatePart
+						? sprintf(
+								/* translators: %s: Template part title or slug. */
+								__( 'Edit overlay template part: %s' ),
+								overlayTemplatePart
+						  )
+						: __( 'Edit overlay template part' )
+				}
+				style={ { marginTop: '8px', width: '100%' } }
+			>
+				{ __( 'Edit' ) }
+			</Button>
+		</div>
+	);
+}
+

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -141,7 +141,7 @@ export default function OverlayTemplatePartSelector( {
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
-				label={ __( 'Overlay' ) }
+				label={ __( 'Overlay template' ) }
 				value={ overlayTemplatePart || '' }
 				options={ options }
 				onChange={ handleSelectChange }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -38,13 +38,13 @@ function parseTemplatePartId( templatePartId ) {
  * Overlay Template Part Selector component.
  *
  * @param {Object}   props                          Component props.
- * @param {string}   props.overlayTemplatePart      Currently selected overlay template part ID.
+ * @param {string}   props.overlay                  Currently selected overlay template part ID.
  * @param {Function} props.setAttributes            Function to update block attributes.
  * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
  * @return {JSX.Element} The overlay template part selector component.
  */
 export default function OverlayTemplatePartSelector( {
-	overlayTemplatePart,
+	overlay,
 	setAttributes,
 	onNavigateToEntityRecord,
 } ) {
@@ -101,35 +101,35 @@ export default function OverlayTemplatePartSelector( {
 
 	// Parse selected template part for navigation
 	const parsedTemplatePart = useMemo( () => {
-		return parseTemplatePartId( overlayTemplatePart );
-	}, [ overlayTemplatePart ] );
+		return parseTemplatePartId( overlay );
+	}, [ overlay ] );
 
 	const handleSelectChange = ( value ) => {
 		setAttributes( {
-			overlayTemplatePart: value || undefined,
+			overlay: value || undefined,
 		} );
 	};
 
 	const handleEditClick = () => {
-		if ( ! overlayTemplatePart || ! onNavigateToEntityRecord ) {
+		if ( ! overlay || ! onNavigateToEntityRecord ) {
 			return;
 		}
 
 		onNavigateToEntityRecord( {
-			postId: overlayTemplatePart,
+			postId: overlay,
 			postType: 'wp_template_part',
 		} );
 	};
 
 	const isEditButtonDisabled =
-		! overlayTemplatePart ||
+		! overlay ||
 		! parsedTemplatePart ||
 		! onNavigateToEntityRecord ||
 		isResolving;
 
 	if ( isResolving && ! hasResolved ) {
 		return (
-			<div>
+			<div className="wp-block-navigation__overlay-selector">
 				<Spinner />
 				<p>{ __( 'Loading overlays…' ) }</p>
 			</div>
@@ -137,12 +137,12 @@ export default function OverlayTemplatePartSelector( {
 	}
 
 	return (
-		<div className="wp-block-navigation__overlay-template-part-selector">
+		<div className="wp-block-navigation__overlay-selector">
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				label={ __( 'Overlay template' ) }
-				value={ overlayTemplatePart || '' }
+				value={ overlay || '' }
 				options={ options }
 				onChange={ handleSelectChange }
 				disabled={ isResolving }
@@ -153,7 +153,7 @@ export default function OverlayTemplatePartSelector( {
 						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>
-			{ overlayTemplatePart && (
+			{ overlay && (
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"
@@ -165,7 +165,7 @@ export default function OverlayTemplatePartSelector( {
 							? sprintf(
 									/* translators: %s: Overlay title or slug. */
 									__( 'Edit overlay: %s' ),
-									overlayTemplatePart
+									overlay
 							  )
 							: __( 'Edit overlay' )
 					}

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -70,7 +70,7 @@ export default function OverlayTemplatePartSelector( {
 	const options = useMemo( () => {
 		const baseOptions = [
 			{
-				label: __( 'None' ),
+				label: __( 'None (default)' ),
 				value: '',
 			},
 		];
@@ -149,9 +149,7 @@ export default function OverlayTemplatePartSelector( {
 				accessibleWhenDisabled
 				help={
 					overlayTemplateParts.length === 0 && hasResolved
-						? __(
-								'No overlays available. Create one in the Site Editor.'
-						  )
+						? __( 'No overlays found. Create one?' )
 						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -39,8 +39,8 @@ function parseTemplatePartId( templatePartId ) {
  *
  * @param {Object}   props                          Component props.
  * @param {string}   props.overlayTemplatePart       Currently selected overlay template part ID.
- * @param {Function} props.setAttributes            Function to update block attributes.
- * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
+ * @param {Function} props.setAttributes             Function to update block attributes.
+ * @param {Function} props.onNavigateToEntityRecord  Function to navigate to template part editor.
  * @return {JSX.Element} The overlay template part selector component.
  */
 export default function OverlayTemplatePartSelector( {
@@ -132,7 +132,7 @@ export default function OverlayTemplatePartSelector( {
 		return (
 			<div>
 				<Spinner />
-				<p>{ __( 'Loading overlay template parts…' ) }</p>
+				<p>{ __( 'Loading overlays…' ) }</p>
 			</div>
 		);
 	}
@@ -142,7 +142,7 @@ export default function OverlayTemplatePartSelector( {
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
-				label={ __( 'Overlay Template Part' ) }
+				label={ __( 'Overlay' ) }
 				value={ overlayTemplatePart || '' }
 				options={ options }
 				onChange={ handleSelectChange }
@@ -151,11 +151,9 @@ export default function OverlayTemplatePartSelector( {
 				help={
 					overlayTemplateParts.length === 0 && hasResolved
 						? __(
-								'No overlay template parts available. Create one in the Site Editor.'
+								'No overlays available. Create one in the Site Editor.'
 						  )
-						: __(
-								'Select a template part to use as the navigation overlay.'
-						  )
+						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>
 			<Button
@@ -167,11 +165,11 @@ export default function OverlayTemplatePartSelector( {
 				aria-label={
 					parsedTemplatePart
 						? sprintf(
-								/* translators: %s: Template part title or slug. */
-								__( 'Edit overlay template part: %s' ),
+								/* translators: %s: Overlay title or slug. */
+								__( 'Edit overlay: %s' ),
 								overlayTemplatePart
 						  )
-						: __( 'Edit overlay template part' )
+						: __( 'Edit overlay' )
 				}
 				style={ { marginTop: '8px', width: '100%' } }
 			>
@@ -180,4 +178,3 @@ export default function OverlayTemplatePartSelector( {
 		</div>
 	);
 }
-

--- a/packages/block-library/src/navigation/edit/overlay-visibility-control.js
+++ b/packages/block-library/src/navigation/edit/overlay-visibility-control.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Overlay Visibility Control component.
  *
- * @param {Object}   props              Component props.
- * @param {string}   props.overlayMenu  Overlay menu setting ('never', 'mobile', 'always').
+ * @param {Object}   props               Component props.
+ * @param {string}   props.overlayMenu   Overlay menu setting ('never', 'mobile', 'always').
  * @param {Function} props.setAttributes Function to update block attributes.
- * @return {JSX.Element} The overlay visibility control.
+ * @return {JSX.Element}                 The overlay visibility control.
  */
 export default function OverlayVisibilityControl( {
 	overlayMenu,
@@ -33,15 +33,8 @@ export default function OverlayVisibilityControl( {
 			isBlock
 		>
 			<ToggleGroupControlOption value="never" label={ __( 'Off' ) } />
-			<ToggleGroupControlOption
-				value="mobile"
-				label={ __( 'Mobile' ) }
-			/>
-			<ToggleGroupControlOption
-				value="always"
-				label={ __( 'Always' ) }
-			/>
+			<ToggleGroupControlOption value="mobile" label={ __( 'Mobile' ) } />
+			<ToggleGroupControlOption value="always" label={ __( 'Always' ) } />
 		</ToggleGroupControl>
 	);
 }
-

--- a/packages/block-library/src/navigation/edit/overlay-visibility-control.js
+++ b/packages/block-library/src/navigation/edit/overlay-visibility-control.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Overlay Visibility Control component.
+ *
+ * @param {Object}   props              Component props.
+ * @param {string}   props.overlayMenu  Overlay menu setting ('never', 'mobile', 'always').
+ * @param {Function} props.setAttributes Function to update block attributes.
+ * @return {JSX.Element} The overlay visibility control.
+ */
+export default function OverlayVisibilityControl( {
+	overlayMenu,
+	setAttributes,
+} ) {
+	return (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Overlay Visibility' ) }
+			aria-label={ __( 'Configure overlay visibility' ) }
+			value={ overlayMenu }
+			help={ __(
+				'Collapses the navigation options in a menu icon opening an overlay.'
+			) }
+			onChange={ ( value ) => setAttributes( { overlayMenu: value } ) }
+			isBlock
+		>
+			<ToggleGroupControlOption value="never" label={ __( 'Off' ) } />
+			<ToggleGroupControlOption
+				value="mobile"
+				label={ __( 'Mobile' ) }
+			/>
+			<ToggleGroupControlOption
+				value="always"
+				label={ __( 'Always' ) }
+			/>
+		</ToggleGroupControl>
+	);
+}
+

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -27,6 +27,8 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	overlayTemplatePart,
+	onNavigateToEntityRecord,
 } ) {
 	if ( ! isResponsive ) {
 		return children;
@@ -75,6 +77,19 @@ export default function ResponsiveWrapper( {
 		} ),
 	};
 
+	const handleToggleClick = () => {
+		// If an overlay template part is selected, navigate to it instead of toggling
+		if ( overlayTemplatePart && onNavigateToEntityRecord ) {
+			onNavigateToEntityRecord( {
+				postId: overlayTemplatePart,
+				postType: 'wp_template_part',
+			} );
+			return;
+		}
+		// Otherwise, use normal toggle behavior
+		onToggle( true );
+	};
+
 	return (
 		<>
 			{ ! isOpen && (
@@ -83,7 +98,7 @@ export default function ResponsiveWrapper( {
 					aria-haspopup="true"
 					aria-label={ hasIcon && __( 'Open menu' ) }
 					className={ openButtonClasses }
-					onClick={ () => onToggle( true ) }
+					onClick={ handleToggleClick }
 				>
 					{ hasIcon && <OverlayMenuIcon icon={ icon } /> }
 					{ ! hasIcon && __( 'Menu' ) }

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -27,7 +27,7 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
-	overlayTemplatePart,
+	overlay,
 	onNavigateToEntityRecord,
 } ) {
 	if ( ! isResponsive ) {
@@ -79,9 +79,9 @@ export default function ResponsiveWrapper( {
 
 	const handleToggleClick = () => {
 		// If an overlay template part is selected, navigate to it instead of toggling
-		if ( overlayTemplatePart && onNavigateToEntityRecord ) {
+		if ( overlay && onNavigateToEntityRecord ) {
 			onNavigateToEntityRecord( {
-				postId: overlayTemplatePart,
+				postId: overlay,
 				postType: 'wp_template_part',
 			} );
 			return;

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -27,7 +27,7 @@ const mockSetAttributes = jest.fn();
 const mockOnNavigateToEntityRecord = jest.fn();
 
 const defaultProps = {
-	overlayTemplatePart: undefined,
+	overlay: undefined,
 	setAttributes: mockSetAttributes,
 	onNavigateToEntityRecord: mockOnNavigateToEntityRecord,
 };
@@ -181,7 +181,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			await user.selectOptions( select, 'twentytwentyfive//my-overlay' );
 
 			expect( mockSetAttributes ).toHaveBeenCalledWith( {
-				overlayTemplatePart: 'twentytwentyfive//my-overlay',
+				overlay: 'twentytwentyfive//my-overlay',
 			} );
 		} );
 
@@ -197,7 +197,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 
@@ -208,7 +208,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			await user.selectOptions( select, '' );
 
 			expect( mockSetAttributes ).toHaveBeenCalledWith( {
-				overlayTemplatePart: undefined,
+				overlay: undefined,
 			} );
 		} );
 
@@ -222,7 +222,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 
@@ -261,7 +261,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 
@@ -286,7 +286,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 
@@ -308,7 +308,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 					onNavigateToEntityRecord={ undefined }
 				/>
 			);
@@ -334,7 +334,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 
@@ -363,7 +363,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 					onNavigateToEntityRecord={ undefined }
 				/>
 			);
@@ -426,7 +426,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlayTemplatePart="twentytwentyfive//my-overlay"
+					overlay="twentytwentyfive//my-overlay"
 				/>
 			);
 

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -1,0 +1,440 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import OverlayTemplatePartSelector from '../overlay-template-part-selector';
+
+// Mock useEntityRecords
+jest.mock( '@wordpress/core-data', () => {
+	const actual = jest.requireActual( '@wordpress/core-data' );
+	return {
+		...actual,
+		useEntityRecords: jest.fn(),
+	};
+} );
+
+const mockSetAttributes = jest.fn();
+const mockOnNavigateToEntityRecord = jest.fn();
+
+const defaultProps = {
+	overlayTemplatePart: undefined,
+	setAttributes: mockSetAttributes,
+	onNavigateToEntityRecord: mockOnNavigateToEntityRecord,
+};
+
+const templatePart1 = {
+	id: 1,
+	theme: 'twentytwentyfive',
+	slug: 'my-overlay',
+	title: {
+		rendered: 'My Overlay',
+	},
+	area: 'overlay',
+};
+
+const templatePart2 = {
+	id: 2,
+	theme: 'twentytwentyfive',
+	slug: 'another-overlay',
+	title: {
+		rendered: 'Another Overlay',
+	},
+	area: 'overlay',
+};
+
+const templatePartOtherArea = {
+	id: 3,
+	theme: 'twentytwentyfive',
+	slug: 'header-part',
+	title: {
+		rendered: 'Header Part',
+	},
+	area: 'header',
+};
+
+const allTemplateParts = [
+	templatePart1,
+	templatePart2,
+	templatePartOtherArea,
+];
+
+describe( 'OverlayTemplatePartSelector', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useEntityRecords.mockReturnValue( {
+			records: [],
+			isResolving: false,
+			hasResolved: false,
+		} );
+	} );
+
+	describe( 'Loading state', () => {
+		it( 'should show loading spinner when template parts are resolving', () => {
+			useEntityRecords.mockReturnValue( {
+				records: null,
+				isResolving: true,
+				hasResolved: false,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Loading overlay template parts…' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Template part selection', () => {
+		it( 'should show selector with "None" option when no template parts are available', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+			expect( select ).toBeInTheDocument();
+			expect( select ).toHaveValue( '' );
+
+			// Check for "None" option
+			expect( screen.getByRole( 'option', { name: 'None' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'should filter template parts by overlay area', () => {
+			useEntityRecords.mockReturnValue( {
+				records: allTemplateParts,
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+
+			// Should have None + 2 overlay template parts (not the header one)
+			const options = screen.getAllByRole( 'option' );
+			expect( options ).toHaveLength( 3 ); // None + 2 overlay parts
+
+			expect(
+				screen.getByRole( 'option', { name: 'My Overlay' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'option', { name: 'Another Overlay' } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'option', { name: 'Header Part' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should display template part slug when title is missing', () => {
+			const templatePartNoTitle = {
+				...templatePart1,
+				title: null,
+			};
+
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePartNoTitle ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			expect(
+				screen.getByRole( 'option', { name: 'my-overlay' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should call setAttributes when a template part is selected', async () => {
+			const user = userEvent.setup();
+
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+
+			await user.selectOptions( select, 'twentytwentyfive//my-overlay' );
+
+			expect( mockSetAttributes ).toHaveBeenCalledWith( {
+				overlayTemplatePart: 'twentytwentyfive//my-overlay',
+			} );
+		} );
+
+		it( 'should call setAttributes with undefined when "None" is selected', async () => {
+			const user = userEvent.setup();
+
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+
+			await user.selectOptions( select, '' );
+
+			expect( mockSetAttributes ).toHaveBeenCalledWith( {
+				overlayTemplatePart: undefined,
+			} );
+		} );
+
+		it( 'should display selected template part', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+
+			expect( select ).toHaveValue( 'twentytwentyfive//my-overlay' );
+		} );
+	} );
+
+	describe( 'Edit button', () => {
+		it( 'should be disabled when no template part is selected', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			expect( editButton ).toBeDisabled();
+		} );
+
+		it( 'should be disabled when template parts are loading', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: true,
+				hasResolved: false,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			expect( editButton ).toBeDisabled();
+		} );
+
+		it( 'should be enabled when a valid template part is selected', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			expect( editButton ).toBeEnabled();
+		} );
+
+		it( 'should be disabled when onNavigateToEntityRecord is not available', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+					onNavigateToEntityRecord={ undefined }
+				/>
+			);
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			expect( editButton ).toBeDisabled();
+		} );
+
+		it( 'should call onNavigateToEntityRecord when edit button is clicked', async () => {
+			const user = userEvent.setup();
+
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			await user.click( editButton );
+
+			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
+				kind: 'postType',
+				name: 'wp_template_part',
+				postId: 'twentytwentyfive//my-overlay',
+			} );
+		} );
+
+		it( 'should not call onNavigateToEntityRecord when button is disabled', async () => {
+			const user = userEvent.setup();
+
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const editButton = screen.getByRole( 'button', {
+				name: 'Edit overlay template part',
+			} );
+
+			// Button should be disabled, but try clicking anyway
+			expect( editButton ).toBeDisabled();
+
+			await user.click( editButton );
+
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Help text', () => {
+		it( 'should show help text when no overlay template parts are available', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			expect(
+				screen.getByText(
+					'No overlay template parts available. Create one in the Site Editor.'
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'should show default help text when overlay template parts are available', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			expect(
+				screen.getByText(
+					'Select a template part to use as the navigation overlay.'
+				)
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Accessibility', () => {
+		it( 'should have proper ARIA labels on edit button', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+				/>
+			);
+
+			const editButton = screen.getByRole( 'button', {
+				name: /Edit overlay template part/,
+			} );
+
+			expect( editButton ).toHaveAccessibleName();
+		} );
+
+		it( 'should disable select control when loading', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [ templatePart1 ],
+				isResolving: true,
+				hasResolved: false,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay Template Part',
+			} );
+
+			expect( select ).toBeDisabled();
+		} );
+	} );
+} );
+

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -394,7 +394,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			expect(
-				screen.getByText( 'No overlays found. Create one?' )
+				screen.getByText( 'No overlays found.' )
 			).toBeInTheDocument();
 		} );
 

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -93,7 +93,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Template part selection', () => {
-		it( 'should show selector with "None" option when no template parts are available', () => {
+		it( 'should show selector with "None (default)" option when no template parts are available', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [],
 				isResolving: false,
@@ -108,8 +108,8 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( select ).toBeInTheDocument();
 			expect( select ).toHaveValue( '' );
 
-			// Check for "None" option
-			expect( screen.getByRole( 'option', { name: 'None' } ) ).toBeInTheDocument();
+			// Check for "None (default)" option
+			expect( screen.getByRole( 'option', { name: 'None (default)' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'should filter template parts by overlay area', () => {
@@ -181,7 +181,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 		} );
 
-		it( 'should call setAttributes with undefined when "None" is selected', async () => {
+		it( 'should call setAttributes with undefined when "None (default)" is selected', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -375,9 +375,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			expect(
-				screen.getByText(
-					'No overlays available. Create one in the Site Editor.'
-				)
+				screen.getByText( 'No overlays found. Create one?' )
 			).toBeInTheDocument();
 		} );
 

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -88,7 +88,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			expect( screen.getByText( 'Loading overlay template parts…' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Loading overlays…' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -103,7 +103,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay',
 			} );
 			expect( select ).toBeInTheDocument();
 			expect( select ).toHaveValue( '' );
@@ -125,7 +125,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 				name: 'Overlay Template Part',
 			} );
 
-			// Should have None + 2 overlay template parts (not the header one)
+			// Should have None + 2 overlays (not the header one)
 			const options = screen.getAllByRole( 'option' );
 			expect( options ).toHaveLength( 3 ); // None + 2 overlay parts
 
@@ -171,7 +171,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay',
 			} );
 
 			await user.selectOptions( select, 'twentytwentyfive//my-overlay' );
@@ -198,7 +198,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay',
 			} );
 
 			await user.selectOptions( select, '' );
@@ -223,7 +223,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay',
 			} );
 
 			expect( select ).toHaveValue( 'twentytwentyfive//my-overlay' );
@@ -241,7 +241,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			expect( editButton ).toBeDisabled();
@@ -262,7 +262,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			expect( editButton ).toBeDisabled();
@@ -283,7 +283,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			expect( editButton ).toBeEnabled();
@@ -305,7 +305,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			expect( editButton ).toBeDisabled();
@@ -328,7 +328,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			await user.click( editButton );
@@ -352,7 +352,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay template part',
+				name: 'Edit overlay',
 			} );
 
 			// Button should be disabled, but try clicking anyway
@@ -365,7 +365,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Help text', () => {
-		it( 'should show help text when no overlay template parts are available', () => {
+		it( 'should show help text when no overlays are available', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [],
 				isResolving: false,
@@ -376,12 +376,12 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			expect(
 				screen.getByText(
-					'No overlay template parts available. Create one in the Site Editor.'
+					'No overlays available. Create one in the Site Editor.'
 				)
 			).toBeInTheDocument();
 		} );
 
-		it( 'should show default help text when overlay template parts are available', () => {
+		it( 'should show default help text when overlays are available', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -392,7 +392,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			expect(
 				screen.getByText(
-					'Select a template part to use as the navigation overlay.'
+					'Select an overlay to use for the navigation.'
 				)
 			).toBeInTheDocument();
 		} );
@@ -414,7 +414,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: /Edit overlay template part/,
+				name: /Edit overlay/,
 			} );
 
 			expect( editButton ).toHaveAccessibleName();
@@ -430,7 +430,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay',
 			} );
 
 			expect( select ).toBeDisabled();

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -88,7 +88,9 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			expect( screen.getByText( 'Loading overlays…' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Loading overlays…' )
+			).toBeInTheDocument();
 		} );
 	} );
 
@@ -109,7 +111,9 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( select ).toHaveValue( '' );
 
 			// Check for "None (default)" option
-			expect( screen.getByRole( 'option', { name: 'None (default)' } ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'option', { name: 'None (default)' } )
+			).toBeInTheDocument();
 		} );
 
 		it( 'should filter template parts by overlay area', () => {
@@ -122,7 +126,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			screen.getByRole( 'combobox', {
-				name: 'Overlay Template Part',
+				name: 'Overlay template',
 			} );
 
 			// Should have None + 2 overlays (not the header one)
@@ -231,7 +235,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Edit button', () => {
-		it( 'should be disabled when no template part is selected', () => {
+		it( 'should not render when no template part is selected', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -240,14 +244,14 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			const editButton = screen.getByRole( 'button', {
+			const editButton = screen.queryByRole( 'button', {
 				name: 'Edit overlay',
 			} );
 
-			expect( editButton ).toBeDisabled();
+			expect( editButton ).not.toBeInTheDocument();
 		} );
 
-		it( 'should be disabled when template parts are loading', () => {
+		it( 'should not render button when template parts are initially loading', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: true,
@@ -261,11 +265,15 @@ describe( 'OverlayTemplatePartSelector', () => {
 				/>
 			);
 
-			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay',
-			} );
-
-			expect( editButton ).toBeDisabled();
+			// Component shows spinner when initially loading, button doesn't render
+			expect(
+				screen.getByText( 'Loading overlays…' )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Edit overlay/,
+				} )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should be enabled when a valid template part is selected', () => {
@@ -283,7 +291,8 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay',
+				name: ( accessibleName ) =>
+					accessibleName.startsWith( 'Edit overlay' ),
 			} );
 
 			expect( editButton ).toBeEnabled();
@@ -305,10 +314,12 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay',
+				name: ( accessibleName ) =>
+					accessibleName.startsWith( 'Edit overlay' ),
 			} );
 
-			expect( editButton ).toBeDisabled();
+			// Button uses accessibleWhenDisabled, so it has aria-disabled instead of disabled
+			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should call onNavigateToEntityRecord when edit button is clicked', async () => {
@@ -328,15 +339,15 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay',
+				name: ( accessibleName ) =>
+					accessibleName.startsWith( 'Edit overlay' ),
 			} );
 
 			await user.click( editButton );
 
 			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
-				kind: 'postType',
-				name: 'wp_template_part',
 				postId: 'twentytwentyfive//my-overlay',
+				postType: 'wp_template_part',
 			} );
 		} );
 
@@ -349,15 +360,23 @@ describe( 'OverlayTemplatePartSelector', () => {
 				hasResolved: true,
 			} );
 
-			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+			render(
+				<OverlayTemplatePartSelector
+					{ ...defaultProps }
+					overlayTemplatePart="twentytwentyfive//my-overlay"
+					onNavigateToEntityRecord={ undefined }
+				/>
+			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: 'Edit overlay',
+				name: ( accessibleName ) =>
+					accessibleName.startsWith( 'Edit overlay' ),
 			} );
 
-			// Button should be disabled, but try clicking anyway
-			expect( editButton ).toBeDisabled();
+			// Button uses accessibleWhenDisabled, so it has aria-disabled instead of disabled
+			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
+			// Even if clicked, the handler checks for onNavigateToEntityRecord and won't call it
 			await user.click( editButton );
 
 			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
@@ -412,27 +431,31 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const editButton = screen.getByRole( 'button', {
-				name: /Edit overlay/,
+				name: ( accessibleName ) =>
+					accessibleName.startsWith( 'Edit overlay' ),
 			} );
 
 			expect( editButton ).toHaveAccessibleName();
 		} );
 
-		it( 'should disable select control when loading', () => {
+		it( 'should show loading spinner instead of select control when initially loading', () => {
 			useEntityRecords.mockReturnValue( {
-				records: [ templatePart1 ],
+				records: null,
 				isResolving: true,
 				hasResolved: false,
 			} );
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
-			} );
-
-			expect( select ).toBeDisabled();
+			// Should show loading spinner, not the select control
+			expect(
+				screen.getByText( 'Loading overlays…' )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'combobox', {
+					name: 'Overlay template',
+				} )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );
-

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -103,7 +103,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay',
+				name: 'Overlay template',
 			} );
 			expect( select ).toBeInTheDocument();
 			expect( select ).toHaveValue( '' );
@@ -171,7 +171,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay',
+				name: 'Overlay template',
 			} );
 
 			await user.selectOptions( select, 'twentytwentyfive//my-overlay' );
@@ -198,7 +198,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay',
+				name: 'Overlay template',
 			} );
 
 			await user.selectOptions( select, '' );
@@ -223,7 +223,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay',
+				name: 'Overlay template',
 			} );
 
 			expect( select ).toHaveValue( 'twentytwentyfive//my-overlay' );
@@ -428,7 +428,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay',
+				name: 'Overlay template',
 			} );
 
 			expect( select ).toBeDisabled();

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -649,3 +649,8 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 .wp-block-navigation__submenu-accessibility-notice {
 	grid-column: span 2;
 }
+
+.wp-block-navigation__overlay-edit-button {
+	margin-top: $grid-unit-10;
+	width: fit-content;
+}


### PR DESCRIPTION
## What

Adds the ability to select an overlay template part from the Navigation block sidebar. When an overlay template part is selected, users can navigate to edit it directly from the block editor. When an overlay is selected, clicking the overlay toggle button in the canvas navigates to the template part editor instead of toggling the menu.

## Why

This enables users to customize navigation overlays by editing dedicated overlay template parts, rather than relying solely on Navigation block controls. This aligns with the block-based approach for overlay customization, allowing styling to be managed within the template part itself.

## How

* Adds `overlayTemplatePart` attribute to Navigation block
* Creates `OverlayTemplatePartSelector` component for selecting overlay template parts
* Adds new "Overlay" panel in Navigation block sidebar
* Updates `ResponsiveWrapper` to navigate to template part editor when overlay is selected
* Integrated with experiment flag `window.__experimentalNavigationOverlays`
* Extracts reusable components (`OverlayVisibilityControl`, `OverlayMenuPreviewButton`, `OverlayMenuPreviewControls`) to avoid code duplication between the Display panel (when experiment is off) and Overlay panel (when experiment is on)

## Notes

### UI/UX Considerations

* Edit button only appears when an overlay is selected
* Edit button width set to `fit-content` for better visual appearance
* Help message: "No overlays found. Create one?"
* The "Overlay" panel remains visible even when "Overlay Visibility" is set to "Off", allowing users to re-enable it

### Future Considerations

* Preview of selected template part (out of scope for this PR)
* Ability to create a new overlay if one doesn't already exist (out of scope for this PR)

## Testing Instructions

### With Experiment Enabled

1. Enable the experiment: Set `window.__experimentalNavigationOverlays = true` in the browser console
2. Add a Navigation block to a page
3. In the block sidebar, find the "Overlay" panel
4. Use the "Overlay template" selector to choose an overlay template part
5. Click the "Edit" button to navigate to the template part editor
6. When an overlay is selected, clicking the overlay toggle button in the canvas should navigate to the template part editor instead of toggling the menu

### With Experiment Disabled

1. Ensure the experiment is disabled: `window.__experimentalNavigationOverlays` should be `undefined` or `false`
2. Add a Navigation block to a page
3. Verify that overlay controls appear in the "Display" panel (as per trunk behavior)
4. Verify all overlay functionality works as expected (overlay visibility toggle, preview controls, etc.)



Part of https://github.com/WordPress/gutenberg/issues/73080