### PR TITLE
DataForm: Fix panel field inaccessible when empty with labelPosition none

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,7 @@
 - DataViews: Combined field alignment in table layout. [#73908](https://github.com/WordPress/gutenberg/pull/73908)
 - DataViews: Fix table row multiselection in Firefox [#73945](https://github.com/WordPress/gutenberg/pull/73945)
 - DataViews: `filterSortAndPaginate()` will ignore sorting on non-sortable fields [#73950](https://github.com/WordPress/gutenberg/pull/73950)
+- DataForm: Fix panel field inaccessible when empty. [#73764](https://github.com/WordPress/gutenberg/pull/73764)
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataform-layouts/panel/style.scss
@@ -62,3 +62,7 @@
 .components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown {
 	z-index: z-index(".components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown");
 }
+
+.dataforms-layouts-panel__summary-button-content:empty::before {
+	content: var(--empty-button-text);
+}

--- a/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
@@ -26,47 +26,17 @@ function SummaryButton< Item >( {
 	onClick: () => void;
 	'aria-expanded'?: boolean;
 } ) {
-	const isEmpty =
-		labelPosition === 'none' &&
-		summaryFields.every( ( summaryField ) => {
-			const value = summaryField.getValue( { item: data } );
-			return value === undefined || value === null || value === '';
-		} );
-
-	let summaryContent;
-	if ( isEmpty ) {
-		summaryContent = __( '(Empty field)' );
-	} else if ( summaryFields.length > 1 ) {
-		summaryContent = (
-			<div
-				style={ {
-					display: 'flex',
-					flexDirection: 'column',
-					alignItems: 'flex-start',
-					width: '100%',
-					gap: '2px',
-				} }
-			>
-				{ summaryFields.map( ( summaryField ) => (
-					<div key={ summaryField.id } style={ { width: '100%' } }>
-						<summaryField.render
-							item={ data }
-							field={ summaryField }
-						/>
-					</div>
-				) ) }
-			</div>
-		);
-	} else {
-		summaryContent = summaryFields.map( ( summaryField ) => (
-			<summaryField.render
-				key={ summaryField.id }
-				item={ data }
-				field={ summaryField }
-			/>
-		) );
+	let emptyPlaceholder: string = __( 'Empty' );
+	if ( fieldLabel ) {
+		emptyPlaceholder =
+			labelPosition === 'none'
+				? sprintf(
+						// translators: %s: Field label e.g: "Title".
+						__( '%s unset' ),
+						fieldLabel
+				  )
+				: fieldLabel;
 	}
-
 	return (
 		<Button
 			className="dataforms-layouts-panel__summary-button"
@@ -86,16 +56,51 @@ function SummaryButton< Item >( {
 			disabled={ disabled }
 			accessibleWhenDisabled
 			style={
-				summaryFields.length > 1
-					? {
-							minHeight: 'auto',
-							height: 'auto',
-							alignItems: 'flex-start',
-					  }
-					: undefined
+				{
+					'--empty-button-text': `"${ emptyPlaceholder }"`,
+					...( summaryFields.length > 1
+						? {
+								minHeight: 'auto',
+								height: 'auto',
+								alignItems: 'flex-start',
+						  }
+						: {} ),
+				} as React.CSSProperties
 			}
 		>
-			{ summaryContent }
+			<span className="dataforms-layouts-panel__summary-button-content">
+				{ summaryFields.length > 1 ? (
+					<div
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'flex-start',
+							width: '100%',
+							gap: '2px',
+						} }
+					>
+						{ summaryFields.map( ( summaryField ) => (
+							<div
+								key={ summaryField.id }
+								style={ { width: '100%' } }
+							>
+								<summaryField.render
+									item={ data }
+									field={ summaryField }
+								/>
+							</div>
+						) ) }
+					</div>
+				) : (
+					summaryFields.map( ( summaryField ) => (
+						<summaryField.render
+							key={ summaryField.id }
+							item={ data }
+							field={ summaryField }
+						/>
+					) )
+				) }
+			</span>
 		</Button>
 	);
 }

--- a/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/summary-button.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { sprintf, _x } from '@wordpress/i18n';
+import { sprintf, _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,6 +26,47 @@ function SummaryButton< Item >( {
 	onClick: () => void;
 	'aria-expanded'?: boolean;
 } ) {
+	const isEmpty =
+		labelPosition === 'none' &&
+		summaryFields.every( ( summaryField ) => {
+			const value = summaryField.getValue( { item: data } );
+			return value === undefined || value === null || value === '';
+		} );
+
+	let summaryContent;
+	if ( isEmpty ) {
+		summaryContent = __( '(Empty field)' );
+	} else if ( summaryFields.length > 1 ) {
+		summaryContent = (
+			<div
+				style={ {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'flex-start',
+					width: '100%',
+					gap: '2px',
+				} }
+			>
+				{ summaryFields.map( ( summaryField ) => (
+					<div key={ summaryField.id } style={ { width: '100%' } }>
+						<summaryField.render
+							item={ data }
+							field={ summaryField }
+						/>
+					</div>
+				) ) }
+			</div>
+		);
+	} else {
+		summaryContent = summaryFields.map( ( summaryField ) => (
+			<summaryField.render
+				key={ summaryField.id }
+				item={ data }
+				field={ summaryField }
+			/>
+		) );
+	}
+
 	return (
 		<Button
 			className="dataforms-layouts-panel__summary-button"
@@ -54,37 +95,7 @@ function SummaryButton< Item >( {
 					: undefined
 			}
 		>
-			{ summaryFields.length > 1 ? (
-				<div
-					style={ {
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'flex-start',
-						width: '100%',
-						gap: '2px',
-					} }
-				>
-					{ summaryFields.map( ( summaryField ) => (
-						<div
-							key={ summaryField.id }
-							style={ { width: '100%' } }
-						>
-							<summaryField.render
-								item={ data }
-								field={ summaryField }
-							/>
-						</div>
-					) ) }
-				</div>
-			) : (
-				summaryFields.map( ( summaryField ) => (
-					<summaryField.render
-						key={ summaryField.id }
-						item={ data }
-						field={ summaryField }
-					/>
-				) )
-			) }
+			{ summaryContent }
 		</Button>
 	);
 }


### PR DESCRIPTION
This PR Adds a fallback placeholder for empty panel fields when `labelPosition` is set to `none`. 

## Why?
When a DataForm panel field has `labelPosition: none` and the field value is empty, the summary button renders with no content, collapsing to zero width. This makes the field inaccessible since there's nothing to click to open the panel. There is no way a use can open the field panel and make the field not empty.

## How?
Display "(Empty field)" text when `labelPosition === 'none'` and all summary field values are empty.

## Testing
1. Open Storybook DataForm panel layout story with `labelPosition: none` http://localhost:50240/?path=/story/dataviews-dataform--layout-panel&args=labelPosition:none
2. Clear the Title field "(Hello World)".
3. Verify the placeholder appears and clicking it opens the panel
