### PR TITLE
Block Editor: Allow iframed script modules

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -115,7 +115,11 @@ function Iframe( {
 			isPreviewMode: settings.isPreviewMode,
 		};
 	}, [] );
-	const { styles = '', scripts = '' } = resolvedAssets;
+	const {
+		styles = '',
+		scripts = '',
+		script_modules: scriptModules = '',
+	} = resolvedAssets;
 	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
@@ -272,6 +276,7 @@ function Iframe( {
 		</style>
 		${ styles }
 		${ scripts }
+		${ scriptModules }
 	</head>
 	<body>
 		<script>document.currentScript.parentElement.remove()</script>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -118,8 +118,9 @@ function Iframe( {
 	const {
 		styles = '',
 		scripts = '',
-		script_modules: scriptModules = '',
+		html: assetsHTML = null,
 	} = resolvedAssets;
+
 	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
@@ -274,9 +275,7 @@ function Iframe( {
 				background-color: white;
 			}
 		</style>
-		${ styles }
-		${ scripts }
-		${ scriptModules }
+		${ assetsHTML ?? styles + scripts }
 	</head>
 	<body>
 		<script>document.currentScript.parentElement.remove()</script>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64360

> [​The enqueue_block_assets action](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/) is used to add scripts and styles in the block editor's iframe.
> 
> It should be possible to add script modules to the block editor's iframe as well.
> 
> See:
> 
> [_wp_get_iframed_editor_assets](https://github.com/WordPress/wordpress-develop/blob/0b50baa5d164bedd17d3ae9e2eafc6286d6255b6/src/wp-includes/block-editor.php#L285-L390) and [​its documentation](https://developer.wordpress.org/reference/functions/_wp_get_iframed_editor_assets/).
> [The WP_Script_Modules class](https://github.com/WordPress/wordpress-develop/blob/0b50baa5d164bedd17d3ae9e2eafc6286d6255b6/src/wp-includes/class-wp-script-modules.php#L16).
> [The block editor Iframe component in Gutenberg.](https://github.com/WordPress/gutenberg/blob/2314c0ceaf727c08a6091fd6ae82bb1759fb3c02/packages/block-editor/src/components/iframe/index.js#L99-L279)
> This will likely require a new method or exposing more of the script modules internal data so that a specific WP_Script_Modules instance can be used for the iframed assets. See [#60597](https://core.trac.wordpress.org/ticket/60597).

Requires Core changes, see https://github.com/WordPress/wordpress-develop/pull/10597.
