### PR TITLE
Storybook: skip transpilation of build-modules files

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -75,12 +75,34 @@ module.exports = {
 		reactDocgen: 'react-docgen-typescript',
 	},
 	webpackFinal: async ( config ) => {
+		// Find the `babel-loader` rule added by `@storybook/addon-webpack5-compiler-babel`
+		// and add exclude for `packages/*/build-module` folders.
+		const rules = config.module.rules.map( ( rule ) => {
+			const usesBabelLoader =
+				Array.isArray( rule.use ) &&
+				rule.use.some(
+					( loader ) =>
+						typeof loader === 'object' &&
+						loader.loader &&
+						loader.loader.includes( 'babel-loader' )
+				);
+
+			// Add exclude for `build-module` folders
+			if ( usesBabelLoader && Array.isArray( rule.exclude ) ) {
+				return {
+					...rule,
+					exclude: [ ...rule.exclude, /build-module/ ],
+				};
+			}
+			return rule;
+		} );
+
 		return {
 			...config,
 			module: {
 				...config.module,
 				rules: [
-					...config.module.rules,
+					...rules,
 					{
 						test: /\.md$/,
 						type: 'asset/source',


### PR DESCRIPTION
Spinoff from #73516 that updates the Storybook build config so that it doesn't transpile files in `build-module` folders. These are already transpiled by `wp-build`.

The method is somewhat complicated: find the `babel-loader` rule added by `@storybook/addon-webpack5-compiler-babel` and modify its `exclude` field.

I hoped to see a performance improvement, but there isn't any 🙁 My tests show that `npm run storybook:build` timings are exactly the same before and after this PR. But I still believe it's worth doing.

There's one thing that could optimize the Storybook build a lot, but I don't know how to do it. When importing stuff from a package like `@wordpress/components`, it can be imported from two different places:
- when a `*.story.tsx` file imports a component, it imports it from the source. For example, the `button/stories/index.story.tsx` file has an `import Button from '..'` statement. That imports the `src/button/index.tsx` file directly.
- when a story imports the same component transitively, i.e., when it imports `@wordpress/block-editor` which in turn imports `Button` from `@wordpress/components`, then the `@wordpress/components` files are resolved from the transpiled `build-module` folder.

In the end, the bundle ends up shipping two copies of the `Button`.

If the `import Button from '..'` statement could be somehow resolved to the transpiled `build-module` folder, that would save a lot of duplication and double transpilation. But I don't know how to do it.

If we figured it out, it would be an optimization valuable even after migrating Storybook build from webpack5 to Vite.
