### PR TITLE
Editor: Remove hardcoded autosave conditions for templates

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -462,11 +462,6 @@ export const autosave =
 	async ( { select, dispatch } ) => {
 		const post = select.getCurrentPost();
 
-		// Currently template autosaving is not supported.
-		if ( post.type === 'wp_template' ) {
-			return;
-		}
-
 		if ( local ) {
 			const isPostNew = select.isEditedPostNew();
 			const title = select.getEditedPostAttribute( 'title' );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -389,12 +389,6 @@ export const getAutosaveAttribute = createRegistrySelector(
 		}
 
 		const postType = getCurrentPostType( state );
-
-		// Currently template autosaving is not supported.
-		if ( postType === 'wp_template' ) {
-			return false;
-		}
-
 		const postId = getCurrentPostId( state );
 		const currentUserId = select( coreStore ).getCurrentUser()?.id;
 		const autosave = select( coreStore ).getAutosave(
@@ -616,12 +610,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		const postType = getCurrentPostType( state );
 		const postTypeObject = select( coreStore ).getPostType( postType );
 
-		// Currently template autosaving is not supported.
-		// @todo: Remove hardcode check for template after bumping required WP version to 6.8.
-		if (
-			postType === 'wp_template' ||
-			! postTypeObject?.supports?.autosave
-		) {
+		if ( ! postTypeObject?.supports?.autosave ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?
Closes #64858.

Remove hardcoded autosave endpoint checks for the templates post type. These checks won't be required when the plugin bumps the minimum WP version to 6.8.

## Why?
The problem was resolved in WordPress core.

## Testing Instructions
1. Open the Site Editor.
2. Smoke test the autosaving feature for Templates and Template Parts.

### Testing Instructions for Keyboard
Same.
