### PR TITLE
Block Editor: Remove unused '__unstableBlockNameContext'

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-name-context.js
+++ b/packages/block-editor/src/components/block-toolbar/block-name-context.js
@@ -1,9 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { createContext } from '@wordpress/element';
-
-const __unstableBlockNameContext = createContext( '' );
-__unstableBlockNameContext.displayName = '__unstableBlockNameContext';
-
-export default __unstableBlockNameContext;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -32,7 +32,6 @@ import { BlockGroupToolbar } from '../convert-to-group-buttons';
 import BlockEditVisuallyButton from '../block-edit-visually-button';
 import { useShowHoveredOrFocusedGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
-import __unstableBlockNameContext from './block-name-context';
 import NavigableToolbar from '../navigable-toolbar';
 import { useHasBlockToolbar } from './use-has-block-toolbar';
 import ChangeDesign from './change-design';
@@ -265,11 +264,7 @@ export function PrivateBlockToolbar( {
 							group="other"
 							className="block-editor-block-toolbar__slot"
 						/>
-						<__unstableBlockNameContext.Provider
-							value={ blockType?.name }
-						>
-							<__unstableBlockToolbarLastItem.Slot />
-						</__unstableBlockNameContext.Provider>
+						<__unstableBlockToolbarLastItem.Slot />
 					</>
 				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -107,7 +107,6 @@ export {
 
 export { default as __unstableBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
 export { default as __unstableBlockToolbarLastItem } from './block-toolbar/block-toolbar-last-item';
-export { default as __unstableBlockNameContext } from './block-toolbar/block-name-context';
 export { default as __unstableInserterMenuExtension } from './inserter-menu-extension';
 export { default as __experimentalPreviewOptions } from './preview-options';
 export { default as __experimentalUseResizeCanvas } from './use-resize-canvas';


### PR DESCRIPTION
## What?
PR entirely removes unused `__unstableBlockNameContext` from the block editor package. Initially introduced in #39290, but hasn't been used since #47032.

There are also easier ways to pass values from Slot to Fills, using `fillProps`.

 I think the complete removal is very low risk. The plugin directory search returns only two results - https://wpdirectory.net/search/01KBQ1C4J030KTKB1844ZTBYS5, which are due to bundled packages.

## Testing Instructions
CI checks are passing.

### Testing Instructions for Keyboard
Same.
