### PR TITLE
Fix Post Date Block: Semantic use of `date` tag inside link

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Post Date Block: Improve semantic HTML to add `<time>` inside link element.
+
 ## 9.36.0 (2025-11-26)
 
 ## 9.35.0 (2025-11-12)

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -81,16 +81,13 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
+	$time_tag = sprintf( '<time datetime="%1$s">%2$s</time>', $unformatted_date, $formatted_date );
+
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] && isset( $block->context['postId'] ) ) {
-		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $block->context['postId'] ), $formatted_date );
+		$time_tag = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $block->context['postId'] ), $time_tag );
 	}
 
-	return sprintf(
-		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
-		$wrapper_attributes,
-		$unformatted_date,
-		$formatted_date
-	);
+	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $time_tag );
 }
 
 /**


### PR DESCRIPTION
## What?
In the Post Date block PHP render function the post link tag is wrapped by `time` tag that is not correct semantically because the time tag should not inlclude interactive element. Also in the block JS render function it works correctly by wrapping the time tag by the link tag.

## Testing Instructions
1. Open a post or page.
2. Insert a Post Date block.
3. Save and check the front end.


## Screenshots
|Before|After|
|-|-|
|<img width="615" height="93" alt="image" src="https://github.com/user-attachments/assets/5a629030-8782-458c-a9f2-e5c4fd48b410" />|<img width="632" height="91" alt="image" src="https://github.com/user-attachments/assets/0d930b24-7ca8-4601-b3cb-654e21af5c6a" />|
