### PR TITLE
Cover block: Only apply overflow:clip when a cover block has a border and a border radius

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -347,8 +347,29 @@ export function getBorderClasses( attributes ) {
 	const { borderColor, style } = attributes;
 	const borderColorClass = getColorClassName( 'border-color', borderColor );
 
+	const hasBorder =
+		style?.border?.width ||
+		style?.border?.style ||
+		style?.border?.top?.width ||
+		style?.border?.right?.width ||
+		style?.border?.bottom?.width ||
+		style?.border?.left?.width ||
+		style?.border?.top?.style ||
+		style?.border?.right?.style ||
+		style?.border?.bottom?.style ||
+		style?.border?.left?.style;
+
+	const hasBorderRadius =
+		style?.border?.radius ||
+		style?.border?.topLeft?.radius ||
+		style?.border?.topRight?.radius ||
+		style?.border?.bottomLeft?.radius ||
+		style?.border?.bottomRight?.radius;
+
 	return clsx( {
 		'has-border-color': borderColor || style?.border?.color,
+		'has-border': hasBorder,
+		'has-border-radius': hasBorderRadius,
 		[ borderColorClass ]: !! borderColorClass,
 	} );
 }

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -24,6 +24,7 @@ import { compose } from '@wordpress/compose';
 import {
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
+	EMBED_VIDEO_BACKGROUND_TYPE,
 	getPositionClassName,
 	isContentPositionCenter,
 	dimRatioToClass,
@@ -176,6 +177,23 @@ const v12toV13BlockAttributes = {
 	},
 };
 
+const v15BlockAttributes = {
+	...v12toV13BlockAttributes,
+	isUserOverlayColor: {
+		type: 'boolean',
+	},
+	sizeSlug: {
+		type: 'string',
+	},
+	alt: {
+		type: 'string',
+		default: '',
+	},
+	poster: {
+		type: 'string',
+	},
+};
+
 const v14BlockAttributes = {
 	...v12toV13BlockAttributes,
 	isUserOverlayColor: {
@@ -258,6 +276,20 @@ const v12BlockSupports = {
 	},
 };
 
+const v15BlockSupports = {
+	...v12BlockSupports,
+	shadow: true,
+	dimensions: {
+		aspectRatio: true,
+	},
+	interactivity: {
+		clientNavigation: true,
+	},
+	filter: {
+		duotone: true,
+	},
+};
+
 const v14BlockSupports = {
 	...v12BlockSupports,
 	shadow: true,
@@ -266,6 +298,181 @@ const v14BlockSupports = {
 	},
 	interactivity: {
 		clientNavigation: true,
+	},
+};
+
+// Deprecation for blocks that have border/border-radius but are missing has-border and has-border-radius classes.
+const v15 = {
+	attributes: v15BlockAttributes,
+	supports: v15BlockSupports,
+	save( { attributes } ) {
+		const {
+			backgroundType,
+			gradient,
+			contentPosition,
+			customGradient,
+			customOverlayColor,
+			dimRatio,
+			focalPoint,
+			useFeaturedImage,
+			hasParallax,
+			isDark,
+			isRepeated,
+			overlayColor,
+			url,
+			alt,
+			id,
+			minHeight: minHeightProp,
+			minHeightUnit,
+			tagName: Tag,
+			sizeSlug,
+			poster,
+		} = attributes;
+		const overlayColorClass = getColorClassName(
+			'background-color',
+			overlayColor
+		);
+		const gradientClass = __experimentalGetGradientClass( gradient );
+		const minHeight =
+			minHeightProp && minHeightUnit
+				? `${ minHeightProp }${ minHeightUnit }`
+				: minHeightProp;
+
+		const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
+		const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
+		const isEmbedVideoBackground =
+			EMBED_VIDEO_BACKGROUND_TYPE === backgroundType;
+
+		const isImgElement = ! ( hasParallax || isRepeated );
+
+		const style = {
+			minHeight: minHeight || undefined,
+		};
+
+		const bgStyle = {
+			backgroundColor: ! overlayColorClass
+				? customOverlayColor
+				: undefined,
+			background: customGradient ? customGradient : undefined,
+		};
+
+		const objectPosition =
+			// prettier-ignore
+			focalPoint && isImgElement
+				  ? mediaPosition(focalPoint)
+				  : undefined;
+
+		const backgroundImage = url ? `url(${ url })` : undefined;
+
+		const backgroundPosition = mediaPosition( focalPoint );
+
+		const classes = clsx(
+			{
+				'is-light': ! isDark,
+				'has-parallax': hasParallax,
+				'is-repeated': isRepeated,
+				'has-custom-content-position':
+					! isContentPositionCenter( contentPosition ),
+			},
+			getPositionClassName( contentPosition )
+		);
+
+		const imgClasses = clsx(
+			'wp-block-cover__image-background',
+			id ? `wp-image-${ id }` : null,
+			{
+				[ `size-${ sizeSlug }` ]: sizeSlug,
+				'has-parallax': hasParallax,
+				'is-repeated': isRepeated,
+			}
+		);
+
+		const gradientValue = gradient || customGradient;
+
+		return (
+			<Tag { ...useBlockProps.save( { className: classes, style } ) }>
+				{ ! useFeaturedImage &&
+					isImageBackground &&
+					url &&
+					( isImgElement ? (
+						<img
+							className={ imgClasses }
+							alt={ alt }
+							src={ url }
+							style={ { objectPosition } }
+							data-object-fit="cover"
+							data-object-position={ objectPosition }
+						/>
+					) : (
+						<div
+							role={ alt ? 'img' : undefined }
+							aria-label={ alt ? alt : undefined }
+							className={ imgClasses }
+							style={ { backgroundPosition, backgroundImage } }
+						/>
+					) ) }
+				{ isVideoBackground && url && (
+					<video
+						className={ clsx(
+							'wp-block-cover__video-background',
+							'intrinsic-ignore'
+						) }
+						autoPlay
+						muted
+						loop
+						playsInline
+						src={ url }
+						poster={ poster }
+						style={ { objectPosition } }
+						data-object-fit="cover"
+						data-object-position={ objectPosition }
+					/>
+				) }
+				{ isEmbedVideoBackground && url && (
+					<figure
+						className={ clsx(
+							'wp-block-cover__video-background',
+							'wp-block-cover__embed-background',
+							'wp-block-embed'
+						) }
+					>
+						<div className="wp-block-embed__wrapper">{ url }</div>
+					</figure>
+				) }
+
+				{ /* The `wp-block-cover__background` needs to be immediately before
+				the `wp-block-cover__inner-container`, so the exclusion CSS selector
+				`.wp-block-cover__background + .wp-block-cover__inner-container`
+				works properly. If it needs to be changed in the future, the
+				selector for the backward compatibility for v14 deprecation also
+				needs change. */ }
+				<span
+					aria-hidden="true"
+					className={ clsx(
+						'wp-block-cover__background',
+						overlayColorClass,
+						dimRatioToClass( dimRatio ),
+						{
+							'has-background-dim': dimRatio !== undefined,
+							// For backwards compatibility. Former versions of the Cover Block applied
+							// `.wp-block-cover__gradient-background` in the presence of
+							// media, a gradient and a dim.
+							'wp-block-cover__gradient-background':
+								url && gradientValue && dimRatio !== 0,
+							'has-background-gradient': gradientValue,
+							[ gradientClass ]: gradientClass,
+						}
+					) }
+					style={ bgStyle }
+				/>
+
+				<div
+					{ ...useInnerBlocksProps.save( {
+						className: 'wp-block-cover__inner-container',
+					} ) }
+				/>
+			</Tag>
+		);
 	},
 };
 
@@ -2014,4 +2221,20 @@ const v1 = {
 	},
 };
 
-export default [ v14, v13, v12, v11, v10, v9, v8, v7, v6, v5, v4, v3, v2, v1 ];
+export default [
+	v15,
+	v14,
+	v13,
+	v12,
+	v11,
+	v10,
+	v9,
+	v8,
+	v7,
+	v6,
+	v5,
+	v4,
+	v3,
+	v2,
+	v1,
+];

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -11,6 +11,7 @@ import {
 	getColorClassName,
 	__experimentalGetGradientClass,
 	useBlockProps,
+	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -85,7 +86,10 @@ export default function save( { attributes } ) {
 
 	const backgroundPosition = mediaPosition( focalPoint );
 
+	const borderProps = getBorderClassesAndStyles( attributes );
+
 	const classes = clsx(
+		borderProps.className,
 		{
 			'is-light': ! isDark,
 			'has-parallax': hasParallax,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -11,11 +11,6 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
-	// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
-	overflow: hidden;
-	// Use clip instead of overflow: hidden so that sticky position works on child elements.
-	overflow: clip;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.
@@ -224,6 +219,14 @@
 			transform: translate(-50%, -50%);
 			pointer-events: none; // Prevent interaction with the iframe
 		}
+	}
+
+	&.has-border-radius.has-border {
+		// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
+		// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
+		overflow: hidden;
+		// Use clip instead of overflow: hidden so that sticky position works on child elements.
+		overflow: clip;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -766,3 +766,4 @@ button.wp-block-navigation-item__content {
 html.has-modal-open {
 	overflow: hidden;
 }
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
##  What?

Adds has-border and has-border-radius CSS classes to the Cover block when border or border-radius styles are applied.

## Why?
The Cover block needs `overflow: clip` applied when it has a border radius and border set, so that the background doesn't bleed around the border. However, `overflow: clip` prevents navigation submenus from appearing outside the block (see #45353)

If we only apply `overflow: clip` when a border radius and border are set on the block, then we'll limit the problem in #45353 to only impact this very specific case, which makes it much more of an edge case.

To only apply `overflow: clip` when the block has a border and border-radius, we need to add classes to the block in these cases.

The Cover block supports border and border-radius styling through block supports, but wasn't outputting semantic CSS classes to indicate when these styles were present. The CSS file already contained styles targeting .has-border-radius.has-border (line 224 in style.scss), but these classes were never being added to the block markup, making those styles unreachable.

 Adding these classes:
  1. Enables the existing overflow: clip styles to work properly when borders and border-radius are combined
  2. Provides semantic class names that themes and plugins can target
  3. Maintains consistency with other blocks that use border support
  4. Allows for easier styling and customization based on border presence

Partially fixes #45353

 ## How?

  1. Updated getBorderClasses function (packages/block-editor/src/hooks/border.js):
    - Extended the function to detect border width/style properties and add has-border class
    - Added detection for border-radius properties and add has-border-radius class
    - Handles both unified properties (style.border.width) and split borders (style.border.top.width, etc.)
    - Handles both unified radius and individual corner radii
  2. Updated Cover block save function (packages/block-library/src/cover/save.js):
    - Imported and called getBorderClassesAndStyles utility
    - Applied the returned border classes to the cover block wrapper
  3. Added v15 deprecation (packages/block-library/src/cover/deprecated.js):
    - Created a deprecation for blocks saved without the border classes
    - Ensures existing Cover blocks with borders automatically migrate to include the new classes
  4. Fixed CSS duplicate selector (packages/block-library/src/cover/style.scss):
    - Merged duplicate .wp-block-cover selectors to resolve linting error
    - Consolidated the has-border-radius.has-border styles into the main selector block

##  Testing Instructions

###  Testing new blocks:

  1. Open a post or page in the editor
  2. Insert a Cover block
  3. Select the Cover block
  4. In the block settings sidebar, go to the Styles panel
  6. Under Border, set a border width (e.g., 5px) and style (e.g., solid)
  7. Verify the border appears on the cover block
  8. Add a border radius (e.g., 20px)
  9. Save and view the post on the frontend
  10. Inspect the Cover block HTML - verify it has has-border and has-border-radius classes
  11. Verify the border and border-radius display correctly and the content is properly clipped

### Testing existing blocks (deprecation):

  1. Create a Cover block and add border styles (width, style, color) and border-radius
  2. Save the post
  3. Manually edit the post HTML to remove the has-border and has-border-radius classes from the Cover block
  4. Save the changes
  5. Reload the editor
  6. Verify the block loads without errors
  7. Verify the has-border and has-border-radius classes have been automatically re-added
  8. Verify the border and border-radius still display correctly

### Testing split borders:

  1. Insert a Cover block
  2. Enable border controls
  3. Set different border widths for individual sides (top, right, bottom, left)
  4. Verify the has-border class is added
  5. Test with individual corner radii as well

### Testing the navigation block
1. Insert a cover block and add a navigation block inside
2. Add a submenu to the navigation block
3. Check that the submenu appears outside the boundary of the cover block
4. Now add a border OR a border radius to the cover block
5. Check that the submenu appears outside the boundary of the cover block
6. Now add a border AND a border radius to the cover block
7. Check that the submenu no longer appears outside the boundary of the cover block (this is the bug we still haven't fixed)



## Screenshots or screencast

<img width="749" height="587" alt="Screenshot 2025-12-05 at 12 48 08" src="https://github.com/user-attachments/assets/fc27592c-c7a0-47d7-b440-df2ef1934dc5" />

