### PR TITLE
Query Loop: Exclude terms support

### DIFF
--- a/backport-changelog/7.0/10632.md
+++ b/backport-changelog/7.0/10632.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10632
+
+* https://github.com/WordPress/gutenberg/pull/73790

--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -291,8 +291,6 @@ if( 'my-plugin/books-list' === $block[ 'attrs' ][ 'namespace' ] ) {
 
 (In the code above, we assume you have some way to access the block, for example within a [`pre_render_block`](https://developer.wordpress.org/reference/hooks/pre_render_block/) filter, but the specific solution can be different depending on the use-case, so this is not a firm recommendation).
 
-**Note:** The Query Loop block's `taxQuery` attribute is automatically processed by the `build_query_vars_from_query_block` function. Both inclusion and exclusion are handled using WordPress's tax_query with `IN` and `NOT IN` operators respectively. If you're adding custom taxonomy filtering, you can follow the same pattern.
-
 ### Making your custom query work on the editor side
 
 To finish up our custom variation, we might want the editor to react to changes in our custom query and display an appropriate preview accordingly. This is not required for a functioning block, but it enables a fully integrated user experience for the consumers of your block.

--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -183,7 +183,7 @@ As of Gutenberg version 14.2, the following controls are available:
 -   `postType` - Shows a dropdown of available post types.
 -   `order` - Shows a dropdown to select the order of the query.
 -   `sticky` - Shows a dropdown to select how to handle sticky posts.
--   `taxQuery` - Shows available taxonomies filters for the currently selected post type.
+-   `taxQuery` - Shows available taxonomies filters for the currently selected post type, including both inclusion and exclusion controls for each taxonomy.
 -   `author` - Shows an input field to filter the query by author.
 -   `search` - Shows an input field to filter the query by keywords.
 -   `format` - Shows an input field to filter the query by array/collection of [formats](https://developer.wordpress.org/advanced-administration/wordpress/post-formats/#supported-formats).
@@ -201,6 +201,27 @@ In our case, the property would look like this:
 If you want to hide all the above available controls, you can set an empty array as a value of `allowedControls`.
 
 Notice that we have also disabled the `postType` control. When the user selects our variation, why show them a confusing dropdown to change the post type? On top of that it might break the block as we can implement custom controls, as we'll see shortly.
+
+### Understanding the `taxQuery` structure
+
+The `taxQuery` attribute supports both inclusion and exclusion of taxonomy terms. The structure looks like this:
+
+```js
+{
+	query: {
+		taxQuery: {
+			category: [1, 2, 3], // Include posts with these category IDs.
+			post_tag: [10, 20], // Include posts with these tag IDs.
+			excludeTerms: { // Exclude posts with specific terms.
+				category: [5, 6],
+				post_tag: [15]
+			}
+		}
+	}
+}
+```
+
+When you use the `taxQuery` control in your variation, users will see both "Include: [Taxonomy]" and "Exclude: [Taxonomy]" controls for each applicable taxonomy. The inclusion and exclusion are mutually exclusive in the UI - terms selected in one won't appear as suggestions in the other.
 
 ### Adding additional controls
 
@@ -267,6 +288,8 @@ if( 'my-plugin/books-list' === $block[ 'attrs' ][ 'namespace' ] ) {
 ```
 
 (In the code above, we assume you have some way to access the block, for example within a [`pre_render_block`](https://developer.wordpress.org/reference/hooks/pre_render_block/) filter, but the specific solution can be different depending on the use-case, so this is not a firm recommendation).
+
+**Note:** The Query Loop block's `taxQuery` attribute is automatically processed by the `build_query_vars_from_query_block` function. Both inclusion and exclusion are handled using WordPress's tax_query with `IN` and `NOT IN` operators respectively. If you're adding custom taxonomy filtering, you can follow the same pattern.
 
 ### Making your custom query work on the editor side
 

--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -210,18 +210,20 @@ The `taxQuery` attribute supports both inclusion and exclusion of taxonomy terms
 {
 	query: {
 		taxQuery: {
-			category: [1, 2, 3], // Include posts with these category IDs.
-			post_tag: [10, 20], // Include posts with these tag IDs.
-			excludeTerms: { // Exclude posts with specific terms.
-				category: [5, 6],
-				post_tag: [15]
+			include: {
+				category: [1, 2, 3], // Include posts with these category IDs.
+				post_tag: [10, 20] // Include posts with these tag IDs.
+			},
+			exclude: {
+				category: [5, 6], // Exclude posts with these category IDs.
+				post_tag: [15] // Exclude posts with these tag IDs.
 			}
 		}
 	}
 }
 ```
 
-When you use the `taxQuery` control in your variation, users will see both "Include: [Taxonomy]" and "Exclude: [Taxonomy]" controls for each applicable taxonomy. The inclusion and exclusion are mutually exclusive in the UI - terms selected in one won't appear as suggestions in the other.
+When you use the `taxQuery` control in your variation, users will see both "[Taxonomy]" (inclusion) and "Exclude: [Taxonomy]" controls for each applicable taxonomy. The inclusion and exclusion are mutually exclusive in the UI - terms selected in one won't appear as suggestions in the other.
 
 ### Adding additional controls
 

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -123,7 +123,7 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 }
 
 /**
- * Adds update `taxQuery` args to handle exclusion of taxonomy terms.
+ * Update Query Loop's `taxQuery` prop to the new structure.
  *
  * @see 'query_loop_block_query_vars'
  *
@@ -132,13 +132,13 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
  * @return array   The filtered query vars.
  */
 function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
-	if ( empty( $block->context['query']['taxQuery'] ) || ! is_array( $block->context['query']['taxQuery'] ) ) {
+	if ( empty( $block->context['query']['taxQuery'] ) ) {
 		return $query;
 	}
 
 	// If there are keys other than include/exclude, it's the old
 	// format and has been handled already.
-	if ( ! empty( array_diff( array_keys( $block->context['query']['taxQuery'] ), array( 'include', 'exclude' ) ) ) ) {
+	if ( ! is_array( $block->context['query']['taxQuery'] ) || ! empty( array_diff( array_keys( $block->context['query']['taxQuery'] ), array( 'include', 'exclude' ) ) ) ) {
 		return $query;
 	}
 
@@ -149,7 +149,7 @@ function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
 	$build_conditions = static function ( $terms, $operator = 'IN' ) {
 		$conditions = array();
 		foreach ( $terms as $taxonomy => $terms ) {
-			if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
+			if ( ! empty( $terms ) && is_taxonomy_viewable( $taxonomy ) ) {
 				$conditions[] = array(
 					'taxonomy'         => $taxonomy,
 					'terms'            => array_filter( array_map( 'intval', $terms ) ),

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -174,7 +174,8 @@ function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
 	);
 
 	if ( ! empty( $tax_query ) ) {
-		$query['tax_query'] = $tax_query;
+		// Merge with any existing `tax_query` conditions.
+		$query['tax_query'] = array_merge( $query['tax_query'], $tax_query );
 	}
 
 	return $query;

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -121,3 +121,55 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
 		return $blocks;
 	}
 }
+
+/**
+ * Adds update `taxQuery` args to handle exclusion of taxonomy terms.
+ *
+ * @see 'query_loop_block_query_vars'
+ *
+ * @param array    $query The query vars.
+ * @param WP_Block $block Block instance.
+ * @return array   The filtered query vars.
+ */
+function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
+	$tax_query_input = $block->context['query']['taxQuery'];
+	if ( empty( $tax_query_input ) ) {
+		return $query;
+	}
+
+	// Helper function to build tax_query conditions from taxonomy terms.
+	$build_conditions = static function ( $terms, $operator = 'IN' ) {
+		$conditions = array();
+		foreach ( $terms as $taxonomy => $terms ) {
+			if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
+				$conditions[] = array(
+					'taxonomy'         => $taxonomy,
+					'terms'            => array_filter( array_map( 'intval', $terms ) ),
+					'operator'         => $operator,
+					'include_children' => false,
+				);
+			}
+		}
+		return $conditions;
+	};
+	// Separate excludeTerms from include terms.
+	$exclude_terms = isset( $tax_query_input['excludeTerms'] ) && is_array( $tax_query_input['excludeTerms'] )
+		? $tax_query_input['excludeTerms']
+		: array();
+	$include_terms = array_diff_key( $tax_query_input, array( 'excludeTerms' => '' ) );
+
+	$tax_query = array_merge(
+		$build_conditions( $include_terms ),
+		$build_conditions( $exclude_terms, 'NOT IN' )
+	);
+
+	if ( ! empty( $tax_query ) ) {
+		// Merge with existing `tax_query` like core does, because
+		// of the deprecated `categoryIds` and `tagIds` props.
+		$query['tax_query'] = array_merge( $query['tax_query'], $tax_query );
+	}
+
+	return $query;
+}
+
+add_filter( 'query_loop_block_query_vars', 'gutenberg_update_tax_query_of_query_loop_block', 10, 2 );

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -132,10 +132,11 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
  * @return array   The filtered query vars.
  */
 function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
-	$tax_query_input = $block->context['query']['taxQuery'];
-	if ( empty( $tax_query_input ) ) {
+	if ( empty( $block->context['query']['taxQuery'] ) ) {
 		return $query;
 	}
+
+	$tax_query_input = $block->context['query']['taxQuery'];
 
 	// Helper function to build tax_query conditions from taxonomy terms.
 	$build_conditions = static function ( $terms, $operator = 'IN' ) {

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -174,9 +174,7 @@ function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
 	);
 
 	if ( ! empty( $tax_query ) ) {
-		// Merge with existing `tax_query` like core does, because
-		// of the deprecated `categoryIds` and `tagIds` props.
-		$query['tax_query'] = array_merge( $query['tax_query'], $tax_query );
+		$query['tax_query'] = $tax_query;
 	}
 
 	return $query;

--- a/lib/compat/wordpress-7.0/blocks.php
+++ b/lib/compat/wordpress-7.0/blocks.php
@@ -132,10 +132,17 @@ if ( ! function_exists( 'gutenberg_resolve_pattern_blocks' ) ) {
  * @return array   The filtered query vars.
  */
 function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
-	if ( empty( $block->context['query']['taxQuery'] ) ) {
+	if ( empty( $block->context['query']['taxQuery'] ) || ! is_array( $block->context['query']['taxQuery'] ) ) {
 		return $query;
 	}
 
+	// If there are keys other than include/exclude, it's the old
+	// format and has been handled already.
+	if ( ! empty( array_diff( array_keys( $block->context['query']['taxQuery'] ), array( 'include', 'exclude' ) ) ) ) {
+		return $query;
+	}
+
+	// Build with the new structure.
 	$tax_query_input = $block->context['query']['taxQuery'];
 
 	// Helper function to build tax_query conditions from taxonomy terms.
@@ -153,11 +160,13 @@ function gutenberg_update_tax_query_of_query_loop_block( $query, $block ) {
 		}
 		return $conditions;
 	};
-	// Separate excludeTerms from include terms.
-	$exclude_terms = isset( $tax_query_input['excludeTerms'] ) && is_array( $tax_query_input['excludeTerms'] )
-		? $tax_query_input['excludeTerms']
+	// Separate exclude from include terms.
+	$exclude_terms = isset( $tax_query_input['exclude'] ) && is_array( $tax_query_input['exclude'] )
+		? $tax_query_input['exclude']
 		: array();
-	$include_terms = array_diff_key( $tax_query_input, array( 'excludeTerms' => '' ) );
+	$include_terms = isset( $tax_query_input['include'] ) && is_array( $tax_query_input['include'] )
+		? $tax_query_input['include']
+		: array();
 
 	$tax_query = array_merge(
 		$build_conditions( $include_terms ),

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -152,20 +152,31 @@ export default function PostTemplateEdit( {
 					per_page: -1,
 					context: 'view',
 				} );
-				// We have to build the tax query for the REST API and use as
-				// keys the taxonomies `rest_base` with the `term ids` as values.
-				const builtTaxQuery = Object.entries( taxQuery ).reduce(
-					( accumulator, [ taxonomySlug, terms ] ) => {
-						const taxonomy = taxonomies?.find(
-							( { slug } ) => slug === taxonomySlug
-						);
-						if ( taxonomy?.rest_base ) {
-							accumulator[ taxonomy?.rest_base ] = terms;
-						}
-						return accumulator;
-					},
-					{}
-				);
+				// Shared utility to build REST API parameters from taxonomy terms.
+				const buildTaxQuery = ( terms, suffix = '' ) => {
+					return Object.entries( terms ).reduce(
+						( accumulator, [ taxonomySlug, termIds ] ) => {
+							const taxonomy = taxonomies?.find(
+								( { slug } ) => slug === taxonomySlug
+							);
+							if ( taxonomy?.rest_base && termIds?.length ) {
+								accumulator[ taxonomy.rest_base + suffix ] =
+									termIds;
+							}
+							return accumulator;
+						},
+						{}
+					);
+				};
+				const { excludeTerms, ...includeTaxQuery } = taxQuery;
+				const builtTaxQuery = buildTaxQuery( includeTaxQuery );
+				if ( excludeTerms ) {
+					Object.assign(
+						builtTaxQuery,
+						buildTaxQuery( excludeTerms, '_exclude' )
+					);
+				}
+
 				if ( !! Object.keys( builtTaxQuery ).length ) {
 					Object.assign( query, builtTaxQuery );
 				}

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -152,7 +152,8 @@ export default function PostTemplateEdit( {
 					per_page: -1,
 					context: 'view',
 				} );
-				// Shared utility to build REST API parameters from taxonomy terms.
+				// Build REST API parameters from taxonomy terms, e.g.
+				// `category`, `tags_exclude`.
 				const buildTaxQuery = ( terms, suffix = '' ) => {
 					return Object.entries( terms || {} ).reduce(
 						( accumulator, [ taxonomySlug, termIds ] ) => {

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -154,7 +154,7 @@ export default function PostTemplateEdit( {
 				} );
 				// Shared utility to build REST API parameters from taxonomy terms.
 				const buildTaxQuery = ( terms, suffix = '' ) => {
-					return Object.entries( terms ).reduce(
+					return Object.entries( terms || {} ).reduce(
 						( accumulator, [ taxonomySlug, termIds ] ) => {
 							const taxonomy = taxonomies?.find(
 								( { slug } ) => slug === taxonomySlug
@@ -168,12 +168,11 @@ export default function PostTemplateEdit( {
 						{}
 					);
 				};
-				const { excludeTerms, ...includeTaxQuery } = taxQuery;
-				const builtTaxQuery = buildTaxQuery( includeTaxQuery );
-				if ( excludeTerms ) {
+				const builtTaxQuery = buildTaxQuery( taxQuery.include );
+				if ( taxQuery.exclude ) {
 					Object.assign(
 						builtTaxQuery,
-						buildTaxQuery( excludeTerms, '_exclude' )
+						buildTaxQuery( taxQuery.exclude, '_exclude' )
 					);
 				}
 

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -18,15 +18,19 @@ const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 const migrateToTaxQuery = ( attributes ) => {
 	const { query } = attributes;
-	const { categoryIds, tagIds, ...newQuery } = query;
-
-	if ( query.categoryIds?.length || query.tagIds?.length ) {
+	const { categoryIds, tagIds, taxQuery, ...newQuery } = query;
+	if ( !! categoryIds?.length || !! tagIds?.length ) {
 		newQuery.taxQuery = {
-			category: !! query.categoryIds?.length
-				? query.categoryIds
-				: undefined,
-			post_tag: !! query.tagIds?.length ? query.tagIds : undefined,
+			include: {
+				category: !! categoryIds?.length ? categoryIds : undefined,
+				post_tag: !! tagIds?.length ? tagIds : undefined,
+			},
 		};
+	}
+	if ( !! Object.keys( taxQuery || {} ).length ) {
+		// Second taxQuery migration that changes the structure from
+		// taxQuery: { taxonomy: [ids] } to taxQuery: { include: { taxonomy: [ids] } }
+		newQuery.taxQuery = { include: taxQuery };
 	}
 	return {
 		...attributes,
@@ -522,6 +526,65 @@ const v5 = {
 	migrate: migrateDisplayLayout,
 };
 
-const deprecated = [ v5, v4, v3, v2, v1 ];
+const v6 = {
+	attributes: {
+		queryId: {
+			type: 'number',
+		},
+		query: {
+			type: 'object',
+			default: {
+				perPage: null,
+				pages: 0,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				exclude: [],
+				sticky: '',
+				inherit: true,
+				taxQuery: null,
+				parents: [],
+				format: [],
+			},
+		},
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		namespace: {
+			type: 'string',
+		},
+		enhancedPagination: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+		layout: true,
+		interactivity: true,
+		contentRole: true,
+	},
+	save( { attributes: { tagName: Tag = 'div' } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+		return <Tag { ...innerBlocksProps } />;
+	},
+	isEligible: ( { query: { taxQuery } = {} } ) =>
+		!! taxQuery &&
+		Object.keys( taxQuery ).some(
+			( key ) => ! [ 'include', 'exclude' ].includes( key )
+		),
+	migrate( attributes, innerBlocks ) {
+		const withTaxQuery = migrateToTaxQuery( attributes );
+		return migrateDisplayLayout( withTaxQuery, innerBlocks );
+	},
+};
+
+const deprecated = [ v6, v5, v4, v3, v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -19,6 +19,8 @@ const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 const migrateToTaxQuery = ( attributes ) => {
 	const { query } = attributes;
 	const { categoryIds, tagIds, taxQuery, ...newQuery } = query;
+	// First `taxQuery` migration that moves `categoryIds` and `tagIds`
+	// into `taxQuery` (v2 deprecation).
 	if ( !! categoryIds?.length || !! tagIds?.length ) {
 		newQuery.taxQuery = {
 			include: {
@@ -27,9 +29,10 @@ const migrateToTaxQuery = ( attributes ) => {
 			},
 		};
 	}
+	// Second `taxQuery` migration that changes the structure from
+	// taxQuery: { taxonomy: [ids] } to
+	// taxQuery: { include: { taxonomy: [ids] } } (v6 deprecation).
 	if ( !! Object.keys( taxQuery || {} ).length ) {
-		// Second taxQuery migration that changes the structure from
-		// taxQuery: { taxonomy: [ids] } to taxQuery: { include: { taxonomy: [ids] } }
 		newQuery.taxQuery = { include: taxQuery };
 	}
 	return {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -70,7 +70,7 @@ export default function QueryInspectorControls( props ) {
 		// We need to dynamically update the `taxQuery` property,
 		// by removing any not supported taxonomy from the query.
 		const supportedTaxonomies = postTypesTaxonomiesMap[ newValue ];
-		if ( !! supportedTaxonomies?.length ) {
+		if ( !! supportedTaxonomies?.length && !! taxQuery ) {
 			// Shared utility to build taxQuery based on supported taxonomies.
 			const buildTaxQuery = ( _taxQuery ) => {
 				return Object.entries( _taxQuery || {} ).reduce(
@@ -83,13 +83,14 @@ export default function QueryInspectorControls( props ) {
 			{}
 		);
 			};
-			const { excludeTerms, ...includeTaxQuery } = taxQuery || {};
-			const updatedTaxQuery = buildTaxQuery( includeTaxQuery );
-			if ( excludeTerms ) {
-				const builtExcludeTaxQuery = buildTaxQuery( excludeTerms );
+			const updatedTaxQuery = {};
+			const builtIncludeTaxQuery = buildTaxQuery( taxQuery.include );
+			if ( !! Object.keys( builtIncludeTaxQuery ).length ) {
+				updatedTaxQuery.include = builtIncludeTaxQuery;
+			}
+			const builtExcludeTaxQuery = buildTaxQuery( taxQuery.exclude );
 				if ( !! Object.keys( builtExcludeTaxQuery ).length ) {
-					updatedTaxQuery.excludeTerms = builtExcludeTaxQuery;
-				}
+				updatedTaxQuery.exclude = builtExcludeTaxQuery;
 			}
 		updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
 			? updatedTaxQuery
@@ -397,19 +398,11 @@ export default function QueryInspectorControls( props ) {
 						<ToolsPanelItem
 							label={ __( 'Taxonomies' ) }
 							hasValue={ () =>
-								Object.entries( taxQuery || {} ).some(
-									( [ key, value ] ) => {
-										// `excludeTerms` is an object similar to taxQuery taxonomy inclusion: ex: { category: [ 1,2 ], excludeTerms: { tag: [3] } }.
-										if ( key === 'excludeTerms' ) {
-											return Object.values(
-												value || {}
-											).some(
-												( excludeTermIds ) =>
-													!! excludeTermIds.length
-											);
-										}
-										return !! value.length;
-									}
+								Object.values( taxQuery || {} ).some(
+									( value ) =>
+										Object.values( value || {} ).some(
+											( termIds ) => !! termIds?.length
+										)
 								)
 							}
 							onDeselect={ () => setQuery( { taxQuery: null } ) }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -77,11 +77,11 @@ export default function QueryInspectorControls( props ) {
 					( accumulator, [ taxonomy, terms ] ) => {
 						if ( supportedTaxonomies.includes( taxonomy ) ) {
 							accumulator[ taxonomy ] = terms;
-				}
-				return accumulator;
-			},
-			{}
-		);
+						}
+						return accumulator;
+					},
+					{}
+				);
 			};
 			const updatedTaxQuery = {};
 			const builtIncludeTaxQuery = buildTaxQuery( taxQuery.include );
@@ -89,12 +89,12 @@ export default function QueryInspectorControls( props ) {
 				updatedTaxQuery.include = builtIncludeTaxQuery;
 			}
 			const builtExcludeTaxQuery = buildTaxQuery( taxQuery.exclude );
-				if ( !! Object.keys( builtExcludeTaxQuery ).length ) {
+			if ( !! Object.keys( builtExcludeTaxQuery ).length ) {
 				updatedTaxQuery.exclude = builtExcludeTaxQuery;
 			}
-		updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
-			? updatedTaxQuery
-			: undefined;
+			updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
+				? updatedTaxQuery
+				: undefined;
 		}
 
 		if ( newValue !== 'post' ) {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -70,18 +70,31 @@ export default function QueryInspectorControls( props ) {
 		// We need to dynamically update the `taxQuery` property,
 		// by removing any not supported taxonomy from the query.
 		const supportedTaxonomies = postTypesTaxonomiesMap[ newValue ];
-		const updatedTaxQuery = Object.entries( taxQuery || {} ).reduce(
-			( accumulator, [ taxonomySlug, terms ] ) => {
-				if ( supportedTaxonomies.includes( taxonomySlug ) ) {
-					accumulator[ taxonomySlug ] = terms;
+		if ( !! supportedTaxonomies?.length ) {
+			// Shared utility to build taxQuery based on supported taxonomies.
+			const buildTaxQuery = ( _taxQuery ) => {
+				return Object.entries( _taxQuery || {} ).reduce(
+					( accumulator, [ taxonomy, terms ] ) => {
+						if ( supportedTaxonomies.includes( taxonomy ) ) {
+							accumulator[ taxonomy ] = terms;
 				}
 				return accumulator;
 			},
 			{}
 		);
+			};
+			const { excludeTerms, ...includeTaxQuery } = taxQuery || {};
+			const updatedTaxQuery = buildTaxQuery( includeTaxQuery );
+			if ( excludeTerms ) {
+				const builtExcludeTaxQuery = buildTaxQuery( excludeTerms );
+				if ( !! Object.keys( builtExcludeTaxQuery ).length ) {
+					updatedTaxQuery.excludeTerms = builtExcludeTaxQuery;
+				}
+			}
 		updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
 			? updatedTaxQuery
 			: undefined;
+		}
 
 		if ( newValue !== 'post' ) {
 			updateQuery.sticky = '';
@@ -384,8 +397,19 @@ export default function QueryInspectorControls( props ) {
 						<ToolsPanelItem
 							label={ __( 'Taxonomies' ) }
 							hasValue={ () =>
-								Object.values( taxQuery || {} ).some(
-									( terms ) => !! terms.length
+								Object.entries( taxQuery || {} ).some(
+									( [ key, value ] ) => {
+										// `excludeTerms` is an object similar to taxQuery taxonomy inclusion: ex: { category: [ 1,2 ], excludeTerms: { tag: [3] } }.
+										if ( key === 'excludeTerms' ) {
+											return Object.values(
+												value || {}
+											).some(
+												( excludeTermIds ) =>
+													!! excludeTermIds.length
+											);
+										}
+										return !! value.length;
+									}
 								)
 							}
 							onDeselect={ () => setQuery( { taxQuery: null } ) }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -63,7 +63,10 @@ export function TaxonomyControls( { onChange, query } ) {
 					taxQuery?.include?.[ taxonomy.slug ] || [];
 				const excludeTermIds =
 					taxQuery?.exclude?.[ taxonomy.slug ] || [];
-				const onChangeTaxQuery = ( newTermIds, key ) => {
+				const onChangeTaxQuery = (
+					newTermIds,
+					/** @type {'include'|'exclude'} */ key
+				) => {
 					const newPartialTaxQuery = {
 						...taxQuery?.[ key ],
 						[ taxonomy.slug ]: newTermIds,

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -96,10 +96,7 @@ export function TaxonomyControls( { onChange, query } ) {
 							termIds={ includeTermIds }
 							oppositeTermIds={ excludeTermIds }
 							onChange={ handleIncludeChange }
-							label={
-								/* translators: %s: taxonomy name */
-								sprintf( __( 'Include: %s' ), taxonomy.name )
-							}
+							label={ taxonomy.name }
 						/>
 						<TaxonomyItem
 							taxonomy={ taxonomy }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -7,9 +7,10 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, Fragment } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -58,8 +59,11 @@ export function TaxonomyControls( { onChange, query } ) {
 	return (
 		<VStack spacing={ 4 }>
 			{ taxonomies.map( ( taxonomy ) => {
-				const termIds = taxQuery?.[ taxonomy.slug ] || [];
-				const handleChange = ( newTermIds ) =>
+				const includeTermIds = taxQuery?.[ taxonomy.slug ] || [];
+				const excludeTermIds =
+					taxQuery?.excludeTerms?.[ taxonomy.slug ] || [];
+
+				const handleIncludeChange = ( newTermIds ) =>
 					onChange( {
 						taxQuery: {
 							...taxQuery,
@@ -67,13 +71,47 @@ export function TaxonomyControls( { onChange, query } ) {
 						},
 					} );
 
+				const handleExcludeChange = ( newTermIds ) => {
+					const newExclude = {
+						...taxQuery?.excludeTerms,
+						[ taxonomy.slug ]: newTermIds,
+					};
+					// Remove empty arrays from excludeTerms.
+					if ( newTermIds.length === 0 ) {
+						delete newExclude[ taxonomy.slug ];
+					}
+					onChange( {
+						taxQuery: {
+							...taxQuery,
+							excludeTerms: !! Object.keys( newExclude ).length
+								? newExclude
+								: undefined,
+						},
+					} );
+				};
 				return (
-					<TaxonomyItem
-						key={ taxonomy.slug }
-						taxonomy={ taxonomy }
-						termIds={ termIds }
-						onChange={ handleChange }
-					/>
+					<Fragment key={ taxonomy.slug }>
+						<TaxonomyItem
+							taxonomy={ taxonomy }
+							termIds={ includeTermIds }
+							oppositeTermIds={ excludeTermIds }
+							onChange={ handleIncludeChange }
+							label={
+								/* translators: %s: taxonomy name */
+								sprintf( __( 'Include: %s' ), taxonomy.name )
+							}
+						/>
+						<TaxonomyItem
+							taxonomy={ taxonomy }
+							termIds={ excludeTermIds }
+							oppositeTermIds={ includeTermIds }
+							onChange={ handleExcludeChange }
+							label={
+								/* translators: %s: taxonomy name */
+								sprintf( __( 'Exclude: %s' ), taxonomy.name )
+							}
+						/>
+					</Fragment>
 				);
 			} ) }
 		</VStack>
@@ -83,13 +121,21 @@ export function TaxonomyControls( { onChange, query } ) {
 /**
  * Renders a `FormTokenField` for a given taxonomy.
  *
- * @param {Object}   props          The props for the component.
- * @param {Object}   props.taxonomy The taxonomy object.
- * @param {number[]} props.termIds  An array with the block's term ids for the given taxonomy.
- * @param {Function} props.onChange Callback `onChange` function.
+ * @param {Object}   props                 The props for the component.
+ * @param {Object}   props.taxonomy        The taxonomy object.
+ * @param {number[]} props.termIds         An array with the block's term ids for the given taxonomy.
+ * @param {number[]} props.oppositeTermIds An array with the opposite control's term ids (to exclude from suggestions).
+ * @param {Function} props.onChange        Callback `onChange` function.
+ * @param {string}   props.label           Label of the control.
  * @return {JSX.Element} The rendered component.
  */
-function TaxonomyItem( { taxonomy, termIds, onChange } ) {
+function TaxonomyItem( {
+	taxonomy,
+	termIds,
+	oppositeTermIds,
+	onChange,
+	label,
+} ) {
 	const [ search, setSearch ] = useState( '' );
 	const [ value, setValue ] = useState( EMPTY_ARRAY );
 	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
@@ -101,6 +147,11 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 			}
 			const { getEntityRecords, hasFinishedResolution } =
 				select( coreStore );
+
+			// Combine current terms and opposite terms for exclusion, to prevent
+			// users from selecting the same term in both include and exclude controls.
+			const combinedExclude = [ ...termIds, ...oppositeTermIds ];
+
 			const selectorArgs = [
 				'taxonomy',
 				taxonomy.slug,
@@ -108,7 +159,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 					...BASE_QUERY,
 					search,
 					orderby: 'name',
-					exclude: termIds,
+					exclude: combinedExclude,
 					per_page: 20,
 				},
 			];
@@ -120,7 +171,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 				),
 			};
 		},
-		[ search, taxonomy.slug, termIds ]
+		[ search, taxonomy.slug, termIds, oppositeTermIds ]
 	);
 	// `existingTerms` are the ones fetched from the API and their type is `{ id: number; name: string }`.
 	// They are used to extract the terms' names to populate the `FormTokenField` properly
@@ -183,7 +234,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 	return (
 		<div className="block-library-query-inspector__taxonomy-control">
 			<FormTokenField
-				label={ taxonomy.name }
+				label={ label }
 				value={ value }
 				onInputChange={ debouncedSearch }
 				suggestions={ suggestions }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -52,41 +52,39 @@ export function TaxonomyControls( { onChange, query } ) {
 	const { postType, taxQuery } = query;
 
 	const taxonomies = useTaxonomies( postType );
-	if ( ! taxonomies || taxonomies.length === 0 ) {
+	if ( ! taxonomies?.length ) {
 		return null;
 	}
 
 	return (
 		<VStack spacing={ 4 }>
 			{ taxonomies.map( ( taxonomy ) => {
-				const includeTermIds = taxQuery?.[ taxonomy.slug ] || [];
+				const includeTermIds =
+					taxQuery?.include?.[ taxonomy.slug ] || [];
 				const excludeTermIds =
-					taxQuery?.excludeTerms?.[ taxonomy.slug ] || [];
-
-				const handleIncludeChange = ( newTermIds ) =>
-					onChange( {
-						taxQuery: {
-							...taxQuery,
-							[ taxonomy.slug ]: newTermIds,
-						},
-					} );
-
-				const handleExcludeChange = ( newTermIds ) => {
-					const newExclude = {
-						...taxQuery?.excludeTerms,
+					taxQuery?.exclude?.[ taxonomy.slug ] || [];
+				const onChangeTaxQuery = ( newTermIds, key ) => {
+					const newPartialTaxQuery = {
+						...taxQuery?.[ key ],
 						[ taxonomy.slug ]: newTermIds,
 					};
-					// Remove empty arrays from excludeTerms.
-					if ( newTermIds.length === 0 ) {
-						delete newExclude[ taxonomy.slug ];
+					// Remove empty arrays from the partial `taxQuery` (include|exclude).
+					if ( ! newTermIds.length ) {
+						delete newPartialTaxQuery[ taxonomy.slug ];
 					}
+					const newTaxQuery = {
+						...taxQuery,
+						[ key ]: !! Object.keys( newPartialTaxQuery ).length
+							? newPartialTaxQuery
+							: undefined,
+					};
 					onChange( {
-						taxQuery: {
-							...taxQuery,
-							excludeTerms: !! Object.keys( newExclude ).length
-								? newExclude
-								: undefined,
-						},
+						// Clean up `taxQuery` if all filters are removed.
+						taxQuery: Object.values( newTaxQuery ).every(
+							( value ) => ! value
+						)
+							? undefined
+							: newTaxQuery,
 					} );
 				};
 				return (
@@ -95,14 +93,18 @@ export function TaxonomyControls( { onChange, query } ) {
 							taxonomy={ taxonomy }
 							termIds={ includeTermIds }
 							oppositeTermIds={ excludeTermIds }
-							onChange={ handleIncludeChange }
+							onChange={ ( value ) =>
+								onChangeTaxQuery( value, 'include' )
+							}
 							label={ taxonomy.name }
 						/>
 						<TaxonomyItem
 							taxonomy={ taxonomy }
 							termIds={ excludeTermIds }
 							oppositeTermIds={ includeTermIds }
-							onChange={ handleExcludeChange }
+							onChange={ ( value ) =>
+								onChangeTaxQuery( value, 'exclude' )
+							}
 							label={
 								/* translators: %s: taxonomy name */
 								sprintf( __( 'Exclude: %s' ), taxonomy.name )

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
@@ -17,8 +17,10 @@
 				"sticky": "",
 				"inherit": false,
 				"taxQuery": {
-					"category": [ 3, 5 ],
-					"post_tag": [ 6 ]
+					"include": {
+						"category": [ 3, 5 ],
+						"post_tag": [ 6 ]
+					}
 				}
 			},
 			"tagName": "div"

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}}} -->
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"include":{"category":[3,5],"post_tag":[6]}}}} -->
 <div class="wp-block-query"><!-- wp:group {"textColor":"pale-cyan-blue","style":{"color":{"background":"#284d5f"},"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} -->
 <div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}}} -->
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"include":{"category":[3,5],"post_tag":[6]}}}} -->
 <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
 <!-- wp:post-title /-->
 <!-- /wp:post-template --></div>

--- a/test/integration/fixtures/blocks/core__query__deprecated-6.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-6.html
@@ -1,0 +1,5 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[5],"post_tag":[27]},"parents":[],"format":[]}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-6.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-6.json
@@ -3,9 +3,9 @@
 		"name": "core/query",
 		"isValid": true,
 		"attributes": {
-			"queryId": 19,
+			"queryId": 3,
 			"query": {
-				"perPage": 3,
+				"perPage": 1,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
@@ -16,24 +16,23 @@
 				"exclude": [],
 				"sticky": "",
 				"inherit": false,
+				"parents": [],
+				"format": [],
 				"taxQuery": {
 					"include": {
-						"category": [ 3, 5 ],
-						"post_tag": [ 6 ]
+						"category": [ 5 ],
+						"post_tag": [ 27 ]
 					}
 				}
 			},
-			"tagName": "div"
+			"tagName": "div",
+			"enhancedPagination": false
 		},
 		"innerBlocks": [
 			{
 				"name": "core/post-template",
 				"isValid": true,
-				"attributes": {
-					"layout": {
-						"type": "default"
-					}
-				},
+				"attributes": {},
 				"innerBlocks": [
 					{
 						"name": "core/post-title",

--- a/test/integration/fixtures/blocks/core__query__deprecated-6.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-6.parsed.json
@@ -1,0 +1,46 @@
+[
+	{
+		"blockName": "core/query",
+		"attrs": {
+			"queryId": 3,
+			"query": {
+				"perPage": 1,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false,
+				"taxQuery": {
+					"category": [ 5 ],
+					"post_tag": [ 27 ]
+				},
+				"parents": [],
+				"format": []
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/post-template",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/post-title",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n\n",
+				"innerContent": [ "\n", null, "\n" ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-query\"></div>\n",
+		"innerContent": [ "\n<div class=\"wp-block-query\">", null, "</div>\n" ]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-6.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-6.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:query {"queryId":3,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[],"format":[],"taxQuery":{"include":{"category":[5],"post_tag":[27]}}}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/53485

This PR adds support to exclude specific terms. The current approach is preserving the same filter (`Filters->Taxonomies`), by adding two inputs for each taxonomy, one for `include` and another for `exclude`. I've updated the labels to `[Taxonomy]` and  `exclude: [Taxonomy]`, and render them sequentially for each taxonomy (see screenshot below). This might need design feedback (@WordPress/gutenberg-design ).

Combination of taxonomy filters are same as before with a logical `AND`. 

The `taxQuery` attribute now supports both inclusion and exclusion of taxonomy terms. The structure looks like this:

```js
{
	query: {
		taxQuery: {
                         include: {
				category: [1, 2, 3],
				post_tag: [10, 20]
			}
			exclude: {
				category: [5, 6],
				post_tag: [15]
			}
		}
	}
}
```

This essentially adds a deprecation in Query Loop block.


## Testing Instructions 
1. Insert Query Loop block and set its `Query type` to `Custom`.
2. Add the taxonomies filter and play around with different settings.
3. Ensure that the results both in the editor and front end are the expected ones.
4. Also test with custom post types and or taxonomies.

## Testing for migrating Query Loop block
1. All previous blocks that had taxonomy filters before should work exactly as before, both in the editor and front-end.
2. If you don't have one already, create a `custom` Query Loop block and apply some taxonomy filters **before** testing this PR.
3. Then test this PR but visiting:
   - front end and observe that the results are the exact same (front end migration)
   - the editor and observe no errors and the previous values are rendered in the filters properly
   - if you save the content, the block should have the new `taxQuery` structure.




## Screenshots or screencast <!-- if applicable -->
<img width="836" height="707" alt="Screenshot 2025-12-08 at 10 17 45 AM" src="https://github.com/user-attachments/assets/2f9c3c11-6bdb-4253-b771-1fb7a3638f17" />


