### PR TITLE
Add support for 'align' to the Breadcrumbs block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Name:** core/breadcrumbs
 -	**Experimental:** true
 -	**Category:** theme
--	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Name:** core/breadcrumbs
 -	**Experimental:** true
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -32,6 +32,7 @@
 	"usesContext": [ "postId", "postType", "templateSlug" ],
 	"supports": {
 		"html": false,
+		"align": true,
 		"spacing": {
 			"margin": true,
 			"padding": true

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -32,7 +32,7 @@
 	"usesContext": [ "postId", "postType", "templateSlug" ],
 	"supports": {
 		"html": false,
-		"align": true,
+		"align": [ "wide", "full" ],
 		"spacing": {
 			"margin": true,
 			"padding": true


### PR DESCRIPTION
## What?

This PR adds `align` support to the _Breadcrumbs_ block.

## Why?

It allows users to change the alignment of the _Breadcrumbs_ block to _Wide_ or _Full_ width. This makes it easier to fit the block into specific layouts, like WooCommerce templates, which default their inner contents to wide.

## Testing Instructions

1. Add the _Breadcrumbs_ block to any template.
2. Verify you can change its alignment to wide and full width and the changes are honored in the frontend.

<img width="550" height="288" alt="imatge" src="https://github.com/user-attachments/assets/37bd7ee5-6893-43b1-9e90-1d460fd3dbd4" />