### PR TITLE
Fix package side effects for esbuild

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -79,7 +79,9 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/*/init.js"
+		"src/*/init.js",
+		"build/*/init.js",
+		"build-module/*/init.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -34,7 +34,12 @@
 	"react-native": "src/index",
 	"wpScript": true,
 	"sideEffects": [
-		"{src,build,build-module}/{index.js,store/index.js}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/autop": "file:../autop",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -37,7 +37,9 @@
 	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": [
-		"{src,build,build-module}/index.js"
+		"src/index.js",
+		"build/index.js",
+		"build-module/index.js"
 	],
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -37,7 +37,12 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -37,7 +37,12 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -36,7 +36,12 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -34,7 +34,12 @@
 	"react-native": "src/index",
 	"wpScript": true,
 	"sideEffects": [
-		"{src,build,build-module}/{index.js,store/index.js}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -37,7 +37,12 @@
 	"types": "build-types",
 	"sideEffects": [
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js}"
+		"src/index.js",
+		"src/store/index.js",
+		"build/index.js",
+		"build/store/index.js",
+		"build-module/index.js",
+		"build-module/store/index.js"
 	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -220,6 +220,7 @@ export function createWordpressExternalsPlugin(
 								return {
 									path: args.path,
 									external: true,
+									sideEffects: !! packageJson.sideEffects,
 								};
 							}
 


### PR DESCRIPTION
Spinoff from #73516 that fixes package side-effects for esbuild.

First, if esbuild sees an external import like `import { foo } from 'foo'`, sometimes the surrounding code that uses the `foo` import is tree-shaked and eliminated. But can esbuild eliminate the `import` statement itself? Only if it knows for sure that the import has no side effects. If an `onResolve` hook handles an import as external, esbuild is not going to look up its `package.json` and we need to specify `sideEffects` in the `onResolve` return value.

Second, esbuild can't interpret bracket expansion (`{build,build-module}/{index.js,store/index.js}`) in the `sideEffects` values. Webpack can, but esbuild can't. It will interpret such a value as `false`, which is wrong. This PR expands the `sideEffects` values into explicit lists. Esbuild understands the `*` and `**` wildcards, but nothing else.