### PR TITLE
Block Editor: remove usage of Emotion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53545,8 +53545,6 @@
 			"version": "15.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -52,8 +52,6 @@
 		"build-module/hooks/**"
 	],
 	"dependencies": {
-		"@emotion/react": "^11.7.1",
-		"@emotion/styled": "^11.6.0",
 		"@react-spring/web": "^9.4.5",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/block-editor/src/components/dimensions-tool/style.module.css
+++ b/packages/block-editor/src/components/dimensions-tool/style.module.css
@@ -1,3 +1,0 @@
-.single-column {
-	grid-column: span 1;
-}

--- a/packages/block-editor/src/components/dimensions-tool/style.module.css
+++ b/packages/block-editor/src/components/dimensions-tool/style.module.css
@@ -1,0 +1,3 @@
+.single-column {
+	grid-column: span 1;
+}

--- a/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
@@ -8,11 +8,6 @@ import {
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import styles from './style.module.css';
-
-/**
  * @typedef {import('@wordpress/components/build-types/unit-control/types').WPUnitControlUnit} WPUnitControlUnit
  */
 
@@ -69,7 +64,7 @@ export default function WidthHeightTool( {
 	return (
 		<>
 			<ToolsPanelItem
-				className={ styles[ 'single-column' ] }
+				style={ { gridColumn: 'span 1' } }
 				label={ __( 'Width' ) }
 				isShownByDefault={ isShownByDefault }
 				hasValue={ () => width !== '' }
@@ -88,7 +83,7 @@ export default function WidthHeightTool( {
 				/>
 			</ToolsPanelItem>
 			<ToolsPanelItem
-				className={ styles[ 'single-column' ] }
+				style={ { gridColumn: 'span 1' } }
 				label={ __( 'Height' ) }
 				isShownByDefault={ isShownByDefault }
 				hasValue={ () => height !== '' }

--- a/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import styled from '@emotion/styled';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -12,9 +7,10 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const SingleColumnToolsPanelItem = styled( ToolsPanelItem )`
-	grid-column: span 1;
-`;
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
 
 /**
  * @typedef {import('@wordpress/components/build-types/unit-control/types').WPUnitControlUnit} WPUnitControlUnit
@@ -72,7 +68,8 @@ export default function WidthHeightTool( {
 
 	return (
 		<>
-			<SingleColumnToolsPanelItem
+			<ToolsPanelItem
+				className={ styles[ 'single-column' ] }
 				label={ __( 'Width' ) }
 				isShownByDefault={ isShownByDefault }
 				hasValue={ () => width !== '' }
@@ -89,8 +86,9 @@ export default function WidthHeightTool( {
 					onChange={ onDimensionChange( 'width' ) }
 					size="__unstable-large"
 				/>
-			</SingleColumnToolsPanelItem>
-			<SingleColumnToolsPanelItem
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				className={ styles[ 'single-column' ] }
 				label={ __( 'Height' ) }
 				isShownByDefault={ isShownByDefault }
 				hasValue={ () => height !== '' }
@@ -107,7 +105,7 @@ export default function WidthHeightTool( {
 					onChange={ onDimensionChange( 'height' ) }
 					size="__unstable-large"
 				/>
-			</SingleColumnToolsPanelItem>
+			</ToolsPanelItem>
 		</>
 	);
 }


### PR DESCRIPTION
Removes a single usage of Emotion in the Block Editor package, which caused the `block-editor` script to bundle the library independently from `components`. That led to two instances being active in the WordPress block editor environment.

All we did use Emotion for was a single `grid-column` style that ensures that the two inputs in `WidthHeightControl` are displayed side-by-side, in two columns:

<img width="671" height="138" alt="Screenshot 2025-12-05 at 19 01 45" src="https://github.com/user-attachments/assets/bd18a32b-5e4a-419d-88ab-e54d959b842a" />

This fixes #72558 as there will be only one Emotion instance remaining, in `components`.