### PR TITLE
Blocks: Add Term Permalink block for Terms Query template

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1041,6 +1041,16 @@ Displays the name of a taxonomy term. ([Source](https://github.com/WordPress/gut
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isLink, level, levelOptions, textAlign
 
+## Term Permalink
+
+Displays a link to the current term's archive page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-permalink))
+
+-	**Name:** core/term-permalink
+-	**Category:** theme
+-	**Ancestor:** core/term-template
+-	**Supports:** color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** content, linkTarget
+
 ## Term Template
 
 Contains the block elements used to render a taxonomy term, like the name, description, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-template))

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -59,6 +59,7 @@
 @use "./post-comments-form/editor.scss" as *;
 @use "./editor-elements.scss" as *;
 @use "./utils/poster-image.scss" as *;
+@use "./term-permalink/editor.scss" as *;
 
 :root .editor-styles-wrapper {
 	@include background-colors-deprecated();

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -134,6 +134,7 @@ import * as templatePart from './template-part';
 import * as termCount from './term-count';
 import * as termDescription from './term-description';
 import * as termName from './term-name';
+import * as termPermalink from './term-permalink';
 import * as termsQuery from './terms-query';
 import * as termTemplate from './term-template';
 import * as textColumns from './text-columns';
@@ -257,6 +258,7 @@ const getAllBlocks = () => {
 		termCount,
 		termDescription,
 		termName,
+		termPermalink,
 		termsQuery,
 		termTemplate,
 		queryTitle,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -77,6 +77,7 @@
 @use "./term-count/style.scss" as *;
 @use "./term-description/style.scss" as *;
 @use "./term-name/style.scss" as *;
+@use "./term-permalink/style.scss" as *;
 @use "./term-template/style.scss" as *;
 @use "./text-columns/style.scss" as *;
 @use "./verse/style.scss" as *;

--- a/packages/block-library/src/term-permalink/block.json
+++ b/packages/block-library/src/term-permalink/block.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/term-permalink",
+	"title": "Term Permalink",
+	"category": "theme",
+	"ancestor": [ "core/term-template" ],
+	"description": "Displays a link to the current term's archive page.",
+	"textdomain": "default",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"role": "content"
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": "_self"
+		}
+	},
+	"usesContext": [ "termId", "taxonomy" ],
+	"supports": {
+		"html": false,
+		"color": {
+			"gradients": true,
+			"text": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"textDecoration": true
+			}
+		},
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"width": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	},
+	"style": "wp-block-term-permalink"
+}

--- a/packages/block-library/src/term-permalink/edit.js
+++ b/packages/block-library/src/term-permalink/edit.js
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+export default function TermPermalinkEdit( {
+	attributes: { content, linkTarget },
+	setAttributes,
+	insertBlocksAfter,
+} ) {
+	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	return (
+		<>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => setAttributes( { linkTarget: '_self' } ) }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						label={ __( 'Open in new tab' ) }
+						isShownByDefault
+						hasValue={ () => linkTarget !== '_self' }
+						onDeselect={ () =>
+							setAttributes( { linkTarget: '_self' } )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Open in new tab' ) }
+							onChange={ ( value ) =>
+								setAttributes( {
+									linkTarget: value ? '_blank' : '_self',
+								} )
+							}
+							checked={ linkTarget === '_blank' }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
+			<RichText
+				identifier="content"
+				tagName="a"
+				aria-label={ __( '"View term" link text' ) }
+				placeholder={ __( 'View term' ) }
+				value={ content }
+				onChange={ ( newValue ) =>
+					setAttributes( { content: newValue } )
+				}
+				__unstableOnSplitAtEnd={ () =>
+					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				}
+				withoutInteractiveFormatting
+				{ ...blockProps }
+			/>
+		</>
+	);
+}

--- a/packages/block-library/src/term-permalink/editor.scss
+++ b/packages/block-library/src/term-permalink/editor.scss
@@ -1,0 +1,13 @@
+.wp-block-term-permalink {
+	display: block;
+	width: fit-content;
+
+	&:where(:not([style*="text-decoration"])) {
+		text-decoration: none;
+
+		&:focus,
+		&:active {
+			text-decoration: none;
+		}
+	}
+}

--- a/packages/block-library/src/term-permalink/index.js
+++ b/packages/block-library/src/term-permalink/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { link as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	example: {},
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/term-permalink/index.php
+++ b/packages/block-library/src/term-permalink/index.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Server-side rendering of the `core/term-permalink` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/term-permalink` block on the server.
+ *
+ * @since 6.9.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns the term permalink link.
+ */
+function render_block_core_term_permalink( $attributes, $content, $block ) {
+	// Get term from context or from the current query.
+	if ( isset( $block->context['termId'] ) && isset( $block->context['taxonomy'] ) ) {
+		$term = get_term( $block->context['termId'], $block->context['taxonomy'] );
+	} else {
+		$term = get_queried_object();
+		if ( ! $term instanceof WP_Term ) {
+			$term = null;
+		}
+	}
+
+	if ( ! $term || is_wp_error( $term ) ) {
+		return '';
+	}
+
+	$term_link = get_term_link( $term );
+	if ( is_wp_error( $term_link ) ) {
+		return '';
+	}
+
+	$term_name = $term->name;
+	if ( '' === $term_name ) {
+		$term_name = sprintf(
+			/* translators: %s is term ID to describe the link for screen readers. */
+			__( 'untitled term %s' ),
+			$term->term_id
+		);
+	}
+
+	$screen_reader_text = sprintf(
+		/* translators: %s is either the term name or term ID to describe the link for screen readers. */
+		__( ': %s' ),
+		$term_name
+	);
+
+	$more_text = ! empty( $attributes['content'] ) ? wp_kses_post( $attributes['content'] ) : __( 'View term' );
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	return sprintf(
+		'<a %1$s href="%2$s" target="%3$s">%4$s<span class="screen-reader-text">%5$s</span></a>',
+		$wrapper_attributes,
+		esc_url( $term_link ),
+		esc_attr( $attributes['linkTarget'] ?? '_self' ),
+		$more_text,
+		$screen_reader_text
+	);
+}
+
+/**
+ * Registers the `core/term-permalink` block on the server.
+ *
+ * @since 6.9.0
+ */
+function register_block_core_term_permalink() {
+	register_block_type_from_metadata(
+		__DIR__ . '/term-permalink',
+		array(
+			'render_callback' => 'render_block_core_term_permalink',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_term_permalink' );

--- a/packages/block-library/src/term-permalink/style.scss
+++ b/packages/block-library/src/term-permalink/style.scss
@@ -1,0 +1,13 @@
+.wp-block-term-permalink {
+	display: block;
+	width: fit-content;
+
+	&:where(:not([style*="text-decoration"])) {
+		text-decoration: none;
+
+		&:focus,
+		&:active {
+			text-decoration: none;
+		}
+	}
+}

--- a/packages/block-library/src/term-permalink/test/edit.js
+++ b/packages/block-library/src/term-permalink/test/edit.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import TermPermalinkEdit from '../edit';
+
+// Mock the useBlockProps hook
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	useBlockProps: jest.fn( () => ( {
+		className: 'wp-block-term-permalink',
+	} ) ),
+} ) );
+
+// Mock the useToolsPanelDropdownMenuProps hook
+jest.mock( '../../utils/hooks', () => ( {
+	useToolsPanelDropdownMenuProps: jest.fn( () => ( {} ) ),
+} ) );
+
+describe( 'Term Permalink block', () => {
+	const defaultProps = {
+		attributes: {
+			content: '',
+			linkTarget: '_self',
+		},
+		setAttributes: jest.fn(),
+		insertBlocksAfter: jest.fn(),
+		context: {
+			termId: 1,
+			taxonomy: 'category',
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should render with placeholder text', () => {
+		render( <TermPermalinkEdit { ...defaultProps } /> );
+
+		const input = screen.getByRole( 'textbox', {
+			name: '"View term" link text',
+		} );
+		expect( input ).toBeInTheDocument();
+	} );
+
+	test( 'should render with custom content', () => {
+		const props = {
+			...defaultProps,
+			attributes: {
+				...defaultProps.attributes,
+				content: 'View Category',
+			},
+		};
+
+		render( <TermPermalinkEdit { ...props } /> );
+
+		const input = screen.getByRole( 'textbox', {
+			name: '"View term" link text',
+		} );
+		expect( input ).toHaveTextContent( 'View Category' );
+	} );
+
+	test( 'should call setAttributes when content changes', async () => {
+		const user = userEvent.setup();
+		render( <TermPermalinkEdit { ...defaultProps } /> );
+
+		const input = screen.getByRole( 'textbox', {
+			name: '"View term" link text',
+		} );
+		await user.click( input );
+		await user.type( input, 'Read more' );
+
+		expect( defaultProps.setAttributes ).toHaveBeenCalled();
+	} );
+
+	test( 'should have correct block props', () => {
+		render( <TermPermalinkEdit { ...defaultProps } /> );
+
+		expect( useBlockProps ).toHaveBeenCalled();
+	} );
+} );

--- a/phpunit/blocks/term-permalink-test.php
+++ b/phpunit/blocks/term-permalink-test.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Tests for the Term Permalink block.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.9.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_TermPermalink extends WP_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private static $category_id;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$category_id = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Test Category',
+				'slug'     => 'test-category',
+			)
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_term( self::$category_id, 'category' );
+	}
+
+	/**
+	 * Test that the block renders correctly with term context.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_block_core_term_permalink_with_context() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(),
+			),
+			array(
+				'termId'   => self::$category_id,
+				'taxonomy' => 'category',
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array(),
+			'',
+			$block
+		);
+
+		$this->assertStringContainsString( 'wp-block-term-permalink', $result );
+		$this->assertStringContainsString( get_term_link( self::$category_id ), $result );
+		$this->assertStringContainsString( 'View term', $result );
+	}
+
+	/**
+	 * Test that the block returns empty string without context.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_returns_empty_without_context() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(),
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array(),
+			'',
+			$block
+		);
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that the block renders with custom content.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_with_custom_content() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(
+					'content' => 'Custom Link Text',
+				),
+			),
+			array(
+				'termId'   => self::$category_id,
+				'taxonomy' => 'category',
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array( 'content' => 'Custom Link Text' ),
+			'',
+			$block
+		);
+
+		$this->assertStringContainsString( 'Custom Link Text', $result );
+	}
+
+	/**
+	 * Test that the block renders with target blank.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_with_link_target_blank() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(
+					'linkTarget' => '_blank',
+				),
+			),
+			array(
+				'termId'   => self::$category_id,
+				'taxonomy' => 'category',
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array( 'linkTarget' => '_blank' ),
+			'',
+			$block
+		);
+
+		$this->assertStringContainsString( 'target="_blank"', $result );
+	}
+
+	/**
+	 * Test that the block includes screen reader text.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_includes_screen_reader_text() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(),
+			),
+			array(
+				'termId'   => self::$category_id,
+				'taxonomy' => 'category',
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array(),
+			'',
+			$block
+		);
+
+		$this->assertStringContainsString( 'screen-reader-text', $result );
+		$this->assertStringContainsString( 'Test Category', $result );
+	}
+
+	/**
+	 * Test that the block returns empty for invalid term.
+	 *
+	 * @ticket 73798
+	 *
+	 * @covers ::gutenberg_render_block_core_term_permalink
+	 */
+	public function test_render_returns_empty_for_invalid_term() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/term-permalink',
+				'attrs'     => array(),
+			),
+			array(
+				'termId'   => 999999,
+				'taxonomy' => 'category',
+			)
+		);
+
+		$result = gutenberg_render_block_core_term_permalink(
+			array(),
+			'',
+			$block
+		);
+
+		$this->assertEmpty( $result );
+	}
+}

--- a/test/integration/fixtures/blocks/core__term-permalink.html
+++ b/test/integration/fixtures/blocks/core__term-permalink.html
@@ -1,0 +1,3 @@
+<!-- wp:term-permalink -->
+<a class="wp-block-term-permalink">View term</a>
+<!-- /wp:term-permalink -->

--- a/test/integration/fixtures/blocks/core__term-permalink__custom-text.html
+++ b/test/integration/fixtures/blocks/core__term-permalink__custom-text.html
@@ -1,0 +1,3 @@
+<!-- wp:term-permalink {"content":"Read more about this category"} -->
+<a class="wp-block-term-permalink">Read more about this category</a>
+<!-- /wp:term-permalink -->


### PR DESCRIPTION
## What?

Closes #73798

Adds a new **Term Permalink** block (`core/term-permalink`) for use inside the Terms Query → Term Template.

## Why?

Currently, when using the Terms Query block, there's no way to add a "Read More" style CTA that links to the term archive page.

- The existing **Read More** block only works with post context (`postId`)
- The **Term Name** block can link to the term archive, but it's meant to display the term name, not serve as a standalone CTA
- Users need a dedicated block for "View Category", "Browse Tag", or similar CTAs within term listings

This enhancement enables complete term listing layouts with actionable links to term archives.

## How?

Creates a new `core/term-permalink` block following the same patterns as the Read More block:

### Implementation Details

1. **Context Usage**: Uses `termId` and `taxonomy` context provided by the Term Template block
2. **Link Generation**: Server-side rendering via `get_term_link()` in PHP
3. **Attributes**:
   - `content` (string): Customizable link text (default: "View term")
   - `linkTarget` (string): `_self` or `_blank` for opening in new tab
4. **Supports**: Typography, colors, spacing, borders (matching Read More block)
5. **Ancestor Restriction**: Can only be inserted inside `core/term-template`

## Testing Instructions

1. Create a new page in the editor
2. Add a **Terms Query** block
3. Configure it to display a taxonomy (e.g., Categories)
4. Ensure you have some terms with content in that taxonomy
5. Inside the **Term Template**, you should see Term Name by default
6. Add a **Term Permalink** block (search for "Term Permalink" in the inserter)
7. Optionally customize the link text (e.g., "View Category →")
8. Optionally enable "Open in new tab" in the block settings sidebar
9. Save and view the page on the frontend
10. Verify that clicking the Term Permalink navigates to the correct term archive page

### Testing Instructions for Keyboard

1. Use `Tab` to navigate into the editor canvas
2. Use arrow keys to navigate to the Terms Query block
3. Press `Enter` to select the Term Template
4. Use the inserter (`/`) to add a Term Permalink block
5. Type custom link text using the keyboard
6. Press `Tab` to move focus to the Settings sidebar
7. Use `Space` or `Enter` to toggle the "Open in new tab" setting
8. Verify all interactions are accessible without a mouse
## Screenshots or screencast

| Editor | Frontend |
|-|-|
| [Editor screenshot 1](https://github.com/user-attachments/assets/69e12ce2-f947-4516-b966-82df9491dff6)  
[Editor screenshot 2](https://github.com/user-attachments/assets/c9e25c6d-38a7-45aa-8ec0-8818e52698c9) | [Frontend screenshot](https://github.com/user-attachments/assets/50415c7c-8196-4611-82f1-7b90280c8aa5) |

