### PR TITLE
Fix Social Link Block: Passing `class`, `id` and other props to block main element in the editor

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+-   Fix Social Link Block: Custom classes should be added to block main element (`li`) in editor and not the button in the editor.
+-   Fix Social Link Block: The `id` and other attrs for defining the main element of block should be added to `li` and not the button in the editor.
+
+
 ## 9.36.0 (2025-11-26)
 
 ## 9.35.0 (2025-11-12)

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -160,7 +160,7 @@ const SocialLinkEdit = ( {
 
 	const ref = useRef();
 	const blockProps = useBlockProps( {
-		className: 'wp-block-social-link-anchor',
+		className: wrapperClasses,
 		ref: useMergeRefs( [ setPopoverAnchor, ref ] ),
 		onClick: () => setPopover( true ),
 		onKeyDown: ( event ) => {
@@ -170,6 +170,34 @@ const SocialLinkEdit = ( {
 			}
 		},
 	} );
+
+	/**
+	 * This is the props that are passed to the wrapper element.
+	 */
+	const wrapperProps = {
+		id: blockProps.id,
+		'data-block': blockProps[ 'data-block' ],
+		'data-type': blockProps[ 'data-type' ],
+		// Set all classes from the blockProps to the wrapperProps to avoid
+		// losing the classes that are applied to the blockProps.
+		// Also by doing it custom classes from block attributes will be applied to the wrapper element (main block element).
+		className: blockProps.className,
+	};
+
+	/**
+	 * Reset the class name that is passed to the button element.
+	 * The `block-editor-block-list__block` class is important for editor styles
+	 * to make sure features like dragging works correctly.
+	 */
+	blockProps.className =
+		'wp-block-social-link-anchor block-editor-block-list__block';
+
+	// Remove the id, data-block, and data-type from the blockProps to avoid
+	// passing them to the button element.
+	// It's important to remove these props because they should be applied to the wrapper element (main element).
+	delete blockProps.id;
+	delete blockProps[ 'data-block' ];
+	delete blockProps[ 'data-type' ];
 
 	return (
 		<>
@@ -266,11 +294,11 @@ const SocialLinkEdit = ( {
 			 */ }
 			<li
 				role="presentation"
-				className={ wrapperClasses }
 				style={ {
 					color: iconColorValue,
 					backgroundColor: iconBackgroundColorValue,
 				} }
+				{ ...wrapperProps }
 			>
 				{ /*
 				 * Disable reason: The `button` ARIA role is redundant but


### PR DESCRIPTION
## What?
The Social Link block in the editor works not like as it work in the front end. In the editor the block main element is the button and all classes, id and other attrs were added to the inner button but in the front end the `li` is the main element. 

This create a inconsistency for styling block in the editor and also in the front end. Also, the custom class for block were not added to main block element and it create another inconsistency while styling and working with block.

This is important to add `id`, `class`, `data-type` and `data-block` to the blocks main element to make the styling easy for editor and front and also enable third-party plugins to easily work with block by finding the block easily by using it's clientId in the editor.

I made changes to make the `li` tag the main element as same as how it is the front end. 

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1558" height="669" alt="image" src="https://github.com/user-attachments/assets/8b9b54b5-ee2e-41ee-b2f8-64e0d891556e" />|<img width="1571" height="675" alt="image" src="https://github.com/user-attachments/assets/fc312673-65d8-4e1c-91a3-32bb4358dfad" />|