### PR TITLE
Command Palette: Remove context from editor commands

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -455,7 +455,6 @@ export default function useCommands() {
 	useCommandLoader( {
 		name: 'core/editor/edit-ui',
 		hook: getEditorCommandLoader(),
-		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
## What?

This PR reverts #73717

## Why?

We added an `entity-edit` context to the editor-related commands to hide unnecessary commands in the template list page. However, the context property simply determines whether the command is visible by default; it does not disable the command itself.

The underlying problem seems a bit complicated, so I'm reverting #73717 for now in case we can't find an ideal solution soon. See https://github.com/WordPress/gutenberg/issues/73716#issuecomment-3624596460 for more details.

## Testing Instructions

- Access http://localhost:8888/wp-admin/site-editor.php?p=%2F&canvas=edit directly
- Launch the Command Palette
- No commands should be displayed

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="441" height="470" alt="image" src="https://github.com/user-attachments/assets/532da373-d360-411b-a78a-84aea5d1d308" />| <img width="440" height="109" alt="image" src="https://github.com/user-attachments/assets/d967e280-c822-43e9-87bd-8ab147a34a0e" /> |
