### PR TITLE
Global Styles UI: Remove unnecessary padding for Navigatior component

### DIFF
--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -9,10 +9,6 @@
 	&__panel {
 		flex: 1;
 	}
-
-	.components-navigator-screen {
-		padding: 0;
-	}
 }
 
 .editor-global-styles-sidebar .editor-global-styles-sidebar__header-title {

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -285,7 +285,3 @@
 .global-styles-ui-gradient-palette-panel {
 	padding: variables.$grid-unit-20;
 }
-
-.components-navigator-screen {
-	padding: variables.$grid-unit-15;
-}


### PR DESCRIPTION
- Follow-up to #72599
- Found while investigating an issue reported at https://github.com/WordPress/create-block-theme/issues/786

## What? Why?

The Global Styles UI package adds padding to the `Navigator.Screen` components without a parent selector. This will cause padding to be applied to all `Navigator.Screen` components, which is not what we want.

## Testing Instructions

- The global styles sidebar content should have the proper padding applied as before.
- Confirm that the following two issues have been resolved:

### 1. Create Block Them Plugin

This is just one example, and may cause issues if the consumer is using the `Navigator.Screen` component.

- Install and activate the [Create Block Theme plugin](https://wordpress.org/plugins/create-block-theme/)
- Access Appearance > Editor
- Open the Create Block Theme setting 

| Before | After |
|--------|--------|
| <img width="312" height="715" alt="before" src="https://github.com/user-attachments/assets/5a04794d-51c2-4eca-a22e-e9a629bce275" /> | <img width="312" height="715" alt="after" src="https://github.com/user-attachments/assets/a22433d7-b5ef-45e5-84f9-c31bb75fd672" /> |

### 2. Preferences Modal (Mobile)

- Open the post editor
- Options > Preferences

| Before | After |
|--------|--------|
| <img width="397" height="377" alt="image" src="https://github.com/user-attachments/assets/f8b99c7e-d7d9-4955-95d6-6b7f2a0ecbfe" /> | <img width="409" height="373" alt="image" src="https://github.com/user-attachments/assets/d005abcd-f8e4-4c52-a24f-6c5b6e061c2a" /> |
