### PR TITLE
Chore: Shorten timeout duration for `Snackbar` component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Menu` and othr menu items: change default size to be 32px tall rather than 40px to improve menu density. ([#73429](https://github.com/WordPress/gutenberg/pull/73429)).
+-   `Snackbar`: Shorten timeout duration ([#73813](https://github.com/WordPress/gutenberg/pull/73813)).
 
 ### Bug Fixes
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -27,7 +27,7 @@ import type { SnackbarProps } from './types';
 import type { NoticeAction } from '../notice/types';
 import type { WordPressComponentProps } from '../context';
 
-const NOTICE_TIMEOUT = 10000;
+const NOTICE_TIMEOUT = 6000;
 
 /**
  * Custom hook which announces the message with the given politeness, if a


### PR DESCRIPTION
## What?
Closes #73813

This PR attempts to adjust the timeout `duration` for the `Snackbar` component to 6 seconds.

## Why?

Previously, I had raised a [PR](https://github.com/WordPress/gutenberg/pull/71154) to introduce a `duration` prop to provide users with the ability to modify the timeout duration of the `Snackbar` component. However, after much concern from other contributors, it was suggested that it would be preferable to reduce the timeout duration than to introduce a prop so as to ensure a much more consistent UX experience for all WP users.

Based on @jasmussen [feedback](https://github.com/WordPress/gutenberg/issues/71153#issuecomment-3191600383) I have adjusted the duration down to 6s.

## How?

This PR adjusts the `NOTICE_TIMEOUT` constant to `6000`.