### PR TITLE
Site icon: Try adding a stroke for black logos on dark gray.

### DIFF
--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -34,7 +34,6 @@
 	.edit-post-fullscreen-mode-close__view-mode-toggle-icon {
 		svg,
 		img {
-			background: $gray-900;
 			display: block;
 		}
 	}
@@ -47,12 +46,23 @@
 	padding: $grid-unit-15;
 }
 
+.edit-post-fullscreen-mode-close-site-icon {
+	// Apply a background color here, so that the image itself can have a stroke.
+	background: $gray-900;
+}
+
 .edit-post-fullscreen-mode-close-site-icon__image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
-	background: #333;
 	aspect-ratio: 1 / 1;
+
+	// Apply a stroke to the image to make transparent PNGs visible on dark backgrounds.
+	filter:
+		drop-shadow($border-width 0 0 $white)
+		drop-shadow((-$border-width) 0 0 $white)
+		drop-shadow(0 ($border-width) 0 $white)
+		drop-shadow(0 (-$border-width) 0 $white);
 }
 
 .edit-post-fullscreen-mode-close.components-button:focus {

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -56,7 +56,6 @@
 	.edit-site-editor__view-mode-toggle-icon {
 		svg,
 		img {
-			background: $gray-900;
 			display: block;
 		}
 	}

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -12,16 +12,29 @@
 	}
 }
 
+.edit-site-site-icon {
+	background: #333;
+}
+
 .edit-site-site-icon__image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
-	background: #333;
 	aspect-ratio: 1 / 1;
 
 	.edit-site-layout.is-full-canvas & {
 		border-radius: 0;
 	}
+
+	// We make the background here transparent so the a stroke filter can be visible. It needs specificity.
+	background-color: transparent;
+
+	// Apply a white stroke to the image, so that for transparent black logos, they become visible on the dark background.
+	filter:
+		drop-shadow($border-width 0 0 $white)
+		drop-shadow((-$border-width) 0 0 $white)
+		drop-shadow(0 ($border-width) 0 $white)
+		drop-shadow(0 (-$border-width) 0 $white);
 }
 
 .edit-site-editor__view-mode-toggle button:focus {

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -13,7 +13,8 @@
 }
 
 .edit-site-site-icon {
-	background: #333;
+	// Apply a background color here, so that the image itself can have a stroke.
+	background: $gray-900;
 }
 
 .edit-site-site-icon__image {
@@ -26,10 +27,7 @@
 		border-radius: 0;
 	}
 
-	// We make the background here transparent so the a stroke filter can be visible. It needs specificity.
-	background-color: transparent;
-
-	// Apply a white stroke to the image, so that for transparent black logos, they become visible on the dark background.
+	// Apply a stroke to the image to make transparent PNGs visible on dark backgrounds.
 	filter:
 		drop-shadow($border-width 0 0 $white)
 		drop-shadow((-$border-width) 0 0 $white)


### PR DESCRIPTION
## What?

Fixes #49501.

Changes some values around, and adds a white stroke to the site icon. This white stroke will only ever be visible on transparnet PNG logos, which should also then make them visible against a dark background, in case they are black or dark gray.

![site icon stroke](https://github.com/user-attachments/assets/09b923c0-5556-4804-b7e8-d7e2c234283a)

Higher resolution screenshot:

<img width="266" height="193" alt="image" src="https://github.com/user-attachments/assets/72a3d302-c0f9-47fa-b2fd-91963ced202c" />

## Why?

A black logo on a dark background is hard to see.

## How?

The `filter` CSS works with PNG transparency.

## Testing Instructions

Try setting this logo as your site icon:

<img width="140" height="140" alt="test" src="https://github.com/user-attachments/assets/04cc2b92-1930-4c1e-ab82-3c21d5bd35a3" />

The with this PR, the logo should still be visible in the post and site editors.
