### PR TITLE
 Link Control: Clear entity metadata when selecting custom URLs

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -292,9 +292,15 @@ function LinkControl( {
 			{}
 		);
 
+		// When selecting a custom URL (no id and no kind), explicitly clear
+		// entity metadata (type/kind) to avoid preserving them from previous links
+		const isCustomLink = ! updatedValue?.id && ! updatedValue?.kind;
+
 		onChange( {
 			...internalControlValue,
 			...nonSettingsChanges,
+			// Explicitly set type and kind to undefined for custom links
+			...( isCustomLink && { type: undefined, kind: undefined } ),
 			// As title is not a setting, it must be manually applied
 			// in such a way as to preserve the users changes over
 			// any "title" value provided by the "suggestion".

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -35,7 +35,7 @@ import LinkSettings from './settings';
 import useCreatePage from './use-create-page';
 import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
-import { DEFAULT_LINK_SETTINGS, LINK_ENTRY_TYPES } from './constants';
+import { DEFAULT_LINK_SETTINGS } from './constants';
 
 /**
  * Default properties associated with a link control value.
@@ -207,16 +207,8 @@ function LinkControl( {
 		createSetInternalSettingValueHandler,
 	] = useInternalValue( value );
 
-	// Helper to check if a link value has a custom URL type (not an entity type)
-	const isCustomURLType = ( linkValue ) =>
-		LINK_ENTRY_TYPES.includes( linkValue?.type );
-
 	// Compute isEntity internally based on handleEntities prop and presence of ID
-	// Exclude custom URLs which have id but type is 'link', 'mailto', 'tel', or 'internal'
-	const isEntity =
-		handleEntities &&
-		!! internalControlValue?.id &&
-		! isCustomURLType( internalControlValue );
+	const isEntity = handleEntities && !! internalControlValue?.id;
 
 	// Generate help text ID for accessibility association
 	const baseId = useInstanceId( LinkControl, 'link-control' );
@@ -300,19 +292,9 @@ function LinkControl( {
 			{}
 		);
 
-		// When selecting a custom URL (not an entity), explicitly clear
-		// entity metadata (type/kind) to avoid preserving them from previous links.
-		const isCustomLink = isCustomURLType( updatedValue );
-
 		onChange( {
 			...internalControlValue,
 			...nonSettingsChanges,
-			// Explicitly set type and kind to undefined for custom links
-			...( isCustomLink && {
-				id: undefined,
-				type: undefined,
-				kind: undefined,
-			} ),
 			// As title is not a setting, it must be manually applied
 			// in such a way as to preserve the users changes over
 			// any "title" value provided by the "suggestion".

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -308,7 +308,11 @@ function LinkControl( {
 			...internalControlValue,
 			...nonSettingsChanges,
 			// Explicitly set type and kind to undefined for custom links
-			...( isCustomLink && { type: undefined, kind: undefined } ),
+			...( isCustomLink && {
+				id: undefined,
+				type: undefined,
+				kind: undefined,
+			} ),
 			// As title is not a setting, it must be manually applied
 			// in such a way as to preserve the users changes over
 			// any "title" value provided by the "suggestion".

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -23,6 +23,7 @@ import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn, linkOff } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -34,8 +35,7 @@ import LinkSettings from './settings';
 import useCreatePage from './use-create-page';
 import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
-import { DEFAULT_LINK_SETTINGS } from './constants';
-import deprecated from '@wordpress/deprecated';
+import { DEFAULT_LINK_SETTINGS, LINK_ENTRY_TYPES } from './constants';
 
 /**
  * Default properties associated with a link control value.
@@ -207,8 +207,16 @@ function LinkControl( {
 		createSetInternalSettingValueHandler,
 	] = useInternalValue( value );
 
+	// Helper to check if a link value has a custom URL type (not an entity type)
+	const isCustomURLType = ( linkValue ) =>
+		LINK_ENTRY_TYPES.includes( linkValue?.type );
+
 	// Compute isEntity internally based on handleEntities prop and presence of ID
-	const isEntity = handleEntities && !! internalControlValue?.id;
+	// Exclude custom URLs which have id but type is 'link', 'mailto', 'tel', or 'internal'
+	const isEntity =
+		handleEntities &&
+		!! internalControlValue?.id &&
+		! isCustomURLType( internalControlValue );
 
 	// Generate help text ID for accessibility association
 	const baseId = useInstanceId( LinkControl, 'link-control' );
@@ -292,9 +300,9 @@ function LinkControl( {
 			{}
 		);
 
-		// When selecting a custom URL (no id and no kind), explicitly clear
-		// entity metadata (type/kind) to avoid preserving them from previous links
-		const isCustomLink = ! updatedValue?.id && ! updatedValue?.kind;
+		// When selecting a custom URL (not an entity), explicitly clear
+		// entity metadata (type/kind) to avoid preserving them from previous links.
+		const isCustomLink = isCustomURLType( updatedValue );
 
 		onChange( {
 			...internalControlValue,

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -3,6 +3,7 @@
  */
 import { forwardRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
-import deprecated from '@wordpress/deprecated';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings
@@ -106,7 +106,8 @@ const LinkControlSearchInput = forwardRef(
 				allowDirectEntry ||
 				( suggestion && Object.keys( suggestion ).length >= 1 )
 			) {
-				const { id, url, ...restLinkProps } = currentLink ?? {};
+				const { id, url, kind, type, ...restLinkProps } =
+					currentLink ?? {};
 				onSelect(
 					// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
 					{ ...restLinkProps, ...suggestion },

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -106,6 +106,11 @@ const LinkControlSearchInput = forwardRef(
 				allowDirectEntry ||
 				( suggestion && Object.keys( suggestion ).length >= 1 )
 			) {
+				// Strip out id, url, kind, and type from the current link to prevent
+				// entity metadata from persisting when switching to a different link type.
+				// For example, when changing from an entity link (kind: 'post-type', type: 'page')
+				// to a custom URL (type: 'link', no kind), we need to ensure the old 'kind'
+				// doesn't carry over. We do want to preserve other properites like title, though.
 				const { id, url, kind, type, ...restLinkProps } =
 					currentLink ?? {};
 				onSelect(

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1648,7 +1648,7 @@ describe( 'Selecting links', () => {
 					id: '1',
 					title: 'https://www.wordpress.org',
 					url: 'https://www.wordpress.org',
-					type: 'URL',
+					type: 'link',
 				},
 			], // Url.
 		] )(
@@ -1710,7 +1710,7 @@ describe( 'Selecting links', () => {
 					id: '1',
 					title: 'https://www.wordpress.org',
 					url: 'https://www.wordpress.org',
-					type: 'URL',
+					type: 'link',
 				},
 			], // Url.
 		] )(
@@ -2162,7 +2162,7 @@ describe( 'Rich link previews', () => {
 		id: '1',
 		title: 'WordPress.org', // Customize this for differentiation in assertions.
 		url: 'https://www.wordpress.org',
-		type: 'URL',
+		type: 'link',
 	};
 
 	beforeAll( () => {
@@ -2861,7 +2861,7 @@ describe( 'Entity handling', () => {
 					id: uniqueId(),
 					title: searchTerm,
 					url: searchTerm,
-					type: 'URL', // URL suggestions use uppercase 'URL'
+					type: 'link', // URL suggestions have type 'link'
 					// Importantly: no 'kind' property (entities have kind)
 				},
 			];
@@ -2907,22 +2907,17 @@ describe( 'Entity handling', () => {
 		} );
 		await user.click( urlSuggestion );
 
-		// Verify that onChange was called with type and kind explicitly set to undefined
+		// Verify that onChange was called with id, type and kind explicitly set to undefined
 		// This is the critical fix - when selecting a custom URL suggestion after unlinking,
 		// entity metadata (type/kind) should be cleared (not just when using the Apply button)
-		// Note: id remains as the URL for custom links (this is historical behavior)
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				url: 'https://custom-url.com',
 				type: undefined,
 				kind: undefined,
+				id: undefined,
 			} )
 		);
-
-		// Verify id is set to the URL (custom links use URL as id)
-		const lastCall =
-			onChange.mock.calls[ onChange.mock.calls.length - 1 ][ 0 ];
-		expect( lastCall.id ).toBe( 'https://custom-url.com' );
 	} );
 
 	it( 'should clear entity metadata when pressing Enter for direct entry (without clicking suggestion)', async () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -731,6 +731,33 @@ describe( 'Manual link entry', () => {
 		}
 	);
 
+	it( 'should return undefined kind and type when submitting a custom URL', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render( <LinkControl onChange={ onChange } /> );
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		// Type a custom URL
+		await user.type( searchInput, 'https://custom.com' );
+
+		// Wait for and click the URL suggestion
+		const urlSuggestion = await screen.findByRole( 'option' );
+		await user.click( urlSuggestion );
+
+		// Verify onChange was called with undefined kind and type (not page/post-type)
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://custom.com',
+				type: undefined,
+				kind: undefined,
+			} )
+		);
+	} );
+
 	describe( 'Handling of empty values', () => {
 		const testTable = [
 			[ 'containing only spaces', '        ' ],
@@ -2896,6 +2923,62 @@ describe( 'Entity handling', () => {
 		const lastCall =
 			onChange.mock.calls[ onChange.mock.calls.length - 1 ][ 0 ];
 		expect( lastCall.id ).toBe( 'https://custom-url.com' );
+	} );
+
+	it( 'should clear entity metadata when pressing Enter for direct entry (without clicking suggestion)', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		const pageLink = {
+			id: 123,
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+			kind: 'post-type',
+		};
+
+		render(
+			<LinkControl
+				value={ pageLink }
+				handleEntities
+				forceIsEditingLink
+				onChange={ onChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		// Initially should be disabled because it's an entity
+		expect( searchInput ).toBeDisabled();
+
+		// Click the unsync button to enable editing
+		const unlinkButton = screen.getByRole( 'button', {
+			name: 'Unsync and edit',
+		} );
+		await user.click( unlinkButton );
+
+		// Input should now be enabled and value should be cleared
+		expect( searchInput ).toBeEnabled();
+		expect( searchInput ).toHaveValue( '' );
+
+		// Type a custom URL
+		await user.type( searchInput, 'https://direct-entry.com' );
+
+		// Press Enter WITHOUT clicking the suggestion (direct entry path)
+		triggerEnter( searchInput );
+
+		// Verify that onChange was called with type and kind explicitly set to undefined
+		// This tests the direct entry path in onSubmit (lines 157-165 in search-input.js)
+		// where the user types a URL and presses Enter without selecting from suggestions
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://direct-entry.com',
+				type: undefined,
+				kind: undefined,
+			} )
+		);
 	} );
 
 	describe( 'Accessibility association for entity links', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -731,33 +731,6 @@ describe( 'Manual link entry', () => {
 		}
 	);
 
-	it( 'should return undefined kind and type when submitting a custom URL', async () => {
-		const user = userEvent.setup();
-		const onChange = jest.fn();
-
-		render( <LinkControl onChange={ onChange } /> );
-
-		const searchInput = screen.getByRole( 'combobox', {
-			name: 'Search or type URL',
-		} );
-
-		// Type a custom URL
-		await user.type( searchInput, 'https://custom.com' );
-
-		// Wait for and click the URL suggestion
-		const urlSuggestion = await screen.findByRole( 'option' );
-		await user.click( urlSuggestion );
-
-		// Verify onChange was called with undefined kind and type (not page/post-type)
-		expect( onChange ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				url: 'https://custom.com',
-				type: undefined,
-				kind: undefined,
-			} )
-		);
-	} );
-
 	describe( 'Handling of empty values', () => {
 		const testTable = [
 			[ 'containing only spaces', '        ' ],
@@ -2827,14 +2800,17 @@ describe( 'Entity handling', () => {
 		} );
 		await user.click( applyButton );
 
-		// Verify that onChange was called with the entity link severed
-		// id, kind, and type should be undefined to indicate it's no longer an entity
+		// Verify that onChange was called with entity metadata cleared.
+		// Kind should be undefined (no longer an entity).
+		// Note: Currently when clicking Apply (vs selecting a suggestion),
+		// type and id are also undefined - that's a separate issue with the
+		// TODO: Apply button handler not processing URLs through handleDirectEntry,
+		// so the shape of the data for a custom link can be different depending on
+		// how it was submitted.
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				url: customUrl,
-				id: undefined,
+				url: 'www.wordpress.org',
 				kind: undefined,
-				type: undefined,
 			} )
 		);
 	} );
@@ -2913,9 +2889,8 @@ describe( 'Entity handling', () => {
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				url: 'https://custom-url.com',
-				type: undefined,
+				type: 'link',
 				kind: undefined,
-				id: undefined,
 			} )
 		);
 	} );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2812,6 +2812,92 @@ describe( 'Entity handling', () => {
 		);
 	} );
 
+	it( 'should clear entity metadata (type/kind) when changing from page link to custom link via suggestion', async () => {
+		const user = userEvent.setup();
+
+		// Start with an entity link that has type and kind
+		const pageLink = {
+			id: 123,
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+			kind: 'post-type',
+		};
+
+		const onChange = jest.fn();
+
+		// Mock search suggestions to return a custom URL
+		// URL suggestions have an id and type but no 'kind' (which indicates entity metadata)
+		mockFetchSearchSuggestions.mockImplementation( ( searchTerm ) => {
+			const suggestions = [
+				{
+					id: uniqueId(),
+					title: searchTerm,
+					url: searchTerm,
+					type: 'URL', // URL suggestions use uppercase 'URL'
+					// Importantly: no 'kind' property (entities have kind)
+				},
+			];
+			return Promise.resolve( suggestions );
+		} );
+
+		render(
+			<LinkControl
+				value={ pageLink }
+				handleEntities
+				forceIsEditingLink
+				onChange={ onChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		// Initially should be disabled because it's an entity
+		expect( searchInput ).toBeDisabled();
+
+		// Click the unsync button to enable editing
+		const unlinkButton = screen.getByRole( 'button', {
+			name: 'Unsync and edit',
+		} );
+		await user.click( unlinkButton );
+
+		// Input should now be enabled and value should be cleared
+		expect( searchInput ).toBeEnabled();
+		expect( searchInput ).toHaveValue( '' );
+
+		// Type a custom URL
+		await user.type( searchInput, 'https://custom-url.com' );
+
+		// Wait for suggestions to appear
+		const suggestionsList = await screen.findByRole( 'listbox' );
+		expect( suggestionsList ).toBeVisible();
+
+		// Select the custom URL suggestion (not clicking Apply button)
+		const urlSuggestion = screen.getByRole( 'option', {
+			name: /https:\/\/custom-url\.com/,
+		} );
+		await user.click( urlSuggestion );
+
+		// Verify that onChange was called with type and kind explicitly set to undefined
+		// This is the critical fix - when selecting a custom URL suggestion after unlinking,
+		// entity metadata (type/kind) should be cleared (not just when using the Apply button)
+		// Note: id remains as the URL for custom links (this is historical behavior)
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://custom-url.com',
+				type: undefined,
+				kind: undefined,
+			} )
+		);
+
+		// Verify id is set to the URL (custom links use URL as id)
+		const lastCall =
+			onChange.mock.calls[ onChange.mock.calls.length - 1 ][ 0 ];
+		expect( lastCall.id ).toBe( 'https://custom-url.com' );
+	} );
+
 	describe( 'Accessibility association for entity links', () => {
 		it( 'should associate unlink button with help text via aria-describedby', () => {
 			const entityLink = {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -39,9 +39,9 @@ import { getColors } from '../navigation/edit/utils';
 import {
 	Controls,
 	LinkUI,
-	updateAttributes,
 	useEntityBinding,
 	MissingEntityHelpText,
+	useHandleLinkChange,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -279,14 +279,15 @@ export default function NavigationLinkEdit( {
 	const { getBlocks } = useSelect( blockEditorStore );
 
 	// URL binding logic
-	const {
-		clearBinding,
-		createBinding,
-		hasUrlBinding,
-		isBoundEntityAvailable,
-	} = useEntityBinding( {
+	const { hasUrlBinding, isBoundEntityAvailable } = useEntityBinding( {
 		clientId,
 		attributes,
+	} );
+
+	const handleLinkChange = useHandleLinkChange( {
+		clientId,
+		attributes,
+		setAttributes,
 	} );
 
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
@@ -642,25 +643,7 @@ export default function NavigationLinkEdit( {
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }
-							onChange={ ( updatedValue ) => {
-								const {
-									isEntityLink,
-									attributes: updatedAttributes,
-								} = updateAttributes(
-									updatedValue,
-									setAttributes,
-									attributes
-								);
-
-								// Handle URL binding based on the final computed state
-								// Only create bindings for entity links (posts, pages, taxonomies)
-								// Never create bindings for custom links (manual URLs)
-								if ( isEntityLink ) {
-									createBinding( updatedAttributes );
-								} else {
-									clearBinding();
-								}
-							} }
+							onChange={ handleLinkChange }
 						/>
 					) }
 				</a>

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -12,3 +12,4 @@ export {
 	buildNavigationLinkEntityBinding,
 } from './use-entity-binding';
 export { LinkUI } from '../link-ui';
+export { useHandleLinkChange } from './use-handle-link-change';

--- a/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
@@ -1,0 +1,804 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+// Mock the entire @wordpress/block-editor module
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: {},
+} ) );
+
+// Mock the entire @wordpress/core-data module
+jest.mock( '@wordpress/core-data', () => ( {
+	store: {},
+} ) );
+
+// Mock useDispatch specifically to avoid needing to set up full data store
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	createSelector: jest.fn( ( fn ) => fn ),
+	createRegistrySelector: jest.fn( ( fn ) => fn ),
+	createReduxStore: jest.fn( () => ( {} ) ),
+	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+		const newState = {};
+		Object.keys( reducers ).forEach( ( key ) => {
+			newState[ key ] = reducers[ key ]( state[ key ], action );
+		} );
+		return newState;
+	} ),
+	register: jest.fn(),
+} ) );
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useHandleLinkChange } from '../use-handle-link-change';
+import { updateAttributes } from '../update-attributes';
+import { useEntityBinding } from '../use-entity-binding';
+
+// Mock internal dependencies
+jest.mock( '../update-attributes' );
+jest.mock( '../use-entity-binding' );
+
+describe( 'useHandleLinkChange', () => {
+	let mockSetAttributes;
+	let mockUpdateBlockAttributes;
+	let mockCreateBinding;
+	let mockClearBinding;
+
+	const clientId = 'test-client-id';
+
+	beforeEach( () => {
+		// Reset mocks
+		mockSetAttributes = jest.fn();
+		mockUpdateBlockAttributes = jest.fn();
+		mockCreateBinding = jest.fn();
+		mockClearBinding = jest.fn();
+
+		// Mock useDispatch
+		useDispatch.mockReturnValue( {
+			updateBlockAttributes: mockUpdateBlockAttributes,
+		} );
+
+		// Mock useEntityBinding
+		useEntityBinding.mockReturnValue( {
+			hasUrlBinding: false,
+			createBinding: mockCreateBinding,
+			clearBinding: mockClearBinding,
+		} );
+
+		// Mock updateAttributes to return default values
+		updateAttributes.mockImplementation( ( attrs ) => ( {
+			isEntityLink: !! ( attrs.id && attrs.kind !== 'custom' ),
+			attributes: attrs,
+		} ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'creating new entity links', () => {
+		it( 'should create binding for new page link', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Test Page',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://example.com/page',
+					kind: 'post-type',
+					type: 'page',
+					id: 123,
+					title: 'Test Page',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 123,
+					kind: 'post-type',
+					type: 'page',
+				} )
+			);
+		} );
+
+		it( 'should create binding for new post link', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 456,
+				url: 'https://example.com/post',
+				title: 'Test Post',
+				kind: 'post-type',
+				type: 'post',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://example.com/post',
+					kind: 'post-type',
+					type: 'post',
+					id: 456,
+					title: 'Test Post',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 456,
+					kind: 'post-type',
+					type: 'post',
+				} )
+			);
+		} );
+
+		it( 'should create binding for new taxonomy link', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 789,
+				url: 'https://example.com/category/news',
+				title: 'News',
+				kind: 'taxonomy',
+				type: 'category',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://example.com/category/news',
+					kind: 'taxonomy',
+					type: 'category',
+					id: 789,
+					title: 'News',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 789,
+					kind: 'taxonomy',
+					type: 'category',
+				} )
+			);
+		} );
+	} );
+
+	describe( 'creating new custom links', () => {
+		it( 'should create new custom URL link with correct attributes', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: attrs,
+			} ) );
+
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				url: 'https://custom-url.com',
+				title: 'Custom Link',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://custom-url.com',
+					title: 'Custom Link',
+					kind: undefined,
+					type: undefined,
+					id: undefined,
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should create mailto link with correct attributes', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: { ...attrs, kind: 'custom' },
+			} ) );
+
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 'mailto:test@example.com',
+				url: 'mailto:test@example.com',
+				title: 'mailto:test@example.com',
+				type: 'mailto',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 'mailto:test@example.com',
+					url: 'mailto:test@example.com',
+					title: 'mailto:test@example.com',
+					type: 'mailto',
+					kind: undefined,
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should create tel link with correct attributes', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: { ...attrs, kind: 'custom' },
+			} ) );
+
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 'tel:5555555',
+				url: 'tel:5555555',
+				title: 'tel:5555555',
+				type: 'tel',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 'tel:5555555',
+					url: 'tel:5555555',
+					title: 'tel:5555555',
+					type: 'tel',
+					kind: undefined,
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'transitioning from entity to custom link', () => {
+		it( 'should use direct store dispatch when converting bound entity to custom link', () => {
+			// Mock that we have a URL binding
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				createBinding: mockCreateBinding,
+				clearBinding: mockClearBinding,
+			} );
+
+			const attributes = {
+				id: 123,
+				url: 'https://example.com/page',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			// Convert to custom link (no id)
+			const updatedLink = {
+				url: 'https://custom-url.com',
+				title: 'Custom URL',
+			};
+
+			result.current( updatedLink );
+
+			// Should clear binding first
+			expect( mockClearBinding ).toHaveBeenCalled();
+
+			// Should use direct store dispatch instead of setAttributes
+			expect( mockUpdateBlockAttributes ).toHaveBeenCalledWith(
+				clientId,
+				{
+					url: 'https://custom-url.com',
+					kind: 'custom',
+					type: 'custom',
+					id: undefined,
+				}
+			);
+
+			// Should NOT call updateAttributes in this path
+			expect( updateAttributes ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should handle transition from bound page link to custom URL', () => {
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				createBinding: mockCreateBinding,
+				clearBinding: mockClearBinding,
+			} );
+
+			const attributes = {
+				id: 456,
+				url: 'https://example.com/my-page',
+				label: 'My Page',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				url: 'https://external-site.com',
+			};
+
+			result.current( updatedLink );
+
+			expect( mockClearBinding ).toHaveBeenCalled();
+			expect( mockUpdateBlockAttributes ).toHaveBeenCalledWith(
+				clientId,
+				expect.objectContaining( {
+					url: 'https://external-site.com',
+					kind: 'custom',
+					type: 'custom',
+					id: undefined,
+				} )
+			);
+		} );
+	} );
+
+	describe( 'updating existing links', () => {
+		it( 'should update entity link to another entity link', () => {
+			const attributes = {
+				id: 123,
+				url: 'https://example.com/page-1',
+				label: 'Page 1',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 456,
+				url: 'https://example.com/page-2',
+				title: 'Page 2',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 456,
+					url: 'https://example.com/page-2',
+					kind: 'post-type',
+					type: 'page',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).toHaveBeenCalled();
+		} );
+
+		it( 'should preserve label when updating existing link with label', () => {
+			const attributes = {
+				id: 123,
+				url: 'https://example.com/page',
+				label: 'Custom Label',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 456,
+				url: 'https://example.com/new-page',
+				title: 'New Page Title',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			// Should not include title in attrs when label exists
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.not.objectContaining( {
+					title: 'New Page Title',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+		} );
+
+		it( 'should include title when creating link without existing label', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Page Title',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: 'Page Title',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+		} );
+
+		it( 'should include title when link has no URL (new link)', () => {
+			const attributes = {
+				label: '',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Page Title',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: 'Page Title',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+		} );
+
+		it( 'should update custom link to another custom link', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: { ...attrs, kind: 'custom' },
+			} ) );
+
+			const attributes = {
+				url: 'https://old-custom-url.com',
+				label: 'Old Custom Link',
+				kind: 'custom',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				url: 'https://new-custom-url.com',
+				title: 'New Custom Link',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://new-custom-url.com',
+					kind: undefined,
+					type: undefined,
+					id: undefined,
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should update custom link to entity link', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: true,
+				attributes: attrs,
+			} ) );
+
+			const attributes = {
+				url: 'https://custom-url.com',
+				label: 'Custom Link',
+				kind: 'custom',
+			};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Page Title',
+				kind: 'post-type',
+				type: 'page',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 123,
+					url: 'https://example.com/page',
+					kind: 'post-type',
+					type: 'page',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'should return early if updatedLink is null', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			result.current( null );
+
+			expect( updateAttributes ).not.toHaveBeenCalled();
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+			expect( mockClearBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should return early if updatedLink is undefined', () => {
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			result.current( undefined );
+
+			expect( updateAttributes ).not.toHaveBeenCalled();
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+			expect( mockClearBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should handle link with only URL (no other properties)', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: { ...attrs, kind: 'custom' },
+			} ) );
+
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				url: 'https://example.com',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: 'https://example.com',
+					kind: undefined,
+					type: undefined,
+					id: undefined,
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not create binding for custom link even with id', () => {
+			updateAttributes.mockImplementation( ( attrs ) => ( {
+				isEntityLink: false,
+				attributes: attrs,
+			} ) );
+
+			const attributes = {};
+
+			const { result } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const updatedLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Page',
+				kind: 'custom',
+				type: 'custom',
+			};
+
+			result.current( updatedLink );
+
+			expect( updateAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 123,
+					url: 'https://example.com/page',
+					kind: 'custom',
+					type: 'custom',
+				} ),
+				mockSetAttributes,
+				attributes
+			);
+			expect( mockCreateBinding ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'callback memoization', () => {
+		it( 'should return same callback reference when dependencies do not change', () => {
+			const attributes = { url: 'https://example.com' };
+
+			const { result, rerender } = renderHook( () =>
+				useHandleLinkChange( {
+					clientId,
+					attributes,
+					setAttributes: mockSetAttributes,
+				} )
+			);
+
+			const firstCallback = result.current;
+
+			rerender();
+
+			const secondCallback = result.current;
+
+			expect( firstCallback ).toBe( secondCallback );
+		} );
+
+		it( 'should return new callback reference when attributes change', () => {
+			let attributes = { url: 'https://example.com' };
+
+			const { result, rerender } = renderHook(
+				( { attrs } ) =>
+					useHandleLinkChange( {
+						clientId,
+						attributes: attrs,
+						setAttributes: mockSetAttributes,
+					} ),
+				{ initialProps: { attrs: attributes } }
+			);
+
+			const firstCallback = result.current;
+
+			attributes = { url: 'https://different.com' };
+			rerender( { attrs: attributes } );
+
+			const secondCallback = result.current;
+
+			expect( firstCallback ).not.toBe( secondCallback );
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
+++ b/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { updateAttributes } from './update-attributes';
+import { useEntityBinding } from './use-entity-binding';
+
+/**
+ * Custom hook that returns a callback for handling link selection/change.
+ * Manages the transition between entity links and custom links,
+ * including proper binding creation and cleanup.
+ *
+ * @param {Object}   options               - Configuration options
+ * @param {string}   options.clientId      - Block client ID
+ * @param {Object}   options.attributes    - Current block attributes
+ * @param {Function} options.setAttributes - Standard setAttribute function
+ * @return {Function} Callback function to handle link changes
+ */
+export function useHandleLinkChange( { clientId, attributes, setAttributes } ) {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { hasUrlBinding, createBinding, clearBinding } = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
+
+	return useCallback(
+		( updatedLink ) => {
+			if ( ! updatedLink ) {
+				return;
+			}
+
+			const attrs = {
+				url: updatedLink.url,
+				kind: updatedLink.kind,
+				type: updatedLink.type,
+				id: updatedLink.id,
+			};
+
+			// Only include title when creating a new link (not updating existing)
+			// This preserves user-customized labels when updating links
+			if ( ! attributes.url || ! attributes.label ) {
+				attrs.title = updatedLink.title;
+			}
+
+			// Check if transitioning from entity to custom link
+			const willBeCustomLink = ! updatedLink.id && hasUrlBinding;
+
+			if ( willBeCustomLink ) {
+				// Clear the binding first
+				clearBinding();
+
+				// Use direct store dispatch to bypass setBoundAttributes wrapper
+				// which prevents updates to bound attributes.
+				updateBlockAttributes( clientId, {
+					url: updatedLink.url,
+					kind: 'custom',
+					type: 'custom',
+					id: undefined,
+				} );
+			} else {
+				// Normal flow for entity links or unbound custom links
+				const { isEntityLink, attributes: updatedAttributes } =
+					updateAttributes( attrs, setAttributes, attributes );
+
+				// Handle URL binding based on the final computed state
+				// Only create bindings for entity links (posts, pages, taxonomies)
+				// Never create bindings for custom links (manual URLs)
+				if ( isEntityLink ) {
+					createBinding( updatedAttributes );
+				} else {
+					clearBinding();
+				}
+			}
+		},
+		[
+			attributes,
+			clientId,
+			hasUrlBinding,
+			createBinding,
+			clearBinding,
+			setAttributes,
+			updateBlockAttributes,
+		]
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Splitting out work from https://github.com/WordPress/gutenberg/pull/73731/

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/73767, but I think there may be a further underlying issue there.

Fixes entity metadata (type/kind) persisting when changing from page links to custom URLs. 




<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Changing to from an entity-bound link to a custom link would persist the kind/type from the previously bound link, which causes odd behavior due to unexpectedly combined values.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
  - Refactor onChange from LinkControl into a hook with defensive checks for updating from an entity to custom link
  - LinkControl: Use LINK_ENTRY_TYPES to detect custom URL selections
  - LinkControl: Improve isEntity check to exclude custom URLs by type field
  - Add unit tests
  - Add e2e test

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to a navigation link item with a bound entity link
2. Edit the link via the link control by clicking the unsync button then typing a new url like "https://test.com"
3. Click Apply
4. The link should be updated to a custom link with value https://test.com

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
