### PR TITLE
Inserter: Allow parent/ancestor filtering by block variation name

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	getActiveBlockVariation,
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
@@ -1650,10 +1651,26 @@ const isBlockVisibleInTheInserter = (
 		let current = rootClientId;
 		let hasParent = false;
 		do {
-			if ( parents.includes( getBlockName( state, current ) ) ) {
+			const ancestorBlockName = getBlockName( state, current );
+			if ( parents.includes( ancestorBlockName ) ) {
 				hasParent = true;
 				break;
 			}
+			const ancestorAttributes = getBlockAttributes( state, current );
+
+			const variation = getActiveBlockVariation(
+				ancestorBlockName,
+				ancestorAttributes,
+				'inserter'
+			);
+
+			if ( variation ) {
+				// TODO: Compare block variation name to parent/ancestor list.
+				// Problem: For template parts that have been persisted to the DB,
+				// variation.name is prefixed with `instance_` (e.g. `instance_header`).
+				console.log( variation );
+			}
+
 			current = state.blocks.parents.get( current );
 		} while ( current );
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -131,6 +131,7 @@ export {
 	getBlockSupport,
 	hasBlockSupport,
 	getBlockVariations,
+	getActiveBlockVariation,
 	isReusableBlock,
 	isTemplatePart,
 	getChildBlockNames,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -708,6 +708,26 @@ export const getBlockVariations = ( blockName, scope ) => {
 };
 
 /**
+ * Returns the active block variation for a given block based on its attributes.
+ * Ignored from documentation as the recommended usage is via useSelect from @wordpress/data.
+ *
+ * @ignore
+ *
+ * @param {string}                blockName  Name of block (example: “core/columns”).
+ * @param {Object}                attributes Block attributes used to determine active variation.
+ * @param {WPBlockVariationScope} [scope]    Block variation scope name.
+ *
+ * @return {(WPBlockVariation|undefined)} Active block variation.
+ */
+export const getActiveBlockVariation = ( blockName, attributes, scope ) => {
+	return select( blocksStore ).getActiveBlockVariation(
+		blockName,
+		attributes,
+		scope
+	);
+};
+
+/**
  * Registers a new block variation for the given block type.
  *
  * For more information on block variations see


### PR DESCRIPTION
## What?
WIP. Details to follow.
See https://github.com/WordPress/gutenberg/pull/73724#discussion_r2599624959 for context.

## Why?
TBD

## How?
TBD

## Testing Instructions
TBD

## Screenshots or screencast

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## TODO

- [ ] Figure out problem with `instance_` and `area_` prefix in Template Part block variations, see https://github.com/WordPress/gutenberg/pull/73828/files#r2602658280.
- [ ] Instead of exposing `getActiveBlockVariation()` as part of the public API of `@wordpress/blocks`, consider extracting the non-state-dependent part of the function into a util that can be used by the `@wordpress/block-editor` package.
