### PR TITLE
Fields: Fix suffix button in Slug field

### DIFF
--- a/packages/fields/src/fields/slug/slug-edit.tsx
+++ b/packages/fields/src/fields/slug/slug-edit.tsx
@@ -6,6 +6,7 @@ import {
 	ExternalLink,
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { copySmall } from '@wordpress/icons';
@@ -93,12 +94,14 @@ const SlugEdit = ( {
 							</InputControlPrefixWrapper>
 						}
 						suffix={
-							<Button
-								__next40pxDefaultSize
-								icon={ copySmall }
-								ref={ copyButtonRef }
-								label={ __( 'Copy' ) }
-							/>
+							<InputControlSuffixWrapper variant="control">
+								<Button
+									size="small"
+									icon={ copySmall }
+									ref={ copyButtonRef }
+									label={ __( 'Copy' ) }
+								/>
+							</InputControlSuffixWrapper>
 						}
 						label={ __( 'Link' ) }
 						hideLabelFromVision


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes the "Copy" button in the suffix of the Slug field to follow design system guidelines.

## Why?

Consistent details throughout the system.

## Testing Instructions

See Base Fields in Storybook.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="992" height="202" alt="Slug field with copy button in suffix, before" src="https://github.com/user-attachments/assets/5bb7773a-51a9-454e-88d4-ffa4864004aa" />|<img width="992" height="204" alt="Slug field with copy button in suffix, after" src="https://github.com/user-attachments/assets/f5f5b2a0-cdd0-4022-914c-3b4af5486a16" />|
