### PR TITLE
Global Styles UI: Revert some of the padding / markup changes from #73334

### DIFF
--- a/packages/edit-site/src/components/sidebar-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles/style.scss
@@ -15,6 +15,14 @@
 		overflow-y: auto;
 		padding-left: 0;
 		padding-right: 0;
+
+		.global-styles-ui-sidebar__navigator-screen {
+			padding-top: $grid-unit-15;
+			padding-left: $grid-unit-15;
+			padding-right: $grid-unit-15;
+			padding-bottom: $grid-unit-15;
+			outline: none;
+		}
 	}
 	.edit-site-sidebar-button {
 		color: $gray-900;

--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -9,10 +9,6 @@
 	&__panel {
 		flex: 1;
 	}
-
-	.components-navigator-screen {
-		padding: 0;
-	}
 }
 
 .editor-global-styles-sidebar .editor-global-styles-sidebar__header-title {

--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -10,8 +10,8 @@
 		flex: 1;
 	}
 
-	.global-styles-ui-sidebar__navigator-screen.components-navigator-screen {
-		padding: $grid-unit-15;
+	.components-navigator-screen {
+		padding: 0;
 	}
 }
 

--- a/packages/global-styles-ui/src/screen-body.tsx
+++ b/packages/global-styles-ui/src/screen-body.tsx
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalSpacer as Spacer } from '@wordpress/components';
+import clsx from 'clsx';
+
+interface ScreenBodyProps {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function ScreenBody( { children, className }: ScreenBodyProps ) {
+	return (
+		<Spacer
+			className={ clsx( 'global-styles-ui-screen-body', className ) }
+			padding={ 4 } // 4 units = 16px. Could be made configurable via prop in the future if needed.
+		>
+			{ children }
+		</Spacer>
+	);
+}

--- a/packages/global-styles-ui/src/screen-colors.tsx
+++ b/packages/global-styles-ui/src/screen-colors.tsx
@@ -14,6 +14,7 @@ import type {
  * Internal dependencies
  */
 import { ScreenHeader } from './screen-header';
+import { ScreenBody } from './screen-body';
 import Palette from './palette';
 import { useStyle, useSetting } from './hooks';
 import { unlock } from './lock-unlock';
@@ -49,17 +50,17 @@ function ScreenColors() {
 					'Palette colors and the application of those colors on site elements.'
 				) }
 			/>
-			<div className="global-styles-ui-screen">
+			<ScreenBody>
 				<VStack spacing={ 7 }>
 					<Palette />
-					<StylesColorPanel
-						inheritedValue={ inheritedStyle }
-						value={ style }
-						onChange={ setStyle }
-						settings={ settings }
-					/>
 				</VStack>
-			</div>
+			</ScreenBody>
+			<StylesColorPanel
+				inheritedValue={ inheritedStyle }
+				value={ style }
+				onChange={ setStyle }
+				settings={ settings }
+			/>
 		</>
 	);
 }

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalSpacer as Spacer,
 	__experimentalHeading as Heading,
 	__experimentalView as View,
+	__experimentalText as Text,
 	Navigator,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
@@ -27,30 +28,32 @@ export function ScreenHeader( {
 		<VStack spacing={ 0 }>
 			<View>
 				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
-					<HStack spacing={ 2 }>
-						<Navigator.BackButton
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							size="small"
-							label={ __( 'Back' ) }
-							onClick={ onBack }
-						/>
-						<Spacer>
-							<Heading
-								className="global-styles-ui-header"
-								level={ 2 }
-								size={ 13 }
-							>
-								{ title }
-							</Heading>
-						</Spacer>
-					</HStack>
+					<VStack spacing={ 2 }>
+						<HStack spacing={ 2 }>
+							<Navigator.BackButton
+								icon={ isRTL() ? chevronRight : chevronLeft }
+								size="small"
+								label={ __( 'Back' ) }
+								onClick={ onBack }
+							/>
+							<Spacer>
+								<Heading
+									className="global-styles-ui-header"
+									level={ 2 }
+									size={ 13 }
+								>
+									{ title }
+								</Heading>
+							</Spacer>
+						</HStack>
+						{ description && (
+							<Text className="global-styles-ui-header__description">
+								{ description }
+							</Text>
+						) }
+					</VStack>
 				</Spacer>
 			</View>
-			{ description && (
-				<p className="global-styles-ui-header__description">
-					{ description }
-				</p>
-			) }
 		</VStack>
 	);
 }

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -4,7 +4,9 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
 	__experimentalHeading as Heading,
+	__experimentalView as View,
 	Navigator,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
@@ -22,22 +24,28 @@ export function ScreenHeader( {
 	onBack,
 }: ScreenHeaderProps ) {
 	return (
-		<VStack spacing={ 0 } className="global-styles-ui-screen-header">
-			<HStack spacing={ 2 } justify="flex-start">
-				<Navigator.BackButton
-					icon={ isRTL() ? chevronRight : chevronLeft }
-					size="small"
-					label={ __( 'Back' ) }
-					onClick={ onBack }
-				/>
-				<Heading
-					className="global-styles-ui-header"
-					level={ 2 }
-					size={ 13 }
-				>
-					{ title }
-				</Heading>
-			</HStack>
+		<VStack spacing={ 0 }>
+			<View>
+				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
+					<HStack spacing={ 2 }>
+						<Navigator.BackButton
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							size="small"
+							label={ __( 'Back' ) }
+							onClick={ onBack }
+						/>
+						<Spacer>
+							<Heading
+								className="global-styles-ui-header"
+								level={ 2 }
+								size={ 13 }
+							>
+								{ title }
+							</Heading>
+						</Spacer>
+					</HStack>
+				</Spacer>
+			</View>
 			{ description && (
 				<p className="global-styles-ui-header__description">
 					{ description }

--- a/packages/global-styles-ui/src/screen-root.tsx
+++ b/packages/global-styles-ui/src/screen-root.tsx
@@ -34,7 +34,7 @@ function ScreenRoot() {
 
 	return (
 		<Card
-			size="none"
+			size="small"
 			isBorderless
 			className="global-styles-ui-screen-root"
 			isRounded={ false }

--- a/packages/global-styles-ui/src/screen-style-variations.tsx
+++ b/packages/global-styles-ui/src/screen-style-variations.tsx
@@ -21,7 +21,7 @@ function ScreenStyleVariations() {
 			/>
 
 			<Card
-				size="none"
+				size="small"
 				isBorderless
 				className="global-styles-ui-screen-style-variations"
 			>

--- a/packages/global-styles-ui/src/screen-typography.tsx
+++ b/packages/global-styles-ui/src/screen-typography.tsx
@@ -9,6 +9,7 @@ import { useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { ScreenHeader } from './screen-header';
+import { ScreenBody } from './screen-body';
 import TypographyElements from './typography-elements';
 import TypographyVariations from './variations/variations-typography';
 import FontFamilies from './font-families';
@@ -26,14 +27,14 @@ function ScreenTypography() {
 					'Available fonts, typographic styles, and the application of those styles.'
 				) }
 			/>
-			<div className="global-styles-ui-screen">
+			<ScreenBody>
 				<VStack spacing={ 7 }>
 					<TypographyVariations title={ __( 'Typesets' ) } />
 					{ fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />
 					<FontSizesCount />
 				</VStack>
-			</div>
+			</ScreenBody>
 		</>
 	);
 }

--- a/packages/global-styles-ui/src/shadows-edit-panel.tsx
+++ b/packages/global-styles-ui/src/shadows-edit-panel.tsx
@@ -41,6 +41,7 @@ import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
  */
 import { Subtitle } from './subtitle';
 import { ScreenHeader } from './screen-header';
+import { ScreenBody } from './screen-body';
 import { defaultShadow } from './shadows-panel';
 import {
 	getShadowParts,
@@ -199,13 +200,13 @@ export default function ShadowsEditPanel() {
 					</Spacer>
 				</FlexItem>
 			</HStack>
-			<div className="global-styles-ui-screen">
+			<ScreenBody>
 				<ShadowsPreview shadow={ selectedShadow.shadow } />
 				<ShadowEditor
 					shadow={ selectedShadow.shadow }
 					onChange={ onShadowChange }
 				/>
-			</div>
+			</ScreenBody>
 			{ isConfirmDialogVisible && (
 				<ConfirmDialog
 					isOpen

--- a/packages/global-styles-ui/src/shadows-panel.tsx
+++ b/packages/global-styles-ui/src/shadows-panel.tsx
@@ -25,6 +25,7 @@ import { useState } from '@wordpress/element';
 import { Subtitle } from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
 import { ScreenHeader } from './screen-header';
+import { ScreenBody } from './screen-body';
 import { getNewIndexFromPresets } from './utils';
 import ConfirmResetShadowDialog from './confirm-reset-shadow-dialog';
 import { useSetting } from './hooks';
@@ -73,7 +74,7 @@ export default function ShadowsPanel() {
 					'Manage and create shadow styles for use across the site.'
 				) }
 			/>
-			<div className="global-styles-ui-screen">
+			<ScreenBody>
 				<VStack
 					className="global-styles-ui__shadows-panel"
 					spacing={ 7 }
@@ -101,7 +102,7 @@ export default function ShadowsPanel() {
 						onReset={ toggleResetDialog }
 					/>
 				</VStack>
-			</div>
+			</ScreenBody>
 		</>
 	);
 }

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -44,10 +44,6 @@
 	color: #757575;
 }
 
-.global-styles-ui-screen {
-	margin: 12px 16px 16px;
-}
-
 .global-styles-ui-screen-typography__indicator {
 	height: 24px;
 	width: 24px;
@@ -60,7 +56,7 @@
 
 .global-styles-ui-block-types-search {
 	margin-bottom: 10px;
-	padding: 0 20px;
+	padding: 0 16px;
 }
 
 .global-styles-ui-screen-typography__font-variants-count {
@@ -77,10 +73,6 @@
 	padding-top: 0;
 	border-top: none;
 	row-gap: calc(4px * 3);
-}
-
-.global-styles-ui-header__description {
-	padding: 0 16px;
 }
 
 .global-styles-ui-header {

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -44,6 +44,10 @@
 	color: #757575;
 }
 
+.global-styles-ui-screen {
+	margin: 12px 16px 16px;
+}
+
 .global-styles-ui-screen-typography__indicator {
 	height: 24px;
 	width: 24px;
@@ -75,17 +79,13 @@
 	row-gap: calc(4px * 3);
 }
 
-.global-styles-ui-screen-header {
-	margin-bottom: variables.$grid-unit-15;
+.global-styles-ui-header__description {
+	padding: 0 16px;
 }
 
 .global-styles-ui-header {
 	// Need to override the too specific bottom margin for complementary areas.
 	margin-bottom: 0 !important;
-}
-
-.global-styles-ui-header__description {
-	margin: variables.$grid-unit-15 0 !important;
 }
 
 .global-styles-ui-subtitle {
@@ -248,12 +248,10 @@
 	height: 100%;
 }
 
-.global-styles-ui-sidebar__navigator-screen.components-navigator-screen {
+.global-styles-ui-sidebar__navigator-screen {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: variables.$grid-unit-30;
-	outline: none;
 }
 
 .global-styles-ui-sidebar__navigator-screen .single-column {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Closes #73843

Reverts some of the global styles UI changes introduced in #73334 — fix the unexpected additional padding. It looks like those changes meant that _some_ of the areas in the right-hand sidebar wind up with (effectively) `24px` padding. I think that's probably a bit beyond the scope of the intention behind #73334, so this PR proposes reverting those changes.

## Why?

These changes were unrelated to the specific task of updating DataViews and Modal to use `24px` padding, and caused some padding issues of their own for particular screens, e.g. Edit Palette, Font size presets, Blocks.

Kudos @t-hamano for flagging. And FYI @youknowriad.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Revert just those changes that appeared to affect these areas of the global styles sidebar. That is, restore the markup structure of the root, header, and style variations, and the kind of padding for `Card`, and revert many of the CSS changes.

Update: also consolidate the components a little and create a `ScreenBody` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Work through each of the panels in global styles and check that they're looking as they were prior to #73334
* Pay particular attention to the font size presets, blocks, and edit palette screens
* Test in the right hand sidebar, but also in the browse mode of the site editor (where Styles can appear in the left-hand area prior to going to edit a template)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="288" height="732" alt="image" src="https://github.com/user-attachments/assets/5be6fc66-eb52-4d8e-9378-372233cb68db" /> | <img width="289" height="733" alt="image" src="https://github.com/user-attachments/assets/c593ea8d-6d08-4ea5-943d-b754ee5e3893" /> |