### PR TITLE
Use relevance pattern matching for parent page search

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -91,9 +91,10 @@ export function PageAttributesParent() {
 				_fields: 'id,title,parent',
 			};
 
-			// Perform a search when the field is changed.
+			// Perform a search by exact keyword when the field is changed.
 			if ( !! fieldValue ) {
 				query.search = fieldValue;
+				query.exact = true;
 			}
 
 			const parentPost = pageId

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -91,10 +91,10 @@ export function PageAttributesParent() {
 				_fields: 'id,title,parent',
 			};
 
-			// Perform a search by exact keyword when the field is changed.
+			// Perform a search by relevance when the field is changed.
 			if ( !! fieldValue ) {
 				query.search = fieldValue;
-				query.exact = true;
+				query.orderby = 'relevance';
 			}
 
 			const parentPost = pageId

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -146,7 +146,9 @@ export function PageAttributesParent( {
 				order: 'asc',
 				_fields: 'id,title,parent',
 				...( fieldValue !== null && {
+					// Perform a search by exact keyword when the field is changed.
 					search: fieldValue,
+					exact: true,
 				} ),
 			};
 

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -146,9 +146,9 @@ export function PageAttributesParent( {
 				order: 'asc',
 				_fields: 'id,title,parent',
 				...( fieldValue !== null && {
-					// Perform a search by exact keyword when the field is changed.
+					// Perform a search by relevance when the field is changed.
 					search: fieldValue,
-					exact: true,
+					orderby: 'relevance',
 				} ),
 			};
 


### PR DESCRIPTION
## What

This PR updates the parent page search functionality to use relevance-based matching when users search for keywords. When a search term is entered, results are now ordered by relevance (how well they match the search term) rather than by menu order, providing more intuitive and useful search results.

## Why

Previously, the search used partial/fuzzy matching, which could return results that didn't match the user's intent. 

This was especially obvious for sites with large page counts. See: https://github.com/Automattic/wp-calypso/issues/49684

## How

- **packages/fields/src/fields/parent/parent-edit.tsx**: Added `orderby: 'relevance'` to the search query when `fieldValue` is not null
- **packages/editor/src/components/page-attributes/parent.js**: Added `orderby: 'relevance'` to the search query when `fieldValue` is truthy


Both implementations now use relevance-based ordering when a search term is provided, ensuring that the WordPress REST API returns results sorted by how well they match the search query, with the most relevant matches appearing first.


## Testing Instructions

### Prerequisites
- WordPress installation with wp-env running
- At least one hierarchical post type (e.g., Pages)

### Test Steps

1. **Create test pages:**
   - Create a page titled "Services"
   - Create a page titled "About Services"
   - Create a page titled "Our Services Page"
   - Create a page titled "Contact"

OR create a bunch using wp-cli:

```
alias wp='npx wp-env run cli wp' 
wp post create --post_type=page --post_title="Services" --post_status=publish
wp post create --post_type=page --post_title="About Services" --post_status=publish
wp post create --post_type=page --post_title="Our Services Page" --post_status=publish
wp post create --post_type=page --post_title="Contact" --post_status=publish
....
```

2. **Test relevance-based ordering in Post Editor:**
   - Open the Post Editor
   - Create or edit a page
   - Open the Page Attributes panel
   - Click on the Parent dropdown/combobox
   - Type "Services" in the search field
   - **Expected:** Pages containing "Services" should appear, ordered by relevance:
     - "Services" should appear first (exact match)
     - "About Services" and "Our Services Page" should appear next (close matches)
     - "Service Information" should appear if it matches (partial match)
   - Clear the search and type "About"
   - **Expected:** "About Services" should appear first (most relevant match)

3. **Test relevance-based ordering in Dataviews/Fields:**
   - Navigate to the Pages list view (if using the new fields interface)
   - Edit a page
   - In the Parent field, start typing a page name
   - **Expected:** Search results should be ordered by relevance, with the most relevant matches appearing first

4. **Test ordering behavior:**
   - When no search term is entered, verify results are still ordered by `menu_order` (default behavior)
   - When a search term is entered, verify results switch to `relevance` ordering
   - Verify that exact matches appear before partial matches
   - Verify that pages starting with the search term appear before pages containing the term elsewhere

5. **Verify no regression:**
   - Ensure that when no search term is entered, the full list of parent pages is still displayed correctly
   - Verify that the hierarchical tree structure is maintained when not searching
   - Confirm that the current parent page is always included in the options list
   - Verify that the `getItemPriority` function still works correctly for client-side sorting of results

<img width="652" height="554" alt="Screenshot 2025-12-09 at 5 10 26 pm" src="https://github.com/user-attachments/assets/ac226add-d4cc-43d7-8f26-817705bacb2e" />

