### PR TITLE
Commands: Fix layout for long label

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -155,6 +155,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	flex: 1;
 }
 
 .commands-command-menu__item mark {


### PR DESCRIPTION
## What?

Because the command palette menu items are configured with a flex layout, we need to make sure the labels stretch. Otherwise, long labels will squash the icons.

|Before|After|
|-|-|
| <img width="422" height="450" alt="image" src="https://github.com/user-attachments/assets/bb6c1500-278e-4ad4-b75c-9e405efbf834" /> | <img width="427" height="460" alt="image" src="https://github.com/user-attachments/assets/fe712700-c9a0-4f82-b2a0-082d03e8bb58" /> |

## Testing Instructions

Run the following code via your browser console:

```javascript
wp.data.dispatch( 'core/commands' ).registerCommand( {
	name: 'myplugin/test-command',
	label: 'My Test Command My Test Command My Test Command My Test Command My Test Command',
	icon: wp.element.createElement(
		'svg',
		{
			width: 24,
			height: 24,
			viewBox: '0 0 24 24',
			xmlns: 'http://www.w3.org/2000/svg',
		},
		wp.element.createElement(
			'path',
			{
				d: 'M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm.5 5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z',
			}
		)
	),
} );
```

- Launch the Command Palette
- Type the wrod "test"


