### PR TITLE
List Block: Fix the top empty list item deletion

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -150,8 +150,10 @@ export default function useMerge( clientId, onMerge ) {
 				isUnmodifiedBlock( getBlock( clientId ) ) &&
 				blockOrder.length > 0
 			) {
-				outdentListItem( getBlockOrder( blockOrder[ 0 ] ) );
-				removeBlock( clientId, true );
+				registry.batch( () => {
+					outdentListItem( getBlockOrder( blockOrder[ 0 ] ) );
+					removeBlock( clientId, true );
+				} );
 			} else {
 				onMerge( forward );
 			}

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -147,7 +147,7 @@ export default function useMerge( clientId, onMerge ) {
 
 			const blockOrder = getBlockOrder( clientId );
 			if (
-				isUnmodifiedBlock( getBlock( clientId ) ) &&
+				isUnmodifiedBlock( getBlock( clientId ), 'content' ) &&
 				blockOrder.length > 0
 			) {
 				registry.batch( () => {

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -3,6 +3,7 @@
  */
 import { useRegistry, useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { isUnmodifiedBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -17,8 +18,9 @@ export default function useMerge( clientId, onMerge ) {
 		getBlockOrder,
 		getBlockRootClientId,
 		getBlockName,
+		getBlock,
 	} = useSelect( blockEditorStore );
-	const { mergeBlocks, moveBlocksToPosition } =
+	const { mergeBlocks, moveBlocksToPosition, removeBlock } =
 		useDispatch( blockEditorStore );
 	const outdentListItem = useOutdentListItem();
 
@@ -132,12 +134,24 @@ export default function useMerge( clientId, onMerge ) {
 		} else {
 			// Merging is only done from the top level. For lowel levels, the
 			// list item is outdented instead.
-			const previousBlockClientId = getPreviousBlockClientId( clientId );
 			if ( getParentListItemId( clientId ) ) {
 				outdentListItem( clientId );
-			} else if ( previousBlockClientId ) {
+				return;
+			}
+			const previousBlockClientId = getPreviousBlockClientId( clientId );
+			if ( previousBlockClientId ) {
 				const trailingId = getTrailingId( previousBlockClientId );
 				mergeWithNested( trailingId, clientId );
+				return;
+			}
+
+			const blockOrder = getBlockOrder( clientId );
+			if (
+				isUnmodifiedBlock( getBlock( clientId ) ) &&
+				blockOrder.length > 0
+			) {
+				outdentListItem( getBlockOrder( blockOrder[ 0 ] ) );
+				removeBlock( clientId, true );
 			} else {
 				onMerge( forward );
 			}

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1611,4 +1611,48 @@ test.describe( 'List (@firefox)', () => {
 			},
 		] );
 	} );
+
+	test( 'should outdent list items when deleting an empty parent at the top', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: '' },
+					innerBlocks: [
+						{
+							name: 'core/list',
+							innerBlocks: [
+								{
+									name: 'core/list-item',
+									attributes: { content: 'a' },
+								},
+								{
+									name: 'core/list-item',
+									attributes: { content: 'b' },
+								},
+							],
+						},
+					],
+				},
+			],
+		} );
+
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{ name: 'core/list-item', attributes: { content: 'a' } },
+					{ name: 'core/list-item', attributes: { content: 'b' } },
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
## What
Closes #56223.
Alternative to #71482.

PR fixes the content loss issue when a user tries to delete an empty list item that has a child list and items.

## Why?
The `useMerge` hook tried to handle this via `onMerge > moveFirstItemUp`, but it currently can't handle complex nested items.

## How?
I tried to re-use the `outdentListItem` method, which is the difference between this PR and #71482. The remaining changes are just conversions to early returns.

## Testing Instructions
1. Open a post or page.
2. Paste the test content.
3. Deleting an empty top-level list item should outdent its children.

<details><summary>Test Blocks</summary>
<p>

```html
<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li><!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>Item</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Item</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Item<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>Testing</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Testing</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Testing</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List 2<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>Item</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Item</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Item</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/26996883/40eee630-fac8-492a-ab18-03a192484c73

**After**

https://github.com/user-attachments/assets/c82a6861-aed3-4509-aa41-a2e2a372bd43

