### PR TITLE
Post Title: Fix empty heading element when post_title is empty but get_the_title returns markup V2

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if ( ! $title || ! strip_tags( $title ) ) {
+	if ( ! strip_tags( $title ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if ( ! $title ) {
+	if ( ! $title || ! strip_tags( $title ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
Fixes #56465

This is a continuation of #70417, here you can find full context
Just for some context:

Fix empty heading element when `post_title` is empty but `get_the_title` returns markup by checking for text content after stripping HTML tags.

cc @ntsekouras