### PR TITLE
Fix Hstack prop in PostCardPanel

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -102,7 +102,7 @@ export default function PostCardPanel( {
 			<HStack
 				spacing={ 2 }
 				className="editor-post-card-panel__header"
-				align="flex-start"
+				alignment="flex-start"
 			>
 				<Icon className="editor-post-card-panel__icon" icon={ icon } />
 				<Text


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixing [prop name](https://wordpress.github.io/gutenberg/?path=/docs/components-hstack--docs) for the HStack. No big change, just fixing a prop name.

## Testing Instructions

1. Open a post or page.
2. Open the sidebar.
3. Confirm the PostCardPanel still looks good.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b2a56c61-16da-45f6-b451-c807ef74e5f1
