### PR TITLE
Routing: Add page title support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53761,6 +53761,7 @@
 			"version": "0.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/commands": "file:../commands",
 				"@wordpress/components": "file:../components",
@@ -56276,7 +56277,17 @@
 				"@wordpress/route": "file:../../packages/route"
 			}
 		},
-		"routes/home": {},
+		"routes/home": {
+			"dependencies": {
+				"@wordpress/i18n": "file:../i18n"
+			}
+		},
+		"routes/home/node_modules/@wordpress/i18n": {
+			"resolved": "routes/i18n",
+			"link": true
+		},
+		"routes/html-entities": {},
+		"routes/i18n": {},
 		"routes/navigation": {
 			"dependencies": {
 				"@wordpress/route": "file:../../packages/route"
@@ -56355,8 +56366,18 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/core-data": "file:../../packages/core-data",
-				"@wordpress/data": "file:../../packages/data"
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/html-entities": "file:../html-entities",
+				"@wordpress/i18n": "file:../i18n"
 			}
+		},
+		"routes/post-edit/node_modules/@wordpress/html-entities": {
+			"resolved": "routes/html-entities",
+			"link": true
+		},
+		"routes/post-edit/node_modules/@wordpress/i18n": {
+			"resolved": "routes/i18n",
+			"link": true
 		},
 		"routes/post-list": {
 			"name": "@wordpress/post-list",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -34,6 +34,7 @@
 	"wpScriptModuleExports": "./build-module/index.js",
 	"types": "build-types",
 	"dependencies": {
+		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/commands": "file:../commands",
 		"@wordpress/components": "file:../components",

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -13,6 +13,8 @@ import {
 	privateApis as routePrivateApis,
 	type AnyRoute,
 } from '@wordpress/route';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -78,12 +80,19 @@ async function createRouteFromDefinition(
 				search: opts.deps || {},
 			};
 
-			const [ loaderData, canvasData ] = await Promise.all( [
+			const [ , loaderData, canvasData, titleData ] = await Promise.all( [
+				resolveSelect( coreStore ).getEntityRecord(
+					'root',
+					'__unstableBase'
+				),
 				routeConfig.loader
 					? routeConfig.loader( context )
 					: Promise.resolve( undefined ),
 				routeConfig.canvas
 					? routeConfig.canvas( context )
+					: Promise.resolve( undefined ),
+				routeConfig.title
+					? routeConfig.title( context )
 					: Promise.resolve( undefined ),
 			] );
 
@@ -96,6 +105,7 @@ async function createRouteFromDefinition(
 				...( loaderData as any ),
 				canvas: canvasData,
 				inspector,
+				title: titleData,
 				routeContentModule: route.content_module,
 			};
 		},

--- a/packages/boot/src/components/app/use-route-title.ts
+++ b/packages/boot/src/components/app/use-route-title.ts
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, type UnstableBase } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import { decodeEntities } from '@wordpress/html-entities';
+import { privateApis as routePrivateApis } from '@wordpress/route';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation, useMatches } = unlock( routePrivateApis );
+
+/**
+ * Hook that manages document title updates based on route changes.
+ * Formats titles with WordPress conventions and announces them to screen readers.
+ *
+ * This hook should be called from the Root component to ensure it runs on every route.
+ */
+export default function useRouteTitle() {
+	const location = useLocation();
+	const matches = useMatches();
+	const currentMatch = matches[ matches.length - 1 ];
+	const routeTitle = ( currentMatch?.loaderData as any )?.title as
+		| string
+		| undefined;
+
+	const siteTitle = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord< UnstableBase >(
+				'root',
+				'__unstableBase'
+			)?.name,
+		[]
+	);
+
+	const isInitialLocationRef = useRef( true );
+
+	useEffect( () => {
+		isInitialLocationRef.current = false;
+	}, [ location ] );
+
+	useEffect( () => {
+		// Don't update or announce the title for initial page load.
+		if ( isInitialLocationRef.current ) {
+			return;
+		}
+
+		if (
+			routeTitle &&
+			typeof routeTitle === 'string' &&
+			siteTitle &&
+			typeof siteTitle === 'string'
+		) {
+			// Decode entities for display
+			const decodedRouteTitle = decodeEntities( routeTitle );
+			const decodedSiteTitle = decodeEntities( siteTitle );
+
+			// Format title following WordPress admin conventions
+			const formattedTitle = sprintf(
+				/* translators: Admin document title. 1: Admin screen name, 2: Site name. */
+				__( '%1$s ‹ %2$s — WordPress' ),
+				decodedRouteTitle,
+				decodedSiteTitle
+			);
+
+			document.title = formattedTitle;
+
+			// Announce title on route change for screen readers.
+			if ( decodedRouteTitle ) {
+				speak( decodedRouteTitle, 'assertive' );
+			}
+		}
+	}, [ routeTitle, siteTitle, location ] );
+}

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -29,6 +29,7 @@ import { Page } from '@wordpress/admin-ui';
 import Sidebar from '../sidebar';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
+import useRouteTitle from '../app/use-route-title';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -47,6 +48,8 @@ export default function Root() {
 	const routeContentModule = ( currentMatch?.loaderData as any )
 		?.routeContentModule as string | undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
+
+	useRouteTitle();
 
 	// Mobile sidebar state
 	const isMobileViewport = useViewportMatch( 'medium', '<' );

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -20,6 +20,7 @@ import CanvasRenderer from '../canvas-renderer';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
+import useRouteTitle from '../app/use-route-title';
 
 const { useMatches, Outlet } = unlock( routePrivateApis );
 const { ThemeProvider } = unlock( themePrivateApis );
@@ -38,6 +39,8 @@ export default function RootSinglePage() {
 	const routeContentModule = ( currentMatch?.loaderData as any )
 		?.routeContentModule as string | undefined;
 	const isFullScreen = canvas && ! canvas.isPreview;
+
+	useRouteTitle();
 
 	return (
 		<ThemeProvider isRoot color={ { bg: '#f8f8f8', primary: '#3858e9' } }>

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -106,6 +106,30 @@ export interface RouteConfig {
 	 * ```
 	 */
 	inspector?: ( context: RouteLoaderContext ) => boolean | Promise< boolean >;
+
+	/**
+	 * Function that returns the document title for the route.
+	 * The returned title will be formatted as: "{title} ‹ {siteTitle} — WordPress"
+	 * and announced to screen readers for accessibility.
+	 *
+	 * @param context Route context with params and search
+	 * @return The document title string or a Promise resolving to a string
+	 *
+	 * @example
+	 * ```tsx
+	 * export const route = {
+	 *   title: async ({ params }) => {
+	 *     const post = await resolveSelect(coreStore).getEntityRecord(
+	 *       'postType',
+	 *       params.type,
+	 *       params.id
+	 *     );
+	 *     return post?.title?.rendered || 'Edit Post';
+	 *   },
+	 * };
+	 * ```
+	 */
+	title?: ( context: RouteLoaderContext ) => string | Promise< string >;
 }
 
 /**

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -5,6 +5,7 @@
 		"checkJs": false
 	},
 	"references": [
+		{ "path": "../a11y" },
 		{ "path": "../admin-ui" },
 		{ "path": "../components" },
 		{ "path": "../compose" },

--- a/routes/font-list/route.ts
+++ b/routes/font-list/route.ts
@@ -4,10 +4,5 @@
 import { __ } from '@wordpress/i18n';
 
 export const route = {
-	title: () => __( 'Home' ),
-	async canvas() {
-		return {
-			isPreview: true,
-		};
-	},
+	title: () => __( 'Fonts' ),
 };

--- a/routes/home/package.json
+++ b/routes/home/package.json
@@ -2,5 +2,8 @@
 	"route": {
 		"path": "/",
 		"page": "gutenberg-boot"
+	},
+	"dependencies": {
+		"@wordpress/i18n": "file:../i18n"
 	}
 }

--- a/routes/navigation-edit/route.ts
+++ b/routes/navigation-edit/route.ts
@@ -3,10 +3,32 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 
 const NAVIGATION_POST_TYPE = 'wp_navigation';
 
 export const route = {
+	title: async ( {
+		params,
+	}: {
+		params: {
+			id: string;
+		};
+	} ) => {
+		const navigationId = parseInt( params.id );
+		const navigation = await resolveSelect( coreStore ).getEntityRecord(
+			'postType',
+			NAVIGATION_POST_TYPE,
+			navigationId
+		);
+
+		if ( navigation?.title?.rendered ) {
+			return decodeEntities( navigation.title.rendered );
+		}
+
+		return __( 'Navigation' );
+	},
 	canvas: async ( {
 		params,
 	}: {

--- a/routes/navigation-list/route.ts
+++ b/routes/navigation-list/route.ts
@@ -3,6 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 const NAVIGATION_POST_TYPE = 'wp_navigation';
 
@@ -14,6 +15,7 @@ const PRELOADED_NAVIGATION_MENUS_QUERY = {
 };
 
 export const route = {
+	title: () => __( 'Navigation' ),
 	canvas: async ( {
 		search,
 	}: {

--- a/routes/pattern-list/route.ts
+++ b/routes/pattern-list/route.ts
@@ -3,11 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Route configuration for pattern list.
+ */
 export const route = {
-	title: () => __( 'Home' ),
-	async canvas() {
-		return {
-			isPreview: true,
-		};
-	},
+	title: () => __( 'Patterns' ),
 };

--- a/routes/post-edit/package.json
+++ b/routes/post-edit/package.json
@@ -8,6 +8,8 @@
 	},
 	"dependencies": {
 		"@wordpress/core-data": "file:../../packages/core-data",
-		"@wordpress/data": "file:../../packages/data"
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/html-entities": "file:../html-entities",
+		"@wordpress/i18n": "file:../i18n"
 	}
 }

--- a/routes/post-edit/route.ts
+++ b/routes/post-edit/route.ts
@@ -1,7 +1,38 @@
 /**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+
+/**
  * Route configuration for post edit.
  */
 export const route = {
+	title: async ( {
+		params,
+	}: {
+		params: {
+			type: string;
+			id: string;
+		};
+	} ) => {
+		const post = await resolveSelect( coreStore ).getEntityRecord(
+			'postType',
+			params.type,
+			params.id
+		);
+
+		if ( post?.title?.rendered ) {
+			return decodeEntities( post.title.rendered );
+		}
+
+		const postType = await resolveSelect( coreStore ).getPostType(
+			params.type
+		);
+		return postType?.labels?.edit_item || __( 'Edit' );
+	},
 	async canvas( context: {
 		params: {
 			type: string;

--- a/routes/post-list/route.ts
+++ b/routes/post-list/route.ts
@@ -13,6 +13,12 @@ import { ensureView, viewToQuery } from './view-utils';
  * Route configuration for post list.
  */
 export const route = {
+	title: async ( { params }: { params: { type: string } } ) => {
+		const postType = await resolveSelect( coreStore ).getPostType(
+			params.type
+		);
+		return postType?.labels?.name || params.type;
+	},
 	async canvas( context: {
 		params: {
 			type: string;

--- a/routes/post-new/route.ts
+++ b/routes/post-new/route.ts
@@ -1,13 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { dispatch } from '@wordpress/data';
+import { dispatch, resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Route configuration for creating a new post.
  */
 export const route = {
+	title: async ( { params }: { params: { type: string } } ) => {
+		const postType = await resolveSelect( coreStore ).getPostType(
+			params.type
+		);
+		return postType?.labels?.add_new_item || postType?.labels?.add_new;
+	},
 	async canvas( context: {
 		params: {
 			type: string;

--- a/routes/styles/route.ts
+++ b/routes/styles/route.ts
@@ -1,7 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Route configuration for styles.
  */
 export const route = {
+	title: () => __( 'Styles' ),
 	async canvas( context: any ) {
 		// If stylebook preview is active, use custom canvas (StyleBookPreview)
 		// Otherwise, use default editor canvas

--- a/routes/template-list/route.ts
+++ b/routes/template-list/route.ts
@@ -3,6 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { ensureView, viewToQuery } from './view-utils';
  * Route configuration for template list.
  */
 export const route = {
+	title: () => __( 'Templates' ),
 	async canvas( context: {
 		params: {
 			activeView: string;

--- a/routes/template-part-list/route.ts
+++ b/routes/template-part-list/route.ts
@@ -3,6 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { ensureView, viewToQuery } from './view-utils';
  * Route configuration for template part list.
  */
 export const route = {
+	title: () => __( 'Template Parts' ),
 	async canvas( context: {
 		params: {
 			area: string;


### PR DESCRIPTION
## What?

Related #70862

This adds a "title" support for each route in the new routing infrastructure. Raised by @jasmussen in the font library PR #73630

This PR also adds titles for all the pages of the current "Gutenberg-boot" experiment.

## Testing Instructions

- Open http://localhost:8888/wp-admin/admin.php?page=gutenberg-boot
- Navigate through the different pages
- Notice the page title changing.