### PR TITLE
wp-ui: add legacy export fields to package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,8 @@
 		"node": ">=20.10.0",
 		"npm": ">=10.2.3"
 	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
 	"exports": {
 		".": {
 			"types": "./build-types/index.d.ts",
@@ -31,6 +33,7 @@
 		"./package.json": "./package.json"
 	},
 	"wpScript": false,
+	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION
Add the legacy `main`, `module`, `types` fields to `package.json`. Our `transpilePackage` build script relies on presence of `packageJson.main` and `packageJson.module`. Without this, the `build` and `build-module` folders are not built and the published package is broken:

https://app.unpkg.com/@wordpress/ui@0.3.0

The `types` field is not strictly necessary, but I'm adding it for consistency with other packages.

After we merge this, let's publish a `next` version of the packages to NPM ASAP.
