### PR TITLE
Rich Text: Make inline toolbar more reactive for proper positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55643,6 +55643,7 @@
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
 				"@wordpress/deprecated": "file:../deprecated",
+				"@wordpress/dom": "file:../dom",
 				"@wordpress/element": "file:../element",
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/i18n": "file:../i18n",

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -126,9 +126,6 @@ export function RichTextWrapper(
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
 	const [ anchorElement, setAnchorElement ] = useState( null );
-	const anchorCallbackRef = useCallback( ( element ) => {
-		setAnchorElement( element );
-	}, [] );
 	const context = useBlockEditContext();
 	const { clientId, isSelected: isBlockSelected } = context;
 	const blockBindings = context[ blockBindingsKey ];
@@ -496,7 +493,7 @@ export function RichTextWrapper(
 						inputEvents,
 					} ),
 					anchorRef,
-					anchorCallbackRef,
+					setAnchorElement,
 				] ) }
 				contentEditable={ ! shouldDisableEditing }
 				suppressContentEditableWarning

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -9,6 +9,7 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  */
 import {
 	useRef,
+	useState,
 	useCallback,
 	forwardRef,
 	createContext,
@@ -124,6 +125,10 @@ export function RichTextWrapper(
 
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
+	const [ anchorElement, setAnchorElement ] = useState( null );
+	const anchorCallbackRef = useCallback( ( element ) => {
+		setAnchorElement( element );
+	}, [] );
 	const context = useBlockEditContext();
 	const { clientId, isSelected: isBlockSelected } = context;
 	const blockBindings = context[ blockBindingsKey ];
@@ -440,7 +445,7 @@ export function RichTextWrapper(
 			{ isSelected && hasFormats && (
 				<FormatToolbarContainer
 					inline={ inlineToolbar }
-					editableContentElement={ anchorRef.current }
+					editableContentElement={ anchorElement }
 				/>
 			) }
 			<TagName
@@ -491,6 +496,7 @@ export function RichTextWrapper(
 						inputEvents,
 					} ),
 					anchorRef,
+					anchorCallbackRef,
 				] ) }
 				contentEditable={ ! shouldDisableEditing }
 				suppressContentEditableWarning

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -114,7 +114,7 @@ _Returns_
 
 ### getRectangleFromRange
 
-Get the rectangle of a given Range. Returns `null` if no suitable rectangle can be found.
+Get the rectangle of a given Range. Returns `null` if no suitable rectangle can be found. Use instead of `Range.getBoundingClientRect()`, which is often broken, especially for uncollapsed ranges.
 
 _Parameters_
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -114,7 +114,7 @@ _Returns_
 
 ### getRectangleFromRange
 
-Get the rectangle of a given Range. Returns `null` if no suitable rectangle can be found. Use instead of `Range.getBoundingClientRect()`, which is often broken, especially for uncollapsed ranges.
+Get the rectangle of a given Range. Returns `null` if no suitable rectangle can be found. Use instead of `Range.getBoundingClientRect()`, which is often broken, especially for collapsed ranges.
 
 _Parameters_
 

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -5,7 +5,8 @@ import { assertIsDefined } from '../utils/assert-is-defined';
 
 /**
  * Get the rectangle of a given Range. Returns `null` if no suitable rectangle
- * can be found.
+ * can be found. Use instead of `Range.getBoundingClientRect()`, which is often
+ * broken, especially for uncollapsed ranges.
  *
  * @param {Range} range The range.
  *

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -6,7 +6,7 @@ import { assertIsDefined } from '../utils/assert-is-defined';
 /**
  * Get the rectangle of a given Range. Returns `null` if no suitable rectangle
  * can be found. Use instead of `Range.getBoundingClientRect()`, which is often
- * broken, especially for uncollapsed ranges.
+ * broken, especially for collapsed ranges.
  *
  * @param {Range} range The range.
  *

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
+		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -3,6 +3,7 @@
  */
 import { usePrevious } from '@wordpress/compose';
 import { useState, useLayoutEffect } from '@wordpress/element';
+import { getRectangleFromRange } from '@wordpress/dom';
 
 /** @typedef {import('../register-format-type').WPFormat} WPFormat */
 /** @typedef {import('../types').RichTextValue} RichTextValue */
@@ -87,7 +88,7 @@ function createVirtualAnchorElement( range, editableContentElement ) {
 		contextElement: editableContentElement,
 		getBoundingClientRect() {
 			return editableContentElement.contains( range.startContainer )
-				? range.getBoundingClientRect()
+				? getRectangleFromRange( range )
 				: editableContentElement.getBoundingClientRect();
 		},
 	};

--- a/packages/rich-text/tsconfig.json
+++ b/packages/rich-text/tsconfig.json
@@ -10,6 +10,7 @@
 		{ "path": "../compose" },
 		{ "path": "../data" },
 		{ "path": "../deprecated" },
+		{ "path": "../dom" },
 		{ "path": "../element" },
 		{ "path": "../escape-html" },
 		{ "path": "../i18n" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes: https://github.com/WordPress/gutenberg/issues/73832

This PR solves the above issue with the Link popover (@ellatrix 's [commit](https://github.com/WordPress/gutenberg/pull/73853/commits/1d2c0815ad6672818c58129197d110fc661d476f)).

The below video from the issue demonstrates the bug:

https://github.com/user-attachments/assets/52feb381-3396-49d5-ab93-d7709e90fb72

When I started exploring the linked issue I observed another bug with a stale reference of the InlineToolbar, when we remove and add again the Caption of some blocks. 


This PR also makes the RichText InlineToolbar more reactive for proper positioning of the popover. 

I used state to track the anchor element and a ref callback to trigger a re-render of InlineToolbar with the valid anchor.

I'm not exactly sure how why it works properly when we click for the first time, but I guess more re-renders are triggered then.  

## Testing Instructions for the InlineToolbar bug
1. You can test any block that uses the block editor `Caption` util. That means `image, audio, embed, gallery, quote, table and video` blocks.
2. Insert these blocks and in the block toolbar click the `add caption` button.
3. Then click it again to remove and toggle it again.
4. The RichText inline toolbar should be anchored properly to the caption rich text.

## Testing Instructions for Link popover bug
1. Repeat the above **3 steps**
2. In the RichText inline toolbar click the `Link` button
3. The Link popover should be anchored properly

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


### Videos for the InlineToolbar bug

### Before

https://github.com/user-attachments/assets/4ac7c95c-e0d7-4cf3-b4dc-28fb5c042645




### After

https://github.com/user-attachments/assets/d6bc4184-f59e-4f9e-8883-ac1e6c841c30


