### PR TITLE
Global Styles: Add text alignment support to elements

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -187,13 +187,8 @@ export function useSettingsForBlockElement(
 			? updatedSettings.shadow
 			: false;
 
-		// Text alignment is only available for blocks.
-		if ( element ) {
-			updatedSettings.typography.textAlign = false;
-		}
-
 		return updatedSettings;
-	}, [ parentSettings, supportedStyles, supports, element ] );
+	}, [ parentSettings, supportedStyles, supports ] );
 }
 
 export function useColorsPerOrigin( settings ) {

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -28,6 +28,7 @@ const ROOT_BLOCK_SUPPORTS = [
 	'contentSize',
 	'wideSize',
 	'blockGap',
+	'textAlign',
 	'textDecoration',
 	'textTransform',
 	'letterSpacing',

--- a/packages/blocks/src/store/test/private-selectors.js
+++ b/packages/blocks/src/store/test/private-selectors.js
@@ -42,6 +42,7 @@ describe( 'private selectors', () => {
 				'contentSize',
 				'wideSize',
 				'blockGap',
+				'textAlign',
 			] );
 		} );
 
@@ -65,6 +66,7 @@ describe( 'private selectors', () => {
 				'contentSize',
 				'wideSize',
 				'blockGap',
+				'textAlign',
 				'textDecoration',
 			] );
 		} );
@@ -92,6 +94,7 @@ describe( 'private selectors', () => {
 				'contentSize',
 				'wideSize',
 				'blockGap',
+				'textAlign',
 				'textTransform',
 				'letterSpacing',
 			] );


### PR DESCRIPTION
## What?

Related https://github.com/WordPress/gutenberg/pull/61717/files#r1603273968

Enables the text alignment control for elements (like text, headings, buttons, etc.) in the Global Styles UI.

## Why?

Even when `typography.textAlign` is set to `true` in theme.json, the text alignment control was not showing up in the Global Styles UI when editing elements. This was because the code explicitly disabled textAlign for all elements.

## How?

  1. Removed the code in `packages/block-editor/src/components/global-styles/hooks.js` that was forcing `textAlign: false` for all elements
  2. Added `textAlign` to the `ROOT_BLOCK_SUPPORTS` array in `packages/blocks/src/store/private-selectors.js` so it's recognized as a valid element style

## Testing Instructions

  1. Open the Site Editor
  2. Navigate to Styles → Typography → Text (or any other element like Headings, Buttons, etc.)
  3. Verify that the "Text alignment" control now appears in the Typography panel
  4. Test that you can set text alignment (left/center/right/justify) for the element
  5. Verify the alignment is applied correctly in the preview