### PR TITLE
DataViews: Try zero intrinsic padding

### DIFF
--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -47,7 +47,9 @@ function Page( {
 			) }
 			{ hasPadding ? (
 				<div className="admin-ui-page__content has-padding">
-					{ children }
+					<div className="admin-ui-page__content-child">
+						{ children }
+					</div>
 				</div>
 			) : (
 				children

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -39,7 +39,7 @@
 	flex-direction: column;
 
 	&.has-padding {
-		padding: $grid-unit-20 $grid-unit-30;
+		padding: $grid-unit-30;
 	}
 }
 

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -15,10 +15,9 @@
 
 .admin-ui-page__header {
 	padding: $grid-unit-20 $grid-unit-30;
-	border-bottom: 1px solid $gray-100;
 	background: $white;
-	position: sticky;
-	top: 0;
+	border-bottom: 1px solid $gray-100;
+	z-index: 2;
 }
 
 .admin-ui-page__sidebar-toggle-slot:empty {
@@ -38,8 +37,12 @@
 	display: flex;
 	flex-direction: column;
 
+	.admin-ui-page__content-child {
+		margin: $grid-unit-30 0 0;
+	}
+
 	&.has-padding {
-		padding: $grid-unit-30;
+		padding: 0 $grid-unit-30;
 	}
 }
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -205,7 +205,7 @@ $z-layers: (
 	".editor-start-page-options__modal__actions": 1,
 
 	// Ensure checkbox + actions don't overlap table header
-	".dataviews-view-table thead": 1,
+	".dataviews-view-table thead": 2,
 
 	// Ensure selection checkbox stays above the preview field.
 	".dataviews-view-grid__card .dataviews-selection-checkbox": 1,

--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -7,7 +7,6 @@
 	bottom: 0;
 	left: 0;
 	background-color: inherit;
-	padding: $grid-unit-15 $grid-unit-30;
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
 

--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -9,12 +9,24 @@
 	background-color: inherit;
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
+	padding-top: $grid-unit-15;
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;
 	}
 
 	z-index: z-index(".dataviews-footer");
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: -12px;
+		width: calc(100% + 24px);
+		height: 100%;
+		background-color: inherit;
+		z-index: -1;
+	}
 }
 
 @container (max-width: 560px) {

--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -10,6 +10,7 @@
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
 	padding-top: $grid-unit-15;
+	padding-bottom: $grid-unit-15;
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -13,7 +13,6 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	background-color: var(--wp-dataviews-color-background, $white);
-	gap: $grid-unit-20;
 }
 
 .dataviews__view-actions,
@@ -23,6 +22,7 @@
 	position: sticky;
 	left: 0;
 	background-color: inherit;
+	padding-bottom: $grid-unit-15;
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -4,8 +4,6 @@
 
 .dataviews-wrapper,
 .dataviews-picker-wrapper {
-	height: 100%;
-	overflow: auto;
 	box-sizing: border-box;
 	scroll-padding-bottom: $grid-unit-80;
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
@@ -15,12 +13,12 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	background-color: var(--wp-dataviews-color-background, $white);
+	gap: $grid-unit-20;
 }
 
 .dataviews__view-actions,
 .dataviews-filters__container {
 	box-sizing: border-box;
-	padding: $grid-unit-20 $grid-unit-30;
 	flex-shrink: 0;
 	position: sticky;
 	left: 0;
@@ -46,13 +44,6 @@
 
 .dataviews-loading-more {
 	text-align: center;
-}
-
-@container (max-width: 430px) {
-	.dataviews__view-actions,
-	.dataviews-filters__container {
-		padding: $grid-unit-15 $grid-unit-30;
-	}
 }
 
 .dataviews-title-field {

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -98,6 +98,5 @@
  */
 .components-card__body:has(> .dataviews-wrapper),
 .components-card__body:has(> .dataviews-picker-wrapper) {
-	padding: $grid-unit-10 0 0;
 	overflow: hidden; // Prevent cells with white backgrounds overflowing the card
 }

--- a/packages/dataviews/src/dataviews-layouts/activity/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/activity/style.scss
@@ -3,7 +3,6 @@
 
 .dataviews-view-activity {
 	margin: 0 0 auto;
-	padding: $grid-unit-10 $grid-unit-30;
 
 	.dataviews-view-activity__group-header {
 		font-size: $font-size-large;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -5,7 +5,6 @@
 @use "../utils/grid-items.scss" as *;
 
 .dataviews-view-grid {
-	padding: 0 $grid-unit-30 $grid-unit-30;
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-40;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -82,12 +82,13 @@ div.dataviews-view-list {
 				&::after {
 					content: "";
 					position: absolute;
-					top: 0;
+					top: -1px;
+					bottom: -1px;
 					left: -12px;
 					width: calc(100% + 24px);
-					height: 100%;
 					background-color: #f8f8f8;
-					border-radius: $radius-medium;
+					border-radius: $radius-large;
+					border: 1px solid $gray-100;
 					z-index: -1;
 				}
 
@@ -116,12 +117,13 @@ div.dataviews-view-list {
 		&::after {
 			content: "";
 			position: absolute;
-			top: 0;
+			top: -1px;
+			bottom: -1px;
 			left: -12px;
 			width: calc(100% + 24px);
-			height: 100%;
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-			border-radius: $radius-medium;
+			border-radius: $radius-large;
+			border: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 		}
 	}
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -12,10 +12,12 @@ div.dataviews-view-list {
 	div[role="article"] {
 		margin: 0;
 		border-top: 1px solid $gray-100;
+		position: relative;
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
 			box-sizing: border-box;
+			padding: $grid-unit-15 0;
 		}
 
 		.dataviews-view-list__item-actions {
@@ -77,6 +79,18 @@ div.dataviews-view-list {
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;
 
+				&::after {
+					content: "";
+					position: absolute;
+					top: 0;
+					left: -12px;
+					width: calc(100% + 24px);
+					height: 100%;
+					background-color: #f8f8f8;
+					border-radius: $radius-medium;
+					z-index: -1;
+				}
+
 				.dataviews-view-list__title-field,
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
@@ -91,13 +105,23 @@ div.dataviews-view-list {
 	div[role="article"].is-selected,
 	div[role="article"].is-selected:focus-within {
 		.dataviews-view-list__item-wrapper {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-900;
 
 			.dataviews-view-list__title-field,
 			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
+		}
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: -12px;
+			width: calc(100% + 24px);
+			height: 100%;
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			border-radius: $radius-medium;
 		}
 	}
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -15,7 +15,6 @@ div.dataviews-view-list {
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
-			padding: $grid-unit-20 $grid-unit-30;
 			box-sizing: border-box;
 		}
 

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -32,7 +32,7 @@
 		&.dataviews-view-table__actions-column--sticky {
 			position: sticky;
 			right: 0;
-			background-color: inherit;
+			background-color: var(--wp-dataviews-color-background, #fff);
 		}
 
 		&.dataviews-view-table__actions-column--stuck {

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -22,6 +22,8 @@
 	td,
 	th {
 		padding: $grid-unit-15;
+		position: relative;
+		z-index: 1;
 
 		&.dataviews-view-table__actions-column {
 			text-align: right;
@@ -58,6 +60,7 @@
 	tr {
 		border-top: 1px solid $gray-100;
 		background-color: inherit;
+		position: relative;
 
 		td:first-child,
 		th:first-child {
@@ -73,9 +76,22 @@
 			border-bottom: 0;
 		}
 
-		&.is-hovered,
-		&.is-hovered .dataviews-view-table__actions-column--sticky {
-			background-color: #f8f8f8;
+		&.is-hovered {
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: -8px;
+				width: calc(100% + 16px);
+				height: 100%;
+				background-color: #f8f8f8;
+				z-index: 0;
+				border-radius: $radius-medium;
+			}
+
+			.dataviews-view-table__actions-column--sticky {
+				background-color: #f8f8f8;
+			}
 		}
 
 		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
@@ -90,8 +106,19 @@
 		}
 
 		&.is-selected {
-			background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
 			color: $gray-700;
+
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: -12px;
+				width: calc(100% + 24px);
+				height: 100%;
+				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
+				z-index: 0;
+				border-radius: $radius-medium;
+			}
 
 			&,
 			& + tr {
@@ -99,7 +126,9 @@
 			}
 
 			&:hover {
-				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 8%, $white);
+				&::after {
+					background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 8%, $white);
+				}
 			}
 
 			.dataviews-view-table__actions-column--sticky {
@@ -117,14 +146,27 @@
 		tr {
 			// Only apply hover background to non-selected rows
 			&:not(.is-selected) {
-				&.is-hovered,
-				&.is-hovered .dataviews-view-table__actions-column--sticky {
-					background-color: #f8f8f8;
+				&.is-hovered {
+					&::after {
+						content: "";
+						position: absolute;
+						top: 0;
+						left: -12px;
+						width: calc(100% + 24px);
+						height: 100%;
+						background-color: #f8f8f8;
+						z-index: 0;
+					}
+
+					.dataviews-view-table__actions-column--sticky {
+						background-color: #f8f8f8;
+					}
 				}
 			}
 
 			&:focus-within,
 			&.is-hovered,
+			&.is-selected,
 			&:hover {
 				.components-checkbox-control__input,
 				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
@@ -139,6 +181,17 @@
 		inset-block-start: 0;
 		z-index: z-index(".dataviews-view-table thead");
 		background-color: inherit;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: -12px;
+			width: calc(100% + 24px);
+			height: 100%;
+			background-color: inherit;
+			z-index: 0;
+		}
 
 		tr {
 			border: 0;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -80,10 +80,10 @@
 			&::after {
 				content: "";
 				position: absolute;
-				top: 0;
+				top: 0.5px;
+				bottom: 0.5px;
 				left: -8px;
 				width: calc(100% + 16px);
-				height: 100%;
 				background-color: #f8f8f8;
 				z-index: 0;
 				border-radius: $radius-medium;
@@ -111,10 +111,10 @@
 			&::after {
 				content: "";
 				position: absolute;
-				top: 0;
+				top: 0.5px;
+				bottom: 0.5px;
 				left: -12px;
 				width: calc(100% + 24px);
-				height: 100%;
 				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
 				z-index: 0;
 				border-radius: $radius-medium;
@@ -150,10 +150,10 @@
 					&::after {
 						content: "";
 						position: absolute;
-						top: 0;
+						top: 0.5px;
+						bottom: 0.5px;
 						left: -12px;
 						width: calc(100% + 24px);
-						height: 100%;
 						background-color: #f8f8f8;
 						z-index: 0;
 					}
@@ -184,10 +184,10 @@
 		&::after {
 			content: "";
 			position: absolute;
-			top: 0;
+			top: 0.5px;
+			bottom: 0.5px;
 			left: -12px;
 			width: calc(100% + 24px);
-			height: 100%;
 			background-color: inherit;
 			z-index: 0;
 		}

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -61,12 +61,12 @@
 
 		td:first-child,
 		th:first-child {
-			padding-left: $grid-unit-30;
+			padding-left: 0;
 		}
 
 		td:last-child,
 		th:last-child {
-			padding-right: $grid-unit-30;
+			padding-right: 0;
 		}
 
 		&:last-child {
@@ -161,13 +161,11 @@
 			}
 
 			&:has(.dataviews-view-table-header-button):first-child {
-				// Table cell padding minus the header button padding.
-				padding-left: $grid-unit-50;
+				padding-left: 0;
 			}
 
 			&:has(.dataviews-view-table-header-button):last-child {
-				// Table cell padding minus the header button padding.
-				padding-right: $grid-unit-50;
+				padding-right: 0;
 			}
 		}
 	}
@@ -305,7 +303,7 @@
 .dataviews-view-table__group-header-row {
 	.dataviews-view-table__group-header-cell {
 		font-weight: $font-weight-medium;
-		padding: $grid-unit-15 $grid-unit-30;
+		padding: $grid-unit-15 0;
 		color: $gray-900;
 	}
 }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -80,13 +80,14 @@
 			&::after {
 				content: "";
 				position: absolute;
-				top: 0.5px;
-				bottom: 0.5px;
-				left: -8px;
-				width: calc(100% + 16px);
+				top: -0.5px;
+				bottom: -0.5px;
+				left: -12px;
+				width: calc(100% + 24px);
 				background-color: #f8f8f8;
 				z-index: 0;
-				border-radius: $radius-medium;
+				border-radius: $radius-large;
+				border: 1px solid $gray-100;
 			}
 
 			.dataviews-view-table__actions-column--sticky {
@@ -111,13 +112,14 @@
 			&::after {
 				content: "";
 				position: absolute;
-				top: 0.5px;
-				bottom: 0.5px;
+				top: -0.5px;
+				bottom: -0.5px;
 				left: -12px;
 				width: calc(100% + 24px);
 				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
 				z-index: 0;
-				border-radius: $radius-medium;
+				border-radius: $radius-large;
+				border: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 			}
 
 			&,
@@ -150,12 +152,14 @@
 					&::after {
 						content: "";
 						position: absolute;
-						top: 0.5px;
-						bottom: 0.5px;
+						top: -0.5px;
+						bottom: -0.5px;
 						left: -12px;
 						width: calc(100% + 24px);
 						background-color: #f8f8f8;
 						z-index: 0;
+						border-radius: $radius-large;
+						border: 1px solid $gray-100;
 					}
 
 					.dataviews-view-table__actions-column--sticky {

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -166,7 +166,6 @@
 
 			&:focus-within,
 			&.is-hovered,
-			&.is-selected,
 			&:hover {
 				.components-checkbox-control__input,
 				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {

--- a/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/dataviews-layouts/utils/grid-items.scss
@@ -6,7 +6,7 @@
 	gap: $grid-unit-40;
 	grid-template-rows: max-content;
 	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-	padding: 0 $grid-unit-30 $grid-unit-30;
+	padding: 0 0 $grid-unit-30;
 	container-type: inline-size;
 
 	@media not (prefers-reduced-motion) {

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -266,14 +266,6 @@ export const WithModal = ( {
 			) }
 			{ isModalOpen && (
 				<>
-					<style>{ `
-						.components-modal__content {
-							padding: 0;
-						}
-						.components-modal__frame.is-full-screen .components-modal__content {
-							margin-bottom: 0;
-						}
-					` }</style>
 					<Modal
 						title="Select Items"
 						onRequestClose={ () => setIsModalOpen( false ) }

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -603,7 +603,6 @@ export const InfiniteScroll = () => {
 			<style>{ `
 			.dataviews-wrapper {
 				height: 600px;
-				overflow: auto;
 			}
 		` }</style>
 			<Text

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -11,6 +11,8 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useView } from '@wordpress/views';
 import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -32,9 +34,7 @@ import {
 	previewField,
 	templatePartAuthorField,
 } from './fields';
-import { addQueryArgs } from '@wordpress/url';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
-import { Button } from '@wordpress/components';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
@@ -202,6 +202,7 @@ export default function DataviewsPatterns() {
 		<ExperimentalBlockEditorProvider settings={ settings }>
 			<Page
 				className="edit-site-page-patterns-dataviews"
+				hasPadding
 				title={ title }
 				subTitle={ description }
 				actions={

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -127,6 +127,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			hasPadding
 			actions={
 				<>
 					{ isModified && (

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -318,6 +318,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			hasPadding
 			actions={
 				<>
 					{ isModified && (

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -251,6 +251,7 @@ export default function PostList( { postType } ) {
 	return (
 		<Page
 			title={ labels?.name }
+			hasPadding
 			actions={
 				<>
 					{ isModified && (


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/73334.

I had to scratch this itch. The code is very messy, but can be tidied if we think this is worth pursuing at all. DataViews now has zero intrinsic padding meaning it can be placed in any container and work as expected without additional code.

<img width="1318" height="531" alt="Screenshot 2025-12-09 at 18 36 27" src="https://github.com/user-attachments/assets/e9442326-fdce-4bbf-8cd6-dbe26857a86d" />

The only piece I couldn't get working is making `.dataviews__view-actions` and `.dataviews-footer` stick to the left of the container when table layout is wide enough to cause horizontal scrolling. This is due to the parent container handling scrolling rather than `.dataviews-wrapper`. Maybe there's a js solution to this, or maybe it's the limiting factor that curtails this approach altogether?

I'm drafting this PR mostly in case it inspires any further ideas. If not that's fine. Like I said, I had to scratch the itch :) 

cc @andrewserong @youknowriad.