### PR TITLE
Categories Block: Fix CSS collision with labels

### DIFF
--- a/packages/block-library/src/categories/style.scss
+++ b/packages/block-library/src/categories/style.scss
@@ -14,8 +14,4 @@
 	&.wp-block-categories-dropdown.aligncenter {
 		text-align: center;
 	}
-	& .wp-block-categories__label {
-		width: 100%;
-		display: block;
-	}
 }

--- a/packages/block-library/src/categories/style.scss
+++ b/packages/block-library/src/categories/style.scss
@@ -14,4 +14,8 @@
 	&.wp-block-categories-dropdown.aligncenter {
 		text-align: center;
 	}
+	& .wp-block-categories__label:not(.screen-reader-text) {
+		width: 100%;
+		display: block;
+	}
 }


### PR DESCRIPTION
## What?
Fixes #71999
`Categories lists` under certain circumstances, as explained in the ticket, create an styles collision with a massive width floating to the right.

## Testing Instructions
1. Use this blueprint:
https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fgist.githubusercontent.com%2FSirLouen%2Fe21dd3cf0c9d548ac9b6b2c23852e459%2Fraw%2F74044b6b7c83faf130e98485d0755c099dc79118%2Fblueprint.json
2. Go to Appearance > Editor 
3. Select the Header, and add the Categories List to the header
4. Add the Display as dropdown, remove Show label, add Show post counts
<img width="1214" height="880" alt="Image" src="https://github.com/user-attachments/assets/922d71c2-03c0-4986-bd54-a8205b891ffa" />

5. Visit the page
6. 🐞Massive `width` appears 

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1847" height="910" alt="image" src="https://github.com/user-attachments/assets/c3344357-de30-4a96-993b-f7fcd6e0fae6" />|<img width="1426" height="870" alt="image" src="https://github.com/user-attachments/assets/3119355d-e629-438a-8a4b-0dcfbdb7ab28" />|
