### PR TITLE
Try removing top and left grid drag handles in stable (auto) mode

### DIFF
--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -61,15 +61,24 @@ function GridItemResizerInner( {
 			const blockClientRect = blockElement.getBoundingClientRect();
 			const rootBlockClientRect =
 				rootBlockElement.getBoundingClientRect();
+
+			const topAvailable = blockClientRect.top > rootBlockClientRect.top;
+			const bottomAvailable =
+				blockClientRect.bottom < rootBlockClientRect.bottom;
+			const leftAvailable =
+				blockClientRect.left > rootBlockClientRect.left;
+			const rightAvailable =
+				blockClientRect.right < rootBlockClientRect.right;
+
 			setEnableSide( {
-				top:
-					!! isManualGrid &&
-					blockClientRect.top > rootBlockClientRect.top,
-				bottom: blockClientRect.bottom < rootBlockClientRect.bottom,
-				left:
-					!! isManualGrid &&
-					blockClientRect.left > rootBlockClientRect.left,
-				right: blockClientRect.right < rootBlockClientRect.right,
+				top: !! isManualGrid
+					? topAvailable
+					: ! bottomAvailable && topAvailable,
+				bottom: bottomAvailable,
+				left: !! isManualGrid
+					? leftAvailable
+					: ! rightAvailable && leftAvailable,
+				right: rightAvailable,
 			} );
 		} );
 		observer.observe( blockElement );

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -62,15 +62,19 @@ function GridItemResizerInner( {
 			const rootBlockClientRect =
 				rootBlockElement.getBoundingClientRect();
 			setEnableSide( {
-				top: blockClientRect.top > rootBlockClientRect.top,
+				top:
+					!! isManualGrid &&
+					blockClientRect.top > rootBlockClientRect.top,
 				bottom: blockClientRect.bottom < rootBlockClientRect.bottom,
-				left: blockClientRect.left > rootBlockClientRect.left,
+				left:
+					!! isManualGrid &&
+					blockClientRect.left > rootBlockClientRect.left,
 				right: blockClientRect.right < rootBlockClientRect.right,
 			} );
 		} );
 		observer.observe( blockElement );
 		return () => observer.disconnect();
-	}, [ blockElement, rootBlockElement ] );
+	}, [ blockElement, rootBlockElement, isManualGrid ] );
 
 	const justification = {
 		right: 'left',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #63966

If the grid experiment is disabled, or when enabled, if the Grid block is in Auto mode, top and left drag handles for grid items shouldn't show. 

The downside to this is, of course, that it now becomes impossible to resize by dragging a block in the bottom right hand corner of a grid, because it won't have any drag handles:

<img width="696" height="606" alt="Screenshot 2025-12-10 at 1 49 59 pm" src="https://github.com/user-attachments/assets/56776cc4-7f1a-429d-abc2-a9d814c3f8c5" />

Blocks on the bottom and right sides will be limited in their draggability. Other blocks should still be draggable towards bottom and right:

<img width="692" height="607" alt="Screenshot 2025-12-10 at 1 50 23 pm" src="https://github.com/user-attachments/assets/6c8d3338-e5db-4973-b2d1-9312d3b71ab2" />


I suppose it would be possible to add top/left drag handles _only_ when blocks are on the bottom or right sides. I might experiment with that as I feel that not being able to drag at all is suboptimal.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block with some items to a post
2. Check that drag handles appear correctly as per above
3. Enable the grid experiment, switch the Grid block to Manual mode and check that all drag handles appear
