### PR TITLE
Classic Block: Restore HTML editing option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -382,7 +382,7 @@ Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/freeform
 -	**Category:** text
--	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
+-	**Supports:** ~~className~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
 -	**Attributes:** content
 
 ## Gallery

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -13,7 +13,6 @@
 		}
 	},
 	"supports": {
-		"html": false,
 		"className": false,
 		"customClassName": false,
 		"lock": false,


### PR DESCRIPTION
## What?
Closes #73792.
Re-opens #10837.

PR restores HTML editing functionality for the Classic block, based on the feedback from #73792.

Let's try to solve the original problem using `autop` and Classic: https://github.com/WordPress/gutenberg/issues/10837#issuecomment-3217860768.

## Testing Instructions
1. Open a post.
2. Insert the Classic block with some content.
3. Confirm you can edit its content as HTML for the block options dropdown.

### Testing Instructions for Keyboard
Same.
