### PR TITLE
Block API: Fallback to all attributes when checking for unmodified block

### DIFF
--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -495,6 +495,14 @@ describe( 'isUnmodifiedBlock', () => {
 		expect( isUnmodifiedBlock( block, 'non-existent-role' ) ).toBe( true );
 	} );
 
+	it( 'should return false if no attributes exist for the role and some are modified', () => {
+		const block = createBlock( 'core/test-block', {
+			align: 'center',
+			content: 'Updated content',
+		} );
+		expect( isUnmodifiedBlock( block, 'non-existent-role' ) ).toBe( false );
+	} );
+
 	it( 'should return true if metadata attributes is not modified for role content', () => {
 		const block = createBlock( 'core/test-block' );
 		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( true );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -43,13 +43,16 @@ export function isUnmodifiedBlock( block, role ) {
 	const blockAttributes = getBlockType( block.name )?.attributes ?? {};
 
 	// Filter attributes by role if a role is provided.
-	const attributesToCheck = role
+	const attributesByRole = role
 		? Object.entries( blockAttributes ).filter( ( [ key, definition ] ) => {
 				// A special case for the metadata attribute.
 				// It can include block bindings that serve as a source of content,
 				// without directly modifying content attributes.
 				if ( role === 'content' && key === 'metadata' ) {
-					return true;
+					return (
+						Object.keys( block.attributes[ key ]?.bindings ?? {} )
+							.length > 0
+					);
 				}
 
 				return (
@@ -57,6 +60,10 @@ export function isUnmodifiedBlock( block, role ) {
 					definition.__experimentalRole === role
 				);
 		  } )
+		: [];
+	// Fallback to all attributes if no attributes match the role.
+	const attributesToCheck = !! attributesByRole.length
+		? attributesByRole
 		: Object.entries( blockAttributes );
 
 	return attributesToCheck.every( ( [ key, definition ] ) => {


### PR DESCRIPTION
## What?
Closes #73851
This is a follow-up to #70764 and #70897.

PR adds fallback logic to `isUnmodifiedBlock` helper to maintainn original behavior for blocks that haven't yet started using attribute roles.

## Why?
Attribute roles are relatively new, and not all blocks have adopted them. The editor should maintain the previous behavior for them - check for any attribute modification as a fallback.

## Testing Instructions
1. Remove attribute roles for Paragraph block definition.
2. Open a post.
3. Type into the first empty paragraph.
4. Confirm that the empty block inserter isn't rendered after the content update.

### Testing Instructions for Keyboard
Same.

## Screencast

<img width="759" height="319" alt="CleanShot 2025-12-10 at 08 22 18" src="https://github.com/user-attachments/assets/36f6c392-6230-40a7-b8d5-efac30c5c4c4" />

