### PR TITLE
Block Editor: Fix ESLint warnings for the 'useInsertionPoint' hook

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -201,6 +201,8 @@ function useInsertionPoint( {
 			onSelect,
 			shouldFocusBlock,
 			selectBlockOnInsert,
+			setLastFocus,
+			registry,
 		]
 	);
 
@@ -234,6 +236,7 @@ function useInsertionPoint( {
 			hideInsertionPoint,
 			destinationRootClientId,
 			destinationIndex,
+			registry,
 		]
 	);
 


### PR DESCRIPTION
## What?
PR fixes missing dependencies, ESLint warnings for the `useInsertionPoint` hook. Both `registry` and `setLastFocus` have stable values and should be safe to declare as dependencies.

## Why?
A minor code quality improvement.

## Testing Instructions
None. CI checks should be green.
