### PR TITLE
Update Additional CSS command label

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -429,7 +429,7 @@ const getGlobalStylesOpenCssCommands = () =>
 			return [
 				{
 					name: 'core/open-styles-css',
-					label: __( 'Open custom CSS' ),
+					label: __( 'Open Additional CSS' ),
 					icon: brush,
 					callback: ( { close } ) => {
 						close();
@@ -446,6 +446,7 @@ const getGlobalStylesOpenCssCommands = () =>
 							);
 						}
 					},
+					keywords: [ __( 'Custom CSS' ) ],
 				},
 			];
 		}, [ history, canEditCSS, isSiteEditor ] );

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -65,11 +65,24 @@ test.describe( 'Site editor command palette', () => {
 	test( 'Open the command palette and navigate to Customize CSS', async ( {
 		page,
 	} ) => {
+		// User types "Additional CSS" (command label).
+		await page
+			.getByRole( 'button', { name: 'Open command palette' } )
+			.click();
+		await page.keyboard.type( 'Additional CSS' );
+		await page
+			.getByRole( 'option', { name: 'Open Additional CSS' } )
+			.click();
+		await expect( page.getByLabel( 'Additional CSS' ) ).toBeVisible();
+
+		// User types "custom CSS" (keyword).
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.click();
 		await page.keyboard.type( 'custom CSS' );
-		await page.getByRole( 'option', { name: 'Open custom CSS' } ).click();
+		await page
+			.getByRole( 'option', { name: 'Open Additional CSS' } )
+			.click();
 		await expect( page.getByLabel( 'Additional CSS' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION

## What?
Closes #73833

Updates the Command Palette label for the Custom CSS command to use the canonical “Additional CSS” wording.  
Also updates the E2E test so the command is discoverable when users search for both “Additional CSS” and “custom CSS”.

## Why?
The Command Palette previously displayed `Open custom CSS`, while the Styles panel uses `Additional CSS` for the same feature.  
This inconsistency caused confusion, duplicated translation strings, and made the command harder to find.

Unifying the label improves UX consistency and ensures predictable search behaviour.  
Adding keyword synonyms preserves backward discoverability.

## How?
- Replaces the command title “Open custom CSS” with “Open Additional CSS”.
- Adds keywords for `Custom CSS` to maintain discoverability.
- Updates the E2E test to:
  - Select the “Additional CSS” option.
  - Verify the command appears when searching for either “Additional CSS” or “custom CSS”.
  - Confirm the Additional CSS panel opens.

## Testing Instructions
1. Open the Site Editor.
2. Open the Command Palette
3. Type **“Additional CSS”**.
   - The **Additional CSS** command should appear and open the correct panel.
4. Open the Command Palette again.
5. Type **“custom CSS”**.
   - The same **Additional CSS** command should appear (via keywords) and open the correct panel.



<img width="1295" height="547" alt="image" src="https://github.com/user-attachments/assets/bc92397d-1cf3-40b8-80a6-509bb30d32a7" />

