### PR TITLE
Editor: Improve offline error notices

### DIFF
--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -92,10 +92,18 @@ export function getNotificationArgumentsForSaveFail( data ) {
 
 	if ( error.code === 'offline_error' ) {
 		const messages = {
-			publish: __( 'Publishing failed because you were offline.' ),
-			private: __( 'Publishing failed because you were offline.' ),
-			future: __( 'Scheduling failed because you were offline.' ),
-			default: __( 'Updating failed because you were offline.' ),
+			publish: __(
+				'Publishing failed because you were offline. Please, verify your connection and try again.'
+			),
+			private: __(
+				'Publishing failed because you were offline. Please, verify your connection and try again.'
+			),
+			future: __(
+				'Scheduling failed because you were offline. Please, verify your connection and try again.'
+			),
+			default: __(
+				'Updating failed because you were offline. Please, verify your connection and try again.'
+			),
 		};
 
 		const noticeMessage =

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -270,7 +270,9 @@ test.describe( 'Autosave', () => {
 
 		await expect(
 			page.locator( '.components-notice__content' )
-		).toContainText( 'Updating failed because you were offline.' );
+		).toContainText(
+			'Updating failed because you were offline. Please, verify your connection and try again.'
+		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
 		).toBe( 1 );

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -243,7 +243,9 @@ test.describe( 'Change detection', () => {
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor content' } )
-				.getByText( 'Updating failed because you were offline.' )
+				.getByText(
+					'Updating failed because you were offline. Please, verify your connection and try again.'
+				)
 		).toBeVisible();
 		await expect(
 			page


### PR DESCRIPTION
## What?

This PR improves the editor save errors when offline.

Closes #67141.

## Why?
When offline, the error messages were a bit vague, so we've been improving them. See #67141 for discussion.

## How?
Adding an extra sentence to make next steps clearer.

## Testing Instructions
* Start a new post
* Go offline 
* Publish the post
* See the improved message.
* Get back online
* Repeat with a post that's already published
* Make changes to it
* Go offline
* Click the button to save the changes
* See the improved error message.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="461" height="91" alt="Screenshot 2025-12-10 at 13 00 29" src="https://github.com/user-attachments/assets/6b257dfe-626b-4ce3-96f6-0f4325920fa5" />|<img width="544" height="94" alt="Screenshot 2025-12-10 at 12 56 16" src="https://github.com/user-attachments/assets/d52387a3-7f26-4b1c-9f03-a58fa6a2baab" />|




