### PR TITLE
Font Library: Allow access for hybrid themes

### DIFF
--- a/lib/experimental/fonts/load.php
+++ b/lib/experimental/fonts/load.php
@@ -11,7 +11,7 @@ add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item' );
  * Registers the Fonts menu item under Appearance using the gutenberg-boot-wp-admin routing infrastructure.
  */
 function gutenberg_register_fonts_menu_item() {
-	if ( ! wp_theme_has_theme_json() ) {
+	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() ) {
 		return;
 	}
 

--- a/lib/experimental/fonts/load.php
+++ b/lib/experimental/fonts/load.php
@@ -11,7 +11,7 @@ add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item' );
  * Registers the Fonts menu item under Appearance using the gutenberg-boot-wp-admin routing infrastructure.
  */
 function gutenberg_register_fonts_menu_item() {
-	if ( ! wp_is_block_theme() ) {
+	if ( ! wp_theme_has_theme_json() ) {
 		return;
 	}
 

--- a/packages/global-styles-ui/src/font-library/context.tsx
+++ b/packages/global-styles-ui/src/font-library/context.tsx
@@ -116,14 +116,14 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		const updatedGlobalStyles = globalStyles.record;
 
 		// Updates the database version of global styles with the edited font families in the client.
-		setImmutably(
+		const finalGlobalStyles = setImmutably(
 			updatedGlobalStyles ?? {},
 			[ 'settings', 'typography', 'fontFamilies' ],
 			fonts
 		);
 
 		// Saves a new version of the global styles in the database.
-		await saveEntityRecord( 'root', 'globalStyles', updatedGlobalStyles );
+		await saveEntityRecord( 'root', 'globalStyles', finalGlobalStyles );
 	};
 
 	// Library Fonts


### PR DESCRIPTION
This PR allows access to the font library for classic themes with theme.json files (sometimes called hybrid themes).

## Testing instructions

I've tested on Astra which fits this description but I'd love some testing on this because I don't have much experience with such themes.