### PR TITLE
Routing: Add title support to php generated pages

### DIFF
--- a/lib/experimental/fonts/load.php
+++ b/lib/experimental/fonts/load.php
@@ -8,14 +8,14 @@
 add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item' );
 
 /**
- * Registers the Fonts menu item under Appearance using the gutenberg-boot-wp-admin routing infrastructure.
+ * Registers the Fonts menu item under Appearance using the font-library page.
  */
 function gutenberg_register_fonts_menu_item() {
 	if ( ! wp_is_block_theme() ) {
 		return;
 	}
 
-	$url = admin_url( 'admin.php?page=gutenberg-boot-wp-admin&p=' . urlencode( '/font-list' ) );
+	$url = admin_url( 'admin.php?page=font-library-wp-admin&p=' . urlencode( '/font-list' ) );
 
 	add_submenu_page(
 		'themes.php',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
 				"id": "gutenberg-boot",
 				"init": [
 					"@wordpress/edit-site-init"
-				]
+				],
+				"title": "Site Editor"
+			},
+			{
+				"id": "font-library",
+				"title": "Fonts"
 			}
 		]
 	},

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -211,7 +211,7 @@ If `handlePrefix` is omitted, it defaults to the namespace key (e.g., `"woo"` â†
 
 Define admin pages that support routes. Each page gets generated PHP functions for route registration and can be extended by other plugins.
 
-Pages can be defined as simple strings or as objects with initialization modules:
+Pages can be defined as simple strings or as objects with initialization modules and titles:
 
 ```json
 {
@@ -220,7 +220,8 @@ Pages can be defined as simple strings or as objects with initialization modules
 			"my-admin-page",
 			{
 				"id": "my-other-page",
-				"init": ["@my-plugin/my-page-init"]
+				"init": ["@my-plugin/my-page-init"],
+				"title": "My Page Title"
 			}
 		]
 	}
@@ -229,7 +230,10 @@ Pages can be defined as simple strings or as objects with initialization modules
 
 **Page Configuration:**
 - **String format**: `"my-admin-page"` - Simple page with no init modules
-- **Object format**: `{ "id": "page-slug", "init": ["@scope/package"] }` - Page with init modules
+- **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "title": "Page Title" }` - Page with optional init modules and title
+  - **`id`** (required): The page slug used in WordPress admin URLs
+  - **`init`** (optional): Array of script module IDs to execute during page initialization
+  - **`title`** (optional): Default page title used in the auto-generated admin page registration (`add_submenu_page`). The title is automatically wrapped in translation functions (`__()`) in the generated PHP. If omitted, defaults to the page ID.
 
 **Generated Files:**
 
@@ -371,7 +375,24 @@ In `routes/{route-name}/package.json`:
 }
 ```
 
-The `page` field must match one of the pages defined in `wpPlugin.pages` in your root `package.json`. This tells the build system which page this route belongs to. It can also map to an existing page registered by another plugin.
+For routes that should appear on multiple pages:
+
+```json
+{
+	"route": {
+		"path": "/settings",
+		"page": ["my-admin-page", "other-page"]
+	}
+}
+```
+
+The `page` field can be either:
+- **String**: Route belongs to a single page
+- **Array**: Route appears on multiple pages (the build system will register the route for each page)
+
+Each page ID must match one of the pages defined in `wpPlugin.pages` in your root `package.json`. This tells the build system which page(s) this route belongs to. It can also map to existing pages registered by other plugins.
+
+Multi-page routes are useful for shared functionality across different admin pages, such as settings routes accessible from both a main page and a dedicated settings page.
 
 ### Components
 

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1448,21 +1448,21 @@ async function buildAll() {
 	// Use flatMap to expand routes with multiple pages into separate entries
 	const routes = getAllRoutes( ROOT_DIR ).flatMap( ( routeName ) => {
 		const metadata = getRouteMetadata( ROOT_DIR, routeName );
-		const routeFiles = getRouteFiles(
-			path.join( ROOT_DIR, 'routes', routeName )
-		);
 
 		// Skip routes without pages
 		if ( ! metadata || ! metadata.pages || metadata.pages.length === 0 ) {
 			return [];
 		}
+		const routeFiles = getRouteFiles(
+			path.join( ROOT_DIR, 'routes', routeName )
+		);
 
 		// Create a route entry for each page
 		return metadata.pages.map( ( page ) => {
 			return {
 				name: routeName,
 				path: metadata.path,
-				page: page,
+				page,
 				hasRoute: routeFiles.hasRoute,
 				hasContent: routeFiles.hasStage || routeFiles.hasInspector,
 			};

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -906,6 +906,7 @@ async function generatePagesPhp( pageData, replacements ) {
 			'{{PREFIX}}': prefixUnderscore,
 			'{{INIT_MODULES_PHP_ARRAY}}': initModulesPhp,
 			'{{INIT_MODULES_JSON}}': JSON.stringify( page.initModules ),
+			'{{PAGE_DEFAULT_TITLE}}': page.title || '',
 		};
 
 		// Generate both page.php and page-wp-admin.php
@@ -1444,26 +1445,40 @@ async function buildAll() {
 	await buildAllRoutes();
 
 	// Collect route and page data for PHP generation
-	const routes = getAllRoutes( ROOT_DIR ).map( ( routeName ) => {
+	// Use flatMap to expand routes with multiple pages into separate entries
+	const routes = getAllRoutes( ROOT_DIR ).flatMap( ( routeName ) => {
 		const metadata = getRouteMetadata( ROOT_DIR, routeName );
 		const routeFiles = getRouteFiles(
 			path.join( ROOT_DIR, 'routes', routeName )
 		);
-		return {
-			name: routeName,
-			path: metadata?.path,
-			page: metadata?.page,
-			hasRoute: routeFiles.hasRoute,
-			hasContent: routeFiles.hasStage || routeFiles.hasInspector,
-		};
+
+		// Skip routes without pages
+		if ( ! metadata || ! metadata.pages || metadata.pages.length === 0 ) {
+			return [];
+		}
+
+		// Create a route entry for each page
+		return metadata.pages.map( ( page ) => {
+			return {
+				name: routeName,
+				path: metadata.path,
+				page: page,
+				hasRoute: routeFiles.hasRoute,
+				hasContent: routeFiles.hasStage || routeFiles.hasInspector,
+			};
+		} );
 	} );
 
 	// Normalize PAGES config to support both string and object formats
 	const normalizedPages = PAGES.map( ( page ) => {
 		if ( typeof page === 'string' ) {
-			return { id: page, init: [] };
+			return { id: page, init: [], title: undefined };
 		}
-		return { id: page.id, init: page.init || [] };
+		return {
+			id: page.id,
+			init: page.init || [],
+			title: page.title || undefined,
+		};
 	} );
 
 	const pageData = normalizedPages.map( ( page ) => {
@@ -1472,6 +1487,7 @@ async function buildAll() {
 			slug: page.id,
 			routes: pageRoutes,
 			initModules: page.init,
+			title: page.title,
 		};
 	} );
 

--- a/packages/wp-build/src/route-utils.mjs
+++ b/packages/wp-build/src/route-utils.mjs
@@ -30,9 +30,9 @@ export function getAllRoutes( rootDir ) {
 
 /**
  * @typedef {Object} RouteMetadata
- * @property {string}      name Route name.
- * @property {string}      path Route path.
- * @property {string|null} page Page slug this route belongs to.
+ * @property {string}   name  Route name.
+ * @property {string}   path  Route path.
+ * @property {string[]} pages Array of page slugs this route belongs to.
  */
 
 /**
@@ -54,10 +54,19 @@ export function getRouteMetadata( rootDir, routeName ) {
 		return null;
 	}
 
+	// Normalize page field to always be an array
+	// Supports both "page": "string" and "page": ["array"]
+	const pageField = routePackageJson.route.page;
+	/** @type {string[]} */
+	let pages = [];
+	if ( pageField ) {
+		pages = Array.isArray( pageField ) ? pageField : [ pageField ];
+	}
+
 	return {
 		name: routeName,
 		path: routePackageJson.route.path,
-		page: routePackageJson.route.page || null,
+		pages,
 	};
 }
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -238,12 +238,12 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_register_page' ) ) {
 	 */
 	function {{PAGE_SLUG_UNDERSCORE}}_wp_admin_register_page() {
 		add_submenu_page(
-			'nothing-{{PAGE_SLUG}}',                        // Hidden page (no parent)
-			__( '{{PAGE_SLUG}} (WP Admin)', '{{PREFIX}}' ), // Page title
-			__( '{{PAGE_SLUG}} (WP Admin)', '{{PREFIX}}' ), // Menu title (not visible)
-			'read',                                          // Minimum capability
-			'{{PAGE_SLUG}}-wp-admin',                       // Menu slug for URL routing
-			'{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page' // Callback function
+			'nothing-{{PAGE_SLUG}}',                                 // Hidden page (no parent)
+			__( '{{PAGE_DEFAULT_TITLE}}', '{{PREFIX}}' ),           // Page title
+			__( '{{PAGE_DEFAULT_TITLE}}', '{{PREFIX}}' ),           // Menu title (not visible)
+			'read',                                                   // Minimum capability
+			'{{PAGE_SLUG}}-wp-admin',                                // Menu slug for URL routing
+			'{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page'          // Callback function
 		);
 	}
 }

--- a/routes/font-list/package.json
+++ b/routes/font-list/package.json
@@ -4,7 +4,10 @@
 	"private": true,
 	"route": {
 		"path": "/font-list",
-		"page": "gutenberg-boot"
+		"page": [
+			"gutenberg-boot",
+			"font-library"
+		]
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",


### PR DESCRIPTION
Related #70862

## What?

This PR allows the generated php pages (that rely on routes and JS) to have default titles set automatically when registering the admin menu in PHP.

## Testing Instructions

 - Load the "Fonts" page under "appearance" 
 - The page title should be set from the start.