### PR TITLE
DataViews: Do not render an item for visible locked items in properties config menu

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
+- DataViews: Stop rendering visible locked fields in the properties section. [#73878](https://github.com/WordPress/gutenberg/pull/73878)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
-- DataViews: Stop rendering visible locked fields in the properties section. [#73878](https://github.com/WordPress/gutenberg/pull/73878)
+- DataViews: Stop rendering locked fields (visible and hidden) in the properties section of the view config. [#73878](https://github.com/WordPress/gutenberg/pull/73878)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -124,22 +124,6 @@ export function PropertiesSection( {
 			) }
 			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
 				<ItemGroup isBordered isSeparated size="medium">
-					{ visibleLockedFields.map( ( { field, isVisibleFlag } ) => {
-						return (
-							<FieldItem
-								key={ field.id }
-								field={ field }
-								isVisible
-								onToggleVisibility={ () => {
-									onChangeView( {
-										...view,
-										[ isVisibleFlag ]: false,
-									} );
-								} }
-							/>
-						);
-					} ) }
-
 					{ hiddenLockedFields.map( ( { field, isVisibleFlag } ) => {
 						return (
 							<FieldItem

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -106,15 +106,6 @@ export function PropertiesSection( {
 		}
 	}
 
-	const hiddenLockedFields = lockedFields.filter(
-		( { field, isVisibleFlag } ) =>
-			// @ts-expect-error
-			isDefined( field ) && ! ( view[ isVisibleFlag ] ?? true )
-	) as Array< {
-		field: NormalizedField< any >;
-		isVisibleFlag: string;
-	} >;
-
 	return (
 		<VStack className="dataviews-field-control" spacing={ 0 }>
 			{ showLabel && (
@@ -124,22 +115,6 @@ export function PropertiesSection( {
 			) }
 			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
 				<ItemGroup isBordered isSeparated size="medium">
-					{ hiddenLockedFields.map( ( { field, isVisibleFlag } ) => {
-						return (
-							<FieldItem
-								key={ field.id }
-								field={ field }
-								isVisible={ false }
-								onToggleVisibility={ () => {
-									onChangeView( {
-										...view,
-										[ isVisibleFlag ]: true,
-									} );
-								} }
-							/>
-						);
-					} ) }
-
 					{ regularFields.map( ( field ) => {
 						// Check if this is the last visible field to prevent hiding
 						const isVisible = visibleFieldIds.includes( field.id );


### PR DESCRIPTION
## What
Stop rendering `FieldItem` components for visible locked fields in the properties section of the DataViews view config.

## Why
Visible locked fields are always visible and cannot be toggled off when they're already shown. Displaying them in the properties list adds unnecessary UI clutter and can confuse users since these items appear interactive but don't provide meaningful actions when visible.

## How
Removed the `visibleLockedFields.map()` block that was rendering `FieldItem` components for visible locked fields. The `visibleLockedFields` variable is still calculated and used for logic (determining total visible fields count and preventing hiding when only one field is visible), but these items are no longer rendered in the UI. Hidden locked fields and regular fields continue to render as before.

| Pages DataView Before | Pages DataView After |
| --- | --- |
| <img width="384" height="715" alt="Screenshot 2025-12-10 at 13 40 55" src="https://github.com/user-attachments/assets/aa965c96-6f24-43a3-a6aa-4c3da694bdb8" /> | <img width="385" height="713" alt="Screenshot 2025-12-10 at 13 44 10" src="https://github.com/user-attachments/assets/396c813c-9547-4385-8fd4-5d22e9e7be47" /> |

Note there is no longer a 'Title' item in the menu because the Title field cannot be toggled on/off.