### PR TITLE
Separated actions and edit functionality in the Pages Template DataForm field

### DIFF
--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -8,6 +8,7 @@ import type { PostType } from '@wordpress/fields';
 import {
 	viewPost,
 	viewPostRevisions,
+	resetTemplate,
 	duplicatePost,
 	duplicatePattern,
 	reorderPage,
@@ -199,6 +200,7 @@ export const registerPostTypeSchema =
 				? reorderPage
 				: undefined,
 			postTypeConfig.slug === 'wp_block' ? exportPattern : undefined,
+			postTypeConfig.slug === 'page' ? resetTemplate : undefined,
 			restorePost,
 			resetPost,
 			deletePost,

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -123,6 +123,10 @@ Reorder action for BasePost.
 
 Reset action for Template and TemplatePart.
 
+### resetTemplate
+
+Reset template action for Post.
+
 ### restorePost
 
 Restore action for PostWithPermissions.

--- a/packages/fields/src/actions/index.ts
+++ b/packages/fields/src/actions/index.ts
@@ -6,6 +6,7 @@ export { default as resetPost } from './reset-post';
 export { default as duplicatePattern } from './duplicate-pattern';
 export { default as exportPattern } from './export-pattern';
 export { default as viewPostRevisions } from './view-post-revisions';
+export { default as resetTemplate } from './reset-template';
 export { default as permanentlyDeletePost } from './permanently-delete-post';
 export { default as restorePost } from './restore-post';
 export { default as trashPost } from './trash-post';

--- a/packages/fields/src/actions/reset-template.tsx
+++ b/packages/fields/src/actions/reset-template.tsx
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { Action } from '@wordpress/dataviews';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import type { Post, CoreDataError } from '../types';
+
+const resetTemplate: Action< Post > = {
+	id: 'reset-template',
+	label: __( 'Reset template' ),
+	isEligible( post ) {
+		if ( post.type !== 'page' ) {
+			return false;
+		}
+
+		if ( ! ( 'template' in post ) ) {
+			return false;
+		}
+
+		// Only show if the page has a custom template set.
+		// Default template is indicated by an empty string.
+		const template = post.template;
+		return typeof template === 'string' && template !== '';
+	},
+	async callback( posts, { registry, onActionPerformed } ) {
+		const post = posts[ 0 ];
+		const { editEntityRecord, saveEditedEntityRecord } =
+			registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+
+		try {
+			// Set template to empty string to use default template.
+			editEntityRecord( 'postType', 'page', post.id, {
+				template: '',
+			} );
+			await saveEditedEntityRecord( 'postType', 'page', post.id, {
+				throwOnError: true,
+			} );
+
+			createSuccessNotice( __( 'Template reset to default.' ), {
+				type: 'snackbar',
+			} );
+
+			if ( onActionPerformed ) {
+				onActionPerformed( posts );
+			}
+		} catch ( error ) {
+			const typedError = error as CoreDataError;
+			const errorMessage =
+				typedError.message && typedError.code !== 'unknown_error'
+					? typedError.message
+					: __( 'An error occurred while resetting the template.' );
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	},
+};
+
+/**
+ * Reset template action for Post.
+ */
+export default resetTemplate;

--- a/packages/fields/src/fields/template/template-edit.tsx
+++ b/packages/fields/src/fields/template/template-edit.tsx
@@ -13,13 +13,7 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
  */
 // @ts-expect-error block-editor is not typed correctly.
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
-import {
-	Button,
-	Dropdown,
-	MenuGroup,
-	MenuItem,
-	Modal,
-} from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -146,46 +140,14 @@ export const TemplateEdit = ( {
 
 	return (
 		<fieldset className="fields-controls__template">
-			<Dropdown
-				popoverProps={ { placement: 'bottom-start' } }
-				renderToggle={ ( { onToggle } ) => (
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						size="compact"
-						onClick={ onToggle }
-					>
-						{ currentTemplate
-							? getItemTitle( currentTemplate )
-							: '' }
-					</Button>
-				) }
-				renderContent={ ( { onToggle } ) => (
-					<MenuGroup>
-						<MenuItem
-							onClick={ () => {
-								setShowModal( true );
-								onToggle();
-							} }
-						>
-							{ __( 'Change template' ) }
-						</MenuItem>
-						{
-							// The default template in a post is indicated by an empty string
-							value !== '' && (
-								<MenuItem
-									onClick={ () => {
-										onChangeControl( '' );
-										onToggle();
-									} }
-								>
-									{ __( 'Use default template' ) }
-								</MenuItem>
-							)
-						}
-					</MenuGroup>
-				) }
-			/>
+			<Button
+				__next40pxDefaultSize
+				variant="tertiary"
+				size="compact"
+				onClick={ () => setShowModal( true ) }
+			>
+				{ currentTemplate ? getItemTitle( currentTemplate ) : '' }
+			</Button>
 			{ showModal && (
 				<Modal
 					title={ __( 'Choose a template' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is a pre-requisite for: https://github.com/WordPress/gutenberg/pull/73036

As mentioned in this comment: https://github.com/WordPress/gutenberg/pull/73036#issuecomment-3570531397

> [...] actions in DataForm are out of scope for now, so this means that:
> - the [template field](https://github.com/WordPress/gutenberg/blob/8e86b65af5ac7a1e24793c8fa457a4a040c352e6/packages/fields/src/fields/template/index.ts#L17) opens a modal to change the template
> - there's a new "reset template" action that is visible in dataviews, and also accesible via the form title

Based on the above, this PR separates the edit functionality from actions in the Pages Template field. The field now directly opens the template selection modal, while the "Reset template" action is moved to the Pages `DataView` and `PostActions` menu.

## Why?

As mentioned above, DataForm fields should not support actions. 

## How?

- Moved "Use default template" functionality to a dedicated `reset-template` action, which is only visible when a page has a custom template assigned.
- Updated the edit functionality of the template field. Clicking the template field value directly now opens the "Change template" modal.

**Files modified**:

- `packages/fields/src/fields/template/template-edit.tsx` - Removed dropdown menu, field now opens modal directly
- `packages/fields/src/actions/reset-template.tsx` - New action implementation
- `packages/fields/src/actions/index.ts` - Export new action.
- `packages/editor/src/dataviews/store/private-actions.ts` - Register action for pages.

## Testing Instructions
1. Go to Site Editor > Pages. 
2. Click on a specific page and open the Details sidebar: 

<img width="1844" height="372" alt="Markup on 2025-12-10 at 16:07:45" src="https://github.com/user-attachments/assets/26335d6b-3500-4197-ab93-2315ca2bea4d" />

3. Click on the Template field. 
4. Notice that the modal to change the Template shows up. 
5. Pick a new template. 
6. Open the Actions menu: 

<img width="1862" height="720" alt="Markup on 2025-12-10 at 16:09:08" src="https://github.com/user-attachments/assets/4fb7964c-86a3-49cb-986f-9ea0036ccf5d" />

7. Notice that there is a Reset template action. 
8. Click it. 
9. Ensure that the template is reset. 
10. Confirm that the Reset template action is no longer visible. 
11. Once again click to select a custom template, but this time save it. 
12. Go to the Pages list and click on the Actions menu in the DataView. 
13. Notice that there is a Reset template action. 
14. Click it. 
15. Ensure that the template is reset. 

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/468450d6-c41d-4dc1-bc16-c4b77e9da143

## Question for the reviewer

When I change the Template for a page, then the Reset template action becomes automatically available in the `PostActions` menu, even if I haven't saved the changed yet. In order for this action to appear on the `DataViews` action, though, I need to first save the new template option. 

Is this expected? If not, is there an obvious way I am missing to make the DataViews action use the edited entity to validate if an action is eligible for the entity? If this is more challenging, could we leave it for a follow-up PR?


