### PR TITLE
Style Book: Fix ESLint warnings

### DIFF
--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -597,12 +597,10 @@ export const StyleBookBody = ( {
 
 	const handleLoad = () => setHasIframeLoaded( true );
 	useLayoutEffect( () => {
-		if ( hasIframeLoaded && iframeRef?.current ) {
-			if ( goTo?.top ) {
-				scrollToSection( 'top', iframeRef?.current );
-			}
+		if ( hasIframeLoaded && iframeRef.current && goTo?.top ) {
+			scrollToSection( 'top', iframeRef.current );
 		}
-	}, [ iframeRef?.current, goTo, scrollToSection, hasIframeLoaded ] );
+	}, [ goTo?.top, hasIframeLoaded ] );
 
 	return (
 		<Iframe


### PR DESCRIPTION
## What?
PR fixes ESLint warnings for `scrollToSection`  side-effect and simplifies its conditions.

## Warnings

```
React Hook useLayoutEffect has unnecessary dependencies: 'iframeRef.current' and 'scrollToSection'. Either exclude them or remove the dependency array. Mutable values like 'iframeRef.current' aren't valid dependencies because mutating them doesn't re-render the component.
```

## Testing Instructions
1. Navigate to Site Editor > Styles
2. Enable Style Book.
3. Navigate to Typography.
4. The Style Book section should automatically scroll into view.

### Testing Instructions for Keyboard
Same.