### PR TITLE
Add callout about broken images in user interface documentation

### DIFF
--- a/docs/explanations/user-interface/README.md
+++ b/docs/explanations/user-interface/README.md
@@ -1,5 +1,9 @@
 # User Interface
 
+<div class="callout callout-info">
+  This page is currently experiencing an issue causing images to appear stretched. <a href="https://github.com/WordPress/gutenberg/blob/trunk/docs/explanations/user-interface/README.md">You can also view this content on Github</a>. 
+</div>
+
 ## The Block Editor
 
 The block editor’s general layout uses a bar at the top, with content below.


### PR DESCRIPTION
This issue was documented in September 2024. It would be nice to provide an alternate path to view this resource.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related: https://github.com/WordPress/wporg-developer/issues/542

<!-- In a few words, what is the PR actually doing? -->

## Why?
Callout provides an alternate path to view image. It also alerts contributors that this is a known issue

## How?
Adds a callout to the documentation page.

## Testing Instructions
View documentation page without without callout: https://developer.wordpress.org/block-editor/explanations/user-interface/ 

