### PR TITLE
Update field colorisation in DataViews list layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
+- DataViews: Simplify list layout field color styles. [#73884](https://github.com/WordPress/gutenberg/pull/73884)
 
 ## 11.0.0 (2025-11-26)
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -69,9 +69,6 @@ div.dataviews-view-list {
 		}
 
 		&:not(.is-selected) {
-			.dataviews-view-list__title-field {
-				color: $gray-900;
-			}
 			&:hover,
 			&.is-hovered,
 			&:focus-within {
@@ -94,7 +91,7 @@ div.dataviews-view-list {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-900;
 
-			.dataviews-view-list__title-field,
+			.dataviews-title-field,
 			.dataviews-view-list__field {
 				color: var(--wp-admin-theme-color);
 			}

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -75,10 +75,10 @@ div.dataviews-view-list {
 			&:hover,
 			&.is-hovered,
 			&:focus-within {
-				color: var(--wp-admin-theme-color);
+				color: $gray-900;
 				background-color: #f8f8f8;
 
-				.dataviews-view-list__fields {
+				.dataviews-view-list__field {
 					color: $gray-900;
 				}
 			}
@@ -95,7 +95,7 @@ div.dataviews-view-list {
 			color: $gray-900;
 
 			.dataviews-view-list__title-field,
-			.dataviews-view-list__fields {
+			.dataviews-view-list__field {
 				color: var(--wp-admin-theme-color);
 			}
 		}
@@ -169,8 +169,11 @@ div.dataviews-view-list {
 		flex-grow: 1;
 	}
 
-	.dataviews-view-list__fields {
+	.dataviews-view-list__field {
 		color: $gray-700;
+	}
+
+	.dataviews-view-list__fields {
 		display: flex;
 		gap: $grid-unit-15;
 		row-gap: $grid-unit-05;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -72,11 +72,12 @@ div.dataviews-view-list {
 			&:hover,
 			&.is-hovered,
 			&:focus-within {
-				color: $gray-900;
-				background-color: #f8f8f8;
+				color: var(--wp-admin-theme-color);
+				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 
+				.dataviews-title-field,
 				.dataviews-view-list__field {
-					color: $gray-900;
+					color: var(--wp-admin-theme-color);
 				}
 			}
 		}
@@ -88,12 +89,12 @@ div.dataviews-view-list {
 	div[role="article"].is-selected,
 	div[role="article"].is-selected:focus-within {
 		.dataviews-view-list__item-wrapper {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 			color: $gray-900;
 
 			.dataviews-title-field,
 			.dataviews-view-list__field {
-				color: var(--wp-admin-theme-color);
+				color: $gray-900;
 			}
 		}
 	}

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -78,9 +78,8 @@ div.dataviews-view-list {
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;
 
-				.dataviews-view-list__title-field,
 				.dataviews-view-list__fields {
-					color: var(--wp-admin-theme-color);
+					color: $gray-900;
 				}
 			}
 		}

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -74,6 +74,12 @@ div.dataviews-view-list {
 			&:focus-within {
 				color: var(--wp-admin-theme-color);
 				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+				border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+
+				& + div[role="row"],
+				& + div[role="article"] {
+					border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+				}
 
 				.dataviews-title-field,
 				.dataviews-view-list__field {


### PR DESCRIPTION
## What
Update and simplify colorisation of fields in DataViews list layout.

## Why
In a previous WP version, hovering a list item caused all text including the title to by colorised by the `theme` color:

<img width="395" height="103" alt="Screenshot 2025-12-10 at 14 58 47" src="https://github.com/user-attachments/assets/67085d4f-b3dc-4a22-8e93-94ba5a5e0cc6" />

At some point that style was lost, and now only the fields are affected:

<img width="459" height="134" alt="Screenshot 2025-12-10 at 15 00 36" src="https://github.com/user-attachments/assets/8dd2d7a2-8f94-41ab-8ce9-b2256bf7ec65" />

Additionally, when an item is selected regular fields use the theme color, but the description field does not:

<img width="991" height="163" alt="Screenshot 2025-12-10 at 15 16 27" src="https://github.com/user-attachments/assets/75366635-13ac-473e-b7ad-a604b87e9d5d" />

There isn't any obvious logic to the colorisation which makes the UX feel a bit confusing.

This PR tidies things up:

* Excluding the title all fields (including description) share color treatment
  * `$gray-700` when 'resting'
  * `var(--wp-admin-theme-color)` when the row is hovered
  * `$gray-900` when selected
* Title is `$gray-900` when resting and selected, and `var(--wp-admin-theme-color)` when hovered

### Before
https://github.com/user-attachments/assets/b253277d-3691-4ac1-9716-d992b012a283

### After
https://github.com/user-attachments/assets/1ce6bc4b-8466-464b-891b-59f4e5058375

## Testing
* `npm run storybook`
* Visit http://localhost:50240/?path=/docs/dataviews-dataviews--docs and check the field color styles match the After video above
* `npm run build`
* Smoke test changes in DataViews pages