### PR TITLE
Add paste logging to writing flow

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -42,8 +42,10 @@ export default ( props ) => ( element ) => {
 		event.preventDefault();
 
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', html );
-		window.console.log( 'Received plain text:\n\n', plainText );
+		// `pasteHandler` also logs this, but we're not using `pasteHandler` in
+		// every case.
+		window.console.log( 'Received HTML (RichText):\n\n', html );
+		window.console.log( 'Received plain text (RichText):\n\n', plainText );
 
 		if ( disableFormats ) {
 			onChange( insert( value, plainText ) );

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -172,6 +172,9 @@ export default function useClipboardHandler() {
 						}, [] )
 						.flat();
 				} else {
+					// Allows us to ask for this information when we get a report.
+					window.console.log( 'Received HTML:\n\n', html );
+					window.console.log( 'Received plain text:\n\n', plainText );
 					blocks = pasteHandler( {
 						HTML: html,
 						plainText,

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -172,9 +172,6 @@ export default function useClipboardHandler() {
 						}, [] )
 						.flat();
 				} else {
-					// Allows us to ask for this information when we get a report.
-					window.console.log( 'Received HTML:\n\n', html );
-					window.console.log( 'Received plain text:\n\n', plainText );
 					blocks = pasteHandler( {
 						HTML: html,
 						plainText,

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -84,6 +84,10 @@ export function pasteHandler( {
 	mode = 'AUTO',
 	tagName,
 } ) {
+	// Allows us to ask for this information when we get a report.
+	log( 'Received HTML (pasteHandler):\n\n', HTML );
+	log( 'Received plain text (pasteHandler):\n\n', plainText );
+
 	// First of all, strip any meta tags.
 	HTML = HTML.replace( /<meta[^>]+>/g, '' );
 	// Strip Windows markers.

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -128,10 +128,6 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 			return;
 		}
 
-		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', html );
-		window.console.log( 'Received plain text:\n\n', plainText );
-
 		const content = pasteHandler( {
 			HTML: html,
 			plainText,

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -355,6 +355,7 @@ describe( 'Blocks raw handling', () => {
 				} )
 			)
 		).toBe( block );
+		expect( console ).toHaveLogged();
 	} );
 
 	it( 'should handle transforms that return an array of blocks', () => {
@@ -493,6 +494,7 @@ describe( 'Blocks raw handling', () => {
 				path.join( __dirname, 'fixtures/documents/windows.html' )
 			);
 			expect( serialize( pasteHandler( { HTML } ) ) ).toMatchSnapshot();
+			expect( console ).toHaveLogged();
 		} );
 
 		it( 'should strip HTML formatting space from inline text', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Since paste handling is mostly routed through the writing flow component since #54543, the paste logging of the original HTML has mostly disappeared.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is invaluable information for bug reports, so let's add it back.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
