### PR TITLE
Components: Fix DateTimePicker timezone handling for non-string values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 -   `Modal`: Fix vertical scroll issue by reducing style specificity to allow overrides. ([#73739](https://github.com/WordPress/gutenberg/pull/73739))
 -   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
+-   `DatePicker`: Fix missing scheduled events and current date indicators. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
+-   `DatePicker`: Fix handling of `currentDate` when passed values as Date or timestamp. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
 
 ### Internal
 

--- a/packages/components/src/date-time/constants.ts
+++ b/packages/components/src/date-time/constants.ts
@@ -1,1 +1,1 @@
-export const TIMEZONELESS_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+export const TIMEZONELESS_FORMAT = 'Y-m-d\\TH:i:s';

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -228,6 +228,12 @@ describe( 'DateTimePicker', () => {
 					transformOnChange: ( nextValue: string ) => nextValue,
 				},
 				{
+					type: 'string with timezone',
+					initialDate: '2025-11-16T01:00:00Z',
+					transformOnChange: ( nextValue: string ) =>
+						transformOnChangeToDate( nextValue ).toISOString(),
+				},
+				{
 					type: 'Date object',
 					initialDate: new Date( Date.UTC( 2025, 10, 16, 1, 0, 0 ) ),
 					transformOnChange: transformOnChangeToDate,

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -179,6 +179,27 @@ describe( 'DateTimePicker', () => {
 							} )
 						).toBeVisible();
 					} );
+
+					it( 'should display event indicators correctly', () => {
+						// Test event indicators, where Date objects constructed
+						// from timezoneless strings are passed to the component
+						// and thus are interpreted in browser timezone.
+
+						timezoneMock.register( timezone );
+
+						render(
+							<DateTimePicker
+								currentDate={ initialDate }
+								events={ [ { date: new Date( initialDate ) } ] }
+							/>
+						);
+
+						expect(
+							screen.getByRole( 'button', {
+								name: `${ initialButton }. There is 1 event`,
+							} )
+						).toBeVisible();
+					} );
 				}
 			);
 		} );
@@ -398,38 +419,5 @@ describe( 'DateTimePicker', () => {
 		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2025-11-20T14:30:00' );
-	} );
-
-	it( 'should display event indicators based on site timezone', () => {
-		timezoneMock.register( 'US/Pacific' );
-
-		render(
-			<DateTimePicker
-				currentDate="2025-11-15T00:00:00"
-				events={ [
-					// Nov 20 10:00 site time
-					{ date: new Date( Date.UTC( 2025, 10, 20, 15, 0, 0 ) ) },
-					// Nov 20 23:00 site time
-					{ date: new Date( Date.UTC( 2025, 10, 21, 4, 0, 0 ) ) },
-					// Nov 21 01:00 site time
-					{ date: new Date( Date.UTC( 2025, 10, 21, 6, 0, 0 ) ) },
-				] }
-			/>
-		);
-		expect(
-			screen.getByRole( 'button', {
-				name: 'November 15, 2025. Selected',
-			} )
-		).toBeVisible();
-		expect(
-			screen.getByRole( 'button', {
-				name: 'November 20, 2025. There are 2 events',
-			} )
-		).toBeVisible();
-		expect(
-			screen.getByRole( 'button', {
-				name: 'November 21, 2025. There is 1 event',
-			} )
-		).toBeVisible();
 	} );
 } );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -185,6 +185,10 @@ describe( 'DateTimePicker', () => {
 	} );
 
 	describe( 'different input types', () => {
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
 		// Input types should be treated assuming the timezone offset configured
 		// through `@wordpress/date` settings, i.e. the site's timezone. Inputs
 		// representing the same site timezone time should display and output
@@ -208,13 +212,30 @@ describe( 'DateTimePicker', () => {
 				transformOnChange: ( nextValue: string ) =>
 					new Date( nextValue ).getTime(),
 			},
+			{
+				type: 'undefined (defaults to current time)',
+				initialDate: undefined,
+				transformOnChange: ( nextValue: string ) => nextValue,
+			},
 		] )( '$type', ( { initialDate, transformOnChange } ) => {
 			it( 'should display and select dates according to site timezone', async () => {
-				const user = userEvent.setup();
-				const onChange = jest.fn();
-
 				timezoneMock.register( 'US/Pacific' );
 
+				// Normalize "current" time to the same time in November, so we
+				// can assert the same beahvior between undefined or explicitly
+				// set initial dates.
+				let user: ReturnType< typeof userEvent.setup >;
+				if ( initialDate === undefined ) {
+					jest.useFakeTimers();
+					jest.setSystemTime( Date.UTC( 2025, 10, 16, 1, 0, 0 ) );
+					user = userEvent.setup( {
+						advanceTimers: jest.advanceTimersByTime,
+					} );
+				} else {
+					user = userEvent.setup();
+				}
+
+				const onChange = jest.fn();
 				const { rerender } = render(
 					<DateTimePicker
 						currentDate={ initialDate }
@@ -248,7 +269,9 @@ describe( 'DateTimePicker', () => {
 				} );
 
 				await user.click(
-					screen.getByRole( 'button', { name: 'November 20, 2025' } )
+					screen.getByRole( 'button', {
+						name: 'November 20, 2025',
+					} )
 				);
 
 				// Changing date should preserve the time, calling onChange with

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -355,6 +355,26 @@ describe( 'DateTimePicker', () => {
 					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
 						0
 					);
+
+					// Ensure week boundaries keyboard navigation is calculated
+					// correctly in the configured timezone, not the browser's.
+					await user.click(
+						screen.getByRole( 'button', {
+							name: 'November 20, 2025. Selected',
+						} )
+					);
+					await user.keyboard( '{Home}' );
+					expect(
+						screen.getByRole( 'button', {
+							name: 'November 16, 2025',
+						} )
+					).toHaveFocus();
+					await user.keyboard( '{End}' );
+					expect(
+						screen.getByRole( 'button', {
+							name: 'November 22, 2025',
+						} )
+					).toHaveFocus();
 				} );
 			} );
 		} );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -184,6 +184,71 @@ describe( 'DateTimePicker', () => {
 		} );
 	} );
 
+	describe( 'different input types', () => {
+		describe.each( [
+			{
+				type: 'timezoneless string',
+				initialDate: '2025-11-15T14:30:00',
+			},
+			{
+				type: 'Date object',
+				initialDate: new Date( Date.UTC( 2025, 10, 15, 14, 30, 0 ) ),
+			},
+			{
+				type: 'timestamp',
+				initialDate: Date.UTC( 2025, 10, 15, 14, 30, 0 ),
+			},
+		] )( '$type', ( { initialDate } ) => {
+			it( 'should display and select dates correctly', async () => {
+				const user = userEvent.setup();
+				const onChange = jest.fn();
+
+				timezoneMock.register( 'US/Pacific' );
+
+				const { rerender } = render(
+					<DateTimePicker
+						currentDate={ initialDate }
+						onChange={ onChange }
+					/>
+				);
+
+				// Should display the correct initial date and time using time
+				// components from the initial date.
+				expect(
+					screen.getByRole( 'button', {
+						name: 'November 15, 2025. Selected',
+					} )
+				).toBeVisible();
+				expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 14 );
+				expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue( 30 );
+
+				onChange.mockImplementation( ( newDate ) => {
+					rerender(
+						<DateTimePicker
+							currentDate={ newDate }
+							onChange={ onChange }
+						/>
+					);
+				} );
+
+				await user.click(
+					screen.getByRole( 'button', { name: 'November 20, 2025' } )
+				);
+
+				// Changing date should preserve the time, calling onChange with
+				// a timezoneless string.
+				expect( onChange ).toHaveBeenCalledWith(
+					'2025-11-20T14:30:00'
+				);
+				expect(
+					screen.getByRole( 'button', {
+						name: 'November 20, 2025. Selected',
+					} )
+				).toBeVisible();
+			} );
+		} );
+	} );
+
 	it( 'should preserve time when changing date', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -185,21 +185,26 @@ describe( 'DateTimePicker', () => {
 	} );
 
 	describe( 'different input types', () => {
+		// Input types should be treated assuming the timezone offset configured
+		// through `@wordpress/date` settings, i.e. the site's timezone. Inputs
+		// representing the same site timezone time should display and output
+		// identically. The site timezone in these tests is UTC-5 (set in
+		// beforeAll), where 20:00 site time = 01:00 UTC the next day.
 		describe.each( [
 			{
-				type: 'timezoneless string',
-				initialDate: '2025-11-15T14:30:00',
+				type: 'timezoneless string (20:00 site time)',
+				initialDate: '2025-11-15T20:00:00',
 			},
 			{
-				type: 'Date object',
-				initialDate: new Date( Date.UTC( 2025, 10, 15, 14, 30, 0 ) ),
+				type: 'Date object (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
+				initialDate: new Date( Date.UTC( 2025, 10, 16, 1, 0, 0 ) ),
 			},
 			{
-				type: 'timestamp',
-				initialDate: Date.UTC( 2025, 10, 15, 14, 30, 0 ),
+				type: 'timestamp (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
+				initialDate: Date.UTC( 2025, 10, 16, 1, 0, 0 ),
 			},
 		] )( '$type', ( { initialDate } ) => {
-			it( 'should display and select dates correctly', async () => {
+			it( 'should display and select dates according to site timezone', async () => {
 				const user = userEvent.setup();
 				const onChange = jest.fn();
 
@@ -212,15 +217,16 @@ describe( 'DateTimePicker', () => {
 					/>
 				);
 
-				// Should display the correct initial date and time using time
-				// components from the initial date.
+				// Should display the correct initial date and time assuming
+				// settings for the current site. If incorrectly using UTC,
+				// this would show Nov 16 at 01:00 instead of Nov 15 at 20:00.
 				expect(
 					screen.getByRole( 'button', {
 						name: 'November 15, 2025. Selected',
 					} )
 				).toBeVisible();
-				expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 14 );
-				expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue( 30 );
+				expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 20 );
+				expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue( 0 );
 
 				onChange.mockImplementation( ( newDate ) => {
 					rerender(
@@ -236,9 +242,10 @@ describe( 'DateTimePicker', () => {
 				);
 
 				// Changing date should preserve the time, calling onChange with
-				// a timezoneless string.
+				// a timezoneless string. The timezoneless string is assumed to
+				// represent the site timezone.
 				expect( onChange ).toHaveBeenCalledWith(
-					'2025-11-20T14:30:00'
+					'2025-11-20T20:00:00'
 				);
 				expect(
 					screen.getByRole( 'button', {
@@ -267,5 +274,57 @@ describe( 'DateTimePicker', () => {
 		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2025-11-20T14:30:00' );
+	} );
+
+	it( 'should be stable when onChange strings are converted to Date and passed back', async () => {
+		// When the site timezone is configured to match the browser timezone,
+		// converting onChange strings to Date objects (via new Date(string))
+		// and passing them back should produce stable results. This is a common
+		// pattern when the consumer wants to work with browser-local times.
+
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		// Configure site timezone to match browser
+		timezoneMock.register( 'US/Pacific' );
+		setSettings( {
+			...originalSettings,
+			timezone: {
+				offset: -8,
+				offsetFormatted: '-8',
+				string: 'America/Los_Angeles',
+				abbr: 'PST',
+			},
+		} );
+
+		let currentDate: string | Date = '2025-11-15T14:30:00';
+
+		const { rerender } = render(
+			<DateTimePicker currentDate={ currentDate } onChange={ onChange } />
+		);
+
+		// Simulate converting onChange string to Date and passing back
+		onChange.mockImplementation( ( newDateString: string ) => {
+			currentDate = new Date( newDateString );
+			rerender(
+				<DateTimePicker
+					currentDate={ currentDate }
+					onChange={ onChange }
+				/>
+			);
+		} );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'November 20, 2025' } )
+		);
+		expect( onChange ).toHaveBeenLastCalledWith( '2025-11-20T14:30:00' );
+
+		// Second interaction should produce identical output (no drift)
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'November 20, 2025. Selected',
+			} )
+		);
+		expect( onChange ).toHaveBeenLastCalledWith( '2025-11-20T14:30:00' );
 	} );
 } );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -246,9 +246,16 @@ describe( 'DateTimePicker', () => {
 				// Should display the correct initial date and time assuming
 				// settings for the current site. If incorrectly using UTC,
 				// this would show Nov 16 at 01:00 instead of Nov 15 at 20:00.
+				//
+				// When initialDate is undefined, the fake time is set to
+				// Nov 16 01:00 UTC (Nov 15 20:00 site time), in which case the
+				// current date of Nov 15 is both "Selected" and "Today".
 				expect(
 					screen.getByRole( 'button', {
-						name: 'November 15, 2025. Selected',
+						name:
+							initialDate === undefined
+								? 'November 15, 2025. Selected. Today'
+								: 'November 15, 2025. Selected',
 					} )
 				).toBeVisible();
 				expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 20 );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -194,16 +194,21 @@ describe( 'DateTimePicker', () => {
 			{
 				type: 'timezoneless string (20:00 site time)',
 				initialDate: '2025-11-15T20:00:00',
+				transformOnChange: ( nextValue: string ) => nextValue,
 			},
 			{
 				type: 'Date object (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
 				initialDate: new Date( Date.UTC( 2025, 10, 16, 1, 0, 0 ) ),
+				transformOnChange: ( nextValue: string ) =>
+					new Date( nextValue ),
 			},
 			{
 				type: 'timestamp (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
 				initialDate: Date.UTC( 2025, 10, 16, 1, 0, 0 ),
+				transformOnChange: ( nextValue: string ) =>
+					new Date( nextValue ).getTime(),
 			},
-		] )( '$type', ( { initialDate } ) => {
+		] )( '$type', ( { initialDate, transformOnChange } ) => {
 			it( 'should display and select dates according to site timezone', async () => {
 				const user = userEvent.setup();
 				const onChange = jest.fn();
@@ -229,9 +234,14 @@ describe( 'DateTimePicker', () => {
 				expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue( 0 );
 
 				onChange.mockImplementation( ( newDate ) => {
+					// Maintain the value in the same format as the initial date
+					// to ensure the next cycle will accurately treat that type
+					// as selected.
+					const nextCurrentDate = transformOnChange( newDate );
+
 					rerender(
 						<DateTimePicker
-							currentDate={ newDate }
+							currentDate={ nextCurrentDate }
 							onChange={ onChange }
 						/>
 					);
@@ -274,57 +284,5 @@ describe( 'DateTimePicker', () => {
 		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2025-11-20T14:30:00' );
-	} );
-
-	it( 'should be stable when onChange strings are converted to Date and passed back', async () => {
-		// When the site timezone is configured to match the browser timezone,
-		// converting onChange strings to Date objects (via new Date(string))
-		// and passing them back should produce stable results. This is a common
-		// pattern when the consumer wants to work with browser-local times.
-
-		const user = userEvent.setup();
-		const onChange = jest.fn();
-
-		// Configure site timezone to match browser
-		timezoneMock.register( 'US/Pacific' );
-		setSettings( {
-			...originalSettings,
-			timezone: {
-				offset: -8,
-				offsetFormatted: '-8',
-				string: 'America/Los_Angeles',
-				abbr: 'PST',
-			},
-		} );
-
-		let currentDate: string | Date = '2025-11-15T14:30:00';
-
-		const { rerender } = render(
-			<DateTimePicker currentDate={ currentDate } onChange={ onChange } />
-		);
-
-		// Simulate converting onChange string to Date and passing back
-		onChange.mockImplementation( ( newDateString: string ) => {
-			currentDate = new Date( newDateString );
-			rerender(
-				<DateTimePicker
-					currentDate={ currentDate }
-					onChange={ onChange }
-				/>
-			);
-		} );
-
-		await user.click(
-			screen.getByRole( 'button', { name: 'November 20, 2025' } )
-		);
-		expect( onChange ).toHaveBeenLastCalledWith( '2025-11-20T14:30:00' );
-
-		// Second interaction should produce identical output (no drift)
-		await user.click(
-			screen.getByRole( 'button', {
-				name: 'November 20, 2025. Selected',
-			} )
-		);
-		expect( onChange ).toHaveBeenLastCalledWith( '2025-11-20T14:30:00' );
 	} );
 } );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -58,17 +58,17 @@ describe( 'DateTimePicker', () => {
 			} )
 		).toBeVisible();
 
-		onChange.mockImplementation( ( newDate ) => {
-			rerender(
-				<DateTimePicker currentDate={ newDate } onChange={ onChange } />
-			);
-		} );
-
 		await user.click(
 			screen.getByRole( 'button', { name: 'November 20, 2025' } )
 		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2025-11-20T00:00:00' );
+
+		const nextDate = onChange.mock.calls[ 0 ][ 0 ];
+		rerender(
+			<DateTimePicker currentDate={ nextDate } onChange={ onChange } />
+		);
+
 		expect(
 			screen.getByRole( 'button', {
 				name: 'November 20, 2025. Selected',
@@ -156,23 +156,23 @@ describe( 'DateTimePicker', () => {
 							} )
 						).toBeVisible();
 
-						onChange.mockImplementation( ( newDate ) => {
-							rerender(
-								<DateTimePicker
-									currentDate={ newDate }
-									onChange={ onChange }
-								/>
-							);
-						} );
-
 						await user.click(
 							screen.getByRole( 'button', { name: clickButton } )
+						);
+
+						expect( onChange ).toHaveBeenCalledWith( expectedDate );
+
+						const nextDate = onChange.mock.calls[ 0 ][ 0 ];
+						rerender(
+							<DateTimePicker
+								currentDate={ nextDate }
+								onChange={ onChange }
+							/>
 						);
 
 						expect( screen.getByLabelText( 'Day' ) ).toHaveValue(
 							expectedDay
 						);
-						expect( onChange ).toHaveBeenCalledWith( expectedDate );
 						expect(
 							screen.getByRole( 'button', {
 								name: selectedButton,
@@ -184,114 +184,172 @@ describe( 'DateTimePicker', () => {
 		} );
 	} );
 
-	describe( 'different input types', () => {
+	describe( 'input types with timezone variations', () => {
 		afterEach( () => {
 			jest.useRealTimers();
+			timezoneMock.unregister();
 		} );
 
-		// Input types should be treated assuming the timezone offset configured
-		// through `@wordpress/date` settings, i.e. the site's timezone. Inputs
-		// representing the same site timezone time should display and output
-		// identically. The site timezone in these tests is UTC-5 (set in
-		// beforeAll), where 20:00 site time = 01:00 UTC the next day.
+		function transformOnChangeToDate( nextValue: string ): Date {
+			// Timezoneless string represents site timezone. Convert to UTC
+			// instant in site timezone. In typical usage, consumers should
+			// align `@wordpress/date` settings to match their browser timezone
+			// when working with dates, to avoid having to manage this
+			// conversion themselves.
+			const settings = getSettings();
+			const offsetMs = settings.timezone.offset * 60 * 60 * 1000;
+			const asUTC = new Date( nextValue + 'Z' );
+			return new Date( asUTC.getTime() - offsetMs );
+		}
+
 		describe.each( [
 			{
-				type: 'timezoneless string (20:00 site time)',
-				initialDate: '2025-11-15T20:00:00',
-				transformOnChange: ( nextValue: string ) => nextValue,
+				direction: 'browser behind site',
+				timezone: 'US/Pacific' as const,
 			},
 			{
-				type: 'Date object (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
-				initialDate: new Date( Date.UTC( 2025, 10, 16, 1, 0, 0 ) ),
-				transformOnChange: ( nextValue: string ) =>
-					new Date( nextValue ),
+				direction: 'browser matches site',
+				timezone: 'US/Eastern' as const,
 			},
 			{
-				type: 'timestamp (01:00 UTC Nov 16 = 20:00 site time Nov 15)',
-				initialDate: Date.UTC( 2025, 10, 16, 1, 0, 0 ),
-				transformOnChange: ( nextValue: string ) =>
-					new Date( nextValue ).getTime(),
+				direction: 'browser ahead of site',
+				timezone: 'Australia/Adelaide' as const,
 			},
-			{
-				type: 'undefined (defaults to current time)',
-				initialDate: undefined,
-				transformOnChange: ( nextValue: string ) => nextValue,
-			},
-		] )( '$type', ( { initialDate, transformOnChange } ) => {
-			it( 'should display and select dates according to site timezone', async () => {
-				timezoneMock.register( 'US/Pacific' );
+		] )( '$direction', ( { timezone } ) => {
+			// Input types should be treated assuming the timezone offset configured
+			// through `@wordpress/date` settings, i.e. the site's timezone. Inputs
+			// representing the same site timezone time should display and output
+			// identically. The site timezone in these tests is UTC-5 (set in
+			// beforeAll), where 20:00 site time = 01:00 UTC the next day.
+			describe.each( [
+				{
+					type: 'timezoneless string',
+					initialDate: '2025-11-15T20:00:00',
+					transformOnChange: ( nextValue: string ) => nextValue,
+				},
+				{
+					type: 'Date object',
+					initialDate: new Date( Date.UTC( 2025, 10, 16, 1, 0, 0 ) ),
+					transformOnChange: transformOnChangeToDate,
+				},
+				{
+					type: 'timestamp',
+					initialDate: Date.UTC( 2025, 10, 16, 1, 0, 0 ),
+					transformOnChange: ( nextValue: string ) =>
+						transformOnChangeToDate( nextValue ).getTime(),
+				},
+				{
+					type: 'undefined',
+					initialDate: undefined,
+					transformOnChange: ( nextValue: string ) => nextValue,
+				},
+			] )( 'with $type', ( { initialDate, transformOnChange } ) => {
+				it( 'should display and select dates according to site timezone', async () => {
+					timezoneMock.register( timezone );
 
-				// Normalize "current" time to the same time in November, so we
-				// can assert the same beahvior between undefined or explicitly
-				// set initial dates.
-				let user: ReturnType< typeof userEvent.setup >;
-				if ( initialDate === undefined ) {
-					jest.useFakeTimers();
-					jest.setSystemTime( Date.UTC( 2025, 10, 16, 1, 0, 0 ) );
-					user = userEvent.setup( {
-						advanceTimers: jest.advanceTimersByTime,
-					} );
-				} else {
-					user = userEvent.setup();
-				}
+					// Normalize "current" time to the same time, so we can
+					// assert the same behavior between undefined or explicitly
+					// set initial dates.
+					let user: ReturnType< typeof userEvent.setup >;
+					if ( initialDate === undefined ) {
+						jest.useFakeTimers();
+						jest.setSystemTime( Date.UTC( 2025, 10, 16, 1, 0, 0 ) );
+						user = userEvent.setup( {
+							advanceTimers: jest.advanceTimersByTime,
+						} );
+					} else {
+						user = userEvent.setup();
+					}
 
-				const onChange = jest.fn();
-				const { rerender } = render(
-					<DateTimePicker
-						currentDate={ initialDate }
-						onChange={ onChange }
-					/>
-				);
-
-				// Should display the correct initial date and time assuming
-				// settings for the current site. If incorrectly using UTC,
-				// this would show Nov 16 at 01:00 instead of Nov 15 at 20:00.
-				//
-				// When initialDate is undefined, the fake time is set to
-				// Nov 16 01:00 UTC (Nov 15 20:00 site time), in which case the
-				// current date of Nov 15 is both "Selected" and "Today".
-				expect(
-					screen.getByRole( 'button', {
-						name:
-							initialDate === undefined
-								? 'November 15, 2025. Selected. Today'
-								: 'November 15, 2025. Selected',
-					} )
-				).toBeVisible();
-				expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 20 );
-				expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue( 0 );
-
-				onChange.mockImplementation( ( newDate ) => {
-					// Maintain the value in the same format as the initial date
-					// to ensure the next cycle will accurately treat that type
-					// as selected.
-					const nextCurrentDate = transformOnChange( newDate );
-
-					rerender(
+					const onChange = jest.fn();
+					const { rerender } = render(
 						<DateTimePicker
-							currentDate={ nextCurrentDate }
+							currentDate={ initialDate }
 							onChange={ onChange }
 						/>
 					);
+
+					// Should display the correct initial date and time assuming
+					// settings for the current site. If incorrectly using UTC,
+					// this would show Nov 16 at 01:00 instead of Nov 15 at 20:00.
+					//
+					// When initialDate is undefined, the fake time is set to
+					// Nov 16 01:00 UTC (Nov 15 20:00 site time), in which case the
+					// current date of Nov 15 is both "Selected" and "Today".
+					expect(
+						screen.getByRole( 'button', {
+							name:
+								initialDate === undefined
+									? 'November 15, 2025. Selected. Today'
+									: 'November 15, 2025. Selected',
+						} )
+					).toBeVisible();
+					expect( screen.getByLabelText( 'Hours' ) ).toHaveValue(
+						20
+					);
+					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
+						0
+					);
+
+					await user.click(
+						screen.getByRole( 'button', {
+							name: 'November 20, 2025',
+						} )
+					);
+
+					// Changing date should preserve the time, calling onChange with
+					// a timezoneless string. The timezoneless string is assumed to
+					// represent the site timezone.
+					expect( onChange ).toHaveBeenCalledWith(
+						'2025-11-20T20:00:00'
+					);
+
+					let nextDate = onChange.mock.calls[ 0 ][ 0 ];
+					rerender(
+						<DateTimePicker
+							currentDate={ transformOnChange( nextDate ) }
+							onChange={ onChange }
+						/>
+					);
+
+					expect(
+						screen.getByRole( 'button', {
+							name: 'November 20, 2025. Selected',
+						} )
+					).toBeVisible();
+					expect( screen.getByLabelText( 'Hours' ) ).toHaveValue(
+						20
+					);
+					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
+						0
+					);
+
+					// Changing the time should output timezoneless string with
+					// only the updated hour, and not changing the date.
+					onChange.mockClear();
+					const hoursInput = screen.getByLabelText( 'Hours' );
+					await user.clear( hoursInput );
+					await user.type( hoursInput, '22' );
+					await user.keyboard( '{Tab}' );
+					expect( onChange ).toHaveBeenCalledWith(
+						'2025-11-20T22:00:00'
+					);
+
+					nextDate = onChange.mock.calls[ 0 ][ 0 ];
+					rerender(
+						<DateTimePicker
+							currentDate={ transformOnChange( nextDate ) }
+							onChange={ onChange }
+						/>
+					);
+
+					expect( screen.getByLabelText( 'Hours' ) ).toHaveValue(
+						22
+					);
+					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
+						0
+					);
 				} );
-
-				await user.click(
-					screen.getByRole( 'button', {
-						name: 'November 20, 2025',
-					} )
-				);
-
-				// Changing date should preserve the time, calling onChange with
-				// a timezoneless string. The timezoneless string is assumed to
-				// represent the site timezone.
-				expect( onChange ).toHaveBeenCalledWith(
-					'2025-11-20T20:00:00'
-				);
-				expect(
-					screen.getByRole( 'button', {
-						name: 'November 20, 2025. Selected',
-					} )
-				).toBeVisible();
 			} );
 		} );
 	} );

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -315,4 +315,37 @@ describe( 'DateTimePicker', () => {
 
 		expect( onChange ).toHaveBeenCalledWith( '2025-11-20T14:30:00' );
 	} );
+
+	it( 'should display event indicators based on site timezone', () => {
+		timezoneMock.register( 'US/Pacific' );
+
+		render(
+			<DateTimePicker
+				currentDate="2025-11-15T00:00:00"
+				events={ [
+					// Nov 20 10:00 site time
+					{ date: new Date( Date.UTC( 2025, 10, 20, 15, 0, 0 ) ) },
+					// Nov 20 23:00 site time
+					{ date: new Date( Date.UTC( 2025, 10, 21, 4, 0, 0 ) ) },
+					// Nov 21 01:00 site time
+					{ date: new Date( Date.UTC( 2025, 10, 21, 6, 0, 0 ) ) },
+				] }
+			/>
+		);
+		expect(
+			screen.getByRole( 'button', {
+				name: 'November 15, 2025. Selected',
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'November 20, 2025. There are 2 events',
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'November 21, 2025. There is 1 event',
+			} )
+		).toBeVisible();
+	} );
 } );

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -5,14 +5,12 @@ import {
 	isSameDay,
 	subMonths,
 	addMonths,
-	startOfDay,
 	isEqual,
 	addDays,
+	subDays,
 	subWeeks,
 	addWeeks,
 	isSameMonth,
-	startOfWeek,
-	endOfWeek,
 } from 'date-fns';
 import type { KeyboardEventHandler } from 'react';
 
@@ -248,11 +246,23 @@ export function DatePicker( {
 										nextFocusable = addMonths( day, 1 );
 									}
 									if ( event.key === 'Home' ) {
-										nextFocusable = startOfWeek( day );
+										const dayOfWeek = day.getDay();
+										const daysToSubtract =
+											( dayOfWeek - weekStartsOn + 7 ) %
+											7;
+										nextFocusable = subDays(
+											day,
+											daysToSubtract
+										);
 									}
 									if ( event.key === 'End' ) {
-										nextFocusable = startOfDay(
-											endOfWeek( day )
+										const dayOfWeek = day.getDay();
+										const daysToAdd =
+											( weekStartsOn + 6 - dayOfWeek ) %
+											7;
+										nextFocusable = addDays(
+											day,
+											daysToAdd
 										);
 									}
 									if ( nextFocusable ) {

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -193,12 +193,7 @@ export function DatePicker( {
 								}
 								numEvents={
 									events.filter( ( event ) =>
-										isSameDay(
-											day,
-											startOfDayInConfiguredTimezone(
-												event.date
-											)
-										)
+										isSameDay( event.date, day )
 									).length
 								}
 								onClick={ () => {

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -191,7 +191,12 @@ export function DatePicker( {
 								}
 								numEvents={
 									events.filter( ( event ) =>
-										isSameDay( event.date, day )
+										isSameDay(
+											day,
+											startOfDayInConfiguredTimezone(
+												event.date
+											)
+										)
 									).length
 								}
 								onClick={ () => {

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -69,7 +69,7 @@ export function DatePicker( {
 	onMonthPreviewed,
 	startOfWeek: weekStartsOn = 0,
 }: DatePickerProps ) {
-	const date = currentDate ? inputToDate( currentDate ) : new Date();
+	const date = inputToDate( currentDate ?? new Date() );
 
 	const {
 		calendar,

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -182,7 +182,10 @@ export function DatePicker( {
 								isSelected={ isSelected( day ) }
 								isFocusable={ isEqual( day, focusable ) }
 								isFocusAllowed={ isFocusWithinCalendar }
-								isToday={ isSameDay( day, new Date() ) }
+								isToday={ isSameDay(
+									day,
+									startOfDayInConfiguredTimezone( new Date() )
+								) }
 								isInvalid={
 									isInvalidDate ? isInvalidDate( day ) : false
 								}
@@ -326,7 +329,7 @@ function Day( {
 			className="components-datetime__date__day" // Unused, for backwards compatibility.
 			disabled={ isInvalid }
 			tabIndex={ isFocusable ? 0 : -1 }
-			aria-label={ getDayLabel( day, isSelected, numEvents ) }
+			aria-label={ getDayLabel( day, isSelected, isToday, numEvents ) }
 			column={ column }
 			isSelected={ isSelected }
 			isToday={ isToday }
@@ -339,43 +342,40 @@ function Day( {
 	);
 }
 
-function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
+function getDayLabel(
+	date: Date,
+	isSelected: boolean,
+	isToday: boolean,
+	numEvents: number
+) {
 	const { formats } = getSettings();
 	const localizedDate = dateI18n(
 		formats.date,
 		date,
 		-date.getTimezoneOffset()
 	);
-	if ( isSelected && numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n(
-				'%1$s. Selected. There is %2$d event',
-				'%1$s. Selected. There are %2$d events',
+
+	const parts = [ localizedDate ];
+
+	if ( isSelected ) {
+		parts.push( __( 'Selected' ) );
+	}
+
+	if ( isToday ) {
+		parts.push( __( 'Today' ) );
+	}
+
+	if ( numEvents > 0 ) {
+		parts.push(
+			sprintf(
+				// translators: %d: Number of events on the calendar date.
+				_n( 'There is %d event', 'There are %d events', numEvents ),
 				numEvents
-			),
-			localizedDate,
-			numEvents
-		);
-	} else if ( isSelected ) {
-		return sprintf(
-			// translators: 1: The calendar date.
-			__( '%1$s. Selected' ),
-			localizedDate
-		);
-	} else if ( numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n(
-				'%1$s. There is %2$d event',
-				'%1$s. There are %2$d events',
-				numEvents
-			),
-			localizedDate,
-			numEvents
+			)
 		);
 	}
-	return localizedDate;
+
+	return parts.join( '. ' );
 }
 
 export default DatePicker;

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	format,
 	isSameDay,
 	subMonths,
 	addMonths,
@@ -22,7 +21,7 @@ import type { KeyboardEventHandler } from 'react';
  */
 import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { getSettings, gmdateI18n } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
@@ -40,7 +39,7 @@ import {
 	DayOfWeek,
 	DayButton,
 } from './styles';
-import { inputToDate } from '../utils';
+import { inputToDate, startOfDayInConfiguredTimezone } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
@@ -81,14 +80,16 @@ export function DatePicker( {
 		viewPreviousMonth,
 		viewNextMonth,
 	} = useLilius( {
-		selected: [ startOfDay( date ) ],
-		viewing: startOfDay( date ),
+		selected: [ startOfDayInConfiguredTimezone( date ) ],
+		viewing: startOfDayInConfiguredTimezone( date ),
 		weekStartsOn,
 	} );
 
 	// Used to implement a roving tab index. Tracks the day that receives focus
 	// when the user tabs into the calendar.
-	const [ focusable, setFocusable ] = useState( startOfDay( date ) );
+	const [ focusable, setFocusable ] = useState(
+		startOfDayInConfiguredTimezone( date )
+	);
 
 	// Allows us to only programmatically focus() a day when focus was already
 	// within the calendar. This stops us stealing focus from e.g. a TimePicker
@@ -100,9 +101,9 @@ export function DatePicker( {
 	const [ prevCurrentDate, setPrevCurrentDate ] = useState( currentDate );
 	if ( currentDate !== prevCurrentDate ) {
 		setPrevCurrentDate( currentDate );
-		setSelected( [ startOfDay( date ) ] );
-		setViewing( startOfDay( date ) );
-		setFocusable( startOfDay( date ) );
+		setSelected( [ startOfDayInConfiguredTimezone( date ) ] );
+		setViewing( startOfDayInConfiguredTimezone( date ) );
+		setFocusable( startOfDayInConfiguredTimezone( date ) );
 	}
 
 	return (
@@ -119,18 +120,26 @@ export function DatePicker( {
 					onClick={ () => {
 						viewPreviousMonth();
 						setFocusable( subMonths( focusable, 1 ) );
+						const prevMonth = subMonths( viewing, 1 );
 						onMonthPreviewed?.(
-							format(
-								subMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
+							dateI18n(
+								TIMEZONELESS_FORMAT,
+								prevMonth,
+								-prevMonth.getTimezoneOffset()
 							)
 						);
 					} }
 					size="compact"
 				/>
 				<NavigatorHeading level={ 3 }>
-					<strong>{ gmdateI18n( 'F', viewing ) }</strong>{ ' ' }
-					{ gmdateI18n( 'Y', viewing ) }
+					<strong>
+						{ dateI18n(
+							'F',
+							viewing,
+							-viewing.getTimezoneOffset()
+						) }
+					</strong>{ ' ' }
+					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
 				</NavigatorHeading>
 				<ViewNextMonthButton
 					icon={ isRTL() ? arrowLeft : arrowRight }
@@ -139,10 +148,12 @@ export function DatePicker( {
 					onClick={ () => {
 						viewNextMonth();
 						setFocusable( addMonths( focusable, 1 ) );
+						const nextMonth = addMonths( viewing, 1 );
 						onMonthPreviewed?.(
-							format(
-								addMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
+							dateI18n(
+								TIMEZONELESS_FORMAT,
+								nextMonth,
+								-nextMonth.getTimezoneOffset()
 							)
 						);
 					} }
@@ -155,7 +166,7 @@ export function DatePicker( {
 			>
 				{ calendar[ 0 ][ 0 ].map( ( day ) => (
 					<DayOfWeek key={ day.toString() }>
-						{ gmdateI18n( 'D', day ) }
+						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
 					</DayOfWeek>
 				) ) }
 				{ calendar[ 0 ].map( ( week ) =>
@@ -183,19 +194,27 @@ export function DatePicker( {
 								onClick={ () => {
 									setSelected( [ day ] );
 									setFocusable( day );
+									// Combine clicked day with current time in configured timezone
+									const { timezone } = getSettings();
+									const offsetMs =
+										timezone.offset * 60 * 60 * 1000;
+									const shiftedDate = new Date(
+										date.getTime() + offsetMs
+									);
+									const combined = new Date(
+										day.getFullYear(),
+										day.getMonth(),
+										day.getDate(),
+										shiftedDate.getUTCHours(),
+										shiftedDate.getUTCMinutes(),
+										shiftedDate.getUTCSeconds()
+									);
+									// Format using browser offset since combined is browser-local
 									onChange?.(
-										format(
-											// Don't change the selected date's time fields.
-											new Date(
-												day.getFullYear(),
-												day.getMonth(),
-												day.getDate(),
-												date.getHours(),
-												date.getMinutes(),
-												date.getSeconds(),
-												date.getMilliseconds()
-											),
-											TIMEZONELESS_FORMAT
+										dateI18n(
+											TIMEZONELESS_FORMAT,
+											combined,
+											-combined.getTimezoneOffset()
 										)
 									);
 								} }
@@ -244,9 +263,10 @@ export function DatePicker( {
 										) {
 											setViewing( nextFocusable );
 											onMonthPreviewed?.(
-												format(
+												dateI18n(
+													TIMEZONELESS_FORMAT,
 													nextFocusable,
-													TIMEZONELESS_FORMAT
+													-nextFocusable.getTimezoneOffset()
 												)
 											);
 										}
@@ -314,14 +334,18 @@ function Day( {
 			onClick={ onClick }
 			onKeyDown={ onKeyDown }
 		>
-			{ gmdateI18n( 'j', day ) }
+			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
 		</DayButton>
 	);
 }
 
 function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
 	const { formats } = getSettings();
-	const localizedDate = gmdateI18n( formats.date, date );
+	const localizedDate = dateI18n(
+		formats.date,
+		date,
+		-date.getTimezoneOffset()
+	);
 	if ( isSelected && numEvents > 0 ) {
 		return sprintf(
 			// translators: 1: The calendar date. 2: Number of events on the calendar date.

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -21,7 +21,7 @@ import type { KeyboardEventHandler } from 'react';
  */
 import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { dateI18n, getSettings } from '@wordpress/date';
+import { dateI18n, date as formatDate, getSettings } from '@wordpress/date';
 import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
@@ -39,7 +39,11 @@ import {
 	DayOfWeek,
 	DayButton,
 } from './styles';
-import { inputToDate, startOfDayInConfiguredTimezone } from '../utils';
+import {
+	inputToDate,
+	setInConfiguredTimezone,
+	startOfDayInConfiguredTimezone,
+} from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
@@ -202,27 +206,18 @@ export function DatePicker( {
 								onClick={ () => {
 									setSelected( [ day ] );
 									setFocusable( day );
-									// Combine clicked day with current time in configured timezone
-									const { timezone } = getSettings();
-									const offsetMs =
-										timezone.offset * 60 * 60 * 1000;
-									const shiftedDate = new Date(
-										date.getTime() + offsetMs
+									const newDate = setInConfiguredTimezone(
+										date,
+										{
+											year: day.getFullYear(),
+											month: day.getMonth(),
+											date: day.getDate(),
+										}
 									);
-									const combined = new Date(
-										day.getFullYear(),
-										day.getMonth(),
-										day.getDate(),
-										shiftedDate.getUTCHours(),
-										shiftedDate.getUTCMinutes(),
-										shiftedDate.getUTCSeconds()
-									);
-									// Format using browser offset since combined is browser-local
 									onChange?.(
-										dateI18n(
+										formatDate(
 											TIMEZONELESS_FORMAT,
-											combined,
-											-combined.getTimezoneOffset()
+											newDate
 										)
 									);
 								} }

--- a/packages/components/src/date-time/date/test/index.tsx
+++ b/packages/components/src/date-time/date/test/index.tsx
@@ -25,7 +25,7 @@ describe( 'DatePicker', () => {
 		const todayDescription = format( new Date(), 'MMMM d, yyyy' );
 		expect(
 			screen.getByRole( 'button', {
-				name: `${ todayDescription }. Selected`,
+				name: `${ todayDescription }. Selected. Today`,
 			} )
 		).toBeInTheDocument();
 	} );

--- a/packages/components/src/date-time/test/utils.test.ts
+++ b/packages/components/src/date-time/test/utils.test.ts
@@ -106,23 +106,33 @@ describe( 'inputToDate', () => {
 		} );
 	} );
 
-	describe( 'non-string inputs', () => {
-		it( 'should handle Date objects', () => {
-			const input = new Date( '2025-11-01T00:00:00Z' );
+	describe( 'Date objects', () => {
+		it( 'should extract the UTC timestamp from Date objects', () => {
+			const timestamp = Date.UTC( 2025, 10, 1, 15, 30, 45 );
+			const input = new Date( timestamp );
 			const result = inputToDate( input );
 
+			// Should preserve the exact UTC moment, not local time components
 			expect( result.getUTCFullYear() ).toBe( 2025 );
-			expect( result.getUTCMonth() ).toBe( 10 );
+			expect( result.getUTCMonth() ).toBe( 10 ); // November
 			expect( result.getUTCDate() ).toBe( 1 );
+			expect( result.getUTCHours() ).toBe( 15 );
+			expect( result.getUTCMinutes() ).toBe( 30 );
+			expect( result.getUTCSeconds() ).toBe( 45 );
 		} );
+	} );
 
-		it( 'should convert timestamps to Date', () => {
-			const timestamp = Date.UTC( 2025, 10, 1, 0, 0, 0 );
+	describe( 'timestamps', () => {
+		it( 'should preserve the UTC moment exactly', () => {
+			const timestamp = Date.UTC( 2025, 10, 1, 15, 30, 45 );
 			const result = inputToDate( timestamp );
 
 			expect( result.getUTCFullYear() ).toBe( 2025 );
-			expect( result.getUTCMonth() ).toBe( 10 );
+			expect( result.getUTCMonth() ).toBe( 10 ); // November
 			expect( result.getUTCDate() ).toBe( 1 );
+			expect( result.getUTCHours() ).toBe( 15 );
+			expect( result.getUTCMinutes() ).toBe( 30 );
+			expect( result.getUTCSeconds() ).toBe( 45 );
 		} );
 	} );
 } );

--- a/packages/components/src/date-time/test/utils.test.ts
+++ b/packages/components/src/date-time/test/utils.test.ts
@@ -185,16 +185,23 @@ describe( 'inputToDate', () => {
 	} );
 
 	describe( 'Date objects', () => {
-		it( 'should extract the UTC timestamp from Date objects', () => {
+		it( 'should extract the UTC timestamp, not local time components', () => {
+			// Mock Pacific timezone where local time differs from UTC.
+			// This ensures the test fails on trunk if we incorrectly preserve
+			// local components instead of extracting the UTC timestamp.
+			timezoneMock.register( 'US/Pacific' );
+
+			// Create Nov 1, 2025 at 15:30:45 UTC
 			const timestamp = Date.UTC( 2025, 10, 1, 15, 30, 45 );
 			const input = new Date( timestamp );
 			const result = inputToDate( input );
 
-			// Should preserve the exact UTC moment, not local time components
+			// Should preserve the exact UTC moment (15:30:45), not the local
+			// Pacific time components (7:30:45 or 8:30:45 depending on DST).
 			expect( result.getUTCFullYear() ).toBe( 2025 );
 			expect( result.getUTCMonth() ).toBe( 10 ); // November
 			expect( result.getUTCDate() ).toBe( 1 );
-			expect( result.getUTCHours() ).toBe( 15 );
+			expect( result.getUTCHours() ).toBe( 15 ); // UTC hour, not 7 or 8
 			expect( result.getUTCMinutes() ).toBe( 30 );
 			expect( result.getUTCSeconds() ).toBe( 45 );
 		} );

--- a/packages/components/src/date-time/test/utils.test.ts
+++ b/packages/components/src/date-time/test/utils.test.ts
@@ -9,6 +9,10 @@ import timezoneMock from 'timezone-mock';
 import { inputToDate } from '../utils';
 
 describe( 'inputToDate', () => {
+	afterEach( () => {
+		timezoneMock.unregister();
+	} );
+
 	describe( 'timezoneless strings parsed as UTC', () => {
 		describe.each( [
 			{
@@ -26,10 +30,6 @@ describe( 'inputToDate', () => {
 		] )( 'in $description', ( { timezone } ) => {
 			beforeEach( () => {
 				timezoneMock.register( timezone );
-			} );
-
-			afterEach( () => {
-				timezoneMock.unregister();
 			} );
 
 			it( 'should parse midnight as UTC midnight, preventing day shifts', () => {
@@ -124,6 +124,10 @@ describe( 'inputToDate', () => {
 
 	describe( 'timestamps', () => {
 		it( 'should preserve the UTC moment exactly', () => {
+			// Ensure we're using a different timezone from UTC (the tests use
+			// UTC by default).
+			timezoneMock.register( 'US/Pacific' );
+
 			const timestamp = Date.UTC( 2025, 10, 1, 15, 30, 45 );
 			const result = inputToDate( timestamp );
 

--- a/packages/components/src/date-time/test/utils.test.ts
+++ b/packages/components/src/date-time/test/utils.test.ts
@@ -4,16 +4,45 @@
 import timezoneMock from 'timezone-mock';
 
 /**
+ * WordPress dependencies
+ */
+import { getSettings, setSettings, type DateSettings } from '@wordpress/date';
+
+/**
  * Internal dependencies
  */
 import { inputToDate } from '../utils';
 
 describe( 'inputToDate', () => {
+	let originalSettings: DateSettings;
+
+	beforeAll( () => {
+		originalSettings = getSettings();
+	} );
+
 	afterEach( () => {
 		timezoneMock.unregister();
 	} );
 
-	describe( 'timezoneless strings parsed as UTC', () => {
+	afterAll( () => {
+		setSettings( originalSettings );
+	} );
+
+	describe( 'timezoneless strings', () => {
+		beforeEach( () => {
+			// Default settings are UTC, but make it explicit so these tests
+			// don't depend on global settings state.
+			setSettings( {
+				...originalSettings,
+				timezone: {
+					offset: 0,
+					offsetFormatted: '0',
+					string: '',
+					abbr: '',
+				},
+			} );
+		} );
+
 		describe.each( [
 			{
 				timezone: 'US/Pacific' as const,
@@ -64,6 +93,55 @@ describe( 'inputToDate', () => {
 				expect( result.getUTCHours() ).toBe( 0 );
 				expect( result.getUTCMinutes() ).toBe( 0 );
 				expect( result.getUTCSeconds() ).toBe( 0 );
+			} );
+		} );
+	} );
+
+	describe( 'timezoneless strings with a site timezone string (DST-aware)', () => {
+		beforeEach( () => {
+			setSettings( {
+				...originalSettings,
+				timezone: {
+					offset: -5,
+					offsetFormatted: '-5',
+					string: 'America/New_York',
+					abbr: 'EST',
+				},
+			} );
+		} );
+
+		describe.each( [
+			{
+				timezone: 'US/Pacific' as const,
+				description: 'Pacific time (behind UTC)',
+			},
+			{
+				timezone: 'UTC' as const,
+				description: 'UTC (zero offset)',
+			},
+			{
+				timezone: 'Australia/Adelaide' as const,
+				description: 'Adelaide (ahead of UTC)',
+			},
+		] )( 'in $description', ( { timezone } ) => {
+			beforeEach( () => {
+				timezoneMock.register( timezone );
+			} );
+
+			it( 'should interpret midnight using site timezone (winter)', () => {
+				// Jan 10 is Eastern Standard Time in New York (UTC-5)
+				const result = inputToDate( '2025-01-10T00:00:00' );
+				expect( result.toISOString() ).toBe(
+					'2025-01-10T05:00:00.000Z'
+				);
+			} );
+
+			it( 'should interpret midnight using site timezone (summer/DST)', () => {
+				// Mar 10 is Eastern Daylight Time in New York (UTC-4)
+				const result = inputToDate( '2025-03-10T00:00:00' );
+				expect( result.toISOString() ).toBe(
+					'2025-03-10T04:00:00.000Z'
+				);
 			} );
 		} );
 	} );

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -8,7 +8,7 @@ import { startOfMinute } from 'date-fns';
  */
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getSettings } from '@wordpress/date';
+import { date as formatDate } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -92,23 +92,19 @@ export function TimePicker( {
 		{ value: '12', label: __( 'December' ) },
 	] as const;
 
-	const { day, month, year, minutes, hours } = useMemo( () => {
-		// Internal date is UTC-normalized, but should be displayed using
-		// configured timezone offset.
-		const { timezone } = getSettings();
-		const offsetMinutes = timezone.offset * 60;
-		return {
-			day: dateI18n( 'd', date, offsetMinutes ),
-			month: dateI18n(
+	const { day, month, year, minutes, hours } = useMemo(
+		() => ( {
+			day: formatDate( 'd', date ),
+			month: formatDate(
 				'm',
-				date,
-				offsetMinutes
+				date
 			) as ( typeof monthOptions )[ number ][ 'value' ],
-			year: dateI18n( 'Y', date, offsetMinutes ),
-			minutes: dateI18n( 'i', date, offsetMinutes ),
-			hours: dateI18n( 'H', date, offsetMinutes ),
-		};
-	}, [ date ] );
+			year: formatDate( 'Y', date ),
+			minutes: formatDate( 'i', date ),
+			hours: formatDate( 'H', date ),
+		} ),
+		[ date ]
+	);
 
 	const buildNumberControlChangeCallback = ( method: 'date' | 'year' ) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
@@ -125,12 +121,7 @@ export function TimePicker( {
 				[ method ]: numberValue,
 			} );
 			setDate( newDate );
-
-			// Format output using configured timezone offset
-			const { timezone } = getSettings();
-			onChange?.(
-				dateI18n( TIMEZONELESS_FORMAT, newDate, timezone.offset * 60 )
-			);
+			onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
 		};
 		return callback;
 	};
@@ -146,12 +137,7 @@ export function TimePicker( {
 			minutes: newMinutes,
 		} );
 		setDate( newDate );
-
-		// Format output using configured timezone offset
-		const { timezone } = getSettings();
-		onChange?.(
-			dateI18n( TIMEZONELESS_FORMAT, newDate, timezone.offset * 60 )
-		);
+		onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
 	};
 
 	const dayField = (
@@ -190,16 +176,7 @@ export function TimePicker( {
 						month: Number( value ) - 1,
 					} );
 					setDate( newDate );
-
-					// Format output using configured timezone offset
-					const { timezone } = getSettings();
-					onChange?.(
-						dateI18n(
-							TIMEZONELESS_FORMAT,
-							newDate,
-							timezone.offset * 60
-						)
-					);
+					onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
 				} }
 			/>
 		</MonthSelectWrapper>

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { startOfMinute, format, set, setMonth } from 'date-fns';
+import { startOfMinute, set, setMonth } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -96,15 +97,15 @@ export function TimePicker( {
 
 	const { day, month, year, minutes, hours } = useMemo(
 		() => ( {
-			day: format( date, 'dd' ),
-			month: format(
-				date,
-				'MM'
+			// Use dateI18n to display values in the configured timezone.
+			day: dateI18n( 'd', date ),
+			month: dateI18n(
+				'm',
+				date
 			) as ( typeof monthOptions )[ number ][ 'value' ],
-			year: format( date, 'yyyy' ),
-			minutes: format( date, 'mm' ),
-			hours: format( date, 'HH' ),
-			am: format( date, 'a' ),
+			year: dateI18n( 'Y', date ),
+			minutes: dateI18n( 'i', date ),
+			hours: dateI18n( 'H', date ),
 		} ),
 		[ date ]
 	);
@@ -120,7 +121,13 @@ export function TimePicker( {
 
 			const newDate = set( date, { [ method ]: numberValue } );
 			setDate( newDate );
-			onChange?.( format( newDate, TIMEZONELESS_FORMAT ) );
+			onChange?.(
+				dateI18n(
+					TIMEZONELESS_FORMAT,
+					newDate,
+					-newDate.getTimezoneOffset()
+				)
+			);
 		};
 		return callback;
 	};
@@ -134,7 +141,13 @@ export function TimePicker( {
 			minutes: newMinutes,
 		} );
 		setDate( newDate );
-		onChange?.( format( newDate, TIMEZONELESS_FORMAT ) );
+		onChange?.(
+			dateI18n(
+				TIMEZONELESS_FORMAT,
+				newDate,
+				-newDate.getTimezoneOffset()
+			)
+		);
 	};
 
 	const dayField = (
@@ -169,7 +182,13 @@ export function TimePicker( {
 				onChange={ ( value ) => {
 					const newDate = setMonth( date, Number( value ) - 1 );
 					setDate( newDate );
-					onChange?.( format( newDate, TIMEZONELESS_FORMAT ) );
+					onChange?.(
+						dateI18n(
+							TIMEZONELESS_FORMAT,
+							newDate,
+							-newDate.getTimezoneOffset()
+						)
+					);
 				} }
 			/>
 		</MonthSelectWrapper>

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { startOfMinute, set, setMonth } from 'date-fns';
+import { startOfMinute } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ import {
 	inputToDate,
 	buildPadInputStateReducer,
 	validateInputElementTarget,
+	setInConfiguredTimezone,
 } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 import { TimeInput } from './time-input';
@@ -91,20 +92,23 @@ export function TimePicker( {
 		{ value: '12', label: __( 'December' ) },
 	] as const;
 
-	const { day, month, year, minutes, hours } = useMemo(
-		() => ( {
-			// Use dateI18n to display values in the configured timezone.
-			day: dateI18n( 'd', date ),
+	const { day, month, year, minutes, hours } = useMemo( () => {
+		// Internal date is UTC-normalized, but should be displayed using
+		// configured timezone offset.
+		const { timezone } = getSettings();
+		const offsetMinutes = timezone.offset * 60;
+		return {
+			day: dateI18n( 'd', date, offsetMinutes ),
 			month: dateI18n(
 				'm',
-				date
+				date,
+				offsetMinutes
 			) as ( typeof monthOptions )[ number ][ 'value' ],
-			year: dateI18n( 'Y', date ),
-			minutes: dateI18n( 'i', date ),
-			hours: dateI18n( 'H', date ),
-		} ),
-		[ date ]
-	);
+			year: dateI18n( 'Y', date, offsetMinutes ),
+			minutes: dateI18n( 'i', date, offsetMinutes ),
+			hours: dateI18n( 'H', date, offsetMinutes ),
+		};
+	}, [ date ] );
 
 	const buildNumberControlChangeCallback = ( method: 'date' | 'year' ) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
@@ -115,14 +119,17 @@ export function TimePicker( {
 			// We can safely assume value is a number if target is valid.
 			const numberValue = Number( value );
 
-			const newDate = set( date, { [ method ]: numberValue } );
+			// Internal date is UTC-normalized, but the field should be updated
+			// as if in the configured timezone.
+			const newDate = setInConfiguredTimezone( date, {
+				[ method ]: numberValue,
+			} );
 			setDate( newDate );
+
+			// Format output using configured timezone offset
+			const { timezone } = getSettings();
 			onChange?.(
-				dateI18n(
-					TIMEZONELESS_FORMAT,
-					newDate,
-					-newDate.getTimezoneOffset()
-				)
+				dateI18n( TIMEZONELESS_FORMAT, newDate, timezone.offset * 60 )
 			);
 		};
 		return callback;
@@ -132,17 +139,18 @@ export function TimePicker( {
 		hours: newHours,
 		minutes: newMinutes,
 	}: TimeInputValue ) => {
-		const newDate = set( date, {
+		// Internal date is UTC-normalized, but the field should be updated
+		// as if in the configured timezone.
+		const newDate = setInConfiguredTimezone( date, {
 			hours: newHours,
 			minutes: newMinutes,
 		} );
 		setDate( newDate );
+
+		// Format output using configured timezone offset
+		const { timezone } = getSettings();
 		onChange?.(
-			dateI18n(
-				TIMEZONELESS_FORMAT,
-				newDate,
-				-newDate.getTimezoneOffset()
-			)
+			dateI18n( TIMEZONELESS_FORMAT, newDate, timezone.offset * 60 )
 		);
 	};
 
@@ -176,13 +184,20 @@ export function TimePicker( {
 				value={ month }
 				options={ monthOptions }
 				onChange={ ( value ) => {
-					const newDate = setMonth( date, Number( value ) - 1 );
+					// Internal date is UTC-normalized, but the field should be updated
+					// as if in the configured timezone.
+					const newDate = setInConfiguredTimezone( date, {
+						month: Number( value ) - 1,
+					} );
 					setDate( newDate );
+
+					// Format output using configured timezone offset
+					const { timezone } = getSettings();
 					onChange?.(
 						dateI18n(
 							TIMEZONELESS_FORMAT,
 							newDate,
-							-newDate.getTimezoneOffset()
+							timezone.offset * 60
 						)
 					);
 				} }

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -67,17 +67,13 @@ export function TimePicker( {
 }: TimePickerProps ) {
 	const [ date, setDate ] = useState( () =>
 		// Truncate the date at the minutes, see: #15495.
-		currentTime ? startOfMinute( inputToDate( currentTime ) ) : new Date()
+		startOfMinute( inputToDate( currentTime ?? new Date() ) )
 	);
 
 	// Reset the state when currentTime changed.
 	// TODO: useEffect() shouldn't be used like this, causes an unnecessary render
 	useEffect( () => {
-		setDate(
-			currentTime
-				? startOfMinute( inputToDate( currentTime ) )
-				: new Date()
-		);
+		setDate( startOfMinute( inputToDate( currentTime ?? new Date() ) ) );
 	}, [ currentTime ] );
 
 	const monthOptions = [

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -3,6 +3,12 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import timezoneMock from 'timezone-mock';
+
+/**
+ * WordPress dependencies
+ */
+import { getSettings, setSettings, type DateSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -422,5 +428,171 @@ describe( 'TimePicker', () => {
 		expect( Number.isNaN( parseInt( yearInput, 10 ) ) ).toBe( false );
 		expect( Number.isNaN( parseInt( hoursInput, 10 ) ) ).toBe( false );
 		expect( Number.isNaN( parseInt( minutesInput, 10 ) ) ).toBe( false );
+	} );
+
+	describe( 'input types with timezone variations', () => {
+		let originalSettings: DateSettings;
+
+		beforeAll( () => {
+			originalSettings = getSettings();
+			setSettings( {
+				...originalSettings,
+				timezone: {
+					offset: -5,
+					offsetFormatted: '-5',
+					string: 'America/New_York',
+					abbr: 'EST',
+				},
+			} );
+		} );
+
+		afterEach( () => {
+			jest.useRealTimers();
+			timezoneMock.unregister();
+		} );
+
+		afterAll( () => {
+			setSettings( originalSettings );
+		} );
+
+		describe.each( [
+			{
+				direction: 'browser behind site',
+				timezone: 'US/Pacific' as const,
+			},
+			{
+				direction: 'browser matches UTC (zero offset)',
+				timezone: 'UTC' as const,
+			},
+			{
+				direction: 'browser ahead of site',
+				timezone: 'Australia/Adelaide' as const,
+			},
+		] )( '$direction', ( { timezone } ) => {
+			beforeEach( () => {
+				timezoneMock.register( timezone );
+			} );
+
+			describe.each( [
+				{
+					type: 'timezoneless string',
+					initialTime: '2025-12-18T07:00:00',
+					transformOnChange: ( nextValue: string ) => nextValue,
+				},
+				{
+					type: 'Date object',
+					initialTime: new Date( Date.UTC( 2025, 11, 18, 12, 0, 0 ) ),
+					transformOnChange: ( nextValue: string ) => {
+						// Timezoneless string represents site timezone.
+						// Convert to UTC instant in site timezone.
+						const settings = getSettings();
+						const offsetMs =
+							settings.timezone.offset * 60 * 60 * 1000;
+						const asUTC = new Date( nextValue + 'Z' );
+						return new Date( asUTC.getTime() - offsetMs );
+					},
+				},
+				{
+					type: 'timestamp',
+					initialTime: Date.UTC( 2025, 11, 18, 12, 0, 0 ),
+					transformOnChange: ( nextValue: string ) => {
+						// For timestamps, properly convert timezoneless string to UTC
+						const settings = getSettings();
+						const offsetMs =
+							settings.timezone.offset * 60 * 60 * 1000;
+						const asUTC = new Date( nextValue + 'Z' );
+						return asUTC.getTime() - offsetMs;
+					},
+				},
+				{
+					type: 'undefined',
+					initialTime: undefined,
+					transformOnChange: ( nextValue: string ) => {
+						// Timezoneless string represents site timezone.
+						// Convert to UTC instant in site timezone.
+						const settings = getSettings();
+						const offsetMs =
+							settings.timezone.offset * 60 * 60 * 1000;
+						const asUTC = new Date( nextValue + 'Z' );
+						return new Date( asUTC.getTime() - offsetMs );
+					},
+				},
+			] )( 'with $type', ( { initialTime, transformOnChange } ) => {
+				it( 'should output timezoneless string matching displayed time', async () => {
+					// For undefined, set fake system time to get a known current time
+					let user: ReturnType< typeof userEvent.setup >;
+					if ( initialTime === undefined ) {
+						jest.useFakeTimers();
+						// Set system time to 12:00 UTC
+						jest.setSystemTime(
+							Date.UTC( 2025, 11, 18, 12, 0, 0 )
+						);
+						user = userEvent.setup( {
+							advanceTimers: jest.advanceTimersByTime,
+						} );
+					} else {
+						user = userEvent.setup();
+					}
+
+					const onChange = jest.fn();
+
+					const { rerender } = render(
+						<TimePicker
+							currentTime={ initialTime }
+							onChange={ onChange }
+						/>
+					);
+
+					// Should display the correct initial date and time assuming
+					// settings for the current site.
+					expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 7 );
+					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
+						0
+					);
+					expect( screen.getByLabelText( 'Day' ) ).toHaveValue( 18 );
+
+					// Changing the hours by one should adjust just the hour.
+					await user.clear( screen.getByLabelText( 'Hours' ) );
+					await user.type( screen.getByLabelText( 'Hours' ), '08' );
+					await user.keyboard( '{Tab}' );
+					expect( onChange ).toHaveBeenCalledWith(
+						'2025-12-18T08:00:00'
+					);
+
+					// Test round-trip by passing onChange output back as input
+					let nextDate = onChange.mock.calls[ 0 ][ 0 ];
+					rerender(
+						<TimePicker
+							currentTime={ transformOnChange( nextDate ) }
+							onChange={ onChange }
+						/>
+					);
+					expect( screen.getByLabelText( 'Hours' ) ).toHaveValue( 8 );
+					expect( screen.getByLabelText( 'Day' ) ).toHaveValue( 18 );
+					onChange.mockClear();
+
+					// Changing the minutes should adjust just the minutes.
+					await user.clear( screen.getByLabelText( 'Minutes' ) );
+					await user.type( screen.getByLabelText( 'Minutes' ), '30' );
+					await user.keyboard( '{Tab}' );
+					expect( onChange ).toHaveBeenCalledWith(
+						'2025-12-18T08:30:00'
+					);
+
+					// Test round-trip by passing onChange output back as input
+					nextDate = onChange.mock.calls[ 0 ][ 0 ];
+					rerender(
+						<TimePicker
+							currentTime={ transformOnChange( nextDate ) }
+							onChange={ onChange }
+						/>
+					);
+					expect( screen.getByLabelText( 'Minutes' ) ).toHaveValue(
+						30
+					);
+					expect( screen.getByLabelText( 'Day' ) ).toHaveValue( 18 );
+				} );
+			} );
+		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -473,6 +473,18 @@ describe( 'TimePicker', () => {
 				timezoneMock.register( timezone );
 			} );
 
+			function transformOnChangeToDate( nextValue: string ): Date {
+				// Timezoneless string represents site timezone. Convert to UTC
+				// instant in site timezone. In typical usage, consumers should
+				// align `@wordpress/date` settings to match their browser timezone
+				// when working with dates, to avoid having to manage this
+				// conversion themselves.
+				const settings = getSettings();
+				const offsetMs = settings.timezone.offset * 60 * 60 * 1000;
+				const asUTC = new Date( nextValue + 'Z' );
+				return new Date( asUTC.getTime() - offsetMs );
+			}
+
 			describe.each( [
 				{
 					type: 'timezoneless string',
@@ -480,42 +492,26 @@ describe( 'TimePicker', () => {
 					transformOnChange: ( nextValue: string ) => nextValue,
 				},
 				{
+					type: 'string with timezone',
+					initialTime: '2025-12-18T12:00:00Z',
+					transformOnChange: ( nextValue: string ) =>
+						transformOnChangeToDate( nextValue ).toISOString(),
+				},
+				{
 					type: 'Date object',
 					initialTime: new Date( Date.UTC( 2025, 11, 18, 12, 0, 0 ) ),
-					transformOnChange: ( nextValue: string ) => {
-						// Timezoneless string represents site timezone.
-						// Convert to UTC instant in site timezone.
-						const settings = getSettings();
-						const offsetMs =
-							settings.timezone.offset * 60 * 60 * 1000;
-						const asUTC = new Date( nextValue + 'Z' );
-						return new Date( asUTC.getTime() - offsetMs );
-					},
+					transformOnChange: transformOnChangeToDate,
 				},
 				{
 					type: 'timestamp',
 					initialTime: Date.UTC( 2025, 11, 18, 12, 0, 0 ),
-					transformOnChange: ( nextValue: string ) => {
-						// For timestamps, properly convert timezoneless string to UTC
-						const settings = getSettings();
-						const offsetMs =
-							settings.timezone.offset * 60 * 60 * 1000;
-						const asUTC = new Date( nextValue + 'Z' );
-						return asUTC.getTime() - offsetMs;
-					},
+					transformOnChange: ( nextValue: string ) =>
+						transformOnChangeToDate( nextValue ).getTime(),
 				},
 				{
 					type: 'undefined',
 					initialTime: undefined,
-					transformOnChange: ( nextValue: string ) => {
-						// Timezoneless string represents site timezone.
-						// Convert to UTC instant in site timezone.
-						const settings = getSettings();
-						const offsetMs =
-							settings.timezone.offset * 60 * 60 * 1000;
-						const asUTC = new Date( nextValue + 'Z' );
-						return new Date( asUTC.getTime() - offsetMs );
-					},
+					transformOnChange: ( nextValue: string ) => nextValue,
 				},
 			] )( 'with $type', ( { initialTime, transformOnChange } ) => {
 				it( 'should output timezoneless string matching displayed time', async () => {

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -124,6 +124,52 @@ export function buildPadInputStateReducer( pad: number ) {
 }
 
 /**
+ * Updates specific date fields in the configured timezone and returns a new
+ * UTC date.
+ *
+ * @param date    A Date object
+ * @param updates Object with fields to update
+ * @return A Date object normalized to UTC with the updated values
+ */
+export function setInConfiguredTimezone(
+	date: Date,
+	updates: Partial< {
+		year: number;
+		month: number;
+		date: number;
+		hours: number;
+		minutes: number;
+		seconds: number;
+	} >
+): Date {
+	const { timezone } = getSettings();
+	const offsetMs = timezone.offset * 60 * 60 * 1000;
+
+	// Shift to configured timezone
+	const targetDate = new Date( date.getTime() + offsetMs );
+	const values = {
+		year: targetDate.getUTCFullYear(),
+		month: targetDate.getUTCMonth(),
+		date: targetDate.getUTCDate(),
+		hours: targetDate.getUTCHours(),
+		minutes: targetDate.getUTCMinutes(),
+		seconds: targetDate.getUTCSeconds(),
+		...updates,
+	};
+
+	return new UTCDateMini(
+		Date.UTC(
+			values.year,
+			values.month,
+			values.date,
+			values.hours,
+			values.minutes,
+			values.seconds
+		) - offsetMs
+	);
+}
+
+/**
  * Validates the target of a React event to ensure it is an input element and
  * that the input is valid.
  * @param event

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -6,7 +6,7 @@ import { UTCDateMini } from '@date-fns/utc';
 /**
  * WordPress dependencies
  */
-import { getSettings } from '@wordpress/date';
+import { date as formatDate, getDate } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -25,10 +25,9 @@ import { COMMIT, PRESS_DOWN, PRESS_UP } from '../input-control/reducer/actions';
  */
 export function inputToDate( input: Date | string | number ): Date {
 	if ( typeof input === 'string' ) {
-		// Strings without timezone indicators are parsed as UTC to prevent day-
-		// shift bugs across browser timezones. Note that JavaScript doesn't
-		// fully support ISO-8601 time strings, so the behavior of passing these
-		// through to the Date constructor is non-deterministic.
+		// Note that JavaScript doesn't fully support ISO-8601 time strings, so
+		// the behavior of passing these through to the Date constructor is
+		// non-deterministic.
 		//
 		// See: https://tc39.es/ecma262/#sec-date-time-string-format
 		const hasTimezone = /Z|[+-]\d{2}(:?\d{2})?$/.test( input );
@@ -38,10 +37,7 @@ export function inputToDate( input: Date | string | number ): Date {
 
 		// Strings without timezone indicators are interpreted using configured
 		// timezone offset, then converted to UTC for internal storage.
-		const { timezone } = getSettings();
-		const offsetMs = timezone.offset * 60 * 60 * 1000;
-		const inputUTC = new Date( input + 'Z' );
-		return new UTCDateMini( inputUTC.getTime() - offsetMs );
+		return new UTCDateMini( getDate( input ).getTime() );
 	}
 
 	// Date objects and number timestamps represent specific UTC moments.
@@ -64,21 +60,12 @@ export function inputToDate( input: Date | string | number ): Date {
  * @return A browser-local Date at midnight for the configured timezone date
  */
 export function startOfDayInConfiguredTimezone( date: Date ): Date {
-	const { timezone } = getSettings();
-	const offsetMs = timezone.offset * 60 * 60 * 1000;
-
-	// Convert UTC timestamp to configured timezone to determine the date,
-	// creating a browser-local Date at midnight for this calendar date.
-	const targetDate = new Date( date.getTime() + offsetMs );
-	return new Date(
-		targetDate.getUTCFullYear(),
-		targetDate.getUTCMonth(),
-		targetDate.getUTCDate(),
-		0,
-		0,
-		0,
-		0
-	);
+	// Determine the calendar day in the configured WordPress timezone and
+	// return a browser-local Date at midnight for that calendar day.
+	const year = Number( formatDate( 'Y', date ) );
+	const month = Number( formatDate( 'n', date ) ) - 1;
+	const day = Number( formatDate( 'j', date ) );
+	return new Date( year, month, day, 0, 0, 0, 0 );
 }
 
 /**
@@ -142,31 +129,26 @@ export function setInConfiguredTimezone(
 		seconds: number;
 	} >
 ): Date {
-	const { timezone } = getSettings();
-	const offsetMs = timezone.offset * 60 * 60 * 1000;
-
-	// Shift to configured timezone
-	const targetDate = new Date( date.getTime() + offsetMs );
 	const values = {
-		year: targetDate.getUTCFullYear(),
-		month: targetDate.getUTCMonth(),
-		date: targetDate.getUTCDate(),
-		hours: targetDate.getUTCHours(),
-		minutes: targetDate.getUTCMinutes(),
-		seconds: targetDate.getUTCSeconds(),
+		year: Number( formatDate( 'Y', date ) ),
+		month: Number( formatDate( 'n', date ) ) - 1,
+		date: Number( formatDate( 'j', date ) ),
+		hours: Number( formatDate( 'H', date ) ),
+		minutes: Number( formatDate( 'i', date ) ),
+		seconds: Number( formatDate( 's', date ) ),
 		...updates,
 	};
 
-	return new UTCDateMini(
-		Date.UTC(
-			values.year,
-			values.month,
-			values.date,
-			values.hours,
-			values.minutes,
-			values.seconds
-		) - offsetMs
-	);
+	const year = String( values.year );
+	const month = String( values.month + 1 ).padStart( 2, '0' );
+	const day = String( values.date ).padStart( 2, '0' );
+	const hours = String( values.hours ).padStart( 2, '0' );
+	const minutes = String( values.minutes ).padStart( 2, '0' );
+	const seconds = String( values.seconds ).padStart( 2, '0' );
+	const timezoneless = `${ year }-${ month }-${ day }T${ hours }:${ minutes }:${ seconds }`;
+
+	// Parse as WordPress-configured timezone time and convert to a UTC instant.
+	return new UTCDateMini( getDate( timezoneless ).getTime() );
 }
 
 /**

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -4,6 +4,11 @@
 import { UTCDateMini } from '@date-fns/utc';
 
 /**
+ * WordPress dependencies
+ */
+import { getSettings } from '@wordpress/date';
+
+/**
  * Internal dependencies
  */
 import type { InputState } from '../input-control/reducer/state';
@@ -12,7 +17,9 @@ import { COMMIT, PRESS_DOWN, PRESS_UP } from '../input-control/reducer/actions';
 
 /**
  * Converts a date input to a UTC-normalized date for consistent date
- * manipulation.
+ * manipulation. Timezoneless strings are interpreted using the timezone
+ * offset from @wordpress/date settings. Date objects and timestamps
+ * represent specific UTC instants.
  *
  * @param input Value to turn into a date.
  */
@@ -25,13 +32,53 @@ export function inputToDate( input: Date | string | number ): Date {
 		//
 		// See: https://tc39.es/ecma262/#sec-date-time-string-format
 		const hasTimezone = /Z|[+-]\d{2}(:?\d{2})?$/.test( input );
-		return new UTCDateMini( hasTimezone ? new Date( input ) : input + 'Z' );
+		if ( hasTimezone ) {
+			return new UTCDateMini( new Date( input ) );
+		}
+
+		// Strings without timezone indicators are interpreted using configured
+		// timezone offset, then converted to UTC for internal storage.
+		const { timezone } = getSettings();
+		const offsetMs = timezone.offset * 60 * 60 * 1000;
+		const inputUTC = new Date( input + 'Z' );
+		return new UTCDateMini( inputUTC.getTime() - offsetMs );
 	}
 
 	// Date objects and number timestamps represent specific UTC moments.
 	// Convert to milliseconds since epoch for consistent UTC handling.
 	const time = input instanceof Date ? input.getTime() : input;
 	return new UTCDateMini( time );
+}
+
+/**
+ * Returns the start of day (midnight) as a browser-local Date for the calendar
+ * day in the configured timezone in @wordpress/date settings. This is necessary
+ * because date-fns's startOfDay operates in browser local time, which can cause
+ * off-by-one-day bugs when browser and configured timezones differ.
+ *
+ * For example, if the UTC time is Nov 16, 01:00 UTC and configured timezone
+ * is UTC-5, the date is Nov 15. This function returns a browser-local Date
+ * at Nov 15, 00:00 (browser local midnight) so it matches calendar days.
+ *
+ * @param date A Date object normalized to UTC
+ * @return A browser-local Date at midnight for the configured timezone date
+ */
+export function startOfDayInConfiguredTimezone( date: Date ): Date {
+	const { timezone } = getSettings();
+	const offsetMs = timezone.offset * 60 * 60 * 1000;
+
+	// Convert UTC timestamp to configured timezone to determine the date,
+	// creating a browser-local Date at midnight for this calendar date.
+	const targetDate = new Date( date.getTime() + offsetMs );
+	return new Date(
+		targetDate.getUTCFullYear(),
+		targetDate.getUTCMonth(),
+		targetDate.getUTCDate(),
+		0,
+		0,
+		0,
+		0
+	);
 }
 
 /**

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { toDate } from 'date-fns';
 import { UTCDateMini } from '@date-fns/utc';
 
 /**
@@ -12,9 +11,8 @@ import type { InputAction } from '../input-control/reducer/actions';
 import { COMMIT, PRESS_DOWN, PRESS_UP } from '../input-control/reducer/actions';
 
 /**
- * Like date-fns's toDate, but tries to guess the format when a string is
- * given. For timezoneless strings, parse it as UTC using `@date-fns/utc` to
- * ensure calendar dates remain consistent across different browser timezones.
+ * Converts a date input to a UTC-normalized date for consistent date
+ * manipulation.
  *
  * @param input Value to turn into a date.
  */
@@ -27,9 +25,13 @@ export function inputToDate( input: Date | string | number ): Date {
 		//
 		// See: https://tc39.es/ecma262/#sec-date-time-string-format
 		const hasTimezone = /Z|[+-]\d{2}(:?\d{2})?$/.test( input );
-		return hasTimezone ? new Date( input ) : new UTCDateMini( input + 'Z' );
+		return new UTCDateMini( hasTimezone ? new Date( input ) : input + 'Z' );
 	}
-	return toDate( input );
+
+	// Date objects and number timestamps represent specific UTC moments.
+	// Convert to milliseconds since epoch for consistent UTC handling.
+	const time = input instanceof Date ? input.getTime() : input;
+	return new UTCDateMini( time );
 }
 
 /**

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Bug Fixes
 
-- Fixed incorrect spacing for the time format. It was `g: i` (`14: 30`), and it's now `g:i` (`14:30`). See [#73924](https://github.com/WordPress/gutenberg/pull/73924).
+-   Fixed incorrect spacing for the time format. It was `g: i` (`14: 30`), and it's now `g:i` (`14:30`). ([#73924](https://github.com/WordPress/gutenberg/pull/73924))
+-   Fixed `timezone` argument handling to properly treat `0` numeric timezone values as a valid UTC offset (UTC+0). Previously, these were treated as if the `timezone` argument was not passed. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
 
 ## 5.36.0 (2025-11-26)
 

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -605,13 +605,11 @@ function buildMoment(
 ) {
 	const dateMoment = momentLib( dateValue );
 
-	if ( timezone && ! isUTCOffset( timezone ) ) {
-		// The ! isUTCOffset() check guarantees that timezone is a string.
-		return dateMoment.tz( timezone as string );
-	}
-
-	if ( timezone && isUTCOffset( timezone ) ) {
-		return dateMoment.utcOffset( timezone );
+	if ( timezone !== '' ) {
+		return isUTCOffset( timezone )
+			? dateMoment.utcOffset( timezone )
+			: // A false isUTCOffset() guarantees that timezone is a string.
+			  dateMoment.tz( timezone as string );
 	}
 
 	if ( settings.timezone.string ) {

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -466,6 +466,29 @@ describe( 'Function dateI18n', () => {
 		setSettings( settings );
 	} );
 
+	it( 'should format date into a UTC date when given UTC offset 0', () => {
+		const settings = getSettings();
+
+		// Simulate different timezone.
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check that offset 0 formats in UTC, not site timezone.
+		// This is a regression test for a bug where offset 0 was falsy
+		// and fell through to use site timezone instead.
+		const formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			0
+		);
+		expect( formattedDate ).toBe( '2019-06-18 11:00' );
+
+		// Restore default settings.
+		setSettings( settings );
+	} );
+
 	it( 'should format date into a UTC date if `gmt` is set to `true`', () => {
 		const settings = getSettings();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes an issue with `DateTimePicker` after #73444 where `Date` or `number` or `string` (with timezone) values passed as `currentDate` would be treated inconsistently from timezoneless strings, potentially resulting in mismatches between displayed and changed values similar to what was seen previously in #67480.

Related to: #67480
Follow-up to #73444
Fixes #73981

## Why?

The intent of the changes with #73444 were to normalize internal handling of dates within the component to use UTC time, but the changes only applied to values passed as timezoneless strings. In current Gutenberg usage, this is primarily how the component is used, since this is how WordPress represents dates.

Since the component internally assumes UTC times, this behavior should also extend to values passed in other formats (date objects, timestamps).

## How?

Updates `inputToDate` to consistently coerce all input values to UTC time.

## Testing Instructions

Verify included tests pass:

- `npm run test:unit packages/components/src/date-time/date-time/test/index.tsx`
- `npm run test:unit packages/components/src/date-time/test/utils.test.ts`

I was able to identify one Gutenberg usage where this bug previously existed, in [the initialization of the "Date" block](https://github.com/WordPress/gutenberg/blob/90c242a3020dc2ed8865cff38e5a33d7aa318fbd/packages/block-library/src/post-date/edit.js#L77).

To verify:

1. Set your local system timezone to a different date from the site's timezone (see instructions in #73444)
2. Go to "Posts" > "Add Post"
3. Insert a "Date" block
4. In the block toolbar, click "Change Date"
5. Verify that the initial date is accurately displayed as the current time on the site

## Screenshots or screencast <!-- if applicable -->\

These screenshots show a before/after of the Date block instructions described above, where my local time (1:52am UTC+10.5 the next day) is incorrectly shown, compared to the site's actual current time (3:22pm UTC).

Before|After
---|---
<img width="392" height="631" alt="Screenshot 2025-12-11 at 1 52 31 AM" src="https://github.com/user-attachments/assets/95d8c97a-8058-4574-ae66-d261564784cb" />|<img width="302" height="590" alt="Screenshot 2025-12-11 at 1 52 54 AM" src="https://github.com/user-attachments/assets/e37ae7b2-7930-4853-acf9-e9687f71fe29" />
