### PR TITLE
ToolsPanel: Remove line-height workaround

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `Menu` and othr menu items: change default size to be 32px tall rather than 40px to improve menu density. ([#73429](https://github.com/WordPress/gutenberg/pull/73429)).
 -   Unify padding using for DataViews, Modals and other container components. ([#73334](https://github.com/WordPress/gutenberg/pull/73334))
 -   `Snackbar`: Shorten timeout duration ([#73814](https://github.com/WordPress/gutenberg/pull/73814)).
+-   `ToolsPanel`: Remove line-height workaround for control labels ([#73892](https://github.com/WordPress/gutenberg/pull/73892)).
 
 ### Bug Fixes
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -12,7 +12,6 @@ import {
 	StyledHelp as BaseControlHelp,
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
-import { LabelWrapper } from '../input-control/styles/input-control-styles';
 import { COLORS, CONFIG, rtl } from '../utils';
 import { space } from '../utils/space';
 
@@ -123,19 +122,6 @@ export const ToolsPanelItem = css`
 
 	${ BaseControlHelp } {
 		margin-bottom: 0;
-	}
-
-	/**
-	 * Standardize InputControl and BaseControl labels with other labels when
-	 * inside ToolsPanel.
-	 *
-	 * This is a temporary fix until the different control components have their
-	 * labels normalized.
-	 */
-	&& ${ LabelWrapper } {
-		label {
-			line-height: 1.4em;
-		}
 	}
 `;
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #42788

Removes the workaround for unifying control label line-heights in `ToolsPanel`.

## Why?

I can no longer reproduce the original issue that motivated the workaround.

## Testing Instructions

Go to a Typography tools panel in the editor, and show the Appearance and Letter Spacing controls next to each other.

You could also try rendering an `InputControl`-based component and a `BaseControl`-based component next to each other in Storybook.

## Screenshots or screencast <!-- if applicable -->

No alignment issues even after removing the workaround. ([Here's](https://github.com/WordPress/gutenberg/pull/36387) what the original misalignment looked like.)

<img width="277" height="280" alt="Typography tools panel" src="https://github.com/user-attachments/assets/807b1979-384c-48ec-8516-4cd0bf98c017" />

Some components rendered next to each other in Storybook:

<img width="513" height="96" alt="Some controls next to each other" src="https://github.com/user-attachments/assets/0886a5bc-ed7b-415c-82f7-aea171bc05b1" />

