### PR TITLE
Fix navigation link popover staying open after creating page

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -238,7 +238,7 @@ function LinkControl( {
 		// We don't auto focus into the Link UI on mount
 		// because otherwise using the keyboard to select text
 		// *within* the link format is not possible.
-		if ( isMountingRef.current ) {
+		if ( isMountingRef.current && isEditingLink ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -238,7 +238,7 @@ function LinkControl( {
 		// We don't auto focus into the Link UI on mount
 		// because otherwise using the keyboard to select text
 		// *within* the link format is not possible.
-		if ( isMountingRef.current && isEditingLink ) {
+		if ( isMountingRef.current ) {
 			return;
 		}
 

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -154,6 +154,7 @@ function UnforwardedLinkUI( props, ref ) {
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
 						handleEntities={ isBoundEntityAvailable }
+						forceIsEditingLink={ link?.url ? false : undefined }
 						renderControlBottom={ () => {
 							// Don't show the tools when there is submitted link (preview state).
 							if ( link?.url?.length ) {

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -73,10 +73,10 @@ function UnforwardedLinkUI( props, ref ) {
 
 	const [ addingBlock, setAddingBlock ] = useState( false );
 	const [ addingPage, setAddingPage ] = useState( false );
-	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
-	const [ focusAddPageButton, setFocusAddPageButton ] = useState( false );
+	const [ shouldFocusPane, setShouldFocusPane ] = useState( null );
 	const linkControlWrapperRef = useRef();
-	const shouldFocusAfterPageCreation = useRef( false );
+	const addPageButtonRef = useRef();
+	const addBlockButtonRef = useRef();
 	const permissions = useResourcePermissions( {
 		kind: 'postType',
 		name: postType,
@@ -105,10 +105,9 @@ function UnforwardedLinkUI( props, ref ) {
 	const handlePageCreated = ( pageLink ) => {
 		// Set the new page as the current link
 		props.onChange( pageLink );
-		// Return to main Link UI
+		// Return to main Link UI and focus the first focusable element
 		setAddingPage( false );
-		// Request focus after the LinkControl remounts in preview mode
-		shouldFocusAfterPageCreation.current = true;
+		setShouldFocusPane( true );
 	};
 
 	const dialogTitleId = useInstanceId(
@@ -120,23 +119,26 @@ function UnforwardedLinkUI( props, ref ) {
 		'link-ui-link-control__description'
 	);
 
-	// Focus the LinkControl after page creation
+	// Focus management when transitioning between panes
 	useEffect( () => {
-		if (
-			! addingPage &&
-			shouldFocusAfterPageCreation.current &&
-			linkControlWrapperRef.current
-		) {
-			const nextFocusTarget =
-				focus.focusable.find( linkControlWrapperRef.current )[ 0 ] ||
-				linkControlWrapperRef.current;
-			nextFocusTarget.focus();
-			// Reset the flag after focusing. We could avoid this eslint rule by
-			// using a state instead of a ref, but it would cause an unnecessary re-render.
-			// eslint-disable-next-line react-compiler/react-compiler
-			shouldFocusAfterPageCreation.current = false;
+		if ( shouldFocusPane && linkControlWrapperRef.current ) {
+			// If we have a specific element to focus, focus it
+			if ( shouldFocusPane?.current ) {
+				// Focus the specific element passed
+				shouldFocusPane.current.focus();
+			} else {
+				// Focus the first focusable element
+				const nextFocusTarget =
+					focus.focusable.find(
+						linkControlWrapperRef.current
+					)[ 0 ] || linkControlWrapperRef.current;
+				nextFocusTarget.focus();
+			}
+
+			// Reset the state
+			setShouldFocusPane( false );
 		}
-	}, [ addingPage ] );
+	}, [ shouldFocusPane ] );
 
 	const blockEditingMode = useBlockEditingMode();
 
@@ -186,15 +188,13 @@ function UnforwardedLinkUI( props, ref ) {
 
 							return (
 								<LinkUITools
-									focusAddBlockButton={ focusAddBlockButton }
-									focusAddPageButton={ focusAddPageButton }
+									addPageButtonRef={ addPageButtonRef }
+									addBlockButtonRef={ addBlockButtonRef }
 									setAddingBlock={ () => {
 										setAddingBlock( true );
-										setFocusAddBlockButton( false );
 									} }
 									setAddingPage={ () => {
 										setAddingPage( true );
-										setFocusAddPageButton( false );
 									} }
 									canAddPage={
 										permissions?.canCreate &&
@@ -215,8 +215,7 @@ function UnforwardedLinkUI( props, ref ) {
 					clientId={ props.clientId }
 					onBack={ () => {
 						setAddingBlock( false );
-						setFocusAddBlockButton( true );
-						setFocusAddPageButton( false );
+						setShouldFocusPane( addBlockButtonRef );
 					} }
 					onBlockInsert={ props?.onBlockInsert }
 				/>
@@ -227,8 +226,7 @@ function UnforwardedLinkUI( props, ref ) {
 					postType={ postType }
 					onBack={ () => {
 						setAddingPage( false );
-						setFocusAddPageButton( true );
-						setFocusAddBlockButton( false );
+						setShouldFocusPane( addPageButtonRef );
 					} }
 					onPageCreated={ handlePageCreated }
 					initialTitle={ link?.url || '' }
@@ -241,30 +239,14 @@ function UnforwardedLinkUI( props, ref ) {
 export const LinkUI = forwardRef( UnforwardedLinkUI );
 
 const LinkUITools = ( {
+	addPageButtonRef,
+	addBlockButtonRef,
 	setAddingBlock,
 	setAddingPage,
-	focusAddBlockButton,
-	focusAddPageButton,
 	canAddPage,
 	canAddBlock,
 } ) => {
 	const blockInserterAriaRole = 'listbox';
-	const addBlockButtonRef = useRef();
-	const addPageButtonRef = useRef();
-
-	// Focus the add block button when the popover is opened.
-	useEffect( () => {
-		if ( focusAddBlockButton ) {
-			addBlockButtonRef.current?.focus();
-		}
-	}, [ focusAddBlockButton ] );
-
-	// Focus the add page button when the popover is opened.
-	useEffect( () => {
-		if ( focusAddPageButton ) {
-			addPageButtonRef.current?.focus();
-		}
-	}, [ focusAddPageButton ] );
 
 	// Don't render anything if neither button should be shown
 	if ( ! canAddPage && ! canAddBlock ) {

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -127,11 +127,12 @@ function UnforwardedLinkUI( props, ref ) {
 				// Focus the specific element passed
 				shouldFocusPane.current.focus();
 			} else {
-				// Focus the first focusable element
+				// Focus the first tabbable element (keyboard-accessible, excluding tabindex="-1")
+				const tabbableElements = focus.tabbable.find(
+					linkControlWrapperRef.current
+				);
 				const nextFocusTarget =
-					focus.focusable.find(
-						linkControlWrapperRef.current
-					)[ 0 ] || linkControlWrapperRef.current;
+					tabbableElements[ 0 ] || linkControlWrapperRef.current;
 				nextFocusTarget.focus();
 			}
 

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { __unstableStripHTML as stripHTML, focus } from '@wordpress/dom';
 import {
 	Popover,
 	Button,
@@ -75,6 +75,8 @@ function UnforwardedLinkUI( props, ref ) {
 	const [ addingPage, setAddingPage ] = useState( false );
 	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
 	const [ focusAddPageButton, setFocusAddPageButton ] = useState( false );
+	const linkControlWrapperRef = useRef();
+	const shouldFocusAfterPageCreation = useRef( false );
 	const permissions = useResourcePermissions( {
 		kind: 'postType',
 		name: postType,
@@ -105,6 +107,8 @@ function UnforwardedLinkUI( props, ref ) {
 		props.onChange( pageLink );
 		// Return to main Link UI
 		setAddingPage( false );
+		// Request focus after the LinkControl remounts in preview mode
+		shouldFocusAfterPageCreation.current = true;
 	};
 
 	const dialogTitleId = useInstanceId(
@@ -115,6 +119,24 @@ function UnforwardedLinkUI( props, ref ) {
 		LinkUI,
 		'link-ui-link-control__description'
 	);
+
+	// Focus the LinkControl after page creation
+	useEffect( () => {
+		if (
+			! addingPage &&
+			shouldFocusAfterPageCreation.current &&
+			linkControlWrapperRef.current
+		) {
+			const nextFocusTarget =
+				focus.focusable.find( linkControlWrapperRef.current )[ 0 ] ||
+				linkControlWrapperRef.current;
+			nextFocusTarget.focus();
+			// Reset the flag after focusing. We could avoid this eslint rule by
+			// using a state instead of a ref, but it would cause an unnecessary re-render.
+			// eslint-disable-next-line react-compiler/react-compiler
+			shouldFocusAfterPageCreation.current = false;
+		}
+	}, [ addingPage ] );
 
 	const blockEditingMode = useBlockEditingMode();
 
@@ -128,6 +150,7 @@ function UnforwardedLinkUI( props, ref ) {
 		>
 			{ ! addingBlock && ! addingPage && (
 				<div
+					ref={ linkControlWrapperRef }
 					role="dialog"
 					aria-labelledby={ dialogTitleId }
 					aria-describedby={ dialogDescriptionId }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -873,6 +873,84 @@ test.describe( 'Navigation block', () => {
 				await expect( inspectorNavigationLabel ).toHaveValue( 'Cat' );
 			} );
 		} );
+
+		test( 'Can create a new page using the navigation block appender', async ( {
+			page,
+			pageUtils,
+			navigation,
+		} ) => {
+			await test.step( 'Open link control', async () => {
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await navigation.useBlockInserter();
+				const linkControlSearch = navigation.getLinkControlSearch();
+				await expect( linkControlSearch ).toBeFocused();
+			} );
+
+			await test.step( 'Click Create Page button', async () => {
+				// Find and click the "Create page" button
+				const createPageButton = page.getByRole( 'button', {
+					name: 'Create page',
+				} );
+				await expect( createPageButton ).toBeVisible();
+				// Press tab twice to reach the "Create page" button
+				await pageUtils.pressKeys( 'Tab', { times: 2 } );
+				// expect the "Create page" button to be focused
+				await expect( createPageButton ).toBeFocused();
+				await page.keyboard.press( 'Enter' );
+			} );
+
+			await test.step( 'Create the page', async () => {
+				const backButton = page.getByRole( 'button', { name: 'Back' } );
+				await expect( backButton ).toBeVisible();
+				await expect( backButton ).toBeFocused();
+
+				// Tab to the title field
+				await page.keyboard.press( 'Tab' );
+
+				await expect(
+					page.getByRole( 'textbox', { name: 'Title' } )
+				).toBeFocused();
+				await page.keyboard.type( 'Newly Created Page' );
+				const createPageButton = page.getByRole( 'button', {
+					name: 'Create page',
+				} );
+				// Publish the page immediately
+				await page.keyboard.press( 'Tab' );
+				const publishCheckbox = page.getByRole( 'checkbox', {
+					name: 'Publish immediately',
+				} );
+				// expect to be on the checkbox
+				await expect( publishCheckbox ).toBeFocused();
+				await page.keyboard.press( 'Space' );
+				// expect the checkbox to be checked
+				await expect( publishCheckbox ).toBeChecked();
+				// Tab to the Create page button
+				await pageUtils.pressKeys( 'Tab', { times: 2 } );
+				await expect( createPageButton ).toBeFocused();
+				await page.keyboard.press( 'Enter' );
+			} );
+
+			await test.step( 'Verify focus is placed in the link preview', async () => {
+				// After page creation, the link control should show the preview
+				// and focus should be on the link
+				const linkPopover = navigation.getLinkPopover();
+				await expect( linkPopover ).toBeVisible();
+
+				// The link preview should show the newly created page
+				const linkPreview =
+					navigation.getLinkControlLink( 'Newly Created Page' );
+				await expect( linkPreview ).toBeVisible();
+
+				// Focus should be on the link preview
+				await expect( linkPreview ).toBeFocused();
+
+				// Click outside the link preview to close it
+				await page.keyboard.press( 'Escape' );
+				await expect( linkPopover ).toBeHidden();
+				await expect( navigation.getNavBlockInserter() ).toBeVisible();
+				await expect( navigation.getNavBlockInserter() ).toBeFocused();
+			} );
+		} );
 	} );
 
 	test( 'Adding new links to a navigation block with existing inner blocks triggers creation of a single Navigation Menu', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -832,9 +832,11 @@ test.describe( 'Navigation block', () => {
 					} )
 				).toBeFocused();
 
-				await linkPopover
-					.getByRole( 'button', { name: 'Add block' } )
-					.click();
+				const addBlockPopoverButton = linkPopover.getByRole( 'button', {
+					name: 'Add block',
+				} );
+
+				await addBlockPopoverButton.click();
 
 				const addBlockDialog = page.getByRole( 'dialog', {
 					name: 'Add block',
@@ -842,9 +844,22 @@ test.describe( 'Navigation block', () => {
 
 				await expect( addBlockDialog ).toBeVisible();
 
-				await expect(
-					addBlockDialog.getByRole( 'button', { name: 'Back' } )
-				).toBeFocused();
+				const addBlockDialogBackButton = addBlockDialog.getByRole(
+					'button',
+					{ name: 'Back' }
+				);
+
+				await expect( addBlockDialogBackButton ).toBeFocused();
+
+				// Step: Verify we can go back to the main Link UI and focus the add block button
+				await page.keyboard.press( 'Enter' );
+
+				// Expect focus to be on the add block button
+				await expect( addBlockPopoverButton ).toBeFocused();
+
+				await page.keyboard.press( 'Enter' );
+
+				await expect( addBlockDialogBackButton ).toBeFocused();
 
 				await addBlockDialog
 					.getByRole( 'option', { name: 'Custom Link' } )
@@ -899,11 +914,28 @@ test.describe( 'Navigation block', () => {
 				await page.keyboard.press( 'Enter' );
 			} );
 
-			await test.step( 'Create the page', async () => {
+			await test.step( 'Verify Back button returns focus to Create page button', async () => {
 				const backButton = page.getByRole( 'button', { name: 'Back' } );
 				await expect( backButton ).toBeVisible();
 				await expect( backButton ).toBeFocused();
 
+				// Click Back button
+				await backButton.click();
+
+				// Verify focus returns to the "Create page" button
+				const createPageButton = page.getByRole( 'button', {
+					name: 'Create page',
+				} );
+				await expect( createPageButton ).toBeVisible();
+				await expect( createPageButton ).toBeFocused();
+
+				// Re-open the Create page dialog
+				await createPageButton.click();
+				await expect( backButton ).toBeVisible();
+				await expect( backButton ).toBeFocused();
+			} );
+
+			await test.step( 'Create the page', async () => {
 				// Tab to the title field
 				await page.keyboard.press( 'Tab' );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -969,14 +969,13 @@ test.describe( 'Navigation block', () => {
 				await expect( linkPopover ).toBeVisible();
 
 				// The link preview should show the newly created page
-				const linkPreview =
+				const previewLink =
 					navigation.getLinkControlLink( 'Newly Created Page' );
-				await expect( linkPreview ).toBeVisible();
+				await expect( previewLink ).toBeVisible();
 
 				// Focus should be on the link preview
-				await expect( linkPreview ).toBeFocused();
+				await expect( previewLink ).toBeFocused();
 
-				// Click outside the link preview to close it
 				await page.keyboard.press( 'Escape' );
 				await expect( linkPopover ).toBeHidden();
 				await expect( navigation.getNavBlockInserter() ).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73861
Fix focus loss after creating page in navigation block. This focus loss means the close on focus outside handler never gets called, so the popover can't be closed.

<!-- In a few words, what is the PR actually doing? -->
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes a bug :)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Only skip auto-focus on mount when entering edit mode, not preview mode. This ensures focus is properly placed in the link preview after creating a page through the navigation block's "Create page" dialog.
2. In the link-ui for the navigation block, force editing to be false after creating a new page. Otherwise, e2e tests will catch that there is a brief transition to the edit state while link values are being updated.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Click the navigation link appender
- Click Add page in the popover
- Add a page title
- Click Create page
- You should see the link preview for your new page
- Click somewhere else on the page to close the popover
- Popover should close

Additional coverage: Copy the contents of the e2e test into trunk and verify it fails on trunk and passes on this branch: `npm run test:e2e test/e2e/specs/editor/blocks/navigation.spec.js -- -g "Can create a new page using the navigation block appender"`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- navigate to the navigation link appender using your tab key
- Press enter
- Tab to Add page button
- Tab to the page title field and enter a title
- Tab to Create page
- You should see the link preview for your new page
- Press escape
- Popover should close
- Focus should be on the appender
## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
