### PR TITLE
Post Title: Reverting strip_tags for Post Title

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if ( ! strip_tags( $title ) ) {
+	if ( ! $title ) {
 		return '';
 	}
 


### PR DESCRIPTION
After a report in the PHP repository, someone [suggested to me](https://github.com/php/php-src/pull/20675#issuecomment-3638348102), regarding the commit
https://github.com/WordPress/gutenberg/commit/feeceda6431848cb1d8a1ea00c906d38eced2248

That we did not consider one approach:
What would happen if the user were actually writing a title, which actually uses tags?

Like:

```
<?php
$title = '<?php //Blog about writing PHP code';
$stripped = strip_tags($title);
echo($stripped);
```
https://3v4l.org/oWcSE

It will strip it and return the `empty`, so the user won't be able to use it.

I did not consider this scenario, but it's technically correct.

I would have preferred to leave it as it is, but I think that we should take this into consideration as it's a correct statement.

The only alternative I can think of to have “everyone” happy is adding a filter here, so if anyone wants to strip code tags, they technically could, but through the filter.