### PR TITLE
Theme: Fix build failure of mode overrides plugin on Windows OS

### DIFF
--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { basename, join, dirname } from 'node:path';
+import { basename, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@terrazzo/parser';
 
@@ -155,9 +155,13 @@ function getModeOverrides(
  * For each mode found in tokens (via $extensions.mode), generates a separate
  * JSON file per source file containing tokens that have values for that mode.
  *
+ * @param options          Plugin options.
+ * @param options.filePath Output path relative to outDir (default: 'modes').
  * @return A Terrazzo plugin that generates mode-specific DTCG override files.
  */
-export default function pluginModeOverrides(): Plugin {
+export default function pluginModeOverrides( {
+	filePath = 'modes',
+} = {} ): Plugin {
 	return {
 		name: '@wordpress/terrazzo-plugin-mode-overrides',
 		async build( { outputFile, sources } ) {
@@ -189,13 +193,20 @@ export default function pluginModeOverrides(): Plugin {
 					}
 
 					// Output as {basename}.{mode}.json (e.g., dimension.compact.json)
-					const filePath = fileURLToPath( filename );
-					const outFile = join(
-						dirname( filePath ),
-						'modes',
-						`${ basename( filePath, '.json' ) }.${ mode }.json`
+					const jsonFileName = `${ basename(
+						fileURLToPath( filename ),
+						'.json'
+					) }.${ mode }.json`;
+
+					const outputFilePath = join(
+						filePath,
+						jsonFileName
+					).replace( /\\/g, '/' );
+
+					outputFile(
+						outputFilePath,
+						JSON.stringify( output, null, '\t' )
 					);
-					outputFile( outFile, JSON.stringify( output, null, '\t' ) );
 				}
 			}
 		},

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -75,7 +75,9 @@ export default defineConfig( {
 		pluginDsTokenDocs( {
 			filename: '../../docs/ds-tokens.md',
 		} ),
-		pluginModeOverrides(),
+		pluginModeOverrides( {
+			filePath: '../../tokens/modes',
+		} ),
 	],
 
 	// Linter rules current error when multiple entry files are used


### PR DESCRIPTION
- Originally reported at Slack: https://wordpress.slack.com/archives/C02RQBWTW/p1765417187646649
- Follow up to #73860

## What?

This PR fixes an issue where some files in the theme package fail to build on Windows OS.

```
npm run --workspace @wordpress/theme build                     

> @wordpress/theme@0.3.0 build
> npm run build:tokens && npm run build:default-ramps


> @wordpress/theme@0.3.0 build:tokens
> node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && cross-env NODE_OPTIONS=--import=esbuild-esm-loader/register tz build --config terrazzo.config.ts

🎨 Starting primitive color tokens generation...
✅ Successfully updated color.json (31.74ms)
✗  Invalid URL
npm error Lifecycle script `build:tokens` failed with error:
npm error code 1
npm error path D:\Desktop\wp_dev\gutenberg\packages\theme
npm error workspace @wordpress/theme@0.3.0
npm error location D:\Desktop\wp_dev\gutenberg\packages\theme
npm error command failed
npm error command C:\WINDOWS\system32\cmd.exe /d /s /c node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && cross-env NODE_OPTIONS=--import=esbuild-esm-loader/register tz build --config terrazzo.config.ts
npm error Lifecycle script `build` failed with error:
npm error code 1
npm error path D:\Desktop\wp_dev\gutenberg\packages\theme
npm error workspace @wordpress/theme@0.3.0
npm error location D:\Desktop\wp_dev\gutenberg\packages\theme
npm error command failed
npm error command C:\WINDOWS\system32\cmd.exe /d /s /c npm run build:tokens && npm run build:default-ramps
```

## Why?

This is where the error is occurring.

On Mac, outFile looks like this.

```
/home/path/to/gutenberg/packages/theme/tokens/modes/border.high-dpi.json
/home/path/to/_core-dev/gutenberg/packages/theme/tokens/modes/dimension.compact.json
/home/path/to/_core-dev/gutenberg/packages/theme/tokens/modes/dimension.comfortable.json
```

On Windows, it looks like this.

```
D:\Desktop\path\to\gutenberg\packages\theme\tokens\modes\border.high-dpi.json
D:\Desktop\path\to\gutenberg\packages\theme\tokens\modes\dimension.compact.json
D:\Desktop\path\to\gutenberg\packages\theme\tokens\modes\dimension.comfortable.json
```

I'm not sure the exact reason, but passing an absolute path as the `outputFile` argument may not work on certain OS. Indeed, it seems that a relative path is recommended.

https://github.com/terrazzoapp/terrazzo/blob/d4b958faa59c8dd9279402521d818f62121fbf28/packages/parser/src/types.ts#L38

https://github.com/terrazzoapp/terrazzo/blob/d4b958faa59c8dd9279402521d818f62121fbf28/www/src/pages/docs/reference/plugin-api.md?plain=1#L399

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

I converted the absolute path to a relative path and it seems to work.

## Testing Instructions

- Manually delete `packages\theme\tokens\modes`
- Run `npm run --workspace @wordpress/theme build`
- The file should be generated correctly and there should be no diff.