### PR TITLE
Fix query pattern selection so query variation patterns can appear

### DIFF
--- a/packages/block-library/src/query/edit/pattern-selection.js
+++ b/packages/block-library/src/query/edit/pattern-selection.js
@@ -48,9 +48,9 @@ export function useBlockPatterns( clientId, attributes ) {
 	// so that a Query block is always replaced by another Query block.
 	const rootBlockPatterns = useMemo( () => {
 		return allPatterns.filter( ( pattern ) => {
-			return pattern.blocks?.[ 0 ]?.name === blockNameForPatterns;
+			return pattern.blocks?.[ 0 ]?.name === 'core/query';
 		} );
-	}, [ allPatterns, blockNameForPatterns ] );
+	}, [ allPatterns ] );
 
 	return rootBlockPatterns;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes issue described [here](https://github.com/WordPress/gutenberg/pull/71686/files#r2607449962). When a Query block variation has several patterns, the "Change design" button should appear in its toolbar. It wasn't appearing because in filtering to check that the patterns have Query as their root block, we were using the variation name instead of the actual block name. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install Sensei LMS and test with its course list block, or create a small plugin with a Query variation and a couple of associated block patterns that use it as a root block.
2. Check that your Query variation displays the "Change design" button in its toolbar.

The patterns for the Sensei block are looking a bit squished, not sure why (cc @m1r0):
<img width="654" height="173" alt="Screenshot 2025-12-11 at 3 32 08 pm" src="https://github.com/user-attachments/assets/f0a247c9-d60c-41e7-b9d1-63806d511e82" />

But this is a block variation I vibe coded for testing purposes:

<img width="697" height="404" alt="Screenshot 2025-12-11 at 3 41 23 pm" src="https://github.com/user-attachments/assets/68f611e6-32a8-405c-8acd-b2cea668da23" />


