### PR TITLE
Embed: Fix Flickr double-padding with responsive wrapper

### DIFF
--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -18,7 +18,7 @@ import {
 	getEmbedInfoByProvider,
 	removeAspectRatioClasses,
 	hasAspectRatioClass,
-	hasResponsiveWrapper,
+	hasInlineResponsivePadding,
 } from '../util';
 import { embedInstagramIcon } from '../icons';
 import variations from '../variations';
@@ -124,28 +124,28 @@ describe( 'utils', () => {
 			);
 		} );
 	} );
-	describe( 'hasResponsiveWrapper', () => {
+	describe( 'hasInlineResponsivePadding', () => {
 		it( 'should return true when HTML contains padding-bottom percentage', () => {
 			const html =
 				'<div style="padding-bottom: 56.25%;"><iframe></iframe></div>';
-			expect( hasResponsiveWrapper( html ) ).toBe( true );
+			expect( hasInlineResponsivePadding( html ) ).toBe( true );
 		} );
 
 		it( 'should return true when HTML contains padding-top percentage', () => {
 			const html =
 				'<div style="padding-top: 75%;"><iframe></iframe></div>';
-			expect( hasResponsiveWrapper( html ) ).toBe( true );
+			expect( hasInlineResponsivePadding( html ) ).toBe( true );
 		} );
 
 		it( 'should return false when HTML has no padding percentage', () => {
 			const html = '<iframe width="640" height="360"></iframe>';
-			expect( hasResponsiveWrapper( html ) ).toBe( false );
+			expect( hasInlineResponsivePadding( html ) ).toBe( false );
 		} );
 
 		it( 'should return false when padding uses pixels instead of percentage', () => {
 			const html =
 				'<div style="padding-bottom: 20px;"><iframe></iframe></div>';
-			expect( hasResponsiveWrapper( html ) ).toBe( false );
+			expect( hasInlineResponsivePadding( html ) ).toBe( false );
 		} );
 	} );
 

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -18,6 +18,7 @@ import {
 	getEmbedInfoByProvider,
 	removeAspectRatioClasses,
 	hasAspectRatioClass,
+	hasResponsiveWrapper,
 } from '../util';
 import { embedInstagramIcon } from '../icons';
 import variations from '../variations';
@@ -101,7 +102,53 @@ describe( 'utils', () => {
 				)
 			).toEqual( expected );
 		} );
+
+		it( 'should not add aspect ratio classes when HTML already contains responsive wrapper with padding-bottom', () => {
+			// Flickr embeds come with their own responsive wrapper
+			const html =
+				'<div style="padding-bottom: 56.25%;"><iframe width="1024" height="576"></iframe></div>';
+			const existingClassNames = 'wp-block-embed';
+			// Should not add wp-embed-aspect-16-9 and wp-has-aspect-ratio
+			// because the HTML already has responsive styling
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
+
+		it( 'should not add aspect ratio classes when HTML already contains responsive wrapper with padding-top', () => {
+			const html =
+				'<div style="padding-top: 56.25%;"><iframe width="1024" height="576"></iframe></div>';
+			const existingClassNames = 'wp-block-embed';
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
 	} );
+	describe( 'hasResponsiveWrapper', () => {
+		it( 'should return true when HTML contains padding-bottom percentage', () => {
+			const html =
+				'<div style="padding-bottom: 56.25%;"><iframe></iframe></div>';
+			expect( hasResponsiveWrapper( html ) ).toBe( true );
+		} );
+
+		it( 'should return true when HTML contains padding-top percentage', () => {
+			const html =
+				'<div style="padding-top: 75%;"><iframe></iframe></div>';
+			expect( hasResponsiveWrapper( html ) ).toBe( true );
+		} );
+
+		it( 'should return false when HTML has no padding percentage', () => {
+			const html = '<iframe width="640" height="360"></iframe>';
+			expect( hasResponsiveWrapper( html ) ).toBe( false );
+		} );
+
+		it( 'should return false when padding uses pixels instead of percentage', () => {
+			const html =
+				'<div style="padding-bottom: 20px;"><iframe></iframe></div>';
+			expect( hasResponsiveWrapper( html ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'hasAspectRatioClass', () => {
 		it( 'should return false if an aspect ratio class does not exist', () => {
 			const existingClassNames = 'wp-block-embed is-type-video';

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -203,7 +203,7 @@ export const removeAspectRatioClasses = ( existingClassNames ) => {
  * @param {string} html The embed HTML to check.
  * @return {boolean} True if the HTML already has responsive styling.
  */
-export function hasResponsiveWrapper( html ) {
+export function hasInlineResponsivePadding( html ) {
 	// Check for padding-bottom or padding-top with percentage values in style attributes
 	// This pattern matches: padding-bottom: 56.25%; or padding-top: 50%; etc.
 	const paddingPattern = /padding-(top|bottom)\s*:\s*[\d.]+%/i;
@@ -229,7 +229,7 @@ export function getClassNames(
 
 	// If the embed HTML already contains responsive wrapper styling (like Flickr),
 	// don't add our own aspect ratio classes to avoid double padding.
-	if ( hasResponsiveWrapper( html ) ) {
+	if ( hasInlineResponsivePadding( html ) ) {
 		return removeAspectRatioClasses( existingClassNames );
 	}
 

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -196,6 +196,21 @@ export const removeAspectRatioClasses = ( existingClassNames ) => {
 };
 
 /**
+ * Checks if HTML already contains responsive aspect ratio styling.
+ * Some embed providers (like Flickr) include their own responsive wrapper
+ * with padding-bottom or padding-top percentages for aspect ratio.
+ *
+ * @param {string} html The embed HTML to check.
+ * @return {boolean} True if the HTML already has responsive styling.
+ */
+export function hasResponsiveWrapper( html ) {
+	// Check for padding-bottom or padding-top with percentage values in style attributes
+	// This pattern matches: padding-bottom: 56.25%; or padding-top: 50%; etc.
+	const paddingPattern = /padding-(top|bottom)\s*:\s*[\d.]+%/i;
+	return paddingPattern.test( html );
+}
+
+/**
  * Returns class names with any relevant responsive aspect ratio names.
  *
  * @param {string}  html               The preview HTML that possibly contains an iframe with width and height set.
@@ -209,6 +224,12 @@ export function getClassNames(
 	allowResponsive = true
 ) {
 	if ( ! allowResponsive ) {
+		return removeAspectRatioClasses( existingClassNames );
+	}
+
+	// If the embed HTML already contains responsive wrapper styling (like Flickr),
+	// don't add our own aspect ratio classes to avoid double padding.
+	if ( hasResponsiveWrapper( html ) ) {
 		return removeAspectRatioClasses( existingClassNames );
 	}
 


### PR DESCRIPTION
Fixes #49320

## Summary

Flickr video embeds displayed unwanted white space above the video when "Resize for smaller devices" was enabled (default setting). This was caused by Flickr's oEmbed response including its own responsive wrapper with `padding-bottom: 56.25%`, while Gutenberg was also adding its own responsive aspect ratio styling via CSS pseudo-element `padding-top: 56.25%`, resulting in double padding.

## Changes

### Modified Files:
- `packages/block-library/src/embed/util.js`
- `packages/block-library/src/embed/test/index.js`

### Implementation:

1. **Added `hasResponsiveWrapper()` function** to detect when embed HTML already contains responsive aspect ratio styling (padding-top/padding-bottom percentages)

2. **Modified `getClassNames()` function** to skip adding Gutenberg's aspect ratio classes when the embed provider has already included responsive wrapper styling

3. **Added comprehensive test coverage** for the new functionality

## How to Test

1. Create a new post/page
2. Add a Flickr embed block with URL: `https://flic.kr/p/2gthFp5`
3. Ensure "Resize for smaller devices" is ON (default)
4. **Expected:** Video displays with no white space above it
5. **Verify:** Toggle "Resize for smaller devices" OFF - video should still display correctly
6. **Regression test:** Add YouTube/Vimeo embeds to ensure they still work correctly

## Technical Details

### Root Cause:
Flickr's oEmbed HTML structure:
```html
<div style="padding-bottom: 56.25%;">
    <iframe style="position: absolute;" width="1024" height="576" ...></iframe>
</div>
```

Gutenberg was detecting the iframe dimensions and adding `wp-embed-aspect-16-9` and `wp-has-aspect-ratio` classes, which triggered additional `padding-top: 56.25%` via CSS, creating ~112.5% total vertical padding.

### Solution:
Detect existing responsive wrapper styling using regex pattern `/padding-(top|bottom)\s*:\s*[\d.]+%/i` and skip adding duplicate aspect ratio classes.

## Backwards Compatibility

### ✅ No Breaking Changes
- **New Flickr embeds:** Fixed - no white space
- **New other embeds (YouTube, Vimeo, etc.):** Unchanged - continue to work correctly
- **Existing Flickr embeds:** No regression - still have the issue until manually updated
- **Generic solution:** Prevents double-padding for any embed provider that includes responsive wrapper styling

### ⚠️ Known Limitations

**Existing Flickr embeds created before this fix will not be automatically corrected.**

This is due to an optimization in `getAttributesFromPreview()` (lines 329-331 in util.js) that skips className regeneration when:
1. The block already has aspect ratio classes, AND
2. The embed URL hasn't changed

**Workarounds for existing embeds:**
- Change the Flickr URL (even slightly) to trigger regeneration
- Remove and re-add the embed block
- Toggle "Resize for smaller devices" off (if acceptable)

**Future Enhancement:**
A separate PR could add automatic migration logic to fix existing Flickr embeds by forcing className regeneration for the Flickr provider. This was intentionally kept separate to:
1. Keep this fix focused and minimal
2. Allow for proper testing of the migration logic
3. Avoid potential performance implications of broader className regeneration

## Testing Performed

- ✅ Manual testing in local wp-env environment
- ✅ Unit tests added for `hasResponsiveWrapper()` function
- ✅ Unit tests added for Flickr double-padding scenario
- ✅ Verified YouTube and Vimeo embeds still work correctly
- ✅ Build successful

## Screenshots

### Before Fix:
![White space above Flickr video](https://user-images.githubusercontent.com/27249804/227388021-5fe6c3ba-7976-4331-933a-91747d75bf6f.png)
_(Screenshot from original issue)_

### After Fix:


https://github.com/user-attachments/assets/9340c38c-9cfd-437d-afdd-cb8cf12c10cc



## Related Issues

- Closes #49320

---

**Note for reviewers:** This fix uses a generic pattern-matching approach rather than Flickr-specific logic, so it will also prevent similar double-padding issues with any other embed provider that includes responsive wrapper styling in their oEmbed HTML.