### PR TITLE
Query loop should show "change design" in toolbar in contentOnly mode

### DIFF
--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -130,7 +130,7 @@ export default function QueryContent( {
 
 	return (
 		<>
-			<BlockControls>
+			<BlockControls group="other">
 				<QueryToolbar
 					clientId={ clientId }
 					attributes={ attributes }

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	ToolbarGroup,
 	ToolbarButton,
 	Dropdown,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
@@ -29,31 +28,29 @@ export default function QueryToolbar( {
 		: __( 'Choose pattern' );
 
 	return (
-		<ToolbarGroup className="wp-block-template-part__block-control-group">
-			<DropdownContentWrapper>
-				<Dropdown
-					contentClassName="block-editor-block-settings-menu__popover"
-					focusOnMount="firstElement"
-					expandOnMobile
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<ToolbarButton
-							aria-haspopup="true"
-							aria-expanded={ isOpen }
-							onClick={ onToggle }
-						>
-							{ buttonLabel }
-						</ToolbarButton>
-					) }
-					renderContent={ () => (
-						<PatternSelection
-							clientId={ clientId }
-							attributes={ attributes }
-							showSearch={ false }
-							showTitlesAsTooltip
-						/>
-					) }
-				/>
-			</DropdownContentWrapper>
-		</ToolbarGroup>
+		<DropdownContentWrapper>
+			<Dropdown
+				contentClassName="block-editor-block-settings-menu__popover"
+				focusOnMount="firstElement"
+				expandOnMobile
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<ToolbarButton
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						onClick={ onToggle }
+					>
+						{ buttonLabel }
+					</ToolbarButton>
+				) }
+				renderContent={ () => (
+					<PatternSelection
+						clientId={ clientId }
+						attributes={ attributes }
+						showSearch={ false }
+						showTitlesAsTooltip
+					/>
+				) }
+			/>
+		</DropdownContentWrapper>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When in contentOnly mode, the Query block should show the "change design" button in its toolbar if patterns are available. #73182 hid most of the toolbar slots in contentOnly mode, and inadvertently this button was hidden too.

This PR moves the button to the "other" slot that is visible when contentOnly is enabled, and which we're using for other contentOnly-allowed functionality already.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the contentOnly experiment
2. Activate TT5 theme
3. Go to blog homepage template and select the Query pattern
4. The "change design" button should be visible

<img width="1017" height="462" alt="Screenshot 2025-12-11 at 4 04 28 pm" src="https://github.com/user-attachments/assets/996b8cc5-7777-4b4f-b6c3-dc1fba591eef" />

There's a tiny padding discrepancy between its current position in trunk and this PR, which seems to be due to different markup structure between slots:

Trunk:

<img width="1009" height="483" alt="Screenshot 2025-12-11 at 4 01 25 pm" src="https://github.com/user-attachments/assets/922aed12-edae-4f13-80df-07aa44e2f993" />

This PR:

<img width="995" height="481" alt="Screenshot 2025-12-11 at 4 00 29 pm" src="https://github.com/user-attachments/assets/f54ed044-aa7c-478b-9d46-1996d7e76e63" />

I'm not sure yet what the best way to address that might be.