### PR TITLE
Editor: Remove extra comma from offline error notices

### DIFF
--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -93,16 +93,16 @@ export function getNotificationArgumentsForSaveFail( data ) {
 	if ( error.code === 'offline_error' ) {
 		const messages = {
 			publish: __(
-				'Publishing failed because you were offline. Please, verify your connection and try again.'
+				'Publishing failed because you were offline. Please verify your connection and try again.'
 			),
 			private: __(
-				'Publishing failed because you were offline. Please, verify your connection and try again.'
+				'Publishing failed because you were offline. Please verify your connection and try again.'
 			),
 			future: __(
-				'Scheduling failed because you were offline. Please, verify your connection and try again.'
+				'Scheduling failed because you were offline. Please verify your connection and try again.'
 			),
 			default: __(
-				'Updating failed because you were offline. Please, verify your connection and try again.'
+				'Updating failed because you were offline. Please verify your connection and try again.'
 			),
 		};
 

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -271,7 +271,7 @@ test.describe( 'Autosave', () => {
 		await expect(
 			page.locator( '.components-notice__content' )
 		).toContainText(
-			'Updating failed because you were offline. Please, verify your connection and try again.'
+			'Updating failed because you were offline. Please verify your connection and try again.'
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -244,7 +244,7 @@ test.describe( 'Change detection', () => {
 			page
 				.getByRole( 'region', { name: 'Editor content' } )
 				.getByText(
-					'Updating failed because you were offline. Please, verify your connection and try again.'
+					'Updating failed because you were offline. Please verify your connection and try again.'
 				)
 		).toBeVisible();
 		await expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removing an extra comma from a few notice strings.

## Why?

Following up on https://github.com/WordPress/gutenberg/pull/73874#issuecomment-3640025034

## How?
Just removing the commas.

## Testing Instructions
Same as #73874.

### Testing Instructions for Keyboard
Same