### PR TITLE
Fix combined field alignment in DataViews table layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)
 - DataViews: Apply primary style to first column if there is no title field. [#73729](https://github.com/WordPress/gutenberg/pull/73729)
+- DataViews: Combined field alignment in table layout. [#73908](https://github.com/WordPress/gutenberg/pull/73908)
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -41,7 +41,7 @@ function ColumnPrimary< Item >( {
 	isItemClickable: ( item: Item ) => boolean;
 } ) {
 	return (
-		<HStack spacing={ 3 } justify="flex-start">
+		<HStack spacing={ 3 } alignment="flex-start" justify="flex-start">
 			{ mediaField && (
 				<ItemClickWrapper
 					item={ item }


### PR DESCRIPTION
## What?
Apply `align-items: flex-start;` to the wrapper for combined fields in the primary column of DataViews table layout.

## Why?
Currently alignment is broken in the Templates dataview:

<img width="1072" height="145" alt="Screenshot 2025-12-11 at 10 02 52" src="https://github.com/user-attachments/assets/02c87c94-493e-4e06-b423-4e6bbb0b095f" />


## How?
Update properties of containing `HStack` to ensure the title remains aligned with other fields regardless of how tall the preview field is:

 
<img width="1377" height="187" alt="Screenshot 2025-12-11 at 10 05 24" src="https://github.com/user-attachments/assets/988f0d6d-42bd-4c8e-a42b-7c2d9347d2d4" />


## Testing
* `npm run build`
* Check the Templates dataview in the site editor and ensure correct alignment
* `npm run storybook` and check the alignment in http://localhost:50240/?path=/docs/dataviews-dataviews--docs

### Before (storybook)
<img width="992" height="102" alt="Screenshot 2025-12-11 at 10 08 44" src="https://github.com/user-attachments/assets/5a083df0-fb19-45c2-8fef-743388562ea7" />


### After (storybook)
<img width="988" height="106" alt="Screenshot 2025-12-11 at 10 08 51" src="https://github.com/user-attachments/assets/27f34618-911e-4996-b97b-53e52ef7858e" />
