### PR TITLE
Fix CI static analysis on Windows

### DIFF
--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { basename, join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { basename } from 'node:path';
 import type { Plugin } from '@terrazzo/parser';
 
 type DTCGPrimitiveValue =
@@ -189,13 +188,19 @@ export default function pluginModeOverrides(): Plugin {
 					}
 
 					// Output as {basename}.{mode}.json (e.g., dimension.compact.json)
-					const filePath = fileURLToPath( filename );
-					const outFile = join(
-						dirname( filePath ),
-						'modes',
-						`${ basename( filePath, '.json' ) }.${ mode }.json`
+					const sourceDir = new URL( './', filename );
+					const outFileName = `${ basename(
+						filename.pathname,
+						'.json'
+					) }.${ mode }.json`;
+					const outFileUrl = new URL(
+						`modes/${ outFileName }`,
+						sourceDir
 					);
-					outputFile( outFile, JSON.stringify( output, null, '\t' ) );
+					outputFile(
+						outFileUrl.href,
+						JSON.stringify( output, null, '\t' )
+					);
 				}
 			}
 		},


### PR DESCRIPTION
## What?
Tries to fix the [Windows CI build failure](https://github.com/WordPress/gutenberg/actions/runs/20112151366/job/57772687579#step:6:29) as a follow-up to #73860.

## Why?
The plugin is passing an absolute Windows path to Terrazzo's outputFile function. Internally, `outputFile` calls new `URL(filename, config.outDir)`, which fails because Windows paths are not valid URL strings.

## How?
Instead of converting URLs to paths, work entirely with URLs; this is cross-platform because the URL API handles path differences automatically.

## Testing
Check that `npm run --workspace @wordpress/theme build` passes locally

## Screenshots
| Before | After |
| -- | -- |
| <img width="1272" height="483" alt="imagen" src="https://github.com/user-attachments/assets/0f13a84e-4402-4c7e-ab45-e54b2688543d" /> | <img width="1257" height="510" alt="imagen" src="https://github.com/user-attachments/assets/fb7ed2d3-7e57-4fc1-a6c0-b3646c47d465" /> |