### PR TITLE
Update: Preserve additional meta properties on client side abilities.

### DIFF
--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -139,7 +139,10 @@ export function registerAbility( ability: Ability ) {
 			annotations.clientRegistered = true;
 		}
 
-		const meta = { annotations };
+		const meta = {
+			...( ability.meta || {} ),
+			annotations,
+		};
 
 		// All validation passed, dispatch the registration action
 		dispatch( {
@@ -233,7 +236,10 @@ export function registerAbilityCategory(
 			annotations.clientRegistered = true;
 		}
 
-		const meta = { annotations };
+		const meta = {
+			...( args.meta || {} ),
+			annotations,
+		};
 		const category: AbilityCategory = {
 			slug,
 			label: args.label,

--- a/packages/abilities/src/store/tests/actions.test.ts
+++ b/packages/abilities/src/store/tests/actions.test.ts
@@ -398,6 +398,35 @@ describe( 'Store Actions', () => {
 			expect( mockDispatch ).not.toHaveBeenCalled();
 		} );
 
+		it( 'should preserve arbitrary meta properties like scope', () => {
+			const ability: Ability = {
+				name: 'test/ability-with-scope',
+				label: 'Test Ability',
+				description: 'Test ability with custom scope',
+				category: 'test-category',
+				callback: jest.fn(),
+				meta: {
+					scope: 'editor',
+					customProperty: 'customValue',
+				},
+			};
+
+			const action = registerAbility( ability );
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: {
+					...ability,
+					meta: {
+						scope: 'editor',
+						customProperty: 'customValue',
+						annotations: { clientRegistered: true },
+					},
+				},
+			} );
+		} );
+
 		it( 'should validate and reject already registered ability', () => {
 			const existingAbility: Ability = {
 				name: 'test/ability',

--- a/packages/abilities/src/types.ts
+++ b/packages/abilities/src/types.ts
@@ -86,6 +86,7 @@ export interface Ability {
 			destructive?: boolean;
 			idempotent?: boolean;
 		};
+		[ key: string ]: any;
 	};
 }
 
@@ -133,6 +134,7 @@ export interface AbilityCategory {
 			clientRegistered?: boolean;
 			serverRegistered?: boolean;
 		};
+		[ key: string ]: any;
 	};
 }
 


### PR DESCRIPTION
This PR reverts a change made on https://github.com/WordPress/gutenberg/pull/73364.
Now we allow arbitrary meta properties again.

cc: @youknowriad, @emdashcodes

## Testing
Verify the unit tests pass.
Load wp.admin and paste the following on the browser console:
```
const abilitiesAPI = (await import( '@wordpress/abilities' ) );
abilitiesAPI.registerAbility( {name: 'a/my-new-ability', label: 'A new ability', description: 'A new ability', callback: () => { alert('ok'); }, category: 'site', meta: {propertyA: 'propertyA' } } );
abilitiesAPI.getAbility('a/my-new-ability').meta
```

Verify propertyA was preserved on the meta object.