### PR TITLE
Add create new overlay button to Navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -12,7 +12,6 @@ import { useDispatch } from '@wordpress/data';
 import { SelectControl, Spinner, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { serialize } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -154,7 +153,6 @@ export default function OverlayTemplatePartSelector( {
 				{
 					slug: cleanSlug,
 					title: uniqueTitle,
-					content: serialize( [] ),
 					area: 'overlay',
 				},
 				{ throwOnError: true }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -143,6 +143,10 @@ export default function OverlayTemplatePartSelector( {
 				} );
 			}
 		} catch ( error ) {
+			// Error handling pattern matches CreateTemplatePartModalContents.
+			// See: packages/fields/src/components/create-template-part-modal/index.tsx
+			// The 'unknown_error' code check ensures generic error codes don't show
+			// potentially confusing technical messages, instead showing a user-friendly fallback.
 			const errorMessage =
 				error instanceof Error &&
 				'code' in error &&

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -18,11 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
-import {
-	parseTemplatePartId,
-	getUniqueTemplatePartTitle,
-	getCleanTemplatePartSlug,
-} from './utils';
+import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
 
 /**
  * Overlay Template Part Selector component.
@@ -94,11 +90,6 @@ export default function OverlayTemplatePartSelector( {
 
 		return [ ...baseOptions, ...templatePartOptions ];
 	}, [ overlayTemplateParts, hasResolved, isResolving ] );
-
-	// Parse selected template part for navigation
-	const parsedTemplatePart = useMemo( () => {
-		return parseTemplatePartId( overlay );
-	}, [ overlay ] );
 
 	// Find the selected template part to get its title
 	const selectedTemplatePart = useMemo( () => {
@@ -197,10 +188,7 @@ export default function OverlayTemplatePartSelector( {
 	] );
 
 	const isEditButtonDisabled =
-		! overlay ||
-		! parsedTemplatePart ||
-		! onNavigateToEntityRecord ||
-		isResolving;
+		! overlay || ! onNavigateToEntityRecord || isResolving;
 
 	const isCreateButtonDisabled = isResolving || isCreating;
 

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -166,18 +166,15 @@ export default function OverlayTemplatePartSelector( {
 			] );
 
 			// Set the newly created overlay as selected
-			const templatePartId = createTemplatePartId(
-				templatePart.theme,
-				templatePart.slug
-			);
+			// templatePart.id is already in the format "theme//slug"
 			setAttributes( {
-				overlay: templatePartId,
+				overlay: templatePart.id,
 			} );
 
 			// Optionally navigate to the new overlay for editing
 			if ( onNavigateToEntityRecord ) {
 				onNavigateToEntityRecord( {
-					postId: templatePartId,
+					postId: templatePart.id,
 					postType: 'wp_template_part',
 				} );
 			}

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -16,31 +16,10 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
 import {
+	parseTemplatePartId,
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
-} from '../../../../fields/src/components/create-template-part-modal/utils';
-
-/**
- * Parses a template part ID into theme and slug components.
- *
- * @param {string} templatePartId Template part ID in format "theme//slug".
- * @return {{theme: string, slug: string}|null} Parsed components or null if invalid.
- */
-function parseTemplatePartId( templatePartId ) {
-	if ( ! templatePartId || typeof templatePartId !== 'string' ) {
-		return null;
-	}
-
-	const parts = templatePartId.split( '//' );
-	if ( parts.length !== 2 ) {
-		return null;
-	}
-
-	return {
-		theme: parts[ 0 ],
-		slug: parts[ 1 ],
-	};
-}
+} from './utils';
 
 /**
  * Overlay Template Part Selector component.

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -186,9 +186,10 @@ export default function OverlayTemplatePartSelector( {
 				disabled={ isCreateButtonDisabled }
 				accessibleWhenDisabled
 				isBusy={ isCreating }
+				aria-label={ __( 'Create new overlay template' ) }
 				className="wp-block-navigation__overlay-create-link"
 			>
-				{ __( 'Create new?' ) }
+				{ __( 'Create New Overlay Template' ) }
 			</Button>
 		);
 
@@ -227,7 +228,7 @@ export default function OverlayTemplatePartSelector( {
 				accessibleWhenDisabled
 				help={ helpText }
 			/>
-			{ overlay && hasResolved && selectedTemplatePart && (
+			{ overlay && ( ! hasResolved || selectedTemplatePart ) && (
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -131,47 +131,52 @@ export default function OverlayTemplatePartSelector( {
 		} );
 	};
 
+	// Create a new overlay template part
+	const createOverlayTemplatePart = useCallback( async () => {
+		// Generate unique name using only overlay area template parts
+		// Filter to only include template parts with titles for uniqueness check
+		const templatePartsWithTitles = overlayTemplateParts.filter(
+			( templatePart ) => templatePart.title?.rendered
+		);
+		const uniqueTitle = getUniqueTemplatePartTitle(
+			__( 'Overlay' ),
+			templatePartsWithTitles
+		);
+		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
+
+		// Create the template part
+		const templatePart = await saveEntityRecord(
+			'postType',
+			'wp_template_part',
+			{
+				slug: cleanSlug,
+				title: uniqueTitle,
+				area: 'overlay',
+			},
+			{ throwOnError: true }
+		);
+
+		// Invalidate the template parts resolution cache to refresh the list
+		invalidateResolution( 'getEntityRecords', [
+			'postType',
+			'wp_template_part',
+			{ per_page: -1 },
+		] );
+
+		return templatePart;
+	}, [ overlayTemplateParts, saveEntityRecord, invalidateResolution ] );
+
 	const handleCreateOverlay = useCallback( async () => {
 		try {
 			setIsCreating( true );
 
-			// Generate unique name using only overlay area template parts
-			// Filter to only include template parts with titles for uniqueness check
-			const templatePartsWithTitles = overlayTemplateParts.filter(
-				( templatePart ) => templatePart.title?.rendered
-			);
-			const uniqueTitle = getUniqueTemplatePartTitle(
-				__( 'Overlay' ),
-				templatePartsWithTitles
-			);
-			const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
+			const templatePart = await createOverlayTemplatePart();
 
-			// Create the template part
-			const templatePart = await saveEntityRecord(
-				'postType',
-				'wp_template_part',
-				{
-					slug: cleanSlug,
-					title: uniqueTitle,
-					area: 'overlay',
-				},
-				{ throwOnError: true }
-			);
-
-			// Invalidate the template parts resolution cache to refresh the list
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'wp_template_part',
-				{ per_page: -1 },
-			] );
-
-			// Set the newly created overlay as selected
-			// templatePart.id is already in the format "theme//slug"
 			setAttributes( {
 				overlay: templatePart.id,
 			} );
 
-			// Optionally navigate to the new overlay for editing
+			// Navigate to the new overlay for editing
 			if ( onNavigateToEntityRecord ) {
 				onNavigateToEntityRecord( {
 					postId: templatePart.id,
@@ -194,11 +199,9 @@ export default function OverlayTemplatePartSelector( {
 			setIsCreating( false );
 		}
 	}, [
-		overlayTemplateParts,
-		saveEntityRecord,
+		createOverlayTemplatePart,
 		setAttributes,
 		onNavigateToEntityRecord,
-		invalidateResolution,
 		createErrorNotice,
 	] );
 

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -1,14 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState, useEffect } from '@wordpress/element';
+import {
+	useMemo,
+	useState,
+	useEffect,
+	useCallback,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { SelectControl, Spinner, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { serialize } from '@wordpress/blocks';
-import { plus } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -151,7 +156,7 @@ export default function OverlayTemplatePartSelector( {
 		} );
 	};
 
-	const handleCreateOverlay = async () => {
+	const handleCreateOverlay = useCallback( async () => {
 		try {
 			// Generate unique name using only overlay area template parts
 			// Filter to only include template parts with titles for uniqueness check
@@ -217,7 +222,14 @@ export default function OverlayTemplatePartSelector( {
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 			setCreatingRecordId( null );
 		}
-	};
+	}, [
+		overlayTemplateParts,
+		saveEntityRecord,
+		setAttributes,
+		onNavigateToEntityRecord,
+		invalidateResolution,
+		createErrorNotice,
+	] );
 
 	const isEditButtonDisabled =
 		! overlay ||
@@ -226,6 +238,45 @@ export default function OverlayTemplatePartSelector( {
 		isResolving;
 
 	const isCreateButtonDisabled = isResolving || isSavingNewRecord;
+
+	// Build help text with create button using createInterpolateElement
+	// Must be called before early return to follow Rules of Hooks
+	const helpText = useMemo( () => {
+		const createButton = (
+			<Button
+				__next40pxDefaultSize
+				variant="link"
+				onClick={ handleCreateOverlay }
+				disabled={ isCreateButtonDisabled }
+				accessibleWhenDisabled
+				isBusy={ isSavingNewRecord }
+				className="wp-block-navigation__overlay-create-link"
+			>
+				{ __( 'Create new?' ) }
+			</Button>
+		);
+
+		if ( overlayTemplateParts.length === 0 && hasResolved ) {
+			return createInterpolateElement(
+				__( 'No overlays found. <button />' ),
+				{
+					button: createButton,
+				}
+			);
+		}
+		return createInterpolateElement(
+			__( 'Select an overlay to use for the navigation. <button />' ),
+			{
+				button: createButton,
+			}
+		);
+	}, [
+		overlayTemplateParts.length,
+		hasResolved,
+		isCreateButtonDisabled,
+		isSavingNewRecord,
+		handleCreateOverlay,
+	] );
 
 	if ( isResolving && ! hasResolved ) {
 		return (
@@ -247,24 +298,8 @@ export default function OverlayTemplatePartSelector( {
 				onChange={ handleSelectChange }
 				disabled={ isResolving }
 				accessibleWhenDisabled
-				help={
-					overlayTemplateParts.length === 0 && hasResolved
-						? __( 'No overlays found.' )
-						: __( 'Select an overlay to use for the navigation.' )
-				}
+				help={ helpText }
 			/>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				onClick={ handleCreateOverlay }
-				disabled={ isCreateButtonDisabled }
-				accessibleWhenDisabled
-				isBusy={ isSavingNewRecord }
-				icon={ plus }
-				className="wp-block-navigation__overlay-create-button"
-			>
-				{ __( 'Create new overlay' ) }
-			</Button>
 			{ overlay && (
 				<Button
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -1,16 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import { useEntityRecords } from '@wordpress/core-data';
+import { useMemo, useState, useEffect } from '@wordpress/element';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { SelectControl, Spinner, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
+import { serialize } from '@wordpress/blocks';
+import { plus } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
+import {
+	getUniqueTemplatePartTitle,
+	getCleanTemplatePartSlug,
+} from '../../../../fields/src/components/create-template-part-modal/utils';
 
 /**
  * Parses a template part ID into theme and slug components.
@@ -55,6 +63,35 @@ export default function OverlayTemplatePartSelector( {
 	} = useEntityRecords( 'postType', 'wp_template_part', {
 		per_page: -1,
 	} );
+
+	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	// Track newly created record ID to check saving state from store
+	const [ creatingRecordId, setCreatingRecordId ] = useState( null );
+
+	// Check if the newly created record is currently saving
+	const isSavingNewRecord = useSelect(
+		( select ) => {
+			if ( ! creatingRecordId ) {
+				return false;
+			}
+			const { isSavingEntityRecord } = select( coreStore );
+			return isSavingEntityRecord(
+				'postType',
+				'wp_template_part',
+				creatingRecordId
+			);
+		},
+		[ creatingRecordId ]
+	);
+
+	// Clear the creating record ID when saving completes
+	useEffect( () => {
+		if ( creatingRecordId && ! isSavingNewRecord ) {
+			setCreatingRecordId( null );
+		}
+	}, [ creatingRecordId, isSavingNewRecord ] );
 
 	// Filter template parts by overlay area
 	const overlayTemplateParts = useMemo( () => {
@@ -135,11 +172,81 @@ export default function OverlayTemplatePartSelector( {
 		} );
 	};
 
+	const handleCreateOverlay = async () => {
+		try {
+			// Generate unique name using only overlay area template parts
+			// Filter to only include template parts with titles for uniqueness check
+			const templatePartsWithTitles = overlayTemplateParts.filter(
+				( templatePart ) => templatePart.title?.rendered
+			);
+			const uniqueTitle = getUniqueTemplatePartTitle(
+				__( 'Overlay' ),
+				templatePartsWithTitles
+			);
+			const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
+
+			// Create the template part
+			const templatePart = await saveEntityRecord(
+				'postType',
+				'wp_template_part',
+				{
+					slug: cleanSlug,
+					title: uniqueTitle,
+					content: serialize( [] ),
+					area: 'overlay',
+				},
+				{ throwOnError: true }
+			);
+
+			// Track the new record ID to check saving state
+			setCreatingRecordId( templatePart.id );
+
+			// Invalidate the template parts resolution cache to refresh the list
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'wp_template_part',
+				{ per_page: -1 },
+			] );
+
+			// Set the newly created overlay as selected
+			const templatePartId = createTemplatePartId(
+				templatePart.theme,
+				templatePart.slug
+			);
+			setAttributes( {
+				overlay: templatePartId,
+			} );
+
+			// Optionally navigate to the new overlay for editing
+			if ( onNavigateToEntityRecord ) {
+				onNavigateToEntityRecord( {
+					postId: templatePartId,
+					postType: 'wp_template_part',
+				} );
+			}
+		} catch ( error ) {
+			const errorMessage =
+				error instanceof Error &&
+				'code' in error &&
+				error.message &&
+				error.code !== 'unknown_error'
+					? error.message
+					: __(
+							'An error occurred while creating the overlay template part.'
+					  );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+			setCreatingRecordId( null );
+		}
+	};
+
 	const isEditButtonDisabled =
 		! overlay ||
 		! parsedTemplatePart ||
 		! onNavigateToEntityRecord ||
 		isResolving;
+
+	const isCreateButtonDisabled = isResolving || isSavingNewRecord;
 
 	if ( isResolving && ! hasResolved ) {
 		return (
@@ -167,6 +274,18 @@ export default function OverlayTemplatePartSelector( {
 						: __( 'Select an overlay to use for the navigation.' )
 				}
 			/>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				onClick={ handleCreateOverlay }
+				disabled={ isCreateButtonDisabled }
+				accessibleWhenDisabled
+				isBusy={ isSavingNewRecord }
+				icon={ plus }
+				className="wp-block-navigation__overlay-create-button"
+			>
+				{ __( 'Create new overlay' ) }
+			</Button>
 			{ overlay && (
 				<Button
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { SelectControl, Spinner, Button } from '@wordpress/components';
+import { SelectControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
@@ -190,9 +190,7 @@ export default function OverlayTemplatePartSelector( {
 				error.message &&
 				error.code !== 'unknown_error'
 					? error.message
-					: __(
-							'An error occurred while creating the overlay template part.'
-					  );
+					: __( 'An error occurred while creating the overlay.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		} finally {
@@ -251,15 +249,6 @@ export default function OverlayTemplatePartSelector( {
 		isCreating,
 		handleCreateOverlay,
 	] );
-
-	if ( isResolving && ! hasResolved ) {
-		return (
-			<div className="wp-block-navigation__overlay-selector">
-				<Spinner />
-				<p>{ __( 'Loading overlays…' ) }</p>
-			</div>
-		);
-	}
 
 	return (
 		<div className="wp-block-navigation__overlay-selector">

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -4,12 +4,11 @@
 import {
 	useMemo,
 	useState,
-	useEffect,
 	useCallback,
 	createInterpolateElement,
 } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { SelectControl, Spinner, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -51,31 +50,8 @@ export default function OverlayTemplatePartSelector( {
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	// Track newly created record ID to check saving state from store
-	const [ creatingRecordId, setCreatingRecordId ] = useState( null );
-
-	// Check if the newly created record is currently saving
-	const isSavingNewRecord = useSelect(
-		( select ) => {
-			if ( ! creatingRecordId ) {
-				return false;
-			}
-			const { isSavingEntityRecord } = select( coreStore );
-			return isSavingEntityRecord(
-				'postType',
-				'wp_template_part',
-				creatingRecordId
-			);
-		},
-		[ creatingRecordId ]
-	);
-
-	// Clear the creating record ID when saving completes
-	useEffect( () => {
-		if ( creatingRecordId && ! isSavingNewRecord ) {
-			setCreatingRecordId( null );
-		}
-	}, [ creatingRecordId, isSavingNewRecord ] );
+	// Track if we're currently creating a new overlay
+	const [ isCreating, setIsCreating ] = useState( false );
 
 	// Filter template parts by overlay area
 	const overlayTemplateParts = useMemo( () => {
@@ -158,6 +134,8 @@ export default function OverlayTemplatePartSelector( {
 
 	const handleCreateOverlay = useCallback( async () => {
 		try {
+			setIsCreating( true );
+
 			// Generate unique name using only overlay area template parts
 			// Filter to only include template parts with titles for uniqueness check
 			const templatePartsWithTitles = overlayTemplateParts.filter(
@@ -181,9 +159,6 @@ export default function OverlayTemplatePartSelector( {
 				},
 				{ throwOnError: true }
 			);
-
-			// Track the new record ID to check saving state
-			setCreatingRecordId( templatePart.id );
 
 			// Invalidate the template parts resolution cache to refresh the list
 			invalidateResolution( 'getEntityRecords', [
@@ -220,7 +195,8 @@ export default function OverlayTemplatePartSelector( {
 					  );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
-			setCreatingRecordId( null );
+		} finally {
+			setIsCreating( false );
 		}
 	}, [
 		overlayTemplateParts,
@@ -237,7 +213,7 @@ export default function OverlayTemplatePartSelector( {
 		! onNavigateToEntityRecord ||
 		isResolving;
 
-	const isCreateButtonDisabled = isResolving || isSavingNewRecord;
+	const isCreateButtonDisabled = isResolving || isCreating;
 
 	// Build help text with create button using createInterpolateElement
 	// Must be called before early return to follow Rules of Hooks
@@ -249,7 +225,7 @@ export default function OverlayTemplatePartSelector( {
 				onClick={ handleCreateOverlay }
 				disabled={ isCreateButtonDisabled }
 				accessibleWhenDisabled
-				isBusy={ isSavingNewRecord }
+				isBusy={ isCreating }
 				className="wp-block-navigation__overlay-create-link"
 			>
 				{ __( 'Create new?' ) }
@@ -274,7 +250,7 @@ export default function OverlayTemplatePartSelector( {
 		overlayTemplateParts.length,
 		hasResolved,
 		isCreateButtonDisabled,
-		isSavingNewRecord,
+		isCreating,
 		handleCreateOverlay,
 	] );
 

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -1,18 +1,14 @@
 /**
  * WordPress dependencies
  */
-import {
-	useMemo,
-	useState,
-	useCallback,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { SelectControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
+import { plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -175,48 +171,27 @@ export default function OverlayTemplatePartSelector( {
 
 	const isCreateButtonDisabled = isResolving || isCreating;
 
-	// Build help text with create button using createInterpolateElement
-	// Must be called before early return to follow Rules of Hooks
+	// Build help text
 	const helpText = useMemo( () => {
-		const createButton = (
+		if ( overlayTemplateParts.length === 0 && hasResolved ) {
+			return __( 'No overlays found.' );
+		}
+		return __( 'Select an overlay to use for the navigation.' );
+	}, [ overlayTemplateParts.length, hasResolved ] );
+
+	return (
+		<div className="wp-block-navigation__overlay-selector">
 			<Button
-				__next40pxDefaultSize
-				variant="link"
+				size="small"
+				icon={ plus }
 				onClick={ handleCreateOverlay }
 				disabled={ isCreateButtonDisabled }
 				accessibleWhenDisabled
 				isBusy={ isCreating }
-				aria-label={ __( 'Create new overlay template' ) }
-				className="wp-block-navigation__overlay-create-link"
-			>
-				{ __( 'Create New Overlay Template' ) }
-			</Button>
-		);
-
-		if ( overlayTemplateParts.length === 0 && hasResolved ) {
-			return createInterpolateElement(
-				__( 'No overlays found. <button />' ),
-				{
-					button: createButton,
-				}
-			);
-		}
-		return createInterpolateElement(
-			__( 'Select an overlay to use for the navigation. <button />' ),
-			{
-				button: createButton,
-			}
-		);
-	}, [
-		overlayTemplateParts.length,
-		hasResolved,
-		isCreateButtonDisabled,
-		isCreating,
-		handleCreateOverlay,
-	] );
-
-	return (
-		<div className="wp-block-navigation__overlay-selector">
+				label={ __( 'Create new overlay template' ) }
+				showTooltip
+				className="wp-block-navigation__overlay-create-button"
+			/>
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -167,7 +167,11 @@ export default function OverlayTemplatePartSelector( {
 	] );
 
 	const isEditButtonDisabled =
-		! overlay || ! onNavigateToEntityRecord || isResolving;
+		! overlay ||
+		! hasResolved ||
+		! selectedTemplatePart ||
+		! onNavigateToEntityRecord ||
+		isResolving;
 
 	const isCreateButtonDisabled = isResolving || isCreating;
 
@@ -223,7 +227,7 @@ export default function OverlayTemplatePartSelector( {
 				accessibleWhenDisabled
 				help={ helpText }
 			/>
-			{ overlay && (
+			{ overlay && hasResolved && selectedTemplatePart && (
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -46,7 +46,7 @@ export default function OverlayTemplatePartSelector( {
 		per_page: -1,
 	} );
 
-	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
+	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	// Track if we're currently creating a new overlay
@@ -156,15 +156,8 @@ export default function OverlayTemplatePartSelector( {
 			{ throwOnError: true }
 		);
 
-		// Invalidate the template parts resolution cache to refresh the list
-		invalidateResolution( 'getEntityRecords', [
-			'postType',
-			'wp_template_part',
-			{ per_page: -1 },
-		] );
-
 		return templatePart;
-	}, [ overlayTemplateParts, saveEntityRecord, invalidateResolution ] );
+	}, [ overlayTemplateParts, saveEntityRecord ] );
 
 	const handleCreateOverlay = useCallback( async () => {
 		try {

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -7,7 +7,7 @@ import {
 	useCallback,
 	createInterpolateElement,
 } from '@wordpress/element';
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { SelectControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -18,7 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
-import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
+import useCreateOverlayTemplatePart from './use-create-overlay';
 
 /**
  * Overlay Template Part Selector component.
@@ -42,7 +42,6 @@ export default function OverlayTemplatePartSelector( {
 		per_page: -1,
 	} );
 
-	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	// Track if we're currently creating a new overlay
@@ -57,6 +56,10 @@ export default function OverlayTemplatePartSelector( {
 			( templatePart ) => templatePart.area === 'overlay'
 		);
 	}, [ templateParts ] );
+
+	// Hook to create overlay template part
+	const createOverlayTemplatePart =
+		useCreateOverlayTemplatePart( overlayTemplateParts );
 
 	// Build options for SelectControl
 	const options = useMemo( () => {
@@ -121,34 +124,6 @@ export default function OverlayTemplatePartSelector( {
 			postType: 'wp_template_part',
 		} );
 	};
-
-	// Create a new overlay template part
-	const createOverlayTemplatePart = useCallback( async () => {
-		// Generate unique name using only overlay area template parts
-		// Filter to only include template parts with titles for uniqueness check
-		const templatePartsWithTitles = overlayTemplateParts.filter(
-			( templatePart ) => templatePart.title?.rendered
-		);
-		const uniqueTitle = getUniqueTemplatePartTitle(
-			__( 'Overlay' ),
-			templatePartsWithTitles
-		);
-		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
-
-		// Create the template part
-		const templatePart = await saveEntityRecord(
-			'postType',
-			'wp_template_part',
-			{
-				slug: cleanSlug,
-				title: uniqueTitle,
-				area: 'overlay',
-			},
-			{ throwOnError: true }
-		);
-
-		return templatePart;
-	}, [ overlayTemplateParts, saveEntityRecord ] );
 
 	const handleCreateOverlay = useCallback( async () => {
 		try {

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -95,8 +95,8 @@ describe( 'OverlayTemplatePartSelector', () => {
 		} );
 	} );
 
-	describe( 'Template part selection', () => {
-		it( 'should show selector with "None (default)" option when no template parts are available', () => {
+	describe( 'Overlay selection', () => {
+		it( 'should show selector with "None (default)" option when no overlays are available', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [],
 				isResolving: false,
@@ -117,7 +117,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should filter template parts by overlay area', () => {
+		it( 'should only show overlay (template parts) in the selector', () => {
 			useEntityRecords.mockReturnValue( {
 				records: allTemplateParts,
 				isResolving: false,
@@ -145,7 +145,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'should display template part slug when title is missing', () => {
+		it( 'should display overlay slug when title is missing', () => {
 			const templatePartNoTitle = {
 				...templatePart1,
 				title: null,
@@ -164,7 +164,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should call setAttributes when a template part is selected', async () => {
+		it( 'should call set the overlay attribute when an overlay is selected', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -213,7 +213,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 		} );
 
-		it( 'should display selected template part', () => {
+		it( 'should display selected overlay', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -236,7 +236,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Edit button', () => {
-		it( 'should not render when no template part is selected', () => {
+		it( 'should not render when no overlay is selected', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -252,7 +252,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).not.toBeInTheDocument();
 		} );
 
-		it( 'should disable button when template parts are initially loading', () => {
+		it( 'should disable button when overlays are initially loading', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: true,
@@ -301,7 +301,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toHaveAccessibleName();
 		} );
 
-		it( 'should be disabled when navigation to focused overlay editor is notavailable', () => {
+		it( 'should be disabled when navigation to focused overlay editor is not available', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -431,7 +431,9 @@ describe( 'OverlayTemplatePartSelector', () => {
 				screen.getByText( 'No overlays found.' )
 			).toBeInTheDocument();
 			expect(
-				screen.getByRole( 'button', { name: 'Create new?' } )
+				screen.getByRole( 'button', {
+					name: 'Create new overlay template',
+				} )
 			).toBeInTheDocument();
 		} );
 
@@ -450,7 +452,9 @@ describe( 'OverlayTemplatePartSelector', () => {
 				)
 			).toBeInTheDocument();
 			expect(
-				screen.getByRole( 'button', { name: 'Create new?' } )
+				screen.getByRole( 'button', {
+					name: 'Create new overlay template',
+				} )
 			).toBeInTheDocument();
 		} );
 	} );
@@ -479,7 +483,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const createButton = screen.getByRole( 'button', {
-				name: 'Create new?',
+				name: 'Create new overlay template',
 			} );
 
 			await user.click( createButton );
@@ -511,7 +515,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const createButton = screen.getByRole( 'button', {
-				name: 'Create new?',
+				name: 'Create new overlay template',
 			} );
 
 			await user.click( createButton );
@@ -537,7 +541,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const createButton = screen.getByRole( 'button', {
-				name: 'Create new?',
+				name: 'Create new overlay template',
 			} );
 
 			expect( createButton ).toHaveAttribute( 'aria-disabled', 'true' );

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -186,7 +186,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 		} );
 
-		it( 'should call setAttributes with undefined when "None (default)" is selected', async () => {
+		it( 'unsets custom overlay when "None (default)" is selected', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -278,7 +278,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
-		it( 'should be enabled when a valid template part is selected', () => {
+		it( 'should be enabled when a valid overlay is selected', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -300,7 +300,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toBeEnabled();
 		} );
 
-		it( 'should be disabled when onNavigateToEntityRecord is not available', () => {
+		it( 'should be disabled when navigation to focused overlay editor is notavailable', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -324,7 +324,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
-		it( 'should call onNavigateToEntityRecord when edit button is clicked', async () => {
+		it( 'should navigate to focused overlay editor when edit button is clicked', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -353,7 +353,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 		} );
 
-		it( 'should not call onNavigateToEntityRecord when button is disabled', async () => {
+		it( 'should not navigate to focused overlay editor when button is disabled', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -298,6 +298,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 
 			expect( editButton ).toBeEnabled();
+			expect( editButton ).toHaveAccessibleName();
 		} );
 
 		it( 'should be disabled when navigation to focused overlay editor is notavailable', () => {
@@ -414,47 +415,6 @@ describe( 'OverlayTemplatePartSelector', () => {
 					'Select an overlay to use for the navigation.'
 				)
 			).toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'Accessibility', () => {
-		it( 'should have proper ARIA labels on edit button', () => {
-			useEntityRecords.mockReturnValue( {
-				records: [ templatePart1 ],
-				isResolving: false,
-				hasResolved: true,
-			} );
-
-			render(
-				<OverlayTemplatePartSelector
-					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
-				/>
-			);
-
-			const editButton = screen.getByRole( 'button', {
-				name: ( accessibleName ) =>
-					accessibleName.startsWith( 'Edit overlay' ),
-			} );
-
-			expect( editButton ).toHaveAccessibleName();
-		} );
-
-		it( 'should show disabled select control when initially loading', () => {
-			useEntityRecords.mockReturnValue( {
-				records: null,
-				isResolving: true,
-				hasResolved: false,
-			} );
-
-			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
-
-			// Should show disabled select control instead of spinner
-			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
-			} );
-			expect( select ).toBeInTheDocument();
-			expect( select ).toBeDisabled();
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -8,20 +8,41 @@ import userEvent from '@testing-library/user-event';
  * WordPress dependencies
  */
 import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import OverlayTemplatePartSelector from '../overlay-template-part-selector';
+import useCreateOverlayTemplatePart from '../use-create-overlay';
 
 // Mock useEntityRecords
-jest.mock( '@wordpress/core-data', () => {
-	const actual = jest.requireActual( '@wordpress/core-data' );
-	return {
-		...actual,
-		useEntityRecords: jest.fn(),
-	};
-} );
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecords: jest.fn(),
+	store: {},
+} ) );
+
+// Mock useCreateOverlayTemplatePart hook
+jest.mock( '../use-create-overlay', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Mock useDispatch specifically to avoid needing to set up full data store
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	createSelector: jest.fn( ( fn ) => fn ),
+	createRegistrySelector: jest.fn( ( fn ) => fn ),
+	createReduxStore: jest.fn( () => ( {} ) ),
+	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+		const newState = {};
+		Object.keys( reducers ).forEach( ( key ) => {
+			newState[ key ] = reducers[ key ]( state[ key ], action );
+		} );
+		return newState;
+	} ),
+	register: jest.fn(),
+} ) );
 
 const mockSetAttributes = jest.fn();
 const mockOnNavigateToEntityRecord = jest.fn();
@@ -69,12 +90,22 @@ const allTemplateParts = [
 ];
 
 describe( 'OverlayTemplatePartSelector', () => {
+	const mockCreateOverlayTemplatePart = jest.fn();
+	const mockCreateErrorNotice = jest.fn();
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		useEntityRecords.mockReturnValue( {
 			records: [],
 			isResolving: false,
 			hasResolved: false,
+		} );
+		useCreateOverlayTemplatePart.mockReturnValue(
+			mockCreateOverlayTemplatePart
+		);
+		// Mock useDispatch to return createErrorNotice for noticesStore
+		useDispatch.mockReturnValue( {
+			createErrorNotice: mockCreateErrorNotice,
 		} );
 	} );
 
@@ -399,6 +430,9 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect(
 				screen.getByText( 'No overlays found.' )
 			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Create new?' } )
+			).toBeInTheDocument();
 		} );
 
 		it( 'should show default help text when overlays are available', () => {
@@ -415,6 +449,98 @@ describe( 'OverlayTemplatePartSelector', () => {
 					'Select an overlay to use for the navigation.'
 				)
 			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Create new?' } )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Create overlay', () => {
+		it( 'should call createOverlayTemplatePart when create button is clicked', async () => {
+			const user = userEvent.setup();
+			const newOverlay = {
+				id: 'twentytwentyfive//overlay',
+				theme: 'twentytwentyfive',
+				slug: 'overlay',
+				title: {
+					rendered: 'Overlay',
+				},
+				area: 'overlay',
+			};
+
+			mockCreateOverlayTemplatePart.mockResolvedValue( newOverlay );
+
+			useEntityRecords.mockReturnValue( {
+				records: [],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const createButton = screen.getByRole( 'button', {
+				name: 'Create new?',
+			} );
+
+			await user.click( createButton );
+
+			expect( mockCreateOverlayTemplatePart ).toHaveBeenCalled();
+			expect( mockSetAttributes ).toHaveBeenCalledWith( {
+				overlay: 'twentytwentyfive//overlay',
+			} );
+			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
+				postId: 'twentytwentyfive//overlay',
+				postType: 'wp_template_part',
+			} );
+		} );
+
+		it( 'should show error notice when creation fails', async () => {
+			const user = userEvent.setup();
+
+			const error = new Error( 'Failed to create overlay' );
+			error.code = 'create_error';
+
+			mockCreateOverlayTemplatePart.mockRejectedValue( error );
+
+			useEntityRecords.mockReturnValue( {
+				records: [],
+				isResolving: false,
+				hasResolved: true,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const createButton = screen.getByRole( 'button', {
+				name: 'Create new?',
+			} );
+
+			await user.click( createButton );
+
+			// Wait for async operations
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Failed to create overlay',
+				{ type: 'snackbar' }
+			);
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should disable create button when overlays are resolving', () => {
+			useEntityRecords.mockReturnValue( {
+				records: [],
+				isResolving: true,
+				hasResolved: false,
+			} );
+
+			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
+
+			const createButton = screen.getByRole( 'button', {
+				name: 'Create new?',
+			} );
+
+			expect( createButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -79,7 +79,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Loading state', () => {
-		it( 'should show loading spinner when template parts are resolving', () => {
+		it( 'should disable select control when template parts are resolving', () => {
 			useEntityRecords.mockReturnValue( {
 				records: null,
 				isResolving: true,
@@ -88,9 +88,10 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			expect(
-				screen.getByText( 'Loading overlays…' )
-			).toBeInTheDocument();
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay template',
+			} );
+			expect( select ).toBeDisabled();
 		} );
 	} );
 
@@ -251,7 +252,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).not.toBeInTheDocument();
 		} );
 
-		it( 'should not render button when template parts are initially loading', () => {
+		it( 'should disable button when template parts are initially loading', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: true,
@@ -265,15 +266,16 @@ describe( 'OverlayTemplatePartSelector', () => {
 				/>
 			);
 
-			// Component shows spinner when initially loading, button doesn't render
-			expect(
-				screen.getByText( 'Loading overlays…' )
-			).toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', {
-					name: /Edit overlay/,
-				} )
-			).not.toBeInTheDocument();
+			// Component shows disabled select and disabled button when loading
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay template',
+			} );
+			expect( select ).toBeDisabled();
+
+			const editButton = screen.getByRole( 'button', {
+				name: /Edit overlay/,
+			} );
+			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be enabled when a valid template part is selected', () => {
@@ -438,7 +440,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toHaveAccessibleName();
 		} );
 
-		it( 'should show loading spinner instead of select control when initially loading', () => {
+		it( 'should show disabled select control when initially loading', () => {
 			useEntityRecords.mockReturnValue( {
 				records: null,
 				isResolving: true,
@@ -447,15 +449,12 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
-			// Should show loading spinner, not the select control
-			expect(
-				screen.getByText( 'Loading overlays…' )
-			).toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'combobox', {
-					name: 'Overlay template',
-				} )
-			).not.toBeInTheDocument();
+			// Should show disabled select control instead of spinner
+			const select = screen.getByRole( 'combobox', {
+				name: 'Overlay template',
+			} );
+			expect( select ).toBeInTheDocument();
+			expect( select ).toBeDisabled();
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useCreateOverlayTemplatePart from '../use-create-overlay';
+
+// Mock useDispatch
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+// Mock coreStore
+jest.mock( '@wordpress/core-data', () => ( {
+	store: {},
+} ) );
+
+describe( 'useCreateOverlayTemplatePart', () => {
+	const mockSaveEntityRecord = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useDispatch.mockReturnValue( {
+			saveEntityRecord: mockSaveEntityRecord,
+		} );
+	} );
+
+	it( 'should save a new overlay with correct parameters when no overlays exist', async () => {
+		const overlayTemplateParts = [];
+		const createdOverlay = {
+			id: 'twentytwentyfive//overlay',
+			theme: 'twentytwentyfive',
+			slug: 'overlay',
+			title: {
+				rendered: 'Overlay',
+			},
+			area: 'overlay',
+		};
+
+		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
+
+		const { result: createOverlayTemplatePart } = renderHook( () =>
+			useCreateOverlayTemplatePart( overlayTemplateParts )
+		);
+
+		let savedOverlay;
+		await act( async () => {
+			savedOverlay = await createOverlayTemplatePart.current();
+		} );
+
+		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'wp_template_part',
+			expect.objectContaining( {
+				slug: 'overlay',
+				title: 'Overlay',
+				area: 'overlay',
+			} ),
+			{ throwOnError: true }
+		);
+		expect( savedOverlay ).toEqual( createdOverlay );
+	} );
+
+	it( 'should generate unique title when overlays already exist', async () => {
+		const existingOverlay = {
+			id: 'twentytwentyfive//overlay',
+			theme: 'twentytwentyfive',
+			slug: 'overlay',
+			title: {
+				rendered: 'Overlay',
+			},
+			area: 'overlay',
+		};
+		const overlayTemplateParts = [ existingOverlay ];
+		const createdOverlay = {
+			id: 'twentytwentyfive//overlay-2',
+			theme: 'twentytwentyfive',
+			slug: 'overlay-2',
+			title: {
+				rendered: 'Overlay 2',
+			},
+			area: 'overlay',
+		};
+
+		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
+
+		const { result: createOverlayTemplatePart } = renderHook( () =>
+			useCreateOverlayTemplatePart( overlayTemplateParts )
+		);
+
+		await act( async () => {
+			await createOverlayTemplatePart.current();
+		} );
+
+		// Verify it generates a unique title (Overlay 2) when Overlay already exists
+		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'wp_template_part',
+			expect.objectContaining( {
+				title: 'Overlay 2',
+				slug: 'overlay-2',
+				area: 'overlay',
+			} ),
+			{ throwOnError: true }
+		);
+	} );
+
+	it( 'should throw errors when save fails', async () => {
+		const overlayTemplateParts = [];
+		const error = new Error( 'Failed to save' );
+		error.code = 'save_error';
+
+		mockSaveEntityRecord.mockRejectedValue( error );
+
+		const { result: createOverlayTemplatePart } = renderHook( () =>
+			useCreateOverlayTemplatePart( overlayTemplateParts )
+		);
+
+		await expect(
+			act( async () => {
+				await createOverlayTemplatePart.current();
+			} )
+		).rejects.toThrow( 'Failed to save' );
+
+		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'wp_template_part',
+			expect.any( Object ),
+			{ throwOnError: true }
+		);
+	} );
+} );

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -1,0 +1,75 @@
+/**
+ * Internal dependencies
+ */
+import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from '../utils';
+
+describe( 'getUniqueTemplatePartTitle', () => {
+	it( 'should return the title if it is unique', () => {
+		const title = 'My Template Part';
+		const templateParts = [
+			{
+				title: {
+					rendered: 'Template Part With Another Title',
+				},
+			},
+		];
+
+		expect( getUniqueTemplatePartTitle( title, templateParts ) ).toBe(
+			title
+		);
+	} );
+
+	it( 'should return the title with a suffix if it is not unique', () => {
+		const title = 'My Template Part';
+		const templateParts = [
+			{
+				title: {
+					rendered: 'My Template Part',
+				},
+			},
+		];
+
+		expect( getUniqueTemplatePartTitle( title, templateParts ) ).toBe(
+			'My Template Part 2'
+		);
+	} );
+
+	it( 'should return the title with correct suffix when multiple titles exist', () => {
+		const title = 'My Template Part';
+		const templateParts = [
+			{
+				title: {
+					rendered: 'My Template Part',
+				},
+			},
+			{
+				title: {
+					rendered: 'My Template Part 2',
+				},
+			},
+		];
+
+		expect( getUniqueTemplatePartTitle( title, templateParts ) ).toBe(
+			'My Template Part 3'
+		);
+	} );
+} );
+
+describe( 'getCleanTemplatePartSlug', () => {
+	it( 'should return a slug with only latin chars', () => {
+		const title = 'Myɶ Template Partɮ';
+		expect( getCleanTemplatePartSlug( title ) ).toBe( 'my-template-part' );
+	} );
+
+	it( 'should return a slug with only latin chars and numbers', () => {
+		const title = 'My Template Part 2';
+		expect( getCleanTemplatePartSlug( title ) ).toBe(
+			'my-template-part-2'
+		);
+	} );
+
+	it( 'should default the slug to wp-custom-part', () => {
+		const title = '';
+		expect( getCleanTemplatePartSlug( title ) ).toBe( 'wp-custom-part' );
+	} );
+} );

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -15,7 +15,8 @@ import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
  * Hook to create a new overlay template part.
  *
  * @param {Array} overlayTemplateParts Array of existing overlay template parts.
- * @return {Function} Function to create a new overlay template part.
+ * @return {function(): Promise<Object>} Function to create a new overlay template part.
+ *                                      The function returns a Promise that resolves to the created template part object.
  */
 export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 	const { saveEntityRecord } = useDispatch( coreStore );

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
+
+/**
+ * Hook to create a new overlay template part.
+ *
+ * @param {Array} overlayTemplateParts Array of existing overlay template parts.
+ * @return {Function} Function to create a new overlay template part.
+ */
+export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	const createOverlayTemplatePart = useCallback( async () => {
+		// Generate unique name using only overlay area template parts
+		// Filter to only include template parts with titles for uniqueness check
+		const templatePartsWithTitles = overlayTemplateParts.filter(
+			( templatePart ) => templatePart.title?.rendered
+		);
+		const uniqueTitle = getUniqueTemplatePartTitle(
+			__( 'Overlay' ),
+			templatePartsWithTitles
+		);
+		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
+
+		// Create the template part
+		const templatePart = await saveEntityRecord(
+			'postType',
+			'wp_template_part',
+			{
+				slug: cleanSlug,
+				title: uniqueTitle,
+				area: 'overlay',
+			},
+			{ throwOnError: true }
+		);
+
+		return templatePart;
+	}, [ overlayTemplateParts, saveEntityRecord ] );
+
+	return createOverlayTemplatePart;
+}

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import { paramCase as kebabCase } from 'change-case';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -110,3 +111,72 @@ export function getNavigationChildBlockProps( innerBlocksColors ) {
 		},
 	};
 }
+
+/**
+ * Parses a template part ID into theme and slug components.
+ *
+ * This is the inverse of createTemplatePartId from:
+ * packages/block-library/src/template-part/edit/utils/create-template-part-id.js
+ *
+ * @param {string} templatePartId Template part ID in format "theme//slug".
+ * @return {{theme: string, slug: string}|null} Parsed components or null if invalid.
+ */
+export const parseTemplatePartId = ( templatePartId ) => {
+	if ( ! templatePartId || typeof templatePartId !== 'string' ) {
+		return null;
+	}
+
+	const parts = templatePartId.split( '//' );
+	if ( parts.length !== 2 ) {
+		return null;
+	}
+
+	return {
+		theme: parts[ 0 ],
+		slug: parts[ 1 ],
+	};
+};
+
+/**
+ * Return a unique template part title based on
+ * the given title and existing template parts.
+ *
+ * This implementation is copied from:
+ * packages/fields/src/components/create-template-part-modal/utils.js
+ *
+ * @param {string} title         The original template part title.
+ * @param {Object} templateParts The array of template part entities.
+ * @return {string} A unique template part title.
+ */
+export const getUniqueTemplatePartTitle = ( title, templateParts ) => {
+	const lowercaseTitle = title.toLowerCase();
+	const existingTitles = templateParts.map( ( templatePart ) =>
+		templatePart.title.rendered.toLowerCase()
+	);
+
+	if ( ! existingTitles.includes( lowercaseTitle ) ) {
+		return title;
+	}
+
+	let suffix = 2;
+	while ( existingTitles.includes( `${ lowercaseTitle } ${ suffix }` ) ) {
+		suffix++;
+	}
+
+	return `${ title } ${ suffix }`;
+};
+
+/**
+ * Get a valid slug for a template part.
+ * Currently template parts only allow latin chars.
+ * The fallback slug will receive suffix by default.
+ *
+ * This implementation is copied from:
+ * packages/fields/src/components/create-template-part-modal/utils.js
+ *
+ * @param {string} title The template part title.
+ * @return {string} A valid template part slug.
+ */
+export const getCleanTemplatePartSlug = ( title ) => {
+	return kebabCase( title ).replace( /[^\w-]+/g, '' ) || 'wp-custom-part';
+};

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -113,31 +113,6 @@ export function getNavigationChildBlockProps( innerBlocksColors ) {
 }
 
 /**
- * Parses a template part ID into theme and slug components.
- *
- * This is the inverse of createTemplatePartId from:
- * packages/block-library/src/template-part/edit/utils/create-template-part-id.js
- *
- * @param {string} templatePartId Template part ID in format "theme//slug".
- * @return {{theme: string, slug: string}|null} Parsed components or null if invalid.
- */
-export const parseTemplatePartId = ( templatePartId ) => {
-	if ( ! templatePartId || typeof templatePartId !== 'string' ) {
-		return null;
-	}
-
-	const parts = templatePartId.split( '//' );
-	if ( parts.length !== 2 ) {
-		return null;
-	}
-
-	return {
-		theme: parts[ 0 ],
-		slug: parts[ 1 ],
-	};
-};
-
-/**
  * Return a unique template part title based on
  * the given title and existing template parts.
  *

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -654,3 +654,16 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-top: $grid-unit-10;
 	width: fit-content;
 }
+
+.wp-block-navigation__overlay-selector {
+	position: relative;
+}
+
+.wp-block-navigation__overlay-create-button {
+	position: absolute;
+	// Align with SelectControl label by offsetting by button padding
+	// Small icon buttons have 0 padding, but we align with default button top padding (4px = $grid-unit-05)
+	top: -$grid-unit-05;
+	right: 0;
+	z-index: 1;
+}


### PR DESCRIPTION
## What

Adds the ability to create new Navigation Overlays directly from the Navigation block sidebar "Overlay" panel. Users can click "Create new?" in the SelectControl help text to automatically create a new overlay template part with a unique sequential name (e.g., "Overlay", "Overlay 2", "Overlay 3").

This PR addresses the overlay creation requirement from #73080, complementing the existing overlay selection functionality.

## Why

This improves the workflow for creating navigation overlays by removing the need to navigate away from the Navigation block to create overlay template parts. It matches the pattern established in PR #73389 and provides a seamless inline creation experience, fulfilling part of the requirements outlined in #73080.

## How

- Added "Create new?" button inline within the SelectControl help text using `createInterpolateElement`
- Implemented automatic unique name generation using sequential naming (Overlay, Overlay 2, etc.)
- Uses store state (`isSavingEntityRecord`) for tracking save operations instead of local state
- Automatically selects the newly created overlay and optionally navigates to it for editing
- Added template part utility functions (`parseTemplatePartId`, `getUniqueTemplatePartTitle`, `getCleanTemplatePartSlug`) to `utils.js` with reference comments to original implementations
- Includes proper error handling and loading states

## ⚠️ Out of scope

- Placement and styling of the `Edit` button. This can be handled in followups.
- Whether the "Create" action should trigger a modal to allow users to choose a title for the Overlay. 
- The precise design implementation of this UI. We can follow up on this.

## Screenshots

<img width="367" height="193" alt="Screen Shot 2025-12-16 at 12 43 14" src="https://github.com/user-attachments/assets/60dd1ff1-4076-4e2f-a1b8-891931bd99f8" />



## Testing Instructions

1. Open the Navigation block sidebar
2. Navigate to the "Overlay" panel
3. Click "Create new?" in the help text below the overlay selector
4. Verify a new overlay is created with a unique name
5. Verify the new overlay is automatically selected
6. Verify the overlay appears in the dropdown list
7. Test creating multiple overlays to verify sequential naming works correctly
8. Test error handling by attempting to create when offline or with invalid permissions