### PR TITLE
TextControl: Deprecate bottom margin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -284,7 +284,6 @@ module.exports = {
 						'RangeControl',
 						'SearchControl',
 						'SelectControl',
-						'TextControl',
 						'TextareaControl',
 						'ToggleControl',
 						'ToggleGroupControl',

--- a/docs/getting-started/fundamentals/block-in-the-editor.md
+++ b/docs/getting-started/fundamentals/block-in-the-editor.md
@@ -139,7 +139,6 @@ export default function Edit( { attributes, setAttributes } ) {
 				</div>
 			</InspectorControls>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				value={ attributes.message }
 				onChange={ ( val ) => setAttributes( { message: val } ) }

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -480,7 +480,6 @@ export default function Edit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'copyright-date-block' ) }>
 					<TextControl
-					    __nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __(
 							'Starting year',
@@ -542,7 +541,6 @@ export default function Edit( { attributes, setAttributes } ) {
 					/>
 					{ showStartingYear && (
 						<TextControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label={ __(
 								'Starting year',

--- a/docs/how-to-guides/data-basics/3-building-an-edit-form.md
+++ b/docs/how-to-guides/data-basics/3-building-an-edit-form.md
@@ -63,7 +63,6 @@ function EditPageForm( { pageId, onCancel, onSaveFinished } ) {
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				value=''
 				label='Page title:'
@@ -141,7 +140,6 @@ function EditPageForm( { pageId, onCancel, onSaveFinished } ) {
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label='Page title:'
 				value={ page.title.rendered }
@@ -168,7 +166,6 @@ function VanillaReactForm({ initialTitle }) {
 	const [title, setTitle] = useState( initialTitle );
 	return (
 		<TextControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			value={ title }
 			onChange={ setTitle }
@@ -239,7 +236,6 @@ function EditPageForm( { pageId, onCancel, onSaveFinished } ) {
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Page title:"
 				value={ page.title }
@@ -509,7 +505,6 @@ function EditPageForm( { pageId, onCancel, onSaveFinished } ) {
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Page title:"
 				value={ page.title }

--- a/docs/how-to-guides/data-basics/4-building-a-create-page-form.md
+++ b/docs/how-to-guides/data-basics/4-building-a-create-page-form.md
@@ -87,7 +87,6 @@ function PageForm( { title, onChangeTitle, hasEdits, lastError, isSaving, onCanc
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Page title:"
 				value={ title }
@@ -348,7 +347,6 @@ function PageForm( { title, onChangeTitle, hasEdits, lastError, isSaving, onCanc
 	return (
 		<div className="my-gutenberg-form">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Page title:"
 				value={ title }

--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -91,7 +91,6 @@ registerBlockType( 'myguten/meta-block', {
 		return (
 			<div { ...blockProps }>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize				
 					label="Meta Block Field"
 					value={ metaFieldValue }

--- a/docs/reference-guides/block-api/block-context.md
+++ b/docs/reference-guides/block-api/block-context.md
@@ -141,7 +141,6 @@ export default function Edit( props ) {
 	return (
 		<div>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'Record ID' ) }
 				value={ recordId }

--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -253,7 +253,6 @@ edit: ( { attributes, setAttributes } ) => {
 	return (
 		<div { ...blockProps }>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label='My Text Field'
 				value={ attributes.content }
@@ -291,7 +290,6 @@ edit: ( { attributes, setAttributes } ) => {
 	return (
 		<div { ...blockProps }>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label='Number Posts to Show'
 				value={ attributes.postsToShow }

--- a/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
@@ -45,7 +45,6 @@ const PluginSidebarMoreMenuItemTest = () => {
 						) }
 					</p>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Text Control' ) }
 						value={ text }

--- a/docs/reference-guides/slotfills/plugin-sidebar.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar.md
@@ -38,7 +38,6 @@ const PluginSidebarExample = () => {
 					) }
 				</p>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label={ __( 'Text Control' ) }
 					value={ text }

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -107,7 +107,6 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 			>
 				<VStack spacing="3">
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						value={ editedBlockName ?? blockName }
 						label={ __( 'Name' ) }

--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -144,7 +144,6 @@ function NonDefaultControls( { format, onChange } ) {
 			{ isCustom && (
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Custom format' ) }
 					hideLabelFromVision
 					help={ createInterpolateElement(

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -115,7 +115,6 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 						/>
 
 						<TextControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label="Text Field"
 							help="Additional help text"
@@ -208,7 +207,6 @@ function MyBlockEdit( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<InspectorAdvancedControls>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label="HTML anchor"
 					value={ attributes.anchor }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -443,7 +443,6 @@ function LinkControl( {
 					>
 						{ showTextControl && (
 							<TextControl
-								__nextHasNoMarginBottom
 								ref={ textInputRef }
 								className="block-editor-link-control__field block-editor-link-control__text-content"
 								label={ __( 'Text' ) }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -235,7 +235,6 @@ const ImageURLInputUI = ( {
 			/>
 			<TextControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label={ __( 'Link relation' ) }
 				value={ rel ?? '' }
 				onChange={ onSetLinkRel }
@@ -252,7 +251,6 @@ const ImageURLInputUI = ( {
 			/>
 			<TextControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label={ __( 'Link CSS class' ) }
 				value={ linkClass || '' }
 				onChange={ onSetLinkClass }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -63,7 +63,6 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 	return (
 		<InspectorControls group="advanced">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				className="html-anchor-control"
 				label={ __( 'HTML anchor' ) }

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -47,7 +47,6 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 	return (
 		<InspectorControls group="advanced">
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				autoComplete="off"
 				label={ __( 'Additional CSS class(es)' ) }

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -240,7 +240,6 @@ export default function BreadcrumbEdit( {
 						}
 					>
 						<TextControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							autoComplete="off"
 							label={ __( 'Separator' ) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -465,7 +465,6 @@ function ButtonEdit( props ) {
 				{ isLinkTag && (
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Link relation' ) }
 						help={ createInterpolateElement(
 							__(

--- a/packages/block-library/src/cover/edit/embed-video-url-input.js
+++ b/packages/block-library/src/cover/edit/embed-video-url-input.js
@@ -63,7 +63,6 @@ export default function EmbedVideoUrlInput( { onSubmit, onClose } ) {
 					placeholder={ __(
 						'Enter YouTube, Vimeo, or other video URL'
 					) }
-					__nextHasNoMarginBottom
 					help={ __(
 						'Add a background video to the cover block that will autoplay in a loop.'
 					) }

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -107,7 +107,6 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Name attribute' ) }
 					value={ name || '' }
 					onChange={ ( newName ) =>

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -105,7 +105,6 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					autoComplete="off"
 					label={ __( 'Name' ) }
 					value={ name }

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -151,7 +151,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 							isShownByDefault
 						>
 							<TextControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								autoComplete="off"
 								label={ __( 'Email for form submissions' ) }
@@ -193,7 +192,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 					/>
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						autoComplete="off"
 						label={ __( 'Form action' ) }
 						value={ action }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -217,7 +217,6 @@ function ContentOnlyControls( {
 						<TextControl
 							__next40pxDefaultSize
 							className="wp-block-image__toolbar_content_textarea"
-							__nextHasNoMarginBottom
 							label={ __( 'Title attribute' ) }
 							value={ attributes.title || '' }
 							onChange={ ( value ) =>
@@ -850,7 +849,6 @@ export default function Image( {
 			</InspectorControls>
 			<InspectorControls group="advanced">
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label={ __( 'Title attribute' ) }
 					value={ title || '' }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -60,7 +60,6 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 					/>
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Start value' ) }
 						type="number"
 						onChange={ ( value ) => {
@@ -136,7 +135,6 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 					>
 						<TextControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Start value' ) }
 							type="number"
 							onChange={ ( value ) => {

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -129,7 +129,6 @@ export function LinkUIPageCreator( {
 					<VStack spacing={ 4 }>
 						<TextControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Title' ) }
 							onChange={ setTitle }
 							placeholder={ __( 'No title' ) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -142,7 +142,6 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				isShownByDefault
 			>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label={ __( 'Text' ) }
 					value={ label ? stripHTML( label ) : '' }
@@ -301,7 +300,6 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				isShownByDefault
 			>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label={ __( 'Rel attribute' ) }
 					value={ rel || '' }

--- a/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
@@ -15,7 +15,6 @@ export default function NavigationMenuNameControl() {
 	return (
 		<TextControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Menu name' ) }
 			value={ title }
 			onChange={ updateTitle }

--- a/packages/block-library/src/post-comment/edit.js
+++ b/packages/block-library/src/post-comment/edit.js
@@ -35,7 +35,6 @@ export default function Edit( { attributes: { commentId }, setAttributes } ) {
 				>
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						value={ commentId }
 						onChange={ ( val ) =>
 							setCommentIdInput( parseInt( val ) )

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -333,7 +333,6 @@ export default function PostFeaturedImageEdit( {
 							>
 								<TextControl
 									__next40pxDefaultSize
-									__nextHasNoMarginBottom
 									label={ __( 'Link relation' ) }
 									help={ createInterpolateElement(
 										__(

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -89,7 +89,6 @@ export default function PostTermsEdit( {
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					autoComplete="off"
 					label={ __( 'Separator' ) }
 					value={ separator || '' }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -220,7 +220,6 @@ export default function PostTitleEdit( {
 									>
 										<TextControl
 											__next40pxDefaultSize
-											__nextHasNoMarginBottom
 											label={ __( 'Link relation' ) }
 											help={ createInterpolateElement(
 												__(

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -418,7 +418,6 @@ export default function QueryInspectorControls( props ) {
 							} }
 						>
 							<TextControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'Keyword' ) }
 								value={ querySearch }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -301,7 +301,6 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Link relation' ) }
 					help={ createInterpolateElement(
 						__(

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -192,7 +192,6 @@ const SocialLinkEdit = ( {
 						renderContent={ () => (
 							<TextControl
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 								className="wp-block-social-link__toolbar_content_text"
 								label={ __( 'Text' ) }
 								help={ __(
@@ -226,7 +225,6 @@ const SocialLinkEdit = ( {
 					>
 						<TextControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Text' ) }
 							help={ __(
 								'The text is visible when enabled from the parent Social Icons block.'
@@ -243,7 +241,6 @@ const SocialLinkEdit = ( {
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Link relation' ) }
 					help={ createInterpolateElement(
 						__(

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -572,7 +572,6 @@ function TableEdit( {
 						onSubmit={ onCreateTable }
 					>
 						<TextControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							type="number"
 							label={ __( 'Column count' ) }
@@ -582,7 +581,6 @@ function TableEdit( {
 							className="blocks-table__placeholder-input"
 						/>
 						<TextControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							type="number"
 							label={ __( 'Row count' ) }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -58,7 +58,6 @@ export function TemplatePartAdvancedControls( {
 				<>
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Title' ) }
 						value={ title }
 						onChange={ ( value ) => {

--- a/packages/block-library/src/template-part/edit/title-modal.js
+++ b/packages/block-library/src/template-part/edit/title-modal.js
@@ -39,7 +39,6 @@ export default function TitleModal( { areaLabel, onClose, onSubmit } ) {
 						value={ title }
 						onChange={ setTitle }
 						placeholder={ __( 'Custom Template Part' ) }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 					<HStack justify="right">

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -121,7 +121,6 @@ function SingleTrackEditor( {
 			<Grid columns={ 2 } gap={ 4 }>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					onChange={ ( newLabel ) =>
 						setTrackState( ( prevTrackState ) => ( {
 							...prevTrackState,
@@ -134,7 +133,6 @@ function SingleTrackEditor( {
 				/>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					onChange={ ( newSrcLang ) =>
 						setTrackState( ( prevTrackState ) => ( {
 							...prevTrackState,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Validated form controls (private API): Removed `onValidate` prop (use `onChange` to set `customValidity` messages, or add conditionals directly inside the `customValidity` prop instead) ([#73559](https://github.com/WordPress/gutenberg/pull/73559)).
 -   `FormTokenField`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73846](https://github.com/WordPress/gutenberg/pull/73846)).
 -   `CheckboxControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73916](https://github.com/WordPress/gutenberg/pull/73916)).
+-   `TextControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73920](https://github.com/WordPress/gutenberg/pull/73920)).
 
 ### Enhancements
 

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -16,7 +16,6 @@ const MyDisabled = () => {
 	let input = (
 		<TextControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label="Input"
 			onChange={ () => {} }
 		/>

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -36,7 +36,6 @@ const { Consumer, Provider } = Context;
  *	let input = (
  *		<TextControl
  *			__next40pxDefaultSize
- *			__nextHasNoMarginBottom
  *			label="Input"
  *			onChange={ () => {} }
  *		/>

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -41,7 +41,6 @@ const Form = () => {
 	return (
 		<VStack>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Text Control"
 				value={ textControlValue }

--- a/packages/components/src/higher-order/with-constrained-tabbing/README.md
+++ b/packages/components/src/higher-order/with-constrained-tabbing/README.md
@@ -24,13 +24,11 @@ const MyComponentWithConstrainedTabbing = () => {
 		<form>
 			<TextControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label="Input 1"
 				onChange={ () => {} }
 			/>
 			<TextControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label="Input 2"
 				onChange={ () => {} }
 			/>

--- a/packages/components/src/higher-order/with-focus-return/README.md
+++ b/packages/components/src/higher-order/with-focus-return/README.md
@@ -14,7 +14,6 @@ const EnhancedComponent = withFocusReturn( () => (
 	<div>
 		Focus will return to the previous input when this component is unmounted
 		<TextControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			autoFocus={ true }
 			onChange={ () => {} }
@@ -32,7 +31,6 @@ const MyComponentWithFocusReturn = () => {
 	return (
 		<div>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				placeholder="Type something"
 				value={ text }

--- a/packages/components/src/placeholder/stories/index.story.tsx
+++ b/packages/components/src/placeholder/stories/index.story.tsx
@@ -44,7 +44,6 @@ const Template: StoryFn< typeof Placeholder > = ( args ) => {
 		<Placeholder { ...args }>
 			<div>
 				<TextControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label="Sample Field"
 					placeholder="Enter something here"

--- a/packages/components/src/text-control/README.md
+++ b/packages/components/src/text-control/README.md
@@ -62,7 +62,6 @@ const MyTextControl = () => {
 
 	return (
 		<TextControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label="Additional CSS Class"
 			value={ className }

--- a/packages/components/src/text-control/index.tsx
+++ b/packages/components/src/text-control/index.tsx
@@ -23,7 +23,8 @@ function UnforwardedTextControl(
 	ref: ForwardedRef< HTMLInputElement >
 ) {
 	const {
-		__nextHasNoMarginBottom,
+		// @ts-expect-error - Prevent passing this to `input`.
+		__nextHasNoMarginBottom: _,
 		__next40pxDefaultSize = false,
 		label,
 		hideLabelFromVision,
@@ -47,8 +48,7 @@ function UnforwardedTextControl(
 
 	return (
 		<BaseControl
-			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-			__associatedWPComponentName="TextControl"
+			__nextHasNoMarginBottom
 			label={ label }
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ id }
@@ -83,7 +83,6 @@ function UnforwardedTextControl(
  *
  *   return (
  *     <TextControl
- *       __nextHasNoMarginBottom
  *       __next40pxDefaultSize
  *       label="Additional CSS Class"
  *       value={ className }

--- a/packages/components/src/text-control/stories/index.story.tsx
+++ b/packages/components/src/text-control/stories/index.story.tsx
@@ -54,7 +54,6 @@ export const Default: StoryFn< typeof TextControl > = DefaultTemplate.bind(
 	{}
 );
 Default.args = {
-	__nextHasNoMarginBottom: true,
 	__next40pxDefaultSize: true,
 	placeholder: 'Placeholder',
 };

--- a/packages/components/src/text-control/test/text-control.tsx
+++ b/packages/components/src/text-control/test/text-control.tsx
@@ -9,13 +9,7 @@ import { render, screen } from '@testing-library/react';
 import _TextControl from '..';
 
 const TextControl = ( props: React.ComponentProps< typeof _TextControl > ) => {
-	return (
-		<_TextControl
-			{ ...props }
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-		/>
-	);
+	return <_TextControl { ...props } __next40pxDefaultSize />;
 };
 
 const noop = () => {};

--- a/packages/components/src/text-control/types.ts
+++ b/packages/components/src/text-control/types.ts
@@ -5,11 +5,7 @@ import type { BaseControlProps } from '../base-control/types';
 
 export type TextControlProps = Pick<
 	BaseControlProps,
-	| 'className'
-	| 'hideLabelFromVision'
-	| 'help'
-	| 'label'
-	| '__nextHasNoMarginBottom'
+	'className' | 'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
 	 * A function that receives the value of the input.

--- a/packages/components/src/validated-form-controls/components/text-control.tsx
+++ b/packages/components/src/validated-form-controls/components/text-control.tsx
@@ -19,7 +19,7 @@ const UnforwardedValidatedTextControl = (
 		...restProps
 	}: Omit<
 		React.ComponentProps< typeof TextControl >,
-		'__next40pxDefaultSize' | '__nextHasNoMarginBottom'
+		'__next40pxDefaultSize'
 	> &
 		ValidatedControlProps,
 	forwardedRef: React.ForwardedRef< HTMLInputElement >
@@ -36,7 +36,6 @@ const UnforwardedValidatedTextControl = (
 		>
 			<TextControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				ref={ mergedRefs }
 				{ ...restProps }
 			/>

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1101,7 +1101,6 @@ function PageRenameForm( { id } ) {
 	return (
 		<form onSubmit={ onRename }>
 			<TextControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'Name' ) }
 				value={ page.editedRecord.title }

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -126,7 +126,6 @@ const EMPTY_OBJECT = {};
  * 	return (
  * 		<form onSubmit={ onRename }>
  * 			<TextControl
- *				__nextHasNoMarginBottom
  *				__next40pxDefaultSize
  * 				label={ __( 'Name' ) }
  * 				value={ page.editedRecord.title }

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -543,7 +543,6 @@ function CustomEditControl< Item >( {
 			help={ description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
 		/>
 	);

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -84,7 +84,6 @@ const withBlockBindingsInspectorControl = createHigherOrderComponent(
 						{ title: 'Bindings' },
 						el( TextControl, {
 							__next40pxDefaultSize: true,
-							__nextHasNoMarginBottom: true,
 							label: 'Content',
 							value: props.attributes.content,
 							onChange: ( content ) =>

--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -59,7 +59,6 @@ export default function InitPatternModal() {
 								onChange={ setTitle }
 								placeholder={ __( 'My pattern' ) }
 								className="patterns-create-modal__name-input"
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 							/>
 							<ToggleControl

--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -99,7 +99,6 @@ export default function AddNewPostModal( { postType, onSave, onClose } ) {
 				<VStack spacing={ 4 }>
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Title' ) }
 						onChange={ setTitle }
 						placeholder={ __( 'No title' ) }

--- a/packages/edit-site/src/components/add-new-template-legacy/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/add-custom-generic-template-modal-content.js
@@ -53,7 +53,6 @@ function AddCustomGenericTemplateModalContent( { createTemplate, onBack } ) {
 			<VStack spacing={ 6 }>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Name' ) }
 					value={ title }
 					onChange={ setTitle }

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -53,7 +53,6 @@ function AddCustomGenericTemplateModalContent( { createTemplate, onBack } ) {
 			<VStack spacing={ 6 }>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Name' ) }
 					value={ title }
 					onChange={ setTitle }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -31,7 +31,6 @@ export default function RenameModal( { menuTitle, onClose, onSave } ) {
 			<form className="sidebar-navigation__rename-modal-form">
 				<VStack spacing="3">
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						value={ editedMenuTitle }
 						placeholder={ __( 'Navigation title' ) }

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -137,7 +137,6 @@ export default function PostPublishPanelPostpublish( {
 				<div className="post-publish-panel__postpublish-post-address-container">
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						className="post-publish-panel__postpublish-post-address"
 						readOnly
 						label={ sprintf(

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -247,7 +247,6 @@ export default function PostStatus() {
 														type="text"
 														id={ passwordInputId }
 														__next40pxDefaultSize
-														__nextHasNoMarginBottom
 														maxLength={ 255 }
 													/>
 												</div>

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -464,7 +464,6 @@ export function HierarchicalTermSelector( { slug } ) {
 					<Flex direction="column" gap="4">
 						<TextControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							className="editor-post-taxonomies__hierarchical-terms-input"
 							label={ newTermLabel }
 							value={ formName }

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -125,7 +125,6 @@ export default function CreateNewTemplateModal( { onClose } ) {
 				<VStack spacing="3">
 					<TextControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Name' ) }
 						value={ title }
 						onChange={ setTitle }

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -83,7 +83,6 @@ export default function PostVisibility( { onClose } ) {
 						type="text"
 						id={ `editor-post-visibility__password-input-${ instanceId }` }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						maxLength={ 255 }
 					/>
 				) }

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -119,7 +119,6 @@ const renamePost: Action< PostWithPermissions > = {
 			<form onSubmit={ onRename }>
 				<VStack spacing="5">
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Name' ) }
 						value={ title }

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -206,7 +206,6 @@ export function CreateTemplatePartModalContents( {
 			<VStack spacing="4">
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Name' ) }
 					value={ title }
 					onChange={ setTitle }

--- a/packages/fields/src/fields/password/edit.tsx
+++ b/packages/fields/src/fields/password/edit.tsx
@@ -56,7 +56,6 @@ function PasswordEdit( {
 						placeholder={ __( 'Use a secure password' ) }
 						type="text"
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						maxLength={ 255 }
 					/>
 				</div>

--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -99,7 +99,6 @@ function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 			>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ title }
 					value={ lang }
 					onChange={ ( val ) => setLang( val ) }

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -90,7 +90,6 @@ function InlineUI( {
 			<div style={ { minWidth: '300px', padding: '4px' } }>
 				<VStack spacing={ 1 }>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						hideLabelFromVision
 						label={ __( 'LaTeX math syntax' ) }

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -67,7 +67,6 @@ export function AllowOverridesModal( {
 						) }
 					</Text>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						value={ editedBlockName }
 						label={ __( 'Name' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -122,7 +122,6 @@ export function CreatePatternModalContents( {
 					onChange={ setTitle }
 					placeholder={ __( 'My pattern' ) }
 					className="patterns-create-modal__name-input"
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 				/>
 				<CategorySelector

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -137,7 +137,6 @@ export default function RenamePatternCategoryModal( {
 					<VStack spacing="2">
 						<TextControl
 							ref={ textControlRef }
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label={ __( 'Name' ) }
 							value={ name }

--- a/packages/patterns/src/components/rename-pattern-modal.js
+++ b/packages/patterns/src/components/rename-pattern-modal.js
@@ -98,7 +98,6 @@ export default function RenamePatternModal( {
 			<form onSubmit={ onRename }>
 				<VStack spacing="5">
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Name' ) }
 						value={ name }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -170,7 +170,6 @@ export default function ReusableBlockConvertButton( {
 						<VStack spacing="5">
 							<TextControl
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 								label={ __( 'Name' ) }
 								value={ title }
 								onChange={ setTitle }

--- a/routes/template-list/add-new-template/add-custom-generic-template-modal-content.tsx
+++ b/routes/template-list/add-new-template/add-custom-generic-template-modal-content.tsx
@@ -64,7 +64,6 @@ function AddCustomGenericTemplateModalContent( {
 			<VStack spacing={ 6 }>
 				<TextControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Name' ) }
 					value={ title }
 					onChange={ setTitle }


### PR DESCRIPTION
## What?

Part of #73848

Remove the deprecated `__nextHasNoMarginBottom` prop from `TextControl`, making the margin-free styles the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0. This removes the prop, completing the deprecation cycle.

## How?

- Remove the `__nextHasNoMarginBottom` prop from `TextControl` and its types and docs.
- Remove all usages of the prop across the codebase.

## Testing Instructions

Smoke test the affected components in Storybook and the app.