### PR TITLE
CheckboxControl: Remove margin bottom prop from missed spots

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -96,7 +96,6 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings' ) }>
 						<CheckboxControl
-							__nextHasNoMarginBottom
 							heading="Checkbox Field"
 							label="Tick Me"
 							help="Additional help text"

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -68,7 +68,6 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 								isShownByDefault
 							>
 								<CheckboxControl
-									__nextHasNoMarginBottom
 									label={ __( 'Inline label' ) }
 									checked={ inlineLabel }
 									onChange={ ( newVal ) => {
@@ -89,7 +88,6 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 							isShownByDefault
 						>
 							<CheckboxControl
-								__nextHasNoMarginBottom
 								label={ __( 'Required' ) }
 								checked={ required }
 								onChange={ ( newVal ) => {

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -137,7 +137,6 @@ export function LinkUIPageCreator( {
 						/>
 
 						<CheckboxControl
-							__nextHasNoMarginBottom
 							label={ __( 'Publish immediately' ) }
 							help={ __(
 								'If unchecked, the page will be created as a draft.'

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -44,6 +44,8 @@ export function CheckboxControl(
 	props: WordPressComponentProps< CheckboxControlProps, 'input', false >
 ) {
 	const {
+		// @ts-expect-error - Prevent passing this to `input`.
+		__nextHasNoMarginBottom: _,
 		label,
 		className,
 		heading,


### PR DESCRIPTION
Follow-up to #73916

## What?

Removes the `__nextHasNoMarginBottom` prop from spots that were missed in the initial clean up (oops!)

## Testing Instructions

Try to find any more missed spots.
