### PR TITLE
Field API: move formatting logic to the field

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Code Quality
 
 - DataViews: Remove extra wrapper for GridItem. [#73665](https://github.com/WordPress/gutenberg/pull/73665)
+- Field API: move validation to the field type. [#73642](https://github.com/WordPress/gutenberg/pull/73642)
+- Field API: move format logic to the field type. [#73922](https://github.com/WordPress/gutenberg/pull/73922)
 
 ### Bug Fixes
 
@@ -18,7 +20,6 @@
 
 - DataViews table layout: remove row click-to-select behavior and hover styles. Selection is now only possible via checkboxes, or by ctrl/cmd clicking. [#73873](https://github.com/WordPress/gutenberg/pull/73873)
 - Better labels for operators and deprecate the `isNotAll` operator. [#73671](https://github.com/WordPress/gutenberg/pull/73671)
-- Field API: move validation to the field type. [#73642](https://github.com/WordPress/gutenberg/pull/73642)
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)
 - Field API: display formats for `number` and `integer` types. [#73644](https://github.com/WordPress/gutenberg/pull/73644)
 - Field API: add display format for `datetime` type. [#73924](https://github.com/WordPress/gutenberg/pull/73924)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1344,13 +1344,70 @@ const item = {
 }
 ```
 
+### `getValueFormatted`
+
+Function that formats the field value for display by computing it from the field's `format` configuration. The formatted value is used for consistent value presentation across different contexts. For example, by the default `render` implementation provided by the field types and by the filter components that display values.
+
+-   Type: `function`.
+-   Optional.
+-   Each field `type` provides a default implementation that formats values appropriately (e.g., dates consider the `format` settings, numbers get thousand separators, etc.).
+-   Args:
+    -   `item`: the data item containing the value.
+    -   `field`: the normalized field configuration.
+-   Returns the formatted value for display (typically a string).
+
+Example of some custom `getValueFormatted` functions:
+
+```js
+// Format a number as currency
+{
+	id: 'price',
+	type: 'number',
+	label: 'Price',
+	getValueFormatted: ( { item, field } ) => {
+		const value = field.getValue( { item } );
+		if ( value === null || value === undefined ) {
+			return '';
+		}
+
+		return `$${ value.toFixed( field.format.decimals ) }`;
+	}
+}
+```
+
+```js
+// Format a date with custom logic
+{
+	id: 'publishDate',
+	type: 'date',
+	label: 'Published',
+	getValueFormatted: ( { item, field } ) => {
+		const value = field.getValue( { item } );
+		if ( ! value ) {
+			return 'Not published';
+		}
+
+		const date = new Date( value );
+		const now = new Date();
+		const diffDays = Math.floor( ( now - date ) / ( 1000 * 60 * 60 * 24 ) );
+		if ( diffDays === 0 ) {
+			return 'Today';
+		}
+		if ( diffDays === 1 ) {
+			return 'Yesterday';
+		}
+		return `${ diffDays } days ago`;
+	}
+}
+```
+
 ### `render`
 
 React component that renders the field.
 
 -   Type: React component.
 -   Optional.
--   The field `type` provides a default render based on `getValue` and `elements` (if provided).
+-   The field `type` provides a default render that uses `getValueFormatted` for value display and `elements` for label lookup (if provided).
 -   Props
     -   `item` value to be processed.
     -   `field` the own field config. Useful to access `getValue`, `elements`, etc.

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1350,7 +1350,7 @@ Function that formats the field value for display by computing it from the field
 
 -   Type: `function`.
 -   Optional.
--   Each field `type` provides a default implementation that formats values appropriately (e.g., dates consider the `format` settings, numbers get thousand separators, etc.).
+-   Each field `type` provides a default implementation that formats values appropriately (e.g., considers weekStartsOn for date, thousand separators for number, etc.).
 -   Args:
     -   `item`: the data item containing the value.
     -   `field`: the normalized field configuration.

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -260,7 +260,6 @@ function CalendarDateControl< Item >( {
 }: DataFormControlProps< Item > ) {
 	const {
 		id,
-		type,
 		label,
 		setValue,
 		getValue,
@@ -271,12 +270,9 @@ function CalendarDateControl< Item >( {
 		null
 	);
 
-	let weekStartsOn = getSettings().l10n.startOfWeek;
-	if ( type === 'date' ) {
-		// If the field type is date, we've already normalized the format,
-		// and so it's safe to tell TypeScript to trust us ("as Required<Format>").
-		weekStartsOn = ( fieldFormat as Required< FormatDate > ).weekStartsOn;
-	}
+	const weekStartsOn =
+		( fieldFormat as FormatDate ).weekStartsOn ??
+		getSettings().l10n.startOfWeek;
 
 	const fieldValue = getValue( { item: data } );
 	const value = typeof fieldValue === 'string' ? fieldValue : undefined;
@@ -425,7 +421,7 @@ function CalendarDateRangeControl< Item >( {
 	hideLabelFromVision,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, type, label, getValue, setValue, format: fieldFormat } = field;
+	const { id, label, getValue, setValue, format: fieldFormat } = field;
 	let value: DateRange;
 	const fieldValue = getValue( { item: data } );
 	if (
@@ -436,12 +432,9 @@ function CalendarDateRangeControl< Item >( {
 		value = fieldValue as DateRange;
 	}
 
-	let weekStartsOn;
-	if ( type === 'date' ) {
-		// If the field type is date, we've already normalized the format,
-		// and so it's safe to tell TypeScript to trust us ("as Required<Format>").
-		weekStartsOn = ( fieldFormat as Required< FormatDate > ).weekStartsOn;
-	}
+	const weekStartsOn =
+		( fieldFormat as FormatDate ).weekStartsOn ??
+		getSettings().l10n.startOfWeek;
 
 	const onChangeCallback = useCallback(
 		( newValue: DateRange ) => {

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -4,6 +4,6 @@
 import type { DataFormControlProps } from '../types';
 import ValidatedNumber from './utils/validated-number';
 
-export default function Number< Item >( props: DataFormControlProps< Item > ) {
-	return <ValidatedNumber { ...props } decimals={ 0 } />;
+export default function Integer< Item >( props: DataFormControlProps< Item > ) {
+	return <ValidatedNumber { ...props } />;
 }

--- a/packages/dataviews/src/dataform-controls/number.tsx
+++ b/packages/dataviews/src/dataform-controls/number.tsx
@@ -1,10 +1,9 @@
 /**
  * Internal dependencies
  */
-import type { DataFormControlProps, FormatNumber } from '../types';
+import type { DataFormControlProps } from '../types';
 import ValidatedNumber from './utils/validated-number';
 
 export default function Number< Item >( props: DataFormControlProps< Item > ) {
-	const decimals = ( props.field.format as FormatNumber )?.decimals ?? 2;
-	return <ValidatedNumber { ...props } decimals={ decimals } />;
+	return <ValidatedNumber { ...props } />;
 }

--- a/packages/dataviews/src/dataform-controls/utils/validated-number.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/validated-number.tsx
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { OPERATOR_BETWEEN } from '../../constants';
-import type { DataFormControlProps } from '../../types';
+import type { DataFormControlProps, FormatNumber } from '../../types';
 import { unlock } from '../../lock-unlock';
 import getCustomValidity from './get-custom-validity';
 
@@ -83,23 +83,15 @@ function BetweenControls( {
 	);
 }
 
-export type DataFormValidatedNumberControlProps< Item > =
-	DataFormControlProps< Item > & {
-		/**
-		 * Number of decimals, acceps non-negative integer.
-		 */
-		decimals: number;
-	};
-
 export default function ValidatedNumber< Item >( {
 	data,
 	field,
 	onChange,
 	hideLabelFromVision,
 	operator,
-	decimals,
 	validity,
-}: DataFormValidatedNumberControlProps< Item > ) {
+}: DataFormControlProps< Item > ) {
+	const decimals = ( field.format as FormatNumber )?.decimals ?? 0;
 	const step = Math.pow( 10, Math.abs( decimals ) * -1 );
 	const { label, description, getValue, setValue, isValid } = field;
 	const value = getValue( { item: data } ) ?? '';

--- a/packages/dataviews/src/field-types/array.tsx
+++ b/packages/dataviews/src/field-types/array.tsx
@@ -21,9 +21,20 @@ import {
 import isValidRequiredForArray from './utils/is-valid-required-for-array';
 import isValidElements from './utils/is-valid-elements';
 
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	const value = field.getValue( { item } );
+	const arr = Array.isArray( value ) ? value : [];
+	return arr.join( ', ' );
+}
+
 function render( { item, field }: DataViewRenderFieldProps< any > ) {
-	const value = field.getValue( { item } ) || [];
-	return value.join( ', ' );
+	return getValueFormatted( { item, field } );
 }
 
 function isValidCustom< Item >( item: Item, field: NormalizedField< Item > ) {
@@ -75,7 +86,8 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequiredForArray,
 		elements: isValidElements,

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -6,31 +6,31 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type {
-	DataViewRenderFieldProps,
-	NormalizedField,
-	SortDirection,
-} from '../types';
+import type { NormalizedField, SortDirection } from '../types';
 import type { FieldType } from '../types/private';
-import RenderFromElements from './utils/render-from-elements';
 import { OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
 import isValidElements from './utils/is-valid-elements';
 import isValidRequiredForBool from './utils/is-valid-required-for-bool';
+import render from './utils/render-default';
 
-function render( { item, field }: DataViewRenderFieldProps< any > ) {
-	if ( field.hasElements ) {
-		return <RenderFromElements item={ item } field={ field } />;
-	}
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	const value = field.getValue( { item } );
 
-	if ( field.getValue( { item } ) === true ) {
+	if ( value === true ) {
 		return __( 'True' );
 	}
 
-	if ( field.getValue( { item } ) === false ) {
+	if ( value === false ) {
 		return __( 'False' );
 	}
 
-	return null;
+	return '';
 }
 
 function isValidCustom< Item >( item: Item, field: NormalizedField< Item > ) {
@@ -77,5 +77,6 @@ export default {
 	enableGlobalSearch: false,
 	defaultOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
 	validOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 } satisfies FieldType< any >;

--- a/packages/dataviews/src/field-types/color.tsx
+++ b/packages/dataviews/src/field-types/color.tsx
@@ -26,14 +26,14 @@ import {
 } from '../constants';
 import isValidElements from './utils/is-valid-elements';
 import isValidRequired from './utils/is-valid-required';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 function render( { item, field }: DataViewRenderFieldProps< any > ) {
 	if ( field.hasElements ) {
 		return <RenderFromElements item={ item } field={ field } />;
 	}
 
-	const value = field.getValue( { item } );
-
+	const value = getValueFormatted( { item, field } );
 	if ( ! value || ! colord( value ).isValid() ) {
 		return value;
 	}
@@ -111,7 +111,8 @@ export default {
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		elements: isValidElements,

--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -26,6 +26,7 @@ import isValidMinLength from './utils/is-valid-min-length';
 import isValidMaxLength from './utils/is-valid-max-length';
 import isValidPattern from './utils/is-valid-pattern';
 import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 // Email validation regex based on HTML5 spec
 // https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
@@ -65,7 +66,8 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		pattern: isValidPattern,

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -28,6 +28,7 @@ import { default as color } from './color';
 import { default as url } from './url';
 import { default as noType } from './no-type';
 import getIsValid from './utils/get-is-valid';
+import getFormat from './utils/get-format';
 
 /**
  *
@@ -110,7 +111,9 @@ export default function normalizeFields< Item >(
 				fieldType.defaultOperators,
 				fieldType.validOperators
 			),
-			format: fieldType.getFormat( field ),
+			format: getFormat( field, fieldType ),
+			getValueFormatted:
+				field.getValueFormatted ?? fieldType.getValueFormatted,
 		};
 	} );
 }

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { FieldType } from '../types/private';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 export default {
 	type: 'media',
@@ -12,7 +13,8 @@ export default {
 	enableGlobalSearch: false,
 	defaultOperators: [],
 	validOperators: [],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	// cannot validate any constraint, so
 	// the only available validation for the field author
 	// would be providing a custom validator.

--- a/packages/dataviews/src/field-types/no-type.tsx
+++ b/packages/dataviews/src/field-types/no-type.tsx
@@ -10,6 +10,7 @@ import sortText from './utils/sort-text';
 import sortNumber from './utils/sort-number';
 import isValidRequired from './utils/is-valid-required';
 import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 const sort = ( a: any, b: any, direction: SortDirection ) => {
 	if ( typeof a === 'number' && typeof b === 'number' ) {
@@ -28,7 +29,8 @@ export default {
 	enableGlobalSearch: false,
 	defaultOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
 	validOperators: getAllOperatorNames(),
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		elements: isValidElements,

--- a/packages/dataviews/src/field-types/password.tsx
+++ b/packages/dataviews/src/field-types/password.tsx
@@ -1,21 +1,23 @@
 /**
  * Internal dependencies
  */
-import type { DataViewRenderFieldProps } from '../types';
+import type { NormalizedField } from '../types';
 import type { FieldType } from '../types/private';
-import RenderFromElements from './utils/render-from-elements';
 import isValidRequired from './utils/is-valid-required';
 import isValidMinLength from './utils/is-valid-min-length';
 import isValidMaxLength from './utils/is-valid-max-length';
 import isValidPattern from './utils/is-valid-pattern';
 import isValidElements from './utils/is-valid-elements';
+import render from './utils/render-default';
 
-function render( { item, field }: DataViewRenderFieldProps< any > ) {
-	return field.hasElements ? (
-		<RenderFromElements item={ item } field={ field } />
-	) : (
-		'••••••••'
-	);
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	return field.getValue( { item } ) ? '••••••••' : '';
 }
 
 export default {
@@ -27,7 +29,8 @@ export default {
 	enableGlobalSearch: false,
 	defaultOperators: [],
 	validOperators: [],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		pattern: isValidPattern,

--- a/packages/dataviews/src/field-types/telephone.tsx
+++ b/packages/dataviews/src/field-types/telephone.tsx
@@ -20,6 +20,7 @@ import isValidMinLength from './utils/is-valid-min-length';
 import isValidMaxLength from './utils/is-valid-max-length';
 import isValidPattern from './utils/is-valid-pattern';
 import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 export default {
 	type: 'telephone',
@@ -41,7 +42,8 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		pattern: isValidPattern,

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -20,6 +20,7 @@ import isValidMinLength from './utils/is-valid-min-length';
 import isValidMaxLength from './utils/is-valid-max-length';
 import isValidPattern from './utils/is-valid-pattern';
 import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 export default {
 	type: 'text',
@@ -42,7 +43,8 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		pattern: isValidPattern,

--- a/packages/dataviews/src/field-types/url.tsx
+++ b/packages/dataviews/src/field-types/url.tsx
@@ -20,6 +20,7 @@ import isValidMinLength from './utils/is-valid-min-length';
 import isValidMaxLength from './utils/is-valid-max-length';
 import isValidPattern from './utils/is-valid-pattern';
 import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
 
 export default {
 	type: 'url',
@@ -41,7 +42,8 @@ export default {
 		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
-	getFormat: () => ( {} ),
+	format: {},
+	getValueFormatted,
 	validate: {
 		required: isValidRequired,
 		pattern: isValidPattern,

--- a/packages/dataviews/src/field-types/utils/get-format.ts
+++ b/packages/dataviews/src/field-types/utils/get-format.ts
@@ -1,0 +1,14 @@
+import type { Field } from '../../types';
+import type { FieldType } from '../../types/private';
+
+function getFormat< Item >(
+	field: Field< Item >,
+	fieldType: FieldType< Item >
+) {
+	return {
+		...fieldType.format,
+		...field.format,
+	};
+}
+
+export default getFormat;

--- a/packages/dataviews/src/field-types/utils/get-value-formatted-default.ts
+++ b/packages/dataviews/src/field-types/utils/get-value-formatted-default.ts
@@ -1,0 +1,13 @@
+import type { NormalizedField } from '../../types';
+
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	return field.getValue( { item } );
+}
+
+export default getValueFormatted;

--- a/packages/dataviews/src/field-types/utils/render-default.tsx
+++ b/packages/dataviews/src/field-types/utils/render-default.tsx
@@ -8,9 +8,9 @@ export default function render( {
 	item,
 	field,
 }: DataViewRenderFieldProps< any > ) {
-	return field.hasElements ? (
-		<RenderFromElements item={ item } field={ field } />
-	) : (
-		field.getValue( { item } )
-	);
+	if ( field.hasElements ) {
+		return <RenderFromElements item={ item } field={ field } />;
+	}
+
+	return field.getValueFormatted( { item, field } );
 }

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -273,7 +273,18 @@ export type Field< Item > = {
 	/**
 	 * Display format configuration for fields.
 	 */
-	format?: FormatDate | FormatDatetime | FormatNumber | FormatInteger;
+	format?: FormatDatetime | FormatDate | FormatNumber | FormatInteger;
+
+	/**
+	 * Callback used to format the value of the field for display.
+	 */
+	getValueFormatted?: ( {
+		item,
+		field,
+	}: {
+		item: Item;
+		field: NormalizedField< Item >;
+	} ) => string;
 };
 
 /**
@@ -329,7 +340,10 @@ export type FormatInteger = {
 	separatorThousand?: string;
 };
 
-type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' | 'isValid' > & {
+export type NormalizedField< Item > = Omit<
+	Field< Item >,
+	'Edit' | 'isValid'
+> & {
 	label: string;
 	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;
@@ -343,35 +357,19 @@ type NormalizedFieldBase< Item > = Omit< Field< Item >, 'Edit' | 'isValid' > & {
 	enableSorting: boolean;
 	filterBy: Required< FilterByConfig > | false;
 	readOnly: boolean;
-	format: {};
+	format:
+		| {}
+		| Required< FormatDate >
+		| Required< FormatInteger >
+		| Required< FormatNumber >;
+	getValueFormatted: ( {
+		item,
+		field,
+	}: {
+		item: Item;
+		field: NormalizedField< Item >;
+	} ) => string;
 };
-
-export type NormalizedFieldDatetime< Item > = NormalizedFieldBase< Item > & {
-	type: 'datetime';
-	format: Required< FormatDatetime >;
-};
-
-export type NormalizedFieldDate< Item > = NormalizedFieldBase< Item > & {
-	type: 'date';
-	format: Required< FormatDate >;
-};
-
-export type NormalizedFieldNumber< Item > = NormalizedFieldBase< Item > & {
-	type: 'number';
-	format: Required< FormatNumber >;
-};
-
-export type NormalizedFieldInteger< Item > = NormalizedFieldBase< Item > & {
-	type: 'integer';
-	format: Required< FormatInteger >;
-};
-
-export type NormalizedField< Item > =
-	| NormalizedFieldBase< Item >
-	| NormalizedFieldDate< Item >
-	| NormalizedFieldDatetime< Item >
-	| NormalizedFieldNumber< Item >
-	| NormalizedFieldInteger< Item >;
 
 /**
  * A collection of dataview fields for a data type.

--- a/packages/dataviews/src/types/private.ts
+++ b/packages/dataviews/src/types/private.ts
@@ -3,11 +3,6 @@
  */
 import type {
 	CustomValidator,
-	Field,
-	FormatDate,
-	FormatDatetime,
-	FormatInteger,
-	FormatNumber,
 	NormalizedField,
 	Operator,
 	Validator,
@@ -17,19 +12,17 @@ export type SelectionOrUpdater = string[] | ( ( prev: string[] ) => string[] );
 export type SetSelection = ( selection: SelectionOrUpdater ) => void;
 export type FieldType< Item > = Pick<
 	NormalizedField< Item >,
-	'type' | 'render' | 'sort' | 'enableSorting' | 'enableGlobalSearch'
+	| 'type'
+	| 'render'
+	| 'sort'
+	| 'enableSorting'
+	| 'enableGlobalSearch'
+	| 'format'
+	| 'getValueFormatted'
 > & {
 	Edit: string | null;
 	validOperators: Operator[];
 	defaultOperators: Operator[];
-	getFormat: (
-		field: Field< Item >
-	) =>
-		| Record< string, any >
-		| Required< FormatDate >
-		| Required< FormatDatetime >
-		| Required< FormatNumber >
-		| Required< FormatInteger >;
 	validate: {
 		required?: Validator< Item >;
 		elements?: Validator< Item >;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/73548

## What?

This PR refactors the DataViews filters and DataForm controls so that they are field type agnostic.

In the filters, move from this:


```js
let label = filterInView.value;
if ( field?.type === 'date' ) {
  label = /**/
} else if ( field.type === 'number' ) {
  label = /**/
} 
// etc.
```

to (delegate the formatting to the field):

```js
const label = field !== undefined ? field.getValueFormatted( /**/ ) : filterInView.value;
```

In the controls, move from:

```js
let weekStartsOn = getSettings().l10n.startOfWeek;
if ( type === 'date' ) {
  weekStartsOn = ( fieldFormat as Required< FormatDate > ).weekStartsOn;
}
```

to (any field whose format has `weekStartsOn` will be used, otherwise the default):

```js
const weekStartsOn = ( fieldFormat as FormatDate ).weekStartsOn ?? getSettings().l10n.startOfWeek;
```

## Why?

To prepare for 3rd party type registration, see https://github.com/WordPress/gutenberg/issues/73548

## How?

- Introduce a `getValueFormatted` in the fields.
- Remove the old `getFormat` in the field types in favor or `format` so they are aligned with the fields.

## Testing Instructions

Visit the storybook and verify the field types still work as before.

https://github.com/user-attachments/assets/ac3df94a-e915-40c6-908a-59ac9e3d9010


