### PR TITLE
Automated Testing: Include Windows build for GitHub Actions static checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -34,7 +34,7 @@ jobs:
                 node: ['20', '22', '24']
                 os: ['macos-15', 'ubuntu-24.04', 'windows-2025']
                 exclude:
-                    # On PRs: Only test Node 20 on Ubuntu
+                    # On PRs: Only test Node 20 on Ubuntu and Windows
                     - event: 'pull_request'
                       node: '22'
                     - event: 'pull_request'

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,8 +41,6 @@ jobs:
                       node: '24'
                     - event: 'pull_request'
                       os: 'macos-15'
-                    - event: 'pull_request'
-                      os: 'windows-2025'
 
         steps:
             - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## What?

Updates GitHub Actions configuration to include Windows on Node.js 20 for "Static Analysis" checks in pull requests.

## Why?

There have been numerous recent issues relating to code changes that are incompatible with Windows environments:

- https://github.com/WordPress/gutenberg/pull/73911
- https://github.com/WordPress/gutenberg/pull/72960
- https://github.com/WordPress/gutenberg/pull/72605
- https://github.com/WordPress/gutenberg/pull/72944

The situation was improved slightly in #72946, where we started running builds for Windows environments on the `trunk` branch. However, this is too late in the process, and is easily overlooked for some time.

## How?

Since previous issues largely manifest as a result of `npm run build`, the changes here are isolated to adding a single build check for pull requests to run the "Static checks" build pipeline for Windows + Node.js 20.

This is a minimal compromise that aims to preserve CI optimizations introduced in #72506.

## Testing Instructions

Observe that the build checks for this pull request include one passing build for Windows + Node.js 20 with "Static checks".