### PR TITLE
Accordion Block open/close icon #73607

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -16,7 +16,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
 -	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
+-	**Attributes:** autoclose, collapseIconId, collapseIconUrl, expandIconId, expandIconUrl, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading
 
@@ -26,7 +26,7 @@ Displays a heading that toggles the accordion panel. ([Source](https://github.co
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
--	**Attributes:** iconPosition, level, openByDefault, showIcon, title
+-	**Attributes:** collapseIconUrl, expandIconUrl, iconPosition, level, openByDefault, showIcon, title
 
 ## Accordion Item
 

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -9,7 +9,9 @@
 	"usesContext": [
 		"core/accordion-icon-position",
 		"core/accordion-show-icon",
-		"core/accordion-heading-level"
+		"core/accordion-heading-level",
+		"core/accordion-expand-icon-url",
+		"core/accordion-collapse-icon-url"
 	],
 	"supports": {
 		"anchor": true,
@@ -88,6 +90,12 @@
 		"showIcon": {
 			"type": "boolean",
 			"default": true
+		},
+		"expandIconUrl": {
+			"type": "string"
+		},
+		"collapseIconUrl": {
+			"type": "string"
 		}
 	},
 	"textdomain": "default"

--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -17,18 +17,39 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		'core/accordion-icon-position': iconPosition,
 		'core/accordion-show-icon': showIcon,
 		'core/accordion-heading-level': headingLevel,
+		'core/accordion-expand-icon-url': expandIconUrl,
+		'core/accordion-collapse-icon-url': collapseIconUrl,
 	} = context;
 	const TagName = 'h' + headingLevel;
 
 	// Set icon attributes.
 	useEffect( () => {
-		if ( iconPosition !== undefined && showIcon !== undefined ) {
-			setAttributes( {
-				iconPosition,
-				showIcon,
-			} );
+		const newAttrs = {};
+		if ( iconPosition !== undefined ) {
+			newAttrs.iconPosition = iconPosition;
 		}
-	}, [ iconPosition, showIcon, setAttributes ] );
+		if ( showIcon !== undefined ) {
+			newAttrs.showIcon = showIcon;
+		}
+		if ( expandIconUrl !== attributes.expandIconUrl ) {
+			newAttrs.expandIconUrl = expandIconUrl;
+		}
+		if ( collapseIconUrl !== attributes.collapseIconUrl ) {
+			newAttrs.collapseIconUrl = collapseIconUrl;
+		}
+
+		if ( Object.keys( newAttrs ).length > 0 ) {
+			setAttributes( newAttrs );
+		}
+	}, [
+		iconPosition,
+		showIcon,
+		expandIconUrl,
+		collapseIconUrl,
+		attributes.expandIconUrl,
+		attributes.collapseIconUrl,
+		setAttributes,
+	] );
 
 	const [ fluidTypographySettings, layout ] = useSettings(
 		'typography.fluid',
@@ -46,6 +67,25 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
+	const renderIcon = () => (
+		<span
+			className="wp-block-accordion-heading__toggle-icon"
+			aria-hidden="true"
+		>
+			{ expandIconUrl && collapseIconUrl ? (
+				<img
+					src={ expandIconUrl }
+					alt={ __( 'Expand icon' ) }
+					className="wp-block-accordion-heading__icon-expand"
+				/>
+			) : (
+				<span className="wp-block-accordion-heading__icon-expand">
+					+
+				</span>
+			) }
+		</span>
+	);
+
 	return (
 		<TagName { ...blockProps }>
 			<button
@@ -53,14 +93,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 				style={ spacingProps.style }
 				tabIndex="-1"
 			>
-				{ showIcon && iconPosition === 'left' && (
-					<span
-						className="wp-block-accordion-heading__toggle-icon"
-						aria-hidden="true"
-					>
-						+
-					</span>
-				) }
+				{ showIcon && iconPosition === 'left' && renderIcon() }
 				<RichText
 					withoutInteractiveFormatting
 					disableLineBreaks
@@ -76,14 +109,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 						textDecoration: typographyProps.style.textDecoration,
 					} }
 				/>
-				{ showIcon && iconPosition === 'right' && (
-					<span
-						className="wp-block-accordion-heading__toggle-icon"
-						aria-hidden="true"
-					>
-						+
-					</span>
-				) }
+				{ showIcon && iconPosition === 'right' && renderIcon() }
 			</button>
 		</TagName>
 	);

--- a/packages/block-library/src/accordion-heading/save.js
+++ b/packages/block-library/src/accordion-heading/save.js
@@ -9,12 +9,50 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { level, title, iconPosition, showIcon } = attributes;
+	const {
+		level,
+		title,
+		iconPosition,
+		showIcon,
+		expandIconUrl,
+		collapseIconUrl,
+	} = attributes;
 	const TagName = 'h' + ( level || 3 );
 	const typographyProps = getTypographyClassesAndStyles( attributes );
 
 	const blockProps = useBlockProps.save();
 	const spacingProps = getSpacingClassesAndStyles( attributes );
+
+	const renderIcon = () => (
+		<span
+			className="wp-block-accordion-heading__toggle-icon"
+			aria-hidden="true"
+		>
+			{ expandIconUrl ? (
+				<img
+					src={ expandIconUrl }
+					className="wp-block-accordion-heading__icon-expand"
+					alt="Expand icon"
+				/>
+			) : (
+				<span className="wp-block-accordion-heading__icon-expand">
+					+
+				</span>
+			) }
+
+			{ collapseIconUrl ? (
+				<img
+					src={ collapseIconUrl }
+					className="wp-block-accordion-heading__icon-collapse"
+					alt="Collapse icon"
+				/>
+			) : (
+				<span className="wp-block-accordion-heading__icon-collapse">
+					&times;
+				</span>
+			) }
+		</span>
+	);
 
 	return (
 		<TagName { ...blockProps }>
@@ -22,14 +60,7 @@ export default function save( { attributes } ) {
 				className="wp-block-accordion-heading__toggle"
 				style={ spacingProps.style }
 			>
-				{ showIcon && iconPosition === 'left' && (
-					<span
-						className="wp-block-accordion-heading__toggle-icon"
-						aria-hidden="true"
-					>
-						+
-					</span>
-				) }
+				{ showIcon && iconPosition === 'left' && renderIcon() }
 				<RichText.Content
 					className="wp-block-accordion-heading__toggle-title"
 					tagName="span"
@@ -39,14 +70,7 @@ export default function save( { attributes } ) {
 						textDecoration: typographyProps.style.textDecoration,
 					} }
 				/>
-				{ showIcon && iconPosition === 'right' && (
-					<span
-						className="wp-block-accordion-heading__toggle-icon"
-						aria-hidden="true"
-					>
-						+
-					</span>
-				) }
+				{ showIcon && iconPosition === 'right' && renderIcon() }
 			</button>
 		</TagName>
 	);

--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -38,4 +38,34 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+		display: block;
+	}
+
+	.wp-block-accordion-heading__icon-expand {
+		display: block;
+	}
+
+	.wp-block-accordion-heading__icon-collapse {
+		display: none;
+	}
+}
+
+.wp-block-accordion-heading__toggle[aria-expanded="true"] {
+	.wp-block-accordion-heading__toggle-icon {
+
+		transform: none !important;
+
+		.wp-block-accordion-heading__icon-expand {
+			display: none;
+		}
+
+		.wp-block-accordion-heading__icon-collapse {
+			display: block;
+		}
+	}
 }

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -76,12 +76,26 @@
 		},
 		"levelOptions": {
 			"type": "array"
+		},
+		"expandIconId": {
+			"type": "number"
+		},
+		"expandIconUrl": {
+			"type": "string"
+		},
+		"collapseIconId": {
+			"type": "number"
+		},
+		"collapseIconUrl": {
+			"type": "string"
 		}
 	},
 	"providesContext": {
 		"core/accordion-icon-position": "iconPosition",
 		"core/accordion-show-icon": "showIcon",
-		"core/accordion-heading-level": "headingLevel"
+		"core/accordion-heading-level": "headingLevel",
+		"core/accordion-expand-icon-url": "expandIconUrl",
+		"core/accordion-collapse-icon-url": "collapseIconUrl"
 	},
 	"allowedBlocks": [ "core/accordion-item" ],
 	"textdomain": "default",

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -9,6 +9,8 @@ import {
 	useBlockEditingMode,
 	store as blockEditorStore,
 	HeadingLevelDropdown,
+	MediaUpload,
+	MediaUploadCheck,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -19,6 +21,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToolbarButton,
 	ToolbarGroup,
+	Button,
 } from '@wordpress/components';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -41,6 +44,10 @@ export default function Edit( {
 		showIcon,
 		headingLevel,
 		levelOptions,
+		expandIconId,
+		expandIconUrl,
+		collapseIconId,
+		collapseIconUrl,
 	},
 	clientId,
 	setAttributes,
@@ -98,6 +105,27 @@ export default function Edit( {
 			} );
 		} );
 	};
+
+	const onSelectExpandIcon = ( media ) =>
+		setAttributes( {
+			expandIconId: media.id,
+			expandIconUrl: media.sizes?.thumbnail?.url || media.url,
+		} );
+	const onRemoveExpandIcon = () =>
+		setAttributes( {
+			expandIconId: undefined,
+			expandIconUrl: undefined,
+		} );
+	const onSelectCollapseIcon = ( media ) =>
+		setAttributes( {
+			collapseIconId: media.id,
+			collapseIconUrl: media.sizes?.thumbnail?.url || media.url,
+		} );
+	const onRemoveCollapseIcon = () =>
+		setAttributes( {
+			collapseIconId: undefined,
+			collapseIconUrl: undefined,
+		} );
 
 	return (
 		<>
@@ -179,34 +207,138 @@ export default function Edit( {
 						/>
 					</ToolsPanelItem>
 					{ showIcon && (
-						<ToolsPanelItem
-							label={ __( 'Icon Position' ) }
-							isShownByDefault
-							hasValue={ () => iconPosition !== 'right' }
-							onDeselect={ () =>
-								setAttributes( { iconPosition: 'right' } )
-							}
-						>
-							<ToggleGroupControl
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								isBlock
+						<>
+							<ToolsPanelItem
 								label={ __( 'Icon Position' ) }
-								value={ iconPosition }
-								onChange={ ( value ) => {
-									setAttributes( { iconPosition: value } );
+								isShownByDefault
+								hasValue={ () => iconPosition !== 'right' }
+								onDeselect={ () =>
+									setAttributes( { iconPosition: 'right' } )
+								}
+							>
+								<ToggleGroupControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									isBlock
+									label={ __( 'Icon Position' ) }
+									value={ iconPosition }
+									onChange={ ( value ) => {
+										setAttributes( {
+											iconPosition: value,
+										} );
+									} }
+								>
+									<ToggleGroupControlOption
+										label={ __( 'Left' ) }
+										value="left"
+									/>
+									<ToggleGroupControlOption
+										label={ __( 'Right' ) }
+										value="right"
+									/>
+								</ToggleGroupControl>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Custom Icons' ) }
+								isShownByDefault
+								hasValue={ () =>
+									!! ( expandIconId || collapseIconId )
+								}
+								onDeselect={ () => {
+									onRemoveExpandIcon();
+									onRemoveCollapseIcon();
 								} }
 							>
-								<ToggleGroupControlOption
-									label={ __( 'Left' ) }
-									value="left"
-								/>
-								<ToggleGroupControlOption
-									label={ __( 'Right' ) }
-									value="right"
-								/>
-							</ToggleGroupControl>
-						</ToolsPanelItem>
+								<div>
+									<h3> { __( 'Custom Icons' ) }</h3>
+									<p> { __( 'Expand Icon' ) }</p>
+									<MediaUploadCheck>
+										<MediaUpload
+											onSelect={ onSelectExpandIcon }
+											allowedTypes={ [ 'image' ] }
+											value={ expandIconId }
+											render={ ( { open } ) => (
+												<Button
+													__next40pxDefaultSize
+													onClick={ open }
+													variant="secondary"
+													className="editor-post-featured-image__toggle"
+												>
+													{ ! expandIconId ? (
+														__( 'Upload' )
+													) : (
+														<img
+															src={
+																expandIconUrl
+															}
+															alt={ __(
+																'Expand icon'
+															) }
+															width="40"
+														/>
+													) }
+												</Button>
+											) }
+										/>
+									</MediaUploadCheck>
+									{ !! expandIconId && (
+										<Button
+											__next40pxDefaultSize
+											onClick={ onRemoveExpandIcon }
+											variant="link"
+											isDestructive
+										>
+											{ __( 'Remove' ) }
+										</Button>
+									) }
+								</div>
+
+								<br />
+
+								<div>
+									<p> { __( 'Collapse Icon' ) }</p>
+									<MediaUploadCheck>
+										<MediaUpload
+											onSelect={ onSelectCollapseIcon }
+											allowedTypes={ [ 'image' ] }
+											value={ collapseIconId }
+											render={ ( { open } ) => (
+												<Button
+													__next40pxDefaultSize
+													onClick={ open }
+													variant="secondary"
+													className="editor-post-featured-image__toggle"
+												>
+													{ ! collapseIconId ? (
+														__( 'Upload' )
+													) : (
+														<img
+															src={
+																collapseIconUrl
+															}
+															alt={ __(
+																'Collapse icon'
+															) }
+															width="40"
+														/>
+													) }
+												</Button>
+											) }
+										/>
+									</MediaUploadCheck>
+									{ !! collapseIconId && (
+										<Button
+											__next40pxDefaultSize
+											onClick={ onRemoveCollapseIcon }
+											variant="link"
+											isDestructive
+										>
+											{ __( 'Remove' ) }
+										</Button>
+									) }
+								</div>
+							</ToolsPanelItem>
+						</>
 					) }
 				</ToolsPanel>
 			</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73607 

Add custom open/close icons for accordion block

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Gives the user ability to add custom icons of their own to expand and collapse the accordion drawer

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added new block settings in accordion block to upload the custom icons for open and close separately, if not set as custom falls back to default

## Testing Instructions

- Open a new page/post
- Add accordion block
- Go to block settings and upload a custom icon using upload button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="258" height="214" alt="image" src="https://github.com/user-attachments/assets/eb269c05-d061-426b-b9bf-77cdd3689eb0" />

<img width="713" height="195" alt="image" src="https://github.com/user-attachments/assets/9baf7b01-eb38-42e5-aaf6-6eb7a263fc58" />

