### PR TITLE
Storybook: Include design tokens styles automatically

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -16,6 +16,24 @@ This is a companion to the `@wordpress/theme` package that provides:
 -   **Design Tokens**: A comprehensive system of design tokens for colors, spacing, typography, and more
 -   **Theme System**: A flexible theming provider for consistent theming across applications
 
+## Installation
+
+Install using NPM:
+
+```
+npm install @wordpress/ui
+```
+
+As an implementation of the design system and companion to the `@wordpress/theme` package, these components depend on CSS custom properties defined by the theme package. This is managed on your behalf in a WordPress admin page context, but you will need to install and include the base theme stylesheet yourself if you're using the components in an application outside WordPress:
+
+```
+npm install @wordpress/theme
+```
+
+```tsx
+import '@wordpress/theme/design-tokens.css';
+```
+
 ## Usage
 
 ### Basic Component Usage

--- a/packages/ui/src/badge/stories/choosing-intent.mdx
+++ b/packages/ui/src/badge/stories/choosing-intent.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/blocks';
 import { Badge } from '../index';
+import '@wordpress/theme/design-tokens.css';
 
 <Meta title="Design System/Components/Badge/Choosing intent" />
 
@@ -109,4 +110,3 @@ Use the least attention‑grabbing intent that still:
 -   Makes it clear what needs attention,
 -   Marks what isn't final, or
 -   Confirms a key success state in that context.
-

--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -7,7 +7,6 @@ import type { Meta, StoryObj } from '@storybook/react';
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/ui/src/box/stories/index.story.tsx
+++ b/packages/ui/src/box/stories/index.story.tsx
@@ -1,6 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { type PaddingSize } from '@wordpress/theme';
-import '@wordpress/theme/design-tokens.css';
 import { Box } from '../box';
 
 const meta: Meta< typeof Box > = {

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -1,16 +1,4 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryObj } from '@storybook/react';
-
-/**
- * WordPress dependencies
- */
-import '@wordpress/theme/design-tokens.css';
-
-/**
- * Internal dependencies
- */
 import { Stack } from '../index';
 import { Box } from '../../box';
 

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -17,6 +17,7 @@ import fieldsLtr from '../package-styles/fields-ltr.lazy.scss';
 import fieldsRtl from '../package-styles/fields-rtl.lazy.scss';
 import mediaFieldsLtr from '../package-styles/media-fields-ltr.lazy.scss';
 import mediaFieldsRtl from '../package-styles/media-fields-rtl.lazy.scss';
+import ui from '../package-styles/ui.lazy.scss';
 
 /**
  * Stylesheets to lazy load when the story's context.componentId matches the
@@ -66,6 +67,11 @@ const CONFIG = [
 		componentIdMatcher: /^fields-/,
 		ltr: [ componentsLtr, dataviewsLtr, fieldsLtr, mediaFieldsLtr ],
 		rtl: [ componentsRtl, dataviewsRtl, fieldsRtl, mediaFieldsRtl ],
+	},
+	{
+		componentIdMatcher: /^design-system-components-/,
+		ltr: [ ui ],
+		rtl: [ ui ],
 	},
 ];
 

--- a/storybook/package-styles/ui.lazy.scss
+++ b/storybook/package-styles/ui.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/theme/src/prebuilt/css/design-tokens.css";

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import {
 	Controls,
 	Description,
@@ -9,10 +6,7 @@ import {
 	Subtitle,
 	Title,
 } from '@storybook/blocks';
-
-/**
- * Internal dependencies
- */
+import '@wordpress/theme/design-tokens.css';
 import { WithGlobalCSS } from './decorators/with-global-css';
 import { WithMarginChecker } from './decorators/with-margin-checker';
 import { WithMaxWidthWrapper } from './decorators/with-max-width-wrapper';

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -6,7 +6,6 @@ import {
 	Subtitle,
 	Title,
 } from '@storybook/blocks';
-import '@wordpress/theme/design-tokens.css';
 import { WithGlobalCSS } from './decorators/with-global-css';
 import { WithMarginChecker } from './decorators/with-margin-checker';
 import { WithMaxWidthWrapper } from './decorators/with-max-width-wrapper';


### PR DESCRIPTION
## What?

Updates Storybook configuration to include the base design system styles automatically in Storybook stories for `@wordpress/ui` components.

## Why?

Improves developer experience and reduces likelihood for error, so that they don't need to be imported in individual stories.

## How?

Augments existing `WithRTL` lazy-loaded styles Storybook decorator to include UI component dependencies stylesheet containing tokens.

## Testing Instructions

Verify no regressions in affected stories:

1. Run `npm run storybook:dev`
2. Go to http://localhost:50240/?path=/docs/design-system-components-stack--docs
3. Observe that you still see a gap between boxes in the Stack
