### PR TITLE
Cover & Group: fix  preview paragraph textAlign

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -56,7 +56,11 @@ function getInnerBlocksTemplate( attributes ) {
 		[
 			'core/paragraph',
 			{
-				align: 'center',
+				style: {
+					typography: {
+						textAlign: 'center',
+					},
+				},
 				placeholder: __( 'Write title…' ),
 				...attributes,
 			},

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -44,7 +44,11 @@ export const settings = {
 				name: 'core/paragraph',
 				attributes: {
 					content: `<strong>${ __( 'Snow Patrol' ) }</strong>`,
-					align: 'center',
+					style: {
+						typography: {
+							textAlign: 'center',
+						},
+					},
 				},
 			},
 		],

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -49,7 +49,11 @@ export const settings = {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					align: 'center',
+					style: {
+						typography: {
+							textAlign: 'center',
+						},
+					},
 					content: __(
 						'In a village of La Mancha, the name of which I have no desire to call to mind, there lived not long since one of those gentlemen that keep a lance in the lance-rack, an old buckler, a lean hack, and a greyhound for coursing.'
 					),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related to  #73111

<!-- In a few words, what is the PR actually doing? -->
Fixed the text alignment of paragraphs in the cover & group preview to be centered.

Fixed the text alignment of the cover block's initial template to be centered.
I made it work the same as before.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="444" height="200" alt="before-cover" src="https://github.com/user-attachments/assets/f80a4524-869c-48a8-9ca4-e80ac7b0fa56" /> | <img width="435" height="193" alt="after-cover" src="https://github.com/user-attachments/assets/0b52e729-2ed9-4eb3-a43d-975ef74bbe5f" /> |
| <img width="295" height="370" alt="before-cover-2" src="https://github.com/user-attachments/assets/3fdb8ce6-af28-4c0e-8f01-e6e19af72260" /> | <img width="293" height="368" alt="after-cover-2" src="https://github.com/user-attachments/assets/6d5e7278-d463-4997-a35a-8c436f304263" /> |
| <img width="293" height="314" alt="vefore-gruop" src="https://github.com/user-attachments/assets/f3000098-9f27-48db-a083-2a45de9b888c" /> | <img width="288" height="315" alt="after-gruop" src="https://github.com/user-attachments/assets/79bb2e9f-b7a1-4131-b669-fa7f9c4877d2" /> |

