### PR TITLE
Abilities API: Add hybrid abilities.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52305,7 +52305,8 @@
 				"@wordpress/i18n": "file:../i18n",
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
-				"ajv-formats": "^3.0.1"
+				"ajv-formats": "^3.0.1",
+				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/abilities/package.json
+++ b/packages/abilities/package.json
@@ -49,7 +49,8 @@
 		"@wordpress/i18n": "file:../i18n",
 		"ajv": "^8.17.1",
 		"ajv-draft-04": "^1.0.0",
-		"ajv-formats": "^3.0.1"
+		"ajv-formats": "^3.0.1",
+		"fast-deep-equal": "^3.1.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/abilities/src/api.ts
+++ b/packages/abilities/src/api.ts
@@ -10,6 +10,7 @@ import { sprintf } from '@wordpress/i18n';
 import { store } from './store';
 import type {
 	Ability,
+	AbilityCallback,
 	AbilityCategory,
 	AbilityCategoryArgs,
 	AbilitiesQueryArgs,
@@ -106,6 +107,33 @@ export function registerAbility( ability: Ability ): void {
  */
 export function unregisterAbility( name: string ): void {
 	dispatch( store ).unregisterAbility( name );
+}
+
+/**
+ * Register a callback for an existing ability.
+ *
+ * This function allows updating the callback of an already registered ability,
+ * which is useful for hybrid abilities that are registered on the server
+ * but need client-side execution callbacks.
+ *
+ * @param  name     The ability name to update.
+ * @param  callback The callback function to register.
+ * @throws {Error} If the ability is not registered or callback is invalid.
+ *
+ * @example
+ * ```js
+ * // Register a callback for a server-registered ability
+ * registerAbilityCallback('my-plugin/server-ability', async (input) => {
+ *   // Client-side implementation
+ *   return { success: true };
+ * });
+ * ```
+ */
+export function registerAbilityCallback(
+	name: string,
+	callback: AbilityCallback
+): void {
+	dispatch( store ).registerAbilityCallback( name, callback );
 }
 
 /**

--- a/packages/abilities/src/index.ts
+++ b/packages/abilities/src/index.ts
@@ -18,6 +18,7 @@ export {
 	getAbilityCategory,
 	executeAbility,
 	registerAbility,
+	registerAbilityCallback,
 	unregisterAbility,
 	registerAbilityCategory,
 	unregisterAbilityCategory,

--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import fastDeepEqual from 'fast-deep-equal/es6';
+
+/**
  * WordPress dependencies
  */
 import { sprintf } from '@wordpress/i18n';
@@ -159,10 +164,7 @@ export function registerAbility( ability: Ability ) {
 				const existingValue = existingAbility[ prop ];
 				const newValue = ability[ prop ];
 				// Deep comparison for objects (schemas)
-				if (
-					JSON.stringify( existingValue ) !==
-					JSON.stringify( newValue )
-				) {
+				if ( ! fastDeepEqual( existingValue, newValue ) ) {
 					throw new Error(
 						sprintf(
 							'Cannot update ability "%1$s": only callback changes are allowed for hybrid abilities. Property "%2$s" differs.',

--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -249,7 +249,6 @@ export function registerAbilityCallback(
 ) {
 	// @ts-expect-error - registry types are not yet available
 	return ( { select, dispatch } ) => {
-		// Validate ability exists
 		const existingAbility = select.getAbility( name );
 		if ( ! existingAbility ) {
 			throw new Error(
@@ -257,21 +256,27 @@ export function registerAbilityCallback(
 			);
 		}
 
-		// Validate callback is a function
+		if ( existingAbility.meta?.annotations?.clientRegistered ) {
+			throw new Error(
+				sprintf(
+					'Ability "%s" is already registered as a client-side ability',
+					name
+				)
+			);
+		}
+
 		if ( typeof callback !== 'function' ) {
 			throw new Error(
 				sprintf( 'Callback for ability "%s" must be a function', name )
 			);
 		}
 
-		// Update annotations to include clientRegistered
 		const existingAnnotations = existingAbility.meta?.annotations || {};
 		const annotations = {
 			...existingAnnotations,
 			clientRegistered: true,
 		};
 
-		// Dispatch update with callback and updated annotations
 		dispatch( {
 			type: REGISTER_ABILITY,
 			ability: {

--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -6,7 +6,12 @@ import { sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { Ability, AbilityCategory, AbilityCategoryArgs } from '../types';
+import type {
+	Ability,
+	AbilityCategory,
+	AbilityCategoryArgs,
+	AbilityCallback,
+} from '../types';
 import {
 	REGISTER_ABILITY,
 	UNREGISTER_ABILITY,
@@ -122,9 +127,83 @@ export function registerAbility( ability: Ability ) {
 		// Check if ability is already registered
 		const existingAbility = select.getAbility( ability.name );
 		if ( existingAbility ) {
-			throw new Error(
-				sprintf( 'Ability "%s" is already registered', ability.name )
-			);
+			// Check if this is a valid hybrid registration scenario
+			const existingAnnotations = existingAbility.meta?.annotations;
+			const newAnnotations = ability.meta?.annotations;
+
+			// Condition 1: Existing ability must be server-registered
+			if ( ! existingAnnotations?.serverRegistered ) {
+				throw new Error(
+					sprintf(
+						'Ability "%s" is already registered',
+						ability.name
+					)
+				);
+			}
+
+			// Condition 2: New ability must not explicitly set clientRegistered to false
+			if ( newAnnotations?.clientRegistered === false ) {
+				throw new Error(
+					sprintf(
+						'Ability "%s" is already registered',
+						ability.name
+					)
+				);
+			}
+
+			// Condition 3: New ability must not set serverRegistered to true
+			if ( newAnnotations?.serverRegistered === true ) {
+				throw new Error(
+					sprintf(
+						'Ability "%s" is already registered',
+						ability.name
+					)
+				);
+			}
+
+			// Condition 4: Only callback change is allowed - all other props must match
+			const propsToCompare = [
+				'name',
+				'label',
+				'description',
+				'category',
+				'input_schema',
+				'output_schema',
+			] as const;
+			for ( const prop of propsToCompare ) {
+				const existingValue = existingAbility[ prop ];
+				const newValue = ability[ prop ];
+				// Deep comparison for objects (schemas)
+				if (
+					JSON.stringify( existingValue ) !==
+					JSON.stringify( newValue )
+				) {
+					throw new Error(
+						sprintf(
+							'Cannot update ability "%1$s": only callback changes are allowed for hybrid abilities. Property "%2$s" differs.',
+							ability.name,
+							prop
+						)
+					);
+				}
+			}
+
+			// Valid hybrid registration - update with callback and set clientRegistered
+			const updatedAnnotations = {
+				...existingAnnotations,
+				clientRegistered: true,
+			};
+
+			dispatch( {
+				type: REGISTER_ABILITY,
+				ability: {
+					...existingAbility,
+					callback: ability.callback,
+					permissionCallback: ability.permissionCallback,
+					meta: { annotations: updatedAnnotations },
+				},
+			} );
+			return;
 		}
 
 		const annotations = filterAnnotations( ability.meta?.annotations, [
@@ -162,6 +241,58 @@ export function unregisterAbility( name: string ) {
 	return {
 		type: UNREGISTER_ABILITY,
 		name,
+	};
+}
+
+/**
+ * Registers a callback for an existing ability.
+ *
+ * This action allows updating the callback of an already registered ability,
+ * which is useful for hybrid abilities that are registered on the server
+ * but need client-side execution callbacks.
+ *
+ * @param  name     The name of the ability to update.
+ * @param  callback The callback function to register.
+ * @return Action object or function.
+ * @throws {Error} If the ability is not registered or callback is invalid.
+ */
+export function registerAbilityCallback(
+	name: string,
+	callback: AbilityCallback
+) {
+	// @ts-expect-error - registry types are not yet available
+	return ( { select, dispatch } ) => {
+		// Validate ability exists
+		const existingAbility = select.getAbility( name );
+		if ( ! existingAbility ) {
+			throw new Error(
+				sprintf( 'Ability "%s" is not registered', name )
+			);
+		}
+
+		// Validate callback is a function
+		if ( typeof callback !== 'function' ) {
+			throw new Error(
+				sprintf( 'Callback for ability "%s" must be a function', name )
+			);
+		}
+
+		// Update annotations to include clientRegistered
+		const existingAnnotations = existingAbility.meta?.annotations || {};
+		const annotations = {
+			...existingAnnotations,
+			clientRegistered: true,
+		};
+
+		// Dispatch update with callback and updated annotations
+		dispatch( {
+			type: REGISTER_ABILITY,
+			ability: {
+				...existingAbility,
+				callback,
+				meta: { annotations },
+			},
+		} );
 	};
 }
 

--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -151,17 +151,7 @@ export function registerAbility( ability: Ability ) {
 				);
 			}
 
-			// Condition 3: New ability must not set serverRegistered to true
-			if ( newAnnotations?.serverRegistered === true ) {
-				throw new Error(
-					sprintf(
-						'Ability "%s" is already registered',
-						ability.name
-					)
-				);
-			}
-
-			// Condition 4: Only callback change is allowed - all other props must match
+			// Condition 3: Only callback change is allowed - all other props must match
 			const propsToCompare = [
 				'name',
 				'label',

--- a/packages/abilities/src/store/actions.ts
+++ b/packages/abilities/src/store/actions.ts
@@ -131,8 +131,13 @@ export function registerAbility( ability: Ability ) {
 			const existingAnnotations = existingAbility.meta?.annotations;
 			const newAnnotations = ability.meta?.annotations;
 
-			// Condition 1: Existing ability must be server-registered
-			if ( ! existingAnnotations?.serverRegistered ) {
+			// Existing ability must be server-registered (not client-only or hybrid)
+			// and the new ability must not be server-registered only.
+			if (
+				! existingAnnotations?.serverRegistered ||
+				existingAnnotations?.clientRegistered ||
+				newAnnotations?.clientRegistered === false
+			) {
 				throw new Error(
 					sprintf(
 						'Ability "%s" is already registered',
@@ -141,17 +146,7 @@ export function registerAbility( ability: Ability ) {
 				);
 			}
 
-			// Condition 2: New ability must not explicitly set clientRegistered to false
-			if ( newAnnotations?.clientRegistered === false ) {
-				throw new Error(
-					sprintf(
-						'Ability "%s" is already registered',
-						ability.name
-					)
-				);
-			}
-
-			// Condition 3: Only callback change is allowed - all other props must match
+			// Only callback change is allowed - all other props must match
 			const propsToCompare = [
 				'name',
 				'label',

--- a/packages/abilities/src/store/tests/actions.test.ts
+++ b/packages/abilities/src/store/tests/actions.test.ts
@@ -721,37 +721,6 @@ describe( 'Store Actions', () => {
 			expect( mockDispatch ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should throw error when new ability sets serverRegistered to true', () => {
-			const existingAbility: Ability = {
-				name: 'test/ability',
-				label: 'Test Ability',
-				description: 'Test description',
-				category: 'test-category',
-				meta: {
-					annotations: { serverRegistered: true },
-				},
-			};
-			mockSelect.getAbility.mockReturnValue( existingAbility );
-
-			const newAbility: Ability = {
-				name: 'test/ability',
-				label: 'Test Ability',
-				description: 'Test description',
-				category: 'test-category',
-				callback: jest.fn(),
-				meta: {
-					annotations: { serverRegistered: true },
-				},
-			};
-
-			const action = registerAbility( newAbility );
-
-			expect( () =>
-				action( { select: mockSelect, dispatch: mockDispatch } )
-			).toThrow( 'Ability "test/ability" is already registered' );
-			expect( mockDispatch ).not.toHaveBeenCalled();
-		} );
-
 		it( 'should throw error when properties other than callback differ', () => {
 			const existingAbility: Ability = {
 				name: 'test/ability',

--- a/packages/abilities/src/store/tests/actions.test.ts
+++ b/packages/abilities/src/store/tests/actions.test.ts
@@ -527,6 +527,28 @@ describe( 'Store Actions', () => {
 			expect( mockDispatch ).not.toHaveBeenCalled();
 		} );
 
+		it( 'should throw error when ability is already client-registered', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { clientRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const action = registerAbilityCallback( 'test/ability', jest.fn() );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow(
+				'Ability "test/ability" is already registered as a client-side ability'
+			);
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should set clientRegistered to true', () => {
 			const existingAbility: Ability = {
 				name: 'test/ability',

--- a/packages/abilities/src/store/tests/actions.test.ts
+++ b/packages/abilities/src/store/tests/actions.test.ts
@@ -7,6 +7,7 @@
  */
 import {
 	registerAbility,
+	registerAbilityCallback,
 	unregisterAbility,
 	registerAbilityCategory,
 	unregisterAbilityCategory,
@@ -443,6 +444,449 @@ describe( 'Store Actions', () => {
 			expect( action ).toEqual( {
 				type: UNREGISTER_ABILITY,
 				name: abilityName,
+			} );
+		} );
+	} );
+
+	describe( 'registerAbilityCallback', () => {
+		let mockSelect: any;
+		let mockDispatch: jest.Mock;
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			mockSelect = {
+				getAbility: jest.fn().mockReturnValue( null ),
+			};
+			mockDispatch = jest.fn();
+		} );
+
+		it( 'should update callback on an existing ability', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const action = registerAbilityCallback(
+				'test/ability',
+				newCallback
+			);
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: {
+					...existingAbility,
+					callback: newCallback,
+					meta: {
+						annotations: {
+							serverRegistered: true,
+							clientRegistered: true,
+						},
+					},
+				},
+			} );
+		} );
+
+		it( 'should throw error when ability does not exist', () => {
+			mockSelect.getAbility.mockReturnValue( null );
+
+			const action = registerAbilityCallback( 'test/ability', jest.fn() );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow( 'Ability "test/ability" is not registered' );
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error when callback is not a function', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const action = registerAbilityCallback(
+				'test/ability',
+				'not a function' as any
+			);
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow(
+				'Callback for ability "test/ability" must be a function'
+			);
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should set clientRegistered to true', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const action = registerAbilityCallback(
+				'test/ability',
+				newCallback
+			);
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					ability: expect.objectContaining( {
+						meta: {
+							annotations: { clientRegistered: true },
+						},
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should preserve existing annotations', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: {
+						serverRegistered: true,
+						readonly: true,
+						destructive: false,
+					},
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const action = registerAbilityCallback(
+				'test/ability',
+				newCallback
+			);
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: {
+					...existingAbility,
+					callback: newCallback,
+					meta: {
+						annotations: {
+							serverRegistered: true,
+							readonly: true,
+							destructive: false,
+							clientRegistered: true,
+						},
+					},
+				},
+			} );
+		} );
+	} );
+
+	describe( 'registerAbility - hybrid abilities', () => {
+		let mockSelect: any;
+		let mockDispatch: jest.Mock;
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			const defaultCategories = [
+				{
+					slug: 'test-category',
+					label: 'Test Category',
+					description: 'Test category for testing',
+				},
+			];
+
+			mockSelect = {
+				getAbility: jest.fn().mockReturnValue( null ),
+				getAbilityCategories: jest
+					.fn()
+					.mockReturnValue( defaultCategories ),
+			};
+			mockDispatch = jest.fn();
+		} );
+
+		it( 'should allow re-registration of server-registered ability with callback', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				input_schema: { type: 'object' },
+				output_schema: { type: 'object' },
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				input_schema: { type: 'object' },
+				output_schema: { type: 'object' },
+				callback: newCallback,
+			};
+
+			const action = registerAbility( newAbility );
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: {
+					...existingAbility,
+					callback: newCallback,
+					permissionCallback: undefined,
+					meta: {
+						annotations: {
+							serverRegistered: true,
+							clientRegistered: true,
+						},
+					},
+				},
+			} );
+		} );
+
+		it( 'should throw error when existing ability is not server-registered', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { clientRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				callback: jest.fn(),
+			};
+
+			const action = registerAbility( newAbility );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow( 'Ability "test/ability" is already registered' );
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error when new ability sets clientRegistered to false', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				callback: jest.fn(),
+				meta: {
+					annotations: { clientRegistered: false },
+				},
+			};
+
+			const action = registerAbility( newAbility );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow( 'Ability "test/ability" is already registered' );
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error when new ability sets serverRegistered to true', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				callback: jest.fn(),
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+
+			const action = registerAbility( newAbility );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow( 'Ability "test/ability" is already registered' );
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error when properties other than callback differ', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Different Label',
+				description: 'Test description',
+				category: 'test-category',
+				callback: jest.fn(),
+			};
+
+			const action = registerAbility( newAbility );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow(
+				'Cannot update ability "test/ability": only callback changes are allowed for hybrid abilities. Property "label" differs.'
+			);
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error when input_schema differs', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				input_schema: { type: 'object' },
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				input_schema: { type: 'string' },
+				callback: jest.fn(),
+			};
+
+			const action = registerAbility( newAbility );
+
+			expect( () =>
+				action( { select: mockSelect, dispatch: mockDispatch } )
+			).toThrow(
+				'Cannot update ability "test/ability": only callback changes are allowed for hybrid abilities. Property "input_schema" differs.'
+			);
+			expect( mockDispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should preserve serverRegistered and add clientRegistered on successful hybrid registration', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: {
+						serverRegistered: true,
+						readonly: true,
+					},
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				callback: newCallback,
+			};
+
+			const action = registerAbility( newAbility );
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: expect.objectContaining( {
+					meta: {
+						annotations: {
+							serverRegistered: true,
+							readonly: true,
+							clientRegistered: true,
+						},
+					},
+				} ),
+			} );
+		} );
+
+		it( 'should also update permissionCallback for hybrid abilities', () => {
+			const existingAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				meta: {
+					annotations: { serverRegistered: true },
+				},
+			};
+			mockSelect.getAbility.mockReturnValue( existingAbility );
+
+			const newCallback = jest.fn();
+			const newPermissionCallback = jest.fn();
+			const newAbility: Ability = {
+				name: 'test/ability',
+				label: 'Test Ability',
+				description: 'Test description',
+				category: 'test-category',
+				callback: newCallback,
+				permissionCallback: newPermissionCallback,
+			};
+
+			const action = registerAbility( newAbility );
+			action( { select: mockSelect, dispatch: mockDispatch } );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( {
+				type: REGISTER_ABILITY,
+				ability: expect.objectContaining( {
+					callback: newCallback,
+					permissionCallback: newPermissionCallback,
+				} ),
 			} );
 		} );
 	} );


### PR DESCRIPTION
Introduces the "hybrid abilities" concept to the `@wordpress/abilities` package, allowing abilities to be registered on the server while also having a client side version on some contexts.
These allows for example, to have a server side ability that edits the post content and saves it in the database, while also having the same ability on the editor, but in that case it just changes the current post the user is seeing without saving to the database so the user can continue the work.

Changes:
- Adds `registerAbilityCallback()` function to register client side callbacks for server-defined abilities.
- Updates registerAbility to allow the user to reregister an ability that was server registered, as a client registered one. The only change possible on this case is changing the callback function. These allows clients to just register their ability not needing to worry if the server already provided the same ability on that context or not.

## Testing

Paste the following on the console in sequence:
```
const abilitiesAPI = (await import( '@wordpress/abilities' ) );

abilitiesAPI.registerAbilityCallback( 'core/get-site-info', () => { alert('hello world'); return {} } );

await abilitiesAPI.executeAbility( 'core/get-site-info' );
```
Verify there was an alert.
```
abilitiesAPI.registerAbilityCallback( 'core/get-site-info', () => { alert('hello world'); return {} } );
```
Verify there is an error as the ability is already client registered.

```
const envInfoAbility = abilitiesAPI.getAbility('core/get-environment-info');

abilitiesAPI.registerAbility({...envInfoAbility,callback: ()=> {alert('ability has a callback'); return {"environment":"production","php_version":"8.3.14","db_server_info":"8.0.40","wp_version":"7.0-alpha-20251114.113128"} } });

await abilitiesAPI.executeAbility( 'core/get-environment-info' );
```
Verify there was an alert.

```
abilitiesAPI.registerAbility({...envInfoAbility,callback: ()=> {alert('ability has a callback'); return {"environment":"production","php_version":"8.3.14","db_server_info":"8.0.40","wp_version":"7.0-alpha-20251114.113128"} } })
```
Verify there we had an error as the ability is already client registered.
