### PR TITLE
DataViews: Fix row selection in table layout in Firefox

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)
 - DataViews: Apply primary style to first column if there is no title field. [#73729](https://github.com/WordPress/gutenberg/pull/73729)
 - DataViews: Combined field alignment in table layout. [#73908](https://github.com/WordPress/gutenberg/pull/73908)
+- DataViews: Fix table row multiselection in Firefox [#73945](https://github.com/WordPress/gutenberg/pull/73945)
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -163,6 +163,20 @@ function TableRow< Item >( {
 			}
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : undefined }
+			onMouseDown={ ( event ) => {
+				// Firefox has a unique feature where ctrl/cmd + click selects a
+				// table cell. This interferes with the bulk selection behavior,
+				// so this code prevents it.
+				const isMetaClick = isAppleOS() ? event.metaKey : event.ctrlKey;
+				if (
+					isMetaClick &&
+					window.navigator.userAgent
+						.toLowerCase()
+						.includes( 'firefox' )
+				) {
+					event?.preventDefault();
+				}
+			} }
 			onClick={ ( event ) => {
 				if ( ! hasPossibleBulkAction ) {
 					return;

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -169,6 +169,7 @@ function TableRow< Item >( {
 				// so this code prevents it.
 				const isMetaClick = isAppleOS() ? event.metaKey : event.ctrlKey;
 				if (
+					event.button === 0 &&
 					isMetaClick &&
 					window.navigator.userAgent
 						.toLowerCase()


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #73910

## Why?
Firefox has a unique feature compared to other browsers, Cmd/Ctrl + Click on a table cell selects the table cell. Try it below (Cmd + Click on a mac, Ctrl + Click on other platforms):
| Header | Header | Header |
|--------|--------|--------|
| Cell | Cell | Cell |
| Cell | Cell | Cell |
| Cell | Cell | Cell | 

For the dataviews table layout, it already uses the same shortcut for table row selection. I think the Firefox behavior isn't something that's expected to happen, and it stops the row selection behavior from working, so this PR prevents it.

## How?
If the browser is firefox, and the user ctrl/cmd + left clicks, prevent the default behavior.

## Testing Instructions (in Firefox)
1. Checkout this branch and run `npm run storybook:dev`
2. Navigate to the DataViews > Default story
3. Cmd + Click (on a Mac) or Ctrl + Click (on other platforms) on a row in the table
4. The table row should be selected
