### PR TITLE
Real-time collaboration: Add type guard for rich-text attributes

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -301,16 +301,17 @@ export function mergeCrdtBlocks(
 							if (
 								isRichText &&
 								'string' === typeof attributeValue &&
-								currentAttributes.has( attributeName )
+								currentAttributes.has( attributeName ) &&
+								currentAttributes.get(
+									attributeName
+								) instanceof Y.Text
 							) {
 								// Rich text values are stored as persistent Y.Text instances.
 								// Update the value with a delta in place.
-								const blockYText = currentAttributes.get(
-									attributeName
-								) as Y.Text;
-
 								mergeRichTextUpdate(
-									blockYText,
+									currentAttributes.get(
+										attributeName
+									) as Y.Text,
 									attributeValue,
 									lastSelection
 								);

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -300,7 +300,8 @@ export function mergeCrdtBlocks(
 
 							if (
 								isRichText &&
-								'string' === typeof attributeValue
+								'string' === typeof attributeValue &&
+								currentAttributes.has( attributeName )
 							) {
 								// Rich text values are stored as persistent Y.Text instances.
 								// Update the value with a delta in place.

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -371,5 +371,44 @@ describe( 'crdt-blocks', () => {
 			 ).get( 'content' ) as Y.Text;
 			expect( content.toString() ).toBe( 'Updated Middle' );
 		} );
+
+		it( 'adds new rich-text attribute to existing block without that attribute', () => {
+			// Start with a block that has NO content attribute
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { level: 1 },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Now add the content attribute (rich-text)
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						level: 1,
+						content: 'New content added',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const block = yblocks.get( 0 );
+			const attributes = block.get( 'attributes' ) as YBlockAttributes;
+
+			// The content attribute should now exist
+			expect( attributes.has( 'content' ) ).toBe( true );
+			const content = attributes.get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'New content added' );
+
+			// The level attribute should still exist
+			expect( attributes.get( 'level' ) ).toBe( 1 );
+		} );
 	} );
 } );

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -9,6 +9,25 @@ import { Y } from '@wordpress/sync';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
+ * Mock uuid module
+ */
+jest.mock( 'uuid', () => ( {
+	v4: jest.fn( () => 'mocked-uuid-' + Math.random() ),
+} ) );
+
+/**
+ * Mock @wordpress/blocks module
+ */
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: jest.fn( () => [
+		{
+			name: 'core/paragraph',
+			attributes: { content: { type: 'rich-text' } },
+		},
+	] ),
+} ) );
+
+/**
  * Internal dependencies
  */
 import {
@@ -261,7 +280,48 @@ describe( 'crdt-blocks', () => {
 			const contentAttr = (
 				block.get( 'attributes' ) as YBlockAttributes
 			 ).get( 'content' ) as Y.Text;
+			expect( contentAttr ).toBeInstanceOf( Y.Text );
 			expect( contentAttr.toString() ).toBe( 'Rich text content' );
+		} );
+
+		it( 'creates Y.Text for rich-text attributes even when the block name changes', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/freeform',
+					attributes: { content: 'Freeform text' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const block = yblocks.get( 0 );
+			const contentAttr = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' );
+			expect( block.get( 'name' ) ).toBe( 'core/freeform' );
+			expect( typeof contentAttr ).toBe( 'string' );
+			expect( contentAttr ).toBe( 'Freeform text' );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Updated text' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( yblocks.length ).toBe( 1 );
+
+			const updatedBlock = yblocks.get( 0 );
+			const updatedContentAttr = (
+				updatedBlock.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( updatedBlock.get( 'name' ) ).toBe( 'core/paragraph' );
+			expect( updatedContentAttr ).toBeInstanceOf( Y.Text );
+			expect( updatedContentAttr.toString() ).toBe( 'Updated text' );
 		} );
 
 		it( 'removes duplicate clientIds', () => {


### PR DESCRIPTION
## What?

Introduce a type guard to ensure that a rich-text attribute is represented by a `Y.Text` type.

## Why?

Our assumption that an attribute is represented in the CRDT doc as a `Y.Text` instance was based on the _current_ block name, which may have changed as part of the current changeset. For example, a block can be transformed from `core/freeform` to `core/paragraph`. Both of those blocks carry a `content` attribute, but only the latter's is a rich-text attribute.

When this happens, we can encounter a fatal error in `mergeRichTextUpdate` by assuming a primitive string is a `Y.Text` instance.

## How?

1. Use an `instanceof` check.
1. Add a test case.

## Testing Instructions

1. Check out this branch.
1. Add a "Classic" block and type a sentence.
1. Click "Convert to blocks."

### Testing Instructions for Keyboard
n/a