### PR TITLE
Add experiment for hiding blocks based on screen size

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -41,6 +41,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-hide-blocks-based-on-screen-size', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalHideBlocksBasedOnScreenSize = true', 'before' );
+	}
 	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalTemplateActivate = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -254,7 +254,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Extends block visiblity block supports to hide blocks based on screen size.', 'gutenberg' ),
+			'label' => __( 'Extends block visibility block supports with responsive design controls for hiding blocks based on screen size.', 'gutenberg' ),
 			'id'    => 'gutenberg-hide-blocks-based-on-screen-size',
 		)
 	);

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -246,6 +246,19 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	// create a new experiment for hiding blocks based on screen size
+	add_settings_field(
+		'gutenberg-hide-blocks-based-on-screen-size',
+		__( 'Hide blocks based on screen size', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Extends block visiblity block supports to hide blocks based on screen size.', 'gutenberg' ),
+			'id'    => 'gutenberg-hide-blocks-based-on-screen-size',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Create initial experiment for https://github.com/WordPress/gutenberg/issues/72502

## Why?
This feature will be iteratively developed behind an experimental flag to start with to minimize impact on the current editor UX

## How?
You know.


### Testing Instructions 

Check that the experiment is there in `/wp-admin/admin.php?page=gutenberg-experiments`

<img width="773" height="86" alt="Screenshot 2025-12-12 at 2 07 23 pm" src="https://github.com/user-attachments/assets/b7cff043-9f95-460a-81a4-203183c9fa7f" />

Enable the experiment and check that `window.__experimentalHideBlocksBasedOnScreenSize` is available in the console.
