### PR TITLE
DataViews: filterSortAndPaginate should ignore sorting on non-sortable fields

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,7 @@
 - DataViews: Apply primary style to first column if there is no title field. [#73729](https://github.com/WordPress/gutenberg/pull/73729)
 - DataViews: Combined field alignment in table layout. [#73908](https://github.com/WordPress/gutenberg/pull/73908)
 - DataViews: Fix table row multiselection in Firefox [#73945](https://github.com/WordPress/gutenberg/pull/73945)
+- DataViews: `filterSortAndPaginate()` will ignore sorting on non-sortable fields [#73950](https://github.com/WordPress/gutenberg/pull/73950)
 
 ### Enhancements
 

--- a/packages/dataviews/src/test/filter-sort-and-paginate.js
+++ b/packages/dataviews/src/test/filter-sort-and-paginate.js
@@ -1136,6 +1136,30 @@ describe( 'sorting', () => {
 
 		expect( groupCount ).toBe( 5 );
 	} );
+
+	it( 'should NOT sort the data if the field is not sortable', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				sort: { field: 'description', direction: 'asc' },
+				filters: [
+					{
+						field: 'type',
+						operator: 'is',
+						value: 'Terrestrial',
+					},
+				],
+			},
+			fields
+		);
+
+		expect( result.map( ( r ) => r.name.description ) ).toEqual( [
+			'Terrestrial planet in the Solar system',
+			'La planète Vénus',
+			'Terrestrial planet in the Solar system',
+			'Terrestrial planet in the Solar system',
+		] );
+	} );
 } );
 
 describe( 'pagination', () => {

--- a/packages/dataviews/src/test/filter-sort-and-paginate.js
+++ b/packages/dataviews/src/test/filter-sort-and-paginate.js
@@ -1137,7 +1137,31 @@ describe( 'sorting', () => {
 		expect( groupCount ).toBe( 5 );
 	} );
 
-	it( 'should NOT sort the data if the field is not sortable', () => {
+	it( 'should NOT sort the data if gropuBy.field is not sortable', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				groupBy: { field: 'description', direction: 'asc' },
+				filters: [
+					{
+						field: 'type',
+						operator: 'is',
+						value: 'Terrestrial',
+					},
+				],
+			},
+			fields
+		);
+
+		expect( result.map( ( r ) => r.name.description ) ).toEqual( [
+			'Terrestrial planet in the Solar system',
+			'La planète Vénus',
+			'Terrestrial planet in the Solar system',
+			'Terrestrial planet in the Solar system',
+		] );
+	} );
+
+	it( 'should NOT sort the data if sort.field is not sortable', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{

--- a/packages/dataviews/src/utils/filter-sort-and-paginate.ts
+++ b/packages/dataviews/src/utils/filter-sort-and-paginate.ts
@@ -389,7 +389,10 @@ export default function filterSortAndPaginate< Item >(
 	// Handle sorting.
 	const sortByField = view.sort?.field
 		? _fields.find( ( field ) => {
-				return field.id === view.sort?.field;
+				return (
+					field.enableSorting !== false &&
+					field.id === view.sort?.field
+				);
 		  } )
 		: null;
 	const groupByField = view.groupBy?.field

--- a/packages/dataviews/src/utils/filter-sort-and-paginate.ts
+++ b/packages/dataviews/src/utils/filter-sort-and-paginate.ts
@@ -397,7 +397,10 @@ export default function filterSortAndPaginate< Item >(
 		: null;
 	const groupByField = view.groupBy?.field
 		? _fields.find( ( field ) => {
-				return field.id === view.groupBy?.field;
+				return (
+					field.enableSorting !== false &&
+					field.id === view.groupBy?.field
+				);
 		  } )
 		: null;
 	if ( sortByField || groupByField ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

`filterSortAndPaginate()` should check whether the requested sort-by field is sortable or not before attempting to sort the data.

<!-- In a few words, what is the PR actually doing? -->

## Why?

[useView()](https://github.com/WordPress/gutenberg/blob/96f35c0c2f4f8ec8bf7f9d0cc2541a6b9096faa1/packages/views/src/use-view.ts#L52) will retrieve the previously-persisted view.

The following faulty sequence of events could happen:

- We (developer) have defined the set of fields.
- A user sorts by a field, which will then persist the view.
- Later, we realize that the data could contain value for that field that cannot be sorted (can't call `localeCompare()` on it). Or we just decide that the field should not be sortable.
- We mark the field as `enableSorting: false`
- The user comes back, and persisted view will be retrieved.
- `filterSortAndPaginate()` runs, and could potentially crash. Example error:

```
Cannot read properties of undefined (reading 'localeCompare')
```

## How?

Check for `field.enableSorting` first before sorting.


## Testing Instructions

Verify the added unit test passes.
