### PR TITLE
Block Editor: Replace default block on paste if it has no content

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -923,7 +923,7 @@ export const __unstableSplitSelection =
 			// If an unmodified default block is selected, replace it. We don't
 			// want to be converting into a default block.
 			if ( blocks.length ) {
-				if ( isUnmodifiedDefaultBlock( blockA ) ) {
+				if ( isUnmodifiedDefaultBlock( blockA, 'content' ) ) {
 					dispatch.replaceBlocks(
 						[ selectionA.clientId ],
 						blocks,


### PR DESCRIPTION
## What?
This is similar to https://github.com/WordPress/gutenberg/pull/70897.
Closes https://github.com/WordPress/gutenberg/issues/64071.
Closes https://github.com/WordPress/gutenberg/issues/73895.

PR relaxes the conditions under which the unmodified default block is replaced; it now checks for modifications to the content role attribute.

## Testing Instructions
1. Open a post or page.
2. Rename the empty paragraph.
3. Insert an image block.
4. Copy the image block and paste it into an empty paragraph.
5. It should replace the paragraph block even though it has `metadata` attributes defined.
6. When a paragraph block has content, the behavior should remain the same as on trunk.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/71afde4e-f67e-45ea-8896-16709ec57a85

**After**

https://github.com/user-attachments/assets/88b2251c-01eb-45ee-9e99-92a3e1cfa0e5

