### PR TITLE
Site editor global styles settings: ensure generated global styles are correct in canvas between views

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -71,11 +71,7 @@ export function useSpecificEditorSettings() {
 		 * Exclude styles and __experimentalFeatures from base settings
 		 * since we're generating fresh ones from the merged config.
 		 */
-		const {
-			styles: _,
-			__experimentalFeatures: __,
-			...baseSettings
-		} = settings;
+		const { styles, __experimentalFeatures, ...baseSettings } = settings;
 
 		return {
 			...baseSettings,

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -73,14 +73,8 @@ export function useSpecificEditorSettings() {
 	}, [ mergedConfig ] );
 
 	const defaultEditorSettings = useMemo( () => {
-		/*
-		 * Exclude styles and __experimentalFeatures from base settings
-		 * since we're generating fresh ones from the merged config.
-		 */
-		const { styles, __experimentalFeatures, ...baseSettings } = settings;
-
 		return {
-			...baseSettings,
+			...settings,
 			styles: [
 				...globalStyles,
 				{

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -5,7 +5,12 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { usePrevious } from '@wordpress/compose';
-import { store as editorStore } from '@wordpress/editor';
+import {
+	store as editorStore,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
+import { getBlockTypes } from '@wordpress/blocks';
+import { generateGlobalStyles } from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -16,6 +21,7 @@ import useNavigateToEntityRecord from './use-navigate-to-entity-record';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { useGlobalStyles } = unlock( editorPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
@@ -39,6 +45,10 @@ export function useSpecificEditorSettings() {
 	const [ onNavigateToEntityRecord, initialBlockSelection ] =
 		useNavigateToEntityRecord();
 
+
+	// Get merged global styles config and generate styles directly
+	// This avoids reading from editorStore which causes infinite loops
+	const { merged: mergedConfig } = useGlobalStyles();
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
 		const { getSettings } = select( editSiteStore );
 		const { getCurrentPostAttribute } = select( editorStore );
@@ -52,11 +62,28 @@ export function useSpecificEditorSettings() {
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
 
+	// Generate global styles from merged config.
+	const [ globalStyles, globalSettings ] = useMemo( () => {
+		if ( ! mergedConfig?.styles || ! mergedConfig?.settings ) {
+			return [ [], {} ];
+		}
+
+		const blockTypes = getBlockTypes();
+		return generateGlobalStyles( mergedConfig, blockTypes, {
+			disableRootPadding: false,
+		} );
+	}, [ mergedConfig ] );
+
 	const defaultEditorSettings = useMemo( () => {
+		// Filter out global styles from base settings and merge with generated global styles
+		const nonGlobalStyles = ( settings.styles ?? [] ).filter(
+			( style ) => ! style.isGlobalStyles
+		);
 		return {
 			...settings,
 			styles: [
-				...settings.styles,
+				...nonGlobalStyles,
+				...globalStyles,
 				{
 					// Forming a "block formatting context" to prevent margin collapsing.
 					// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
@@ -70,6 +97,8 @@ export function useSpecificEditorSettings() {
 							: undefined,
 				},
 			],
+			__experimentalFeatures:
+				globalSettings || settings.__experimentalFeatures,
 			richEditingEnabled: true,
 			supportsTemplateMode: true,
 			focusMode: canvas !== 'view',
@@ -80,6 +109,8 @@ export function useSpecificEditorSettings() {
 		};
 	}, [
 		settings,
+		globalStyles,
+		globalSettings,
 		canvas,
 		currentPostIsTrashed,
 		onNavigateToEntityRecord,

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -44,7 +44,6 @@ export function useSpecificEditorSettings() {
 	const [ onNavigateToEntityRecord, initialBlockSelection ] =
 		useNavigateToEntityRecord();
 
-
 	// Get merged global styles config and generate styles directly
 	// This avoids reading from editorStore which causes infinite loops
 	const { merged: mergedConfig } = useGlobalStyles();
@@ -68,8 +67,10 @@ export function useSpecificEditorSettings() {
 	}, [ mergedConfig ] );
 
 	const defaultEditorSettings = useMemo( () => {
-		// Exclude styles and __experimentalFeatures from base settings
-		// since we're generating fresh ones from the merged config
+		/*
+		 * Exclude styles and __experimentalFeatures from base settings
+		 * since we're generating fresh ones from the merged config.
+		 */
 		const {
 			styles: _,
 			__experimentalFeatures: __,

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -9,7 +9,6 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
-import { getBlockTypes } from '@wordpress/blocks';
 import { generateGlobalStyles } from '@wordpress/global-styles-engine';
 
 /**
@@ -62,27 +61,24 @@ export function useSpecificEditorSettings() {
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
 
-	// Generate global styles from merged config.
 	const [ globalStyles, globalSettings ] = useMemo( () => {
-		if ( ! mergedConfig?.styles || ! mergedConfig?.settings ) {
-			return [ [], {} ];
-		}
-
-		const blockTypes = getBlockTypes();
-		return generateGlobalStyles( mergedConfig, blockTypes, {
+		return generateGlobalStyles( mergedConfig, [], {
 			disableRootPadding: false,
 		} );
 	}, [ mergedConfig ] );
 
 	const defaultEditorSettings = useMemo( () => {
-		// Filter out global styles from base settings and merge with generated global styles
-		const nonGlobalStyles = ( settings.styles ?? [] ).filter(
-			( style ) => ! style.isGlobalStyles
-		);
+		// Exclude styles and __experimentalFeatures from base settings
+		// since we're generating fresh ones from the merged config
+		const {
+			styles: _,
+			__experimentalFeatures: __,
+			...baseSettings
+		} = settings;
+
 		return {
-			...settings,
+			...baseSettings,
 			styles: [
-				...nonGlobalStyles,
 				...globalStyles,
 				{
 					// Forming a "block formatting context" to prevent margin collapsing.
@@ -97,8 +93,7 @@ export function useSpecificEditorSettings() {
 							: undefined,
 				},
 			],
-			__experimentalFeatures:
-				globalSettings || settings.__experimentalFeatures,
+			__experimentalFeatures: globalSettings,
 			richEditingEnabled: true,
 			supportsTemplateMode: true,
 			focusMode: canvas !== 'view',

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -44,8 +44,7 @@ export function useSpecificEditorSettings() {
 	const [ onNavigateToEntityRecord, initialBlockSelection ] =
 		useNavigateToEntityRecord();
 
-	// Get merged global styles config and generate styles directly
-	// This avoids reading from editorStore which causes infinite loops
+	// Get merged global styles config and generate styles directly.
 	const { merged: mergedConfig } = useGlobalStyles();
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
 		const { getSettings } = select( editSiteStore );

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -44,8 +44,15 @@ export function useSpecificEditorSettings() {
 	const [ onNavigateToEntityRecord, initialBlockSelection ] =
 		useNavigateToEntityRecord();
 
-	// Get merged global styles config and generate styles directly.
+	/*
+	 * Generate global styles directly to avoid circular dependency with GlobalStylesRenderer
+	 * (which runs inside ExperimentalEditorProvider after this hook).
+	 * GlobalStylesRenderer updates editorStore, but reading from it here would cause infinite
+	 * loops. Reading config from useGlobalStyles and generating CSS directly keeps us in sync.
+	 * See: https://github.com/WordPress/gutenberg/issues/73350
+	 */
 	const { merged: mergedConfig } = useGlobalStyles();
+
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
 		const { getSettings } = select( editSiteStore );
 		const { getCurrentPostAttribute } = select( editorStore );

--- a/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
+++ b/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
@@ -4,6 +4,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { generateGlobalStyles } from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -12,7 +14,12 @@ import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import { filterOutDuplicatesByName } from './utils';
 
+const { useGlobalStyles } = unlock( editorPrivateApis );
+
 export default function usePatternSettings() {
+	// Get merged global styles config and generate styles directly.
+	const { merged: mergedConfig } = useGlobalStyles();
+
 	const storedSettings = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 		return getSettings();
@@ -36,16 +43,28 @@ export default function usePatternSettings() {
 		[ settingsBlockPatterns, restBlockPatterns ]
 	);
 
+	const [ globalStyles, globalSettings ] = useMemo( () => {
+		return generateGlobalStyles( mergedConfig, [], {
+			disableRootPadding: false,
+		} );
+	}, [ mergedConfig ] );
+
 	const settings = useMemo( () => {
-		const { __experimentalAdditionalBlockPatterns, ...restStoredSettings } =
-			storedSettings;
+		const {
+			__experimentalAdditionalBlockPatterns,
+			styles,
+			__experimentalFeatures,
+			...restStoredSettings
+		} = storedSettings;
 
 		return {
 			...restStoredSettings,
+			styles: globalStyles,
+			__experimentalFeatures: globalSettings,
 			__experimentalBlockPatterns: blockPatterns,
 			isPreviewMode: true,
 		};
-	}, [ storedSettings, blockPatterns ] );
+	}, [ storedSettings, blockPatterns, globalStyles, globalSettings ] );
 
 	return settings;
 }

--- a/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
+++ b/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
@@ -17,7 +17,12 @@ import { filterOutDuplicatesByName } from './utils';
 const { useGlobalStyles } = unlock( editorPrivateApis );
 
 export default function usePatternSettings() {
-	// Get merged global styles config and generate styles directly.
+	/*
+	 * Generate global styles directly because block previews use a separate
+	 * ExperimentalBlockEditorProvider and can't access GlobalStylesRenderer's output.
+	 * Reading config from useGlobalStyles and generating CSS directly keeps us in sync.
+	 * See: https://github.com/WordPress/gutenberg/issues/73350
+	 */
 	const { merged: mergedConfig } = useGlobalStyles();
 
 	const storedSettings = useSelect( ( select ) => {


### PR DESCRIPTION
closes #73350 

## What? How?

Selecting a theme style variation in the Site Editor does not persist between the editor view (`canvas=edit`) and the main design view (`canvas=view`). The styles appear correctly in the editor view but remain stale in the main design view.

This PR fixes that by generating global styles directly from the merged config in `useSpecificEditorSettings()` instead of reading from either store.

## Why? 

A git bisect led me to this PR:

- https://github.com/WordPress/gutenberg/pull/72681

**Before PR #72681:**
- `GlobalStylesRenderer` updated `editSiteStore` via `updateSettings()`
- `useSpecificEditorSettings()` read from `editSiteStore` via `getSettings()`
- Both used the same store, so styles stayed in sync ✅

**After PR #72681:**
- `GlobalStylesRenderer` now updates `editorStore` via `updateEditorSettings()`
- `useSpecificEditorSettings()` still reads from `editSiteStore` via `getSettings()`
- They use different stores, so the main design view doesn't see updates ❌

The entity is saved correctly, but the visual representation in the main design view is stale because it's reading from a different store than the one being updated.



## Testing Instructions


1. Apply the TT5 theme
1. In the Site Editor, select a new style variation, e.g., Twilight
2. Switch to View mode - verify styles match Twilight
3. Switch back to Edit mode
4. Select another style variation
5. Switch to View mode - verify styles match your new variation
6. Repeat with multiple variations to ensure each switch updates correctly
7. Also switch to a new theme and then edit a template part. 
8. The isolated editor should reflect your chose style
9. Ensure any customization to your theme show in the canvas as well.
10. Also check the templates page after switching styles. See https://github.com/WordPress/gutenberg/pull/73952#issuecomment-3645249360

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/6a18a110-39e5-4a01-98ff-0e161176fa9f




### After


https://github.com/user-attachments/assets/e006b818-40f3-46dc-809f-6bd3ca4f02f7


