### PR TITLE
Global Styles: fix infinite loop in Font Style UI

### DIFF
--- a/test/e2e/specs/editor/various/font-appearance-control.spec.js
+++ b/test/e2e/specs/editor/various/font-appearance-control.spec.js
@@ -80,9 +80,6 @@ test.describe( 'Font Appearance Control dropdown menu', () => {
 		await page
 			.getByRole( 'button', { name: 'Typography options' } )
 			.click();
-		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Show Appearance' } )
-			.click();
 		await expect(
 			page.getByRole( 'combobox', { name: 'Appearance' } )
 		).toHaveText( 'Default' );


### PR DESCRIPTION
- Fixes: #73904
- Follow-up to:
  - #61915
  - #63215

## What?

I found that changing any setting in the Typography panel would cause the UI to crash due to infinite rendering if the `fontStyle` field had a value other than `normal` or `italic`. This problem has likely existed latent for some time, but it became apparent when #70676 added `"fontStyle": "inherit"` to the button element by default.

This PR solves that issue by refactoring the logic to not use `useEffect`.

## Why?

According to my research, any font style other than `normal`, `italic`, or `oblique` is not considered valid, and [the `findNearestFontStyle()` function returns an empty string](https://github.com/WordPress/gutenberg/blob/e26a3ad24c54d55effe7d2854f2317a62921f80d/packages/block-editor/src/components/global-styles/typography-utils.js#L87), causing an infinite loop within `useEffect`.

## How?

In the first place, fallback processing should only be necessary when the font family is changed, so `useEffect` is not necessary. When the font family is changed, change the logic to find a similar font style and font weight.

## Testing Instructions

Test the following three scenarios, all of which should crash the UI in the trunk branch:

### Example 1

Activate Emptytheme and update `theme.json` with the following code:

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"typography": {
			"fontStyle": "inherit"
		}
	}
}
```

1. Appearance > Editor
2. Global Styles > Typography > Elements section > Text
3. Change some settings.
4. The global styles sidebar should not crash.

### Example 2

Activate Emptytheme and update `theme.json` with the following code:

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/paragraph": {
				"typography": {
					"fontStyle": "test"
				}
			}
		}
	}
}
```

1. Appearance > Editor
2. Global Styles > Blocks > Paragraph
3. Change some settings.
4. The global styles sidebar should not crash.

### Example 3

1. Appearance > Editor
2. Globak Styles > Typography > Elements section > Button
3. Change some settings.
4. The global styles sidebar should not crash.
