### PR TITLE
Refine overlay edit button UI: move to link variant and add tooltip

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -225,7 +225,7 @@ export default function OverlayTemplatePartSelector( {
 						help={ helpText }
 					/>
 				</FlexBlock>
-				{ overlay && ( ! hasResolved || selectedTemplatePart ) && (
+				{ overlay && hasResolved && selectedTemplatePart && (
 					<FlexItem>
 						<Button
 							__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -168,13 +168,6 @@ export default function OverlayTemplatePartSelector( {
 		createErrorNotice,
 	] );
 
-	const isEditButtonDisabled =
-		! overlay ||
-		! hasResolved ||
-		! selectedTemplatePart ||
-		! onNavigateToEntityRecord ||
-		isResolving;
-
 	const isCreateButtonDisabled = isResolving || isCreating;
 
 	// Build help text
@@ -231,7 +224,7 @@ export default function OverlayTemplatePartSelector( {
 							__next40pxDefaultSize
 							variant="secondary"
 							onClick={ handleEditClick }
-							disabled={ isEditButtonDisabled }
+							disabled={ ! onNavigateToEntityRecord }
 							accessibleWhenDisabled
 							label={ editButtonLabel }
 							showTooltip

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -175,7 +175,7 @@ export default function OverlayTemplatePartSelector( {
 		if ( overlayTemplateParts.length === 0 && hasResolved ) {
 			return __( 'No overlays found.' );
 		}
-		return __( 'Select an overlay to use for the navigation.' );
+		return __( 'Select an overlay for navigation.' );
 	}, [ overlayTemplateParts.length, hasResolved ] );
 
 	// Tooltip/aria-label text for the edit button

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -233,7 +233,6 @@ export default function OverlayTemplatePartSelector( {
 							onClick={ handleEditClick }
 							disabled={ isEditButtonDisabled }
 							accessibleWhenDisabled
-							aria-label={ editButtonLabel }
 							label={ editButtonLabel }
 							showTooltip
 							className="wp-block-navigation__overlay-edit-button"

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -179,6 +179,19 @@ export default function OverlayTemplatePartSelector( {
 		return __( 'Select an overlay to use for the navigation.' );
 	}, [ overlayTemplateParts.length, hasResolved ] );
 
+	// Tooltip/aria-label text for the edit button
+	const editButtonLabel = useMemo( () => {
+		return selectedTemplatePart
+			? sprintf(
+					/* translators: %s: Overlay title. */
+					__( 'Edit overlay: %s' ),
+					selectedTemplatePart.title?.rendered
+						? decodeEntities( selectedTemplatePart.title.rendered )
+						: selectedTemplatePart.slug
+			  )
+			: __( 'Edit overlay' );
+	}, [ selectedTemplatePart ] );
+
 	return (
 		<div className="wp-block-navigation__overlay-selector">
 			<Button
@@ -209,23 +222,12 @@ export default function OverlayTemplatePartSelector( {
 					onClick={ handleEditClick }
 					disabled={ isEditButtonDisabled }
 					accessibleWhenDisabled
-					aria-label={
-						selectedTemplatePart
-							? sprintf(
-									/* translators: %s: Overlay title. */
-									__( 'Edit overlay: %s' ),
-									selectedTemplatePart.title?.rendered
-										? decodeEntities(
-												selectedTemplatePart.title
-													.rendered
-										  )
-										: selectedTemplatePart.slug
-							  )
-							: __( 'Edit overlay' )
-					}
+					aria-label={ editButtonLabel }
+					label={ editButtonLabel }
+					showTooltip
 					className="wp-block-navigation__overlay-edit-button"
 				>
-					[{ __( 'Edit' ) }]
+					{ __( 'Edit' ) }
 				</Button>
 			) }
 		</div>

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -205,7 +205,7 @@ export default function OverlayTemplatePartSelector( {
 			{ overlay && ( ! hasResolved || selectedTemplatePart ) && (
 				<Button
 					__next40pxDefaultSize
-					variant="secondary"
+					variant="link"
 					onClick={ handleEditClick }
 					disabled={ isEditButtonDisabled }
 					accessibleWhenDisabled
@@ -225,7 +225,7 @@ export default function OverlayTemplatePartSelector( {
 					}
 					className="wp-block-navigation__overlay-edit-button"
 				>
-					{ __( 'Edit' ) }
+					[{ __( 'Edit' ) }]
 				</Button>
 			) }
 		</div>

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -4,7 +4,13 @@
 import { useMemo, useState, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { SelectControl, Button } from '@wordpress/components';
+import {
+	SelectControl,
+	Button,
+	FlexBlock,
+	FlexItem,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
@@ -205,31 +211,38 @@ export default function OverlayTemplatePartSelector( {
 				showTooltip
 				className="wp-block-navigation__overlay-create-button"
 			/>
-			<SelectControl
-				__next40pxDefaultSize
-				label={ __( 'Overlay template' ) }
-				value={ overlay || '' }
-				options={ options }
-				onChange={ handleSelectChange }
-				disabled={ isResolving }
-				accessibleWhenDisabled
-				help={ helpText }
-			/>
-			{ overlay && ( ! hasResolved || selectedTemplatePart ) && (
-				<Button
-					__next40pxDefaultSize
-					variant="link"
-					onClick={ handleEditClick }
-					disabled={ isEditButtonDisabled }
-					accessibleWhenDisabled
-					aria-label={ editButtonLabel }
-					label={ editButtonLabel }
-					showTooltip
-					className="wp-block-navigation__overlay-edit-button"
-				>
-					{ __( 'Edit' ) }
-				</Button>
-			) }
+			<HStack alignment="flex-start">
+				<FlexBlock>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Overlay template' ) }
+						value={ overlay || '' }
+						options={ options }
+						onChange={ handleSelectChange }
+						disabled={ isResolving }
+						accessibleWhenDisabled
+						help={ helpText }
+					/>
+				</FlexBlock>
+				{ overlay && ( ! hasResolved || selectedTemplatePart ) && (
+					<FlexItem>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ handleEditClick }
+							disabled={ isEditButtonDisabled }
+							accessibleWhenDisabled
+							aria-label={ editButtonLabel }
+							label={ editButtonLabel }
+							showTooltip
+							className="wp-block-navigation__overlay-edit-button"
+						>
+							{ __( 'Edit' ) }
+						</Button>
+					</FlexItem>
+				) }
+			</HStack>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -447,9 +447,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			expect(
-				screen.getByText(
-					'Select an overlay to use for the navigation.'
-				)
+				screen.getByText( 'Select an overlay for navigation.' )
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole( 'button', {

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -283,7 +283,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).not.toBeInTheDocument();
 		} );
 
-		it( 'should disable button when overlays are initially loading', () => {
+		it( 'should not display edit button while overlays templates are loading', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: true,
@@ -303,10 +303,13 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 			expect( select ).toBeDisabled();
 
-			const editButton = screen.getByRole( 'button', {
-				name: /Edit overlay/,
-			} );
-			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
+			// Expect Edit button to not be in the document
+			expect(
+				screen.queryByRole( 'button', {
+					name: ( accessibleName ) =>
+						accessibleName.startsWith( 'Edit overlay' ),
+				} )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should be enabled when a valid overlay is selected', () => {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -650,16 +650,15 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	grid-column: span 2;
 }
 
-.wp-block-navigation__overlay-selector {
-	position: relative;
+// Nudge the edit button down to align with the select control input field.
+// The SelectControl has a label above it, so we need to offset the button
+// to align it with the input rather than the top of the control.
+.wp-block-navigation__overlay-edit-button {
+	margin-top: $grid-unit-30;
 }
 
 .wp-block-navigation__overlay-edit-button {
 	margin-top: $grid-unit-10;
-	width: fit-content;
-	position: absolute;
-	right: 0;
-	top: 0;
 }
 
 .wp-block-navigation__overlay-selector {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -657,10 +657,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-top: $grid-unit-30;
 }
 
-.wp-block-navigation__overlay-edit-button {
-	margin-top: $grid-unit-10;
-}
-
 .wp-block-navigation__overlay-selector {
 	position: relative;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -650,9 +650,16 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	grid-column: span 2;
 }
 
+.wp-block-navigation__overlay-selector {
+	position: relative;
+}
+
 .wp-block-navigation__overlay-edit-button {
 	margin-top: $grid-unit-10;
 	width: fit-content;
+	position: absolute;
+	right: 0;
+	top: 0;
 }
 
 .wp-block-navigation__overlay-selector {


### PR DESCRIPTION
## What

Refines the overlay template selector UI by moving the edit button to a more streamlined position and adding a tooltip for improved clarity.

## Why

The previous implementation had the edit button as a large isolated button below the input, which created visual separation and took up unnecessary space. Moving it to a link variant positioned to the right of the control creates a more compact and intuitive UI. Additionally, the button's purpose wasn't immediately clear to all users since it only showed "[Edit]" as visible text, with additional context only available via aria-label for screen readers.

## How

- Moved the edit button from below the SelectControl to a link variant positioned to the right of the control, providing a more streamlined UI
- Added a tooltip to the button that displays the same information as the aria-label (e.g., "Edit overlay: [title]" or "Edit overlay"), making the button's purpose clear to all users
- Extracted the aria-label text into a reusable `editButtonLabel` memoized value for both the tooltip and aria-label
- The aria-label is retained to ensure screen readers continue to receive the full context






## Screenshot
| Before | After |
|--------|-------|
| <img width="598" height="336" alt="Screenshot 2025-12-11 at 16 26 51" src="https://github.com/user-attachments/assets/b9cb5e18-b2f3-4ef7-a31e-3da0a158932b" /> | <img width="274" height="118" alt="Screenshot 2025-12-16 at 13 07 37" src="https://github.com/user-attachments/assets/88abe2e3-146c-4fe7-8a1e-69db888e5b7e" /> |

## Testing

- Enable experiment
- Open Nav block sidebar "Overlay" controls
- See new Edit button position
- Confirm same functionality as per `trunk`.
