### PR TITLE
Paragraph: add align wide full supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -601,7 +601,7 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 
 -	**Name:** core/paragraph
 -	**Category:** text
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
 -	**Attributes:** content, direction, dropCap, placeholder
 
 ## Pattern Placeholder

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -27,6 +27,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "wide", "full" ],
 		"splitting": true,
 		"anchor": true,
 		"className": false,

--- a/packages/block-library/src/paragraph/deprecated-attributes.js
+++ b/packages/block-library/src/paragraph/deprecated-attributes.js
@@ -36,7 +36,11 @@ export default function useDeprecatedAlign( align, style, setAttributes ) {
 	} );
 	const lastUpdatedAlignRef = useRef();
 	useEffect( () => {
-		if ( align === lastUpdatedAlignRef.current ) {
+		if (
+			align === 'full' ||
+			align === 'wide' ||
+			align === lastUpdatedAlignRef.current
+		) {
 			return;
 		}
 		lastUpdatedAlignRef.current = align;

--- a/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
@@ -136,6 +136,9 @@ class KeyboardNavigableBlocks {
 		await this.expectLabelToHaveFocus( 'Move down' );
 
 		await this.page.keyboard.press( 'ArrowRight' );
+		await this.expectLabelToHaveFocus( 'Align' );
+
+		await this.page.keyboard.press( 'ArrowRight' );
 		await this.expectLabelToHaveFocus( 'Align text' );
 
 		await this.page.keyboard.press( 'ArrowRight' );

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -66,6 +66,7 @@ test.describe( 'Block Toolbar', () => {
 			).toBeFocused();
 			// // Navigate to Align Text
 			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'ArrowRight' );
 			await expect(
 				page.getByRole( 'button', { name: 'Align text', exact: true } )
 			).toBeFocused();

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -130,7 +130,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await pageUtils.pressKeys( 'alt+F10' );
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowRight' );
-		await ToolbarRovingTabindexUtils.expectLabelToHaveFocus( 'Bold' );
+		await ToolbarRovingTabindexUtils.expectLabelToHaveFocus( 'Align text' );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #31429
Related 
- #73111
- #73578

<!-- In a few words, what is the PR actually doing? -->
Paragraph block add align wide full supports

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Heading blocks have wide and full, but paragraph blocks do not.
There didn't seem to be any negative comments in the issue, so I made the adjustment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Paragraph block.
3. You can see that the toolbar allows you to set the text alignment to full width, wide, and so on.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="385" height="80" alt="before" src="https://github.com/user-attachments/assets/f2da385e-53fb-4b7f-99b7-4a746800dbab" /> | <img width="422" height="214" alt="after" src="https://github.com/user-attachments/assets/a70a86b3-aa51-4d58-b36b-ab3192ecc4bf" /> |
