### PR TITLE
Add custom CSS support for individual block instances

### DIFF
--- a/backport-changelog/7.0/10777.md
+++ b/backport-changelog/7.0/10777.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10777
+
+* https://github.com/WordPress/gutenberg/pull/73959

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -55,7 +55,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 
 -	**Name:** core/archives
 -	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~customCSS~~, ~~html~~
 -	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -55,7 +55,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 
 -	**Name:** core/archives
 -	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~customCSS~~, ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -12,1086 +12,1088 @@ This page lists the blocks included in the block-library package.
 
 Displays a foldable layout that groups content in collapsible sections. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion))
 
--	**Name:** core/accordion
--	**Category:** design
--	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
+-   **Name:** core/accordion
+-   **Category:** design
+-   **Allowed Blocks:** core/accordion-item
+-   **Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading
 
 Displays a heading that toggles the accordion panel. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-heading))
 
--	**Name:** core/accordion-heading
--	**Category:** design
--	**Parent:** core/accordion-item
--	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
--	**Attributes:** iconPosition, level, openByDefault, showIcon, title
+-   **Name:** core/accordion-heading
+-   **Category:** design
+-   **Parent:** core/accordion-item
+-   **Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
+-   **Attributes:** iconPosition, level, openByDefault, showIcon, title
 
 ## Accordion Item
 
 Wraps the heading and panel in one unit. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-item))
 
--	**Name:** core/accordion-item
--	**Category:** design
--	**Parent:** core/accordion
--	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
--	**Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** openByDefault
+-   **Name:** core/accordion-item
+-   **Category:** design
+-   **Parent:** core/accordion
+-   **Allowed Blocks:** core/accordion-heading, core/accordion-panel
+-   **Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** openByDefault
 
 ## Accordion Panel
 
 Contains the hidden or revealed content beneath the heading. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-panel))
 
--	**Name:** core/accordion-panel
--	**Category:** design
--	**Parent:** core/accordion-item
--	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
--	**Attributes:** templateLock
+-   **Name:** core/accordion-panel
+-   **Category:** design
+-   **Parent:** core/accordion-item
+-   **Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
+-   **Attributes:** templateLock
 
 ## Archives
 
 Display a date archive of your posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/archives))
 
--	**Name:** core/archives
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
+-   **Name:** core/archives
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio
 
 Embed a simple audio player. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/audio))
 
--	**Name:** core/audio
--	**Category:** media
--	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
--	**Attributes:** autoplay, blob, caption, id, loop, preload, src
+-   **Name:** core/audio
+-   **Category:** media
+-   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
+-   **Attributes:** autoplay, blob, caption, id, loop, preload, src
 
 ## Avatar
 
 Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/avatar))
 
--	**Name:** core/avatar
--	**Category:** theme
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
--	**Attributes:** isLink, linkTarget, size, userId
+-   **Name:** core/avatar
+-   **Category:** theme
+-   **Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
+-   **Attributes:** isLink, linkTarget, size, userId
 
 ## Pattern
 
 Reuse this design across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
 
--	**Name:** core/block
--	**Category:** reusable
--	**Supports:** interactivity (clientNavigation), ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--	**Attributes:** content, ref
+-   **Name:** core/block
+-   **Category:** reusable
+-   **Supports:** interactivity (clientNavigation), ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
+-   **Attributes:** content, ref
 
 ## Breadcrumbs
 
 Display a breadcrumb trail showing the path to the current page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
 
--	**Name:** core/breadcrumbs
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-   **Name:** core/breadcrumbs
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 
 Prompt visitors to take action with a button-style link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/button))
 
--	**Name:** core/button
--	**Category:** design
--	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
+-   **Name:** core/button
+-   **Category:** design
+-   **Parent:** core/buttons
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-   **Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
 
 ## Buttons
 
 Prompt visitors to take action with a group of button-style links. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/buttons))
 
--	**Name:** core/buttons
--	**Category:** design
--	**Allowed Blocks:** core/button
--	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Name:** core/buttons
+-   **Category:** design
+-   **Allowed Blocks:** core/button
+-   **Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Calendar
 
 A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/calendar))
 
--	**Name:** core/calendar
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** month, year
+-   **Name:** core/calendar
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** month, year
 
 ## Terms List
 
 Display a list of all terms of a given taxonomy. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/categories))
 
--	**Name:** core/categories
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-   **Name:** core/categories
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 
 Display code snippets that respect your spacing and tabs. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/code))
 
--	**Name:** core/code
--	**Category:** text
--	**Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content
+-   **Name:** core/code
+-   **Category:** text
+-   **Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** content
 
 ## Column
 
 A single column within a columns block. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/column))
 
--	**Name:** core/column
--	**Category:** design
--	**Parent:** core/columns
--	**Supports:** allowedBlocks, anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** templateLock, verticalAlignment, width
+-   **Name:** core/column
+-   **Category:** design
+-   **Parent:** core/columns
+-   **Supports:** allowedBlocks, anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** templateLock, verticalAlignment, width
 
 ## Columns
 
 Display content in multiple columns, with blocks added to each column. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/columns))
 
--	**Name:** core/columns
--	**Category:** design
--	**Allowed Blocks:** core/column
--	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
+-   **Name:** core/columns
+-   **Category:** design
+-   **Allowed Blocks:** core/column
+-   **Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 
 This block is deprecated. Please use the Avatar block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-avatar))
 
--	**Name:** core/comment-author-avatar
--	**Experimental:** fse
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~, ~~inserter~~
--	**Attributes:** height, width
+-   **Name:** core/comment-author-avatar
+-   **Experimental:** fse
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~, ~~inserter~~
+-   **Attributes:** height, width
 
 ## Comment Author Name
 
 Displays the name of the author of the comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
 
--	**Name:** core/comment-author-name
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
--	**Attributes:** isLink, linkTarget
+-   **Name:** core/comment-author-name
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-   **Attributes:** isLink, linkTarget
 
 ## Comment Content
 
 Displays the contents of a comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-content))
 
--	**Name:** core/comment-content
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-   **Name:** core/comment-content
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight, textAlign), ~~html~~
 
 ## Comment Date
 
 Displays the date on which the comment was posted. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-date))
 
--	**Name:** core/comment-date
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** format, isLink
+-   **Name:** core/comment-date
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** format, isLink
 
 ## Comment Edit Link
 
 Displays a link to edit the comment in the WordPress Dashboard. This link is only visible to users with the edit comment capability. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-edit-link))
 
--	**Name:** core/comment-edit-link
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** linkTarget, textAlign
+-   **Name:** core/comment-edit-link
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** linkTarget, textAlign
 
 ## Comment Reply Link
 
 Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-reply-link))
 
--	**Name:** core/comment-reply-link
--	**Category:** theme
--	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-   **Name:** core/comment-reply-link
+-   **Category:** theme
+-   **Ancestor:** core/comment-template
+-   **Supports:** anchor, color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** textAlign
 
 ## Comment Template
 
 Contains the block elements used to display a comment, like the title, date, author, avatar and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-template))
 
--	**Name:** core/comment-template
--	**Category:** design
--	**Parent:** core/comments
--	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Name:** core/comment-template
+-   **Category:** design
+-   **Parent:** core/comments
+-   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments
 
 An advanced block that allows displaying post comments using different visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments))
 
--	**Name:** core/comments
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** legacy, tagName
+-   **Name:** core/comments
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** legacy, tagName
 
 ## Comments Pagination
 
 Displays a paginated navigation to next/previous set of comments, when applicable. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination))
 
--	**Name:** core/comments-pagination
--	**Category:** theme
--	**Parent:** core/comments
--	**Allowed Blocks:** core/comments-pagination-previous, core/comments-pagination-numbers, core/comments-pagination-next
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** paginationArrow
+-   **Name:** core/comments-pagination
+-   **Category:** theme
+-   **Parent:** core/comments
+-   **Allowed Blocks:** core/comments-pagination-previous, core/comments-pagination-numbers, core/comments-pagination-next
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** paginationArrow
 
 ## Comments Next Page
 
 Displays the next comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-next))
 
--	**Name:** core/comments-pagination-next
--	**Category:** theme
--	**Parent:** core/comments-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/comments-pagination-next
+-   **Category:** theme
+-   **Parent:** core/comments-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Comments Page Numbers
 
 Displays a list of page numbers for comments pagination. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-numbers))
 
--	**Name:** core/comments-pagination-numbers
--	**Category:** theme
--	**Parent:** core/comments-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Name:** core/comments-pagination-numbers
+-   **Category:** theme
+-   **Parent:** core/comments-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments Previous Page
 
 Displays the previous comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-previous))
 
--	**Name:** core/comments-pagination-previous
--	**Category:** theme
--	**Parent:** core/comments-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/comments-pagination-previous
+-   **Category:** theme
+-   **Parent:** core/comments-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Comments Title
 
 Displays a title with the number of comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-title))
 
--	**Name:** core/comments-title
--	**Category:** theme
--	**Ancestor:** core/comments
--	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, showCommentsCount, showPostTitle, textAlign
+-   **Name:** core/comments-title
+-   **Category:** theme
+-   **Ancestor:** core/comments
+-   **Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** level, levelOptions, showCommentsCount, showPostTitle, textAlign
 
 ## Cover
 
 Add an image or video with a text overlay. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/cover))
 
--	**Name:** core/cover
--	**Category:** media
--	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
+-   **Name:** core/cover
+-   **Category:** media
+-   **Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details
 
 Hide and show additional content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/details))
 
--	**Name:** core/details
--	**Category:** text
--	**Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** name, placeholder, showContent, summary
+-   **Name:** core/details
+-   **Category:** text
+-   **Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** name, placeholder, showContent, summary
 
 ## Embed
 
 Add a block that displays content pulled from other sites, like Twitter or YouTube. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/embed))
 
--	**Name:** core/embed
--	**Category:** embed
--	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-   **Name:** core/embed
+-   **Category:** embed
+-   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
+-   **Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
 
 ## File
 
 Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/file))
 
--	**Name:** core/file
--	**Category:** media
--	**Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
--	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
+-   **Name:** core/file
+-   **Category:** media
+-   **Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
+-   **Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
 
 ## Footnotes
 
 Display footnotes added to the page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/footnotes))
 
--	**Name:** core/footnotes
--	**Category:** text
--	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
+-   **Name:** core/footnotes
+-   **Category:** text
+-   **Supports:** anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
 
 ## Form
 
 A form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form))
 
--	**Name:** core/form
--	**Experimental:** true
--	**Category:** common
--	**Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
--	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** action, email, method, submissionMethod
+-   **Name:** core/form
+-   **Experimental:** true
+-   **Category:** common
+-   **Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
+-   **Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** action, email, method, submissionMethod
 
 ## Input Field
 
 The basic building block for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-input))
 
--	**Name:** core/form-input
--	**Experimental:** true
--	**Category:** common
--	**Ancestor:** core/form
--	**Supports:** anchor, spacing (margin), ~~reusable~~
--	**Attributes:** inlineLabel, label, name, placeholder, required, type, value, visibilityPermissions
+-   **Name:** core/form-input
+-   **Experimental:** true
+-   **Category:** common
+-   **Ancestor:** core/form
+-   **Supports:** anchor, spacing (margin), ~~reusable~~
+-   **Attributes:** inlineLabel, label, name, placeholder, required, type, value, visibilityPermissions
 
 ## Form Submission Notification
 
 Provide a notification message after the form has been submitted. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-submission-notification))
 
--	**Name:** core/form-submission-notification
--	**Experimental:** true
--	**Category:** common
--	**Ancestor:** core/form
--	**Attributes:** type
+-   **Name:** core/form-submission-notification
+-   **Experimental:** true
+-   **Category:** common
+-   **Ancestor:** core/form
+-   **Attributes:** type
 
 ## Form Submit Button
 
 A submission button for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-submit-button))
 
--	**Name:** core/form-submit-button
--	**Experimental:** true
--	**Category:** common
--	**Ancestor:** core/form
--	**Allowed Blocks:** core/buttons, core/button
+-   **Name:** core/form-submit-button
+-   **Experimental:** true
+-   **Category:** common
+-   **Ancestor:** core/form
+-   **Allowed Blocks:** core/buttons, core/button
 
 ## Classic
 
 Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/freeform))
 
--	**Name:** core/freeform
--	**Category:** text
--	**Supports:** ~~className~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
--	**Attributes:** content
+-   **Name:** core/freeform
+-   **Category:** text
+-   **Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
+-   **Attributes:** content
 
 ## Gallery
 
 Display multiple images in a rich gallery. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/gallery))
 
--	**Name:** core/gallery
--	**Category:** media
--	**Allowed Blocks:** core/image
--	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
+-   **Name:** core/gallery
+-   **Category:** media
+-   **Allowed Blocks:** core/image
+-   **Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
+-   **Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
 
 Gather blocks in a layout container. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/group))
 
--	**Name:** core/group
--	**Category:** design
--	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** tagName, templateLock
+-   **Name:** core/group
+-   **Category:** design
+-   **Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** tagName, templateLock
 
 ## Heading
 
 Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/heading))
 
--	**Name:** core/heading
--	**Category:** text
--	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign)
--	**Attributes:** content, level, levelOptions, placeholder
+-   **Name:** core/heading
+-   **Category:** text
+-   **Supports:** \_\_unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign)
+-   **Attributes:** content, level, levelOptions, placeholder
 
 ## Home Link
 
 Create a link that always points to the homepage of the site. Usually not necessary if there is already a site title link present in the header. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/home-link))
 
--	**Name:** core/home-link
--	**Category:** design
--	**Parent:** core/navigation
--	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/home-link
+-   **Category:** design
+-   **Parent:** core/navigation
+-   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Custom HTML
 
 Add custom HTML code and preview it as you edit. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/html))
 
--	**Name:** core/html
--	**Category:** widgets
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** content
+-   **Name:** core/html
+-   **Category:** widgets
+-   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-   **Attributes:** content
 
 ## Image
 
 Insert an image to make a visual statement. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/image))
 
--	**Name:** core/image
--	**Category:** media
--	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
--	**Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-   **Name:** core/image
+-   **Category:** media
+-   **Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
+-   **Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 
 Display a list of your most recent comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/latest-comments))
 
--	**Name:** core/latest-comments
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
+-   **Name:** core/latest-comments
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
 
 ## Latest Posts
 
 Display a list of your most recent posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/latest-posts))
 
--	**Name:** core/latest-posts
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
+-   **Name:** core/latest-posts
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
 
 ## List
 
 An organized collection of items displayed in a specific order. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list))
 
--	**Name:** core/list
--	**Category:** text
--	**Allowed Blocks:** core/list-item
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** ordered, placeholder, reversed, start, type, values
+-   **Name:** core/list
+-   **Category:** text
+-   **Allowed Blocks:** core/list-item
+-   **Supports:** \_\_unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item
 
 An individual item within a list. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list-item))
 
--	**Name:** core/list-item
--	**Category:** text
--	**Parent:** core/list
--	**Allowed Blocks:** core/list
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
--	**Attributes:** content, placeholder
+-   **Name:** core/list-item
+-   **Category:** text
+-   **Parent:** core/list
+-   **Allowed Blocks:** core/list
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-   **Attributes:** content, placeholder
 
 ## Login/out
 
 Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/loginout))
 
--	**Name:** core/loginout
--	**Category:** theme
--	**Supports:** anchor, className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** displayLoginAsForm, redirectToCurrent
+-   **Name:** core/loginout
+-   **Category:** theme
+-   **Supports:** anchor, className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** displayLoginAsForm, redirectToCurrent
 
 ## Math
 
 Display mathematical notation using LaTeX. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/math))
 
--	**Name:** core/math
--	**Category:** text
--	**Supports:** anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize), ~~html~~
--	**Attributes:** latex, mathML
+-   **Name:** core/math
+-   **Category:** text
+-   **Supports:** anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize), ~~html~~
+-   **Attributes:** latex, mathML
 
 ## Media & Text
 
 Set media and words side-by-side for a richer layout. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/media-text))
 
--	**Name:** core/media-text
--	**Category:** media
--	**Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** align, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, useFeaturedImage, verticalAlignment
+-   **Name:** core/media-text
+-   **Category:** media
+-   **Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** align, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, useFeaturedImage, verticalAlignment
 
 ## Unsupported
 
 Your site doesn’t include support for this block. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/missing))
 
--	**Name:** core/missing
--	**Category:** text
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
--	**Attributes:** originalContent, originalName, originalUndelimitedContent
+-   **Name:** core/missing
+-   **Category:** text
+-   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
+-   **Attributes:** originalContent, originalName, originalUndelimitedContent
 
 ## More
 
 Content before this block will be shown in the excerpt on your archives page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/more))
 
--	**Name:** core/more
--	**Category:** design
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~, ~~visibility~~
--	**Attributes:** customText, noTeaser
+-   **Name:** core/more
+-   **Category:** design
+-   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~, ~~visibility~~
+-   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~multiple~~
+-   **Attributes:** customText, noTeaser
 
 ## Navigation
 
 A collection of blocks that allow visitors to get around your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation))
 
--	**Name:** core/navigation
--	**Category:** theme
--	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
--	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-   **Name:** core/navigation
+-   **Category:** theme
+-   **Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
+-   **Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
+-   **Attributes:** \_\_unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 
 Add a page, link, or another item to your navigation. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-link))
 
--	**Name:** core/navigation-link
--	**Category:** design
--	**Parent:** core/navigation
--	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
--	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
+-   **Name:** core/navigation-link
+-   **Category:** design
+-   **Parent:** core/navigation
+-   **Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
+-   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
+-   **Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
 
 ## Navigation Overlay Close
 
 A customizable button to close overlays. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-overlay-close))
 
--	**Name:** core/navigation-overlay-close
--	**Experimental:** true
--	**Category:** design
--	**Supports:** color (background, text, ~~gradients~~), spacing (padding), typography (fontSize, lineHeight)
--	**Attributes:** displayMode, text
+-   **Name:** core/navigation-overlay-close
+-   **Experimental:** true
+-   **Category:** design
+-   **Supports:** color (background, text, ~~gradients~~), spacing (padding), typography (fontSize, lineHeight)
+-   **Attributes:** displayMode, text
 
 ## Submenu
 
 Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-submenu))
 
--	**Name:** core/navigation-submenu
--	**Category:** design
--	**Parent:** core/navigation
--	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
+-   **Name:** core/navigation-submenu
+-   **Category:** design
+-   **Parent:** core/navigation
+-   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break
 
 Separate your content into a multi-page experience. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/nextpage))
 
--	**Name:** core/nextpage
--	**Category:** design
--	**Parent:** core/post-content
--	**Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~visibility~~
+-   **Name:** core/nextpage
+-   **Category:** design
+-   **Parent:** core/post-content
+-   **Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~visibility~~
+-   **Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
 
 ## Page List
 
 Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/page-list))
 
--	**Name:** core/page-list
--	**Category:** widgets
--	**Allowed Blocks:** core/page-list-item
--	**Supports:** anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** isNested, parentPageID
+-   **Name:** core/page-list
+-   **Category:** widgets
+-   **Allowed Blocks:** core/page-list-item
+-   **Supports:** anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** isNested, parentPageID
 
 ## Page List Item
 
 Displays a page inside a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/page-list-item))
 
--	**Name:** core/page-list-item
--	**Category:** widgets
--	**Parent:** core/page-list
--	**Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~lock~~, ~~reusable~~
--	**Attributes:** hasChildren, id, label, link, title
+-   **Name:** core/page-list-item
+-   **Category:** widgets
+-   **Parent:** core/page-list
+-   **Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~lock~~, ~~reusable~~
+-   **Attributes:** hasChildren, id, label, link, title
 
 ## Paragraph
 
 Start with the basic building block of all narrative. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/paragraph))
 
--	**Name:** core/paragraph
--	**Category:** text
--	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
--	**Attributes:** content, direction, dropCap, placeholder
+-   **Name:** core/paragraph
+-   **Category:** text
+-   **Supports:** \_\_unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
+-   **Attributes:** content, direction, dropCap, placeholder
 
 ## Pattern Placeholder
 
 Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
 
--	**Name:** core/pattern
--	**Category:** theme
--	**Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~renaming~~, ~~visibility~~
--	**Attributes:** slug
+-   **Name:** core/pattern
+-   **Category:** theme
+-   **Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~renaming~~, ~~visibility~~
+-   **Attributes:** slug
 
 ## Author
 
 Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
 
--	**Name:** core/post-author
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
+-   **Name:** core/post-author
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
 
 ## Author Biography
 
 The author biography. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-biography))
 
--	**Name:** core/post-author-biography
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** textAlign
+-   **Name:** core/post-author-biography
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** textAlign
 
 ## Author Name
 
 The author name. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-name))
 
--	**Name:** core/post-author-name
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, linkTarget, textAlign
+-   **Name:** core/post-author-name
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** isLink, linkTarget, textAlign
 
 ## Comment (deprecated)
 
 This block is deprecated. Please use the Comments block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comment))
 
--	**Name:** core/post-comment
--	**Experimental:** fse
--	**Category:** theme
--	**Allowed Blocks:** core/avatar, core/comment-author-name, core/comment-content, core/comment-date, core/comment-edit-link, core/comment-reply-link
--	**Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~
--	**Attributes:** commentId
+-   **Name:** core/post-comment
+-   **Experimental:** fse
+-   **Category:** theme
+-   **Allowed Blocks:** core/avatar, core/comment-author-name, core/comment-content, core/comment-date, core/comment-edit-link, core/comment-reply-link
+-   **Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~
+-   **Attributes:** commentId
 
 ## Comments Count
 
 Display a post's comments count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-count))
 
--	**Name:** core/post-comments-count
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-   **Name:** core/post-comments-count
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** textAlign
 
 ## Comments Form
 
 Display a post's comments form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-form))
 
--	**Name:** core/post-comments-form
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-   **Name:** core/post-comments-form
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** textAlign
 
 ## Comments Link
 
 Displays the link to the current post comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-link))
 
--	**Name:** core/post-comments-link
--	**Category:** theme
--	**Supports:** anchor, color (background, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-   **Name:** core/post-comments-link
+-   **Category:** theme
+-   **Supports:** anchor, color (background, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** textAlign
 
 ## Content
 
 Displays the contents of a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-content))
 
--	**Name:** core/post-content
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** tagName
+-   **Name:** core/post-content
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** tagName
 
 ## Date
 
 Display a custom date. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
 
--	**Name:** core/post-date
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** datetime, format, isLink, textAlign
+-   **Name:** core/post-date
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** datetime, format, isLink, textAlign
 
 ## Excerpt
 
 Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
 
--	**Name:** core/post-excerpt
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-   **Name:** core/post-excerpt
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
 
 ## Featured Image
 
 Display a post's featured image. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-featured-image))
 
--	**Name:** core/post-featured-image
--	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-   **Name:** core/post-featured-image
+-   **Category:** theme
+-   **Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
+-   **Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 
 Displays the next or previous post link that is adjacent to the current post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-navigation-link))
 
--	**Name:** core/post-navigation-link
--	**Category:** theme
--	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
+-   **Name:** core/post-navigation-link
+-   **Category:** theme
+-   **Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
 
 ## Post Template
 
 Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-template))
 
--	**Name:** core/post-template
--	**Category:** theme
--	**Ancestor:** core/query
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Name:** core/post-template
+-   **Category:** theme
+-   **Ancestor:** core/query
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Post Terms
 
 Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-terms))
 
--	**Name:** core/post-terms
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefix, separator, suffix, term, textAlign
+-   **Name:** core/post-terms
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** prefix, separator, suffix, term, textAlign
 
 ## Time to Read
 
 Show minutes required to finish reading the post. Can also show a word count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-time-to-read))
 
--	**Name:** core/post-time-to-read
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
+-   **Name:** core/post-time-to-read
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
 
 ## Title
 
 Displays the title of a post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-title))
 
--	**Name:** core/post-title
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget, rel, textAlign
+-   **Name:** core/post-title
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** isLink, level, levelOptions, linkTarget, rel, textAlign
 
 ## Preformatted
 
 Add text that respects your spacing and tabs, and also allows styling. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/preformatted))
 
--	**Name:** core/preformatted
--	**Category:** text
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content
+-   **Name:** core/preformatted
+-   **Category:** text
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** content
 
 ## Pullquote (deprecated)
 
 This block is deprecated. Please use the Quote block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pullquote))
 
--	**Name:** core/pullquote
--	**Category:** text
--	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~inserter~~
--	**Attributes:** citation, textAlign, value
+-   **Name:** core/pullquote
+-   **Category:** text
+-   **Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~inserter~~
+-   **Attributes:** citation, textAlign, value
 
 ## Query Loop
 
 An advanced block that allows displaying post types based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query))
 
--	**Name:** core/query
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, contentRole, interactivity, layout, ~~html~~
--	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
+-   **Name:** core/query
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, contentRole, interactivity, layout, ~~html~~
+-   **Attributes:** enhancedPagination, namespace, query, queryId, tagName
 
 ## No Results
 
 Contains the block elements used to render content when no query results are found. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-no-results))
 
--	**Name:** core/query-no-results
--	**Category:** theme
--	**Ancestor:** core/query
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Name:** core/query-no-results
+-   **Category:** theme
+-   **Ancestor:** core/query
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Pagination
 
 Displays a paginated navigation to next/previous set of posts, when applicable. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination))
 
--	**Name:** core/query-pagination
--	**Category:** theme
--	**Ancestor:** core/query
--	**Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** paginationArrow, showLabel
+-   **Name:** core/query-pagination
+-   **Category:** theme
+-   **Ancestor:** core/query
+-   **Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** paginationArrow, showLabel
 
 ## Next Page
 
 Displays the next posts page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-next))
 
--	**Name:** core/query-pagination-next
--	**Category:** theme
--	**Parent:** core/query-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/query-pagination-next
+-   **Category:** theme
+-   **Parent:** core/query-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Page Numbers
 
 Displays a list of page numbers for pagination. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-numbers))
 
--	**Name:** core/query-pagination-numbers
--	**Category:** theme
--	**Parent:** core/query-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** midSize
+-   **Name:** core/query-pagination-numbers
+-   **Category:** theme
+-   **Parent:** core/query-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** midSize
 
 ## Previous Page
 
 Displays the previous posts page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-previous))
 
--	**Name:** core/query-pagination-previous
--	**Category:** theme
--	**Parent:** core/query-pagination
--	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/query-pagination-previous
+-   **Category:** theme
+-   **Parent:** core/query-pagination
+-   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Query Title
 
 Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-title))
 
--	**Name:** core/query-title
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
+-   **Name:** core/query-title
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
 
 ## Query Total
 
 Display the total number of results in a query. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-total))
 
--	**Name:** core/query-total
--	**Category:** theme
--	**Ancestor:** core/query
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayType
+-   **Name:** core/query-total
+-   **Category:** theme
+-   **Ancestor:** core/query
+-   **Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** displayType
 
 ## Quote
 
 Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/quote))
 
--	**Name:** core/quote
--	**Category:** text
--	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** citation, textAlign, value
+-   **Name:** core/quote
+-   **Category:** text
+-   **Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** citation, textAlign, value
 
 ## Read More
 
 Displays the link of a post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/read-more))
 
--	**Name:** core/read-more
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** content, linkTarget
+-   **Name:** core/read-more
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** content, linkTarget
 
 ## RSS
 
 Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/rss))
 
--	**Name:** core/rss
--	**Category:** widgets
--	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab, rel
+-   **Name:** core/rss
+-   **Category:** widgets
+-   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
+-   **Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab, rel
 
 ## Search
 
 Help visitors find your content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/search))
 
--	**Name:** core/search
--	**Category:** widgets
--	**Supports:** align (center, left, right), anchor, color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
+-   **Name:** core/search
+-   **Category:** widgets
+-   **Supports:** align (center, left, right), anchor, color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
 
 ## Separator
 
 Create a break between ideas or sections with a horizontal separator. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/separator))
 
--	**Name:** core/separator
--	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
--	**Attributes:** opacity, tagName
+-   **Name:** core/separator
+-   **Category:** design
+-   **Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
+-   **Attributes:** opacity, tagName
 
 ## Shortcode
 
 Insert additional custom elements with a WordPress shortcode. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/shortcode))
 
--	**Name:** core/shortcode
--	**Category:** widgets
--	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** text
+-   **Name:** core/shortcode
+-   **Category:** widgets
+-   **Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-   **Attributes:** text
 
 ## Site Logo
 
 Display an image to represent this site. Update this block and the changes apply everywhere. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-logo))
 
--	**Name:** core/site-logo
--	**Category:** theme
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
--	**Attributes:** isLink, linkTarget, shouldSyncIcon, width
+-   **Name:** core/site-logo
+-   **Category:** theme
+-   **Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
+-   **Attributes:** isLink, linkTarget, shouldSyncIcon, width
 
 ## Site Tagline
 
 Describe in a few words what this site is about. This is important for search results, sharing on social media, and gives overall clarity to visitors. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-tagline))
 
--	**Name:** core/site-tagline
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, textAlign
+-   **Name:** core/site-tagline
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** level, levelOptions, textAlign
 
 ## Site Title
 
 Displays the name of this site. Update the block, and the changes apply everywhere it’s used. This will also appear in the browser title bar and in search results. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-title))
 
--	**Name:** core/site-title
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget, textAlign
+-   **Name:** core/site-title
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** isLink, level, levelOptions, linkTarget, textAlign
 
 ## Social Icon
 
 Display an icon linking to a social profile or site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-link))
 
--	**Name:** core/social-link
--	**Category:** widgets
--	**Parent:** core/social-links
--	**Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~reusable~~
--	**Attributes:** label, rel, service, url
+-   **Name:** core/social-link
+-   **Category:** widgets
+-   **Parent:** core/social-links
+-   **Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~reusable~~
+-   **Attributes:** label, rel, service, url
 
 ## Social Icons
 
 Display icons linking to your social profiles or sites. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-links))
 
--	**Name:** core/social-links
--	**Category:** widgets
--	**Allowed Blocks:** core/social-link
--	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
--	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
+-   **Name:** core/social-links
+-   **Category:** widgets
+-   **Allowed Blocks:** core/social-link
+-   **Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
+-   **Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer
 
 Add white space between blocks and customize its height. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/spacer))
 
--	**Name:** core/spacer
--	**Category:** design
--	**Supports:** anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** height, width
+-   **Name:** core/spacer
+-   **Category:** design
+-   **Supports:** anchor, interactivity (clientNavigation), spacing (margin)
+-   **Attributes:** height, width
 
 ## Tab
 
 Content for a tab in a tabbed interface. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tab))
 
--	**Name:** core/tab
--	**Experimental:** true
--	**Category:** design
--	**Parent:** core/tabs
--	**Supports:** anchor, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
--	**Attributes:** label
+-   **Name:** core/tab
+-   **Experimental:** true
+-   **Category:** design
+-   **Parent:** core/tabs
+-   **Supports:** anchor, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
+-   **Attributes:** label
 
 ## Table
 
 Create structured content in rows and columns to display information. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/table))
 
--	**Name:** core/table
--	**Category:** text
--	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** body, caption, foot, hasFixedLayout, head
+-   **Name:** core/table
+-   **Category:** text
+-   **Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** body, caption, foot, hasFixedLayout, head
 
 ## Table of Contents
 
 Summarize your post with a list of headings. Add HTML anchors to Heading blocks to link them here. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/table-of-contents))
 
--	**Name:** core/table-of-contents
--	**Experimental:** true
--	**Category:** design
--	**Supports:** anchor, ariaLabel, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage, ordered
+-   **Name:** core/table-of-contents
+-   **Experimental:** true
+-   **Category:** design
+-   **Supports:** anchor, ariaLabel, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** headings, maxLevel, onlyIncludeCurrentPage, ordered
 
 ## Tabs
 
 Display content in a tabbed interface to help users navigate detailed content with ease. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tabs))
 
--	**Name:** core/tabs
--	**Experimental:** true
--	**Category:** design
--	**Allowed Blocks:** core/tab
--	**Supports:** align, color (~~background~~, ~~text~~), interactivity, spacing (blockGap, margin, ~~padding~~), typography (fontSize), ~~html~~
--	**Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
+-   **Name:** core/tabs
+-   **Experimental:** true
+-   **Category:** design
+-   **Allowed Blocks:** core/tab
+-   **Supports:** align, color (~~background~~, ~~text~~), interactivity, spacing (blockGap, margin, ~~padding~~), typography (fontSize), ~~html~~
+-   **Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
 
 ## Tag Cloud
 
 A cloud of popular keywords, each sized by how often it appears. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tag-cloud))
 
--	**Name:** core/tag-cloud
--	**Category:** widgets
--	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (lineHeight), ~~html~~
--	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
+-   **Name:** core/tag-cloud
+-   **Category:** widgets
+-   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (lineHeight), ~~html~~
+-   **Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
 ## Template Part
 
 Edit the different global regions of your site, like the header, footer, sidebar, or create your own. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template-part))
 
--	**Name:** core/template-part
--	**Category:** theme
--	**Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
--	**Attributes:** area, slug, tagName, theme
+-   **Name:** core/template-part
+-   **Category:** theme
+-   **Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
+-   **Attributes:** area, slug, tagName, theme
 
 ## Term Count
 
 Displays the post count of a taxonomy term. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-count))
 
--	**Name:** core/term-count
--	**Category:** theme
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** bracketType
+-   **Name:** core/term-count
+-   **Category:** theme
+-   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** bracketType
 
 ## Term Description
 
 Display the description of categories, tags and custom taxonomies when viewing an archive. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-description))
 
--	**Name:** core/term-description
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-   **Name:** core/term-description
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** textAlign
 
 ## Term Name
 
 Displays the name of a taxonomy term. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-name))
 
--	**Name:** core/term-name
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, levelOptions, textAlign
+-   **Name:** core/term-name
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
+-   **Attributes:** isLink, level, levelOptions, textAlign
 
 ## Term Template
 
 Contains the block elements used to render a taxonomy term, like the name, description, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-template))
 
--	**Name:** core/term-template
--	**Category:** theme
--	**Ancestor:** core/terms-query
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-   **Name:** core/term-template
+-   **Category:** theme
+-   **Ancestor:** core/terms-query
+-   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Terms Query
 
 An advanced block that allows displaying taxonomy terms based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/terms-query))
 
--	**Name:** core/terms-query
--	**Category:** theme
--	**Supports:** align (full, wide), anchor, interactivity, layout, ~~html~~
--	**Attributes:** tagName, termQuery
+-   **Name:** core/terms-query
+-   **Category:** theme
+-   **Supports:** align (full, wide), anchor, interactivity, layout, ~~html~~
+-   **Attributes:** tagName, termQuery
 
 ## Text Columns (deprecated)
 
 This block is deprecated. Please use the Columns block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/text-columns))
 
--	**Name:** core/text-columns
--	**Category:** design
--	**Supports:** interactivity (clientNavigation), ~~inserter~~
--	**Attributes:** columns, content, width
+-   **Name:** core/text-columns
+-   **Category:** design
+-   **Supports:** interactivity (clientNavigation), ~~inserter~~
+-   **Attributes:** columns, content, width
 
 ## Verse
 
 Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/verse))
 
--	**Name:** core/verse
--	**Category:** text
--	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content, textAlign
+-   **Name:** core/verse
+-   **Category:** text
+-   **Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-   **Attributes:** content, textAlign
 
 ## Video
 
 Embed a video from your media library or upload a new one. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/video))
 
--	**Name:** core/video
--	**Category:** media
--	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
--	**Attributes:** autoplay, blob, caption, controls, id, loop, muted, playsInline, poster, preload, src, tracks
+-   **Name:** core/video
+-   **Category:** media
+-   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
+-   **Attributes:** autoplay, blob, caption, controls, id, loop, muted, playsInline, poster, preload, src, tracks
 
 <!-- END TOKEN Autogenerated - DO NOT EDIT -->

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -12,1088 +12,1086 @@ This page lists the blocks included in the block-library package.
 
 Displays a foldable layout that groups content in collapsible sections. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion))
 
--   **Name:** core/accordion
--   **Category:** design
--   **Allowed Blocks:** core/accordion-item
--   **Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
+-	**Name:** core/accordion
+-	**Category:** design
+-	**Allowed Blocks:** core/accordion-item
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading
 
 Displays a heading that toggles the accordion panel. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-heading))
 
--   **Name:** core/accordion-heading
--   **Category:** design
--   **Parent:** core/accordion-item
--   **Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
--   **Attributes:** iconPosition, level, openByDefault, showIcon, title
+-	**Name:** core/accordion-heading
+-	**Category:** design
+-	**Parent:** core/accordion-item
+-	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
+-	**Attributes:** iconPosition, level, openByDefault, showIcon, title
 
 ## Accordion Item
 
 Wraps the heading and panel in one unit. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-item))
 
--   **Name:** core/accordion-item
--   **Category:** design
--   **Parent:** core/accordion
--   **Allowed Blocks:** core/accordion-heading, core/accordion-panel
--   **Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** openByDefault
+-	**Name:** core/accordion-item
+-	**Category:** design
+-	**Parent:** core/accordion
+-	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
+-	**Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** openByDefault
 
 ## Accordion Panel
 
 Contains the hidden or revealed content beneath the heading. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-panel))
 
--   **Name:** core/accordion-panel
--   **Category:** design
--   **Parent:** core/accordion-item
--   **Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
--   **Attributes:** templateLock
+-	**Name:** core/accordion-panel
+-	**Category:** design
+-	**Parent:** core/accordion-item
+-	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
+-	**Attributes:** templateLock
 
 ## Archives
 
 Display a date archive of your posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/archives))
 
--   **Name:** core/archives
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** displayAsDropdown, showLabel, showPostCounts, type
+-	**Name:** core/archives
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio
 
 Embed a simple audio player. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/audio))
 
--   **Name:** core/audio
--   **Category:** media
--   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
--   **Attributes:** autoplay, blob, caption, id, loop, preload, src
+-	**Name:** core/audio
+-	**Category:** media
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
+-	**Attributes:** autoplay, blob, caption, id, loop, preload, src
 
 ## Avatar
 
 Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/avatar))
 
--   **Name:** core/avatar
--   **Category:** theme
--   **Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
--   **Attributes:** isLink, linkTarget, size, userId
+-	**Name:** core/avatar
+-	**Category:** theme
+-	**Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
+-	**Attributes:** isLink, linkTarget, size, userId
 
 ## Pattern
 
 Reuse this design across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
 
--   **Name:** core/block
--   **Category:** reusable
--   **Supports:** interactivity (clientNavigation), ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--   **Attributes:** content, ref
+-	**Name:** core/block
+-	**Category:** reusable
+-	**Supports:** interactivity (clientNavigation), ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
+-	**Attributes:** content, ref
 
 ## Breadcrumbs
 
 Display a breadcrumb trail showing the path to the current page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
 
--   **Name:** core/breadcrumbs
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-	**Name:** core/breadcrumbs
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 
 Prompt visitors to take action with a button-style link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/button))
 
--   **Name:** core/button
--   **Category:** design
--   **Parent:** core/buttons
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
--   **Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
+-	**Name:** core/button
+-	**Category:** design
+-	**Parent:** core/buttons
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
 
 ## Buttons
 
 Prompt visitors to take action with a group of button-style links. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/buttons))
 
--   **Name:** core/buttons
--   **Category:** design
--   **Allowed Blocks:** core/button
--   **Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Name:** core/buttons
+-	**Category:** design
+-	**Allowed Blocks:** core/button
+-	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Calendar
 
 A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/calendar))
 
--   **Name:** core/calendar
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** month, year
+-	**Name:** core/calendar
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** month, year
 
 ## Terms List
 
 Display a list of all terms of a given taxonomy. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/categories))
 
--   **Name:** core/categories
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Name:** core/categories
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 
 Display code snippets that respect your spacing and tabs. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/code))
 
--   **Name:** core/code
--   **Category:** text
--   **Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** content
+-	**Name:** core/code
+-	**Category:** text
+-	**Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** content
 
 ## Column
 
 A single column within a columns block. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/column))
 
--   **Name:** core/column
--   **Category:** design
--   **Parent:** core/columns
--   **Supports:** allowedBlocks, anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** templateLock, verticalAlignment, width
+-	**Name:** core/column
+-	**Category:** design
+-	**Parent:** core/columns
+-	**Supports:** allowedBlocks, anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** templateLock, verticalAlignment, width
 
 ## Columns
 
 Display content in multiple columns, with blocks added to each column. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/columns))
 
--   **Name:** core/columns
--   **Category:** design
--   **Allowed Blocks:** core/column
--   **Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** isStackedOnMobile, templateLock, verticalAlignment
+-	**Name:** core/columns
+-	**Category:** design
+-	**Allowed Blocks:** core/column
+-	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 
 This block is deprecated. Please use the Avatar block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-avatar))
 
--   **Name:** core/comment-author-avatar
--   **Experimental:** fse
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~, ~~inserter~~
--   **Attributes:** height, width
+-	**Name:** core/comment-author-avatar
+-	**Experimental:** fse
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~, ~~inserter~~
+-	**Attributes:** height, width
 
 ## Comment Author Name
 
 Displays the name of the author of the comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
 
--   **Name:** core/comment-author-name
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
--   **Attributes:** isLink, linkTarget
+-	**Name:** core/comment-author-name
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** isLink, linkTarget
 
 ## Comment Content
 
 Displays the contents of a comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-content))
 
--   **Name:** core/comment-content
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Name:** core/comment-content
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight, textAlign), ~~html~~
 
 ## Comment Date
 
 Displays the date on which the comment was posted. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-date))
 
--   **Name:** core/comment-date
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** format, isLink
+-	**Name:** core/comment-date
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** format, isLink
 
 ## Comment Edit Link
 
 Displays a link to edit the comment in the WordPress Dashboard. This link is only visible to users with the edit comment capability. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-edit-link))
 
--   **Name:** core/comment-edit-link
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** linkTarget, textAlign
+-	**Name:** core/comment-edit-link
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** linkTarget, textAlign
 
 ## Comment Reply Link
 
 Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-reply-link))
 
--   **Name:** core/comment-reply-link
--   **Category:** theme
--   **Ancestor:** core/comment-template
--   **Supports:** anchor, color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** textAlign
+-	**Name:** core/comment-reply-link
+-	**Category:** theme
+-	**Ancestor:** core/comment-template
+-	**Supports:** anchor, color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
 
 ## Comment Template
 
 Contains the block elements used to display a comment, like the title, date, author, avatar and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-template))
 
--   **Name:** core/comment-template
--   **Category:** design
--   **Parent:** core/comments
--   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Name:** core/comment-template
+-	**Category:** design
+-	**Parent:** core/comments
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments
 
 An advanced block that allows displaying post comments using different visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments))
 
--   **Name:** core/comments
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** legacy, tagName
+-	**Name:** core/comments
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** legacy, tagName
 
 ## Comments Pagination
 
 Displays a paginated navigation to next/previous set of comments, when applicable. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination))
 
--   **Name:** core/comments-pagination
--   **Category:** theme
--   **Parent:** core/comments
--   **Allowed Blocks:** core/comments-pagination-previous, core/comments-pagination-numbers, core/comments-pagination-next
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** paginationArrow
+-	**Name:** core/comments-pagination
+-	**Category:** theme
+-	**Parent:** core/comments
+-	**Allowed Blocks:** core/comments-pagination-previous, core/comments-pagination-numbers, core/comments-pagination-next
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** paginationArrow
 
 ## Comments Next Page
 
 Displays the next comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-next))
 
--   **Name:** core/comments-pagination-next
--   **Category:** theme
--   **Parent:** core/comments-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/comments-pagination-next
+-	**Category:** theme
+-	**Parent:** core/comments-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Comments Page Numbers
 
 Displays a list of page numbers for comments pagination. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-numbers))
 
--   **Name:** core/comments-pagination-numbers
--   **Category:** theme
--   **Parent:** core/comments-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Name:** core/comments-pagination-numbers
+-	**Category:** theme
+-	**Parent:** core/comments-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments Previous Page
 
 Displays the previous comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-previous))
 
--   **Name:** core/comments-pagination-previous
--   **Category:** theme
--   **Parent:** core/comments-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/comments-pagination-previous
+-	**Category:** theme
+-	**Parent:** core/comments-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Comments Title
 
 Displays a title with the number of comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-title))
 
--   **Name:** core/comments-title
--   **Category:** theme
--   **Ancestor:** core/comments
--   **Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** level, levelOptions, showCommentsCount, showPostTitle, textAlign
+-	**Name:** core/comments-title
+-	**Category:** theme
+-	**Ancestor:** core/comments
+-	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** level, levelOptions, showCommentsCount, showPostTitle, textAlign
 
 ## Cover
 
 Add an image or video with a text overlay. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/cover))
 
--   **Name:** core/cover
--   **Category:** media
--   **Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
+-	**Name:** core/cover
+-	**Category:** media
+-	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details
 
 Hide and show additional content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/details))
 
--   **Name:** core/details
--   **Category:** text
--   **Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** name, placeholder, showContent, summary
+-	**Name:** core/details
+-	**Category:** text
+-	**Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** name, placeholder, showContent, summary
 
 ## Embed
 
 Add a block that displays content pulled from other sites, like Twitter or YouTube. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/embed))
 
--   **Name:** core/embed
--   **Category:** embed
--   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
--   **Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Name:** core/embed
+-	**Category:** embed
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
+-	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
 
 ## File
 
 Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/file))
 
--   **Name:** core/file
--   **Category:** media
--   **Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
--   **Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
+-	**Name:** core/file
+-	**Category:** media
+-	**Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
+-	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
 
 ## Footnotes
 
 Display footnotes added to the page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/footnotes))
 
--   **Name:** core/footnotes
--   **Category:** text
--   **Supports:** anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
+-	**Name:** core/footnotes
+-	**Category:** text
+-	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
 
 ## Form
 
 A form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form))
 
--   **Name:** core/form
--   **Experimental:** true
--   **Category:** common
--   **Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
--   **Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** action, email, method, submissionMethod
+-	**Name:** core/form
+-	**Experimental:** true
+-	**Category:** common
+-	**Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** action, email, method, submissionMethod
 
 ## Input Field
 
 The basic building block for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-input))
 
--   **Name:** core/form-input
--   **Experimental:** true
--   **Category:** common
--   **Ancestor:** core/form
--   **Supports:** anchor, spacing (margin), ~~reusable~~
--   **Attributes:** inlineLabel, label, name, placeholder, required, type, value, visibilityPermissions
+-	**Name:** core/form-input
+-	**Experimental:** true
+-	**Category:** common
+-	**Ancestor:** core/form
+-	**Supports:** anchor, spacing (margin), ~~reusable~~
+-	**Attributes:** inlineLabel, label, name, placeholder, required, type, value, visibilityPermissions
 
 ## Form Submission Notification
 
 Provide a notification message after the form has been submitted. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-submission-notification))
 
--   **Name:** core/form-submission-notification
--   **Experimental:** true
--   **Category:** common
--   **Ancestor:** core/form
--   **Attributes:** type
+-	**Name:** core/form-submission-notification
+-	**Experimental:** true
+-	**Category:** common
+-	**Ancestor:** core/form
+-	**Attributes:** type
 
 ## Form Submit Button
 
 A submission button for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-submit-button))
 
--   **Name:** core/form-submit-button
--   **Experimental:** true
--   **Category:** common
--   **Ancestor:** core/form
--   **Allowed Blocks:** core/buttons, core/button
+-	**Name:** core/form-submit-button
+-	**Experimental:** true
+-	**Category:** common
+-	**Ancestor:** core/form
+-	**Allowed Blocks:** core/buttons, core/button
 
 ## Classic
 
 Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/freeform))
 
--   **Name:** core/freeform
--   **Category:** text
--   **Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
--   **Attributes:** content
+-	**Name:** core/freeform
+-	**Category:** text
+-	**Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
+-	**Attributes:** content
 
 ## Gallery
 
 Display multiple images in a rich gallery. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/gallery))
 
--   **Name:** core/gallery
--   **Category:** media
--   **Allowed Blocks:** core/image
--   **Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--   **Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
+-	**Name:** core/gallery
+-	**Category:** media
+-	**Allowed Blocks:** core/image
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
+-	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
 
 Gather blocks in a layout container. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/group))
 
--   **Name:** core/group
--   **Category:** design
--   **Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** tagName, templateLock
+-	**Name:** core/group
+-	**Category:** design
+-	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** tagName, templateLock
 
 ## Heading
 
 Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/heading))
 
--   **Name:** core/heading
--   **Category:** text
--   **Supports:** \_\_unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign)
--   **Attributes:** content, level, levelOptions, placeholder
+-	**Name:** core/heading
+-	**Category:** text
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign)
+-	**Attributes:** content, level, levelOptions, placeholder
 
 ## Home Link
 
 Create a link that always points to the homepage of the site. Usually not necessary if there is already a site title link present in the header. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/home-link))
 
--   **Name:** core/home-link
--   **Category:** design
--   **Parent:** core/navigation
--   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/home-link
+-	**Category:** design
+-	**Parent:** core/navigation
+-	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Custom HTML
 
 Add custom HTML code and preview it as you edit. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/html))
 
--   **Name:** core/html
--   **Category:** widgets
--   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
--   **Attributes:** content
+-	**Name:** core/html
+-	**Category:** widgets
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-	**Attributes:** content
 
 ## Image
 
 Insert an image to make a visual statement. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/image))
 
--   **Name:** core/image
--   **Category:** media
--   **Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
--   **Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Name:** core/image
+-	**Category:** media
+-	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
+-	**Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 
 Display a list of your most recent comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/latest-comments))
 
--   **Name:** core/latest-comments
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
+-	**Name:** core/latest-comments
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
 
 ## Latest Posts
 
 Display a list of your most recent posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/latest-posts))
 
--   **Name:** core/latest-posts
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
+-	**Name:** core/latest-posts
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
 
 ## List
 
 An organized collection of items displayed in a specific order. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list))
 
--   **Name:** core/list
--   **Category:** text
--   **Allowed Blocks:** core/list-item
--   **Supports:** \_\_unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** ordered, placeholder, reversed, start, type, values
+-	**Name:** core/list
+-	**Category:** text
+-	**Allowed Blocks:** core/list-item
+-	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item
 
 An individual item within a list. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list-item))
 
--   **Name:** core/list-item
--   **Category:** text
--   **Parent:** core/list
--   **Allowed Blocks:** core/list
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
--   **Attributes:** content, placeholder
+-	**Name:** core/list-item
+-	**Category:** text
+-	**Parent:** core/list
+-	**Allowed Blocks:** core/list
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-	**Attributes:** content, placeholder
 
 ## Login/out
 
 Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/loginout))
 
--   **Name:** core/loginout
--   **Category:** theme
--   **Supports:** anchor, className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** displayLoginAsForm, redirectToCurrent
+-	**Name:** core/loginout
+-	**Category:** theme
+-	**Supports:** anchor, className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** displayLoginAsForm, redirectToCurrent
 
 ## Math
 
 Display mathematical notation using LaTeX. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/math))
 
--   **Name:** core/math
--   **Category:** text
--   **Supports:** anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize), ~~html~~
--   **Attributes:** latex, mathML
+-	**Name:** core/math
+-	**Category:** text
+-	**Supports:** anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize), ~~html~~
+-	**Attributes:** latex, mathML
 
 ## Media & Text
 
 Set media and words side-by-side for a richer layout. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/media-text))
 
--   **Name:** core/media-text
--   **Category:** media
--   **Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** align, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, useFeaturedImage, verticalAlignment
+-	**Name:** core/media-text
+-	**Category:** media
+-	**Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** align, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, useFeaturedImage, verticalAlignment
 
 ## Unsupported
 
 Your site doesn’t include support for this block. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/missing))
 
--   **Name:** core/missing
--   **Category:** text
--   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
--   **Attributes:** originalContent, originalName, originalUndelimitedContent
+-	**Name:** core/missing
+-	**Category:** text
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~, ~~visibility~~
+-	**Attributes:** originalContent, originalName, originalUndelimitedContent
 
 ## More
 
 Content before this block will be shown in the excerpt on your archives page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/more))
 
--   **Name:** core/more
--   **Category:** design
--   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~, ~~visibility~~
--   **Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~multiple~~
--   **Attributes:** customText, noTeaser
+-	**Name:** core/more
+-	**Category:** design
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~multiple~~, ~~visibility~~
+-	**Attributes:** customText, noTeaser
 
 ## Navigation
 
 A collection of blocks that allow visitors to get around your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation))
 
--   **Name:** core/navigation
--   **Category:** theme
--   **Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
--   **Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--   **Attributes:** \_\_unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Name:** core/navigation
+-	**Category:** theme
+-	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
+-	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 
 Add a page, link, or another item to your navigation. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-link))
 
--   **Name:** core/navigation-link
--   **Category:** design
--   **Parent:** core/navigation
--   **Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
--   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
--   **Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
+-	**Name:** core/navigation-link
+-	**Category:** design
+-	**Parent:** core/navigation
+-	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
+-	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
 
 ## Navigation Overlay Close
 
 A customizable button to close overlays. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-overlay-close))
 
--   **Name:** core/navigation-overlay-close
--   **Experimental:** true
--   **Category:** design
--   **Supports:** color (background, text, ~~gradients~~), spacing (padding), typography (fontSize, lineHeight)
--   **Attributes:** displayMode, text
+-	**Name:** core/navigation-overlay-close
+-	**Experimental:** true
+-	**Category:** design
+-	**Supports:** color (background, text, ~~gradients~~), spacing (padding), typography (fontSize, lineHeight)
+-	**Attributes:** displayMode, text
 
 ## Submenu
 
 Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-submenu))
 
--   **Name:** core/navigation-submenu
--   **Category:** design
--   **Parent:** core/navigation
--   **Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
+-	**Name:** core/navigation-submenu
+-	**Category:** design
+-	**Parent:** core/navigation
+-	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break
 
 Separate your content into a multi-page experience. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/nextpage))
 
--   **Name:** core/nextpage
--   **Category:** design
--   **Parent:** core/post-content
--   **Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~visibility~~
--   **Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-	**Name:** core/nextpage
+-	**Category:** design
+-	**Parent:** core/post-content
+-	**Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 
 ## Page List
 
 Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/page-list))
 
--   **Name:** core/page-list
--   **Category:** widgets
--   **Allowed Blocks:** core/page-list-item
--   **Supports:** anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** isNested, parentPageID
+-	**Name:** core/page-list
+-	**Category:** widgets
+-	**Allowed Blocks:** core/page-list-item
+-	**Supports:** anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** isNested, parentPageID
 
 ## Page List Item
 
 Displays a page inside a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/page-list-item))
 
--   **Name:** core/page-list-item
--   **Category:** widgets
--   **Parent:** core/page-list
--   **Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~lock~~, ~~reusable~~
--   **Attributes:** hasChildren, id, label, link, title
+-	**Name:** core/page-list-item
+-	**Category:** widgets
+-	**Parent:** core/page-list
+-	**Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~lock~~, ~~reusable~~
+-	**Attributes:** hasChildren, id, label, link, title
 
 ## Paragraph
 
 Start with the basic building block of all narrative. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/paragraph))
 
--   **Name:** core/paragraph
--   **Category:** text
--   **Supports:** \_\_unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
--   **Attributes:** content, direction, dropCap, placeholder
+-	**Name:** core/paragraph
+-	**Category:** text
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
+-	**Attributes:** content, direction, dropCap, placeholder
 
 ## Pattern Placeholder
 
 Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
 
--   **Name:** core/pattern
--   **Category:** theme
--   **Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~renaming~~, ~~visibility~~
--   **Attributes:** slug
+-	**Name:** core/pattern
+-	**Category:** theme
+-	**Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~renaming~~, ~~visibility~~
+-	**Attributes:** slug
 
 ## Author
 
 Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
 
--   **Name:** core/post-author
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
+-	**Name:** core/post-author
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
 
 ## Author Biography
 
 The author biography. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-biography))
 
--   **Name:** core/post-author-biography
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** textAlign
+-	**Name:** core/post-author-biography
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** textAlign
 
 ## Author Name
 
 The author name. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-name))
 
--   **Name:** core/post-author-name
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** isLink, linkTarget, textAlign
+-	**Name:** core/post-author-name
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isLink, linkTarget, textAlign
 
 ## Comment (deprecated)
 
 This block is deprecated. Please use the Comments block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comment))
 
--   **Name:** core/post-comment
--   **Experimental:** fse
--   **Category:** theme
--   **Allowed Blocks:** core/avatar, core/comment-author-name, core/comment-content, core/comment-date, core/comment-edit-link, core/comment-reply-link
--   **Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~
--   **Attributes:** commentId
+-	**Name:** core/post-comment
+-	**Experimental:** fse
+-	**Category:** theme
+-	**Allowed Blocks:** core/avatar, core/comment-author-name, core/comment-content, core/comment-date, core/comment-edit-link, core/comment-reply-link
+-	**Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~
+-	**Attributes:** commentId
 
 ## Comments Count
 
 Display a post's comments count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-count))
 
--   **Name:** core/post-comments-count
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** textAlign
+-	**Name:** core/post-comments-count
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
 
 ## Comments Form
 
 Display a post's comments form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-form))
 
--   **Name:** core/post-comments-form
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** textAlign
+-	**Name:** core/post-comments-form
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
 
 ## Comments Link
 
 Displays the link to the current post comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-link))
 
--   **Name:** core/post-comments-link
--   **Category:** theme
--   **Supports:** anchor, color (background, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** textAlign
+-	**Name:** core/post-comments-link
+-	**Category:** theme
+-	**Supports:** anchor, color (background, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
 
 ## Content
 
 Displays the contents of a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-content))
 
--   **Name:** core/post-content
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** tagName
+-	**Name:** core/post-content
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** tagName
 
 ## Date
 
 Display a custom date. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
 
--   **Name:** core/post-date
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** datetime, format, isLink, textAlign
+-	**Name:** core/post-date
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** datetime, format, isLink, textAlign
 
 ## Excerpt
 
 Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))
 
--   **Name:** core/post-excerpt
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-	**Name:** core/post-excerpt
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
 
 ## Featured Image
 
 Display a post's featured image. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-featured-image))
 
--   **Name:** core/post-featured-image
--   **Category:** theme
--   **Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--   **Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Name:** core/post-featured-image
+-	**Category:** theme
+-	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 
 Displays the next or previous post link that is adjacent to the current post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-navigation-link))
 
--   **Name:** core/post-navigation-link
--   **Category:** theme
--   **Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
+-	**Name:** core/post-navigation-link
+-	**Category:** theme
+-	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
 
 ## Post Template
 
 Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-template))
 
--   **Name:** core/post-template
--   **Category:** theme
--   **Ancestor:** core/query
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Name:** core/post-template
+-	**Category:** theme
+-	**Ancestor:** core/query
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Post Terms
 
 Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-terms))
 
--   **Name:** core/post-terms
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** prefix, separator, suffix, term, textAlign
+-	**Name:** core/post-terms
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** prefix, separator, suffix, term, textAlign
 
 ## Time to Read
 
 Show minutes required to finish reading the post. Can also show a word count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-time-to-read))
 
--   **Name:** core/post-time-to-read
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
+-	**Name:** core/post-time-to-read
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
 
 ## Title
 
 Displays the title of a post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-title))
 
--   **Name:** core/post-title
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** isLink, level, levelOptions, linkTarget, rel, textAlign
+-	**Name:** core/post-title
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isLink, level, levelOptions, linkTarget, rel, textAlign
 
 ## Preformatted
 
 Add text that respects your spacing and tabs, and also allows styling. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/preformatted))
 
--   **Name:** core/preformatted
--   **Category:** text
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** content
+-	**Name:** core/preformatted
+-	**Category:** text
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** content
 
 ## Pullquote (deprecated)
 
 This block is deprecated. Please use the Quote block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pullquote))
 
--   **Name:** core/pullquote
--   **Category:** text
--   **Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~inserter~~
--   **Attributes:** citation, textAlign, value
+-	**Name:** core/pullquote
+-	**Category:** text
+-	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~inserter~~
+-	**Attributes:** citation, textAlign, value
 
 ## Query Loop
 
 An advanced block that allows displaying post types based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query))
 
--   **Name:** core/query
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, contentRole, interactivity, layout, ~~html~~
--   **Attributes:** enhancedPagination, namespace, query, queryId, tagName
+-	**Name:** core/query
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, contentRole, interactivity, layout, ~~html~~
+-	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
 
 ## No Results
 
 Contains the block elements used to render content when no query results are found. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-no-results))
 
--   **Name:** core/query-no-results
--   **Category:** theme
--   **Ancestor:** core/query
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Name:** core/query-no-results
+-	**Category:** theme
+-	**Ancestor:** core/query
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Pagination
 
 Displays a paginated navigation to next/previous set of posts, when applicable. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination))
 
--   **Name:** core/query-pagination
--   **Category:** theme
--   **Ancestor:** core/query
--   **Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** paginationArrow, showLabel
+-	**Name:** core/query-pagination
+-	**Category:** theme
+-	**Ancestor:** core/query
+-	**Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** paginationArrow, showLabel
 
 ## Next Page
 
 Displays the next posts page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-next))
 
--   **Name:** core/query-pagination-next
--   **Category:** theme
--   **Parent:** core/query-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/query-pagination-next
+-	**Category:** theme
+-	**Parent:** core/query-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Page Numbers
 
 Displays a list of page numbers for pagination. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-numbers))
 
--   **Name:** core/query-pagination-numbers
--   **Category:** theme
--   **Parent:** core/query-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** midSize
+-	**Name:** core/query-pagination-numbers
+-	**Category:** theme
+-	**Parent:** core/query-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** midSize
 
 ## Previous Page
 
 Displays the previous posts page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-pagination-previous))
 
--   **Name:** core/query-pagination-previous
--   **Category:** theme
--   **Parent:** core/query-pagination
--   **Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/query-pagination-previous
+-	**Category:** theme
+-	**Parent:** core/query-pagination
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Query Title
 
 Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-title))
 
--   **Name:** core/query-title
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
+-	**Name:** core/query-title
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
 
 ## Query Total
 
 Display the total number of results in a query. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-total))
 
--   **Name:** core/query-total
--   **Category:** theme
--   **Ancestor:** core/query
--   **Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** displayType
+-	**Name:** core/query-total
+-	**Category:** theme
+-	**Ancestor:** core/query
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** displayType
 
 ## Quote
 
 Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/quote))
 
--   **Name:** core/quote
--   **Category:** text
--   **Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** citation, textAlign, value
+-	**Name:** core/quote
+-	**Category:** text
+-	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** citation, textAlign, value
 
 ## Read More
 
 Displays the link of a post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/read-more))
 
--   **Name:** core/read-more
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** content, linkTarget
+-	**Name:** core/read-more
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** content, linkTarget
 
 ## RSS
 
 Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/rss))
 
--   **Name:** core/rss
--   **Category:** widgets
--   **Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--   **Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab, rel
+-	**Name:** core/rss
+-	**Category:** widgets
+-	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
+-	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab, rel
 
 ## Search
 
 Help visitors find your content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/search))
 
--   **Name:** core/search
--   **Category:** widgets
--   **Supports:** align (center, left, right), anchor, color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
+-	**Name:** core/search
+-	**Category:** widgets
+-	**Supports:** align (center, left, right), anchor, color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
 
 ## Separator
 
 Create a break between ideas or sections with a horizontal separator. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/separator))
 
--   **Name:** core/separator
--   **Category:** design
--   **Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
--   **Attributes:** opacity, tagName
+-	**Name:** core/separator
+-	**Category:** design
+-	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
+-	**Attributes:** opacity, tagName
 
 ## Shortcode
 
 Insert additional custom elements with a WordPress shortcode. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/shortcode))
 
--   **Name:** core/shortcode
--   **Category:** widgets
--   **Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
--   **Attributes:** text
+-	**Name:** core/shortcode
+-	**Category:** widgets
+-	**Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-	**Attributes:** text
 
 ## Site Logo
 
 Display an image to represent this site. Update this block and the changes apply everywhere. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-logo))
 
--   **Name:** core/site-logo
--   **Category:** theme
--   **Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
--   **Attributes:** isLink, linkTarget, shouldSyncIcon, width
+-	**Name:** core/site-logo
+-	**Category:** theme
+-	**Supports:** align, anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
+-	**Attributes:** isLink, linkTarget, shouldSyncIcon, width
 
 ## Site Tagline
 
 Describe in a few words what this site is about. This is important for search results, sharing on social media, and gives overall clarity to visitors. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-tagline))
 
--   **Name:** core/site-tagline
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** level, levelOptions, textAlign
+-	**Name:** core/site-tagline
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** level, levelOptions, textAlign
 
 ## Site Title
 
 Displays the name of this site. Update the block, and the changes apply everywhere it’s used. This will also appear in the browser title bar and in search results. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-title))
 
--   **Name:** core/site-title
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** isLink, level, levelOptions, linkTarget, textAlign
+-	**Name:** core/site-title
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isLink, level, levelOptions, linkTarget, textAlign
 
 ## Social Icon
 
 Display an icon linking to a social profile or site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-link))
 
--   **Name:** core/social-link
--   **Category:** widgets
--   **Parent:** core/social-links
--   **Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~reusable~~
--   **Attributes:** label, rel, service, url
+-	**Name:** core/social-link
+-	**Category:** widgets
+-	**Parent:** core/social-links
+-	**Supports:** anchor, interactivity (clientNavigation), ~~html~~, ~~reusable~~
+-	**Attributes:** label, rel, service, url
 
 ## Social Icons
 
 Display icons linking to your social profiles or sites. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-links))
 
--   **Name:** core/social-links
--   **Category:** widgets
--   **Allowed Blocks:** core/social-link
--   **Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
--   **Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
+-	**Name:** core/social-links
+-	**Category:** widgets
+-	**Allowed Blocks:** core/social-link
+-	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
+-	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer
 
 Add white space between blocks and customize its height. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/spacer))
 
--   **Name:** core/spacer
--   **Category:** design
--   **Supports:** anchor, interactivity (clientNavigation), spacing (margin)
--   **Attributes:** height, width
+-	**Name:** core/spacer
+-	**Category:** design
+-	**Supports:** anchor, interactivity (clientNavigation), spacing (margin)
+-	**Attributes:** height, width
 
 ## Tab
 
 Content for a tab in a tabbed interface. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tab))
 
--   **Name:** core/tab
--   **Experimental:** true
--   **Category:** design
--   **Parent:** core/tabs
--   **Supports:** anchor, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
--   **Attributes:** label
+-	**Name:** core/tab
+-	**Experimental:** true
+-	**Category:** design
+-	**Parent:** core/tabs
+-	**Supports:** anchor, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
+-	**Attributes:** label
 
 ## Table
 
 Create structured content in rows and columns to display information. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/table))
 
--   **Name:** core/table
--   **Category:** text
--   **Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** body, caption, foot, hasFixedLayout, head
+-	**Name:** core/table
+-	**Category:** text
+-	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** body, caption, foot, hasFixedLayout, head
 
 ## Table of Contents
 
 Summarize your post with a list of headings. Add HTML anchors to Heading blocks to link them here. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/table-of-contents))
 
--   **Name:** core/table-of-contents
--   **Experimental:** true
--   **Category:** design
--   **Supports:** anchor, ariaLabel, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** headings, maxLevel, onlyIncludeCurrentPage, ordered
+-	**Name:** core/table-of-contents
+-	**Experimental:** true
+-	**Category:** design
+-	**Supports:** anchor, ariaLabel, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage, ordered
 
 ## Tabs
 
 Display content in a tabbed interface to help users navigate detailed content with ease. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tabs))
 
--   **Name:** core/tabs
--   **Experimental:** true
--   **Category:** design
--   **Allowed Blocks:** core/tab
--   **Supports:** align, color (~~background~~, ~~text~~), interactivity, spacing (blockGap, margin, ~~padding~~), typography (fontSize), ~~html~~
--   **Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
+-	**Name:** core/tabs
+-	**Experimental:** true
+-	**Category:** design
+-	**Allowed Blocks:** core/tab
+-	**Supports:** align, color (~~background~~, ~~text~~), interactivity, spacing (blockGap, margin, ~~padding~~), typography (fontSize), ~~html~~
+-	**Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
 
 ## Tag Cloud
 
 A cloud of popular keywords, each sized by how often it appears. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tag-cloud))
 
--   **Name:** core/tag-cloud
--   **Category:** widgets
--   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (lineHeight), ~~html~~
--   **Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
+-	**Name:** core/tag-cloud
+-	**Category:** widgets
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (lineHeight), ~~html~~
+-	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
 ## Template Part
 
 Edit the different global regions of your site, like the header, footer, sidebar, or create your own. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template-part))
 
--   **Name:** core/template-part
--   **Category:** theme
--   **Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
--   **Attributes:** area, slug, tagName, theme
+-	**Name:** core/template-part
+-	**Category:** theme
+-	**Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Attributes:** area, slug, tagName, theme
 
 ## Term Count
 
 Displays the post count of a taxonomy term. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-count))
 
--   **Name:** core/term-count
--   **Category:** theme
--   **Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** bracketType
+-	**Name:** core/term-count
+-	**Category:** theme
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** bracketType
 
 ## Term Description
 
 Display the description of categories, tags and custom taxonomies when viewing an archive. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-description))
 
--   **Name:** core/term-description
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** textAlign
+-	**Name:** core/term-description
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
 
 ## Term Name
 
 Displays the name of a taxonomy term. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-name))
 
--   **Name:** core/term-name
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--   **Attributes:** isLink, level, levelOptions, textAlign
+-	**Name:** core/term-name
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isLink, level, levelOptions, textAlign
 
 ## Term Template
 
 Contains the block elements used to render a taxonomy term, like the name, description, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-template))
 
--   **Name:** core/term-template
--   **Category:** theme
--   **Ancestor:** core/terms-query
--   **Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Name:** core/term-template
+-	**Category:** theme
+-	**Ancestor:** core/terms-query
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Terms Query
 
 An advanced block that allows displaying taxonomy terms based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/terms-query))
 
--   **Name:** core/terms-query
--   **Category:** theme
--   **Supports:** align (full, wide), anchor, interactivity, layout, ~~html~~
--   **Attributes:** tagName, termQuery
+-	**Name:** core/terms-query
+-	**Category:** theme
+-	**Supports:** align (full, wide), anchor, interactivity, layout, ~~html~~
+-	**Attributes:** tagName, termQuery
 
 ## Text Columns (deprecated)
 
 This block is deprecated. Please use the Columns block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/text-columns))
 
--   **Name:** core/text-columns
--   **Category:** design
--   **Supports:** interactivity (clientNavigation), ~~inserter~~
--   **Attributes:** columns, content, width
+-	**Name:** core/text-columns
+-	**Category:** design
+-	**Supports:** interactivity (clientNavigation), ~~inserter~~
+-	**Attributes:** columns, content, width
 
 ## Verse
 
 Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/verse))
 
--   **Name:** core/verse
--   **Category:** text
--   **Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--   **Attributes:** content, textAlign
+-	**Name:** core/verse
+-	**Category:** text
+-	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Attributes:** content, textAlign
 
 ## Video
 
 Embed a video from your media library or upload a new one. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/video))
 
--   **Name:** core/video
--   **Category:** media
--   **Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
--   **Attributes:** autoplay, blob, caption, controls, id, loop, muted, playsInline, poster, preload, src, tracks
+-	**Name:** core/video
+-	**Category:** media
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
+-	**Attributes:** autoplay, blob, caption, controls, id, loop, muted, playsInline, poster, preload, src, tracks
 
 <!-- END TOKEN Autogenerated - DO NOT EDIT -->

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -119,7 +119,6 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		$settings['spacingSizes'] = $spacing_sizes_by_origin['custom'] ?? $spacing_sizes_by_origin['theme'] ?? $spacing_sizes_by_origin['default'];
 	}
 
-	// Check if user has capability to edit custom CSS.
 	$settings['canEditCSS'] = current_user_can( 'edit_css' );
 
 	return $settings;

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -119,6 +119,9 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		$settings['spacingSizes'] = $spacing_sizes_by_origin['custom'] ?? $spacing_sizes_by_origin['theme'] ?? $spacing_sizes_by_origin['default'];
 	}
 
+	// Check if user has capability to edit custom CSS.
+	$settings['canEditCSS'] = current_user_can( 'edit_css' );
+
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -26,6 +26,11 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
+	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
+	if ( preg_match( '#</?\w+#', $custom_css ) ) {
+		return $parsed_block;
+	}
+
 	// Generate a unique class name for this block instance.
 	$class_name         = wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
 	$updated_class_name = isset( $parsed_block['attrs']['className'] )

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -20,7 +20,7 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
-	$custom_css = $parsed_block['attrs']['style']['css'] ?? null;
+	$custom_css = trim( $parsed_block['attrs']['style']['css'] ?? '' );
 
 	if ( empty( $custom_css ) ) {
 		return $parsed_block;

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -22,7 +22,7 @@ $gutenberg_block_custom_css = '';
  * @return string The custom CSS class name.
  */
 function gutenberg_get_custom_css_class_name( $block ) {
-	return 'wp-custom-css-' . md5( serialize( $block ) );
+	return wp_unique_id_from_values( $block, 'wp-custom-css-' );
 }
 
 /**

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -6,14 +6,6 @@
  */
 
 /**
- * Stores the custom CSS for block instances to be output in the footer.
- *
- * @var string
- */
-global $gutenberg_block_custom_css;
-$gutenberg_block_custom_css = '';
-
-/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @since 7.0.0
@@ -22,8 +14,6 @@ $gutenberg_block_custom_css = '';
  * @return array The same parsed block with custom CSS class name added if appropriate.
  */
 function gutenberg_render_custom_css_support_styles( $parsed_block ) {
-	global $gutenberg_block_custom_css;
-
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 
 	if ( ! block_has_support( $block_type, 'customCSS', true ) ) {
@@ -49,29 +39,25 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON_Gutenberg::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		// Store the CSS to be output later.
-		$gutenberg_block_custom_css .= $processed_css;
+		/*
+		 * Register and add inline style for block custom CSS.
+		 * The style depends on global-styles to ensure custom CSS loads after
+		 * and can override global styles.
+		 */
+		wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
+		wp_add_inline_style( 'wp-block-custom-css', $processed_css );
 	}
 
 	return $parsed_block;
 }
 
 /**
- * Outputs the collected block custom CSS in the footer.
- *
- * The CSS is output in the footer because it's collected during block rendering
- * (via render_block_data filter), which happens after wp_head.
+ * Enqueues the block custom CSS styles.
  *
  * @since 7.0.0
  */
-function gutenberg_output_block_custom_css() {
-	global $gutenberg_block_custom_css;
-
-	if ( empty( $gutenberg_block_custom_css ) ) {
-		return;
-	}
-
-	echo '<style id="wp-block-custom-css">' . $gutenberg_block_custom_css . '</style>';
+function gutenberg_enqueue_block_custom_css() {
+	wp_enqueue_style( 'wp-block-custom-css' );
 }
 
 /**
@@ -105,4 +91,4 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 
 add_filter( 'render_block', 'gutenberg_render_custom_css_class_name', 10, 2 );
 add_filter( 'render_block_data', 'gutenberg_render_custom_css_support_styles', 10, 1 );
-add_action( 'wp_footer', 'gutenberg_output_block_custom_css' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_block_custom_css', 1 );

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -24,6 +24,12 @@ $gutenberg_block_custom_css = '';
 function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	global $gutenberg_block_custom_css;
 
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
+
+	if ( ! block_has_support( $block_type, 'customCSS', true ) ) {
+		return $parsed_block;
+	}
+
 	$custom_css = $parsed_block['attrs']['style']['css'] ?? null;
 
 	if ( empty( $custom_css ) ) {
@@ -31,7 +37,7 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	}
 
 	// Generate a unique class name for this block instance.
-	$class_name         =  wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
+	$class_name         = wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
 	$updated_class_name = isset( $parsed_block['attrs']['className'] )
 		? $parsed_block['attrs']['className'] . " $class_name"
 		: $class_name;

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Custom CSS block support.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Stores the custom CSS for block instances to be output in the footer.
+ *
+ * @var string
+ */
+global $gutenberg_block_custom_css;
+$gutenberg_block_custom_css = '';
+
+/**
+ * Get the custom CSS class name for a block.
+ *
+ * @since 7.0.0
+ *
+ * @param array $block Block object.
+ * @return string The custom CSS class name.
+ */
+function gutenberg_get_custom_css_class_name( $block ) {
+	return 'wp-custom-css-' . md5( serialize( $block ) );
+}
+
+/**
+ * Render the custom CSS stylesheet and add class name to block as required.
+ *
+ * @since 7.0.0
+ *
+ * @param array $parsed_block The parsed block.
+ * @return array The same parsed block with custom CSS class name added if appropriate.
+ */
+function gutenberg_render_custom_css_support_styles( $parsed_block ) {
+	global $gutenberg_block_custom_css;
+
+	$custom_css = $parsed_block['attrs']['style']['css'] ?? null;
+
+	if ( empty( $custom_css ) ) {
+		return $parsed_block;
+	}
+
+	// Generate a unique class name for this block instance.
+	$class_name         = gutenberg_get_custom_css_class_name( $parsed_block );
+	$updated_class_name = isset( $parsed_block['attrs']['className'] )
+		? $parsed_block['attrs']['className'] . " $class_name"
+		: $class_name;
+
+	_wp_array_set( $parsed_block, array( 'attrs', 'className' ), $updated_class_name );
+
+	// Process the custom CSS using the same method as global styles.
+	$selector      = '.' . $class_name;
+	$processed_css = WP_Theme_JSON_Gutenberg::process_blocks_custom_css( $custom_css, $selector );
+
+	if ( ! empty( $processed_css ) ) {
+		// Store the CSS to be output later.
+		$gutenberg_block_custom_css .= $processed_css;
+	}
+
+	return $parsed_block;
+}
+
+/**
+ * Outputs the collected block custom CSS in the footer.
+ *
+ * The CSS is output in the footer because it's collected during block rendering
+ * (via render_block_data filter), which happens after wp_head.
+ *
+ * @since 7.0.0
+ */
+function gutenberg_output_block_custom_css() {
+	global $gutenberg_block_custom_css;
+
+	if ( empty( $gutenberg_block_custom_css ) ) {
+		return;
+	}
+
+	echo '<style id="wp-block-custom-css">' . $gutenberg_block_custom_css . '</style>';
+}
+
+/**
+ * Applies the custom CSS class name to the block's rendered HTML.
+ *
+ * The class name is generated in `gutenberg_render_custom_css_support_styles`
+ * and stored in block attributes. This filter adds it to the actual markup.
+ *
+ * @since 7.0.0
+ *
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
+ * @return string               Filtered block content.
+ */
+function gutenberg_render_custom_css_class_name( $block_content, $block ) {
+	$class_string = $block['attrs']['className'] ?? '';
+	preg_match( '/\bwp-custom-css-\S+\b/', $class_string, $matches );
+
+	if ( empty( $matches ) ) {
+		return $block_content;
+	}
+
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+
+	if ( $tags->next_tag() ) {
+		$tags->add_class( $matches[0] );
+	}
+
+	return $tags->get_updated_html();
+}
+
+add_filter( 'render_block', 'gutenberg_render_custom_css_class_name', 10, 2 );
+add_filter( 'render_block_data', 'gutenberg_render_custom_css_support_styles', 10, 1 );
+add_action( 'wp_footer', 'gutenberg_output_block_custom_css' );

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -14,18 +14,6 @@ global $gutenberg_block_custom_css;
 $gutenberg_block_custom_css = '';
 
 /**
- * Get the custom CSS class name for a block.
- *
- * @since 7.0.0
- *
- * @param array $block Block object.
- * @return string The custom CSS class name.
- */
-function gutenberg_get_custom_css_class_name( $block ) {
-	return wp_unique_id_from_values( $block, 'wp-custom-css-' );
-}
-
-/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @since 7.0.0
@@ -43,7 +31,7 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	}
 
 	// Generate a unique class name for this block instance.
-	$class_name         = gutenberg_get_custom_css_class_name( $parsed_block );
+	$class_name         =  wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
 	$updated_class_name = isset( $parsed_block['attrs']['className'] )
 		? $parsed_block['attrs']['className'] . " $class_name"
 		: $class_name;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1153,7 +1153,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $to_append Selector to append.
 	 * @return string The new selector.
 	 */
-	protected static function append_to_selector( $selector, $to_append ) {
+	public static function append_to_selector( $selector, $to_append ) {
 		if ( ! str_contains( $selector, ',' ) ) {
 			return $selector . $to_append;
 		}
@@ -1494,7 +1494,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $selector The selector to nest.
 	 * @return string The processed CSS.
 	 */
-	protected function process_blocks_custom_css( $css, $selector ) {
+	public static function process_blocks_custom_css( $css, $selector ) {
 		$processed_css = '';
 
 		if ( empty( $css ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1153,7 +1153,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $to_append Selector to append.
 	 * @return string The new selector.
 	 */
-	public static function append_to_selector( $selector, $to_append ) {
+	protected static function append_to_selector( $selector, $to_append ) {
 		if ( ! str_contains( $selector, ',' ) ) {
 			return $selector . $to_append;
 		}

--- a/lib/load.php
+++ b/lib/load.php
@@ -183,6 +183,7 @@ require __DIR__ . '/block-supports/block-style-variations.php';
 require __DIR__ . '/block-supports/aria-label.php';
 require __DIR__ . '/block-supports/anchor.php';
 require __DIR__ . '/block-supports/block-visibility.php';
+require __DIR__ . '/block-supports/custom-css.php';
 
 // Client-side media processing.
 if ( gutenberg_is_experiment_enabled( 'gutenberg-media-processing' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54284,6 +54284,16 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"packages/react-native-editor/node_modules/@babel/helper-plugin-utils": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"packages/react-native-editor/node_modules/@babel/plugin-transform-arrow-functions": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54284,16 +54284,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"packages/react-native-editor/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"packages/react-native-editor/node_modules/@babel/plugin-transform-arrow-functions": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -14,6 +14,21 @@ import { __ } from '@wordpress/i18n';
  */
 import { default as transformStyles } from '../../utils/transform-styles';
 
+/**
+ * Validates that a CSS string doesn't contain HTML markup.
+ * Uses the same validation as the PHP/global styles REST API.
+ *
+ * @param {string} css The CSS string to validate.
+ * @return {boolean} True if the CSS is valid, false otherwise.
+ */
+export function validateCSS( css ) {
+	// Check for HTML markup.
+	if ( typeof css === 'string' && /<\/?\w/.test( css ) ) {
+		return false;
+	}
+	return true;
+}
+
 export default function AdvancedPanel( {
 	value,
 	onChange,
@@ -28,30 +43,32 @@ export default function AdvancedPanel( {
 			...value,
 			css: newValue,
 		} );
-		if ( cssError ) {
-			// Check if the new value is valid CSS, and pass a wrapping selector
-			// to ensure that `transformStyles` validates the CSS. Note that the
-			// wrapping selector here is not used in the actual output of any styles.
-			const [ transformed ] = transformStyles(
-				[ { css: newValue } ],
-				'.for-validation-only'
+
+		// Validate immediately on change for quick feedback.
+		if ( ! validateCSS( newValue ) ) {
+			setCSSError(
+				__( 'The custom CSS is invalid. Do not use <> markup.' )
 			);
-			if ( transformed ) {
-				setCSSError( null );
-			}
-		}
-	}
-	function handleOnBlur( event ) {
-		if ( ! event?.target?.value ) {
-			setCSSError( null );
 			return;
 		}
 
-		// Check if the new value is valid CSS, and pass a wrapping selector
-		// to ensure that `transformStyles` validates the CSS. Note that the
-		// wrapping selector here is not used in the actual output of any styles.
+		// Clear HTML markup error if CSS is now valid.
+		if ( cssError ) {
+			setCSSError( null );
+		}
+	}
+	function handleOnBlur( event ) {
+		const cssValue = event?.target?.value;
+
+		if ( ! cssValue || ! validateCSS( cssValue ) ) {
+			return;
+		}
+
+		// Check if the value is valid CSS structure on blur (more expensive check).
+		// Pass a wrapping selector to ensure that `transformStyles` validates the CSS.
+		// Note that the wrapping selector here is not used in the actual output of any styles.
 		const [ transformed ] = transformStyles(
-			[ { css: event.target.value } ],
+			[ { css: cssValue } ],
 			'.for-validation-only'
 		);
 

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -70,8 +70,6 @@ export default function AdvancedPanel( {
 				</Notice>
 			) }
 			<TextareaControl
-				__nextHasNoMarginBottom
-				__next40pxDefaultSize
 				label={ __( 'Additional CSS' ) }
 				value={ customCSS }
 				onChange={ ( newValue ) => handleOnChange( newValue ) }

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -18,6 +18,7 @@ export default function AdvancedPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	help,
 } ) {
 	// Custom CSS
 	const [ cssError, setCSSError ] = useState( null );
@@ -69,12 +70,15 @@ export default function AdvancedPanel( {
 				</Notice>
 			) }
 			<TextareaControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				label={ __( 'Additional CSS' ) }
 				value={ customCSS }
 				onChange={ ( newValue ) => handleOnChange( newValue ) }
 				onBlur={ handleOnBlur }
 				className="block-editor-global-styles-advanced-panel__custom-css-input"
 				spellCheck={ false }
+				help={ help }
 			/>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -100,11 +100,15 @@
 	}
 }
 
-.block-editor-global-styles-advanced-panel__custom-css-input textarea {
-	font-family: $editor_html_font;
-	// CSS input is always LTR regardless of language.
-	/*rtl:ignore*/
-	direction: ltr;
+.block-editor-global-styles-advanced-panel__custom-css-input {
+	margin-bottom: $grid-unit-20;
+
+	textarea {
+		font-family: $editor_html_font;
+		// CSS input is always LTR regardless of language.
+		/*rtl:ignore*/
+		direction: ltr;
+	}
 }
 
 .block-editor-panel-duotone-settings__reset {

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,0 +1,145 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
+import { getBlockType } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
+import { processCSSNesting } from '@wordpress/global-styles-engine';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../components/inspector-controls';
+import AdvancedPanel from '../components/global-styles/advanced-panel';
+import { cleanEmptyObject, useStyleOverride } from './utils';
+import { store as blockEditorStore } from '../store';
+
+// Stable reference for useInstanceId.
+const CUSTOM_CSS_INSTANCE_REFERENCE = {};
+
+/**
+ * Inspector control for custom CSS.
+ *
+ * @param {Object}   props               Component props.
+ * @param {string}   props.blockName     Block name.
+ * @param {Function} props.setAttributes Function to set block attributes.
+ * @param {Object}   props.style         Block style attribute.
+ */
+function CustomCSSControl( { blockName, setAttributes, style } ) {
+	const blockType = getBlockType( blockName );
+
+	function onChange( newStyle ) {
+		setAttributes( {
+			style: cleanEmptyObject( newStyle ),
+		} );
+	}
+
+	const cssHelpText = sprintf(
+		// translators: %s: is the name of a block e.g., 'Image' or 'Quote'.
+		__(
+			'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value.'
+		),
+		blockType?.title
+	);
+
+	return (
+		<InspectorControls group="advanced">
+			<AdvancedPanel
+				value={ style }
+				onChange={ onChange }
+				inheritedValue={ style }
+				help={ cssHelpText }
+			/>
+		</InspectorControls>
+	);
+}
+
+function CustomCSSEdit( { clientId, name, setAttributes } ) {
+	const style = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style ||
+			{},
+		[ clientId ]
+	);
+
+	return (
+		<CustomCSSControl
+			blockName={ name }
+			setAttributes={ setAttributes }
+			style={ style }
+		/>
+	);
+}
+
+/**
+ * Hook to handle custom CSS for a block in the editor.
+ * Generates a unique class and applies scoped CSS via style override.
+ *
+ * @param {Object} props       Block props.
+ * @param {Object} props.style Block style attribute.
+ * @return {Object} Block props including className for custom CSS scoping.
+ */
+function useBlockProps( { style } ) {
+	const customCSS = style?.css;
+
+	const customCSSIdentifier = useInstanceId(
+		CUSTOM_CSS_INSTANCE_REFERENCE,
+		'wp-custom-css'
+	);
+
+	const customCSSSelector = `.${ customCSSIdentifier }`;
+
+	// Transform the custom CSS using the same logic as global styles.
+	const transformedCSS = useMemo( () => {
+		return processCSSNesting( customCSS, customCSSSelector );
+	}, [ customCSS, customCSSSelector ] );
+
+	// Inject the CSS via style override.
+	useStyleOverride( { css: transformedCSS } );
+
+	// Only add the class if there's custom CSS.
+	if ( ! customCSS ) {
+		return {};
+	}
+
+	return {
+		className: customCSSIdentifier,
+	};
+}
+
+/**
+ * Adds a marker class to blocks with custom CSS for server-side rendering.
+ *
+ * @param {Object} props      Additional props applied to save element.
+ * @param {Object} blockType  Block type definition.
+ * @param {Object} attributes Block's attributes.
+ * @return {Object} Filtered props applied to save element.
+ */
+function addSaveProps( props, blockType, attributes ) {
+	if ( ! attributes?.style?.css ) {
+		return props;
+	}
+
+	// Add a class to indicate this block has custom CSS.
+	// The actual CSS is rendered server-side using the render_block filter.
+	const className = props.className
+		? `${ props.className } has-custom-css`
+		: 'has-custom-css';
+
+	return {
+		...props,
+		className,
+	};
+}
+
+export default {
+	edit: CustomCSSEdit,
+	useBlockProps,
+	addSaveProps,
+	attributeKeys: [ 'style' ],
+	hasSupport() {
+		return true;
+	},
+};

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
 
@@ -118,6 +118,10 @@ function useBlockProps( { style } ) {
  * @return {Object} Filtered props applied to save element.
  */
 function addSaveProps( props, blockType, attributes ) {
+	if ( ! hasBlockSupport( blockType, 'customCSS', true ) ) {
+		return props;
+	}
+
 	if ( ! attributes?.style?.css ) {
 		return props;
 	}
@@ -139,7 +143,7 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'style' ],
-	hasSupport() {
-		return true;
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'customCSS', true );
 	},
 };

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -12,7 +12,9 @@ import { processCSSNesting } from '@wordpress/global-styles-engine';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import AdvancedPanel from '../components/global-styles/advanced-panel';
+import AdvancedPanel, {
+	validateCSS,
+} from '../components/global-styles/advanced-panel';
 import { cleanEmptyObject, useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 
@@ -97,6 +99,12 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
 function useBlockProps( { style } ) {
 	const customCSS = style?.css;
 
+	// Validate CSS is non-empty and passes validation checks.
+	const isValidCSS =
+		typeof customCSS === 'string' &&
+		customCSS.length > 0 &&
+		validateCSS( customCSS );
+
 	const customCSSIdentifier = useInstanceId(
 		CUSTOM_CSS_INSTANCE_REFERENCE,
 		'wp-custom-css'
@@ -105,15 +113,19 @@ function useBlockProps( { style } ) {
 	const customCSSSelector = `.${ customCSSIdentifier }`;
 
 	// Transform the custom CSS using the same logic as global styles.
+	// Only process if CSS is valid (doesn't contain HTML markup).
 	const transformedCSS = useMemo( () => {
+		if ( ! isValidCSS ) {
+			return undefined;
+		}
 		return processCSSNesting( customCSS, customCSSSelector );
-	}, [ customCSS, customCSSSelector ] );
+	}, [ customCSS, customCSSSelector, isValidCSS ] );
 
 	// Inject the CSS via style override.
 	useStyleOverride( { css: transformedCSS } );
 
-	// Only add the class if there's custom CSS.
-	if ( ! customCSS ) {
+	// Only add the class if there's valid custom CSS.
+	if ( ! isValidCSS ) {
 		return {};
 	}
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -7,12 +7,12 @@ import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
-import { TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
+import AdvancedPanel from '../components/global-styles/advanced-panel';
 import { cleanEmptyObject, useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 
@@ -33,12 +33,9 @@ const EMPTY_STYLE = {};
 function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const blockType = getBlockType( blockName );
 
-	function onChange( newValue ) {
+	function onChange( newStyle ) {
 		setAttributes( {
-			style: cleanEmptyObject( {
-				...style,
-				css: newValue,
-			} ),
+			style: cleanEmptyObject( newStyle ),
 		} );
 	}
 
@@ -52,14 +49,10 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 
 	return (
 		<InspectorControls group="advanced">
-			<TextareaControl
-				__nextHasNoMarginBottom
-				__next40pxDefaultSize
-				label={ __( 'Additional CSS' ) }
-				value={ style?.css || '' }
+			<AdvancedPanel
+				value={ style }
 				onChange={ onChange }
-				className="block-editor-global-styles-advanced-panel__custom-css-input"
-				spellCheck={ false }
+				inheritedValue={ style }
 				help={ cssHelpText }
 			/>
 		</InspectorControls>

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -19,6 +19,9 @@ import { store as blockEditorStore } from '../store';
 // Stable reference for useInstanceId.
 const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 
+// Stable empty object reference for useSelect.
+const EMPTY_STYLE = {};
+
 /**
  * Inspector control for custom CSS.
  *
@@ -57,12 +60,22 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 }
 
 function CustomCSSEdit( { clientId, name, setAttributes } ) {
-	const style = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockAttributes( clientId )?.style ||
-			{},
+	const { style, canEditCSS } = useSelect(
+		( select ) => {
+			const { getBlockAttributes, getSettings } =
+				select( blockEditorStore );
+			return {
+				style: getBlockAttributes( clientId )?.style || EMPTY_STYLE,
+				canEditCSS: getSettings().canEditCSS,
+			};
+		},
 		[ clientId ]
 	);
+
+	// Don't render the panel if user lacks edit_css capability.
+	if ( ! canEditCSS ) {
+		return null;
+	}
 
 	return (
 		<CustomCSSControl

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -36,8 +36,10 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const blockType = getBlockType( blockName );
 
 	function onChange( newStyle ) {
+		// Normalize whitespace-only CSS to undefined so it gets cleaned up.
+		const css = newStyle?.css?.trim() ? newStyle.css : undefined;
 		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
+			style: cleanEmptyObject( { ...newStyle, css } ),
 		} );
 	}
 
@@ -102,7 +104,7 @@ function useBlockProps( { style } ) {
 	// Validate CSS is non-empty and passes validation checks.
 	const isValidCSS =
 		typeof customCSS === 'string' &&
-		customCSS.length > 0 &&
+		customCSS.trim().length > 0 &&
 		validateCSS( customCSS );
 
 	const customCSSIdentifier = useInstanceId(
@@ -147,7 +149,7 @@ function addSaveProps( props, blockType, attributes ) {
 		return props;
 	}
 
-	if ( ! attributes?.style?.css ) {
+	if ( ! attributes?.style?.css?.trim() ) {
 		return props;
 	}
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -7,12 +7,12 @@ import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
+import { TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import AdvancedPanel from '../components/global-styles/advanced-panel';
 import { cleanEmptyObject, useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 
@@ -33,9 +33,12 @@ const EMPTY_STYLE = {};
 function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const blockType = getBlockType( blockName );
 
-	function onChange( newStyle ) {
+	function onChange( newValue ) {
 		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
+			style: cleanEmptyObject( {
+				...style,
+				css: newValue,
+			} ),
 		} );
 	}
 
@@ -49,10 +52,14 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 
 	return (
 		<InspectorControls group="advanced">
-			<AdvancedPanel
-				value={ style }
+			<TextareaControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Additional CSS' ) }
+				value={ style?.css || '' }
 				onChange={ onChange }
-				inheritedValue={ style }
+				className="block-editor-global-styles-advanced-panel__custom-css-input"
+				spellCheck={ false }
 				help={ cssHelpText }
 			/>
 		</InspectorControls>

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -42,7 +42,7 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const cssHelpText = sprintf(
 		// translators: %s: is the name of a block e.g., 'Image' or 'Quote'.
 		__(
-			'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value.'
+			'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value, e.g. color: red;.'
 		),
 		blockType?.title
 	);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -27,6 +27,7 @@ import fontSize from './font-size';
 import textAlign from './text-align';
 import fitText from './fit-text';
 import border from './border';
+import customCSS from './custom-css';
 import position from './position';
 import blockStyleVariation from './block-style-variation';
 import layout from './layout';
@@ -47,6 +48,7 @@ createBlockEditFilter(
 		anchor,
 		customClassName,
 		style,
+		customCSS,
 		duotone,
 		fitText,
 		position,
@@ -72,6 +74,7 @@ createBlockListBlockFilter( [
 	fontSize,
 	fitText,
 	border,
+	customCSS,
 	position,
 	blockStyleVariation,
 	childLayout,
@@ -83,6 +86,7 @@ createBlockSaveFilter( [
 	ariaLabel,
 	customClassName,
 	border,
+	customCSS,
 	fitText,
 	color,
 	style,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -157,6 +157,10 @@ export const SETTINGS_DEFAULTS = {
 	// Allows to disable block locking interface.
 	canLockBlocks: true,
 
+	// Whether the user can edit custom CSS (requires edit_css capability).
+	// Defaults to false for safety - PHP passes true when user has capability.
+	canEditCSS: false,
+
 	// Allows to disable Openverse media category in the inserter.
 	enableOpenverseMediaCategory: true,
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -66,7 +66,6 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		},
-		"customCSS": false
+		}
 	}
 }

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -66,6 +66,7 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	}
 }

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -26,6 +26,7 @@
 		"renaming": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	}
 }

--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -18,7 +18,8 @@
 		"lock": false,
 		"reusable": false,
 		"renaming": false,
-		"visibility": false
+		"visibility": false,
+		"customCSS": false
 	},
 	"editorStyle": "wp-block-freeform-editor"
 }

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -20,7 +20,8 @@
 		"html": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	},
 	"editorStyle": "wp-block-html-editor"
 }

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -29,6 +29,7 @@
 		"visibility": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	}
 }

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -26,7 +26,8 @@
 		"visibility": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	},
 	"editorStyle": "wp-block-more-editor"
 }

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -16,7 +16,8 @@
 		"visibility": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"customCSS": false
 	},
 	"editorStyle": "wp-block-nextpage-editor"
 }

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -16,7 +16,8 @@
 	"supports": {
 		"className": false,
 		"customClassName": false,
-		"html": false
+		"html": false,
+		"customCSS": false
 	},
 	"editorStyle": "wp-block-shortcode-editor"
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -50,6 +50,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'maxUploadFileSize',
 	'allowedMimeTypes',
 	'bodyPlaceholder',
+	'canEditCSS',
 	'canLockBlocks',
 	'canUpdateBlockBindings',
 	'capabilities',

--- a/packages/global-styles-engine/src/index.ts
+++ b/packages/global-styles-engine/src/index.ts
@@ -16,6 +16,7 @@ export {
 	transformToStyles as toStyles,
 	getBlockSelectors,
 	getLayoutStyles,
+	processCSSNesting,
 } from './core/render';
 export { getBlockSelector } from './core/selectors';
 

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -347,19 +347,17 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 
 			{ canEditCSS && (
 				<PanelBody title={ __( 'Advanced' ) } initialOpen={ false }>
-					<p>
-						{ sprintf(
+					<StylesAdvancedPanel
+						value={ style }
+						onChange={ setStyle }
+						inheritedValue={ inheritedStyle }
+						help={ sprintf(
 							// translators: %s: is the name of a block e.g., 'Image' or 'Table'.
 							__(
 								'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value.'
 							),
 							blockType?.title
 						) }
-					</p>
-					<StylesAdvancedPanel
-						value={ style }
-						onChange={ setStyle }
-						inheritedValue={ inheritedStyle }
 					/>
 				</PanelBody>
 			) }

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Test the custom CSS block support.
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		if ( $this->test_block_name ) {
+			unregister_block_type( $this->test_block_name );
+		}
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing custom CSS support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_custom_css_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Tests that custom CSS support adds class name when block has custom CSS.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_adds_class_name_when_css_present() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-block',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-block',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'color: red;',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added.' );
+		$this->assertMatchesRegularExpression( '/wp-custom-css-/', $result['attrs']['className'], 'className should contain wp-custom-css- prefix.' );
+	}
+
+	/**
+	 * Tests that custom CSS support preserves existing className.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_preserves_existing_class_name() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-block-existing',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-block-existing',
+			'attrs'     => array(
+				'className' => 'my-existing-class',
+				'style'     => array(
+					'css' => 'color: blue;',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertStringContainsString( 'my-existing-class', $result['attrs']['className'], 'Existing className should be preserved.' );
+		$this->assertMatchesRegularExpression( '/wp-custom-css-/', $result['attrs']['className'], 'className should also contain wp-custom-css- prefix.' );
+	}
+
+	/**
+	 * Tests that custom CSS support returns unchanged block when support is disabled.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_returns_unchanged_when_support_disabled() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-disabled',
+			array( 'customCSS' => false )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-disabled',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'color: green;',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when support is disabled.' );
+	}
+
+	/**
+	 * Tests that custom CSS support returns unchanged block when no CSS attribute present.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_returns_unchanged_when_no_css() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-no-css',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-no-css',
+			'attrs'     => array(
+				'style' => array(
+					'color' => 'red',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when no CSS attribute.' );
+	}
+
+	/**
+	 * Tests that custom CSS support returns unchanged block when CSS is empty.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_returns_unchanged_when_css_empty() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-empty',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-empty',
+			'attrs'     => array(
+				'style' => array(
+					'css' => '',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when CSS is empty.' );
+	}
+
+	/**
+	 * Tests that custom CSS support returns unchanged block when style attribute is missing.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_returns_unchanged_when_no_style_attribute() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-no-style',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-no-style',
+			'attrs'     => array(),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when no style attribute.' );
+	}
+
+	/**
+	 * Tests that render_block filter adds custom CSS class to block content.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_adds_class_to_content() {
+		$block_content = '<div class="wp-block-paragraph">Test content</div>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'wp-custom-css-123abc',
+			),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertStringContainsString( 'wp-custom-css-123abc', $result, 'Custom CSS class should be added to block content.' );
+	}
+
+	/**
+	 * Tests that render_block filter preserves existing classes when adding custom CSS class.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_preserves_existing_classes() {
+		$block_content = '<div class="existing-class another-class">Test content</div>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'wp-custom-css-456def',
+			),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertStringContainsString( 'existing-class', $result, 'Existing classes should be preserved.' );
+		$this->assertStringContainsString( 'another-class', $result, 'All existing classes should be preserved.' );
+		$this->assertStringContainsString( 'wp-custom-css-456def', $result, 'Custom CSS class should be added.' );
+	}
+
+	/**
+	 * Tests that render_block filter returns unchanged content when no custom CSS class in attrs.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_returns_unchanged_when_no_custom_css_class() {
+		$block_content = '<div class="wp-block-paragraph">Test content</div>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'some-other-class',
+			),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when no custom CSS class.' );
+	}
+
+	/**
+	 * Tests that render_block filter returns unchanged content when className is empty.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_returns_unchanged_when_classname_empty() {
+		$block_content = '<div class="wp-block-paragraph">Test content</div>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when className is empty.' );
+	}
+
+	/**
+	 * Tests that render_block filter returns empty string when content is empty.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_returns_empty_when_content_empty() {
+		$block_content = '';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'wp-custom-css-789ghi',
+			),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Result should be empty when block content is empty.' );
+	}
+
+	/**
+	 * Tests that custom CSS class is extracted correctly when mixed with other classes.
+	 *
+	 * @covers ::gutenberg_render_custom_css_class_name
+	 */
+	public function test_render_custom_css_class_name_extracts_class_from_mixed_classnames() {
+		$block_content = '<p>Test content</p>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'my-class wp-custom-css-mixed123 another-class',
+			),
+		);
+
+		$result = gutenberg_render_custom_css_class_name( $block_content, $block );
+
+		$this->assertStringContainsString( 'wp-custom-css-mixed123', $result, 'Custom CSS class should be extracted and added.' );
+	}
+
+	/**
+	 * Tests that custom CSS support is enabled by default.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_enabled_by_default() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-default',
+			array() // No explicit customCSS support defined.
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-default',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'font-weight: bold;',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added by default when customCSS support is not explicitly set.' );
+	}
+}

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -338,4 +338,79 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added by default when customCSS support is not explicitly set.' );
 	}
+
+	/**
+	 * Tests that custom CSS containing HTML opening tags is rejected.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_rejects_html_opening_tags() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-html-open',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-html-open',
+			'attrs'     => array(
+				'style' => array(
+					'css' => '<script>alert(1)</script>',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when CSS contains HTML opening tags.' );
+	}
+
+	/**
+	 * Tests that custom CSS containing HTML closing tags is rejected.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_rejects_html_closing_tags() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-html-close',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-html-close',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'color: red;</style><script>alert(1)</script>',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when CSS contains HTML closing tags.' );
+	}
+
+	/**
+	 * Tests that valid CSS without HTML markup is accepted.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_accepts_valid_css() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-valid',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-valid',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'color: red; background: url("image.png"); font-size: 16px;',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added for valid CSS.' );
+	}
 }

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -180,6 +180,31 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that custom CSS support returns unchanged block when CSS is whitespace only.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_returns_unchanged_when_css_whitespace_only() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-whitespace',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-whitespace',
+			'attrs'     => array(
+				'style' => array(
+					'css' => '   ',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not have className added when CSS is whitespace only.' );
+	}
+
+	/**
 	 * Tests that custom CSS support returns unchanged block when style attribute is missing.
 	 *
 	 * @covers ::gutenberg_render_custom_css_support_styles

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -310,7 +310,12 @@
 					}
 				},
 				"customClassName": {
-					"description": "This property adds a field to define a custom className for the block’s wrapper.",
+					"description": "This property adds a field to define a custom className for the block's wrapper.",
+					"type": "boolean",
+					"default": true
+				},
+				"customCSS": {
+					"description": "This property adds a field to define custom CSS for the block instance.",
 					"type": "boolean",
 					"default": true
 				},

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -99,13 +99,15 @@ test.describe( 'Editing Navigation Menus', () => {
 				sidebar.getByRole( 'heading', { name: 'Menu', exact: true } )
 			).toBeVisible();
 
-			// Check the standard tabs are not present.
+			// Check the Document Overview tab is not present.
 			await expect(
 				sidebar.getByRole( 'tab', { name: 'Document Overview' } )
 			).toBeHidden();
+
+			// The Settings tab is visible due to Custom CSS support.
 			await expect(
 				sidebar.getByRole( 'tab', { name: 'Settings' } )
-			).toBeHidden();
+			).toBeVisible();
 			await expect(
 				sidebar.getByRole( 'tab', { name: 'Styles' } )
 			).toBeHidden();


### PR DESCRIPTION
Closes #56127

Extends the existing block-type-level custom CSS feature from Global Styles to work at the individual block instance level. Users can now add custom CSS to any block via the Advanced panel in the block inspector.

<img width="1292" height="512" alt="image" src="https://github.com/user-attachments/assets/aa0b738b-94b5-4e44-8ced-75acdc0f4fed" />

**Serialization:**

```html
<!-- wp:heading {"level":6,"style":{"css":"color: blue;\n"}} -->
<h6 class="wp-block-heading has-custom-css">Heading</h6>
<!-- /wp:heading -->
```

**Frontend:**

```html
<h6 class="wp-block-heading has-custom-css wp-custom-css-8841bf3c3cc97689d62771455cc88782">Heading</h6>

// Style block
<style id="wp-block-custom-css">:root :where(.wp-custom-css-8841bf3c3cc97689d62771455cc88782){color: blue;}</style>
```

## Testing

- As an admin user and blocks and make sure custom CSS box appears in advanced panel and that CSS added appears in editor and front end
- Make sure invalid content like HTML tags do not save (uses the same basic sanitization as the existing global custom CSS)
- Make sure a user with no can-edit-css permissions does not see the custom CSS box in the advanced panel