### PR TITLE
Try: Responsive table scroll visual cue.

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -7,7 +7,10 @@
 	$subtle-pale-blue: #e7f5fe;
 	$subtle-pale-pink: #fcf0ef;
 
+	// Allow scrolling overflow, with visual cue.
+	--scroll-cue: color-mix(in srgb, currentColor 20%, transparent);
 	overflow-x: auto;
+	box-shadow: inset 1px 0 0 0 var(--scroll-cue), inset -1px 0 0 0 var(--scroll-cue);
 
 	table {
 		border-collapse: collapse;


### PR DESCRIPTION
## What?

Closes: #8401.

When a table block is set to not have fixed-width table cells, i.e. let the table be wider than the viewport, it scrolls horizontally on mobile. When you have fancy auto-hiding scrollbars (which most mobile operating systems do), it isn't always obvious you can scroll:

![trunk](https://github.com/user-attachments/assets/acfbad4d-bb49-4c20-8d38-079bc0704525)

This PR adds a visual cue that you can:

![scroll cue](https://github.com/user-attachments/assets/c6603306-19b1-483d-85e5-060ac7e78f7c)

This works by adding a 1px box shadow to the left and right of the containing table `figure`. That's the one that allows the `table` inside to scroll. The trick: those box-shadows are hidden by the 1px default table border. This also shows the shortcomings of the trick, when you change the color or width of the border, because that is set on the table inside the figure, the trick is not able to inherit. But so long as a border is actually set, it still works fairly well:

![colors](https://github.com/user-attachments/assets/5095a050-4833-4860-b574-31886a652d13)

The shortcoming, but also how the trick works, is very visible when you turn off borders on the table:

![no-border](https://github.com/user-attachments/assets/95a23af4-0a8b-420d-9890-086ea60e7898)

In a sense, that also shows the shortcomings of #8401 as far as finding a generic solution that works across anything that scrolls horizontally. For that reason I'm tempted to suggest that issue to:

1.  Either be addressed by this PR, marking it as an intentional addition to whe you toggle off the "Fixed width cells"
2. Refactoring the table block so that the border style is set on the `figure` element instead, thus this PR can inherit border colors and widths and thus be zeroed out, or bigger, depending on the style you set.
3. Change this PR for the visual cue to be a toggle on the block.

Each of the three options come with their own tradeoffs. I would honestly think 2 could be the best solution, assuming it is feasible to do in a non-breaking way.

## Testing Instructions

Test this branch with this markup:

```
<!-- wp:table {"hasFixedLayout":false} -->
<figure class="wp-block-table"><table><tbody><tr><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td></tr></tbody></table></figure>
<!-- /wp:table -->
```