### PR TITLE
PM: Add checks for author association in first-time contributor label…

### DIFF
--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -21,7 +21,7 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		return;
 	}
 
-	if ( authorAssociation !== 'FIRST_TIME_CONTRIBUTOR' ) {
+	if ( authorAssociation && authorAssociation !== 'FIRST_TIME_CONTRIBUTOR' ) {
 		debug(
 			`first-time-contributor: Author association is ${ authorAssociation }. Aborting`
 		);

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -32,23 +32,6 @@ async function firstTimeContributorLabel( payload, octokit ) {
 	const owner = payload.repository.owner.login;
 	const author = payload.pull_request.user.login;
 
-	debug(
-		`first-time-contributor: Searching for commits in ${ owner }/${ repo } by @${ author }`
-	);
-
-	const { data: commits } = await octokit.rest.repos.listCommits( {
-		owner,
-		repo,
-		author,
-	} );
-
-	if ( commits.length > 0 ) {
-		debug(
-			`first-time-contributor-label: Not the first commit for author. Aborting`
-		);
-		return;
-	}
-
 	const pullRequestNumber = payload.pull_request.number;
 
 	debug(

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -14,9 +14,17 @@ const debug = require( '../../debug' );
  */
 async function firstTimeContributorLabel( payload, octokit ) {
 	const userType = payload.pull_request.user.type;
+	const authorAssociation = payload.pull_request.author_association;
 
 	if ( userType === 'Bot' ) {
 		debug( 'first-time-contributor: User is a bot. Aborting' );
+		return;
+	}
+
+	if ( authorAssociation !== 'FIRST_TIME_CONTRIBUTOR' ) {
+		debug(
+			`first-time-contributor: Author association is ${ authorAssociation }. Aborting`
+		);
 		return;
 	}
 


### PR DESCRIPTION
Following the troubles with First Time Contribution triggering wrongly

Like in:
https://github.com/WordPress/gutenberg/pull/73961#issuecomment-3645912163.

I'm proposing here adding the `author_association` to check for more trustworthy references.

More info: https://michaelheap.com/github-actions-check-permission/