### PR TITLE
Render custom overlay template parts in Navigation block (behind experiment)

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/style.scss
+++ b/packages/block-library/src/navigation-overlay-close/style.scss
@@ -10,7 +10,6 @@
 	text-decoration: none;
 
 	&:focus {
-		outline: 2px solid currentColor;
 		outline-offset: 2px;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -643,13 +643,40 @@ class WP_Navigation_Block_Renderer {
 		$colors          = block_core_navigation_build_css_colors( $attributes );
 		$modal_unique_id = wp_unique_id( 'modal-' );
 
-		$is_hidden_by_default = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
-		$has_custom_overlay   = ! empty( $attributes['overlay'] );
+		$is_hidden_by_default          = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
 
+		// Set-up variables for the custom overlay experiment. 
+		// Values are set to "off" so they don't affect the default behavior.
+		$is_overlay_experiment_enabled = static::is_overlay_experiment_enabled();
+		$has_custom_overlay = false;
+		$close_button_markup = '';
+		$has_custom_overlay_close_block = false;
+
+		if( $is_overlay_experiment_enabled ) {
+			// Check if an overlay template part is selected and render it.
+			// This needs to happen before building classes so we know if overlay blocks actually exist.
+			if ( ! empty( $attributes['overlay'] ) ) {
+				// Get blocks from the overlay template part.
+				$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
+				// Check if overlay contains a navigation-overlay-close block.
+				$has_custom_overlay_close_block = static::has_navigation_overlay_close_block( $overlay_blocks );
+				// Render template part blocks directly without navigation container wrapper.
+				$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
+				// Add Interactivity API directives to the overlay close block if present.
+				if ( $has_custom_overlay_close_block && $is_interactive ) {
+					$tags                = new WP_HTML_Tag_Processor( $overlay_blocks_html );
+					$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
+				}
+			}
+
+			$has_custom_overlay = ! empty( $overlay_blocks_html );
+		}
+
+		// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
 		$responsive_container_classes = array(
 			'wp-block-navigation__responsive-container',
 			$is_hidden_by_default ? 'hidden-by-default' : '',
-			$has_custom_overlay ? 'has-custom-overlay' : '',
+			$has_custom_overlay ? 'disable-default-overlay' : '',
 			implode( ' ', $colors['overlay_css_classes'] ),
 		);
 		$open_button_classes          = array(
@@ -703,57 +730,25 @@ class WP_Navigation_Block_Renderer {
 
 		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
-		// Check if an overlay template part is selected.
-		$has_overlay = ! empty( $attributes['overlay'] );
-		$overlay_blocks_html = '';
-		$has_overlay_close_block = false;
-
-		if ( $has_overlay ) {
-			// Get blocks from the overlay template part.
-			$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
-			// Check if overlay contains a navigation-overlay-close block.
-			$has_overlay_close_block = static::has_navigation_overlay_close_block( $overlay_blocks );
-			// Render template part blocks directly without navigation container wrapper.
-			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
-			// Add Interactivity API directives to the overlay close block if present.
-			if ( $has_overlay_close_block && $is_interactive ) {
-				$tags              = new WP_HTML_Tag_Processor( $overlay_blocks_html );
-				$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
-			}
-		}
-
-		// Build the content markup with desktop and overlay containers.
+		// Build the content markup with inline and overlay containers.
 		$content_markup = '';
-		$is_overlay_experiment_enabled = static::is_overlay_experiment_enabled();
 
-		if ( $has_overlay && ! empty( $overlay_blocks_html ) ) {
-			// Render both desktop and overlay blocks in separate containers.
-			// IMPORTANT: The desktop container wrapper is gated behind the experiment to ensure
-			// backward compatibility. Without the experiment enabled, the desktop navigation
-			// should not be wrapped in a container div, maintaining the exact same markup structure
-			// as before this feature. This prevents any potential CSS or layout issues for users
-			// who don't have the experiment enabled.
-			if ( $is_overlay_experiment_enabled ) {
-				$content_markup = sprintf(
-					'<div class="wp-block-navigation__desktop-container">%1$s</div>
-					<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
-					$inner_blocks_html,
-					$overlay_blocks_html
-				);
-			} else {
-				// Experiment not enabled: Don't wrap desktop navigation to maintain backward compatibility.
-				// Render desktop blocks without wrapper (maintains exact same markup as before this feature).
-				// Note: UI prevents overlay selection when experiment is off, but handle gracefully if attribute exists.
-				$content_markup = $inner_blocks_html;
-			}
+		if ( $has_custom_overlay ) {
+			// Render both inline and overlay blocks in separate containers.
+			$content_markup = sprintf(
+				'<div class="wp-block-navigation__inline-container">%1$s</div>
+				<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
+				$inner_blocks_html,
+				$overlay_blocks_html
+			);
 		} else {
 			// No overlay selected, use existing behavior.
 			$content_markup = $inner_blocks_html;
 		}
 
-		// Conditionally show the default close button only if overlay doesn't have its own close block.
-		$close_button_markup = '';
-		if ( ! $has_overlay_close_block ) {
+		// Show default close button for all responsive navigation,
+		// unless custom overlay has its own close block.
+		if ( ! $has_custom_overlay_close_block ) {
 			$close_button_markup = sprintf(
 				'<button %1$s class="wp-block-navigation__responsive-container-close" %2$s>%3$s</button>',
 				$toggle_aria_label_close,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -562,10 +562,12 @@ class WP_Navigation_Block_Renderer {
 		$modal_unique_id = wp_unique_id( 'modal-' );
 
 		$is_hidden_by_default = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
+		$has_custom_overlay   = ! empty( $attributes['overlay'] );
 
 		$responsive_container_classes = array(
 			'wp-block-navigation__responsive-container',
 			$is_hidden_by_default ? 'hidden-by-default' : '',
+			$has_custom_overlay ? 'has-custom-overlay' : '',
 			implode( ' ', $colors['overlay_css_classes'] ),
 		);
 		$open_button_classes          = array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -171,35 +171,6 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
-	 * Checks if blocks contain a core/navigation-overlay-close block.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Block_List $blocks The list of blocks to check.
-	 * @return bool Returns true if a navigation-overlay-close block is found.
-	 */
-	private static function has_navigation_overlay_close_block( $blocks ) {
-		if ( empty( $blocks ) ) {
-			return false;
-		}
-
-		foreach ( $blocks as $block ) {
-			if ( 'core/navigation-overlay-close' === $block->name ) {
-				return true;
-			}
-
-			// Recursively check inner blocks, but skip navigation blocks.
-			if ( 'core/navigation' !== $block->name && ! empty( $block->inner_blocks ) ) {
-				if ( static::has_navigation_overlay_close_block( $block->inner_blocks ) ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Returns the html for blocks from a template part (without navigation container wrapper).
 	 *
 	 * @since 6.5.0
@@ -661,7 +632,11 @@ class WP_Navigation_Block_Renderer {
 				// Get blocks from the overlay template part.
 				$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
 				// Check if overlay contains a navigation-overlay-close block.
-				$has_custom_overlay_close_block = static::has_navigation_overlay_close_block( $overlay_blocks );
+				$has_custom_overlay_close_block = block_tree_has_block_type(
+					$overlay_blocks,
+					'core/navigation-overlay-close',
+					array( 'core/navigation' ) // Skip navigation blocks, as they cannot contain an overlay close block
+				);
 				// Render template part blocks directly without navigation container wrapper.
 				$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
 				// Add Interactivity API directives to the overlay close block if present.
@@ -929,7 +904,10 @@ class WP_Navigation_Block_Renderer {
 
 		$inner_blocks = static::get_inner_blocks( $attributes, $block );
 		// Prevent navigation blocks referencing themselves from rendering.
-		if ( block_core_navigation_block_contains_core_navigation( $inner_blocks ) ) {
+		if ( block_tree_has_block_type(
+			$inner_blocks,
+			'core/navigation'
+		) ) {
 			return '';
 		}
 
@@ -1273,24 +1251,52 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
 }
 
 /**
+ * Recursively checks if blocks contain a specific block type.
+ *
+ * @since 7.0.0
+ *
+ * @param WP_Block_List $blocks           The list of blocks to check.
+ * @param string        $block_type       The block type to search for (e.g., 'core/navigation').
+ * @param array         $skip_block_types Optional. Block types to skip when recursing. Default empty array.
+ * @return bool Returns true if the specified block type is found.
+ */
+function block_tree_has_block_type( $blocks, $block_type, $skip_block_types = array() ) {
+	if ( empty( $blocks ) ) {
+		return false;
+	}
+
+	foreach ( $blocks as $block ) {
+		if ( $block_type === $block->name ) {
+			return true;
+		}
+
+		// Recursively check inner blocks, skipping specified block types.
+		if ( ! in_array( $block->name, $skip_block_types, true ) && ! empty( $block->inner_blocks ) ) {
+			if ( block_tree_has_block_type( $block->inner_blocks, $block_type, $skip_block_types ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
  * Returns true if the navigation block contains a nested navigation block.
  *
  * @since 6.2.0
+ * @deprecated 7.0.0 Use block_tree_has_block_type() instead.
  *
  * @param WP_Block_List $inner_blocks Inner block instance to be normalized.
  * @return bool true if the navigation block contains a nested navigation block.
  */
 function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
-	foreach ( $inner_blocks as $block ) {
-		if ( 'core/navigation' === $block->name ) {
-			return true;
-		}
-		if ( $block->inner_blocks && block_core_navigation_block_contains_core_navigation( $block->inner_blocks ) ) {
-			return true;
-		}
-	}
+	_deprecated_function( __FUNCTION__, '7.0.0', 'block_tree_has_block_type()' );
 
-	return false;
+	return block_tree_has_block_type(
+		$inner_blocks,
+		'core/navigation'
+	);
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -42,6 +42,18 @@ class WP_Navigation_Block_Renderer {
 	private static $seen_menu_names = array();
 
 	/**
+	 * Returns whether the navigation overlay experiment is enabled.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return bool Returns whether the navigation overlay experiment is enabled.
+	 */
+	private static function is_overlay_experiment_enabled() {
+		$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+		return $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments );
+	}
+
+	/**
 	 * Returns whether or not this is responsive navigation.
 	 *
 	 * @since 6.5.0
@@ -712,14 +724,28 @@ class WP_Navigation_Block_Renderer {
 
 		// Build the content markup with desktop and overlay containers.
 		$content_markup = '';
+		$is_overlay_experiment_enabled = static::is_overlay_experiment_enabled();
+
 		if ( $has_overlay && ! empty( $overlay_blocks_html ) ) {
 			// Render both desktop and overlay blocks in separate containers.
-			$content_markup = sprintf(
-				'<div class="wp-block-navigation__desktop-container">%1$s</div>
-				<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
-				$inner_blocks_html,
-				$overlay_blocks_html
-			);
+			// IMPORTANT: The desktop container wrapper is gated behind the experiment to ensure
+			// backward compatibility. Without the experiment enabled, the desktop navigation
+			// should not be wrapped in a container div, maintaining the exact same markup structure
+			// as before this feature. This prevents any potential CSS or layout issues for users
+			// who don't have the experiment enabled.
+			if ( $is_overlay_experiment_enabled ) {
+				$content_markup = sprintf(
+					'<div class="wp-block-navigation__desktop-container">%1$s</div>
+					<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
+					$inner_blocks_html,
+					$overlay_blocks_html
+				);
+			} else {
+				// Experiment not enabled: Don't wrap desktop navigation to maintain backward compatibility.
+				// Render desktop blocks without wrapper (maintains exact same markup as before this feature).
+				// Note: UI prevents overlay selection when experiment is off, but handle gracefully if attribute exists.
+				$content_markup = $inner_blocks_html;
+			}
 		} else {
 			// No overlay selected, use existing behavior.
 			$content_markup = $inner_blocks_html;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -645,12 +645,14 @@ class WP_Navigation_Block_Renderer {
 
 		$is_hidden_by_default          = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
 
-		// Set-up variables for the custom overlay experiment. 
+		// Set-up variables for the custom overlay experiment.
 		// Values are set to "off" so they don't affect the default behavior.
 		$is_overlay_experiment_enabled = static::is_overlay_experiment_enabled();
 		$has_custom_overlay = false;
 		$close_button_markup = '';
 		$has_custom_overlay_close_block = false;
+		$overlay_blocks_html = '';
+		$custom_overlay_markup = '';
 
 		if( $is_overlay_experiment_enabled ) {
 			// Check if an overlay template part is selected and render it.
@@ -730,20 +732,12 @@ class WP_Navigation_Block_Renderer {
 
 		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
-		// Build the content markup with inline and overlay containers.
-		$content_markup = '';
-
+		
 		if ( $has_custom_overlay ) {
-			// Render both inline and overlay blocks in separate containers.
-			$content_markup = sprintf(
-				'<div class="wp-block-navigation__inline-container">%1$s</div>
-				<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
-				$inner_blocks_html,
+			$custom_overlay_markup = sprintf(
+				'<div class="wp-block-navigation__overlay-container" aria-hidden="true">%s</div>',
 				$overlay_blocks_html
 			);
-		} else {
-			// No overlay selected, use existing behavior.
-			$content_markup = $inner_blocks_html;
 		}
 
 		// Show default close button for all responsive navigation,
@@ -765,12 +759,13 @@ class WP_Navigation_Block_Renderer {
 							%13$s
 							<div class="wp-block-navigation__responsive-container-content" %14$s id="%1$s-content">
 								%2$s
+								%15$s
 							</div>
 						</div>
 					</div>
 				</div>',
 			esc_attr( $modal_unique_id ),
-			$content_markup,
+			$inner_blocks_html,
 			$toggle_aria_label_open,
 			$toggle_aria_label_close,
 			esc_attr( trim( implode( ' ', $responsive_container_classes ) ) ),
@@ -782,7 +777,8 @@ class WP_Navigation_Block_Renderer {
 			$responsive_container_directives,
 			$responsive_dialog_directives,
 			$close_button_markup,
-			$responsive_container_content_directives
+			$responsive_container_content_directives,
+			$has_custom_overlay ? $custom_overlay_markup : ''
 		);
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -159,6 +159,22 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Returns the html for blocks from a template part (without navigation container wrapper).
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_Block_List $blocks The list of blocks to render.
+	 * @return string Returns the html for the template part blocks.
+	 */
+	private static function get_template_part_blocks_html( $blocks ) {
+		$html = '';
+		foreach ( $blocks as $block ) {
+			$html .= $block->render();
+		}
+		return $html;
+	}
+
+	/**
 	 * Returns the html for the inner blocks of the navigation block.
 	 *
 	 * @since 6.5.0
@@ -270,6 +286,86 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		return new WP_Block_List( $fallback_blocks, $attributes );
+	}
+
+	/**
+	 * Gets the inner blocks for the navigation block from an overlay template part.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $overlay_template_part_id The overlay template part ID in format "theme//slug".
+	 * @param array  $attributes                The block attributes.
+	 * @return WP_Block_List Returns the inner blocks for the overlay template part.
+	 */
+	private static function get_overlay_blocks_from_template_part( $overlay_template_part_id, $attributes ) {
+		if ( empty( $overlay_template_part_id ) || ! is_string( $overlay_template_part_id ) ) {
+			return new WP_Block_List( array(), $attributes );
+		}
+
+		// Parse the template part ID (format: "theme//slug").
+		$parts = explode( '//', $overlay_template_part_id, 2 );
+		if ( count( $parts ) !== 2 ) {
+			return new WP_Block_List( array(), $attributes );
+		}
+
+		$theme = $parts[0];
+		$slug  = $parts[1];
+
+		// Only query for template parts from the active theme.
+		if ( get_stylesheet() !== $theme ) {
+			return new WP_Block_List( array(), $attributes );
+		}
+
+		// Query for the template part post.
+		$template_part_query = new WP_Query(
+			array(
+				'post_type'           => 'wp_template_part',
+				'post_status'         => 'publish',
+				'post_name__in'       => array( $slug ),
+				'tax_query'           => array(
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => $theme,
+					),
+				),
+				'posts_per_page'      => 1,
+				'no_found_rows'       => true,
+				'lazy_load_term_meta' => false, // Do not lazy load term meta, as template parts only have one term.
+			)
+		);
+
+		$template_part_post = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+
+		if ( ! $template_part_post ) {
+			// Try to get from theme file if not in database.
+			$block_template = get_block_file_template( $overlay_template_part_id, 'wp_template_part' );
+			if ( isset( $block_template->content ) ) {
+				$parsed_blocks = parse_blocks( $block_template->content );
+				$blocks        = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
+				return new WP_Block_List( $blocks, $attributes );
+			}
+			return new WP_Block_List( array(), $attributes );
+		}
+
+		// Get the template part content.
+		$block_template = _build_block_template_result_from_post( $template_part_post );
+		if ( ! isset( $block_template->content ) ) {
+			return new WP_Block_List( array(), $attributes );
+		}
+
+		$parsed_blocks = parse_blocks( $block_template->content );
+
+		// 'parse_blocks' includes a null block with '\n\n' as the content when
+		// it encounters whitespace. This code strips it.
+		$blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
+
+		// Re-serialize, and run Block Hooks algorithm to inject hooked blocks.
+		$markup = serialize_blocks( $blocks );
+		$markup = apply_block_hooks_to_content_from_post_object( $markup, $template_part_post );
+		$blocks = parse_blocks( $markup );
+
+		return new WP_Block_List( $blocks, $attributes );
 	}
 
 	/**
@@ -523,6 +619,32 @@ class WP_Navigation_Block_Renderer {
 
 		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
+		// Check if an overlay template part is selected.
+		$has_overlay = ! empty( $attributes['overlay'] );
+		$overlay_blocks_html = '';
+
+		if ( $has_overlay ) {
+			// Get blocks from the overlay template part.
+			$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
+			// Render template part blocks directly without navigation container wrapper.
+			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
+		}
+
+		// Build the content markup with desktop and overlay containers.
+		$content_markup = '';
+		if ( $has_overlay && ! empty( $overlay_blocks_html ) ) {
+			// Render both desktop and overlay blocks in separate containers.
+			$content_markup = sprintf(
+				'<div class="wp-block-navigation__desktop-container">%1$s</div>
+				<div class="wp-block-navigation__overlay-container" aria-hidden="true">%2$s</div>',
+				$inner_blocks_html,
+				$overlay_blocks_html
+			);
+		} else {
+			// No overlay selected, use existing behavior.
+			$content_markup = $inner_blocks_html;
+		}
+
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 				<div class="%5$s" %7$s id="%1$s" %11$s>
@@ -536,7 +658,7 @@ class WP_Navigation_Block_Renderer {
 					</div>
 				</div>',
 			esc_attr( $modal_unique_id ),
-			$inner_blocks_html,
+			$content_markup,
 			$toggle_aria_label_open,
 			$toggle_aria_label_close,
 			esc_attr( trim( implode( ' ', $responsive_container_classes ) ) ),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -662,6 +662,11 @@ class WP_Navigation_Block_Renderer {
 			$has_overlay_close_block = static::has_navigation_overlay_close_block( $overlay_blocks );
 			// Render template part blocks directly without navigation container wrapper.
 			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
+			// Add Interactivity API directives to the overlay close block if present.
+			if ( $has_overlay_close_block && $is_interactive ) {
+				$tags              = new WP_HTML_Tag_Processor( $overlay_blocks_html );
+				$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
+			}
 		}
 
 		// Build the content markup with desktop and overlay containers.
@@ -963,6 +968,29 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$parsed_blocks           = block_core_navigation_parse_blocks_from_menu_items( $menu_items_by_parent_id[0], $menu_items_by_parent_id );
 		return new WP_Block_List( $parsed_blocks, $attributes );
 	}
+}
+
+/**
+ * Add Interactivity API directives to the navigation-overlay-close block
+ * markup using the Tag Processor.
+ *
+ * @since 6.5.0
+ *
+ * @param WP_HTML_Tag_Processor $tags Markup of the navigation block.
+ * @return string Overlay close markup with the directives injected.
+ */
+function block_core_navigation_add_directives_to_overlay_close( $tags ) {
+	// Find the navigation-overlay-close button.
+	if ( $tags->next_tag(
+		array(
+			'tag_name'   => 'BUTTON',
+			'class_name' => 'wp-block-navigation-overlay-close',
+		)
+	) ) {
+		// Add the same close directive as the default close button.
+		$tags->set_attribute( 'data-wp-on--click', 'actions.closeMenuOnClick' );
+	}
+	return $tags->get_updated_html();
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -159,6 +159,35 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Checks if blocks contain a core/navigation-overlay-close block.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_Block_List $blocks The list of blocks to check.
+	 * @return bool Returns true if a navigation-overlay-close block is found.
+	 */
+	private static function has_navigation_overlay_close_block( $blocks ) {
+		if ( empty( $blocks ) ) {
+			return false;
+		}
+
+		foreach ( $blocks as $block ) {
+			if ( 'core/navigation-overlay-close' === $block->name ) {
+				return true;
+			}
+
+			// Recursively check inner blocks, but skip navigation blocks.
+			if ( 'core/navigation' !== $block->name && ! empty( $block->inner_blocks ) ) {
+				if ( static::has_navigation_overlay_close_block( $block->inner_blocks ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns the html for blocks from a template part (without navigation container wrapper).
 	 *
 	 * @since 6.5.0
@@ -624,10 +653,13 @@ class WP_Navigation_Block_Renderer {
 		// Check if an overlay template part is selected.
 		$has_overlay = ! empty( $attributes['overlay'] );
 		$overlay_blocks_html = '';
+		$has_overlay_close_block = false;
 
 		if ( $has_overlay ) {
 			// Get blocks from the overlay template part.
 			$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
+			// Check if overlay contains a navigation-overlay-close block.
+			$has_overlay_close_block = static::has_navigation_overlay_close_block( $overlay_blocks );
 			// Render template part blocks directly without navigation container wrapper.
 			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
 		}
@@ -647,12 +679,23 @@ class WP_Navigation_Block_Renderer {
 			$content_markup = $inner_blocks_html;
 		}
 
+		// Conditionally show the default close button only if overlay doesn't have its own close block.
+		$close_button_markup = '';
+		if ( ! $has_overlay_close_block ) {
+			$close_button_markup = sprintf(
+				'<button %1$s class="wp-block-navigation__responsive-container-close" %2$s>%3$s</button>',
+				$toggle_aria_label_close,
+				$close_button_directives,
+				$toggle_close_button_content
+			);
+		}
+
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 				<div class="%5$s" %7$s id="%1$s" %11$s>
 					<div class="wp-block-navigation__responsive-close" tabindex="-1">
 						<div class="wp-block-navigation__responsive-dialog" %12$s>
-							<button %4$s class="wp-block-navigation__responsive-container-close" %13$s>%9$s</button>
+							%13$s
 							<div class="wp-block-navigation__responsive-container-content" %14$s id="%1$s-content">
 								%2$s
 							</div>
@@ -671,7 +714,7 @@ class WP_Navigation_Block_Renderer {
 			$open_button_directives,
 			$responsive_container_directives,
 			$responsive_dialog_directives,
-			$close_button_directives,
+			$close_button_markup,
 			$responsive_container_content_directives
 		);
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -318,6 +318,42 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Recursively disables overlay menu for navigation blocks within overlay blocks.
+	 * Prevents nested overlays (inception).
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param array $blocks Array of parsed block arrays.
+	 * @return array Modified blocks with overlayMenu set to 'never' for navigation blocks.
+	 */
+	private static function disable_overlay_menu_for_nested_navigation_blocks( $blocks ) {
+		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
+			return $blocks;
+		}
+
+		foreach ( $blocks as &$block ) {
+			if ( ! isset( $block['blockName'] ) ) {
+				continue;
+			}
+
+			// If this is a navigation block, disable its overlay menu.
+			if ( 'core/navigation' === $block['blockName'] ) {
+				if ( ! isset( $block['attrs'] ) ) {
+					$block['attrs'] = array();
+				}
+				$block['attrs']['overlayMenu'] = 'never';
+			}
+
+			// Recursively process inner blocks.
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$block['innerBlocks'] = static::disable_overlay_menu_for_nested_navigation_blocks( $block['innerBlocks'] );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
 	 * Gets the inner blocks for the navigation block from an overlay template part.
 	 *
 	 * @since 6.5.0
@@ -372,6 +408,8 @@ class WP_Navigation_Block_Renderer {
 			if ( isset( $block_template->content ) ) {
 				$parsed_blocks = parse_blocks( $block_template->content );
 				$blocks        = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
+				// Disable overlay menu for any navigation blocks within the overlay to prevent nested overlays.
+				$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks );
 				return new WP_Block_List( $blocks, $attributes );
 			}
 			return new WP_Block_List( array(), $attributes );
@@ -393,6 +431,9 @@ class WP_Navigation_Block_Renderer {
 		$markup = serialize_blocks( $blocks );
 		$markup = apply_block_hooks_to_content_from_post_object( $markup, $template_part_post );
 		$blocks = parse_blocks( $markup );
+
+		// Disable overlay menu for any navigation blocks within the overlay to prevent nested overlays.
+		$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks );
 
 		return new WP_Block_List( $blocks, $attributes );
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -735,7 +735,7 @@ class WP_Navigation_Block_Renderer {
 		
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(
-				'<div class="wp-block-navigation__overlay-container" aria-hidden="true">%s</div>',
+				'<div class="wp-block-navigation__overlay-container">%s</div>',
 				$overlay_blocks_html
 			);
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -614,25 +614,25 @@ class WP_Navigation_Block_Renderer {
 		$colors          = block_core_navigation_build_css_colors( $attributes );
 		$modal_unique_id = wp_unique_id( 'modal-' );
 
-		$is_hidden_by_default          = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
+		$is_hidden_by_default = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
 
 		// Set-up variables for the custom overlay experiment.
 		// Values are set to "off" so they don't affect the default behavior.
-		$is_overlay_experiment_enabled = static::is_overlay_experiment_enabled();
-		$has_custom_overlay = false;
-		$close_button_markup = '';
+		$is_overlay_experiment_enabled  = static::is_overlay_experiment_enabled();
+		$has_custom_overlay             = false;
+		$close_button_markup            = '';
 		$has_custom_overlay_close_block = false;
-		$overlay_blocks_html = '';
-		$custom_overlay_markup = '';
+		$overlay_blocks_html            = '';
+		$custom_overlay_markup          = '';
 
-		if( $is_overlay_experiment_enabled ) {
+		if ( $is_overlay_experiment_enabled ) {
 			// Check if an overlay template part is selected and render it.
 			// This needs to happen before building classes so we know if overlay blocks actually exist.
 			if ( ! empty( $attributes['overlay'] ) ) {
 				// Get blocks from the overlay template part.
 				$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
 				// Check if overlay contains a navigation-overlay-close block.
-				$has_custom_overlay_close_block = block_tree_has_block_type(
+				$has_custom_overlay_close_block = block_core_navigation_block_tree_has_block_type(
 					$overlay_blocks,
 					'core/navigation-overlay-close',
 					array( 'core/navigation' ) // Skip navigation blocks, as they cannot contain an overlay close block
@@ -707,7 +707,6 @@ class WP_Navigation_Block_Renderer {
 
 		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
-		
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(
 				'<div class="wp-block-navigation__overlay-container">%s</div>',
@@ -904,7 +903,7 @@ class WP_Navigation_Block_Renderer {
 
 		$inner_blocks = static::get_inner_blocks( $attributes, $block );
 		// Prevent navigation blocks referencing themselves from rendering.
-		if ( block_tree_has_block_type(
+		if ( block_core_navigation_block_tree_has_block_type(
 			$inner_blocks,
 			'core/navigation'
 		) ) {
@@ -1260,7 +1259,7 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
  * @param array         $skip_block_types Optional. Block types to skip when recursing. Default empty array.
  * @return bool Returns true if the specified block type is found.
  */
-function block_tree_has_block_type( $blocks, $block_type, $skip_block_types = array() ) {
+function block_core_navigation_block_tree_has_block_type( $blocks, $block_type, $skip_block_types = array() ) {
 	if ( empty( $blocks ) ) {
 		return false;
 	}
@@ -1272,7 +1271,7 @@ function block_tree_has_block_type( $blocks, $block_type, $skip_block_types = ar
 
 		// Recursively check inner blocks, skipping specified block types.
 		if ( ! in_array( $block->name, $skip_block_types, true ) && ! empty( $block->inner_blocks ) ) {
-			if ( block_tree_has_block_type( $block->inner_blocks, $block_type, $skip_block_types ) ) {
+			if ( block_core_navigation_block_tree_has_block_type( $block->inner_blocks, $block_type, $skip_block_types ) ) {
 				return true;
 			}
 		}
@@ -1285,15 +1284,15 @@ function block_tree_has_block_type( $blocks, $block_type, $skip_block_types = ar
  * Returns true if the navigation block contains a nested navigation block.
  *
  * @since 6.2.0
- * @deprecated 7.0.0 Use block_tree_has_block_type() instead.
+ * @deprecated 7.0.0 Use block_core_navigation_block_tree_has_block_type() instead.
  *
  * @param WP_Block_List $inner_blocks Inner block instance to be normalized.
  * @return bool true if the navigation block contains a nested navigation block.
  */
 function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
-	_deprecated_function( __FUNCTION__, '7.0.0', 'block_tree_has_block_type()' );
+	_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_navigation_block_tree_has_block_type()' );
 
-	return block_tree_has_block_type(
+	return block_core_navigation_block_tree_has_block_type(
 		$inner_blocks,
 		'core/navigation'
 	);

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -353,7 +353,8 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-dialog,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
-.wp-block-navigation__responsive-container-content {
+.wp-block-navigation__responsive-container-content,
+.wp-block-navigation__desktop-container {
 	gap: inherit;
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -777,6 +777,12 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// When default close button is within a custom overlay, add spacing from edges.
+.has-custom-overlay .wp-block-navigation__responsive-container-close {
+	top: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
+	right: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
+}
+
 // The menu adds wrapping containers.
 .wp-block-navigation__responsive-close {
 	width: 100%;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -353,8 +353,7 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-dialog,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
-.wp-block-navigation__responsive-container-content,
-.wp-block-navigation__inline-container {
+.wp-block-navigation__responsive-container-content {
 	gap: inherit;
 }
 
@@ -500,32 +499,6 @@ button.wp-block-navigation-item__content {
 		align-items: var(--navigation-layout-align, initial);
 	}
 
-	// Inline and overlay container visibility.
-	// By default, show inline container and hide overlay container.
-	.wp-block-navigation__inline-container {
-		display: block;
-	}
-
-	.wp-block-navigation__overlay-container {
-		display: none;
-		width: 100%;
-		// Visually hidden and hidden from assistive tech by default.
-		// aria-hidden is set in the markup.
-	}
-
-	// When menu is closed (not open), show inline container and hide overlay container.
-	&:not(.is-menu-open) {
-		.wp-block-navigation__responsive-container-content {
-			.wp-block-navigation__inline-container {
-				display: block;
-			}
-
-			.wp-block-navigation__overlay-container {
-				display: none;
-			}
-		}
-	}
-
 	// If the responsive wrapper is present but overlay is not open,
 	// overlay styles shouldn't apply.
 	&:not(.is-menu-open.is-menu-open) {
@@ -583,17 +556,6 @@ button.wp-block-navigation-item__content {
 
 			// Inherit alignment settings from container.
 			align-items: var(--navigation-layout-justification-setting, inherit);
-
-			// When menu is open at mobile, show overlay container and hide inline container.
-			.wp-block-navigation__inline-container {
-				display: none;
-			}
-
-			.wp-block-navigation__overlay-container {
-				display: block;
-				width: 100%;
-				// Remove aria-hidden when visible (handled by JavaScript/Interactivity API).
-			}
 
 			// Always align the contents of the menu to the top.
 			&,
@@ -667,6 +629,29 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
+	// Custom overlay container visibility.
+	// When there's a custom overlay, by default hide overlay container.
+	&.disable-default-overlay {
+		.wp-block-navigation__overlay-container {
+			display: none;
+			width: 100%;
+		}
+
+		// When menu is open with custom overlay, hide default navigation and show overlay.
+		&.is-menu-open {
+			.wp-block-navigation__responsive-container-content {
+				// Hides the content of the non-overlay navigation.
+				> .wp-block-navigation__container {
+					display: none;
+				}
+
+				.wp-block-navigation__overlay-container {
+					display: block;
+				}
+			}
+		}
+	}
+
 	@include break-small() {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
@@ -686,17 +671,6 @@ button.wp-block-navigation-item__content {
 			// Override breakpoint-inherited submenu rules.
 			.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 				left: 0;
-			}
-		}
-
-		// At desktop breakpoint, always show inline container and hide overlay container.
-		.wp-block-navigation__responsive-container-content {
-			.wp-block-navigation__inline-container {
-				display: block;
-			}
-
-			.wp-block-navigation__overlay-container {
-				display: none;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -354,7 +354,7 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
 .wp-block-navigation__responsive-container-content,
-.wp-block-navigation__desktop-container {
+.wp-block-navigation__inline-container {
 	gap: inherit;
 }
 
@@ -500,9 +500,9 @@ button.wp-block-navigation-item__content {
 		align-items: var(--navigation-layout-align, initial);
 	}
 
-	// Desktop and overlay container visibility.
-	// By default, show desktop container and hide overlay container.
-	.wp-block-navigation__desktop-container {
+	// Inline and overlay container visibility.
+	// By default, show inline container and hide overlay container.
+	.wp-block-navigation__inline-container {
 		display: block;
 	}
 
@@ -513,10 +513,10 @@ button.wp-block-navigation-item__content {
 		// aria-hidden is set in the markup.
 	}
 
-	// When menu is closed (not open), show desktop container and hide overlay container.
+	// When menu is closed (not open), show inline container and hide overlay container.
 	&:not(.is-menu-open) {
 		.wp-block-navigation__responsive-container-content {
-			.wp-block-navigation__desktop-container {
+			.wp-block-navigation__inline-container {
 				display: block;
 			}
 
@@ -551,7 +551,7 @@ button.wp-block-navigation-item__content {
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
 		// Don't apply default padding when custom overlay is present.
-		&:not(.has-custom-overlay) {
+		&:not(.disable-default-overlay) {
 			padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);
 			padding-right: clamp(1rem, var(--wp--style--root--padding-right), 20rem);
 			padding-bottom: clamp(1rem, var(--wp--style--root--padding-bottom), 20rem);
@@ -566,7 +566,7 @@ button.wp-block-navigation-item__content {
 
 		// Add padding above to accommodate close button.
 		// Don't apply default padding when custom overlay is present.
-		&:not(.has-custom-overlay) .wp-block-navigation__responsive-container-content {
+		&:not(.disable-default-overlay) .wp-block-navigation__responsive-container-content {
 			padding-top: calc(2rem + #{ $navigation-icon-size });
 		}
 
@@ -584,8 +584,8 @@ button.wp-block-navigation-item__content {
 			// Inherit alignment settings from container.
 			align-items: var(--navigation-layout-justification-setting, inherit);
 
-			// When menu is open at mobile, show overlay container and hide desktop container.
-			.wp-block-navigation__desktop-container {
+			// When menu is open at mobile, show overlay container and hide inline container.
+			.wp-block-navigation__inline-container {
 				display: none;
 			}
 
@@ -689,9 +689,9 @@ button.wp-block-navigation-item__content {
 			}
 		}
 
-		// At desktop breakpoint, always show desktop container and hide overlay container.
+		// At desktop breakpoint, always show inline container and hide overlay container.
 		.wp-block-navigation__responsive-container-content {
-			.wp-block-navigation__desktop-container {
+			.wp-block-navigation__inline-container {
 				display: block;
 			}
 
@@ -705,12 +705,12 @@ button.wp-block-navigation-item__content {
 // Default menu background and font color.
 // Don't apply default colors when custom overlay is present.
 .wp-block-navigation:not(.has-background)
-.wp-block-navigation__responsive-container.is-menu-open:not(.has-custom-overlay) {
+.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
 	background-color: #fff;
 }
 
 .wp-block-navigation:not(.has-text-color)
-.wp-block-navigation__responsive-container.is-menu-open:not(.has-custom-overlay) {
+.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
 	color: #000;
 }
 
@@ -778,7 +778,7 @@ button.wp-block-navigation-item__content {
 }
 
 // When default close button is within a custom overlay, add spacing from edges.
-.has-custom-overlay .wp-block-navigation__responsive-container-close {
+.disable-default-overlay .wp-block-navigation__responsive-container-close {
 	top: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
 	right: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
 }
@@ -816,7 +816,7 @@ button.wp-block-navigation-item__content {
 // Adjust open dialog top margin when admin-bar is visible.
 // Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
 // Don't apply margin when custom overlay is present.
-.has-modal-open .admin-bar .is-menu-open:not(.has-custom-overlay) .wp-block-navigation__responsive-dialog {
+.has-modal-open .admin-bar .is-menu-open:not(.disable-default-overlay) .wp-block-navigation__responsive-dialog {
 	margin-top: $admin-bar-height-big;
 
 	// Handle smaller admin-bar.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -549,10 +549,13 @@ button.wp-block-navigation-item__content {
 		}
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
-		padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);
-		padding-right: clamp(1rem, var(--wp--style--root--padding-right), 20rem);
-		padding-bottom: clamp(1rem, var(--wp--style--root--padding-bottom), 20rem);
-		padding-left: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
+		// Don't apply default padding when custom overlay is present.
+		&:not(.has-custom-overlay) {
+			padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);
+			padding-right: clamp(1rem, var(--wp--style--root--padding-right), 20rem);
+			padding-bottom: clamp(1rem, var(--wp--style--root--padding-bottom), 20rem);
+			padding-left: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
+		}
 
 		// Allow modal to scroll.
 		overflow: auto;
@@ -560,10 +563,13 @@ button.wp-block-navigation-item__content {
 		// Give it a z-index just higher than the adminbar.
 		z-index: 100000;
 
-		.wp-block-navigation__responsive-container-content {
-			// Add padding above to accommodate close button.
+		// Add padding above to accommodate close button.
+		// Don't apply default padding when custom overlay is present.
+		&:not(.has-custom-overlay) .wp-block-navigation__responsive-container-content {
 			padding-top: calc(2rem + #{ $navigation-icon-size });
+		}
 
+		.wp-block-navigation__responsive-container-content {
 			// Don't crop the focus style.
 			overflow: visible;
 
@@ -696,13 +702,14 @@ button.wp-block-navigation-item__content {
 }
 
 // Default menu background and font color.
+// Don't apply default colors when custom overlay is present.
 .wp-block-navigation:not(.has-background)
-.wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation__responsive-container.is-menu-open:not(.has-custom-overlay) {
 	background-color: #fff;
 }
 
 .wp-block-navigation:not(.has-text-color)
-.wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation__responsive-container.is-menu-open:not(.has-custom-overlay) {
 	color: #000;
 }
 
@@ -801,7 +808,8 @@ button.wp-block-navigation-item__content {
 
 // Adjust open dialog top margin when admin-bar is visible.
 // Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
-.has-modal-open .admin-bar .is-menu-open .wp-block-navigation__responsive-dialog {
+// Don't apply margin when custom overlay is present.
+.has-modal-open .admin-bar .is-menu-open:not(.has-custom-overlay) .wp-block-navigation__responsive-dialog {
 	margin-top: $admin-bar-height-big;
 
 	// Handle smaller admin-bar.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -499,6 +499,32 @@ button.wp-block-navigation-item__content {
 		align-items: var(--navigation-layout-align, initial);
 	}
 
+	// Desktop and overlay container visibility.
+	// By default, show desktop container and hide overlay container.
+	.wp-block-navigation__desktop-container {
+		display: block;
+	}
+
+	.wp-block-navigation__overlay-container {
+		display: none;
+		width: 100%;
+		// Visually hidden and hidden from assistive tech by default.
+		// aria-hidden is set in the markup.
+	}
+
+	// When menu is closed (not open), show desktop container and hide overlay container.
+	&:not(.is-menu-open) {
+		.wp-block-navigation__responsive-container-content {
+			.wp-block-navigation__desktop-container {
+				display: block;
+			}
+
+			.wp-block-navigation__overlay-container {
+				display: none;
+			}
+		}
+	}
+
 	// If the responsive wrapper is present but overlay is not open,
 	// overlay styles shouldn't apply.
 	&:not(.is-menu-open.is-menu-open) {
@@ -550,6 +576,17 @@ button.wp-block-navigation-item__content {
 
 			// Inherit alignment settings from container.
 			align-items: var(--navigation-layout-justification-setting, inherit);
+
+			// When menu is open at mobile, show overlay container and hide desktop container.
+			.wp-block-navigation__desktop-container {
+				display: none;
+			}
+
+			.wp-block-navigation__overlay-container {
+				display: block;
+				width: 100%;
+				// Remove aria-hidden when visible (handled by JavaScript/Interactivity API).
+			}
 
 			// Always align the contents of the menu to the top.
 			&,
@@ -642,6 +679,17 @@ button.wp-block-navigation-item__content {
 			// Override breakpoint-inherited submenu rules.
 			.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 				left: 0;
+			}
+		}
+
+		// At desktop breakpoint, always show desktop container and hide overlay container.
+		.wp-block-navigation__responsive-container-content {
+			.wp-block-navigation__desktop-container {
+				display: block;
+			}
+
+			.wp-block-navigation__overlay-container {
+				display: none;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -18,6 +18,28 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
+/**
+ * Gets all visible focusable elements within a container.
+ * Filters out elements that are hidden.
+ *
+ * @param {HTMLElement} ref - The container element to search within
+ * @return {HTMLElement[]} Array of visible focusable elements
+ */
+function getFocusableElements( ref ) {
+	const focusableElements = ref.querySelectorAll( focusableSelectors );
+	return Array.from( focusableElements ).filter( ( element ) => {
+		// Use modern checkVisibility API if available (Chrome 105+, Firefox 106+, Safari 17.4+)
+		if ( typeof element.checkVisibility === 'function' ) {
+			return element.checkVisibility( {
+				checkOpacity: false,
+				checkVisibilityCSS: true,
+			} );
+		}
+		// Fallback for older browsers
+		return element.offsetParent !== null;
+	} );
+}
+
 // This is a fix for Safari in iOS/iPadOS. Without it, Safari doesn't focus out
 // when the user taps in the body. It can be removed once we add an overlay to
 // capture the clicks, instead of relying on the focusout event.
@@ -198,8 +220,7 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				if ( state.isMenuOpen ) {
-					const focusableElements =
-						ref.querySelectorAll( focusableSelectors );
+					const focusableElements = getFocusableElements( ref );
 					ctx.modal = ref;
 					ctx.firstFocusableElement = focusableElements[ 0 ];
 					ctx.lastFocusableElement =
@@ -209,8 +230,7 @@ const { state, actions } = store(
 			focusFirstElement() {
 				const { ref } = getElement();
 				if ( state.isMenuOpen ) {
-					const focusableElements =
-						ref.querySelectorAll( focusableSelectors );
+					const focusableElements = getFocusableElements( ref );
 					focusableElements?.[ 0 ]?.focus();
 				}
 			},

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -8,12 +8,6 @@
 
 class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
-		// Navigation block functions are loaded via lib/blocks.php which loads
-		// the built files with prefixed function names. No need to manually require.
-	}
-
 	/**
 	 * Test that navigation links are wrapped in list items to preserve accessible markup
 	 *

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -10,11 +10,8 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
-		// Ensure the navigation block functions are loaded.
-		// Only load if the specific function we need doesn't exist yet.
-		if ( ! function_exists( 'block_core_navigation_block_tree_has_block_type' ) ) {
-			require_once __DIR__ . '/../../packages/block-library/src/navigation/index.php';
-		}
+		// Navigation block functions are loaded via lib/blocks.php which loads
+		// the built files with prefixed function names. No need to manually require.
 	}
 
 	/**
@@ -188,11 +185,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_core_navigation_block_tree_has_block_type finds a block at the top level.
+	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type finds a block at the top level.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers ::gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_finds_top_level_block() {
 		$parsed_blocks = parse_blocks(
@@ -200,7 +197,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_core_navigation_block_tree_has_block_type(
+		$result = gutenberg_block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -209,11 +206,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_core_navigation_block_tree_has_block_type finds a deeply nested block.
+	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type finds a deeply nested block.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers ::gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_finds_nested_block() {
 		$parsed_blocks = parse_blocks(
@@ -233,7 +230,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_core_navigation_block_tree_has_block_type(
+		$result = gutenberg_block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -242,11 +239,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_core_navigation_block_tree_has_block_type returns false when block is not found.
+	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type returns false when block is not found.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers ::gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_returns_false_when_not_found() {
 		$parsed_blocks = parse_blocks(
@@ -254,7 +251,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_core_navigation_block_tree_has_block_type(
+		$result = gutenberg_block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -263,11 +260,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_core_navigation_block_tree_has_block_type skips searching inside specified block types.
+	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type skips searching inside specified block types.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers ::gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_skips_specified_blocks() {
 		$parsed_blocks = parse_blocks(
@@ -280,7 +277,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
 		// Should NOT find the block because it's inside a navigation block which we're skipping
-		$result = block_core_navigation_block_tree_has_block_type(
+		$result = gutenberg_block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-link',
 			array( 'core/navigation' )

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -8,6 +8,12 @@
 
 class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		// Ensure the navigation block functions are loaded.
+		require_once __DIR__ . '/../../packages/block-library/src/navigation/index.php';
+	}
+
 	/**
 	 * Test that navigation links are wrapped in list items to preserve accessible markup
 	 *

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -11,7 +11,10 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		// Ensure the navigation block functions are loaded.
-		require_once __DIR__ . '/../../packages/block-library/src/navigation/index.php';
+		// Only load if the specific function we need doesn't exist yet.
+		if ( ! function_exists( 'block_core_navigation_block_tree_has_block_type' ) ) {
+			require_once __DIR__ . '/../../packages/block-library/src/navigation/index.php';
+		}
 	}
 
 	/**

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -177,4 +177,106 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $actual, $expected );
 		$this->assertCount( 0, $actual );
 	}
+
+	/**
+	 * Test that block_tree_has_block_type finds a block at the top level.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::block_tree_has_block_type
+	 */
+	public function test_gutenberg_block_tree_has_block_type_finds_top_level_block() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:navigation-overlay-close /-->'
+		);
+		$blocks        = new WP_Block_List( $parsed_blocks, array() );
+
+		$result = block_tree_has_block_type(
+			$blocks,
+			'core/navigation-overlay-close'
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that block_tree_has_block_type finds a deeply nested block.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::block_tree_has_block_type
+	 */
+	public function test_gutenberg_block_tree_has_block_type_finds_nested_block() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:group -->
+			<div class="wp-block-group">
+				<!-- wp:columns -->
+				<div class="wp-block-columns">
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:navigation-overlay-close /-->
+					</div>
+					<!-- /wp:column -->
+				</div>
+				<!-- /wp:columns -->
+			</div>
+			<!-- /wp:group -->'
+		);
+		$blocks        = new WP_Block_List( $parsed_blocks, array() );
+
+		$result = block_tree_has_block_type(
+			$blocks,
+			'core/navigation-overlay-close'
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that block_tree_has_block_type returns false when block is not found.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::block_tree_has_block_type
+	 */
+	public function test_gutenberg_block_tree_has_block_type_returns_false_when_not_found() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:heading --><h2>Title</h2><!-- /wp:heading -->'
+		);
+		$blocks        = new WP_Block_List( $parsed_blocks, array() );
+
+		$result = block_tree_has_block_type(
+			$blocks,
+			'core/navigation-overlay-close'
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that block_tree_has_block_type skips searching inside specified block types.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::block_tree_has_block_type
+	 */
+	public function test_gutenberg_block_tree_has_block_type_skips_specified_blocks() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation -->
+			<nav class="wp-block-navigation">
+				<!-- wp:navigation-link /-->
+			</nav>
+			<!-- /wp:navigation -->'
+		);
+		$blocks        = new WP_Block_List( $parsed_blocks, array() );
+
+		// Should NOT find the block because it's inside a navigation block which we're skipping
+		$result = block_tree_has_block_type(
+			$blocks,
+			'core/navigation-link',
+			array( 'core/navigation' )
+		);
+
+		$this->assertFalse( $result );
+	}
 }

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -179,19 +179,19 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_tree_has_block_type finds a block at the top level.
+	 * Test that block_core_navigation_block_tree_has_block_type finds a block at the top level.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_tree_has_block_type
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
-	public function test_gutenberg_block_tree_has_block_type_finds_top_level_block() {
+	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_finds_top_level_block() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:navigation-overlay-close /-->'
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_tree_has_block_type(
+		$result = block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -200,13 +200,13 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_tree_has_block_type finds a deeply nested block.
+	 * Test that block_core_navigation_block_tree_has_block_type finds a deeply nested block.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_tree_has_block_type
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
-	public function test_gutenberg_block_tree_has_block_type_finds_nested_block() {
+	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_finds_nested_block() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:group -->
 			<div class="wp-block-group">
@@ -224,7 +224,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_tree_has_block_type(
+		$result = block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -233,19 +233,19 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_tree_has_block_type returns false when block is not found.
+	 * Test that block_core_navigation_block_tree_has_block_type returns false when block is not found.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_tree_has_block_type
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
-	public function test_gutenberg_block_tree_has_block_type_returns_false_when_not_found() {
+	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_returns_false_when_not_found() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph --><!-- wp:heading --><h2>Title</h2><!-- /wp:heading -->'
 		);
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		$result = block_tree_has_block_type(
+		$result = block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-overlay-close'
 		);
@@ -254,13 +254,13 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that block_tree_has_block_type skips searching inside specified block types.
+	 * Test that block_core_navigation_block_tree_has_block_type skips searching inside specified block types.
 	 *
 	 * @group navigation-renderer
 	 *
-	 * @covers ::block_tree_has_block_type
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
-	public function test_gutenberg_block_tree_has_block_type_skips_specified_blocks() {
+	public function test_gutenberg_block_core_navigation_block_tree_has_block_type_skips_specified_blocks() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:navigation -->
 			<nav class="wp-block-navigation">
@@ -271,7 +271,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
 		// Should NOT find the block because it's inside a navigation block which we're skipping
-		$result = block_tree_has_block_type(
+		$result = block_core_navigation_block_tree_has_block_type(
 			$blocks,
 			'core/navigation-link',
 			array( 'core/navigation' )


### PR DESCRIPTION
## What

This PR implements rendering of custom overlay template parts in the Navigation block, addressing a significant part of #73081. When a custom overlay template part is selected, the block now renders both the standard desktop navigation blocks and the overlay template part blocks, with proper show/hide behavior based on breakpoint and menu state.

## Why

This enables users to create custom overlay designs for mobile navigation while maintaining the standard desktop navigation. The overlay template part can contain any blocks, allowing for fully customized mobile menu experiences.

## How

- Added `get_overlay_blocks_from_template_part()` helper to retrieve blocks from overlay template parts
- Modified `get_responsive_container_markup()` to render both desktop and overlay blocks in separate containers
- Added CSS rules to show/hide desktop and overlay containers based on breakpoint and menu state
- Removed default spacing and colors when custom overlay is present
- Added support for `core/navigation-overlay-close` block as alternative close button
- Conditionally show/hide default close button based on presence of overlay close block
- Added interactivity API directives to overlay close block for closing functionality
- Disabled overlay menu for navigation blocks within overlay template parts to prevent nested overlays
- Added spacing to default close button when rendered within custom overlay

## Markup Changes and Backwards Compatibility

**Important**: The desktop container wrapper (`wp-block-navigation__desktop-container`) is gated behind the `gutenberg-customizable-navigation-overlays` experiment to ensure backward compatibility.

- **With experiment enabled**: Desktop navigation is wrapped in `<div class="wp-block-navigation__desktop-container">` to enable proper show/hide behavior with overlay containers
- **Without experiment enabled**: Desktop navigation markup remains exactly as before (no wrapper div), maintaining full backward compatibility
- This ensures that users without the experiment enabled will not experience any CSS or layout changes to their existing navigation blocks

The experiment gate prevents the markup change from affecting trunk until the feature is ready for general availability. All other functionality (overlay rendering, close button handling, etc.) only activates when an overlay is selected, which the UI prevents unless the experiment is enabled.

## Default/Fallback Scenarios

- When no overlay is selected: Navigation block behaves exactly as before (backward compatible)
- When overlay template part is not found: Falls back to desktop-only rendering
- When overlay has no blocks: Falls back to desktop-only rendering
- Default close button is shown when overlay doesn't contain `core/navigation-overlay-close` block

## Testing Instructions

1. **Overlays containing Nav blocks with overlay set to "Always"**:
   - Create an overlay template part that contains a Navigation block
   - Set the Navigation block's overlay menu to "Always"
   - Verify that the nested Navigation block does NOT render its own overlay (should be disabled to prevent inception)
   - The nested Navigation block should render as a standard navigation without overlay functionality

2. **Overlays with/without Nav Overlay Close block**:
   - **With `core/navigation-overlay-close` block**: Create an overlay template part that includes a `core/navigation-overlay-close` block. Verify that:
     - The default close button is hidden
     - The custom overlay close block can close the overlay when clicked
   - **Without `core/navigation-overlay-close` block**: Create an overlay template part without the close block. Verify that:
     - The default close button is visible and positioned with spacing from edges
     - The default close button can close the overlay when clicked

3. **With and without custom overlay**:
   - **Without custom overlay**: Verify that the Navigation block behaves exactly as before (backward compatible)
     - Desktop navigation displays normally
     - Mobile overlay works with default styling
     - Default close button appears and functions correctly
   - **With custom overlay**: Verify that:
     - Desktop navigation displays normally (desktop container visible)
     - Mobile overlay shows custom overlay content when menu is opened (overlay container visible)
     - Custom overlay content is properly styled (no default padding/colors applied)
     - Both containers are properly hidden/shown based on breakpoint

## Accessibility and SEO Considerations

⚠️ **Important Note**: This implementation renders overlay content directly in the DOM, which may lead to accessibility and SEO concerns:

- **Accessibility**: Overlay content (including any navigation blocks within it) is present in the DOM even when visually hidden. While we use `aria-hidden="true"` by default, this may not be sufficient for all assistive technologies.

- **SEO**: Search engines may index overlay content that is intended to be mobile-only, potentially causing duplicate content issues if the overlay contains navigation blocks.

### Potential Mitigations

To address these concerns, we could consider:

1. **Dynamic `aria-hidden` management**: Use Interactivity API to toggle `aria-hidden` based on breakpoint and menu state (currently only set statically)
2. **`hidden` attribute**: Add `hidden` attribute when overlay is not visible (in addition to CSS display:none)
3. **`inert` attribute**: Use `inert` attribute to make overlay content non-interactive when hidden
4. **Meta tags**: Add `data-noindex` or similar attributes to overlay container when hidden
5. **Lazy loading**: Consider lazy loading overlay content only when menu is opened (future enhancement)

These mitigations should be evaluated and potentially implemented in a follow-up PR based on testing and feedback.