### PR TITLE
TextareaControl: Deprecate bottom margin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -283,7 +283,6 @@ module.exports = {
 						'RangeControl',
 						'SearchControl',
 						'SelectControl',
-						'TextareaControl',
 						'ToggleControl',
 						'ToggleGroupControl',
 						'TreeSelect',

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -70,7 +70,6 @@ export default function AdvancedPanel( {
 			) }
 			<TextareaControl
 				label={ __( 'Additional CSS' ) }
-				__nextHasNoMarginBottom
 				value={ customCSS }
 				onChange={ ( newValue ) => handleOnChange( newValue ) }
 				onBlur={ handleOnBlur }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -297,7 +297,6 @@ export default function CoverInspectorControls( {
 								}
 							>
 								<TextareaControl
-									__nextHasNoMarginBottom
 									label={ __( 'Alternative text' ) }
 									value={ alt }
 									onChange={ ( newAlt ) =>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -200,7 +200,6 @@ function ContentOnlyControls( {
 									</>
 								)
 							}
-							__nextHasNoMarginBottom
 						/>
 					</div>
 				</Popover>
@@ -832,7 +831,6 @@ export default function Image( {
 										</>
 									)
 								}
-								__nextHasNoMarginBottom
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -79,7 +79,6 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>
 							<TextareaControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'LaTeX math syntax' ) }
 								hideLabelFromVision

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -420,7 +420,6 @@ function MediaTextEdit( {
 					onDeselect={ () => setAttributes( { mediaAlt: '' } ) }
 				>
 					<TextareaControl
-						__nextHasNoMarginBottom
 						label={ __( 'Alternative text' ) }
 						value={ mediaAlt }
 						onChange={ onMediaAltChange }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -281,7 +281,6 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				isShownByDefault
 			>
 				<TextareaControl
-					__nextHasNoMarginBottom
 					label={ __( 'Description' ) }
 					value={ description || '' }
 					onChange={ ( descriptionValue ) => {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `FormTokenField`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73846](https://github.com/WordPress/gutenberg/pull/73846)).
 -   `CheckboxControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73916](https://github.com/WordPress/gutenberg/pull/73916)).
 -   `TextControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73920](https://github.com/WordPress/gutenberg/pull/73920)).
+-   `TextareaControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73970](https://github.com/WordPress/gutenberg/pull/73970)).
 -   `DimensionControl`: Completely remove deprecated component ([#73944](https://github.com/WordPress/gutenberg/pull/73944)).
 
 ### Enhancements

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -47,7 +47,6 @@ const Form = () => {
 				onChange={ setTextControlValue }
 			/>
 			<TextareaControl
-				__nextHasNoMarginBottom
 				label="TextArea Control"
 				value={ textAreaValue }
 				onChange={ setTextAreaValue }

--- a/packages/components/src/textarea-control/README.md
+++ b/packages/components/src/textarea-control/README.md
@@ -79,7 +79,6 @@ const MyTextareaControl = () => {
 
 	return (
 		<TextareaControl
-		  __nextHasNoMarginBottom
 			label="Text"
 			help="Enter some text"
 			value={ text }
@@ -131,13 +130,6 @@ The number of rows the textarea should contain.
 The current value of the textarea.
 
 -   Required: Yes
-
-#### `__nextHasNoMarginBottom`: `Boolean`
-
-Start opting into the new margin-free styles that will become the default in a future version.
-
--   Required: No
--   Default: `false`
 
 ## Related components
 

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -22,7 +22,8 @@ function UnforwardedTextareaControl(
 	ref: React.ForwardedRef< HTMLTextAreaElement >
 ) {
 	const {
-		__nextHasNoMarginBottom,
+		// @ts-expect-error - Prevent passing this to `textarea`.
+		__nextHasNoMarginBottom: _,
 		label,
 		hideLabelFromVision,
 		value,
@@ -41,8 +42,7 @@ function UnforwardedTextareaControl(
 
 	return (
 		<BaseControl
-			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-			__associatedWPComponentName="TextareaControl"
+			__nextHasNoMarginBottom
 			label={ label }
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ id }
@@ -77,7 +77,6 @@ function UnforwardedTextareaControl(
  *
  *   return (
  *     <TextareaControl
- *       __nextHasNoMarginBottom
  *       label="Text"
  *       help="Enter some text"
  *       value={ text }

--- a/packages/components/src/textarea-control/stories/index.story.tsx
+++ b/packages/components/src/textarea-control/stories/index.story.tsx
@@ -52,7 +52,6 @@ const Template: StoryFn< typeof TextareaControl > = ( {
 
 export const Default: StoryFn< typeof TextareaControl > = Template.bind( {} );
 Default.args = {
-	__nextHasNoMarginBottom: true,
 	label: 'Text',
 	help: 'Enter some text',
 	placeholder: 'Placeholder',

--- a/packages/components/src/textarea-control/types.ts
+++ b/packages/components/src/textarea-control/types.ts
@@ -10,7 +10,7 @@ import type { BaseControlProps } from '../base-control/types';
 
 export type TextareaControlProps = Pick<
 	BaseControlProps,
-	'hideLabelFromVision' | 'help' | 'label' | '__nextHasNoMarginBottom'
+	'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
 	 * A function that receives the new value of the textarea each time it

--- a/packages/components/src/validated-form-controls/components/textarea-control.tsx
+++ b/packages/components/src/validated-form-controls/components/textarea-control.tsx
@@ -17,11 +17,7 @@ const UnforwardedValidatedTextareaControl = (
 		customValidity,
 		markWhenOptional,
 		...restProps
-	}: Omit<
-		React.ComponentProps< typeof TextareaControl >,
-		'__nextHasNoMarginBottom'
-	> &
-		ValidatedControlProps,
+	}: React.ComponentProps< typeof TextareaControl > & ValidatedControlProps,
 	forwardedRef: React.ForwardedRef< HTMLTextAreaElement >
 ) => {
 	const validityTargetRef = useRef< HTMLTextAreaElement >( null );
@@ -34,11 +30,7 @@ const UnforwardedValidatedTextareaControl = (
 			customValidity={ customValidity }
 			getValidityTarget={ () => validityTargetRef.current }
 		>
-			<TextareaControl
-				__nextHasNoMarginBottom
-				ref={ mergedRefs }
-				{ ...restProps }
-			/>
+			<TextareaControl ref={ mergedRefs } { ...restProps } />
 		</ControlWithError>
 	);
 };

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -66,7 +66,6 @@ export default function PostExcerpt( {
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl
-				__nextHasNoMarginBottom
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
 				className="editor-post-excerpt__textarea"

--- a/packages/editor/src/components/post-title/post-title-raw.js
+++ b/packages/editor/src/components/post-title/post-title-raw.js
@@ -79,7 +79,6 @@ function PostTitleRaw( _, forwardedRef ) {
 			autoComplete="off"
 			dir="auto"
 			rows={ 1 }
-			__nextHasNoMarginBottom
 		/>
 	);
 }

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -112,7 +112,6 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					/>
 					<TextareaControl
 						label={ __( 'Alternative text' ) }
-						__nextHasNoMarginBottom
 						value={ editedAlt }
 						onChange={ ( newAlt ) => {
 							setEditedAlt( newAlt );

--- a/packages/media-fields/src/alt_text/index.tsx
+++ b/packages/media-fields/src/alt_text/index.tsx
@@ -19,7 +19,6 @@ const altTextField: Partial< Field< Updatable< Attachment > > > = {
 				value={ data.alt_text || '' }
 				onChange={ ( value ) => onChange( { alt_text: value } ) }
 				rows={ 2 }
-				__nextHasNoMarginBottom
 			/>
 		);
 	},

--- a/packages/media-fields/src/caption/index.tsx
+++ b/packages/media-fields/src/caption/index.tsx
@@ -24,7 +24,6 @@ const captionField: Partial< Field< Updatable< Attachment > > > = {
 				value={ getRawContent( data.caption ) || '' }
 				onChange={ ( value ) => onChange( { caption: value } ) }
 				rows={ 2 }
-				__nextHasNoMarginBottom
 			/>
 		);
 	},

--- a/packages/media-fields/src/description/index.tsx
+++ b/packages/media-fields/src/description/index.tsx
@@ -26,7 +26,6 @@ const descriptionField: Partial< Field< Updatable< Attachment > > > = {
 				value={ getRawContent( data.description ) || '' }
 				onChange={ ( value ) => onChange( { description: value } ) }
 				rows={ 5 }
-				__nextHasNoMarginBottom
 			/>
 		);
 	},


### PR DESCRIPTION
## What?

Part of #73848

Remove the deprecated `__nextHasNoMarginBottom` prop from `TextareaControl`, making the margin-free styles the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0. This removes the prop, completing the deprecation cycle.

## How?

- Remove the `__nextHasNoMarginBottom` prop from `TextareaControl` and its types and docs.
- Remove all usages of the prop across the codebase.

## Testing Instructions

Smoke test the affected components in Storybook and the app.

