### PR TITLE
Classic Themes: Enable Fonts and thus global styles

### DIFF
--- a/backport-changelog/7.0/10623.md
+++ b/backport-changelog/7.0/10623.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10623
+
+* https://github.com/WordPress/gutenberg/pull/73971

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -41,53 +41,33 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		}
 	}
 
-	if ( wp_theme_has_theme_json() ) {
-		$block_classes = array(
-			'css'            => 'styles',
-			'__unstableType' => 'theme',
-			'isGlobalStyles' => true,
-		);
-		$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
-		if ( '' !== $actual_css ) {
-			$block_classes['css'] = $actual_css;
-			$global_styles[]      = $block_classes;
-		}
-
-		// Get any additional css from the customizer and add it before global styles custom CSS.
-		$global_styles[] = array(
-			'css'            => wp_get_custom_css(),
-			'__unstableType' => 'user',
-			'isGlobalStyles' => false,
-		);
-
-		/*
-		 * Add the custom CSS as a separate stylesheet so any invalid CSS
-		 * entered by users does not break other global styles.
-		 */
-		$global_styles[] = array(
-			'css'            => gutenberg_get_global_stylesheet( array( 'custom-css' ) ),
-			'__unstableType' => 'user',
-			'isGlobalStyles' => true,
-		);
-	} else {
-		// If there is no `theme.json` file, ensure base layout styles are still available.
-		$block_classes = array(
-			'css'            => 'base-layout-styles',
-			'__unstableType' => 'base-layout',
-			'isGlobalStyles' => true,
-		);
-		$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
-		if ( '' !== $actual_css ) {
-			$block_classes['css'] = $actual_css;
-			$global_styles[]      = $block_classes;
-		}
-		// Get any additional css from the customizer.
-		$global_styles[] = array(
-			'css'            => wp_get_custom_css(),
-			'__unstableType' => 'user',
-			'isGlobalStyles' => false,
-		);
+	$block_classes = array(
+		'css'            => 'styles',
+		'__unstableType' => 'theme',
+		'isGlobalStyles' => true,
+	);
+	$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
+	if ( '' !== $actual_css ) {
+		$block_classes['css'] = $actual_css;
+		$global_styles[]      = $block_classes;
 	}
+
+	// Get any additional css from the customizer and add it before global styles custom CSS.
+	$global_styles[] = array(
+		'css'            => wp_get_custom_css(),
+		'__unstableType' => 'user',
+		'isGlobalStyles' => false,
+	);
+
+	/*
+	 * Add the custom CSS as a separate stylesheet so any invalid CSS
+	 * entered by users does not break other global styles.
+	 */
+	$global_styles[] = array(
+		'css'            => gutenberg_get_global_stylesheet( array( 'custom-css' ) ),
+		'__unstableType' => 'user',
+		'isGlobalStyles' => true,
+	);
 
 	$settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1397,6 +1397,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *                       - 'scope' that makes sure all style are scoped to a given selector
 	 *                       - `root_selector` which overwrites and forces a given selector to be used on the root node
 	 *                       - `skip_root_layout_styles` which omits root layout styles from the generated stylesheet.
+	 *                       - `base_layout_styles` which when true generates only base layout styles without alignment rules. Defaults to false.
 	 *                       - `include_block_style_variations` which includes CSS for block style variations.
 	 * @return string The resulting stylesheet.
 	 */
@@ -1451,7 +1452,7 @@ class WP_Theme_JSON_Gutenberg {
 
 		if ( in_array( 'styles', $types, true ) ) {
 			if ( false !== $root_style_key && empty( $options['skip_root_layout_styles'] ) ) {
-				$stylesheet .= $this->get_root_layout_rules( $style_nodes[ $root_style_key ]['selector'], $style_nodes[ $root_style_key ] );
+				$stylesheet .= $this->get_root_layout_rules( $style_nodes[ $root_style_key ]['selector'], $style_nodes[ $root_style_key ], $options );
 			}
 			$stylesheet .= $this->get_block_classes( $style_nodes );
 		}
@@ -1688,9 +1689,10 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0
 	 *
 	 * @param array $block_metadata Metadata about the block to get styles for.
+	 * @param array $options        Optional. An array of options for now used for internal purposes only.
 	 * @return string Layout styles for the block.
 	 */
-	protected function get_layout_styles( $block_metadata ) {
+	protected function get_layout_styles( $block_metadata, $options = array() ) {
 		$block_rules = '';
 		$block_type  = null;
 
@@ -1836,9 +1838,9 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( $base_style_rules as $base_style_rule ) {
 						$declarations = array();
 
-						// Skip outputting base styles for flow and constrained layout types for classic themes without theme.json.
+						// Skip outputting base styles for flow and constrained layout types when base_layout_styles is enabled.
 						// These themes don't use .wp-site-blocks wrapper, so these layout-specific alignment styles aren't needed.
-						if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() && ( 'default' === $layout_definition['name'] || 'constrained' === $layout_definition['name'] ) ) {
+						if ( ! empty( $options['base_layout_styles'] ) && ( 'default' === $layout_definition['name'] || 'constrained' === $layout_definition['name'] ) ) {
 							continue;
 						}
 
@@ -3166,11 +3168,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0
 	 * @since 6.6.0 Use `ROOT_CSS_PROPERTIES_SELECTOR` for CSS custom properties.
 	 *
-	 * @param string $selector The root node selector.
+	 * @param string $selector       The root node selector.
 	 * @param array  $block_metadata The metadata for the root block.
+	 * @param array  $options        Optional. An array of options. Default empty array.
 	 * @return string The additional root rules CSS.
 	 */
-	public function get_root_layout_rules( $selector, $block_metadata ) {
+	public function get_root_layout_rules( $selector, $block_metadata, $options = array() ) {
 		$css              = '';
 		$settings         = $this->theme_json['settings'] ?? array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
@@ -3211,9 +3214,9 @@ class WP_Theme_JSON_Gutenberg {
 			$css .= '.has-global-padding :where(:not(.alignfull.is-layout-flow) > .has-global-padding:not(.wp-block-block, .alignfull)) > .alignfull { margin-left: 0; margin-right: 0; }';
 		}
 
-		// Skip outputting alignment styles for classic themes without theme.json.
+		// Skip outputting alignment styles when base_layout_styles is enabled.
 		// These styles target .wp-site-blocks which is only used by block themes.
-		if ( wp_is_block_theme() || wp_theme_has_theme_json() ) {
+		if ( empty( $options['base_layout_styles'] ) ) {
 			$css .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
 			$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 			$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
@@ -3229,7 +3232,7 @@ class WP_Theme_JSON_Gutenberg {
 			// For backwards compatibility, ensure the legacy block gap CSS variable is still available.
 			$css .= static::ROOT_CSS_PROPERTIES_SELECTOR . " { --wp--style--block-gap: $block_gap_value; }";
 		}
-		$css .= $this->get_layout_styles( $block_metadata );
+		$css .= $this->get_layout_styles( $block_metadata, $options );
 
 		return $css;
 	}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1690,7 +1690,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $block_metadata Metadata about the block to get styles for.
 	 * @return string Layout styles for the block.
 	 */
-	protected function get_layout_styles( $block_metadata, $types = array() ) {
+	protected function get_layout_styles( $block_metadata ) {
 		$block_rules = '';
 		$block_type  = null;
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1390,7 +1390,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *                       - `variables`: only the CSS Custom Properties for presets & custom ones.
 	 *                       - `styles`: only the styles section in theme.json.
 	 *                       - `presets`: only the classes for the presets.
-	 *                       - `base-layout-styles`: only the base layout styles.
 	 *                       - `custom-css`: only the custom CSS.
 	 * @param array $origins A list of origins to include. By default it includes VALID_ORIGINS.
 	 * @param array $options An array of options for now used for internal purposes only (may change without notice).
@@ -1455,40 +1454,6 @@ class WP_Theme_JSON_Gutenberg {
 				$stylesheet .= $this->get_root_layout_rules( $style_nodes[ $root_style_key ]['selector'], $style_nodes[ $root_style_key ] );
 			}
 			$stylesheet .= $this->get_block_classes( $style_nodes );
-		} elseif ( in_array( 'base-layout-styles', $types, true ) ) {
-			$root_selector          = static::ROOT_BLOCK_SELECTOR;
-			$columns_selector       = '.wp-block-columns';
-			$post_template_selector = '.wp-block-post-template';
-			if ( ! empty( $options['scope'] ) ) {
-				$root_selector          = static::scope_selector( $options['scope'], $root_selector );
-				$columns_selector       = static::scope_selector( $options['scope'], $columns_selector );
-				$post_template_selector = static::scope_selector( $options['scope'], $post_template_selector );
-			}
-			if ( ! empty( $options['root_selector'] ) ) {
-				$root_selector = $options['root_selector'];
-			}
-			// Base layout styles are provided as part of `styles`, so only output separately if explicitly requested.
-			// For backwards compatibility, the Columns block is explicitly included, to support a different default gap value.
-			$base_styles_nodes = array(
-				array(
-					'path'     => array( 'styles' ),
-					'selector' => $root_selector,
-				),
-				array(
-					'path'     => array( 'styles', 'blocks', 'core/columns' ),
-					'selector' => $columns_selector,
-					'name'     => 'core/columns',
-				),
-				array(
-					'path'     => array( 'styles', 'blocks', 'core/post-template' ),
-					'selector' => $post_template_selector,
-					'name'     => 'core/post-template',
-				),
-			);
-
-			foreach ( $base_styles_nodes as $base_style_node ) {
-				$stylesheet .= $this->get_layout_styles( $base_style_node, $types );
-			}
 		}
 
 		if ( in_array( 'presets', $types, true ) ) {
@@ -1871,8 +1836,9 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( $base_style_rules as $base_style_rule ) {
 						$declarations = array();
 
-						// Skip outputting base styles for flow and constrained layout types if theme doesn't support theme.json. The 'base-layout-styles' type flags this.
-						if ( in_array( 'base-layout-styles', $types, true ) && ( 'default' === $layout_definition['name'] || 'constrained' === $layout_definition['name'] ) ) {
+						// Skip outputting base styles for flow and constrained layout types for classic themes without theme.json.
+						// These themes don't use .wp-site-blocks wrapper, so these layout-specific alignment styles aren't needed.
+						if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() && ( 'default' === $layout_definition['name'] || 'constrained' === $layout_definition['name'] ) ) {
 							continue;
 						}
 
@@ -3245,9 +3211,14 @@ class WP_Theme_JSON_Gutenberg {
 			$css .= '.has-global-padding :where(:not(.alignfull.is-layout-flow) > .has-global-padding:not(.wp-block-block, .alignfull)) > .alignfull { margin-left: 0; margin-right: 0; }';
 		}
 
-		$css .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
-		$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
-		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+		// Skip outputting alignment styles for classic themes without theme.json.
+		// These styles target .wp-site-blocks which is only used by block themes.
+		if ( wp_is_block_theme() || wp_theme_has_theme_json() ) {
+			$css .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
+			$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
+			$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+		}
+
 		// Block gap styles will be output unless explicitly set to `null`. See static::PROTECTED_PROPERTIES.
 		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -459,17 +459,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$theme = wp_get_theme();
 		}
 
-		/*
-		 * Bail early if the theme does not support a theme.json.
-		 *
-		 * Since wp_theme_has_theme_json only supports the active
-		 * theme, the extra condition for whether $theme is the active theme is
-		 * present here.
-		 */
-		if ( $theme->get_stylesheet() === get_stylesheet() && ! wp_theme_has_theme_json() ) {
-			return array();
-		}
-
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
 		$stylesheet       = $theme->get_stylesheet();

--- a/lib/compat/wordpress-7.0/global-styles.php
+++ b/lib/compat/wordpress-7.0/global-styles.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * WordPress 7.0 compatibility functions for Global Styles.
+ *
+ * Overrides WordPress Core functions to enable full global styles support
+ * (including fonts) for classic themes without theme.json.
+ *
+ * @package gutenberg
+ */
+
+// Remove WordPress Core's wp_print_font_faces action.
+remove_action( 'wp_head', 'wp_print_font_faces', 50 );
+
+/**
+ * Gets font-face styles CSS for fonts from Gutenberg's global styles.
+ *
+ * WordPress Core's wp_print_font_faces() relies on wp_get_global_settings()
+ * which excludes custom origin for classic themes. This function uses
+ * Gutenberg's settings resolver to include user-customized fonts.
+ *
+ * @since Gutenberg 20.0.0
+ * @return string Font-face CSS.
+ */
+function gutenberg_get_font_face_styles() {
+	// Get settings using Gutenberg's resolver with custom origin.
+	$settings = gutenberg_get_global_settings();
+
+	// Bail out early if there are no font settings.
+	if ( empty( $settings['typography']['fontFamilies'] ) ) {
+		return '';
+	}
+
+	// Parse fonts from settings.
+	$fonts = array();
+	foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
+		foreach ( $font_families as $definition ) {
+			// Skip if "fontFace" is not defined, meaning there are no variations.
+			if ( empty( $definition['fontFace'] ) ) {
+				continue;
+			}
+
+			// Skip if "fontFamily" is not defined.
+			if ( empty( $definition['fontFamily'] ) ) {
+				continue;
+			}
+
+			$font_family_name = $definition['fontFamily'];
+			// Parse font-family name from comma-separated lists.
+			if ( str_contains( $font_family_name, ',' ) ) {
+				$font_family_name = explode( ',', $font_family_name )[0];
+			}
+			$font_family_name = trim( $font_family_name, "\"'" );
+
+			// Skip if no font family is defined.
+			if ( empty( $font_family_name ) ) {
+				continue;
+			}
+
+			// Convert font face properties.
+			$converted_font_faces = array();
+			foreach ( $definition['fontFace'] as $font_face ) {
+				// Add the font-family property to the font-face.
+				$font_face['font-family'] = $font_family_name;
+
+				// Convert camelCase to kebab-case.
+				$converted_face = array();
+				foreach ( $font_face as $key => $value ) {
+					$kebab_case                  = _wp_to_kebab_case( $key );
+					$converted_face[ $kebab_case ] = $value;
+				}
+
+				$converted_font_faces[] = $converted_face;
+			}
+
+			$fonts[] = $converted_font_faces;
+		}
+	}
+
+	if ( empty( $fonts ) ) {
+		return '';
+	}
+
+	// Use WordPress Core's WP_Font_Face class to generate the CSS.
+	if ( ! class_exists( 'WP_Font_Face' ) ) {
+		return '';
+	}
+
+	// WP_Font_Face only has generate_and_print(), so use output buffering to capture.
+	ob_start();
+	$wp_font_face = new WP_Font_Face();
+	$wp_font_face->generate_and_print( $fonts );
+	$css = ob_get_clean();
+
+	// Remove the wrapping <style> tags if present, we'll add our own.
+	$css = preg_replace( '/<\/?style[^>]*>/', '', $css );
+
+	return trim( $css );
+}
+
+/**
+ * Prints font-face styles for fonts on the frontend.
+ *
+ * @since Gutenberg 20.0.0
+ */
+function gutenberg_print_font_faces() {
+	$font_face_styles = gutenberg_get_font_face_styles();
+	if ( ! empty( $font_face_styles ) ) {
+		printf( "<style id='wp-fonts-local'>\n%s\n</style>\n", $font_face_styles );
+	}
+}
+add_action( 'wp_head', 'gutenberg_print_font_faces', 50 );
+
+/**
+ * Adds font-face styles to block editor settings.
+ *
+ * @since Gutenberg 20.0.0
+ *
+ * @param array $settings Block editor settings.
+ * @return array Modified settings.
+ */
+function gutenberg_add_font_face_styles_to_editor( $settings ) {
+	$font_face_styles = gutenberg_get_font_face_styles();
+
+	if ( ! empty( $font_face_styles ) ) {
+		// Add font faces as a style entry in the editor settings.
+		if ( ! isset( $settings['styles'] ) ) {
+			$settings['styles'] = array();
+		}
+
+		// Insert font faces at the beginning so they load before other styles.
+		array_unshift(
+			$settings['styles'],
+			array(
+				'css'            => $font_face_styles,
+				'__unstableType' => 'font-faces',
+				'isGlobalStyles' => false,
+			)
+		);
+	}
+
+	return $settings;
+}
+// Run after gutenberg_get_block_editor_settings() which runs at priority 0.
+add_filter( 'block_editor_settings_all', 'gutenberg_add_font_face_styles_to_editor', 5 );

--- a/lib/compat/wordpress-7.0/global-styles.php
+++ b/lib/compat/wordpress-7.0/global-styles.php
@@ -65,7 +65,7 @@ function gutenberg_get_font_face_styles() {
 				// Convert camelCase to kebab-case.
 				$converted_face = array();
 				foreach ( $font_face as $key => $value ) {
-					$kebab_case                  = _wp_to_kebab_case( $key );
+					$kebab_case                    = _wp_to_kebab_case( $key );
 					$converted_face[ $kebab_case ] = $value;
 				}
 

--- a/lib/experimental/fonts/load.php
+++ b/lib/experimental/fonts/load.php
@@ -11,10 +11,6 @@ add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item' );
  * Registers the Fonts menu item under Appearance using the font-library page.
  */
 function gutenberg_register_fonts_menu_item() {
-	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() ) {
-		return;
-	}
-
 	add_submenu_page(
 		'themes.php',
 		__( 'Fonts', 'gutenberg' ),

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -69,7 +69,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * at a later phase (render cycle) so we only render the ones in use.
 		 * @see wp_add_global_styles_for_blocks
 		 */
-		$origins = array( 'default', 'theme', 'custom' );
+		$origins     = array( 'default', 'theme', 'custom' );
 		$styles_rest = $tree->get_stylesheet( $types, $origins );
 	}
 	$stylesheet = $styles_variables . $styles_rest;

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -30,10 +30,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 
-	$supports_theme_json = wp_theme_has_theme_json();
-	if ( empty( $types ) && ! $supports_theme_json ) {
-		$types = array( 'variables', 'presets', 'base-layout-styles' );
-	} elseif ( empty( $types ) ) {
+	if ( empty( $types ) ) {
 		$types = array( 'variables', 'presets', 'styles' );
 	}
 
@@ -73,16 +70,6 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins = array( 'default', 'theme', 'custom' );
-
-		/*
-		* If the theme doesn't have theme.json but supports both appearance tools and color palette,
-		* the 'theme' origin should be included so color palette presets are also output.
-		*/
-		if ( ! $supports_theme_json && ( current_theme_supports( 'appearance-tools' ) || current_theme_supports( 'border' ) ) && current_theme_supports( 'editor-color-palette' ) ) {
-			$origins = array( 'default', 'theme' );
-		} elseif ( ! $supports_theme_json ) {
-			$origins = array( 'default' );
-		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );
 	}
 	$stylesheet = $styles_variables . $styles_rest;
@@ -120,10 +107,7 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 
 	// This is the default value when no origin is provided or when it is 'all'.
 	$origin = 'custom';
-	if (
-		! wp_theme_has_theme_json() ||
-		( isset( $context['origin'] ) && 'base' === $context['origin'] )
-	) {
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
 	}
 
@@ -159,10 +143,6 @@ function gutenberg_get_global_styles_custom_css() {
 		}
 	}
 
-	if ( ! wp_theme_has_theme_json() ) {
-		return '';
-	}
-
 	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$stylesheet = $tree->get_custom_css();
 
@@ -182,9 +162,6 @@ function gutenberg_get_global_styles_custom_css() {
  */
 function gutenberg_get_global_styles_base_custom_css() {
 	_deprecated_function( __FUNCTION__, 'Gutenberg 18.6.0', 'gutenberg_get_global_stylesheet' );
-	if ( ! wp_theme_has_theme_json() ) {
-		return '';
-	}
 
 	$can_use_cached = ! WP_DEBUG;
 
@@ -219,7 +196,7 @@ function gutenberg_add_global_styles_block_custom_css() {
 	_deprecated_function( __FUNCTION__, 'Gutenberg 18.6.0', 'gutenberg_add_global_styles_for_blocks' );
 	global $wp_styles;
 
-	if ( ! wp_theme_has_theme_json() || ! wp_should_load_separate_core_block_assets() ) {
+	if ( ! wp_should_load_separate_core_block_assets() ) {
 		return;
 	}
 

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -33,6 +33,15 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	}
 
 	/*
+	 * Enable base layout styles only mode for classic themes without theme.json.
+	 * This skips alignment styles that target .wp-site-blocks which is only used by block themes.
+	 */
+	$options = array();
+	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() ) {
+		$options['base_layout_styles'] = true;
+	}
+
+	/*
 	 * If variables are part of the stylesheet,
 	 * we add them.
 	 *
@@ -49,7 +58,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins          = array( 'default', 'theme', 'custom' );
-		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
+		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins, $options );
 		$types            = array_diff( $types, array( 'variables' ) );
 	}
 
@@ -68,7 +77,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins     = array( 'default', 'theme', 'custom' );
-		$styles_rest = $tree->get_stylesheet( $types, $origins );
+		$styles_rest = $tree->get_stylesheet( $types, $origins, $options );
 	}
 	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -10,9 +10,7 @@
  *
  * @param array $types Types of styles to load. Optional.
  *                     See {@see 'WP_Theme_JSON::get_stylesheet'} for all valid types.
- *                     If empty, it'll load the following:
- *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.
- *                     - for themes with theme.json: 'variables', 'presets', 'styles'.
+ *                     If empty, will load: 'variables', 'presets', 'styles'.
  *
  * @return string Stylesheet.
  */

--- a/lib/load.php
+++ b/lib/load.php
@@ -66,6 +66,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-static-templates-controller.php';
 	require __DIR__ . '/compat/wordpress-7.0/template-activate.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
+	require __DIR__ . '/compat/wordpress-7.0/global-styles.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -44,38 +44,36 @@ function gutenberg_enqueue_global_styles() {
 
 	$stylesheet = gutenberg_get_global_stylesheet();
 
-	if ( $is_block_theme ) {
-		/*
-		 * Dequeue the Customizer's custom CSS
-		 * and add it before the global styles custom CSS.
-		 */
-		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+	/*
+	 * Dequeue the Customizer's custom CSS
+	 * and add it before the global styles custom CSS.
+	 */
+	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 
-		/*
-		 * Get the custom CSS from the Customizer and add it to the global stylesheet.
-		 * Always do this in Customizer preview for the sake of live preview since it be empty.
-		 */
-		$custom_css = trim( wp_get_custom_css() );
-		if ( $custom_css || is_customize_preview() ) {
-			if ( is_customize_preview() ) {
-				/*
-				 * When in the Customizer preview, wrap the Custom CSS in milestone comments to allow customize-preview.js
-				 * to locate the CSS to replace for live previewing. Make sure that the milestone comments are omitted from
-				 * the stored Custom CSS if by chance someone tried to add them, which would be highly unlikely, but it
-				 * would break live previewing.
-				 */
-				$before_milestone = '/*BEGIN_CUSTOMIZER_CUSTOM_CSS*/';
-				$after_milestone  = '/*END_CUSTOMIZER_CUSTOM_CSS*/';
-				$custom_css       = str_replace( array( $before_milestone, $after_milestone ), '', $custom_css );
-				$custom_css       = $before_milestone . "\n" . $custom_css . "\n" . $after_milestone;
-			}
-			$custom_css = "\n" . $custom_css;
+	/*
+	 * Get the custom CSS from the Customizer and add it to the global stylesheet.
+	 * Always do this in Customizer preview for the sake of live preview since it be empty.
+	 */
+	$custom_css = trim( wp_get_custom_css() );
+	if ( $custom_css || is_customize_preview() ) {
+		if ( is_customize_preview() ) {
+			/*
+			 * When in the Customizer preview, wrap the Custom CSS in milestone comments to allow customize-preview.js
+			 * to locate the CSS to replace for live previewing. Make sure that the milestone comments are omitted from
+			 * the stored Custom CSS if by chance someone tried to add them, which would be highly unlikely, but it
+			 * would break live previewing.
+			 */
+			$before_milestone = '/*BEGIN_CUSTOMIZER_CUSTOM_CSS*/';
+			$after_milestone  = '/*END_CUSTOMIZER_CUSTOM_CSS*/';
+			$custom_css       = str_replace( array( $before_milestone, $after_milestone ), '', $custom_css );
+			$custom_css       = $before_milestone . "\n" . $custom_css . "\n" . $after_milestone;
 		}
-		$stylesheet .= $custom_css;
-
-		// Add the global styles custom CSS at the end.
-		$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+		$custom_css = "\n" . $custom_css;
 	}
+	$stylesheet .= $custom_css;
+
+	// Add the global styles custom CSS at the end.
+	$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
 
 	if ( empty( $stylesheet ) ) {
 		return;
@@ -98,9 +96,6 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  */
 function gutenberg_enqueue_global_styles_custom_css() {
 	_deprecated_function( __FUNCTION__, 'Gutenberg 17.8.0', 'gutenberg_enqueue_global_styles' );
-	if ( ! wp_is_block_theme() ) {
-		return;
-	}
 
 	// Don't enqueue Customizer's custom CSS separately.
 	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -693,22 +693,22 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles
 	 */
-	public function test_get_user_data_from_wp_global_styles_does_not_run_for_theme_without_support() {
-		// The 'default' theme does not support theme.json.
+	public function test_get_user_data_from_wp_global_styles_runs_for_classic_themes() {
+		// The 'default' theme does not support theme.json (classic theme).
 		switch_theme( 'default' );
 		wp_set_current_user( self::$administrator_id );
 		$theme = wp_get_theme();
 
-		$start_queries = get_num_queries();
-
-		// When theme.json is not supported, the method should not run a query and always return an empty result.
-		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
-		$this->assertEmpty( $user_cpt, 'User CPT is expected to be empty.' );
-		$this->assertSame( 0, get_num_queries() - $start_queries, 'Unexpected SQL query detected for theme without theme.json support.' );
-
+		// Classic themes should now be able to access user global styles data.
+		// When should_create_post is true, it should create a post.
 		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme, true );
-		$this->assertEmpty( $user_cpt, 'User CPT is expected to be empty.' );
-		$this->assertSame( 0, get_num_queries() - $start_queries, 'Unexpected SQL query detected for theme without theme.json support.' );
+		$this->assertIsArray( $user_cpt, 'User CPT should be an array for classic themes.' );
+		$this->assertArrayHasKey( 'ID', $user_cpt, 'User CPT should have an ID for classic themes.' );
+
+		// Clean up the created post.
+		if ( isset( $user_cpt['ID'] ) ) {
+			wp_delete_post( $user_cpt['ID'], true );
+		}
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1206,14 +1206,20 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'blockGap' => null,
 					),
 				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '1em',
+					),
+				),
 			),
 			'default'
 		);
-		$stylesheet = $theme_json->get_stylesheet( array( 'base-layout-styles' ) );
+		// Set base_layout_styles to true to generate only base layout styles without alignment rules.
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'base_layout_styles' => true ) );
 
-		// Note the `base-layout-styles` includes a fallback gap for the Columns block for backwards compatibility.
+		// Verify that layout styles are still generated, but without .wp-site-blocks alignment rules and flow/constrained base styles.
 		$this->assertSameCSS(
-			':where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}',
+			':where(body) { margin: 0; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}',
 			$stylesheet
 		);
 	}
@@ -1231,10 +1237,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$stylesheet = $theme_json->get_stylesheet( array( 'base-layout-styles' ) );
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), array( 'default' ) );
 		remove_theme_support( 'disable-layout-styles' );
 
-		// All Layout styles should be skipped.
+		// All Layout styles should be skipped when disable-layout-styles theme support is added.
 		$this->assertSameCSS(
 			'',
 			$stylesheet


### PR DESCRIPTION
## What?

Closes #64409 

This PR enables the Fonts page for classic themes. That said, the fonts page relies on Global styles working to be able to work properly:

 - We need to be able to save global styles
 - We need global styles to generate CSS properly to be able to use the fonts in posts, pages...

This basically means that by enabling fonts, we're literally enabling all of global styles for classic themes (the UI for global styles remain hidden for the context of this PR).

I tested this briefly using 2019 theme, I installed some fonts, used them in some posts... Things are working decently to be honest. Now, I'm well aware that enabling global styles CSS generation can potentially have some side effects on these themes.

So I'd like some help from folks to test different kind of classic themes to see if this PR impacts frontend rendering in any way. Also check that you can install fonts and use them.
