### PR TITLE
Try: Responsive table scroll visual cue, alternative

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -244,13 +244,13 @@
 				// This buffer is necessary to prevent the border from being cropped by overflow-y: clip;.
 				// When set to half a pixel, it ensures the figure element is the same height as the table.
 				margin: 1px 0;
-				transform: translateY(2px);
 			}
 
 			&::before {
 				left: 0;
 				margin-block-end: calc(-infinity * 1px);
 				background: linear-gradient(90deg, var(--scroll-cue-color), transparent);
+				transform: translateY(-2px);
 			}
 
 			&::after {
@@ -258,6 +258,7 @@
 				left: calc(100% - var(--scroll-cue-size));
 				margin-block-start: calc(-infinity * 1px);
 				background: linear-gradient(-90deg, var(--scroll-cue-color), transparent);
+				transform: translateY(2px);
 			}
 		}
 	}

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -7,7 +7,32 @@
 	$subtle-pale-blue: #e7f5fe;
 	$subtle-pale-pink: #fcf0ef;
 
+	// Allow scrolling overflow, with visual cue.
 	overflow-x: auto;
+	animation: scroll-shadow linear;
+	animation-timeline: scroll(self inline);
+
+	--scroll-shadow-color: color-mix(in srgb, currentColor 15%, transparent);
+	--scroll-shadow-width: 6px;
+	--scroll-shadow-height: min(96px, 80%);
+
+	@keyframes scroll-shadow {
+		// Leftmost - only right shadow.
+		0% {
+			background: radial-gradient(farthest-side at right, var(--scroll-shadow-color), transparent) right center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
+		}
+		0.1%,
+		99.9% {
+			// Middle - both shadows.
+			background:
+				radial-gradient(farthest-side at left, var(--scroll-shadow-color), transparent) left center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat,
+				radial-gradient(farthest-side at right, var(--scroll-shadow-color), transparent) right center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
+		}
+		// Rightmost - only left shadow.
+		100% {
+			background: radial-gradient(farthest-side at left, var(--scroll-shadow-color), transparent) left center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
+		}
+	}
 
 	table {
 		border-collapse: collapse;

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -242,7 +242,8 @@
 				animation-timeline: --scroll-timeline;
 
 				// This buffer is necessary to prevent the border from being cropped by overflow-y: clip;.
-				padding: 1px 0;
+				// When set to half a pixel, it ensures the figure element is the same height as the table.
+				padding: 0.5px 0;
 			}
 
 			&::before {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -7,32 +7,8 @@
 	$subtle-pale-blue: #e7f5fe;
 	$subtle-pale-pink: #fcf0ef;
 
-	// Allow scrolling overflow, with visual cue.
+	// Allow scrolling overflow.
 	overflow-x: auto;
-	animation: scroll-shadow linear;
-	animation-timeline: scroll(self inline);
-
-	--scroll-shadow-color: color-mix(in srgb, currentColor 15%, transparent);
-	--scroll-shadow-width: 6px;
-	--scroll-shadow-height: min(96px, 80%);
-
-	@keyframes scroll-shadow {
-		// Leftmost - only right shadow.
-		0% {
-			background: radial-gradient(farthest-side at right, var(--scroll-shadow-color), transparent) right center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
-		}
-		0.1%,
-		99.9% {
-			// Middle - both shadows.
-			background:
-				radial-gradient(farthest-side at left, var(--scroll-shadow-color), transparent) left center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat,
-				radial-gradient(farthest-side at right, var(--scroll-shadow-color), transparent) right center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
-		}
-		// Rightmost - only left shadow.
-		100% {
-			background: radial-gradient(farthest-side at left, var(--scroll-shadow-color), transparent) left center / var(--scroll-shadow-width) var(--scroll-shadow-height) no-repeat;
-		}
-	}
 
 	table {
 		border-collapse: collapse;
@@ -225,6 +201,62 @@
 		td {
 			border-width: inherit;
 			border-style: inherit;
+		}
+	}
+}
+
+// Progressive enhancement: show scroll cues when table overflows horizontally.
+@media ( prefers-reduced-motion: no-preference ) {
+	@supports ( animation-timeline: scroll() ) {
+		.wp-block-table {
+			--scroll-cue-color: color-mix(in srgb, currentColor 10%, transparent);
+			--scroll-cue-size: 1rem;
+
+			@keyframes scroll-cue {
+				0% {
+					opacity: 0;
+				}
+				15% {
+					opacity: 1;
+				}
+				100% {
+					opacity: 1;
+				}
+			}
+
+			position: relative;
+			overflow-y: clip;
+			scroll-timeline-name: --scroll-timeline;
+			scroll-timeline-axis: inline;
+
+			&::before,
+			&::after {
+				content: "";
+				position: sticky;
+				display: block;
+				width: var(--scroll-cue-size);
+				height: calc(infinity * 1px);
+				opacity: 0;
+				pointer-events: none;
+				animation-name: scroll-cue;
+				animation-timeline: --scroll-timeline;
+
+				// This buffer is necessary to prevent the border from being cropped by overflow-y: clip;.
+				padding: 1px 0;
+			}
+
+			&::before {
+				left: 0;
+				margin-block-end: calc(-infinity * 1px);
+				background: linear-gradient(90deg, var(--scroll-cue-color), transparent);
+			}
+
+			&::after {
+				animation-direction: reverse;
+				left: calc(100% - var(--scroll-cue-size));
+				margin-block-start: calc(-infinity * 1px);
+				background: linear-gradient(-90deg, var(--scroll-cue-color), transparent);
+			}
 		}
 	}
 }

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -243,7 +243,8 @@
 
 				// This buffer is necessary to prevent the border from being cropped by overflow-y: clip;.
 				// When set to half a pixel, it ensures the figure element is the same height as the table.
-				padding: 0.5px 0;
+				margin: 1px 0;
+				transform: translateY(2px);
 			}
 
 			&::before {


### PR DESCRIPTION
## What?

Alternative to #73961. Closes #8401.

This is a different approach to solving the same issue as outlined in 73961, showing a visual cue that you can scroll horizontally. This one uses an animated background, locked to scrolling. That is subject to some decent but [not perfect browser support](https://caniuse.com/mdn-css_properties_animation-timeline_scroll), making this a **progressive enhancement** unlike 73961.

![scroll](https://github.com/user-attachments/assets/acf410be-f6c4-4430-8546-6e90cb24608a)

I don't love the visual style of this shadow, it feels very opinionated. But I think if we tinker with the variables, we can get it fairly generic, and the shadow is still the same color as the _text color_, so it will work in any color context.

## Testing Instructions

Test this branch with this markup:

```
<!-- wp:table {"hasFixedLayout":false} -->
<figure class="wp-block-table"><table><tbody><tr><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td><td>testtest</td></tr></tbody></table></figure>
<!-- /wp:table -->
```