### PR TITLE
Template Activation: Make template edit test less flaky

### DIFF
--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -71,6 +71,12 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
+		// Ensure save button is enabled before saving.
+		const saveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } );
+		await expect( saveButton ).toBeEnabled();
+
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty:
 				! experiments.includes( 'active_templates' ),
@@ -85,6 +91,12 @@ test.describe( 'Template ID Format', () => {
 			attributes: { content: secondEditText },
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
+
+		// Ensure save button is enabled before saving.
+		const secondSaveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } );
+		await expect( secondSaveButton ).toBeEnabled();
 
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -26,6 +26,9 @@ async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
 		.click();
 	await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
 	await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
+	// Wait for editor to be fully ready before proceeding.
+	// eslint-disable-next-line playwright/no-networkidle
+	await page.waitForLoadState( 'networkidle' );
 
 	await editor.setPreferences( 'core/edit-post', {
 		welcomeGuideTemplate: false,
@@ -71,11 +74,9 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
-		// Ensure save button is enabled before saving.
-		const saveButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save' } );
-		await expect( saveButton ).toBeEnabled();
+		// Wait a moment for editor to register the change and be ready to save.
+		// eslint-disable-next-line playwright/no-networkidle
+		await page.waitForLoadState( 'networkidle' );
 
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty:
@@ -92,11 +93,9 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		// Ensure save button is enabled before saving.
-		const secondSaveButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save' } );
-		await expect( secondSaveButton ).toBeEnabled();
+		// Wait a moment for editor to register the change and be ready to save.
+		// eslint-disable-next-line playwright/no-networkidle
+		await page.waitForLoadState( 'networkidle' );
 
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -26,9 +26,6 @@ async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
 		.click();
 	await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
 	await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
-	// Wait for editor to be fully ready before proceeding.
-	// eslint-disable-next-line playwright/no-networkidle
-	await page.waitForLoadState( 'networkidle' );
 
 	await editor.setPreferences( 'core/edit-post', {
 		welcomeGuideTemplate: false,

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -74,10 +74,6 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
-		// Wait a moment for editor to register the change and be ready to save.
-		// eslint-disable-next-line playwright/no-networkidle
-		await page.waitForLoadState( 'networkidle' );
-
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty:
 				! experiments.includes( 'active_templates' ),
@@ -93,13 +89,20 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		// Wait a moment for editor to register the change and be ready to save.
-		// eslint-disable-next-line playwright/no-networkidle
-		await page.waitForLoadState( 'networkidle' );
-
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
+		const editorTopBar = page.getByRole( 'region', {
+			name: 'Editor top bar',
 		} );
+		const saveButton = editorTopBar.getByRole( 'button', {
+			name: 'Save',
+			exact: true,
+		} );
+		await saveButton.click();
+
+		await page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.getByText( /(updated|published)\./ )
+			.first()
+			.waitFor();
 	};
 
 	test( 'should open and edit templates correctly when active_templates experiment is enabled', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73752

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Attempts to fix this test to make it less flaky.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checks that the save button is enabled before attempting to save the template edits.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

All tests should pass first time.
