### PR TITLE
Fonts: Improve initial rendering

### DIFF
--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -7,7 +7,7 @@ import type { ComponentType } from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { Page } from '@wordpress/admin-ui';
 import {
 	privateApis as routePrivateApis,
@@ -52,29 +52,33 @@ function NotFoundComponent() {
  * @param parentRoute Parent route.
  * @return Tanstack Route.
  */
-async function createRouteFromDefinition(
-	route: Route,
-	parentRoute: AnyRoute
-) {
-	let routeConfig: RouteConfig = {};
-
-	if ( route.route_module ) {
-		const module = await import( route.route_module );
-		routeConfig = module.route || {};
-	}
-
+function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
 	// Create route without component initially
 	let tanstackRoute = createRoute( {
 		getParentRoute: () => parentRoute,
 		path: route.path,
-		beforeLoad: routeConfig.beforeLoad
-			? ( opts: any ) =>
-					routeConfig.beforeLoad!( {
+		beforeLoad: async ( opts: any ) => {
+			// Import route module here (lazy)
+			if ( route.route_module ) {
+				const module = await import( route.route_module );
+				const routeConfig = module.route || {};
+
+				if ( routeConfig.beforeLoad ) {
+					return routeConfig.beforeLoad( {
 						params: opts.params || {},
 						search: opts.search || {},
-					} )
-			: undefined,
+					} );
+				}
+			}
+		},
 		loader: async ( opts: any ) => {
+			// Import route module here (lazy)
+			let routeConfig: RouteConfig = {};
+			if ( route.route_module ) {
+				const module = await import( route.route_module );
+				routeConfig = module.route || {};
+			}
+
 			const context: RouteLoaderContext = {
 				params: opts.params || {},
 				search: opts.deps || {},
@@ -154,7 +158,7 @@ async function createRouteFromDefinition(
  * @param rootComponent Root component to use for the router.
  * @return Router tree.
  */
-async function createRouteTree(
+function createRouteTree(
 	routes: Route[],
 	rootComponent: ComponentType = Root
 ) {
@@ -163,9 +167,9 @@ async function createRouteTree(
 		context: () => ( {} ),
 	} );
 
-	// Create routes from definitions
-	const dynamicRoutes = await Promise.all(
-		routes.map( ( route ) => createRouteFromDefinition( route, rootRoute ) )
+	// Create routes from definitions (now synchronous)
+	const dynamicRoutes = routes.map( ( route ) =>
+		createRouteFromDefinition( route, rootRoute )
 	);
 
 	return rootRoute.addChildren( dynamicRoutes );
@@ -197,37 +201,28 @@ export default function Router( {
 	routes,
 	rootComponent = Root,
 }: RouterProps ) {
-	const [ router, setRouter ] = useState< any >( null );
+	const router = useMemo( () => {
+		const history = createPathHistory();
+		const routeTree = createRouteTree( routes, rootComponent );
 
-	useEffect( () => {
-		let cancelled = false;
+		return createRouter( {
+			history,
+			routeTree,
+			defaultPreload: 'intent',
+			defaultNotFoundComponent: NotFoundComponent,
+			defaultViewTransition: {
+				types: ( { fromLocation } ) => {
+					// Disable view transition on initial navigation (no previous location)
+					if ( ! fromLocation ) {
+						return false;
+					}
 
-		async function initializeRouter() {
-			const history = createPathHistory();
-			const routeTree = await createRouteTree( routes, rootComponent );
-
-			if ( ! cancelled ) {
-				const newRouter = createRouter( {
-					history,
-					routeTree,
-					defaultPreload: 'intent',
-					defaultNotFoundComponent: NotFoundComponent,
-					defaultViewTransition: true,
-				} );
-				setRouter( newRouter );
-			}
-		}
-
-		initializeRouter();
-
-		return () => {
-			cancelled = true;
-		};
+					// Enable with navigation type for subsequent navigations
+					return [ 'navigate' ];
+				},
+			},
+		} );
 	}, [ routes, rootComponent ] );
-
-	if ( ! router ) {
-		return <div>Loading routes...</div>;
-	}
 
 	return <RouterProvider router={ router } />;
 }

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -211,7 +211,15 @@ export default function Router( {
 			defaultPreload: 'intent',
 			defaultNotFoundComponent: NotFoundComponent,
 			defaultViewTransition: {
-				types: ( { fromLocation } ) => {
+				types: ( {
+					fromLocation,
+				}: {
+					fromLocation?: unknown;
+					toLocation: unknown;
+					pathChanged: boolean;
+					hrefChanged: boolean;
+					hashChanged: boolean;
+				} ) => {
 					// Disable view transition on initial navigation (no previous location)
 					if ( ! fromLocation ) {
 						return false;

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -3,19 +3,6 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-// Fix issue with wp-admin menu not scrolling between 170% and 200% zoom.
-#wpwrap {
-	background: var(--wpds-color-fg-content-neutral, #1e1e1e);
-	overflow-y: auto;
-	@include break-medium() {
-		overflow-y: initial;
-	}
-}
-
-body:has(.boot-layout-container) {
-	@include wp-admin-reset( ".boot-layout-container" );
-}
-
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke
 	// the overscroll bounce on the non-scrolling container, for a bad experience.

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -218,6 +218,59 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page' ) ) {
 	 */
 	function {{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 		?>
+		<style>
+			/* Critical styles to prevent layout shifts - inlined for immediate application */
+
+			/* Background colors */
+			#wpwrap {
+				background: var(--wpds-color-fg-content-neutral, #1e1e1e);
+				overflow-y: auto;
+			}
+			body {
+				background: #fff;
+			}
+
+			/* Reset wp-admin padding */
+			#wpcontent {
+				padding-left: 0;
+			}
+			#wpbody-content {
+				padding-bottom: 0;
+			}
+
+			/* Hide legacy admin elements */
+			#wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
+				display: none;
+			}
+			#wpfooter {
+				display: none;
+			}
+
+			/* Accessibility regions */
+			.a11y-speak-region {
+				left: -1px;
+				top: -1px;
+			}
+
+			/* Admin menu indicators */
+			ul#adminmenu a.wp-has-current-submenu::after,
+			ul#adminmenu > li.current > a.current::after {
+				border-right-color: #fff;
+			}
+
+			/* Media frame fix */
+			.media-frame select.attachment-filters:last-of-type {
+				width: auto;
+				max-width: 100%;
+			}
+
+			/* Responsive overflow fix for #wpwrap */
+			@media (min-width: 782px) {
+				#wpwrap {
+					overflow-y: initial;
+				}
+			}
+		</style>
 		<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
 		<?php
 	}


### PR DESCRIPTION
## What?

Related #70862 

This improves the initial loading of the font library page to reduce the number of layout shifts:

 - Moves the WP-Admin reset styles to inline styles (that way they're rendered before the page loads).
 - Synchronously build the router object.
 - Avoid initial animation.

## Testing instructions

 - Load fonts
 - Compare with trunk
 - Less layout shifts