### PR TITLE
Add/style variations system

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -45,6 +45,28 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 	 * @since 5.9.0
 	 */
 	public function register_routes() {
+		// Collection endpoint for listing and creating global styles (including style variations).
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+				'schema'      => array( $this, 'get_public_item_schema' ),
+				'allow_batch' => $this->allow_batch,
+			)
+		);
+
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)/variations',
@@ -104,7 +126,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 			true
 		);
 
-		// Lists/updates a single global style variation based on the given id.
+		// Lists/updates/deletes a single global style variation based on the given id.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\/\w-]+)',
@@ -126,6 +148,23 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => array(
+						'id'    => array(
+							'description'       => __( 'The id of a template', 'gutenberg' ),
+							'type'              => 'string',
+							'sanitize_callback' => array( $this, '_sanitize_global_styles_callback' ),
+						),
+						'force' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Whether to bypass Trash and force deletion.', 'gutenberg' ),
+						),
+					),
 				),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 				'allow_batch' => $this->allow_batch,
@@ -458,14 +497,219 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 	}
 
 	/**
-	 * Retrieves the query params for the global styles collection.
+	 * Checks if a given request has access to read global styles.
 	 *
-	 * @since 5.9.0
+	 * @since 7.0.0
 	 *
-	 * @return array Collection parameters.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_collection_params() {
-		return array();
+	public function get_items_permissions_check( $request ) {
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_cannot_read_global_styles',
+			__( 'Sorry, you are not allowed to access global styles.', 'gutenberg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Retrieves a collection of style variations.
+	 *
+	 * Returns all wp_global_styles posts that are style variations
+	 * (identified by _wp_style_variation meta).
+	 * Excludes the main theme global styles entry.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$args = array(
+			'post_type'      => $this->post_type,
+			'post_status'    => 'publish',
+			'posts_per_page' => 100, // We need to set up a data views interface for this
+			'meta_query'     => array(
+				array(
+					'key'   => '_wp_style_variation',
+					'value' => '1',
+				),
+			),
+		);
+
+		$query           = new WP_Query( $args );
+		$style_variations = array();
+
+		foreach ( $query->posts as $post ) {
+			$data               = $this->prepare_item_for_response( $post, $request );
+			$style_variations[] = $this->prepare_response_for_collection( $data );
+		}
+
+		return rest_ensure_response( $style_variations );
+	}
+
+	/**
+	 * Checks if a given request has access to create a global style.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has create access, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_cannot_create_global_styles',
+			__( 'Sorry, you are not allowed to create global styles.', 'gutenberg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Creates a new style variation.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$title = '';
+		if ( isset( $request['title'] ) ) {
+			if ( is_string( $request['title'] ) ) {
+				$title = sanitize_text_field( $request['title'] );
+			} elseif ( ! empty( $request['title']['raw'] ) ) {
+				$title = sanitize_text_field( $request['title']['raw'] );
+			}
+		}
+
+		// We are only using titles for idenitifcation in the UI
+		if ( empty( $title ) ) {
+			return new WP_Error(
+				'rest_empty_title',
+				__( 'Style variation title cannot be empty.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$content = array(
+			'version'                     => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+		);
+
+		// Include settings and styles if provided.
+		if ( isset( $request['settings'] ) ) {
+			$content['settings'] = $request['settings'];
+		}
+		if ( isset( $request['styles'] ) ) {
+			$content['styles'] = $request['styles'];
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_content' => wp_json_encode( $content ),
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_type'    => $this->post_type,
+				'post_name'    => 'wp-style-variation-' . sanitize_title( $title ),
+				'meta_input'   => array(
+					'_wp_style_variation' => true,
+				),
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$post     = get_post( $post_id );
+		$response = $this->prepare_item_for_response( $post, $request );
+		$response = rest_ensure_response( $response );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $post_id ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Checks if a given request has access to delete a global style.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has delete access, WP_Error object otherwise.
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$post = $this->get_post( $request['id'] );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		// Only allow deleting style variations, not the main global styles.
+		$is_style_variation = get_post_meta( $post->ID, '_wp_style_variation', true );
+		if ( ! $is_style_variation ) {
+			return new WP_Error(
+				'rest_cannot_delete_global_styles',
+				__( 'Sorry, you can only delete style variations, not the main global styles.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_cannot_delete_global_styles',
+				__( 'Sorry, you are not allowed to delete this global style.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deletes a style variation.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		$post = $this->get_post( $request['id'] );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+
+		$previous = $this->prepare_item_for_response( $post, $request );
+		$result   = wp_delete_post( $post->ID, $force );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'rest_cannot_delete',
+				__( 'The variation cannot be deleted.', 'gutenberg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
+		);
+
+		return $response;
 	}
 
 	/**

--- a/lib/experimental/style-variations.php
+++ b/lib/experimental/style-variations.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Style Variations define reusable global styles that can be linked
+ * to post types (posts, pages, templates, etc.).
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Meta key used to identify style variations (against main global styles).
+ */
+define( 'GUTENBERG_STYLE_VARIATION_META_KEY', '_wp_style_variation' );
+
+/**
+ * Meta key used on posts/templates to reference a connected style variation.
+ * TODO: this could use a better name, like _wp_style_variation_id
+ */
+define( 'GUTENBERG_CONNECTED_STYLE_VARIATION_META_KEY', '_wp_connected_style_variation' );
+
+/**
+ * Register meta for style variations.
+ */
+function gutenberg_register_style_variation_meta() {
+	// Meta to identify a wp_global_styles post as a style variation.
+	register_post_meta(
+		'wp_global_styles',
+		GUTENBERG_STYLE_VARIATION_META_KEY,
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'default'       => false,
+			'auth_callback' => function () {
+				return current_user_can( 'edit_theme_options' );
+			},
+		)
+	);
+
+	// Meta to connect posts/pages/templates to a style variation.
+	$post_types = array( 'post', 'page', 'wp_template', 'wp_template_part', 'wp_block' );
+	foreach ( $post_types as $post_type ) {
+		register_post_meta(
+			$post_type,
+			GUTENBERG_CONNECTED_STYLE_VARIATION_META_KEY,
+			array(
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'integer',
+				'default'       => 0,
+				'auth_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+}
+add_action( 'init', 'gutenberg_register_style_variation_meta' );
+
+/**
+ * Get a style variation by ID.
+ *
+ * @param int $style_variation_id The style variation post ID.
+ * @return array|null The style variation data or null if not found.
+ */
+function gutenberg_get_style_variation( $style_variation_id ) {
+	$post = get_post( $style_variation_id );
+
+	if ( ! $post || 'wp_global_styles' !== $post->post_type ) {
+		return null;
+	}
+
+	// Verify it's a style variation.
+	$is_style_variation = get_post_meta( $style_variation_id, GUTENBERG_STYLE_VARIATION_META_KEY, true );
+	if ( ! $is_style_variation ) {
+		return null;
+	}
+
+	return array(
+		'id'      => $post->ID,
+		'title'   => $post->post_title,
+		'content' => json_decode( $post->post_content, true ),
+	);
+}
+
+/**
+ * Get the connected style variation ID for a post.
+ *
+ * @param int $post_id The post ID.
+ * @return int The connected style variation ID, or 0 if none.
+ */
+function gutenberg_get_connected_style_variation_id( $post_id ) {
+	return (int) get_post_meta( $post_id, GUTENBERG_CONNECTED_STYLE_VARIATION_META_KEY, true );
+}
+
+/**
+ * Get a WP_Theme_JSON_Gutenberg object from a style variation's content.
+ *
+ * @param array $style_variation The style variation data.
+ * @return WP_Theme_JSON_Gutenberg The theme JSON object.
+ */
+function gutenberg_get_style_variation_theme_json( $style_variation ) {
+	$content = $style_variation['content'];
+
+	// Ensure content is valid.
+	if ( ! is_array( $content ) ) {
+		$content = array();
+	}
+
+	// Remove the flag that marks it as user theme JSON.
+	unset( $content['isGlobalStylesUserThemeJSON'] );
+
+	return new WP_Theme_JSON_Gutenberg( $content, 'custom' );
+}
+
+/**
+ * Add style variation data to the block editor settings.
+ *
+ * This provides the editor with information about connected style variations
+ * so it can load the correct styles via the JavaScript side.
+ *
+ * @param array $settings The block editor settings.
+ * @return array Modified settings.
+ */
+function gutenberg_add_style_variations_to_editor_settings( $settings ) {
+	$post_id = 0;
+
+	// Get the post ID from the editor context.
+	if ( isset( $settings['postId'] ) ) {
+		$post_id = $settings['postId'];
+	}
+
+	if ( ! $post_id ) {
+		return $settings;
+	}
+
+	// Get the connected style variation for this post.
+	$connected_style_variation_id = gutenberg_get_connected_style_variation_id( $post_id );
+
+	$settings['connectedStyleVariationId'] = $connected_style_variation_id;
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_add_style_variations_to_editor_settings' );
+
+/**
+ * Enqueue style variation CSS on the frontend.
+ *
+ * This ensures connected style variations are properly applied on singular pages.
+ */
+function gutenberg_enqueue_style_variation_css() {
+	// Only run on singular pages.
+	if ( ! is_singular() ) {
+		return;
+	}
+
+	$post_id = get_the_ID();
+	if ( ! $post_id ) {
+		return;
+	}
+
+	// Get the connected style variation.
+	$style_variation_id = gutenberg_get_connected_style_variation_id( $post_id );
+	if ( ! $style_variation_id ) {
+		return;
+	}
+
+	$style_variation = gutenberg_get_style_variation( $style_variation_id );
+	if ( ! $style_variation || empty( $style_variation['content'] ) ) {
+		return;
+	}
+
+	// Generate CSS from the style variation.
+	$style_variation_json = gutenberg_get_style_variation_theme_json( $style_variation );
+	$css                  = $style_variation_json->get_stylesheet( array( 'styles', 'presets', 'variables' ) );
+
+	if ( empty( $css ) ) {
+		return;
+	}
+
+	// Output the CSS.
+	wp_register_style( 'gutenberg-style-variation-' . $style_variation_id, false );
+	wp_enqueue_style( 'gutenberg-style-variation-' . $style_variation_id );
+	wp_add_inline_style( 'gutenberg-style-variation-' . $style_variation_id, $css );
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_style_variation_css', 100 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -117,6 +117,7 @@ require __DIR__ . '/experimental/synchronization.php';
 require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/gutenberg-boot.php';
 require __DIR__ . '/experimental/fonts/load.php';
+require __DIR__ . '/experimental/style-variations.php';
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-workflow-palette' ) ) {
 	require __DIR__ . '/experimental/workflow-palette.php';

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -16,8 +16,12 @@ import { seen } from '@wordpress/icons';
  */
 import { unlock } from '../../lock-unlock';
 
-const { GlobalStylesUIWrapper, GlobalStylesActionMenu } =
-	unlock( editorPrivateApis );
+const {
+	GlobalStylesUIWrapper,
+	GlobalStylesActionMenu,
+	StyleVariationSelector,
+	useStyleVariations,
+} = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const GlobalStylesPageActions = ( {
@@ -25,11 +29,26 @@ const GlobalStylesPageActions = ( {
 	setIsStyleBookOpened,
 	path,
 	onChangeSection,
+	selectedStyleVariation,
+	onSelectStyleVariation,
 } ) => {
 	const history = useHistory();
 
+	const openStyleBook = () => {
+		if ( ! isStyleBookOpened ) {
+			setIsStyleBookOpened( true );
+			const updatedPath = addQueryArgs( path, { preview: 'stylebook' } );
+			history.navigate( updatedPath );
+		}
+	};
+
 	return (
 		<HStack>
+			<StyleVariationSelector
+				selectedStyleVariation={ selectedStyleVariation }
+				onSelect={ onSelectStyleVariation }
+				onOpenStyleBook={ openStyleBook }
+			/>
 			<Button
 				isPressed={ isStyleBookOpened }
 				icon={ seen }
@@ -80,8 +99,20 @@ export default function SidebarGlobalStyles() {
 	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState(
 		path.includes( 'preview=stylebook' )
 	);
+	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState( 0 );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ section, onChangeSection ] = useSection();
+
+	// Get style variations for showing info paragraph.
+	const { styleVariations } = useStyleVariations();
+
+	// Find the selected style variation info.
+	const selectedStyleVariationInfo =
+		selectedStyleVariation !== 0
+			? styleVariations.find(
+					( variation ) => variation.id === selectedStyleVariation
+			  )
+			: null;
 
 	return (
 		<Page
@@ -92,15 +123,23 @@ export default function SidebarGlobalStyles() {
 						setIsStyleBookOpened={ setIsStyleBookOpened }
 						path={ path }
 						onChangeSection={ onChangeSection }
+						selectedStyleVariation={ selectedStyleVariation }
+						onSelectStyleVariation={ setSelectedStyleVariation }
 					/>
 				) : null
 			}
 			className="edit-site-styles"
 			title={ __( 'Styles' ) }
 		>
+			{ selectedStyleVariationInfo && (
+				<p className="edit-site-styles__style-variation-info">
+					{ `Editing "${ selectedStyleVariationInfo.title }" style variation. Changes apply only when this style is connected to a post, page, template, or pattern.` }
+				</p>
+			) }
 			<GlobalStylesUIWrapper
 				path={ section }
 				onPathChange={ onChangeSection }
+				styleVariationId={ selectedStyleVariation }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/sidebar-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles/style.scss
@@ -27,5 +27,30 @@
 	.edit-site-sidebar-button {
 		color: $gray-900;
 	}
+
+	&__style-variation-info {
+		padding: $grid-unit-15 $grid-unit-20;
+		margin: 0;
+		font-size: $helptext-font-size;
+		color: var(--wp-block-synced-color);
+		background: color-mix(in srgb, var(--wp-block-synced-color) 5%, transparent);
+		border-bottom: $border-width solid $gray-200;
+	}
+}
+
+// Style variation selector button - purple styling when a non-main style is selected.
+.is-style-variation-selected.components-button {
+	background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
+	color: var(--wp-block-synced-color);
+
+	&:hover,
+	&:focus {
+		background: color-mix(in srgb, var(--wp-block-synced-color) 20%, transparent);
+		color: var(--wp-block-synced-color);
+	}
+
+	svg {
+		fill: var(--wp-block-synced-color);
+	}
 }
 

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -11,8 +11,11 @@ import { mergeGlobalStyles } from '@wordpress/global-styles-engine';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
+
+const STYLE_VARIATION_META_KEY = '_wp_connected_style_variation';
 
 function useGlobalStylesUserConfig() {
 	const { globalStylesId, isReady, settings, styles, _links } = useSelect(
@@ -173,26 +176,135 @@ function useGlobalStylesBaseConfig() {
 	return [ !! baseConfig, baseConfig ];
 }
 
-export function useGlobalStylesContext() {
+/**
+ * Hook to fetch the connected style variation's config for the current post.
+ * This allows the editor to render with the style variation's styles when a post
+ * is linked to a style variation.
+ *
+ * @param {string} postType Optional post type. If not provided, uses editor store.
+ * @param {string} postId   Optional post ID. If not provided, uses editor store.
+ * @return {Array} Tuple of [isReady, connectedStyleVariationId, styleVariationConfig].
+ */
+function useConnectedStyleVariationConfig( postType, postId ) {
+	// First, get the connected style variation ID from the current post's meta.
+	const connectedStyleVariationId = useSelect(
+		( select ) => {
+			const editorSelectors = select( editorStore );
+
+			// Safely get current post info.
+			const currentPostId =
+				postId ?? editorSelectors?.getCurrentPostId?.();
+			const currentPostType =
+				postType ?? editorSelectors?.getCurrentPostType?.();
+
+			if ( ! currentPostId || ! currentPostType ) {
+				return 0;
+			}
+
+			const { getEditedEntityRecord } = select( coreStore );
+			const post = getEditedEntityRecord(
+				'postType',
+				currentPostType,
+				currentPostId
+			);
+
+			return post?.meta?.[ STYLE_VARIATION_META_KEY ] || 0;
+		},
+		[ postType, postId ]
+	);
+
+	// Separately fetch the style variation if we have an ID.
+	const { styleVariationConfig, isReady } = useSelect(
+		( select ) => {
+			if ( ! connectedStyleVariationId ) {
+				return {
+					styleVariationConfig: null,
+					isReady: true,
+				};
+			}
+
+			const { getEntityRecord, hasFinishedResolution } =
+				select( coreStore );
+
+			// Fetch the style variation.
+			const styleVariation = getEntityRecord(
+				'postType',
+				'wp_global_styles',
+				connectedStyleVariationId
+			);
+
+			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'wp_global_styles',
+				connectedStyleVariationId,
+			] );
+
+			const config =
+				styleVariation && hasResolved
+					? {
+							settings: styleVariation.settings ?? {},
+							styles: styleVariation.styles ?? {},
+					  }
+					: null;
+
+			return {
+				styleVariationConfig: config,
+				isReady: hasResolved,
+			};
+		},
+		[ connectedStyleVariationId ]
+	);
+
+	return [ isReady, connectedStyleVariationId, styleVariationConfig ];
+}
+
+/**
+ * Hook to get the global styles context, including connected style variation if applicable.
+ *
+ * @param {string} postType Optional post type for connected style variation lookup.
+ * @param {string} postId   Optional post ID for connected style variation lookup.
+ * @return {Object} Global styles context.
+ */
+export function useGlobalStylesContext( postType, postId ) {
 	const [ isUserConfigReady, userConfig, setUserConfig ] =
 		useGlobalStylesUserConfig();
 	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
+	const [
+		isStyleVariationReady,
+		connectedStyleVariationId,
+		styleVariationConfig,
+	] = useConnectedStyleVariationConfig( postType, postId );
 
 	const mergedConfig = useMemo( () => {
 		if ( ! baseConfig || ! userConfig ) {
 			return {};
 		}
 
-		return mergeGlobalStyles( baseConfig, userConfig );
-	}, [ userConfig, baseConfig ] );
+		// First merge base with user config (main global styles).
+		const baseUserMerged = mergeGlobalStyles( baseConfig, userConfig );
+
+		// If there's a connected style variation, merge its config on top.
+		if ( connectedStyleVariationId && styleVariationConfig ) {
+			return mergeGlobalStyles( baseUserMerged, styleVariationConfig );
+		}
+
+		return baseUserMerged;
+	}, [
+		userConfig,
+		baseConfig,
+		connectedStyleVariationId,
+		styleVariationConfig,
+	] );
 
 	const context = useMemo( () => {
 		return {
-			isReady: isUserConfigReady && isBaseConfigReady,
+			isReady:
+				isUserConfigReady && isBaseConfigReady && isStyleVariationReady,
 			user: userConfig,
 			base: baseConfig,
 			merged: mergedConfig,
 			setUserConfig,
+			connectedStyleVariationId,
 		};
 	}, [
 		mergedConfig,
@@ -201,6 +313,8 @@ export function useGlobalStylesContext() {
 		setUserConfig,
 		isUserConfigReady,
 		isBaseConfigReady,
+		isStyleVariationReady,
+		connectedStyleVariationId,
 	] );
 
 	return context;

--- a/packages/editor/src/components/global-styles-renderer/index.js
+++ b/packages/editor/src/components/global-styles-renderer/index.js
@@ -8,10 +8,16 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { useGlobalStylesOutput } from '../../hooks/use-global-styles-output';
+import { useGlobalStylesOutputWithConfig } from '../../hooks/use-global-styles-output';
+import { useGlobalStylesContext } from '../global-styles-provider';
 
 function useGlobalStylesRenderer( disableRootPadding ) {
-	const [ styles, settings ] = useGlobalStylesOutput( disableRootPadding );
+	// Use useGlobalStylesContext which includes connected style variation for the current post.
+	const { merged: mergedConfig } = useGlobalStylesContext();
+	const [ styles, settings ] = useGlobalStylesOutputWithConfig(
+		mergedConfig,
+		disableRootPadding
+	);
 	const { getEditorSettings } = useSelect( editorStore );
 	const { updateEditorSettings } = useDispatch( editorStore );
 

--- a/packages/editor/src/components/global-styles-sidebar/index.js
+++ b/packages/editor/src/components/global-styles-sidebar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { FlexItem, Flex, Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { styles, seen, backup } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -16,6 +16,10 @@ import { store as interfaceStore } from '@wordpress/interface';
  */
 import GlobalStylesUI from '../global-styles';
 import { GlobalStylesActionMenu } from '../global-styles/menu';
+import {
+	StyleVariationSelector,
+	useStyleVariations,
+} from '../global-styles/style-variation-selector';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import DefaultSidebar from './default-sidebar';
@@ -29,11 +33,11 @@ export default function GlobalStylesSidebar() {
 		showListViewByDefault,
 		hasRevisions,
 		activeComplementaryArea,
+		selectedStyleVariation,
 	} = useSelect( ( select ) => {
 		const { getActiveComplementaryArea } = select( interfaceStore );
-		const { getStylesPath, getShowStylebook } = unlock(
-			select( editorStore )
-		);
+		const { getStylesPath, getShowStylebook, getSelectedStyleVariationId } =
+			unlock( select( editorStore ) );
 		const _isVisualEditorMode =
 			'visual' === select( editorStore ).getEditorMode();
 		const _showListViewByDefault = select( preferencesStore ).get(
@@ -60,11 +64,15 @@ export default function GlobalStylesSidebar() {
 				!! globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count,
 			activeComplementaryArea:
 				select( interfaceStore ).getActiveComplementaryArea( 'core' ),
+			selectedStyleVariation: getSelectedStyleVariationId(),
 		};
 	}, [] );
-	const { setStylesPath, setShowStylebook, resetStylesNavigation } = unlock(
-		useDispatch( editorStore )
-	);
+	const {
+		setStylesPath,
+		setShowStylebook,
+		resetStylesNavigation,
+		setSelectedStyleVariationId,
+	} = unlock( useDispatch( editorStore ) );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	// Derive state from path and showStylebook
@@ -92,6 +100,17 @@ export default function GlobalStylesSidebar() {
 	}, [ shouldResetNavigation, resetStylesNavigation ] );
 
 	const { setIsListViewOpened } = useDispatch( editorStore );
+
+	// Get style variations for the selector.
+	const { styleVariations } = useStyleVariations();
+
+	// Find the selected style variation info.
+	const selectedStyleVariationInfo =
+		selectedStyleVariation !== 0
+			? styleVariations.find(
+					( variation ) => variation.id === selectedStyleVariation
+			  )
+			: null;
 
 	const toggleRevisions = () => {
 		setIsListViewOpened( false );
@@ -132,6 +151,17 @@ export default function GlobalStylesSidebar() {
 							gap={ 1 }
 							className="editor-global-styles-sidebar__header-actions"
 						>
+							<FlexItem>
+								<StyleVariationSelector
+									selectedStyleVariation={
+										selectedStyleVariation
+									}
+									onSelect={ setSelectedStyleVariationId }
+									onOpenStyleBook={ () =>
+										setShowStylebook( true )
+									}
+								/>
+							</FlexItem>
 							{ ! isMobileViewport && (
 								<FlexItem>
 									<Button
@@ -166,9 +196,21 @@ export default function GlobalStylesSidebar() {
 					</Flex>
 				}
 			>
+				{ selectedStyleVariationInfo && (
+					<p className="editor-global-styles-sidebar__style-variation-info">
+						{ sprintf(
+							/* translators: %s: The name of the style variation being edited. */
+							__(
+								'Editing "%s" style variation. Changes apply only when this style is connected to a post, page, template, or pattern.'
+							),
+							selectedStyleVariationInfo.title
+						) }
+					</p>
+				) }
 				<GlobalStylesUI
 					path={ stylesPath }
 					onPathChange={ setStylesPath }
+					styleVariationId={ selectedStyleVariation }
 				/>
 			</DefaultSidebar>
 			<WelcomeGuideStyles />

--- a/packages/editor/src/components/global-styles-sidebar/style.scss
+++ b/packages/editor/src/components/global-styles-sidebar/style.scss
@@ -120,3 +120,27 @@
 		}
 	}
 }
+
+.is-style-variation-selected.components-button {
+	background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
+	color: var(--wp-block-synced-color);
+
+	&:hover,
+	&:focus {
+		background: color-mix(in srgb, var(--wp-block-synced-color) 20%, transparent);
+		color: var(--wp-block-synced-color);
+	}
+
+	svg {
+		fill: var(--wp-block-synced-color);
+	}
+}
+
+.editor-global-styles-sidebar__style-variation-info {
+	padding: $grid-unit-15 $grid-unit-20;
+	margin: 0;
+	font-size: $helptext-font-size;
+	color: var(--wp-block-synced-color);
+	background: color-mix(in srgb, var(--wp-block-synced-color) 5%, transparent);
+	border-bottom: $border-width solid $gray-200;
+}

--- a/packages/editor/src/components/global-styles/hooks.js
+++ b/packages/editor/src/components/global-styles/hooks.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useCallback } from '@wordpress/element';
+import {
+	useMemo,
+	useCallback,
+	createContext,
+	useContext,
+} from '@wordpress/element';
 import {
 	mergeGlobalStyles,
 	getStyle,
@@ -19,9 +24,17 @@ import { unlock } from '../../lock-unlock';
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 /**
- * Hook to fetch and manage user global styles config
+ * Context for the currently editing style variation ID.
+ * When null or 0, the main global styles is being edited.
  */
-function useGlobalStylesUserConfig() {
+export const StyleVariationContext = createContext( 0 );
+
+/**
+ * Hook to fetch and manage user global styles config
+ *
+ * @param {number} styleVariationId Optional style variation ID. If provided, edits that style variation instead of main styles.
+ */
+function useGlobalStylesUserConfig( styleVariationId = 0 ) {
 	const { globalStylesId, isReady, settings, styles, _links } = useSelect(
 		( select ) => {
 			const {
@@ -30,58 +43,79 @@ function useGlobalStylesUserConfig() {
 				hasFinishedResolution,
 				canUser,
 			} = select( coreStore );
-			const _globalStylesId =
-				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
+
+			// If editing a style variation, use that ID. Otherwise use main global styles.
+			const _globalStylesId = styleVariationId
+				? styleVariationId
+				: select( coreStore ).__experimentalGetCurrentGlobalStylesId();
 
 			let record;
 
-			const userCanEditGlobalStyles = _globalStylesId
-				? canUser( 'update', {
-						kind: 'root',
-						name: 'globalStyles',
-						id: _globalStylesId,
-				  } )
-				: null;
+			// For style variations, use postType entity. For main styles, use root/globalStyles.
+			// Both use the same REST endpoint (/wp/v2/global-styles) but different entity tracking.
+			const entityKind = styleVariationId ? 'postType' : 'root';
+			const entityName = styleVariationId
+				? 'wp_global_styles'
+				: 'globalStyles';
 
-			if (
-				_globalStylesId &&
-				typeof userCanEditGlobalStyles === 'boolean'
-			) {
-				if ( userCanEditGlobalStyles ) {
-					record = getEditedEntityRecord(
-						'root',
-						'globalStyles',
-						_globalStylesId
-					);
-				} else {
-					record = getEntityRecord(
-						'root',
-						'globalStyles',
-						_globalStylesId,
-						{ context: 'view' }
-					);
+			// For style variations, fetch immediately without waiting for canUser.
+			// This avoids a waterfall where we wait for permission check before fetching.
+			if ( styleVariationId && _globalStylesId ) {
+				// Trigger the fetch.
+				getEntityRecord( entityKind, entityName, _globalStylesId );
+				// Use edited record to include local edits.
+				record = getEditedEntityRecord(
+					entityKind,
+					entityName,
+					_globalStylesId
+				);
+			} else if ( _globalStylesId ) {
+				// For main global styles, use the original canUser-gated logic.
+				const userCanEdit = canUser( 'update', {
+					kind: entityKind,
+					name: entityName,
+					id: _globalStylesId,
+				} );
+
+				if ( typeof userCanEdit === 'boolean' ) {
+					getEntityRecord( entityKind, entityName, _globalStylesId );
+
+					if ( userCanEdit ) {
+						record = getEditedEntityRecord(
+							entityKind,
+							entityName,
+							_globalStylesId
+						);
+					} else {
+						record = getEntityRecord(
+							entityKind,
+							entityName,
+							_globalStylesId,
+							{ context: 'view' }
+						);
+					}
 				}
 			}
 
 			let hasResolved = false;
-			if (
+			if ( styleVariationId ) {
+				// For style variations, check if the entity record has resolved.
+				hasResolved = hasFinishedResolution( 'getEntityRecord', [
+					entityKind,
+					entityName,
+					_globalStylesId,
+				] );
+			} else if (
 				hasFinishedResolution(
 					'__experimentalGetCurrentGlobalStylesId'
 				)
 			) {
 				if ( _globalStylesId ) {
-					hasResolved = userCanEditGlobalStyles
-						? hasFinishedResolution( 'getEditedEntityRecord', [
-								'root',
-								'globalStyles',
-								_globalStylesId,
-						  ] )
-						: hasFinishedResolution( 'getEntityRecord', [
-								'root',
-								'globalStyles',
-								_globalStylesId,
-								{ context: 'view' },
-						  ] );
+					hasResolved = hasFinishedResolution( 'getEntityRecord', [
+						entityKind,
+						entityName,
+						_globalStylesId,
+					] );
 				} else {
 					hasResolved = true;
 				}
@@ -95,7 +129,7 @@ function useGlobalStylesUserConfig() {
 				_links: record?._links,
 			};
 		},
-		[]
+		[ styleVariationId ]
 	);
 
 	const { getEditedEntityRecord } = useSelect( coreStore );
@@ -111,9 +145,15 @@ function useGlobalStylesUserConfig() {
 
 	const setConfig = useCallback(
 		( callbackOrObject, options = {} ) => {
+			// For style variations, use postType entity. For main styles, use root/globalStyles.
+			const entityKind = styleVariationId ? 'postType' : 'root';
+			const entityName = styleVariationId
+				? 'wp_global_styles'
+				: 'globalStyles';
+
 			const record = getEditedEntityRecord(
-				'root',
-				'globalStyles',
+				entityKind,
+				entityName,
 				globalStylesId
 			);
 
@@ -128,19 +168,28 @@ function useGlobalStylesUserConfig() {
 					? callbackOrObject( currentConfig )
 					: callbackOrObject;
 
+			// Both style variations and main global styles use the same format.
+			const newStyles = cleanEmptyObject( updatedConfig.styles ) || {};
+			const newSettings =
+				cleanEmptyObject( updatedConfig.settings ) || {};
+
 			editEntityRecord(
-				'root',
-				'globalStyles',
+				entityKind,
+				entityName,
 				globalStylesId,
 				{
-					styles: cleanEmptyObject( updatedConfig.styles ) || {},
-					settings: cleanEmptyObject( updatedConfig.settings ) || {},
-					_links: cleanEmptyObject( updatedConfig._links ) || {},
+					styles: newStyles,
+					settings: newSettings,
 				},
 				options
 			);
 		},
-		[ globalStylesId, editEntityRecord, getEditedEntityRecord ]
+		[
+			globalStylesId,
+			styleVariationId,
+			editEntityRecord,
+			getEditedEntityRecord,
+		]
 	);
 
 	return [ isReady, config, setConfig ];
@@ -161,12 +210,18 @@ function useGlobalStylesBaseConfig() {
 /**
  * Hook to get merged global styles configuration
  *
+ * @param {number} styleVariationId Optional style variation ID. If provided, edits that style variation.
  * @return {Object} Object containing merged, base, user configs and setUser function
  *                  { merged, base, user, setUser }
  */
-export function useGlobalStyles() {
+export function useGlobalStyles( styleVariationId ) {
+	// Use context if no styleVariationId is provided directly.
+	const contextStyleVariationId = useContext( StyleVariationContext );
+	const effectiveStyleVariationId =
+		styleVariationId ?? contextStyleVariationId;
+
 	const [ isUserConfigReady, userConfig, setUserConfig ] =
-		useGlobalStylesUserConfig();
+		useGlobalStylesUserConfig( effectiveStyleVariationId );
 	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
 
 	const merged = useMemo( () => {

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -12,7 +12,7 @@ import { uploadMedia } from '@wordpress/media-utils';
  */
 import { store as editorStore } from '../../store';
 import { GlobalStylesBlockLink } from './block-link';
-import { useGlobalStyles } from './hooks';
+import { useGlobalStyles, StyleVariationContext } from './hooks';
 
 /**
  * Hook to fetch server CSS and settings for BlockEditorProvider that are not Global Styles.
@@ -87,13 +87,17 @@ function useServerData() {
 	return { serverCSS, serverSettings, fontLibraryEnabled };
 }
 
-export default function GlobalStylesUIWrapper( { path, onPathChange } ) {
+export default function GlobalStylesUIWrapper( {
+	path,
+	onPathChange,
+	styleVariationId = 0,
+} ) {
 	const {
 		user: userConfig,
 		base: baseConfig,
 		setUser: setUserConfig,
 		isReady,
-	} = useGlobalStyles();
+	} = useGlobalStyles( styleVariationId );
 	const { serverCSS, serverSettings, fontLibraryEnabled } = useServerData();
 
 	// Show loading state while data is being fetched
@@ -102,7 +106,7 @@ export default function GlobalStylesUIWrapper( { path, onPathChange } ) {
 	}
 
 	return (
-		<>
+		<StyleVariationContext.Provider value={ styleVariationId }>
 			<GlobalStylesUI
 				value={ userConfig }
 				baseValue={ baseConfig || {} }
@@ -117,7 +121,7 @@ export default function GlobalStylesUIWrapper( { path, onPathChange } ) {
 				path={ path }
 				onPathChange={ onPathChange }
 			/>
-		</>
+		</StyleVariationContext.Provider>
 	);
 }
 

--- a/packages/editor/src/components/global-styles/style-variation-selector.js
+++ b/packages/editor/src/components/global-styles/style-variation-selector.js
@@ -1,0 +1,309 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Modal,
+	TextControl,
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useState, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { category, check, plus } from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Hook to fetch and manage style variations.
+ *
+ * Uses the entity system to interact with wp_global_styles post type.
+ * The REST controller at /wp/v2/global-styles handles filtering for style variations.
+ *
+ * @return {Object} Style variations data and actions.
+ */
+export function useStyleVariations() {
+	const { styleVariations, isLoading } = useSelect( ( select ) => {
+		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
+
+		// Fetch style variations via the entity system.
+		// The REST controller's get_items() already filters for _wp_style_variation meta.
+		const records = getEntityRecords( 'postType', 'wp_global_styles', {
+			per_page: 100, // TODO: We need to handle proper limits, pagination, and search
+		} );
+
+		const hasResolved = hasFinishedResolution( 'getEntityRecords', [
+			'postType',
+			'wp_global_styles',
+			{ per_page: 100 },
+		] );
+
+		// Transform to expected format.
+		const transformed = ( records || [] ).map( ( item ) => ( {
+			id: item.id,
+			title: item.title?.rendered || item.title?.raw || '',
+		} ) );
+
+		return {
+			styleVariations: transformed,
+			isLoading: ! hasResolved,
+		};
+	}, [] );
+
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
+
+	const createStyleVariation = useCallback(
+		async ( title ) => {
+			const newVariation = await saveEntityRecord(
+				'postType',
+				'wp_global_styles',
+				{ title, status: 'publish' },
+				{ throwOnError: true }
+			);
+			return {
+				id: newVariation.id,
+				title:
+					newVariation.title?.rendered ||
+					newVariation.title?.raw ||
+					title,
+			};
+		},
+		[ saveEntityRecord ]
+	);
+
+	const deleteStyleVariation = useCallback(
+		async ( id ) => {
+			await deleteEntityRecord( 'postType', 'wp_global_styles', id, {
+				force: true,
+				throwOnError: true,
+			} );
+		},
+		[ deleteEntityRecord ]
+	);
+
+	return {
+		styleVariations,
+		isLoading,
+		createStyleVariation,
+		deleteStyleVariation,
+	};
+}
+
+/**
+ * Modal for creating a new style variation.
+ *
+ * @param {Object}   props          Component props.
+ * @param {boolean}  props.isOpen   Whether the modal is open.
+ * @param {Function} props.onClose  Callback when modal closes.
+ * @param {Function} props.onCreate Callback when style variation is created.
+ * @return {JSX.Element|null} The modal component.
+ */
+function CreateStyleVariationModal( { isOpen, onClose, onCreate } ) {
+	const [ title, setTitle ] = useState( '' );
+	const [ isCreating, setIsCreating ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const handleCreate = async () => {
+		if ( ! title.trim() ) {
+			setError( __( 'Please enter a name for the style variation.' ) );
+			return;
+		}
+
+		setIsCreating( true );
+		setError( null );
+
+		try {
+			await onCreate( title );
+			setTitle( '' );
+			onClose();
+		} catch ( err ) {
+			setError( err.message );
+		} finally {
+			setIsCreating( false );
+		}
+	};
+
+	return (
+		<Modal
+			title={ __( 'Create style variation' ) }
+			onRequestClose={ onClose }
+			size="small"
+		>
+			<VStack spacing={ 4 }>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					placeholder={ __( 'Enter style variation name…' ) }
+					help={ __(
+						'Give your style variation a descriptive name so you can easily identify it later.'
+					) }
+				/>
+				{ error && (
+					<p className="editor-style-variation-selector__error">
+						{ error }
+					</p>
+				) }
+				<HStack justify="flex-end">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ handleCreate }
+						isBusy={ isCreating }
+						disabled={ isCreating || ! title.trim() }
+						accessibleWhenDisabled
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}
+
+/**
+ * Style Variation Selector dropdown component.
+ *
+ * @param {Object}   props                        Component props.
+ * @param {number}   props.selectedStyleVariation The currently selected style variation ID (0 for main).
+ * @param {Function} props.onSelect               Callback when a style variation is selected.
+ * @param {Function} props.onOpenStyleBook        Optional callback to open the Style Book for preview.
+ * @return {JSX.Element} The style variation selector component.
+ */
+export function StyleVariationSelector( {
+	selectedStyleVariation = 0,
+	onSelect,
+	onOpenStyleBook,
+} ) {
+	const { styleVariations, isLoading, createStyleVariation } =
+		useStyleVariations();
+	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
+
+	const selectedVariation = styleVariations.find(
+		( variation ) => variation.id === selectedStyleVariation
+	);
+
+	const handleCreate = async ( title ) => {
+		const newVariation = await createStyleVariation( title );
+		onSelect( newVariation.id );
+		// When creating a new style variation open the Style Book automatically.
+		onOpenStyleBook?.();
+	};
+
+	const handleSelectStyleVariation = ( id ) => {
+		onSelect( id );
+		// When selecting a style variation open the Style Book automatically.
+		if ( id !== 0 ) {
+			onOpenStyleBook?.();
+		}
+	};
+
+	const dropdownLabel = selectedVariation
+		? sprintf(
+				/* translators: %s: style variation name */
+				__( 'Style: %s' ),
+				selectedVariation.title
+		  )
+		: __( 'Default' );
+
+	const isStyleVariationSelected = selectedStyleVariation !== 0;
+
+	return (
+		<>
+			<DropdownMenu
+				icon={ category }
+				label={ __( 'Select Style Variation' ) }
+				toggleProps={ {
+					size: 'compact',
+					showTooltip: true,
+					label: dropdownLabel,
+					className: isStyleVariationSelected
+						? 'is-style-variation-selected'
+						: undefined,
+				} }
+			>
+				{ ( { onClose } ) => (
+					<>
+						<MenuGroup label={ __( 'Style Variations' ) }>
+							<MenuItem
+								role="menuitemradio"
+								isSelected={ selectedStyleVariation === 0 }
+								icon={
+									selectedStyleVariation === 0 ? check : null
+								}
+								onClick={ () => {
+									handleSelectStyleVariation( 0 );
+									onClose();
+								} }
+							>
+								{ __( 'Default' ) }
+							</MenuItem>
+							{ isLoading && (
+								<MenuItem disabled>
+									{ __( 'Loading…' ) }
+								</MenuItem>
+							) }
+							{ ! isLoading &&
+								styleVariations.map( ( styleVariation ) => (
+									<MenuItem
+										key={ styleVariation.id }
+										role="menuitemradio"
+										isSelected={
+											selectedStyleVariation ===
+											styleVariation.id
+										}
+										icon={
+											selectedStyleVariation ===
+											styleVariation.id
+												? check
+												: null
+										}
+										onClick={ () => {
+											handleSelectStyleVariation(
+												styleVariation.id
+											);
+											onClose();
+										} }
+									>
+										{ styleVariation.title }
+									</MenuItem>
+								) ) }
+						</MenuGroup>
+						<MenuGroup>
+							<MenuItem
+								icon={ plus }
+								onClick={ () => {
+									setIsCreateModalOpen( true );
+									onClose();
+								} }
+							>
+								{ __( 'Create new style variation' ) }
+							</MenuItem>
+						</MenuGroup>
+					</>
+				) }
+			</DropdownMenu>
+			<CreateStyleVariationModal
+				isOpen={ isCreateModalOpen }
+				onClose={ () => setIsCreateModalOpen( false ) }
+				onCreate={ handleCreate }
+			/>
+		</>
+	);
+}

--- a/packages/editor/src/components/post-style-variation/index.js
+++ b/packages/editor/src/components/post-style-variation/index.js
@@ -1,0 +1,155 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { check } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelRow from '../post-panel-row';
+import { useStyleVariations } from '../global-styles/style-variation-selector';
+import { store as editorStore } from '../../store';
+
+const STYLE_VARIATION_META_KEY = '_wp_connected_style_variation';
+
+/**
+ * Component to select and connect a style variation to the current post.
+ *
+ * @return {JSX.Element|null} The post style variation selector.
+ */
+export default function PostStyleVariation() {
+	const { styleVariations, isLoading } = useStyleVariations();
+
+	const { postId, postType, connectedStyleVariation } = useSelect(
+		( select ) => {
+			const { getCurrentPostId, getCurrentPostType } =
+				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const currentPostId = getCurrentPostId();
+			const currentPostType = getCurrentPostType();
+
+			const post = getEditedEntityRecord(
+				'postType',
+				currentPostType,
+				currentPostId
+			);
+
+			return {
+				postId: currentPostId,
+				postType: currentPostType,
+				connectedStyleVariation:
+					post?.meta?.[ STYLE_VARIATION_META_KEY ] || 0,
+			};
+		},
+		[]
+	);
+
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			anchor: popoverAnchor,
+			className: 'editor-post-style-variation__dropdown',
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+
+	const handleSelectStyleVariation = ( styleVariationId ) => {
+		editEntityRecord( 'postType', postType, postId, {
+			meta: {
+				[ STYLE_VARIATION_META_KEY ]: styleVariationId,
+			},
+		} );
+	};
+
+	const selectedVariation = styleVariations.find(
+		( variation ) => variation.id === connectedStyleVariation
+	);
+
+	// If we have a connected style variation ID but haven't loaded the style variation
+	// data yet, show a loading message.
+	const getDisplayText = () => {
+		if ( selectedVariation ) {
+			return selectedVariation.title;
+		}
+		if ( connectedStyleVariation && isLoading ) {
+			return __( 'Loading…' );
+		}
+		return __( 'Default' );
+	};
+	const displayText = getDisplayText();
+
+	return (
+		<PostPanelRow label={ __( 'Style' ) } ref={ setPopoverAnchor }>
+			<DropdownMenu
+				popoverProps={ popoverProps }
+				focusOnMount
+				toggleProps={ {
+					size: 'compact',
+					variant: 'tertiary',
+					tooltipPosition: 'middle left',
+				} }
+				label={ __( 'Style variation options' ) }
+				text={ displayText }
+				icon={ null }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup label={ __( 'Style Variations' ) }>
+						<MenuItem
+							role="menuitemradio"
+							isSelected={ connectedStyleVariation === 0 }
+							icon={
+								connectedStyleVariation === 0 ? check : null
+							}
+							onClick={ () => {
+								handleSelectStyleVariation( 0 );
+								onClose();
+							} }
+						>
+							{ __( 'Default' ) }
+						</MenuItem>
+						{ isLoading && (
+							<MenuItem disabled>{ __( 'Loading…' ) }</MenuItem>
+						) }
+						{ ! isLoading &&
+							styleVariations.map( ( styleVariation ) => (
+								<MenuItem
+									key={ styleVariation.id }
+									role="menuitemradio"
+									isSelected={
+										connectedStyleVariation ===
+										styleVariation.id
+									}
+									icon={
+										connectedStyleVariation ===
+										styleVariation.id
+											? check
+											: null
+									}
+									onClick={ () => {
+										handleSelectStyleVariation(
+											styleVariation.id
+										);
+										onClose();
+									} }
+								>
+									{ styleVariation.title }
+								</MenuItem>
+							) ) }
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+		</PostPanelRow>
+	);
+}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -197,7 +197,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		[ postType, postId, isLargeViewport, renderingMode ]
 	);
 
-	const { merged: mergedGlobalStyles } = useGlobalStylesContext();
+	const { merged: mergedGlobalStyles } = useGlobalStylesContext(
+		postType,
+		postId
+	);
 	const globalStylesData = mergedGlobalStyles.styles ?? EMPTY_OBJECT;
 	const globalStylesLinksData = mergedGlobalStyles._links ?? EMPTY_OBJECT;
 

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -22,6 +22,7 @@ import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
 import PostSyncStatus from '../post-sync-status';
 import PostTemplatePanel from '../post-template/panel';
+import PostStyleVariation from '../post-style-variation';
 import PostURLPanel from '../post-url/panel';
 import BlogTitle from '../blog-title';
 import PostsPerPage from '../posts-per-page';
@@ -79,6 +80,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostURLPanel />
 										<PostAuthorPanel />
 										<PostTemplatePanel />
+										<PostStyleVariation />
 										<PostDiscussionPanel />
 										<PrivatePostLastRevision />
 										<PageAttributesPanel />

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -252,9 +252,20 @@ function StyleBook(
 		showTabs = true,
 		userConfig = {},
 		path = '',
+		styleVariationId = 0,
 	},
 	ref
 ) {
+	// Get styles from the selected style variation (or main styles if styleVariationId is 0).
+	const { user: styleVariationConfig, base: baseConfig } =
+		useGlobalStyles( styleVariationId );
+
+	// Use the style variation's config if available, otherwise fall back to passed userConfig.
+	const effectiveUserConfig =
+		styleVariationId && ! isObjectEmpty( styleVariationConfig )
+			? styleVariationConfig
+			: userConfig;
+
 	const textColor = useStyle( 'color.text' );
 	const backgroundColor = useStyle( 'color.background' );
 	const colors = useMultiOriginPalettes();
@@ -271,15 +282,17 @@ function StyleBook(
 
 	const examplesForSinglePageUse = getExamplesForSinglePageUse( examples );
 
-	const { base: baseConfig } = useGlobalStyles();
 	const goTo = getStyleBookNavigationFromPath( path );
 
 	const mergedConfig = useMemo( () => {
-		if ( ! isObjectEmpty( userConfig ) && ! isObjectEmpty( baseConfig ) ) {
-			return mergeGlobalStyles( baseConfig, userConfig );
+		if (
+			! isObjectEmpty( effectiveUserConfig ) &&
+			! isObjectEmpty( baseConfig )
+		) {
+			return mergeGlobalStyles( baseConfig, effectiveUserConfig );
 		}
 		return {};
-	}, [ baseConfig, userConfig ] );
+	}, [ baseConfig, effectiveUserConfig ] );
 
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -291,12 +304,13 @@ function StyleBook(
 		() => ( {
 			...originalSettings,
 			styles:
-				! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
+				! isObjectEmpty( globalStyles ) &&
+				! isObjectEmpty( effectiveUserConfig )
 					? globalStyles
 					: originalSettings.styles,
 			isPreviewMode: true,
 		} ),
-		[ globalStyles, originalSettings, userConfig ]
+		[ globalStyles, originalSettings, effectiveUserConfig ]
 	);
 
 	return (

--- a/packages/editor/src/components/styles-canvas/index.js
+++ b/packages/editor/src/components/styles-canvas/index.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount, useFocusReturn } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';
+
 /**
  * Internal dependencies
  */
@@ -41,25 +42,27 @@ export function getStylesCanvasTitle( path, showStylebook ) {
  * @return {JSX.Element|null} The styles canvas or null if nothing to render.
  */
 export default function StylesCanvas() {
-	const { stylesPath, showStylebook, showListViewByDefault } = useSelect(
-		( select ) => {
-			const { getStylesPath, getShowStylebook } = unlock(
-				select( editorStore )
-			);
+	const {
+		stylesPath,
+		showStylebook,
+		showListViewByDefault,
+		styleVariationId,
+	} = useSelect( ( select ) => {
+		const { getStylesPath, getShowStylebook, getSelectedStyleVariationId } =
+			unlock( select( editorStore ) );
 
-			const _showListViewByDefault = select( preferencesStore ).get(
-				'core',
-				'showListViewByDefault'
-			);
+		const _showListViewByDefault = select( preferencesStore ).get(
+			'core',
+			'showListViewByDefault'
+		);
 
-			return {
-				stylesPath: getStylesPath(),
-				showStylebook: getShowStylebook(),
-				showListViewByDefault: _showListViewByDefault,
-			};
-		},
-		[]
-	);
+		return {
+			stylesPath: getStylesPath(),
+			showStylebook: getShowStylebook(),
+			showListViewByDefault: _showListViewByDefault,
+			styleVariationId: getSelectedStyleVariationId(),
+		};
+	}, [] );
 	const { resetStylesNavigation, setStylesPath } = unlock(
 		useDispatch( editorStore )
 	);
@@ -76,6 +79,7 @@ export default function StylesCanvas() {
 			<StylesCanvasStyleBook
 				path={ stylesPath }
 				onPathChange={ setStylesPath }
+				styleVariationId={ styleVariationId }
 				ref={ sectionFocusReturnRef }
 			/>
 		);

--- a/packages/editor/src/components/styles-canvas/style-book.js
+++ b/packages/editor/src/components/styles-canvas/style-book.js
@@ -13,16 +13,21 @@ import { STYLE_BOOK_COLOR_GROUPS } from '../style-book/constants';
  * Style Book content component for global styles.
  * Provides the business logic for StyleBook behavior in the global styles context.
  *
- * @param {Object}                       props              Component props.
- * @param {string}                       props.path         Current path in global styles.
- * @param {Function}                     props.onPathChange Callback when the path changes.
- * @param {import('react').ForwardedRef} ref                Ref to the Style Book component.
+ * @param {Object}                       props                  Component props.
+ * @param {string}                       props.path             Current path in global styles.
+ * @param {Function}                     props.onPathChange     Callback when the path changes.
+ * @param {number}                       props.styleVariationId Optional style variation ID for preview.
+ * @param {import('react').ForwardedRef} ref                    Ref to the Style Book component.
  * @return {JSX.Element} The Style Book component.
  */
-function StylesCanvasStyleBook( { path, onPathChange }, ref ) {
+function StylesCanvasStyleBook(
+	{ path, onPathChange, styleVariationId = 0 },
+	ref
+) {
 	return (
 		<StyleBook
 			ref={ ref }
+			styleVariationId={ styleVariationId }
 			isSelected={ ( blockName ) =>
 				// Match '/blocks/core%2Fbutton' and
 				// '/blocks/core%2Fbutton/typography', but not

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -2,6 +2,11 @@
  * WordPress dependencies
  */
 import * as interfaceApis from '@wordpress/interface';
+import {
+	CreateTemplatePartModal,
+	patternTitleField,
+	templateTitleField,
+} from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -18,17 +23,16 @@ import usePostFields from './components/post-fields';
 import ToolsMoreMenuGroup from './components/more-menu/tools-more-menu-group';
 import ViewMoreMenuGroup from './components/more-menu/view-more-menu-group';
 import ResizableEditor from './components/resizable-editor';
-import {
-	CreateTemplatePartModal,
-	patternTitleField,
-	templateTitleField,
-} from '@wordpress/fields';
 import { registerCoreBlockBindingsSources } from './bindings/api';
 import { getTemplateInfo } from './utils/get-template-info';
 import GlobalStylesUIWrapper from './components/global-styles';
 import { StyleBookPreview } from './components/style-book';
 import { useGlobalStyles, useStyle } from './components/global-styles/hooks';
 import { GlobalStylesActionMenu } from './components/global-styles/menu';
+import {
+	StyleVariationSelector,
+	useStyleVariations,
+} from './components/global-styles/style-variation-selector';
 import {
 	useGenerateBlockPath,
 	useRestoreBlockFromPath,
@@ -57,6 +61,8 @@ lock( privateApis, {
 	// Global Styles
 	GlobalStylesUIWrapper,
 	GlobalStylesActionMenu,
+	StyleVariationSelector,
+	useStyleVariations,
 	StyleBookPreview,
 	useGlobalStyles,
 	useStyle,

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -576,3 +576,17 @@ export function setCanvasMinHeight( minHeight ) {
 		minHeight,
 	};
 }
+
+/**
+ * Set the currently selected style variation ID.
+ * Use 0 to select the main global styles.
+ *
+ * @param {number} id Style variation ID.
+ * @return {Object} Action object.
+ */
+export function setSelectedStyleVariationId( id ) {
+	return {
+		type: 'SET_SELECTED_STYLE_VARIATION_ID',
+		id,
+	};
+}

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -300,3 +300,14 @@ export function getShowStylebook( state ) {
 export function getCanvasMinHeight( state ) {
 	return state.canvasMinHeight;
 }
+
+/**
+ * Get the currently selected style variation ID.
+ * Returns 0 when main global styles are selected.
+ *
+ * @param {Object} state Global application state.
+ * @return {number} The selected style variation ID.
+ */
+export function getSelectedStyleVariationId( state ) {
+	return state.selectedStyleVariationId ?? 0;
+}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -433,6 +433,24 @@ export function canvasMinHeight( state = 0, action ) {
 	return state;
 }
 
+/**
+ * Reducer for the currently selected style variation ID.
+ * When 0, the main global styles are being edited.
+ *
+ * @param {number} state  Current state.
+ * @param {Object} action Dispatched action.
+ * @return {number} Updated state.
+ */
+export function selectedStyleVariationId( state = 0, action ) {
+	switch ( action.type ) {
+		case 'SET_SELECTED_STYLE_VARIATION_ID':
+			return action.id;
+		case 'RESET_STYLES_NAVIGATION':
+			return 0;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -455,5 +473,6 @@ export default combineReducers( {
 	stylesPath,
 	showStylebook,
 	canvasMinHeight,
+	selectedStyleVariationId,
 	dataviews: dataviewsReducer,
 } );


### PR DESCRIPTION
_WIP: Not to merge!_

Closes #39281, #40318 and #53480; See #59404

This work implements style variations as objects of wp_global_styles.

Style Variations allow users to create named sets of global styles and connect them to specific posts, pages, templates, or patterns. When a post type is connected to a variation, it renders with that variation's styles instead of the main global styles.

https://github.com/user-attachments/assets/a82dd335-ed4c-41a4-92e8-658014d9a6f6

The variations are managed through the existing **Styles** interface in the **Site Editor**, and the styles are applied using the same global styles merging system. On the frontend, connected content receives the variation's CSS; in the editor, the canvas reflects the connected variation's styles during editing.

**Management**

Users can create new variations and they are customized using the style book.

<img width="586" height="322" alt="image" src="https://github.com/user-attachments/assets/4813b7d9-1ff1-461b-be03-5d2837efe122" />

Variations can be named:

<img width="615" height="400" alt="image" src="https://github.com/user-attachments/assets/fc03a450-32c0-4d0d-b63e-ea00ba1b9646" />

---

**Connection**

<img width="604" height="284" alt="image" src="https://github.com/user-attachments/assets/8de30798-ad50-4a9b-845a-492e58c14a89" />

Posts can be assigned to a style variation in the post inspector.


