### PR TITLE
Add back type defs for no margin bottom prop

### DIFF
--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -44,7 +44,7 @@ export function CheckboxControl(
 	props: WordPressComponentProps< CheckboxControlProps, 'input', false >
 ) {
 	const {
-		// @ts-expect-error - Prevent passing this to `input`.
+		// Prevent passing this to `input`.
 		__nextHasNoMarginBottom: _,
 		label,
 		className,

--- a/packages/components/src/checkbox-control/types.ts
+++ b/packages/components/src/checkbox-control/types.ts
@@ -10,6 +10,15 @@ import type { BaseControlProps } from '../base-control/types';
 
 export type CheckboxControlProps = Pick< BaseControlProps, 'help' > & {
 	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WP 7.0. Prop can be safely removed.
+	 * @ignore
+	 *
+	 * @default false
+	 */
+	__nextHasNoMarginBottom?: boolean;
+	/**
 	 * A function that receives the checked state (boolean) as input.
 	 */
 	onChange: ( value: boolean ) => void;

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -179,6 +179,15 @@ export interface FormTokenFieldProps
 	 */
 	__experimentalRenderItem?: ( args: { item: string } ) => ReactNode;
 	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WP 7.0. Prop can be safely removed.
+	 * @ignore
+	 *
+	 * @default false
+	 */
+	__nextHasNoMarginBottom?: boolean;
+	/**
 	 * If true, add any incompleteTokenValue as a new token when the field loses focus.
 	 *
 	 * @default false

--- a/packages/components/src/text-control/index.tsx
+++ b/packages/components/src/text-control/index.tsx
@@ -23,7 +23,7 @@ function UnforwardedTextControl(
 	ref: ForwardedRef< HTMLInputElement >
 ) {
 	const {
-		// @ts-expect-error - Prevent passing this to `input`.
+		// Prevent passing this to `input`.
 		__nextHasNoMarginBottom: _,
 		__next40pxDefaultSize = false,
 		label,

--- a/packages/components/src/text-control/types.ts
+++ b/packages/components/src/text-control/types.ts
@@ -8,6 +8,15 @@ export type TextControlProps = Pick<
 	'className' | 'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WP 7.0. Prop can be safely removed.
+	 * @ignore
+	 *
+	 * @default false
+	 */
+	__nextHasNoMarginBottom?: boolean;
+	/**
 	 * A function that receives the value of the input.
 	 */
 	onChange: ( value: string ) => void;

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -22,7 +22,7 @@ function UnforwardedTextareaControl(
 	ref: React.ForwardedRef< HTMLTextAreaElement >
 ) {
 	const {
-		// @ts-expect-error - Prevent passing this to `textarea`.
+		// Prevent passing this to `textarea`.
 		__nextHasNoMarginBottom: _,
 		label,
 		hideLabelFromVision,

--- a/packages/components/src/textarea-control/types.ts
+++ b/packages/components/src/textarea-control/types.ts
@@ -13,6 +13,15 @@ export type TextareaControlProps = Pick<
 	'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WP 7.0. Prop can be safely removed.
+	 * @ignore
+	 *
+	 * @default false
+	 */
+	__nextHasNoMarginBottom?: boolean;
+	/**
 	 * A function that receives the new value of the textarea each time it
 	 * changes.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds back type defs for the `__nextHasNoMarginBottom` prop (for the components already done in #73848).

## Why?

I remembered that we [agreed](https://github.com/WordPress/gutenberg/issues/55401#issuecomment-1907998703) to keep the type def around to prevent consumer builds from failing. Whether or not this prop exists in a consumer codebase is not important, so we shouldn't penalize early adopters by triggering errors.

I will continue this pattern for `FocalPointPicker` (#73980) and onwards.

## Testing Instructions

Passing a `__nextHasNoMarginBottom` to any of these components should not trigger a TypeScript error. Just a deprecation indicator.