### PR TITLE
Real-time collaboration: Don't sync core/freeform block without `content`

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -395,14 +395,21 @@ export function mergeCrdtBlocks(
  * @return True if the block should be synced, false otherwise.
  */
 function shouldBlockBeSynced( block: Block ): boolean {
-	// Verify that the gallery block is ready to be synced.
-	// This means that, all images have had their blobs converted to full URLs.
-	// Checking for only the blobs ensures that blocks that have just been inserted work as well.
-	if ( 'core/gallery' === block.name ) {
-		return ! block.innerBlocks.some(
-			( innerBlock ) =>
-				innerBlock.attributes && innerBlock.attributes.blob
-		);
+	switch ( block.name ) {
+		case 'core/freeform': {
+			// A freeform block without a content attribute will trigger an open modal
+			// in all peers, which we want to prevent.
+			return 'string' === typeof block.attributes.content;
+		}
+
+		case 'core/gallery': {
+			// Verify that all images have had their blobs converted to full URLs so
+			// that other peers can render them correctly.
+			return ! block.innerBlocks.some(
+				( innerBlock ) =>
+					innerBlock.attributes && innerBlock.attributes.blob
+			);
+		}
 	}
 
 	// Allow all other blocks to be synced.

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -196,6 +196,57 @@ describe( 'crdt-blocks', () => {
 			expect( block.get( 'name' ) ).toBe( 'core/gallery' );
 		} );
 
+		it( 'skips freeform blocks without a content attribute', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/freeform',
+					attributes: {},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			// Freeform block should not be synced because it has no content attribute.
+			expect( yblocks.length ).toBe( 0 );
+		} );
+
+		it( 'syncs freeform blocks with defined content attribute', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/freeform',
+					attributes: {
+						content: 'Some freeform content',
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/freeform',
+					attributes: {
+						content: '',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			expect( yblocks.length ).toBe( 2 );
+			expect( yblocks.get( 0 ).get( 'name' ) ).toBe( 'core/freeform' );
+			expect(
+				(
+					yblocks.get( 0 ).get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' )
+			).toBe( 'Some freeform content' );
+
+			expect( yblocks.get( 1 ).get( 'name' ) ).toBe( 'core/freeform' );
+			expect(
+				(
+					yblocks.get( 1 ).get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' )
+			).toBe( '' );
+		} );
+
 		it( 'handles block reordering', () => {
 			const initialBlocks: Block[] = [
 				{


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Don't sync core/freeform (Classic) block without a defined content attribute.

<!-- In a few words, what is the PR actually doing? -->

## Why?

A core/freeform block without a defined content attribute triggers an open modal. If we sync the block in this "not-ready" state, connected peers will experience an open modal as well.

## How?

Withhold syncing until the content attribute is defined. This follows a similar approach used to withhold syncing of gallery blocks until the uploaded images are available.

## Testing Instructions

1. Check out branch.
2. Add a "Classic" block.
3. Ensure modal only opens for the user who added the block.

### Testing Instructions for Keyboard
n/a


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/f0977d06-f3dc-4fd6-b22e-37858e61a8b5

### After

https://github.com/user-attachments/assets/5a81d8e2-94cd-4dd1-9ae8-e2e847dccbe5

