### PR TITLE
Real-time collaboration: Do not overwrite a "floating" date

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -297,8 +297,8 @@ export function getPostChangesFromCRDTDoc(
 				}
 
 				case 'date': {
-					// Do not sync an empty date if our current value is a "floating" date.
-					// Borrowing logic from the isEditedPostDateFloating selector.
+					// Do not overwrite a "floating" date. Borrowing logic from the
+					// isEditedPostDateFloating selector.
 					const currentDateIsFloating =
 						[ 'draft', 'auto-draft', 'pending' ].includes(
 							ymap.get( 'status' ) as string
@@ -306,7 +306,7 @@ export function getPostChangesFromCRDTDoc(
 						( null === currentValue ||
 							editedRecord.modified === currentValue );
 
-					if ( ! newValue && currentDateIsFloating ) {
+					if ( currentDateIsFloating ) {
 						return false;
 					}
 

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -269,7 +269,7 @@ describe( 'crdt', () => {
 			expect( changes ).not.toHaveProperty( 'status' );
 		} );
 
-		it( 'does not sync empty date for floating dates', () => {
+		it( 'does not overwrite null floating date', () => {
 			map.set( 'status', 'draft' );
 			map.set( 'date', '' );
 
@@ -279,13 +279,52 @@ describe( 'crdt', () => {
 				modified: '2025-01-01',
 			} as unknown as Post;
 
-			const changes = getPostChangesFromCRDTDoc(
+			const changesWithEmptyDate = getPostChangesFromCRDTDoc(
 				doc,
 				editedRecord,
 				mockPostType
 			);
 
-			expect( changes ).not.toHaveProperty( 'date' );
+			expect( changesWithEmptyDate ).not.toHaveProperty( 'date' );
+
+			map.set( 'date', '2025-01-02' );
+
+			const changesWithDefinedDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithDefinedDate ).not.toHaveProperty( 'date' );
+		} );
+
+		it( 'does not overwrite defined floating date', () => {
+			map.set( 'status', 'draft' );
+			map.set( 'date', '' );
+
+			const editedRecord = {
+				status: 'draft',
+				date: '2025-01-01', // matches modified
+				modified: '2025-01-01',
+			} as unknown as Post;
+
+			const changesWithEmptyDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithEmptyDate ).not.toHaveProperty( 'date' );
+
+			map.set( 'date', '2025-01-02' );
+
+			const changesWithDefinedDate = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				mockPostType
+			);
+
+			expect( changesWithDefinedDate ).not.toHaveProperty( 'date' );
 		} );
 
 		it( 'includes blocks in changes', () => {


### PR DESCRIPTION

## What?

When applying changes from remote CRDT documents, do not overwrite a "floating date" for draft or pending post statuses.

## Why?

A "floating date" encodes the current time (or is `null`) as a signal that a post will be published immediately. We don't want to adopt a post date from a remote peer unless it is accompanied by a meaningful post status change (e.g, to `scheduled`).

## How?

Remove the value check to make sure floating dates are never overwritten for draft or pending post statuses.
