### PR TITLE
[create-block] Updates variant handling for missing directory files

### DIFF
--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -127,6 +127,7 @@ program
 						// Transforms slug to title as a fallback.
 						title: capitalCase( slug ),
 						...optionsValues,
+						variant,
 					};
 					await scaffold( projectTemplate, answers );
 				} else {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
+const { existsSync } = require( 'fs' );
+const { mkdtemp, readFile } = require( 'fs' ).promises;
+const { tmpdir } = require( 'os' );
+const { join, resolve } = require( 'path' );
 const inquirer = require( '@inquirer/prompts' );
 const { command } = require( 'execa' );
 const glob = require( 'fast-glob' );
-const { resolve } = require( 'path' );
-const { existsSync } = require( 'fs' );
-const { mkdtemp, readFile } = require( 'fs' ).promises;
 const npmPackageArg = require( 'npm-package-arg' );
-const { tmpdir } = require( 'os' );
-const { join } = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 
 /**
@@ -153,6 +152,49 @@ const configToTemplate = async ( {
 			blockTemplatesPath || join( __dirname, 'templates', 'block' );
 	}
 
+	// Process variant-specific template paths
+	const variantTemplates = {};
+	for ( const [ variantName, variantConfig ] of Object.entries( variants ) ) {
+		if ( ! variantConfig ) {
+			continue;
+		}
+
+		const variantPluginTemplatesPath = variantConfig.pluginTemplatesPath;
+		const variantBlockTemplatesPath = variantConfig.blockTemplatesPath;
+		const variantAssetsPath = variantConfig.assetsPath;
+
+		let pluginOutputTemplates = null;
+		if ( variantPluginTemplatesPath === null ) {
+			pluginOutputTemplates = {};
+		} else if ( variantPluginTemplatesPath ) {
+			pluginOutputTemplates = await getOutputTemplates(
+				variantPluginTemplatesPath
+			);
+		}
+
+		let blockOutputTemplates = null;
+		if ( variantBlockTemplatesPath === null ) {
+			blockOutputTemplates = {};
+		} else if ( variantBlockTemplatesPath ) {
+			blockOutputTemplates = await getOutputTemplates(
+				variantBlockTemplatesPath
+			);
+		}
+
+		let outputAssets = null;
+		if ( variantAssetsPath === null ) {
+			outputAssets = {};
+		} else if ( variantAssetsPath ) {
+			outputAssets = await getOutputAssets( variantAssetsPath );
+		}
+
+		variantTemplates[ variantName ] = {
+			pluginOutputTemplates,
+			blockOutputTemplates,
+			outputAssets,
+		};
+	}
+
 	return {
 		blockOutputTemplates: blockTemplatesPath
 			? await getOutputTemplates( blockTemplatesPath )
@@ -161,6 +203,7 @@ const configToTemplate = async ( {
 		outputAssets: assetsPath ? await getOutputAssets( assetsPath ) : {},
 		defaultValues,
 		variants,
+		variantTemplates,
 	};
 };
 


### PR DESCRIPTION
## What?

Fixes external template variants not loading files in `@wordpress/create-block`

When using an external npm template (like `@woocommerce/create-woo-extension`) with the `--variant` flag, variant-specific template files were not being scaffolded, resulting in empty directories. This only occurred when pulling the templates from NPM, if you try to pull a template from your local machine (i.e. `path/to/woocommerce/create-woo-extension`), it doesn't have the same issue because the files are persistent on your machine.

*Note: this PR was drafted with the help of Claude Code.*

Related: #70855

## Why?

External templates are downloaded to a temporary directory, loaded via `require()`, then the temp directory is immediately deleted. The bug occurred because:

1. The main template files were processed while the temp directory existed
2. Variant-specific template paths were stored but **not processed**
3. The temp directory was cleaned up via `rimraf()`
4. Later, when scaffolding tried to read variant files from those paths, the directories no longer existed

This made it impossible to use variants with external templates, severely limiting the extensibility of `@wordpress/create-block`.

## How?

The fix ensures all variant template files are loaded **before** the temporary directory is deleted:

1. **templates.js** - Modified `configToTemplate()` to eagerly process all variant template paths and return a `variantTemplates` object containing pre-loaded template content
2. **scaffold.js** - Updated to use pre-processed variant templates when available, with fallback to legacy path-based loading for backward compatibility
3. **index.js** - Fixed variant parameter passing in quick mode to ensure the variant name reaches the scaffold function

## Testing Instructions

### Test 1: External template with custom variant

1. Run: `npx path/to/local/gutenberg/packages/create-block -t @woocommerce/create-woo-extension --variant=sql-modification test-variant`
2. Verify the plugin directory is created with all files (should include `composer.json`, `includes/Admin/Setup.php`, `tests/Test.php`, etc.)
3. Check `src/` directory contains variant-specific JS files

**Before**: Directory would be created but most files missing, variant directories empty  
**After**: All 14 plugin template files and 2 block template files created correctly

### Test 2: External template with default variant

1. Run: `npx path/to/local/gutenberg/packages/create-block -t @woocommerce/create-woo-extension test-default`
2. Verify all default template files are created
3. Ensure no regression from the fix

### Test 3: Built-in template variants (regression test)

1. Run: `npx path/to/local/gutenberg/packages/create-block -t es5 --variant=dynamic test-builtin`
2. Verify the dynamic variant files are created, including `render.php`
3. Confirm built-in templates still work as expected

### Testing Instructions for Keyboard

Not applicable - this is a CLI tool with no UI changes.

## Screenshots or screencast

**Before:**

```bash
$ npx @wordpress/create-block -t @woocommerce/create-woo-extension --variant=sql-modification test
# Variant directories show as empty:
/tmp/wp-create-block-xxx/variants/sql-modification
[]
/tmp/wp-create-block-xxx/variants/sql-modification/src
[]
```

**After:**

```bash
$ npx @wordpress/create-block -t @woocommerce/create-woo-extension --variant=sql-modification test
# All variant files successfully scaffolded:
test/
├── composer.json
├── includes/Admin/Setup.php
├── languages/woo-plugin-setup.pot
├── src/index.js
├── src/index.scss
├── tests/Test.php
└── ... (14 total files)
```