### PR TITLE
Refactor: Convert annotations sidebar to function component

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
+++ b/packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js
@@ -5,86 +5,83 @@
 	const dispatch = wp.data.dispatch;
 	const Fragment = wp.element.Fragment;
 	const el = wp.element.createElement;
-	const Component = wp.element.Component;
+	const { useState } = wp.element;
 	const __ = wp.i18n.__;
 	const registerPlugin = wp.plugins.registerPlugin;
 	const PluginSidebar = wp.editor.PluginSidebar;
 	const PluginSidebarMoreMenuItem = wp.editor.PluginSidebarMoreMenuItem;
 
-	class SidebarContents extends Component {
-		constructor( props ) {
-			super( props );
+	function SidebarContents() {
+		const [ state, setState ] = useState( { start: 0, end: 0 } );
 
-			this.state = {
-				start: 0,
-				end: 0,
-			};
-		}
-
-		render() {
-			return el(
-				PanelBody,
-				{},
-				el( 'input', {
-					type: 'number',
-					id: 'annotations-tests-range-start',
-					onChange: ( reactEvent ) => {
-						this.setState( {
+		return el(
+			PanelBody,
+			{},
+			el( 'input', {
+				type: 'number',
+				id: 'annotations-tests-range-start',
+				onChange: ( reactEvent ) => {
+					setState( ( prev ) => ( {
+						...prev,
+						...{
 							start: reactEvent.target.value,
-						} );
-					},
-					value: this.state.start,
-				} ),
-				el( 'input', {
-					type: 'number',
-					id: 'annotations-tests-range-end',
-					onChange: ( reactEvent ) => {
-						this.setState( {
+						},
+					} ) );
+				},
+				value: state.start,
+			} ),
+			el( 'input', {
+				type: 'number',
+				id: 'annotations-tests-range-end',
+				onChange: ( reactEvent ) => {
+					setState( ( prev ) => ( {
+						...prev,
+						...{
 							end: reactEvent.target.value,
+						},
+					} ) );
+				},
+				value: state.end,
+			} ),
+			el(
+				Button,
+				{
+					variant: 'primary',
+					onClick: () => {
+						dispatch(
+							'core/annotations'
+						).__experimentalAddAnnotation( {
+							source: 'e2e-tests',
+							blockClientId:
+								select(
+									'core/block-editor'
+								).getBlockOrder()[ 0 ],
+							richTextIdentifier: 'content',
+							range: {
+								start: parseInt( state.start, 10 ),
+								end: parseInt( state.end, 10 ),
+							},
 						} );
 					},
-					value: this.state.end,
-				} ),
-				el(
-					Button,
-					{
-						variant: 'primary',
-						onClick: () => {
-							dispatch(
-								'core/annotations'
-							).__experimentalAddAnnotation( {
-								source: 'e2e-tests',
-								blockClientId:
-									select(
-										'core/block-editor'
-									).getBlockOrder()[ 0 ],
-								richTextIdentifier: 'content',
-								range: {
-									start: parseInt( this.state.start, 10 ),
-									end: parseInt( this.state.end, 10 ),
-								},
-							} );
-						},
+				},
+				__( 'Add annotation' )
+			),
+			el(
+				Button,
+				{
+					variant: 'primary',
+					onClick: () => {
+						dispatch(
+							'core/annotations'
+						).__experimentalRemoveAnnotationsBySource(
+							'e2e-tests'
+						);
 					},
-					__( 'Add annotation' )
-				),
-				el(
-					Button,
-					{
-						variant: 'primary',
-						onClick: () => {
-							dispatch(
-								'core/annotations'
-							).__experimentalRemoveAnnotationsBySource(
-								'e2e-tests'
-							);
-						},
-					},
+				},
 
-					__( 'Remove annotations' )
-				)
-			);
-		}
+				__( 'Remove annotations' )
+			)
+		);
 	}
 
 	function AnnotationsSidebar() {


### PR DESCRIPTION
## What?

Contributes to #22890

Convert the annotations sidebar test plugin from a class component to a function component.

## Why?

This PR contributes to the ongoing effort to modernize the Gutenberg codebase by converting React class components to function components with hooks, as tracked in #22890.

This aligns test plugins with the same modern patterns used in the main codebase.

## How?

- Replace `class SidebarContents extends Component` with function component
- Replace `this.state` with `useState` hook
- Remove constructor boilerplate
- Update `this.setState` calls to use the useState setter

Files changed:
- `packages/e2e-tests/plugins/plugins-api/annotations-sidebar.js`

## Testing Instructions

1. Run the e2e tests that use the annotations sidebar plugin (if applicable)
2. Alternatively, manually test:
   - Install and activate the test plugin
   - Open a post in the editor
   - Open the annotations sidebar
   - Add and remove annotations
   - Verify functionality works as expected

### Testing Instructions for Keyboard

N/A - This is a test plugin used for e2e testing, not a user-facing component.

## Screenshots or screencast

N/A - Test plugin changes with no direct UI impact.