### PR TITLE
Refactor: Convert test class components to functions in blocks/compon…

### DIFF
--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createElement, Component } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -73,14 +73,12 @@ describe( 'block serializer', () => {
 			it( 'should return element as string', () => {
 				const saved = getSaveContent(
 					{
-						save: class extends Component {
-							render() {
-								return createElement(
-									'div',
-									null,
-									this.props.attributes.fruit
-								);
-							}
+						save: ( props ) => {
+							return createElement(
+								'div',
+								null,
+								props.attributes.fruit
+							);
 						},
 						name: 'core/fruit',
 					},

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -5,35 +5,30 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { Slot, Fill, Provider } from '../';
 
-/**
- * WordPress dependencies
- */
-import { Component } from '@wordpress/element';
-
-class Filler extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			num: 1,
-		};
-	}
-	render() {
-		return [
-			<button
-				key="1"
-				type="button"
-				onClick={ () => this.setState( { num: this.state.num + 1 } ) }
-			/>,
-			<Fill name={ this.props.name } key="2">
-				{ this.props.text || this.state.num.toString() }
-			</Fill>,
-		];
-	}
+/** @param {any} props */
+function Filler( props ) {
+	const [ state, setState ] = useState( { num: 1 } );
+	return [
+		<button
+			key="1"
+			type="button"
+			onClick={ () =>
+				setState( ( prev ) => ( { ...prev, num: state.num + 1 } ) )
+			}
+		/>,
+		<Fill name={ props.name } key="2">
+			{ props.text || state.num.toString() }
+		</Fill>,
+	];
 }
 
 describe( 'Slot', () => {


### PR DESCRIPTION
## What?

Contributes to #22890

Convert class components to function components in blocks and components package tests.

## Why?

This PR contributes to the ongoing effort to modernize the Gutenberg codebase by converting React class components to function components with hooks, as tracked in #22890.

React's official documentation recommends function components as the modern approach, and this aligns the test code with current React best practices.

## How?

- Replace `class extends Component` with function components
- Replace `this.state` with `useState` hook
- Update `this.props` references to use props parameter
- Remove constructor and render method boilerplate

Files changed:
- `packages/blocks/src/api/test/serializer.js`
- `packages/components/src/slot-fill/test/slot.js`

## Testing Instructions

1. Run the blocks serializer tests:
   ```
   npm run test:unit -- --testPathPattern="packages/blocks/src/api/test/serializer"
   ```
2. Run the slot-fill tests:
   ```
   npm run test:unit -- --testPathPattern="packages/components/src/slot-fill/test"
   ```
3. Verify all tests pass

### Testing Instructions for Keyboard

N/A - This PR only affects test files, not user interface components.

## Screenshots or screencast

N/A - Test-only changes with no UI impact.