### PR TITLE
Refactor: Convert withState HOC to use hooks internally

### DIFF
--- a/packages/compose/src/higher-order/with-state/index.js
+++ b/packages/compose/src/higher-order/with-state/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -26,24 +26,16 @@ export default function withState( initialState = {} ) {
 	} );
 
 	return createHigherOrderComponent( ( OriginalComponent ) => {
-		return class WrappedComponent extends Component {
-			constructor( /** @type {any} */ props ) {
-				super( props );
+		return function WrappedComponent( props ) {
+			const [ state, setState ] = useState( initialState );
 
-				this.setState = this.setState.bind( this );
-
-				this.state = initialState;
-			}
-
-			render() {
-				return (
-					<OriginalComponent
-						{ ...this.props }
-						{ ...this.state }
-						setState={ this.setState }
-					/>
-				);
-			}
+			return (
+				<OriginalComponent
+					{ ...props }
+					{ ...state }
+					setState={ setState }
+				/>
+			);
 		};
 	}, 'withState' );
 }

--- a/packages/compose/src/utils/create-higher-order-component/test/index.js
+++ b/packages/compose/src/utils/create-higher-order-component/test/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -42,10 +41,8 @@ describe( 'createHigherOrderComponent', () => {
 	} );
 
 	it( 'should use component class name', () => {
-		class SomeAnotherComponent extends Component {
-			render() {
-				return <div />;
-			}
+		function SomeAnotherComponent() {
+			return <div />;
 		}
 		const TestComponent = createHigherOrderComponent(
 			( OriginalComponent ) => OriginalComponent,
@@ -58,10 +55,8 @@ describe( 'createHigherOrderComponent', () => {
 	} );
 
 	it( 'should use displayName property', () => {
-		class SomeYetAnotherComponent extends Component {
-			render() {
-				return <div />;
-			}
+		function SomeYetAnotherComponent() {
+			return <div />;
 		}
 		SomeYetAnotherComponent.displayName = 'CustomDisplayName';
 		const TestComponent = createHigherOrderComponent(


### PR DESCRIPTION
## What?

Contributes to #22890

Convert the `withState` higher-order component to use hooks internally.

## Why?

This PR contributes to the ongoing effort to modernize the Gutenberg codebase by converting React class components to function components with hooks, as tracked in #22890.

The `withState` HOC is deprecated but still used in parts of the codebase. This change modernizes its internal implementation while maintaining the same external API.

## How?

- Replace class-based `WrappedComponent` with function component
- Replace `this.state` with `useState` hook
- Remove constructor and manual `setState` binding
- Update test file to use function components

Files changed:
- `packages/compose/src/higher-order/with-state/index.js`
- `packages/compose/src/utils/create-higher-order-component/test/index.js`

## Testing Instructions

1. Run the compose package tests:
   ```
   npm run test:unit -- --testPathPattern="packages/compose/src"
   ```
2. Verify all tests pass, particularly `with-state` tests

### Testing Instructions for Keyboard

N/A - This is an internal implementation change with no direct UI impact. The external API remains unchanged.

## Screenshots or screencast

N/A - Internal refactoring with no visual changes.