### PR TITLE
Refactor: Convert publish components to function components

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -12,25 +12,17 @@ import { compose } from '@wordpress/compose';
 import PublishButtonLabel from './label';
 import { store as editorStore } from '../../store';
 
-const noop = () => {};
+function noop() {}
 
-export class PostPublishButton extends Component {
-	constructor( props ) {
-		super( props );
+export function PostPublishButton( props ) {
+	const [ state, setState ] = useState( {
+		entitiesSavedStatesCallback: false,
+	} );
 
-		this.createOnClick = this.createOnClick.bind( this );
-		this.closeEntitiesSavedStates =
-			this.closeEntitiesSavedStates.bind( this );
-
-		this.state = {
-			entitiesSavedStatesCallback: false,
-		};
-	}
-
-	createOnClick( callback ) {
+	function createOnClick( callback ) {
 		return ( ...args ) => {
 			const { hasNonPostEntityChanges, setEntitiesSavedStatesCallback } =
-				this.props;
+				props;
 			// If a post with non-post entities is published, but the user
 			// elects to not save changes to the non-post entities, those
 			// entities will still be dirty when the Publish button is clicked.
@@ -40,16 +32,19 @@ export class PostPublishButton extends Component {
 				// The modal for multiple entity saving will open,
 				// hold the callback for saving/publishing the post
 				// so that we can call it if the post entity is checked.
-				this.setState( {
-					entitiesSavedStatesCallback: () => callback( ...args ),
-				} );
+				setState( ( prev ) => ( {
+					...prev,
+					...{
+						entitiesSavedStatesCallback: () => callback( ...args ),
+					},
+				} ) );
 
 				// Open the save panel by setting its callback.
 				// To set a function on the useState hook, we must set it
 				// with another function (() => myFunction). Passing the
 				// function on its own will cause an error when called.
 				setEntitiesSavedStatesCallback(
-					() => this.closeEntitiesSavedStates
+					() => closeEntitiesSavedStates
 				);
 				return noop;
 			}
@@ -58,10 +53,14 @@ export class PostPublishButton extends Component {
 		};
 	}
 
-	closeEntitiesSavedStates( savedEntities ) {
-		const { postType, postId } = this.props;
-		const { entitiesSavedStatesCallback } = this.state;
-		this.setState( { entitiesSavedStatesCallback: false }, () => {
+	function closeEntitiesSavedStates( savedEntities ) {
+		const { postType, postId } = props;
+		const { entitiesSavedStatesCallback } = state;
+		setState( ( prev ) => ( {
+			...prev,
+			entitiesSavedStatesCallback: false,
+		} ) );
+		{
 			if (
 				savedEntities &&
 				savedEntities.some(
@@ -74,10 +73,10 @@ export class PostPublishButton extends Component {
 				// The post entity was checked, call the held callback from `createOnClick`.
 				entitiesSavedStatesCallback();
 			}
-		} );
+		}
 	}
 
-	render() {
+	function render() {
 		const {
 			forceIsDirty,
 			hasPublishAction,
@@ -98,7 +97,7 @@ export class PostPublishButton extends Component {
 			isSavingNonPostEntityChanges,
 			postStatus,
 			postStatusHasChanged,
-		} = this.props;
+		} = props;
 
 		const isButtonDisabled =
 			( isSaving ||
@@ -129,28 +128,28 @@ export class PostPublishButton extends Component {
 			publishStatus = 'future';
 		}
 
-		const onClickButton = () => {
+		function onClickButton() {
 			if ( isButtonDisabled ) {
 				return;
 			}
 			onSubmit();
 			savePostStatus( publishStatus );
-		};
+		}
 
 		// Callback to open the publish panel.
-		const onClickToggle = () => {
+		function onClickToggle() {
 			if ( isToggleDisabled ) {
 				return;
 			}
 			onToggle();
-		};
+		}
 
 		const buttonProps = {
 			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
 			isBusy: ! isAutoSaving && isSaving,
 			variant: 'primary',
-			onClick: this.createOnClick( onClickButton ),
+			onClick: createOnClick( onClickButton ),
 			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
 		};
 
@@ -161,7 +160,7 @@ export class PostPublishButton extends Component {
 			isBusy: isSaving && isPublished,
 			variant: 'primary',
 			size: 'compact',
-			onClick: this.createOnClick( onClickToggle ),
+			onClick: createOnClick( onClickToggle ),
 			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
 		};
 		const componentProps = isToggle ? toggleProps : buttonProps;
@@ -177,6 +176,7 @@ export class PostPublishButton extends Component {
 			</>
 		);
 	}
+	return render();
 }
 
 /**

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	Spinner,
@@ -23,47 +23,47 @@ import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
 import { store as editorStore } from '../../store';
 
-export class PostPublishPanel extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onSubmit = this.onSubmit.bind( this );
-		this.cancelButtonNode = createRef();
-	}
+export function PostPublishPanel( props ) {
+	/** @type {any} */
+	const timeoutIDRef = useRef( null );
+	const cancelButtonNode = useRef( null );
 
-	componentDidMount() {
-		// This timeout is necessary to make sure the `useEffect` hook of
-		// `useFocusReturn` gets the correct element (the button that opens the
-		// PostPublishPanel) otherwise it will get this button.
-		this.timeoutID = setTimeout( () => {
-			this.cancelButtonNode.current.focus();
+	useEffect( () => {
+		timeoutIDRef.current = setTimeout( () => {
+			cancelButtonNode.current.focus();
 		}, 0 );
-	}
+	}, [] );
 
-	componentWillUnmount() {
-		clearTimeout( this.timeoutID );
-	}
+	useEffect( () => {
+		return () => {
+			clearTimeout( timeoutIDRef.current );
+		};
+	}, [] );
 
-	componentDidUpdate( prevProps ) {
-		// Automatically collapse the publish sidebar when a post
-		// is published and the user makes an edit.
-		if (
-			( prevProps.isPublished &&
-				! this.props.isSaving &&
-				this.props.isDirty ) ||
-			this.props.currentPostId !== prevProps.currentPostId
-		) {
-			this.props.onClose();
+	const prevPropsRef = useRef();
+	useEffect( () => {
+		if ( prevPropsRef.current ) {
+			const prevProps = prevPropsRef.current;
+			if (
+				( prevProps.isPublished &&
+					! props.isSaving &&
+					props.isDirty ) ||
+				props.currentPostId !== prevProps.currentPostId
+			) {
+				props.onClose();
+			}
 		}
-	}
+		prevPropsRef.current = props;
+	} );
 
-	onSubmit() {
-		const { onClose, hasPublishAction, isPostTypeViewable } = this.props;
+	function onSubmit() {
+		const { onClose, hasPublishAction, isPostTypeViewable } = props;
 		if ( ! hasPublishAction || ! isPostTypeViewable ) {
 			onClose();
 		}
 	}
 
-	render() {
+	function render() {
 		const {
 			forceIsDirty,
 			isBeingScheduled,
@@ -78,7 +78,7 @@ export class PostPublishPanel extends Component {
 			PrePublishExtension,
 			currentPostId,
 			...additionalProps
-		} = this.props;
+		} = props;
 		const {
 			hasPublishAction,
 			isDirty,
@@ -103,7 +103,7 @@ export class PostPublishPanel extends Component {
 						<>
 							<div className="editor-post-publish-panel__header-cancel-button">
 								<Button
-									ref={ this.cancelButtonNode }
+									ref={ cancelButtonNode }
 									accessibleWhenDisabled
 									disabled={ isSavingNonPostEntityChanges }
 									onClick={ onClose }
@@ -115,7 +115,7 @@ export class PostPublishPanel extends Component {
 							</div>
 							<div className="editor-post-publish-panel__header-publish-button">
 								<PostPublishButton
-									onSubmit={ this.onSubmit }
+									onSubmit={ onSubmit }
 									forceIsDirty={ forceIsDirty }
 								/>
 							</div>
@@ -146,6 +146,7 @@ export class PostPublishPanel extends Component {
 			</div>
 		);
 	}
+	return render();
 }
 
 /**

--- a/packages/editor/src/hooks/media-upload.js
+++ b/packages/editor/src/hooks/media-upload.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import deprecated from '@wordpress/deprecated';
 import {
@@ -22,26 +22,20 @@ const { MediaUploadModal: MediaUploadModalComponent } = unlock(
  * Class component wrapper for MediaUploadModal to maintain compatibility
  * with the stable MediaUpload component API (render prop pattern).
  */
-class MediaUploadModalWrapper extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isOpen: false,
-		};
-		this.openModal = this.openModal.bind( this );
-		this.closeModal = this.closeModal.bind( this );
+/** @param {any} props */
+function MediaUploadModalWrapper( props ) {
+	const [ state, setState ] = useState( { isOpen: false } );
+
+	function openModal() {
+		setState( ( prev ) => ( { ...prev, isOpen: true } ) );
 	}
 
-	openModal() {
-		this.setState( { isOpen: true } );
+	function closeModal() {
+		setState( ( prev ) => ( { ...prev, isOpen: false } ) );
+		props.onClose?.();
 	}
 
-	closeModal() {
-		this.setState( { isOpen: false } );
-		this.props.onClose?.();
-	}
-
-	render() {
+	function render() {
 		const {
 			allowedTypes,
 			multiple,
@@ -49,22 +43,22 @@ class MediaUploadModalWrapper extends Component {
 			onSelect,
 			title,
 			modalClass,
-			render,
-		} = this.props;
-		const { isOpen } = this.state;
+			render: renderProp,
+		} = props;
+		const { isOpen } = state;
 
 		return (
 			<>
-				{ render( { open: this.openModal } ) }
+				{ renderProp( { open: openModal } ) }
 				<MediaUploadModalComponent
 					allowedTypes={ allowedTypes }
 					multiple={ multiple }
 					value={ value }
 					onSelect={ ( media ) => {
 						onSelect( media );
-						this.closeModal();
+						closeModal();
 					} }
-					onClose={ this.closeModal }
+					onClose={ closeModal }
 					title={ title }
 					isOpen={ isOpen }
 					modalClass={ modalClass }
@@ -72,6 +66,7 @@ class MediaUploadModalWrapper extends Component {
 			</>
 		);
 	}
+	return render();
 }
 
 if ( window.__experimentalDataViewsMediaModal ) {


### PR DESCRIPTION
## What?

Contributes to #22890

Convert publish-related components from class components to function components.

## Why?

This PR contributes to the ongoing effort to modernize the Gutenberg codebase by converting React class components to function components with hooks, as tracked in #22890.

These components are part of the core publishing flow, and modernizing them aligns with React best practices.

## How?

- Replace `class extends Component` with function components
- Replace `this.state` with `useState` hook
- Replace lifecycle methods (`componentDidMount`, `componentDidUpdate`, `componentWillUnmount`) with `useEffect` hooks
- Replace `createRef` with `useRef` hook
- Update `this.props` references to use props parameter

Files changed:
- `packages/editor/src/components/post-publish-button/index.js`
- `packages/editor/src/components/post-publish-panel/index.js`
- `packages/editor/src/hooks/media-upload.js`

## Testing Instructions

1. Run the editor publish tests:
   ```
   npm run test:unit -- --testPathPattern="packages/editor/src/components/post-publish"
   ```
2. Start the development environment:
   ```
   npm run dev
   ```
3. Create a new post with some content
4. Click the Publish button in the top bar
5. Verify the publish panel opens correctly
6. Complete the publish flow
7. Verify the post is published successfully
8. Edit the published post and verify the Update button works

### Testing Instructions for Keyboard

1. Create a new post
2. Tab to the Publish button
3. Press Enter to open the publish panel
4. Tab through the publish panel options
5. Press Enter on the Publish button to publish
6. Verify focus management after publishing

## Screenshots or screencast

N/A - No visual changes, only internal refactoring.