### PR TITLE
Block visibility based on screen size: add backend block support

### DIFF
--- a/backport-changelog/7.0/10629.md
+++ b/backport-changelog/7.0/10629.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10629
+
+* https://github.com/WordPress/gutenberg/pull/73994

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -82,7 +82,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			return $block_content;
 		}
 
-		// If the block is hidden on all breakpoints, return empty string.
+		// If the block is hidden on all breakpoints, do not render the block.
 		if ( count( $hidden_on ) === count( $breakpoint_queries ) ) {
 			return '';
 		}
@@ -90,27 +90,17 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		// Maintain consistent order of breakpoints for class name generation.
 		sort( $hidden_on );
 
-		$sanitized_hidden_on = array_map( 'sanitize_html_class', $hidden_on );
-		$sanitized_hidden_on = array_filter( $sanitized_hidden_on );
-
-		// If all breakpoint names were invalid after sanitization, return unchanged.
-		if ( empty( $sanitized_hidden_on ) ) {
-			return $block_content;
-		}
-
-		$visibility_class = 'wp-block-hidden-' . implode( '-', $sanitized_hidden_on );
+		$visibility_class = 'wp-block-hidden-' . implode( '-', $hidden_on );
 		$css_rules        = array();
 
 		foreach ( $hidden_on as $breakpoint ) {
-			if ( isset( $breakpoint_queries[ $breakpoint ] ) ) {
-				$css_rules[] = array(
-					'selector'     => '.' . $visibility_class,
-					'declarations' => array(
-						'display' => 'none !important',
-					),
-					'rules_group'  => $breakpoint_queries[ $breakpoint ],
-				);
-			}
+			$css_rules[] = array(
+				'selector'     => '.' . $visibility_class,
+				'declarations' => array(
+					'display' => 'none !important',
+				),
+				'rules_group'  => $breakpoint_queries[ $breakpoint ],
+			);
 		}
 
 		if ( ! empty( $css_rules ) ) {

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -75,7 +75,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 				$query_parts[] = '(max-width: ' . $size . ')';
 			} elseif ( count( $breakpoints ) - 1 === $index ) {
 				// Last item: min = calc(previous size + 1px), no max.
-				$query_parts[] = '(min-width: ' . $previous_size . ')';
+				$query_parts[] = '(min-width: calc(' . $previous_size . ' + 1px))';
 			} else {
 				// Middle items: min = calc(previous size + 1px), max = size.
 				$query_parts[] = '(min-width: calc(' . $previous_size . ' + 1px))';
@@ -103,7 +103,12 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			return $block_content;
 		}
 
-		// If the block is hidden on all breakpoints, do not render the block.
+		/*
+		 * If the block is hidden on all breakpoints,
+		 * do not render the block. If these values ever become user-defined,
+		 * we might need to output the CSS regardless of the breakpoint count.
+		 * For example, if there is one breakpoint defined and it's hidden.
+		 */
 		if ( count( $hidden_on ) === count( $breakpoint_queries ) ) {
 			return '';
 		}
@@ -111,10 +116,16 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		// Maintain consistent order of breakpoints for class name generation.
 		sort( $hidden_on );
 
-		$css_rules = array();
+		$css_rules   = array();
+		$class_names = array();
 
 		foreach ( $hidden_on as $breakpoint ) {
+			/*
+			 * If these values ever become user-defined,
+			 * they should be sanitized and kebab-cased.
+			 */
 			$visibility_class = 'wp-block-hidden-' . $breakpoint;
+			$class_names[]    = $visibility_class;
 			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,
 				'declarations' => array(
@@ -136,10 +147,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			if ( ! empty( $block_content ) ) {
 				$processor = new WP_HTML_Tag_Processor( $block_content );
 				if ( $processor->next_tag() ) {
-					// Add a separate class for each breakpoint.
-					foreach ( $hidden_on as $breakpoint ) {
-						$processor->add_class( 'wp-block-hidden-' . $breakpoint );
-					}
+					$processor->add_class( implode( ' ', $class_names ) );
 					$block_content = $processor->get_updated_html();
 				}
 			}

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -73,7 +73,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			// First item: max = size.
 			if ( 0 === $index ) {
 				$query_parts[] = '(max-width: ' . $size . ')';
-			} elseif ( $index === count( $breakpoints ) - 1 ) {
+			} elseif ( count( $breakpoints ) - 1 === $index ) {
 				// Last item: min = calc(previous size + 1px), no max.
 				$query_parts[] = '(min-width: ' . $previous_size . ')';
 			} else {

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -101,27 +101,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 	return $block_content;
 }
 
-/**
- * Add 'display' to the list of safe CSS properties.
- * This is needed for responsive visibility support.
- *
- * @param array $attr List of allowed CSS attributes.
- * @return array Modified list of allowed CSS attributes.
- */
-function gutenberg_add_display_to_safe_style_css( $attr ) {
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) ) {
-		return $attr;
-	}
-
-	if ( ! in_array( 'display', $attr, true ) ) {
-		$attr[] = 'display';
-	}
-
-	return $attr;
-}
-
 if ( function_exists( 'wp_render_block_visibility_support' ) ) {
 	remove_filter( 'render_block', 'wp_render_block_visibility_support' );
 }
 add_filter( 'render_block', 'gutenberg_render_block_visibility_support', 10, 2 );
-add_filter( 'safe_style_css', 'gutenberg_add_display_to_safe_style_css' );

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -33,7 +33,11 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 	// If blockVisibility is an object with breakpoint settings, generate responsive styles.
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
-		// Matches a future JSON format.
+		/*
+		 * Breakpoints definitions are in several places in WordPress packages.
+		 * The following are taken from: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss
+		 * THe array is in a future, potential JSON format.
+		 */
 		$breakpoints = array(
 			'mobile'  => array(
 				'max' => '599px',

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -38,7 +38,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		 *
 		 * Breakpoints as array items are defined sequentially. The first item's size is the max value.
 		 * Each subsequent item's min is calc(previous size + 1px), and its size is the max.
-		 * The last item's min is calc(previous size + 1px) with no max.
+		 * The last item's min is previous size with no max.
 		 */
 		$breakpoints = array(
 			array(

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -36,7 +36,8 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		/*
 		 * Breakpoints definitions are in several places in WordPress packages.
 		 * The following are taken from: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss
-		 * THe array is in a future, potential JSON format.
+		 * The array is in a future, potential JSON format, and will be centralized
+		 * as the feature is developed.
 		 */
 		$breakpoints = array(
 			'mobile'  => array(

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -35,17 +35,26 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		 * The following are taken from: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss
 		 * The array is in a future, potential JSON format, and will be centralized
 		 * as the feature is developed.
+		 *
+		 * Breakpoints as array items are defined sequentially. The first item's size is the max value.
+		 * Each subsequent item's min is calc(previous size + 1px), and its size is the max.
+		 * The last item's min is calc(previous size + 1px) with no max.
 		 */
 		$breakpoints = array(
-			'mobile'  => array(
-				'max' => '599px',
+			array(
+				'name' => 'Mobile',
+				'slug' => 'mobile',
+				'size' => '599px',
 			),
-			'tablet'  => array(
-				'min' => '600px',
-				'max' => '959px',
+			array(
+				'name' => 'Tablet',
+				'slug' => 'tablet',
+				'size' => '959px',
 			),
-			'desktop' => array(
-				'min' => '960px',
+			array(
+				'name' => 'Desktop',
+				'slug' => 'desktop',
+				'size' => '960px',
 			),
 		);
 
@@ -55,17 +64,29 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		 * as well as classname building, and declaration of the display property, if required.
 		 */
 		$breakpoint_queries = array();
-		foreach ( $breakpoints as $name => $values ) {
+		$previous_size      = null;
+		foreach ( $breakpoints as $index => $breakpoint ) {
+			$slug        = $breakpoint['slug'];
+			$size        = $breakpoint['size'];
 			$query_parts = array();
-			if ( isset( $values['min'] ) ) {
-				$query_parts[] = '(min-width: ' . $values['min'] . ')';
+
+			// First item: max = size.
+			if ( 0 === $index ) {
+				$query_parts[] = '(max-width: ' . $size . ')';
+			} elseif ( $index === count( $breakpoints ) - 1 ) {
+				// Last item: min = calc(previous size + 1px), no max.
+				$query_parts[] = '(min-width: ' . $previous_size . ')';
+			} else {
+				// Middle items: min = calc(previous size + 1px), max = size.
+				$query_parts[] = '(min-width: calc(' . $previous_size . ' + 1px))';
+				$query_parts[] = '(max-width: ' . $size . ')';
 			}
-			if ( isset( $values['max'] ) ) {
-				$query_parts[] = '(max-width: ' . $values['max'] . ')';
-			}
+
 			if ( ! empty( $query_parts ) ) {
-				$breakpoint_queries[ $name ] = '@media ' . implode( ' and ', $query_parts );
+				$breakpoint_queries[ $slug ] = '@media ' . implode( ' and ', $query_parts );
 			}
+
+			$previous_size = $size;
 		}
 
 		$hidden_on = array();
@@ -90,11 +111,11 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		// Maintain consistent order of breakpoints for class name generation.
 		sort( $hidden_on );
 
-		$visibility_class = 'wp-block-hidden-' . implode( '-', $hidden_on );
-		$css_rules        = array();
+		$css_rules = array();
 
 		foreach ( $hidden_on as $breakpoint ) {
-			$css_rules[] = array(
+			$visibility_class = 'wp-block-hidden-' . $breakpoint;
+			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,
 				'declarations' => array(
 					'display' => 'none !important',
@@ -115,7 +136,10 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			if ( ! empty( $block_content ) ) {
 				$processor = new WP_HTML_Tag_Processor( $block_content );
 				if ( $processor->next_tag() ) {
-					$processor->add_class( $visibility_class );
+					// Add a separate class for each breakpoint.
+					foreach ( $hidden_on as $breakpoint ) {
+						$processor->add_class( 'wp-block-hidden-' . $breakpoint );
+					}
 					$block_content = $processor->get_updated_html();
 				}
 			}

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Render nothing if the block is hidden.
+ * Render nothing if the block is hidden, or add responsive visibility styles.
  *
  * @param string $block_content Rendered block content.
  * @param array  $block         Block object.
@@ -19,14 +19,109 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	if ( isset( $block['attrs']['metadata']['blockVisibility'] ) && false === $block['attrs']['metadata']['blockVisibility'] ) {
+	$block_visibility = $block['attrs']['metadata']['blockVisibility'] ?? null;
+
+	// If blockVisibility is false, hide the block completely.
+	if ( false === $block_visibility ) {
 		return '';
 	}
 
+	// Check if the responsive breakpoint experiment is enabled.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) ) {
+		return $block_content;
+	}
+
+	// If blockVisibility is an object with breakpoint settings, generate responsive styles.
+	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
+		$breakpoint_queries = array(
+			'mobile'  => '@media (max-width: 599px)',
+			'tablet'  => '@media (min-width: 600px) and (max-width: 959px)',
+			'desktop' => '@media (min-width: 960px)',
+		);
+
+		$hidden_on = array();
+
+		// Collect which breakpoints the block is hidden on.
+		foreach ( $block_visibility as $breakpoint => $is_visible ) {
+			if ( false === $is_visible ) {
+				$hidden_on[] = $breakpoint;
+			}
+		}
+
+		// If no breakpoints have visibility set to false, return unchanged.
+		if ( empty( $hidden_on ) ) {
+			return $block_content;
+		}
+
+		// If the block is hidden on all breakpoints, return empty string.
+		if ( count( $hidden_on ) === count( $breakpoint_queries ) ) {
+			return '';
+		}
+
+		// Generate a unique class name based on which breakpoints are hidden.
+		sort( $hidden_on );
+		$visibility_class = 'wp-block-hidden-' . implode( '-', $hidden_on );
+
+		// Generate CSS rules for each hidden breakpoint.
+		$css_rules = array();
+
+		foreach ( $hidden_on as $breakpoint ) {
+			if ( isset( $breakpoint_queries[ $breakpoint ] ) ) {
+				$css_rules[] = array(
+					'selector'     => '.' . $visibility_class,
+					'declarations' => array(
+						'display' => 'none !important',
+					),
+					'rules_group'  => $breakpoint_queries[ $breakpoint ],
+				);
+			}
+		}
+
+		// Use the style engine to enqueue the CSS.
+		if ( ! empty( $css_rules ) ) {
+			gutenberg_style_engine_get_stylesheet_from_css_rules(
+				$css_rules,
+				array(
+					'context'  => 'block-supports',
+					'prettify' => false,
+				)
+			);
+
+			// Add the visibility class to the block content.
+			if ( ! empty( $block_content ) ) {
+				$processor = new WP_HTML_Tag_Processor( $block_content );
+				if ( $processor->next_tag() ) {
+					$processor->add_class( $visibility_class );
+					$block_content = $processor->get_updated_html();
+				}
+			}
+		}
+	}
+
 	return $block_content;
+}
+
+/**
+ * Add 'display' to the list of safe CSS properties.
+ * This is needed for responsive visibility support.
+ *
+ * @param array $attr List of allowed CSS attributes.
+ * @return array Modified list of allowed CSS attributes.
+ */
+function gutenberg_add_display_to_safe_style_css( $attr ) {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) ) {
+		return $attr;
+	}
+
+	if ( ! in_array( 'display', $attr, true ) ) {
+		$attr[] = 'display';
+	}
+
+	return $attr;
 }
 
 if ( function_exists( 'wp_render_block_visibility_support' ) ) {
 	remove_filter( 'render_block', 'wp_render_block_visibility_support' );
 }
 add_filter( 'render_block', 'gutenberg_render_block_visibility_support', 10, 2 );
+add_filter( 'safe_style_css', 'gutenberg_add_display_to_safe_style_css' );

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -68,9 +68,9 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 		$hidden_on = array();
 
-		// Collect which breakpoints the block is hidden on.
+		// Collect which breakpoints the block is hidden on (only known breakpoints).
 		foreach ( $block_visibility as $breakpoint => $is_visible ) {
-			if ( false === $is_visible ) {
+			if ( false === $is_visible && isset( $breakpoint_queries[ $breakpoint ] ) ) {
 				$hidden_on[] = $breakpoint;
 			}
 		}
@@ -87,7 +87,17 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 		// Generate a unique class name based on which breakpoints are hidden.
 		sort( $hidden_on );
-		$visibility_class = 'wp-block-hidden-' . implode( '-', $hidden_on );
+
+		// Sanitize breakpoint names for use in HTML class attribute.
+		$sanitized_hidden_on = array_map( 'sanitize_html_class', $hidden_on );
+		$sanitized_hidden_on = array_filter( $sanitized_hidden_on );
+
+		// If all breakpoint names were invalid after sanitization, return unchanged.
+		if ( empty( $sanitized_hidden_on ) ) {
+			return $block_content;
+		}
+
+		$visibility_class = 'wp-block-hidden-' . implode( '-', $sanitized_hidden_on );
 
 		// Generate CSS rules for each hidden breakpoint.
 		$css_rules = array();

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -33,11 +33,38 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 	// If blockVisibility is an object with breakpoint settings, generate responsive styles.
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
-		$breakpoint_queries = array(
-			'mobile'  => '@media (max-width: 599px)',
-			'tablet'  => '@media (min-width: 600px) and (max-width: 959px)',
-			'desktop' => '@media (min-width: 960px)',
+		// Matches a future JSON format.
+		$breakpoints = array(
+			'mobile'  => array(
+				'max' => '599px',
+			),
+			'tablet'  => array(
+				'min' => '600px',
+				'max' => '959px',
+			),
+			'desktop' => array(
+				'min' => '960px',
+			),
 		);
+
+		/*
+		 * Build media queries from breakpoint definitions.
+		 * Could be absorbed into the style engine,
+		 * as well as classname building, and declaration of the display property, if required.
+		 */
+		$breakpoint_queries = array();
+		foreach ( $breakpoints as $name => $values ) {
+			$query_parts = array();
+			if ( isset( $values['min'] ) ) {
+				$query_parts[] = '(min-width: ' . $values['min'] . ')';
+			}
+			if ( isset( $values['max'] ) ) {
+				$query_parts[] = '(max-width: ' . $values['max'] . ')';
+			}
+			if ( ! empty( $query_parts ) ) {
+				$breakpoint_queries[ $name ] = '@media ' . implode( ' and ', $query_parts );
+			}
+		}
 
 		$hidden_on = array();
 

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Render nothing if the block is hidden, or add responsive visibility styles.
+ * Render nothing if the block is hidden, or add viewport visibility styles.
  *
  * @param string $block_content Rendered block content.
  * @param array  $block         Block object.
@@ -21,17 +21,14 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 	$block_visibility = $block['attrs']['metadata']['blockVisibility'] ?? null;
 
-	// If blockVisibility is false, hide the block completely.
 	if ( false === $block_visibility ) {
 		return '';
 	}
 
-	// Check if the responsive breakpoint experiment is enabled.
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) ) {
 		return $block_content;
 	}
 
-	// If blockVisibility is an object with breakpoint settings, generate responsive styles.
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
 		/*
 		 * Breakpoints definitions are in several places in WordPress packages.
@@ -90,10 +87,9 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			return '';
 		}
 
-		// Generate a unique class name based on which breakpoints are hidden.
+		// Maintain consistent order of breakpoints for class name generation.
 		sort( $hidden_on );
 
-		// Sanitize breakpoint names for use in HTML class attribute.
 		$sanitized_hidden_on = array_map( 'sanitize_html_class', $hidden_on );
 		$sanitized_hidden_on = array_filter( $sanitized_hidden_on );
 
@@ -103,9 +99,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		}
 
 		$visibility_class = 'wp-block-hidden-' . implode( '-', $sanitized_hidden_on );
-
-		// Generate CSS rules for each hidden breakpoint.
-		$css_rules = array();
+		$css_rules        = array();
 
 		foreach ( $hidden_on as $breakpoint ) {
 			if ( isset( $breakpoint_queries[ $breakpoint ] ) ) {
@@ -119,7 +113,6 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			}
 		}
 
-		// Use the style engine to enqueue the CSS.
 		if ( ! empty( $css_rules ) ) {
 			gutenberg_style_engine_get_stylesheet_from_css_rules(
 				$css_rules,
@@ -129,7 +122,6 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 				)
 			);
 
-			// Add the visibility class to the block content.
 			if ( ! empty( $block_content ) ) {
 				$processor = new WP_HTML_Tag_Processor( $block_content );
 				if ( $processor->next_tag() ) {

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -38,7 +38,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		 *
 		 * Breakpoints as array items are defined sequentially. The first item's size is the max value.
 		 * Each subsequent item's min is calc(previous size + 1px), and its size is the max.
-		 * The last item's min is previous size with no max.
+		 * The last item's min is previous size plus 1px, and it has no max.
 		 */
 		$breakpoints = array(
 			array(

--- a/lib/compat/wordpress-7.0/kses.php
+++ b/lib/compat/wordpress-7.0/kses.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Compatibility shims for KSES (content filtering) for WordPress 7.0.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Add 'display' to the list of safe CSS properties.
+ * This is needed for responsive visibility support.
+ *
+ * @param array $attr List of allowed CSS attributes.
+ * @return array Modified list of allowed CSS attributes.
+ */
+function gutenberg_add_display_to_safe_style_css( $attr ) {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) ) {
+		return $attr;
+	}
+
+	if ( ! in_array( 'display', $attr, true ) ) {
+		$attr[] = 'display';
+	}
+
+	return $attr;
+}
+add_filter( 'safe_style_css', 'gutenberg_add_display_to_safe_style_css' );

--- a/lib/compat/wordpress-7.0/kses.php
+++ b/lib/compat/wordpress-7.0/kses.php
@@ -7,7 +7,7 @@
 
 /**
  * Add 'display' to the list of safe CSS properties.
- * This is needed for responsive visibility support.
+ * This is needed for viewport visibility support.
  *
  * @param array $attr List of allowed CSS attributes.
  * @return array Modified list of allowed CSS attributes.

--- a/lib/load.php
+++ b/lib/load.php
@@ -108,6 +108,7 @@ require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
 require __DIR__ . '/compat/wordpress-7.0/preload.php';
 require __DIR__ . '/compat/wordpress-7.0/php-only-blocks.php';
 require __DIR__ . '/compat/wordpress-7.0/blocks.php';
+require __DIR__ . '/compat/wordpress-7.0/kses.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -163,37 +163,6 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result );
 	}
 
-	public function test_block_visibility_support_generated_css_with_display_none() {
-		$this->enable_viewport_visibility_experiment();
-
-		$this->register_visibility_block_with_support(
-			'test/css-generation',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/css-generation',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		gutenberg_render_block_visibility_support( $block_content, $block );
-
-		// Get the generated stylesheet from the style engine context.
-		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
-
-		// Verify the stylesheet contains display:none.
-		$this->assertStringContainsString( 'display:none!important', str_replace( ' ', '', $stylesheet ), 'display:none!important should be in the CSS' );
-		$this->assertStringContainsString( '.wp-block-hidden-mobile', $stylesheet, 'Stylesheet should contain the visibility class' );
-		$this->assertStringContainsString( '@media', $stylesheet, 'Stylesheet should contain media query' );
-	}
-
 	public function test_block_visibility_support_without_experiment() {
 		$this->disable_viewport_visibility_experiment();
 

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -160,32 +160,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( $block_content, $result );
-	}
-
-	public function test_block_visibility_support_without_experiment() {
-		$this->disable_viewport_visibility_experiment();
-
-		$this->register_visibility_block_with_support(
-			'test/viewport-no-experiment',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/viewport-no-experiment',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
-
-		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when the experiment is not enabled.' );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when no visibility attribute is present.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_mobile_breakpoint() {

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -53,7 +53,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	 *
 	 * @return WP_Block_Type The block type for the newly registered test block.
 	 */
-	private function register_block_with_visibility_support( $block_name, $supports = array() ) {
+	private function register_visibility_block_with_support( $block_name, $supports = array() ) {
 		$this->test_block_name = $block_name;
 		register_block_type(
 			$this->test_block_name,
@@ -104,14 +104,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_false_hides_block() {
-		self::register_block_with_visibility_support(
-			'test/block-visibility-false',
+	public function test_block_visibility_support_hides_block_when_visibility_false() {
+		$this->register_visibility_block_with_support(
+			'test/visibility-block',
 			array( 'visibility' => true )
 		);
 
-		$block = array(
-			'blockName' => 'test/block-visibility-false',
+		$block_content = '<p>This is a test block.</p>';
+		$block         = array(
+			'blockName' => 'test/visibility-block',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => false,
@@ -119,35 +120,34 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+		$result = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '', $result );
+		$this->assertSame( '', $result, 'Block content should be empty when blockVisibility is false and support is opted in.' );
 	}
 
-	public function test_block_visibility_true_shows_block() {
-		self::register_block_with_visibility_support(
-			'test/block-visibility-true',
-			array( 'visibility' => true )
+	public function test_block_visibility_support_shows_block_when_support_not_opted_in() {
+		$this->register_visibility_block_with_support(
+			'test/visibility-block',
+			array( 'visibility' => false )
 		);
 
-		$block = array(
-			'blockName' => 'test/block-visibility-true',
+		$block_content = '<p>This is a test block.</p>';
+		$block         = array(
+			'blockName' => 'test/visibility-block',
 			'attrs'     => array(
 				'metadata' => array(
-					'blockVisibility' => true,
+					'blockVisibility' => false,
 				),
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+		$result = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertEquals( $block_content, $result );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility support is not opted in.' );
 	}
 
-	public function test_block_visibility_no_visibility_attribute() {
-		self::register_block_with_visibility_support(
+	public function test_block_visibility_support_no_visibility_attribute() {
+		$this->register_visibility_block_with_support(
 			'test/block-visibility-none',
 			array( 'visibility' => true )
 		);
@@ -160,40 +160,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertEquals( $block_content, $result );
+		$this->assertSame( $block_content, $result );
 	}
 
-	public function test_block_without_visibility_support() {
-		self::register_block_with_visibility_support(
-			'test/no-visibility-support',
-			array( 'visibility' => false )
-		);
-
-		$block = array(
-			'blockName' => 'test/no-visibility-support',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => false,
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
-
-		// Block should not be hidden because it doesn't have visibility support.
-		$this->assertEquals( $block_content, $result );
-	}
-
-	public function test_experiment_can_be_enabled() {
-		$this->enable_responsive_visibility_experiment();
-		$this->assertTrue( gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) );
-	}
-
-	public function test_css_with_display_none_is_generated() {
+	public function test_block_visibility_support_generated_css_with_display_none() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/css-generation',
 			array( 'visibility' => true )
 		);
@@ -216,17 +189,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		// Verify the stylesheet contains display:none.
-		$this->assertStringContainsString( 'display', $stylesheet, 'Stylesheet should contain display property' );
-		$this->assertStringContainsString( 'none', $stylesheet, 'Stylesheet should contain none value' );
+		$this->assertStringContainsString( 'display:none!important', str_replace( ' ', '', $stylesheet ), 'display:none!important should be in the CSS' );
 		$this->assertStringContainsString( '.wp-block-hidden-mobile', $stylesheet, 'Stylesheet should contain the visibility class' );
 		$this->assertStringContainsString( '@media', $stylesheet, 'Stylesheet should contain media query' );
 	}
 
-
-	public function test_responsive_visibility_without_experiment() {
+	public function test_block_visibility_support_without_experiment() {
 		$this->disable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-no-experiment',
 			array( 'visibility' => true )
 		);
@@ -245,14 +216,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Without experiment enabled, responsive visibility should not work.
-		$this->assertEquals( $block_content, $result );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when the experiment is not enabled.' );
 	}
 
-	public function test_responsive_visibility_with_experiment_mobile() {
+	public function test_block_visibility_support_generated_css_with_mobile_breakpoint() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-mobile',
 			array( 'visibility' => true )
 		);
@@ -271,14 +241,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Block should have the visibility class added.
-		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result );
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
 	}
 
-	public function test_responsive_visibility_with_experiment_multiple_breakpoints() {
+	public function test_block_visibility_support_generated_css_with_multiple_breakpoints() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-multiple',
 			array( 'visibility' => true )
 		);
@@ -298,14 +267,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Block should have the visibility class for both breakpoints (sorted alphabetically).
-		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result );
+		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result, 'Block should have the visibility class for both breakpoints (sorted alphabetically).' );
 	}
 
-	public function test_responsive_visibility_tablet_only() {
+	public function test_block_visibility_support_generated_css_with_tablet_breakpoint() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-tablet',
 			array( 'visibility' => true )
 		);
@@ -324,15 +292,14 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Block should have both the existing class and the new visibility class.
-		$this->assertStringContainsString( 'existing-class', $result );
-		$this->assertStringContainsString( 'wp-block-hidden-tablet', $result );
+		$this->assertStringContainsString( 'existing-class', $result, 'Block should have the existing class.' );
+		$this->assertStringContainsString( 'wp-block-hidden-tablet', $result, 'Block should have the visibility class for the tablet breakpoint.' );
 	}
 
-	public function test_responsive_visibility_all_visible() {
+	public function test_block_visibility_support_generated_css_with_all_breakpoints_visible() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-all-visible',
 			array( 'visibility' => true )
 		);
@@ -353,14 +320,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// No classes should be added if all breakpoints are visible.
-		$this->assertEquals( $block_content, $result );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when all breakpoints are visible.' );
 	}
 
-	public function test_responsive_visibility_empty_object() {
+	public function test_block_visibility_support_generated_css_with_empty_object() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-empty',
 			array( 'visibility' => true )
 		);
@@ -377,14 +343,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Empty visibility object should not modify content.
-		$this->assertEquals( $block_content, $result );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when there is no visibility object.' );
 	}
 
-	public function test_responsive_visibility_unknown_breakpoints_ignored() {
+	public function test_block_visibility_support_generated_css_with_unknown_breakpoints_ignored() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/responsive-unknown-breakpoints',
 			array( 'visibility' => true )
 		);
@@ -405,17 +370,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Only the known 'mobile' breakpoint should be processed.
-		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result );
-		// Unknown breakpoints should not appear in the class name.
-		$this->assertStringNotContainsString( 'unknownBreak', $result );
-		$this->assertStringNotContainsString( 'largeScreen', $result );
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
+		$this->assertStringNotContainsString( 'unknownBreak', $result, 'Unknown breakpoints should not appear in the class name.' );
+		$this->assertStringNotContainsString( 'largeScreen', $result, 'Large screen breakpoints should not appear in the class name.' );
 	}
 
-	public function test_html_processor_fallback_with_empty_content() {
+	public function test_block_visibility_support_generated_css_with_empty_content() {
 		$this->enable_responsive_visibility_experiment();
 
-		self::register_block_with_visibility_support(
+		$this->register_visibility_block_with_support(
 			'test/empty-content',
 			array( 'visibility' => true )
 		);
@@ -434,95 +397,6 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		// Empty content should remain empty (WP_HTML_Tag_Processor fallback).
-		$this->assertSame( '', $result );
-	}
-
-	public function test_important_flag_in_generated_css() {
-		$this->enable_responsive_visibility_experiment();
-
-		self::register_block_with_visibility_support(
-			'test/important-css',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/important-css',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		gutenberg_render_block_visibility_support( $block_content, $block );
-
-		// Get the generated stylesheet from the style engine context.
-		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
-
-		// Verify the stylesheet contains !important flag.
-		$this->assertStringContainsString( '!important', $stylesheet, 'Stylesheet should contain !important flag' );
-		$this->assertStringContainsString( 'display:none!important', str_replace( ' ', '', $stylesheet ), 'display:none!important should be in the CSS' );
-	}
-
-	public function test_sanitize_breakpoint_names_in_class() {
-		$this->enable_responsive_visibility_experiment();
-
-		self::register_block_with_visibility_support(
-			'test/sanitize-class',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/sanitize-class',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile'  => false,
-						'tablet'  => false,
-						'desktop' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
-
-		// Known breakpoints should be sanitized but remain valid.
-		// With all three hidden, block should be completely hidden (empty string).
-		$this->assertSame( '', $result );
-	}
-
-	public function test_breakpoint_names_remain_valid_after_sanitization() {
-		$this->enable_responsive_visibility_experiment();
-
-		self::register_block_with_visibility_support(
-			'test/valid-names',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/valid-names',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile'  => false,
-						'desktop' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
-
-		// Verify that valid breakpoint names pass through sanitization correctly.
-		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result );
-		// Ensure no unexpected characters were added or removed.
-		$this->assertStringNotContainsString( 'wp-block-hidden--', $result, 'Should not have double hyphens' );
+		$this->assertSame( '', $result, 'Block content should be empty when there is no content.' );
 	}
 }

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -122,7 +122,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertEquals( '', $result );
+		$this->assertSame( '', $result );
 	}
 
 	public function test_block_visibility_true_shows_block() {
@@ -379,5 +379,150 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 
 		// Empty visibility object should not modify content.
 		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_responsive_visibility_unknown_breakpoints_ignored() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-unknown-breakpoints',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-unknown-breakpoints',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'       => false,
+						'unknownBreak' => false,
+						'largeScreen'  => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Only the known 'mobile' breakpoint should be processed.
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result );
+		// Unknown breakpoints should not appear in the class name.
+		$this->assertStringNotContainsString( 'unknownBreak', $result );
+		$this->assertStringNotContainsString( 'largeScreen', $result );
+	}
+
+	public function test_html_processor_fallback_with_empty_content() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/empty-content',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/empty-content',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Empty content should remain empty (WP_HTML_Tag_Processor fallback).
+		$this->assertSame( '', $result );
+	}
+
+	public function test_important_flag_in_generated_css() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/important-css',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/important-css',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Get the generated stylesheet from the style engine context.
+		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+
+		// Verify the stylesheet contains !important flag.
+		$this->assertStringContainsString( '!important', $stylesheet, 'Stylesheet should contain !important flag' );
+		$this->assertStringContainsString( 'display:none!important', str_replace( ' ', '', $stylesheet ), 'display:none!important should be in the CSS' );
+	}
+
+	public function test_sanitize_breakpoint_names_in_class() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/sanitize-class',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/sanitize-class',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => false,
+						'tablet'  => false,
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Known breakpoints should be sanitized but remain valid.
+		// With all three hidden, block should be completely hidden (empty string).
+		$this->assertSame( '', $result );
+	}
+
+	public function test_breakpoint_names_remain_valid_after_sanitization() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/valid-names',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/valid-names',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => false,
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Verify that valid breakpoint names pass through sanitization correctly.
+		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result );
+		// Ensure no unexpected characters were added or removed.
+		$this->assertStringNotContainsString( 'wp-block-hidden--', $result, 'Should not have double hyphens' );
 	}
 }

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * Test the block visibility block supports.
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	/**
+	 * Original experiments option value.
+	 *
+	 * @var array|null
+	 */
+	private $original_experiments;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name      = null;
+		$this->original_experiments = get_option( 'gutenberg-experiments' );
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+
+		// Remove all filters on pre_option_gutenberg-experiments to avoid pollution.
+		remove_all_filters( 'pre_option_gutenberg-experiments' );
+
+		// Restore original experiments option.
+		if ( null !== $this->original_experiments ) {
+			update_option( 'gutenberg-experiments', $this->original_experiments );
+		} else {
+			delete_option( 'gutenberg-experiments' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing visibility support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_block_with_visibility_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'metadata' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Enable the responsive visibility experiment.
+	 */
+	private function enable_responsive_visibility_experiment() {
+		add_filter(
+			'pre_option_gutenberg-experiments',
+			function ( $value ) {
+				if ( ! is_array( $value ) ) {
+					$value = array();
+				}
+				$value['gutenberg-hide-blocks-based-on-screen-size'] = true;
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * Disable the responsive visibility experiment.
+	 */
+	private function disable_responsive_visibility_experiment() {
+		add_filter(
+			'pre_option_gutenberg-experiments',
+			function ( $value ) {
+				if ( ! is_array( $value ) ) {
+					$value = array();
+				}
+				unset( $value['gutenberg-hide-blocks-based-on-screen-size'] );
+				return $value;
+			}
+		);
+	}
+
+	public function test_block_visibility_false_hides_block() {
+		self::register_block_with_visibility_support(
+			'test/block-visibility-false',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/block-visibility-false',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => false,
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertEquals( '', $result );
+	}
+
+	public function test_block_visibility_true_shows_block() {
+		self::register_block_with_visibility_support(
+			'test/block-visibility-true',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/block-visibility-true',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => true,
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_block_visibility_no_visibility_attribute() {
+		self::register_block_with_visibility_support(
+			'test/block-visibility-none',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/block-visibility-none',
+			'attrs'     => array(),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_block_without_visibility_support() {
+		self::register_block_with_visibility_support(
+			'test/no-visibility-support',
+			array( 'visibility' => false )
+		);
+
+		$block = array(
+			'blockName' => 'test/no-visibility-support',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => false,
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Block should not be hidden because it doesn't have visibility support.
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_experiment_can_be_enabled() {
+		$this->enable_responsive_visibility_experiment();
+		$this->assertTrue( gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) );
+	}
+
+	public function test_responsive_visibility_without_experiment() {
+		$this->disable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-no-experiment',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-no-experiment',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Without experiment enabled, responsive visibility should not work.
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_responsive_visibility_with_experiment_mobile() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-mobile',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-mobile',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Block should have the visibility class added.
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result );
+	}
+
+	public function test_responsive_visibility_with_experiment_multiple_breakpoints() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-multiple',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-multiple',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => false,
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Block should have the visibility class for both breakpoints (sorted alphabetically).
+		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result );
+	}
+
+	public function test_responsive_visibility_tablet_only() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-tablet',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-tablet',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'tablet' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div class="existing-class">Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Block should have both the existing class and the new visibility class.
+		$this->assertStringContainsString( 'existing-class', $result );
+		$this->assertStringContainsString( 'wp-block-hidden-tablet', $result );
+	}
+
+	public function test_responsive_visibility_all_visible() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-all-visible',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-all-visible',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => true,
+						'tablet'  => true,
+						'desktop' => true,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// No classes should be added if all breakpoints are visible.
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_responsive_visibility_empty_object() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/responsive-empty',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/responsive-empty',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Empty visibility object should not modify content.
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_safe_style_css_without_experiment() {
+		$this->disable_responsive_visibility_experiment();
+
+		$original_styles = array( 'color', 'background-color' );
+		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
+
+		// Display should not be added without experiment.
+		$this->assertEquals( $original_styles, $result );
+		$this->assertNotContains( 'display', $result );
+	}
+
+	public function test_safe_style_css_with_experiment() {
+		$this->enable_responsive_visibility_experiment();
+
+		$original_styles = array( 'color', 'background-color' );
+		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
+
+		// Display should be added with experiment enabled.
+		$this->assertContains( 'display', $result );
+		$this->assertContains( 'color', $result );
+		$this->assertContains( 'background-color', $result );
+	}
+
+	public function test_safe_style_css_with_experiment_already_has_display() {
+		$this->enable_responsive_visibility_experiment();
+
+		$original_styles = array( 'color', 'display', 'background-color' );
+		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
+
+		// Display should not be duplicated.
+		$this->assertContains( 'display', $result );
+		$this->assertEquals( 3, count( $result ) );
+	}
+}

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -211,7 +211,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'wp-block-hidden-desktop-mobile', $result, 'Block should have the visibility class for both breakpoints (sorted alphabetically).' );
+		$this->assertStringContainsString( 'wp-block-hidden-desktop wp-block-hidden-mobile', $result, 'Block should have the visibility class for both breakpoints (sorted alphabetically).' );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		// Verify mobile breakpoint: max-width: 599px.
+		$this->assertStringContainsString(
+			'@media (min-width: 959px){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
+			$actual_stylesheet,
+			'Correct CSS should be generated'
+		);
 	}
 
 	public function test_block_visibility_support_generated_css_with_tablet_breakpoint() {

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -88,22 +88,6 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * Disable the viewport visibility experiment.
-	 */
-	private function disable_viewport_visibility_experiment() {
-		add_filter(
-			'pre_option_gutenberg-experiments',
-			function ( $value ) {
-				if ( ! is_array( $value ) ) {
-					$value = array();
-				}
-				unset( $value['gutenberg-hide-blocks-based-on-screen-size'] );
-				return $value;
-			}
-		);
-	}
-
 	public function test_block_visibility_support_hides_block_when_visibility_false() {
 		$this->register_visibility_block_with_support(
 			'test/visibility-block',

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -186,39 +186,13 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
-	}
-
-	public function test_block_visibility_support_generated_css_with_multiple_breakpoints() {
-		$this->enable_viewport_visibility_experiment();
-
-		$this->register_visibility_block_with_support(
-			'test/viewport-multiple',
-			array( 'visibility' => true )
-		);
-
-		$block = array(
-			'blockName' => 'test/viewport-multiple',
-			'attrs'     => array(
-				'metadata' => array(
-					'blockVisibility' => array(
-						'mobile'  => false,
-						'desktop' => false,
-					),
-				),
-			),
-		);
-
-		$block_content = '<div>Test content</div>';
-		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
-
-		$this->assertStringContainsString( 'wp-block-hidden-desktop wp-block-hidden-mobile', $result, 'Block should have the visibility class for both breakpoints (sorted alphabetically).' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
-		// Verify mobile breakpoint: max-width: 599px.
-		$this->assertStringContainsString(
-			'@media (min-width: 959px){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
+
+		$this->assertSame(
+			'@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
-			'Correct CSS should be generated'
+			'CSS should contain mobile visibility rule'
 		);
 	}
 
@@ -244,8 +218,86 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'existing-class', $result, 'Block should have the existing class.' );
-		$this->assertStringContainsString( 'wp-block-hidden-tablet', $result, 'Block should have the visibility class for the tablet breakpoint.' );
+		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet breakpoint in the class attribute.' );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+
+		$this->assertSame(
+			'@media (min-width: calc(599px + 1px)) and (max-width: 959px){.wp-block-hidden-tablet{display:none !important;}}',
+			$actual_stylesheet,
+			'CSS should contain tablet visibility rule'
+		);
+	}
+
+	public function test_block_visibility_support_generated_css_with_desktop_breakpoint() {
+		$this->enable_viewport_visibility_experiment();
+
+		$this->register_visibility_block_with_support(
+			'test/viewport-desktop',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/viewport-desktop',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop breakpoint in the class attribute.' );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+
+		$this->assertSame(
+			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}',
+			$actual_stylesheet,
+			'CSS should contain desktop visibility rule'
+		);
+	}
+
+	public function test_block_visibility_support_generated_css_with_multiple_breakpoints() {
+		$this->enable_viewport_visibility_experiment();
+
+		$this->register_visibility_block_with_support(
+			'test/viewport-multiple',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/viewport-multiple',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => false,
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertStringContainsString(
+			'class="wp-block-hidden-desktop wp-block-hidden-mobile"',
+			$result,
+			'Block should have both visibility classes in the class attribute'
+		);
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+
+		$this->assertSame(
+			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
+			$actual_stylesheet,
+			'CSS should contain both visibility rules'
+		);
 	}
 
 	public function test_block_visibility_support_generated_css_with_all_breakpoints_visible() {
@@ -349,9 +401,11 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
-		$this->assertStringNotContainsString( 'unknownBreak', $result, 'Unknown breakpoints should not appear in the class name.' );
-		$this->assertStringNotContainsString( 'largeScreen', $result, 'Large screen breakpoints should not appear in the class name.' );
+		$this->assertStringContainsString(
+			'class="wp-block-hidden-mobile"',
+			$result,
+			'Block should have the visibility class for the mobile breakpoint in the class attribute'
+		);
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_content() {

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -23,6 +23,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		parent::set_up();
 		$this->test_block_name      = null;
 		$this->original_experiments = get_option( 'gutenberg-experiments' );
+
+		// Clear the style engine store to avoid test pollution.
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
 	}
 
 	public function tear_down() {
@@ -186,6 +189,39 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->enable_responsive_visibility_experiment();
 		$this->assertTrue( gutenberg_is_experiment_enabled( 'gutenberg-hide-blocks-based-on-screen-size' ) );
 	}
+
+	public function test_css_with_display_none_is_generated() {
+		$this->enable_responsive_visibility_experiment();
+
+		self::register_block_with_visibility_support(
+			'test/css-generation',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/css-generation',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		gutenberg_render_block_visibility_support( $block_content, $block );
+
+		// Get the generated stylesheet from the style engine context.
+		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+
+		// Verify the stylesheet contains display:none.
+		$this->assertStringContainsString( 'display', $stylesheet, 'Stylesheet should contain display property' );
+		$this->assertStringContainsString( 'none', $stylesheet, 'Stylesheet should contain none value' );
+		$this->assertStringContainsString( '.wp-block-hidden-mobile', $stylesheet, 'Stylesheet should contain the visibility class' );
+		$this->assertStringContainsString( '@media', $stylesheet, 'Stylesheet should contain media query' );
+	}
+
 
 	public function test_responsive_visibility_without_experiment() {
 		$this->disable_responsive_visibility_experiment();

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -344,38 +344,4 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		// Empty visibility object should not modify content.
 		$this->assertEquals( $block_content, $result );
 	}
-
-	public function test_safe_style_css_without_experiment() {
-		$this->disable_responsive_visibility_experiment();
-
-		$original_styles = array( 'color', 'background-color' );
-		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
-
-		// Display should not be added without experiment.
-		$this->assertEquals( $original_styles, $result );
-		$this->assertNotContains( 'display', $result );
-	}
-
-	public function test_safe_style_css_with_experiment() {
-		$this->enable_responsive_visibility_experiment();
-
-		$original_styles = array( 'color', 'background-color' );
-		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
-
-		// Display should be added with experiment enabled.
-		$this->assertContains( 'display', $result );
-		$this->assertContains( 'color', $result );
-		$this->assertContains( 'background-color', $result );
-	}
-
-	public function test_safe_style_css_with_experiment_already_has_display() {
-		$this->enable_responsive_visibility_experiment();
-
-		$original_styles = array( 'color', 'display', 'background-color' );
-		$result          = gutenberg_add_display_to_safe_style_css( $original_styles );
-
-		// Display should not be duplicated.
-		$this->assertContains( 'display', $result );
-		$this->assertEquals( 3, count( $result ) );
-	}
 }

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -73,9 +73,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Enable the responsive visibility experiment.
+	 * Enable the viewport visibility experiment.
 	 */
-	private function enable_responsive_visibility_experiment() {
+	private function enable_viewport_visibility_experiment() {
 		add_filter(
 			'pre_option_gutenberg-experiments',
 			function ( $value ) {
@@ -89,9 +89,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Disable the responsive visibility experiment.
+	 * Disable the viewport visibility experiment.
 	 */
-	private function disable_responsive_visibility_experiment() {
+	private function disable_viewport_visibility_experiment() {
 		add_filter(
 			'pre_option_gutenberg-experiments',
 			function ( $value ) {
@@ -164,7 +164,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_display_none() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
 			'test/css-generation',
@@ -195,15 +195,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_without_experiment() {
-		$this->disable_responsive_visibility_experiment();
+		$this->disable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-no-experiment',
+			'test/viewport-no-experiment',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-no-experiment',
+			'blockName' => 'test/viewport-no-experiment',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -220,15 +220,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_mobile_breakpoint() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-mobile',
+			'test/viewport-mobile',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-mobile',
+			'blockName' => 'test/viewport-mobile',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -245,15 +245,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_multiple_breakpoints() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-multiple',
+			'test/viewport-multiple',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-multiple',
+			'blockName' => 'test/viewport-multiple',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -271,15 +271,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_tablet_breakpoint() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-tablet',
+			'test/viewport-tablet',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-tablet',
+			'blockName' => 'test/viewport-tablet',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -297,15 +297,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_all_breakpoints_visible() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-all-visible',
+			'test/viewport-all-visible',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-all-visible',
+			'blockName' => 'test/viewport-all-visible',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -324,15 +324,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-empty',
+			'test/viewport-empty',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-empty',
+			'blockName' => 'test/viewport-empty',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(),
@@ -347,15 +347,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_unknown_breakpoints_ignored() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/responsive-unknown-breakpoints',
+			'test/viewport-unknown-breakpoints',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/responsive-unknown-breakpoints',
+			'blockName' => 'test/viewport-unknown-breakpoints',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -376,15 +376,15 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_content() {
-		$this->enable_responsive_visibility_experiment();
+		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/empty-content',
+			'test/viewport-empty-content',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/empty-content',
+			'blockName' => 'test/viewport-empty-content',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -292,6 +292,33 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when all breakpoints are visible.' );
 	}
 
+	public function test_block_visibility_support_generated_css_with_all_breakpoints_hidden() {
+		$this->enable_viewport_visibility_experiment();
+
+		$this->register_visibility_block_with_support(
+			'test/viewport-all-hidden',
+			array( 'visibility' => true )
+		);
+
+		$block = array(
+			'blockName' => 'test/viewport-all-hidden',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => array(
+						'mobile'  => false,
+						'tablet'  => false,
+						'desktop' => false,
+					),
+				),
+			),
+		);
+
+		$block_content = '<div>Test content</div>';
+		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Block content should be empty when all breakpoints are hidden.' );
+	}
+
 	public function test_block_visibility_support_generated_css_with_empty_object() {
 		$this->enable_viewport_visibility_experiment();
 
@@ -312,7 +339,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when there is no visibility object.' );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility is an empty array.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_unknown_breakpoints_ignored() {


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/72502

Backport Core PR:

- https://github.com/WordPress/wordpress-develop/pull/10629

## What?

Implements backend support for responsive block visibility, allowing blocks to be hidden on specific viewport breakpoints (mobile, tablet, desktop) using CSS media queries.

Functionality is gated behind the `gutenberg-hide-blocks-based-on-screen-size` experiment flag. The existing boolean blockVisibility: false behavior works without the experiment enabled.

Clientside state is happening over in:

- https://github.com/WordPress/gutenberg/pull/74025

## How?
This PR borrows approaches from #73735 and #73888 to implement the backend that:

- generates media queries based on block metadata
- applies the classname and enqueues the CSS via the style engine

## Testing


Unit tests:


`npm run test:unit:php:base -- --filter=WP_Block_Supports_Block_Visibility_Test`

To test manually, enable the experiment:

<img width="998" height="90" alt="Screenshot 2025-12-15 at 10 53 52 am" src="https://github.com/user-attachments/assets/ec7052f1-3758-4f2c-8ad1-93ddd50fd0c5" />

Then copy and paste this into your post editor, publish and view the frontend. 

```html


<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false}}} -->
<p>🔴 Hidden on MOBILE (≤599px) - You should see this on tablet and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false}}} -->
<p>🟡 Hidden on TABLET (600-959px) - You should see this on mobile and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"desktop":false}}} -->
<p>🟢 Hidden on DESKTOP (≥960px) - You should see this on mobile and tablet only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"desktop":false}}} -->
<p>🟣 Hidden on MOBILE and DESKTOP - You should only see this on tablet (600-959px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"tablet":false}}} -->
<p>🔵 Hidden on MOBILE and TABLET - You should only see this on desktop (≥960px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false,"desktop":false}}} -->
<p>🟠 Hidden on TABLET and DESKTOP - You should only see this on mobile (≤599px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":true,"tablet":true,"desktop":true}}} -->
<p>✅ Visible on ALL breakpoints - You should always see this</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
<p>❌ Completely HIDDEN (boolean false) - You should never see this</p>
<!-- /wp:paragraph -->
```

https://github.com/user-attachments/assets/45f86b73-f8f8-4763-a1eb-2303fda96105

Make sure to test with the experiment off as well. The last item should never show with the experiment on and off.

