### PR TITLE
Enhance tab block: Add color support for single tab

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -963,7 +963,7 @@ Content for a tab in a tabbed interface. ([Source](https://github.com/WordPress/
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tabs
--	**Supports:** anchor, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), layout (allowJustification, allowOrientation, allowSizingOnChildren, allowSwitching, allowVerticalAlignment, ~~allowInheriting~~), spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Table

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -45,6 +45,7 @@
 @use "./social-link/editor.scss" as *;
 @use "./social-links/editor.scss" as *;
 @use "./spacer/editor.scss" as *;
+@use "./tab/editor.scss" as *;
 @use "./table/editor.scss" as *;
 @use "./tabs/editor.scss" as *;
 @use "./tag-cloud/editor.scss" as *;

--- a/packages/block-library/src/tab/block.json
+++ b/packages/block-library/src/tab/block.json
@@ -17,6 +17,11 @@
 	"parent": [ "core/tabs" ],
 	"supports": {
 		"anchor": true,
+		"color": {
+			"text": true,
+			"background": true,
+			"gradients": true
+		},
 		"html": false,
 		"reusable": false,
 		"layout": {

--- a/packages/block-library/src/tab/edit.js
+++ b/packages/block-library/src/tab/edit.js
@@ -215,14 +215,14 @@ export default function Edit( {
 
 	return (
 		<>
-			<Controls
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				tabsClientId={ tabsClientId }
-				blockIndex={ blockIndex }
-				isDefaultTab={ isDefaultTab }
-			/>
 			<div { ...blockProps }>
+				<Controls
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					tabsClientId={ tabsClientId }
+					blockIndex={ blockIndex }
+					isDefaultTab={ isDefaultTab }
+				/>
 				{ isSelectedTab && (
 					<>
 						<TabsList

--- a/packages/block-library/src/tab/edit.js
+++ b/packages/block-library/src/tab/edit.js
@@ -184,6 +184,7 @@ export default function Edit( {
 
 	const tabItemColorProps = useColorProps( tabsAttributes );
 	const tabContentTypographyProps = useTypographyProps( attributes );
+	const tabContentColorProps = useColorProps( attributes );
 
 	const blockProps = useBlockProps( {
 		hidden: ! isSelectedTab,
@@ -198,11 +199,13 @@ export default function Edit( {
 			tabIndex: isSelectedTab ? 0 : -1,
 			className: clsx(
 				tabContentTypographyProps.className,
+				tabContentColorProps.className,
 				'tabs__tab-editor-content',
 				layoutClassNames
 			),
 			style: {
 				...tabContentTypographyProps.style,
+				...tabContentColorProps.style,
 			},
 		},
 		{
@@ -212,14 +215,14 @@ export default function Edit( {
 
 	return (
 		<>
+			<Controls
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				tabsClientId={ tabsClientId }
+				blockIndex={ blockIndex }
+				isDefaultTab={ isDefaultTab }
+			/>
 			<div { ...blockProps }>
-				<Controls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					tabsClientId={ tabsClientId }
-					blockIndex={ blockIndex }
-					isDefaultTab={ isDefaultTab }
-				/>
 				{ isSelectedTab && (
 					<>
 						<TabsList

--- a/packages/block-library/src/tab/editor.scss
+++ b/packages/block-library/src/tab/editor.scss
@@ -1,0 +1,6 @@
+// Override WordPress color utility classes that interfere with tab styling in the editor
+.block-editor-block-list__block.wp-block-tab {
+	// Reset color and background for tabs in editor to prevent color conflicts with tab styles
+	color: unset !important;
+	background-color: unset !important;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73934

<!-- In a few words, what is the PR actually doing? -->
- Added color support to the tab block so the user can change the specific tab color and background color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- User can change the specific tab color and background color
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a support to colors in block.json
- Used the color props in the innerBlockAttributes
## Testing Instructions
- Open any page/post in edit
- Add the tabs block
- Change color and background color for tab

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8b80c401-df4f-4ffe-95c5-d4e641adb91d

