### PR TITLE
Fix invalid theme.json color value in Global Styles documentation

### DIFF
--- a/packages/global-styles-engine/README.md
+++ b/packages/global-styles-engine/README.md
@@ -101,7 +101,7 @@ The global styles object follows the theme.json schema:
     color: { text: '#000', background: '#fff' },
     typography: { fontSize: '16px' },
     elements: {
-      button: { color: { background: '#blue' } }
+      button: { color: { background: 'blue' } }
     },
     blocks: {
       'core/paragraph': { color: { text: '#333' } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

While reviewing another PR, I noticed that `#blue` is used as a color value in the Global Styles Engine README. Updating the example to avoid confusion.

