### PR TITLE
ToggleGroupControl: Deprecate bottom margin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -284,7 +284,6 @@ module.exports = {
 						'SearchControl',
 						'SelectControl',
 						'ToggleControl',
-						'ToggleGroupControl',
 						'TreeSelect',
 					].map( ( componentName ) => ( {
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -592,7 +592,6 @@ function BackgroundSizeControls( {
 				onChange={ toggleScrollWithPage }
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				size="__unstable-large"
 				label={ __( 'Size' ) }
 				value={ currentValueForToggle }

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -120,7 +120,6 @@ function VariationsToggleGroupControl( {
 				hideLabelFromVision
 				onChange={ onSelectVariation }
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 			>
 				{ variations.map( ( variation ) => (
 					<ToggleGroupControlOptionIcon

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -137,7 +137,6 @@ function FlexControls( {
 			panelId={ panelId }
 		>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				size="__unstable-large"
 				label={ childLayoutOrientation( parentLayout ) }
 				value={ selfStretch || 'fit' }

--- a/packages/block-editor/src/components/dimensions-tool/scale-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/scale-tool.js
@@ -105,7 +105,6 @@ export default function ScaleTool( {
 			panelId={ panelId }
 		>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				label={ __( 'Scale' ) }
 				isBlock
 				help={ scaleHelp[ displayValue ] }

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -129,7 +129,6 @@ export default function ImageSizeControl( {
 						value={ selectedValue }
 						isBlock
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					>
 						{ IMAGE_SIZE_PRESETS.map( ( scale ) => {
 							return (

--- a/packages/block-editor/src/components/text-alignment-control/index.js
+++ b/packages/block-editor/src/components/text-alignment-control/index.js
@@ -76,7 +76,6 @@ export default function TextAlignmentControl( {
 	return (
 		<ToggleGroupControl
 			isDeselectable
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Text alignment' ) }
 			className={ clsx(

--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -49,7 +49,6 @@ export default function TextDecorationControl( {
 	return (
 		<ToggleGroupControl
 			isDeselectable
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Decoration' ) }
 			className={ clsx(

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -55,7 +55,6 @@ export default function TextTransformControl( { className, value, onChange } ) {
 	return (
 		<ToggleGroupControl
 			isDeselectable
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Letter case' ) }
 			className={ clsx(

--- a/packages/block-editor/src/components/writing-mode-control/index.js
+++ b/packages/block-editor/src/components/writing-mode-control/index.js
@@ -40,7 +40,6 @@ export default function WritingModeControl( { className, value, onChange } ) {
 	return (
 		<ToggleGroupControl
 			isDeselectable
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Orientation' ) }
 			className={ clsx( 'block-editor-writing-mode-control', className ) }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -323,7 +323,6 @@ function LayoutTypeSwitcher( { type, onChange } ) {
 			__next40pxDefaultSize
 			isBlock
 			label={ __( 'Layout type' ) }
-			__nextHasNoMarginBottom
 			hideLabelFromVision
 			isAdaptiveWidth
 			value={ type }

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -137,7 +137,6 @@ export default {
 				{ allowJustification && (
 					<ToggleGroupControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Justification' ) }
 						value={ justifyContent }
 						onChange={ onJustificationChange }

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -298,7 +298,6 @@ function FlexLayoutJustifyContentControl( {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Justification' ) }
 			value={ justifyContent }
 			onChange={ onJustificationChange }
@@ -344,7 +343,6 @@ function OrientationControl( { layout, onChange } ) {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			className="block-editor-hooks__flex-layout-orientation-controls"
 			label={ __( 'Orientation' ) }
 			value={ orientation }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -429,7 +429,6 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Grid item position' ) }
 			value={ gridPlacement }
 			onChange={ onChangeType }

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -188,7 +188,6 @@ export default function Edit( {
 							}
 						>
 							<ToggleGroupControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								isBlock
 								label={ __( 'Icon Position' ) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -152,7 +152,6 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 					}
 					isBlock
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 				>
 					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
 						return (

--- a/packages/block-library/src/comments-pagination/comments-pagination-arrow-controls.js
+++ b/packages/block-library/src/comments-pagination/comments-pagination-arrow-controls.js
@@ -11,7 +11,6 @@ export function CommentsPaginationArrowControls( { value, onChange } ) {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Arrow' ) }
 			value={ value }
 			onChange={ onChange }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -419,7 +419,6 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						>
 							<ToggleGroupControl
 								className="editor-latest-posts-image-alignment-control"
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'Image alignment' ) }
 								value={ featuredImageAlign || 'none' }

--- a/packages/block-library/src/navigation-overlay-close/edit.js
+++ b/packages/block-library/src/navigation-overlay-close/edit.js
@@ -58,7 +58,6 @@ export default function NavigationOverlayCloseEdit( {
 							}
 							isBlock
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 						>
 							<ToggleGroupControlOption
 								value="icon"

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
@@ -42,7 +42,6 @@ export default function OverlayMenuPreviewControls( {
 			/>
 			<ToggleGroupControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				className="wp-block-navigation__overlay-menu-icon-toggle-group"
 				label={ __( 'Icon' ) }
 				value={ icon }

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -42,14 +42,14 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 				hasValue={ () => icon !== 'handle' }
 				onDeselect={ () => setAttributes( { icon: 'handle' } ) }
 			>
-<ToggleGroupControl
-				__next40pxDefaultSize
-				className="wp-block-navigation__overlay-menu-icon-toggle-group"
-				label={ __( 'Icon' ) }
-				value={ icon }
-				onChange={ ( value ) => setAttributes( { icon: value } ) }
-				isBlock
-			>
+				<ToggleGroupControl
+					__next40pxDefaultSize
+					className="wp-block-navigation__overlay-menu-icon-toggle-group"
+					label={ __( 'Icon' ) }
+					value={ icon }
+					onChange={ ( value ) => setAttributes( { icon: value } ) }
+					isBlock
+				>
 					<ToggleGroupControlOption
 						value="handle"
 						aria-label={ __( 'handle' ) }

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -42,15 +42,14 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 				hasValue={ () => icon !== 'handle' }
 				onDeselect={ () => setAttributes( { icon: 'handle' } ) }
 			>
-				<ToggleGroupControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					className="wp-block-navigation__overlay-menu-icon-toggle-group"
-					label={ __( 'Icon' ) }
-					value={ icon }
-					onChange={ ( value ) => setAttributes( { icon: value } ) }
-					isBlock
-				>
+<ToggleGroupControl
+				__next40pxDefaultSize
+				className="wp-block-navigation__overlay-menu-icon-toggle-group"
+				label={ __( 'Icon' ) }
+				value={ icon }
+				onChange={ ( value ) => setAttributes( { icon: value } ) }
+				isBlock
+			>
 					<ToggleGroupControlOption
 						value="handle"
 						aria-label={ __( 'handle' ) }

--- a/packages/block-library/src/navigation/edit/overlay-visibility-control.js
+++ b/packages/block-library/src/navigation/edit/overlay-visibility-control.js
@@ -22,7 +22,6 @@ export default function OverlayVisibilityControl( {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Overlay Visibility' ) }
 			aria-label={ __( 'Configure overlay visibility' ) }
 			value={ overlayMenu }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -189,7 +189,6 @@ const DimensionControls = ( {
 				>
 					<ToggleGroupControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ scaleLabel }
 						value={ scale }
 						help={ scaleHelp[ scale ] }

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -171,7 +171,6 @@ export default function PostNavigationLinkEdit( {
 					>
 						<ToggleGroupControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Arrow' ) }
 							value={ arrow }
 							onChange={ ( value ) => {

--- a/packages/block-library/src/query-pagination/query-pagination-arrow-controls.js
+++ b/packages/block-library/src/query-pagination/query-pagination-arrow-controls.js
@@ -11,7 +11,6 @@ export function QueryPaginationArrowControls( { value, onChange } ) {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Arrow' ) }
 			value={ value }
 			onChange={ onChange }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -205,7 +205,6 @@ export default function QueryInspectorControls( props ) {
 							<VStack spacing={ 4 }>
 								<ToggleGroupControl
 									__next40pxDefaultSize
-									__nextHasNoMarginBottom
 									label={ __( 'Query type' ) }
 									isBlock
 									onChange={ ( value ) => {
@@ -265,12 +264,11 @@ export default function QueryInspectorControls( props ) {
 									help={ postTypeControlHelp }
 								/>
 							) : (
-								<ToggleGroupControl
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-									isBlock
-									value={ postType }
-									label={ postTypeControlLabel }
+<ToggleGroupControl
+								__next40pxDefaultSize
+								isBlock
+								value={ postType }
+								label={ postTypeControlLabel }
 									onChange={ onPostTypeChange }
 									help={ postTypeControlHelp }
 								>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -264,11 +264,11 @@ export default function QueryInspectorControls( props ) {
 									help={ postTypeControlHelp }
 								/>
 							) : (
-<ToggleGroupControl
-								__next40pxDefaultSize
-								isBlock
-								value={ postType }
-								label={ postTypeControlLabel }
+								<ToggleGroupControl
+									__next40pxDefaultSize
+									isBlock
+									value={ postType }
+									label={ postTypeControlLabel }
 									onChange={ onPostTypeChange }
 									help={ postTypeControlHelp }
 								>

--- a/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
@@ -9,11 +9,11 @@ import { __ } from '@wordpress/i18n';
 
 export default function InheritControl( { value, onChange, label } ) {
 	return (
-<ToggleGroupControl
-		__next40pxDefaultSize
-		label={ label }
-		isBlock
-		onChange={ ( newValue ) => {
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			label={ label }
+			isBlock
+			onChange={ ( newValue ) => {
 				onChange( {
 					inherit: newValue === 'default',
 				} );

--- a/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
@@ -9,12 +9,11 @@ import { __ } from '@wordpress/i18n';
 
 export default function InheritControl( { value, onChange, label } ) {
 	return (
-		<ToggleGroupControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ label }
-			isBlock
-			onChange={ ( newValue ) => {
+<ToggleGroupControl
+		__next40pxDefaultSize
+		label={ label }
+		isBlock
+		onChange={ ( newValue ) => {
 				onChange( {
 					inherit: newValue === 'default',
 				} );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `CheckboxControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73916](https://github.com/WordPress/gutenberg/pull/73916)).
 -   `TextControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73920](https://github.com/WordPress/gutenberg/pull/73920)).
 -   `TextareaControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73970](https://github.com/WordPress/gutenberg/pull/73970)).
+-   `ToggleGroupControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74004](https://github.com/WordPress/gutenberg/pull/74004)).
 -   `DimensionControl`: Completely remove deprecated component ([#73944](https://github.com/WordPress/gutenberg/pull/73944)).
 
 ### Enhancements

--- a/packages/components/src/border-control/border-control-style-picker/component.tsx
+++ b/packages/components/src/border-control/border-control-style-picker/component.tsx
@@ -26,7 +26,6 @@ function UnconnectedBorderControlStylePicker(
 ) {
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			ref={ forwardedRef }
 			isDeselectable

--- a/packages/components/src/date-time/time/time-input/index.tsx
+++ b/packages/components/src/date-time/time/time-input/index.tsx
@@ -168,7 +168,6 @@ export function TimeInput( {
 				{ is12Hour && (
 					<ToggleGroupControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'Select AM or PM' ) }
 						hideLabelFromVision

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -56,7 +56,6 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize={ __next40pxDefaultSize }
 			__shouldNotWarnDeprecated36pxSize
 			label={ __( 'Font size' ) }

--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -51,7 +51,6 @@ const Template: StoryFn< typeof ToggleGroupControl > = ( {
 
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			{ ...props }
 			onChange={ ( ...changeArgs ) => {

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -28,13 +28,7 @@ const hoverOutside = async () => {
 };
 
 const ToggleGroupControl = ( props: ToggleGroupControlProps ) => {
-	return (
-		<_ToggleGroupControl
-			{ ...props }
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-		/>
-	);
+	return <_ToggleGroupControl { ...props } __next40pxDefaultSize />;
 };
 
 const ControlledToggleGroupControl = ( {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
@@ -17,7 +17,7 @@ import { formatLowercase, formatUppercase } from '@wordpress/icons';
 
 function Example() {
 	return (
-		<ToggleGroupControl __nextHasNoMarginBottom __next40pxDefaultSize>
+		<ToggleGroupControl __next40pxDefaultSize>
 			<ToggleGroupControlOptionIcon
 				value="uppercase"
 				icon={ formatUppercase }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
@@ -52,7 +52,7 @@ function UnforwardedToggleGroupControlOptionIcon(
  *
  * function Example() {
  *  return (
- *    <ToggleGroupControl __nextHasNoMarginBottom __next40pxDefaultSize>
+ *    <ToggleGroupControl __next40pxDefaultSize>
  *      <ToggleGroupControlOptionIcon
  *        value="uppercase"
  *        label="Uppercase"

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
@@ -20,7 +20,6 @@ function Example() {
 			label="my label"
 			value="vertical"
 			isBlock
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 		>
 			<ToggleGroupControlOption

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -52,7 +52,6 @@ function UnforwardedToggleGroupControlOption(
  *       label="my label"
  *       value="vertical"
  *       isBlock
- *       __nextHasNoMarginBottom
  *       __next40pxDefaultSize
  *     >
  *       <ToggleGroupControlOption value="horizontal" label="Horizontal" />

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -24,7 +24,6 @@ function Example() {
 			label="my label"
 			value="vertical"
 			isBlock
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 		>
 			<ToggleGroupControlOption value="horizontal" label="Horizontal" />
@@ -92,13 +91,6 @@ The value of the `ToggleGroupControl`.
 ### `__next40pxDefaultSize`: `boolean`
 
 Start opting into the larger default height that will become the default size in a future version.
-
--   Required: No
--   Default: `false`
-
-### `__nextHasNoMarginBottom`: `boolean`
-
-Start opting into the new margin-free styles that will become the default in a future version.
 
 -   Required: No
 -   Default: `false`

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -7,6 +7,7 @@ import type { ForwardedRef } from 'react';
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import * as styles from './styles';
 import { ToggleGroupControlAsRadioGroup } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 import { useTrackElementOffsetRect } from '../../utils/element-rect';
-import { useMergeRefs } from '@wordpress/compose';
 import { useAnimatedOffsetRect } from '../../utils/hooks/use-animated-offset-rect';
 import { maybeWarnDeprecated36pxSize } from '../../utils/deprecated-36px-size';
 
@@ -30,7 +30,8 @@ function UnconnectedToggleGroupControl(
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {
-		__nextHasNoMarginBottom = false,
+		// Prevent passing this to the internal component.
+		__nextHasNoMarginBottom: _,
 		__next40pxDefaultSize = false,
 		__shouldNotWarnDeprecated36pxSize,
 		className,
@@ -91,11 +92,7 @@ function UnconnectedToggleGroupControl(
 	} );
 
 	return (
-		<BaseControl
-			help={ help }
-			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-			__associatedWPComponentName="ToggleGroupControl"
-		>
+		<BaseControl help={ help } __nextHasNoMarginBottom>
 			{ ! hideLabelFromVision && (
 				<VisualLabelWrapper>
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
@@ -143,7 +140,6 @@ function UnconnectedToggleGroupControl(
  *       label="my label"
  *       value="vertical"
  *       isBlock
- *       __nextHasNoMarginBottom
  *       __next40pxDefaultSize
  *     >
  *       <ToggleGroupControlOption value="horizontal" label="Horizontal" />

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -30,8 +30,7 @@ function UnconnectedToggleGroupControl(
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {
-		// Prevent passing this to the internal component.
-		__nextHasNoMarginBottom: _,
+		__nextHasNoMarginBottom: _, // Prevent passing this to the internal component
 		__next40pxDefaultSize = false,
 		__shouldNotWarnDeprecated36pxSize,
 		className,

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -70,10 +70,14 @@ export type WithToolTipProps = {
 	showTooltip?: boolean;
 };
 
-export type ToggleGroupControlProps = Pick<
-	BaseControlProps,
-	'help' | '__nextHasNoMarginBottom'
-> & {
+export type ToggleGroupControlProps = Pick< BaseControlProps, 'help' > & {
+	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.0. Prop can be safely removed.
+	 * @ignore
+	 */
+	__nextHasNoMarginBottom?: boolean;
 	/**
 	 * Label for the control.
 	 */

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -116,7 +116,6 @@ export const Default: StoryFn< typeof ToolsPanel > = ( {
 						onDeselect={ () => setScale( undefined ) }
 					>
 						<ToggleGroupControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label="Scale"
 							value={ scale }
@@ -472,7 +471,6 @@ export const WithConditionalDefaultControl: StoryFn< typeof ToolsPanel > = ( {
 					isShownByDefault={ !! height }
 				>
 					<ToggleGroupControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label="Scale"
 						value={ scale }
@@ -576,7 +574,6 @@ export const WithConditionallyRenderedControl: StoryFn<
 						isShownByDefault
 					>
 						<ToggleGroupControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label="Scale"
 							value={ scale }

--- a/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
@@ -18,7 +18,7 @@ const UnforwardedValidatedToggleGroupControl = (
 		...restProps
 	}: Omit<
 		React.ComponentProps< typeof ToggleGroupControl >,
-		'__next40pxDefaultSize' | '__nextHasNoMarginBottom'
+		'__next40pxDefaultSize'
 	> &
 		ValidatedControlProps,
 	forwardedRef: React.ForwardedRef< HTMLInputElement >
@@ -36,7 +36,6 @@ const UnforwardedValidatedToggleGroupControl = (
 				getValidityTarget={ () => validityTargetRef.current }
 			>
 				<ToggleGroupControl
-					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					ref={ forwardedRef }
 					{ ...restProps }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -164,7 +164,6 @@ function SortDirectionControl() {
 	return (
 		<ToggleGroupControl
 			className="dataviews-view-config__sort-direction"
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			isBlock
 			label={ __( 'Order' ) }
@@ -219,7 +218,6 @@ function ItemsPerPageControl() {
 
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			isBlock
 			label={ __( 'Items per page' ) }

--- a/packages/dataviews/src/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/dataform-controls/toggle-group.tsx
@@ -53,7 +53,6 @@ export default function ToggleGroup< Item >( {
 			required={ !! field.isValid?.required }
 			customValidity={ getCustomValidity( isValid, validity ) }
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			isBlock
 			label={ field.label }
 			help={ selectedOption?.description || field.description }

--- a/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
@@ -19,7 +19,6 @@ export default function DensityPicker() {
 	const view = context.view as ViewTable;
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom
 			size="__unstable-large"
 			label={ __( 'Density' ) }
 			value={ view.layout?.density || 'balanced' }

--- a/packages/global-styles-ui/src/screen-typography-element.tsx
+++ b/packages/global-styles-ui/src/screen-typography-element.tsx
@@ -69,7 +69,6 @@ function ScreenTypographyElement( { element }: ScreenTypographyElementProps ) {
 						}
 						isBlock
 						size="__unstable-large"
-						__nextHasNoMarginBottom
 					>
 						<ToggleGroupControlOption
 							value="heading"

--- a/packages/global-styles-ui/src/shadows-edit-panel.tsx
+++ b/packages/global-styles-ui/src/shadows-edit-panel.tsx
@@ -488,7 +488,6 @@ function ShadowPopover( { shadowObj, onChange }: ShadowPopoverProps ) {
 			/>
 			<ToggleGroupControl
 				label={ __( 'Shadow Type' ) }
-				__nextHasNoMarginBottom
 				value={ shadowObj.inset ? 'inset' : 'outset' }
 				isBlock
 				onChange={ ( value ) =>


### PR DESCRIPTION
## What?

Part of #73848

Remove the deprecated `__nextHasNoMarginBottom` prop from `ToggleGroupControl`, making the margin-free styles the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0. This removes the prop, completing the deprecation cycle.

## How?

- Remove the `__nextHasNoMarginBottom` prop from `ToggleGroupControl` and its types and docs.
- Remove all usages of the prop across the codebase.

## Testing Instructions

Smoke test the affected components in Storybook and the app.


