### PR TITLE
UI: Remove support for numeric multiplier on Box padding

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Remove numeric multiplier option for spacing tokens from `Stack` and `Box` components. ([#73852](https://github.com/WordPress/gutenberg/pull/73852))
+
 ### New Features
 
-- Add `Stack` component
+-   Add `Stack` component. ([#73928](https://github.com/WordPress/gutenberg/pull/73928))

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Remove numeric multiplier option for spacing tokens from `Stack` and `Box` components. ([#73852](https://github.com/WordPress/gutenberg/pull/73852))
+-   Remove numeric multiplier option for spacing tokens from `Stack` and `Box` components. ([#73852](https://github.com/WordPress/gutenberg/pull/73852), [#74008](https://github.com/WordPress/gutenberg/pull/74008))
 
 ### New Features
 

--- a/packages/ui/src/box/box.tsx
+++ b/packages/ui/src/box/box.tsx
@@ -28,7 +28,7 @@ const capitalize = ( str: string ): string =>
 	str.charAt( 0 ).toUpperCase() + str.slice( 1 );
 
 /**
- * Converts a size value to a CSS design token property reference (with
+ * Converts a size token name to a CSS design token property reference (with
  * fallback).
  *
  * @param property The CSS property name.

--- a/packages/ui/src/box/box.tsx
+++ b/packages/ui/src/box/box.tsx
@@ -29,7 +29,7 @@ const capitalize = ( str: string ): string =>
 
 /**
  * Converts a size value to a CSS design token property reference (with
- * fallback) or a calculated value based on the base unit.
+ * fallback).
  *
  * @param property The CSS property name.
  * @param target   The design system token target.
@@ -41,9 +41,7 @@ const getSpacingValue = (
 	target: string,
 	value: number | string
 ): string =>
-	typeof value === 'number'
-		? `calc(var(--wpds-dimension-base) * ${ value })`
-		: `var(--wpds-dimension-${ property }-${ target }-${ value }, var(--wpds-dimension-${ property }-surface-${ value }))`;
+	`var(--wpds-dimension-${ property }-${ target }-${ value }, var(--wpds-dimension-${ property }-surface-${ value }))`;
 
 /**
  * Generates CSS styles for properties with optionally directional values,

--- a/packages/ui/src/box/box.tsx
+++ b/packages/ui/src/box/box.tsx
@@ -33,13 +33,13 @@ const capitalize = ( str: string ): string =>
  *
  * @param property The CSS property name.
  * @param target   The design system token target.
- * @param value    The size value, either a number (multiplier of base unit) or a string (token name).
+ * @param value    The size token name.
  * @return A CSS value string with variable references.
  */
 const getSpacingValue = (
 	property: string,
 	target: string,
-	value: number | string
+	value: string
 ): string =>
 	`var(--wpds-dimension-${ property }-${ target }-${ value }, var(--wpds-dimension-${ property }-surface-${ value }))`;
 

--- a/packages/ui/src/box/types.ts
+++ b/packages/ui/src/box/types.ts
@@ -50,6 +50,14 @@ type StrokeColor =
 	| 'warning'
 	| 'warning-strong';
 
+type Target =
+	| 'surface'
+	| 'interactive'
+	| 'content'
+	| 'track'
+	| 'thumb'
+	| 'focus';
+
 type DimensionVariant< T > = {
 	block?: T;
 	blockStart?: T;
@@ -63,7 +71,7 @@ export interface BoxProps extends ComponentProps< 'div' > {
 	/**
 	 * The target rendering element design token grouping to use for the box.
 	 */
-	target?: string;
+	target?: Target;
 
 	/**
 	 * The surface background design token for box background color.

--- a/packages/ui/src/box/types.ts
+++ b/packages/ui/src/box/types.ts
@@ -3,9 +3,7 @@
  */
 import { type ComponentProps } from '../utils/types';
 
-type SizeToken = '2xs' | 'xs' | 'sm' | 'md' | 'lg';
-
-type Size = number | SizeToken;
+type Size = '2xs' | 'xs' | 'sm' | 'md' | 'lg';
 
 type BackgroundColor =
 	| 'neutral'
@@ -85,12 +83,12 @@ export interface BoxProps extends ComponentProps< 'div' > {
 	/**
 	 * The surface border radius design token.
 	 */
-	borderRadius?: Exclude< SizeToken, '2xs' >;
+	borderRadius?: Exclude< Size, '2xs' >;
 
 	/**
 	 * The surface border width design token.
 	 */
-	borderWidth?: Exclude< SizeToken, '2xs' >;
+	borderWidth?: Exclude< Size, '2xs' >;
 
 	/**
 	 * The surface border stroke color design token.


### PR DESCRIPTION
## What?

Updates `@wordpress/ui`'s `Box` component to remove support for passing a number as a padding value, requiring consumers to use one of the available token values.

Extracted from #74001 (see https://github.com/WordPress/gutenberg/pull/74001#discussion_r2620316479).

## Why?

See #73852 for context:

> Since this component is a foundational component of the design system, it should aim to build on design tokens that form the basis of expressing spacing in a systems-based manner.

## Testing Instructions

None of the current stories or tests provide coverage for this, likely because it was always considered an edge case, now completely unsupported.

You can still verify there is no impact to the rendering behavior of existing Storybook stories:

1. `npm run storybook:start`
2. Go to http://localhost:50240/?path=/docs/design-system-components-box--docs
3. Verify no regression in appearance of `Box`