### PR TITLE
Boot: Wire user admin theme preference to ThemeProvider

### DIFF
--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
-import { privateApis as themePrivateApis } from '@wordpress/theme';
 import { EditorSnackbars } from '@wordpress/editor';
 import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
 import {
@@ -33,8 +32,8 @@ import useRouteTitle from '../app/use-route-title';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
+import { UserThemeProvider } from '../user-theme-provider';
 
-const { ThemeProvider } = unlock( themePrivateApis );
 const { useLocation, useMatches, Outlet } = unlock( routePrivateApis );
 
 export default function Root() {
@@ -62,11 +61,8 @@ export default function Root() {
 
 	return (
 		<SlotFillProvider>
-			<ThemeProvider
-				isRoot
-				color={ { bg: '#f8f8f8', primary: '#3858e9' } }
-			>
-				<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
+			<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
+				<UserThemeProvider color={ { bg: '#1d2327' } }>
 					<div
 						className={ clsx( 'boot-layout', {
 							'has-canvas': !! canvas || canvas === null,
@@ -146,11 +142,9 @@ export default function Root() {
 							</div>
 						) }
 						<div className="boot-layout__surfaces">
-							<ThemeProvider
-								color={ { bg: '#ffffff', primary: '#3858e9' } }
-							>
+							<UserThemeProvider color={ { bg: '#ffffff' } }>
 								<Outlet />
-							</ThemeProvider>
+							</UserThemeProvider>
 							{ /* Render Canvas in Root to prevent remounting on route changes */ }
 							{ ( canvas || canvas === null ) && (
 								<div
@@ -186,8 +180,8 @@ export default function Root() {
 							) }
 						</div>
 					</div>
-				</ThemeProvider>
-			</ThemeProvider>
+				</UserThemeProvider>
+			</UserThemeProvider>
 		</SlotFillProvider>
 	);
 }

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { privateApis as routePrivateApis } from '@wordpress/route';
 // @ts-expect-error Commands is not typed properly.
 import { CommandMenu } from '@wordpress/commands';
-import { privateApis as themePrivateApis } from '@wordpress/theme';
 import { EditorSnackbars } from '@wordpress/editor';
 
 /**
@@ -21,9 +20,9 @@ import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
 import useRouteTitle from '../app/use-route-title';
+import { UserThemeProvider } from '../user-theme-provider';
 
 const { useMatches, Outlet } = unlock( routePrivateApis );
-const { ThemeProvider } = unlock( themePrivateApis );
 
 /**
  * Root component for single page mode (no sidebar).
@@ -43,8 +42,8 @@ export default function RootSinglePage() {
 	useRouteTitle();
 
 	return (
-		<ThemeProvider isRoot color={ { bg: '#f8f8f8', primary: '#3858e9' } }>
-			<ThemeProvider color={ { bg: '#1d2327', primary: '#3858e9' } }>
+		<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
+			<UserThemeProvider color={ { bg: '#1d2327' } }>
 				<div
 					className={ clsx( 'boot-layout boot-layout--single-page', {
 						'has-canvas': !! canvas || canvas === null,
@@ -55,11 +54,9 @@ export default function RootSinglePage() {
 					<SavePanel />
 					<EditorSnackbars />
 					<div className="boot-layout__surfaces">
-						<ThemeProvider
-							color={ { bg: '#ffffff', primary: '#3858e9' } }
-						>
+						<UserThemeProvider color={ { bg: '#ffffff' } }>
 							<Outlet />
-						</ThemeProvider>
+						</UserThemeProvider>
 						{ /* Render Canvas in Root to prevent remounting on route changes */ }
 						{ ( canvas || canvas === null ) && (
 							<div className="boot-layout__canvas">
@@ -71,7 +68,7 @@ export default function RootSinglePage() {
 						) }
 					</div>
 				</div>
-			</ThemeProvider>
-		</ThemeProvider>
+			</UserThemeProvider>
+		</UserThemeProvider>
 	);
 }

--- a/packages/boot/src/components/user-theme-provider/index.tsx
+++ b/packages/boot/src/components/user-theme-provider/index.tsx
@@ -7,30 +7,22 @@ import { unlock } from '../../lock-unlock';
 const ThemeProvider: typeof ThemeProviderType =
 	unlock( themePrivateApis ).ThemeProvider;
 
+const THEME_PRIMARY_COLORS = new Map< string, string >( [
+	[ 'light', '#0085ba' ],
+	[ 'modern', '#3858e9' ],
+	[ 'blue', '#096484' ],
+	[ 'coffee', '#46403c' ],
+	[ 'ectoplasm', '#523f6d' ],
+	[ 'midnight', '#e14d43' ],
+	[ 'ocean', '#627c83' ],
+	[ 'sunrise', '#dd823b' ],
+] );
+
 export function getAdminThemePrimaryColor(): string | undefined {
 	const theme =
 		document.body.className.match( /admin-color-([a-z]+)/ )?.[ 1 ];
 
-	switch ( theme ) {
-		case 'light':
-			return '#0085ba';
-		case 'modern':
-			return '#3858e9';
-		case 'blue':
-			return '#096484';
-		case 'coffee':
-			return '#46403c';
-		case 'ectoplasm':
-			return '#523f6d';
-		case 'midnight':
-			return '#e14d43';
-		case 'ocean':
-			return '#627c83';
-		case 'sunrise':
-			return '#dd823b';
-	}
-
-	return undefined;
+	return theme && THEME_PRIMARY_COLORS.get( theme );
 }
 
 export function UserThemeProvider( {

--- a/packages/boot/src/components/user-theme-provider/index.tsx
+++ b/packages/boot/src/components/user-theme-provider/index.tsx
@@ -7,7 +7,7 @@ import { unlock } from '../../lock-unlock';
 const ThemeProvider: typeof ThemeProviderType =
 	unlock( themePrivateApis ).ThemeProvider;
 
-function getAdminThemePrimaryColor(): string | undefined {
+export function getAdminThemePrimaryColor(): string | undefined {
 	const theme =
 		document.body.className.match( /admin-color-([a-z]+)/ )?.[ 1 ];
 

--- a/packages/boot/src/components/user-theme-provider/index.tsx
+++ b/packages/boot/src/components/user-theme-provider/index.tsx
@@ -1,0 +1,43 @@
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../../lock-unlock';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
+
+function getAdminThemePrimaryColor(): string | undefined {
+	const theme =
+		document.body.className.match( /admin-color-([a-z]+)/ )?.[ 1 ];
+
+	switch ( theme ) {
+		case 'light':
+			return '#0085ba';
+		case 'modern':
+			return '#3858e9';
+		case 'blue':
+			return '#096484';
+		case 'coffee':
+			return '#46403c';
+		case 'ectoplasm':
+			return '#523f6d';
+		case 'midnight':
+			return '#e14d43';
+		case 'ocean':
+			return '#627c83';
+		case 'sunrise':
+			return '#dd823b';
+	}
+
+	return undefined;
+}
+
+export function UserThemeProvider( {
+	color,
+	...restProps
+}: React.ComponentProps< typeof ThemeProvider > ) {
+	const primary = getAdminThemePrimaryColor();
+
+	return <ThemeProvider { ...restProps } color={ { primary, ...color } } />;
+}

--- a/packages/boot/src/components/user-theme-provider/test/index.test.ts
+++ b/packages/boot/src/components/user-theme-provider/test/index.test.ts
@@ -1,0 +1,11 @@
+import { getAdminThemePrimaryColor } from '../index';
+
+describe( 'getAdminThemePrimaryColor', () => {
+	it( 'should return the primary color for the admin theme from the body class', () => {
+		document.body.className = 'foo admin-color-coffee bar';
+
+		const primaryColor = getAdminThemePrimaryColor();
+
+		expect( primaryColor ).toBe( '#46403c' );
+	} );
+} );

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### New Features
 
--   Expose `ThemeProvider` TypeScript type from package. While the component is still experimental, this makes it easier to use TypeScript typings in your code, which would otherwise be inaccessible.
+-   Expose `ThemeProvider` TypeScript type from package. While the component is still experimental, this makes it easier to use TypeScript typings in your code, which would otherwise be inaccessible. ([#74011](https://github.com/WordPress/gutenberg/pull/74011))

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### New Features
+
+-   Expose `ThemeProvider` TypeScript type from package. While the component is still experimental, this makes it easier to use TypeScript typings in your code, which would otherwise be inaccessible.

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,3 +1,2 @@
-// Private APIs.
 export { privateApis } from './private-apis';
 export { type ThemeProvider } from './theme-provider';

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,2 +1,3 @@
 // Private APIs.
 export { privateApis } from './private-apis';
+export { type ThemeProvider } from './theme-provider';


### PR DESCRIPTION
## What?

Updates boot screens to initialize `ThemeProvider` using the user's color preference, extracted from the document body's `admin-theme-*` class. 

Includes a supporting change to expose `ThemeProvider` TypeScript type from the package, which ensures that the component is still private, but its types are available (e.g. as used to inherit props for `UserThemeProvider` wrapper).

Related discussion: https://github.com/WordPress/gutenberg/pull/69130#issuecomment-3654300467

## Why?

- Ensures that the user's selected color preference is respected on these new screens.
- Helps validate the implementation of color theming and its built-in backwards-compatibility for initializing CSS properties like `--wp-admin-theme-color`.

## How?

Creates a new `UserThemeProvider` component in the `boot` package, which wraps `ThemeProvider` and maps the admin body class to the expected `primary` seed value.

This follows from how `base-styles` maps admin schemes to equivalent seed colors ([source](https://github.com/WordPress/gutenberg/blob/d6e97990368dc9c7f2ee4d2ee6c0e8587399b05d/packages/base-styles/_mixins.scss#L513-L564)).

## Testing Instructions

Prerequisite: Use a user theme other than the default:

1. Go to Users > Profile
2. Pick an "Administration Color Scheme" other than "Default", e.g. "Ectoplasm"

Verify that the Fonts page respects the configured color theme:

1. Go to Appearance > Fonts
2. Color accent should follow from the configured user preference. You should see it take effect in tabs border underline and the button in the bottom-right (see screenshot below)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1266" height="1086" alt="Screenshot 2025-12-15 at 3 16 52 PM" src="https://github.com/user-attachments/assets/b50dd295-ed32-413b-831b-513cdcdcb881" />|<img width="1266" height="1086" alt="Screenshot 2025-12-15 at 3 16 44 PM" src="https://github.com/user-attachments/assets/b169bb92-5e9f-46a3-b6ec-bbb164c3f137" />|