### PR TITLE
Navigation Link: Preserve custom label when adding URL via LinkPicker

### DIFF
--- a/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
+++ b/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
@@ -42,9 +42,9 @@ export function useHandleLinkChange( { clientId, attributes, setAttributes } ) {
 				id: updatedLink.id,
 			};
 
-			// Only include title when creating a new link (not updating existing)
+			// Only include title when there's no existing label
 			// This preserves user-customized labels when updating links
-			if ( ! attributes.url || ! attributes.label ) {
+			if ( ! attributes.label ) {
 				attrs.title = updatedLink.title;
 			}
 

--- a/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
+++ b/packages/block-library/src/navigation-link/shared/use-handle-link-change.js
@@ -44,7 +44,7 @@ export function useHandleLinkChange( { clientId, attributes, setAttributes } ) {
 
 			// Only include title when there's no existing label
 			// This preserves user-customized labels when updating links
-			if ( ! attributes.label ) {
+			if ( ! attributes.label || attributes.label === '' ) {
 				attrs.title = updatedLink.title;
 			}
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1928,21 +1928,12 @@ test.describe( 'Navigation block', () => {
 			pageUtils,
 		} ) => {
 			await test.step( 'Select third navigation link (Empty Link)', async () => {
-				// To do this, we have to select the second link then arrow to the third link.
-				// Otherwise, clicking the empty link directly will open the link control
-				// in the canvas, then remove it once we do not add a link.
-				const navLinkBlock = navigation
-					.getNavBlock()
-					.getByRole( 'document', {
-						name: 'Block: Custom Link',
-					} )
-					.first();
+				// Select the navigation
+				await navigation.getNavBlock().click();
 
-				await navLinkBlock.click();
-
-				// Use arrow keys to select the third link
-				await pageUtils.pressKeys( 'Shift+End' );
-				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+				// select the block via the inspector list view instead of the canvas, as that will
+				// open the link control in the canvas
+				await page.getByRole( 'link', { name: 'Empty Link' } ).click();
 			} );
 
 			await test.step( 'Open inspector and verify LinkPicker shows "Add link" button', async () => {
@@ -1995,17 +1986,13 @@ test.describe( 'Navigation block', () => {
 				await expect( linkButton ).toBeVisible();
 			} );
 
-			// TODO: Verify navigation link in canvas has the correct title of "Empty Link"
-			// await test.step( 'Verify navigation link in canvas updated', async () => {
-			// 	const navLinkBlock = navigation
-			// 		.getNavBlock()
-			// 		.getByRole( 'document', {
-			// 			name: 'Block: Page Link',
-			// 		} )
-			// 		.last();
+			await test.step( 'Verify navigation link in canvas updated with existing title', async () => {
+				const navLinkBlock = navigation
+					.getNavBlock()
+					.getByText( 'Empty Link' );
 
-			// 	await expect( navLinkBlock ).toContainText( 'Empty Link' );
-			// } );
+				await expect( navLinkBlock ).toBeVisible();
+			} );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1929,7 +1929,7 @@ test.describe( 'Navigation block', () => {
 		} ) => {
 			await test.step( 'Select third navigation link (Empty Link)', async () => {
 				// Select the navigation
-				await navigation.getNavBlock().click();
+				await editor.selectBlocks( navigation.getNavBlock() );
 
 				// select the block via the inspector list view instead of the canvas, as that will
 				// open the link control in the canvas


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/74005

<!-- In a few words, what is the PR actually doing? -->
Fix an issue where selecting a page from the LinkPicker would overwrite a custom link label.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
LinkPicker should respect the exiting label/title if present, not overwrite it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changes the condition in useHandleLinkChange from checking both url and label to only checking if a label exists, ensuring custom labels are always preserved when present.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Edit a navigation to have an empty link via the code editor view: `<!-- wp:navigation-link {"label":"Empty Link"} /-->`
2. Select this block via the list view (selecting it on canvas opens the link ui popover on canvas)
3. Use the Link Picker in the inspector sidebar to select a new link 
4. The title "Empty Link" should show in the canvas and not be overwritten


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
