### PR TITLE
TreeSelect: Deprecate bottom margin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -283,7 +283,6 @@ module.exports = {
 						'SearchControl',
 						'SelectControl',
 						'ToggleControl',
-						'TreeSelect',
 					].map( ( componentName ) => ( {
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,
 						message:

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `FocalPointPicker`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73980](https://github.com/WordPress/gutenberg/pull/73980)).
 -   `TextareaControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#73970](https://github.com/WordPress/gutenberg/pull/73970)).
 -   `ToggleGroupControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74004](https://github.com/WordPress/gutenberg/pull/74004)).
+-   `TreeSelect`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74014](https://github.com/WordPress/gutenberg/pull/74014)).
 -   `DimensionControl`: Completely remove deprecated component ([#73944](https://github.com/WordPress/gutenberg/pull/73944)).
 
 ### Enhancements

--- a/packages/components/src/query-controls/author-select.tsx
+++ b/packages/components/src/query-controls/author-select.tsx
@@ -30,7 +30,6 @@ export default function AuthorSelect( {
 					? String( selectedAuthorId )
 					: undefined
 			}
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize={ __next40pxDefaultSize }
 		/>
 	);

--- a/packages/components/src/query-controls/category-select.tsx
+++ b/packages/components/src/query-controls/category-select.tsx
@@ -1,13 +1,6 @@
-/**
- * Internal dependencies
- */
+import { useMemo } from '@wordpress/element';
 import { buildTermsTree } from './terms';
 import TreeSelect from '../tree-select';
-
-/**
- * WordPress dependencies
- */
-import { useMemo } from '@wordpress/element';
 import type { CategorySelectProps } from './types';
 
 export default function CategorySelect( {
@@ -37,7 +30,6 @@ export default function CategorySelect( {
 					: undefined
 			}
 			{ ...props }
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize={ __next40pxDefaultSize }
 		/>
 	);

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -15,7 +15,6 @@ const MyTreeSelect = () => {
 
 	return (
 		<TreeSelect
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label="Parent page"
 			noOptionLabel="No parent page"
@@ -61,14 +60,6 @@ const MyTreeSelect = () => {
  - Default: `false`
 
 Start opting into the larger default height that will become the default size in a future version.
-
-### `__nextHasNoMarginBottom`
-
- - Type: `boolean`
- - Required: No
- - Default: `false`
-
-Start opting into the new margin-free styles that will become the default in a future version.
 
 ### `children`
 

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -10,16 +10,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { SelectControl } from '../select-control';
 import type { TreeSelectProps, Tree, Truthy } from './types';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
-import { ContextSystemProvider } from '../context';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
-
-const CONTEXT_VALUE = {
-	BaseControl: {
-		// Temporary during deprecation grace period: Overrides the underlying `__associatedWPComponentName`
-		// via the context system to override the value set by SelectControl.
-		_overrides: { __associatedWPComponentName: 'TreeSelect' },
-	},
-};
 
 function getSelectOptions(
 	tree: Tree[],
@@ -47,7 +38,6 @@ function getSelectOptions(
  *
  * 	return (
  * 		<TreeSelect
- * 			__nextHasNoMarginBottom
  * 			__next40pxDefaultSize
  * 			label="Parent page"
  * 			noOptionLabel="No parent page"
@@ -86,6 +76,7 @@ function getSelectOptions(
  */
 export function TreeSelect( props: TreeSelectProps ) {
 	const {
+		__nextHasNoMarginBottom: _, // Prevent passing to internal component
 		label,
 		noOptionLabel,
 		onChange,
@@ -108,14 +99,13 @@ export function TreeSelect( props: TreeSelectProps ) {
 	} );
 
 	return (
-		<ContextSystemProvider value={ CONTEXT_VALUE }>
-			<SelectControl
-				__shouldNotWarnDeprecated36pxSize
-				{ ...{ label, options, onChange } }
-				value={ selectedId }
-				{ ...restProps }
-			/>
-		</ContextSystemProvider>
+		<SelectControl
+			__shouldNotWarnDeprecated36pxSize
+			{ ...{ label, options, onChange } }
+			value={ selectedId }
+			{ ...restProps }
+			__nextHasNoMarginBottom
+		/>
 	);
 }
 

--- a/packages/components/src/tree-select/stories/index.story.tsx
+++ b/packages/components/src/tree-select/stories/index.story.tsx
@@ -49,7 +49,6 @@ const TreeSelectWithState: StoryFn< typeof TreeSelect > = ( props ) => {
 
 export const Default = TreeSelectWithState.bind( {} );
 Default.args = {
-	__nextHasNoMarginBottom: true,
 	__next40pxDefaultSize: true,
 	label: 'Label Text',
 	noOptionLabel: 'No parent page',

--- a/packages/components/src/tree-select/types.ts
+++ b/packages/components/src/tree-select/types.ts
@@ -18,8 +18,15 @@ export interface Tree {
 export interface TreeSelectProps
 	extends Omit<
 		SelectControlSingleSelectionProps,
-		'value' | 'multiple' | 'onChange'
+		'value' | 'multiple' | 'onChange' | '__nextHasNoMarginBottom'
 	> {
+	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.0. Prop can be safely removed.
+	 * @ignore
+	 */
+	__nextHasNoMarginBottom?: boolean;
 	/**
 	 * If this property is added, an option will be added with this label to represent empty selection.
 	 */

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -473,7 +473,6 @@ export function HierarchicalTermSelector( { slug } ) {
 						{ !! availableTerms.length && (
 							<TreeSelect
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 								label={ parentSelectLabel }
 								noOptionLabel={ noParentOption }
 								onChange={ onChangeFormParent }


### PR DESCRIPTION
## What?

Part of #73848

Remove the deprecated `__nextHasNoMarginBottom` prop from `TreeSelect`, making the margin-free styles the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0. This removes the prop, completing the deprecation cycle.

## How?

- Remove the `__nextHasNoMarginBottom` prop from `TreeSelect` and its types and docs.
- Remove all usages of the prop across the codebase.

## Testing Instructions

Smoke test the affected components in Storybook and the app.
