### PR TITLE
Media fields: Add tests for fields with unique logic

### DIFF
--- a/packages/media-fields/src/filename/test/index.test.ts
+++ b/packages/media-fields/src/filename/test/index.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import filenameField from '../index';
+import type { MediaItem } from '../../types';
+
+describe( 'filenameField', () => {
+	it( 'has correct field configuration', () => {
+		expect( filenameField ).toMatchObject( {
+			id: 'filename',
+			type: 'text',
+			label: 'File name',
+			enableSorting: false,
+			filterBy: false,
+			readOnly: true,
+		} );
+	} );
+
+	it( 'extracts filename from source_url', () => {
+		const item: Partial< MediaItem > = {
+			source_url: 'https://example.com/wp-content/uploads/2024/image.jpg',
+		};
+
+		const result = filenameField.getValue?.( {
+			item: item as MediaItem,
+		} );
+
+		expect( result ).toBe( 'image.jpg' );
+	} );
+
+	it( 'has a render function', () => {
+		expect( filenameField.render ).toBeDefined();
+	} );
+} );

--- a/packages/media-fields/src/filename/test/index.test.ts
+++ b/packages/media-fields/src/filename/test/index.test.ts
@@ -16,16 +16,41 @@ describe( 'filenameField', () => {
 		} );
 	} );
 
-	it( 'extracts filename from source_url', () => {
-		const item: Partial< MediaItem > = {
-			source_url: 'https://example.com/wp-content/uploads/2024/image.jpg',
-		};
+	describe( 'getValue', () => {
+		it( 'extracts filename from source_url', () => {
+			const item: Partial< MediaItem > = {
+				source_url:
+					'https://example.com/wp-content/uploads/2024/image.jpg',
+			};
 
-		const result = filenameField.getValue?.( {
-			item: item as MediaItem,
+			const result = filenameField.getValue?.( {
+				item: item as MediaItem,
+			} );
+
+			expect( result ).toBe( 'image.jpg' );
 		} );
 
-		expect( result ).toBe( 'image.jpg' );
+		it( 'returns undefined when source_url is undefined', () => {
+			const item: Partial< MediaItem > = {};
+
+			const result = filenameField.getValue?.( {
+				item: item as MediaItem,
+			} );
+
+			expect( result ).toBeUndefined();
+		} );
+
+		it( 'returns undefined when source_url is empty string', () => {
+			const item: Partial< MediaItem > = {
+				source_url: '',
+			};
+
+			const result = filenameField.getValue?.( {
+				item: item as MediaItem,
+			} );
+
+			expect( result ).toBeUndefined();
+		} );
 	} );
 
 	it( 'has a render function', () => {

--- a/packages/media-fields/src/filename/test/view.test.tsx
+++ b/packages/media-fields/src/filename/test/view.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import FileNameView from '../view';
+import filenameField from '../index';
+import type { MediaItem } from '../../types';
+
+describe( 'FileNameView', () => {
+	describe( 'filename rendering', () => {
+		it( 'renders short filename (15 characters or less)', () => {
+			const item: Partial< MediaItem > = {
+				source_url: 'https://example.com/uploads/12345678901.jpg', // exactly 15 chars
+			};
+
+			render(
+				<FileNameView
+					item={ item as MediaItem }
+					field={ filenameField as NormalizedField< MediaItem > }
+				/>
+			);
+
+			// Verify the filename is visible to users
+			expect( screen.getByText( '12345678901.jpg' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders long filename (more than 15 characters)', () => {
+			const longFilename =
+				'very-long-filename-that-exceeds-fifteen-characters.jpg';
+			const item: Partial< MediaItem > = {
+				source_url: `https://example.com/uploads/${ longFilename }`,
+			};
+
+			render(
+				<FileNameView
+					item={ item as MediaItem }
+					field={ filenameField as NormalizedField< MediaItem > }
+				/>
+			);
+
+			// Verify the full filename text is accessible to users
+			// (the component handles truncation via Truncate/Tooltip, but the text is still present)
+			expect( screen.getByText( longFilename ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'renders nothing when source_url is missing', () => {
+			const item: Partial< MediaItem > = {};
+
+			const { container } = render(
+				<FileNameView
+					item={ item as MediaItem }
+					field={ filenameField as NormalizedField< MediaItem > }
+				/>
+			);
+
+			// When there's no source_url, component should render nothing
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		it( 'renders nothing when source_url is empty', () => {
+			const item: Partial< MediaItem > = {
+				source_url: '',
+			};
+
+			const { container } = render(
+				<FileNameView
+					item={ item as MediaItem }
+					field={ filenameField as NormalizedField< MediaItem > }
+				/>
+			);
+
+			// When source_url is empty, component should render nothing
+			expect( container ).toBeEmptyDOMElement();
+		} );
+	} );
+} );

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -44,30 +44,51 @@ describe( 'filesizeField', () => {
 				'fractional sizes with proper decimals',
 			],
 			[ 1024, /^1\s+KB$/, 'boundary value (exactly 1 KB)' ],
-		] )( 'formats %s bytes correctly: %s', ( filesize, expected ) => {
-			const item = {
-				media_details: {
-					filesize,
-					sizes: {},
-				},
-			} as MediaItem;
+		] )(
+			'formats %s bytes correctly: %s',
+			( filesize, expected, description ) => {
+				const item = {
+					media_details: {
+						filesize,
+						sizes: {},
+					},
+				} as MediaItem;
 
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
+				const result = filesizeField.getValue?.( {
+					item,
+				} );
 
-			expect( result ).toMatch( expected );
-		} );
+				try {
+					expect( result ).toMatch( expected );
+				} catch ( error ) {
+					const message =
+						error instanceof Error
+							? error.message
+							: String( error );
+					throw new Error(
+						`Failed to format filesize (${ description }): ${ message }`
+					);
+				}
+			}
+		);
 
 		it.each( [
 			[ { media_details: { sizes: {} } }, 'when filesize is missing' ],
 			[ {}, 'when media_details is missing' ],
-		] )( 'returns empty string %s', ( item ) => {
+		] )( 'returns empty string %s', ( item, description ) => {
 			const result = filesizeField.getValue?.( {
 				item: item as MediaItem,
 			} );
 
-			expect( result ).toBe( '' );
+			try {
+				expect( result ).toBe( '' );
+			} catch ( error ) {
+				const message =
+					error instanceof Error ? error.message : String( error );
+				throw new Error(
+					`Failed getValue test (${ description }): ${ message }`
+				);
+			}
 		} );
 	} );
 

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -17,7 +17,7 @@ describe( 'filesizeField', () => {
 	} );
 
 	describe( 'getValue - byte formatting logic', () => {
-		it( 'returns empty string for 0 bytes (handled by isVisible)', () => {
+		it( 'returns empty string for 0 bytes due to truthy check', () => {
 			const item = {
 				media_details: {
 					filesize: 0,
@@ -29,7 +29,7 @@ describe( 'filesizeField', () => {
 				item,
 			} );
 
-			// 0 bytes returns empty string because isVisible will hide it
+			// 0 bytes returns empty string because the truthy check in getValue treats 0 as falsy
 			expect( result ).toBe( '' );
 		} );
 

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Internal dependencies
+ */
+import filesizeField from '../index';
+import type { MediaItem } from '../../types';
+
+describe( 'filesizeField', () => {
+	it( 'has correct field configuration', () => {
+		expect( filesizeField ).toMatchObject( {
+			id: 'filesize',
+			type: 'text',
+			label: 'File size',
+			enableSorting: false,
+			filterBy: false,
+			readOnly: true,
+		} );
+	} );
+
+	describe( 'getValue - byte formatting logic', () => {
+		it( 'returns empty string for 0 bytes (handled by isVisible)', () => {
+			const item = {
+				media_details: {
+					filesize: 0,
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			// 0 bytes returns empty string because isVisible will hide it
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'formats bytes (less than 1 KB)', () => {
+			const item = {
+				media_details: {
+					filesize: 512,
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^512\s+B$/ );
+		} );
+
+		it( 'formats kilobytes', () => {
+			const item = {
+				media_details: {
+					filesize: 1024 * 50, // 50 KB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^50\s+KB$/ );
+		} );
+
+		it( 'formats megabytes', () => {
+			const item = {
+				media_details: {
+					filesize: 1024 * 1024 * 5, // 5 MB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^5\s+MB$/ );
+		} );
+
+		it( 'formats gigabytes', () => {
+			const item = {
+				media_details: {
+					filesize: 1024 * 1024 * 1024 * 2.5, // 2.5 GB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^2\.5\s+GB$/ );
+		} );
+
+		it( 'formats terabytes', () => {
+			const item = {
+				media_details: {
+					filesize: 1024 * 1024 * 1024 * 1024 * 1.5, // 1.5 TB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^1\.5\s+TB$/ );
+		} );
+
+		it( 'formats with proper decimals for fractional sizes', () => {
+			const item = {
+				media_details: {
+					filesize: 1024 * 1024 * 3.14159, // ~3.14 MB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			// Should have at most 2 decimal places
+			expect( result ).toMatch( /^3\.14\s+MB$/ );
+		} );
+
+		it( 'uses correct unit for boundary values', () => {
+			const item = {
+				media_details: {
+					filesize: 1024, // Exactly 1 KB
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /^1\s+KB$/ );
+		} );
+
+		it( 'returns empty string when filesize is missing', () => {
+			const item = {
+				media_details: {
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when media_details is missing', () => {
+			const item = {} as MediaItem;
+
+			const result = filesizeField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+	} );
+
+	describe( 'isVisible', () => {
+		it( 'returns true when filesize exists', () => {
+			const item = {
+				media_details: {
+					filesize: 1024,
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.isVisible?.( item );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns false when filesize is 0', () => {
+			const item = {
+				media_details: {
+					filesize: 0,
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when filesize is missing', () => {
+			const item = {
+				media_details: {
+					sizes: {},
+				},
+			} as MediaItem;
+
+			const result = filesizeField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -202,5 +202,13 @@ describe( 'filesizeField', () => {
 
 			expect( result ).toBe( false );
 		} );
+
+		it( 'returns false when media_details is missing', () => {
+			const item = {} as MediaItem;
+
+			const result = filesizeField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
 	} );
 } );

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -29,15 +29,25 @@ describe( 'filesizeField', () => {
 				item,
 			} );
 
-			// 0 bytes returns empty string because getValue uses a truthy check on filesize
-			// Note: formatFileSize would return "0 B" if called with 0, but it's never reached
 			expect( result ).toBe( '' );
 		} );
 
-		it( 'formats bytes (less than 1 KB)', () => {
+		it.each( [
+			[ 512, /^512\s+B$/, 'bytes (less than 1 KB)' ],
+			[ 1024 * 50, /^50\s+KB$/, '50 kilobytes' ],
+			[ 1024 * 1024 * 5, /^5\s+MB$/, '5 megabytes' ],
+			[ 1024 * 1024 * 1024 * 2.5, /^2\.5\s+GB$/, '2.5 gigabytes' ],
+			[ 1024 * 1024 * 1024 * 1024 * 1.5, /^1\.5\s+TB$/, '1.5 terabytes' ],
+			[
+				1024 * 1024 * 3.14159,
+				/^3\.14\s+MB$/,
+				'fractional sizes with proper decimals',
+			],
+			[ 1024, /^1\s+KB$/, 'boundary value (exactly 1 KB)' ],
+		] )( 'formats %s bytes correctly: %s', ( filesize, expected ) => {
 			const item = {
 				media_details: {
-					filesize: 512,
+					filesize,
 					sizes: {},
 				},
 			} as MediaItem;
@@ -46,119 +56,15 @@ describe( 'filesizeField', () => {
 				item,
 			} );
 
-			expect( result ).toMatch( /^512\s+B$/ );
+			expect( result ).toMatch( expected );
 		} );
 
-		it( 'formats kilobytes', () => {
-			const item = {
-				media_details: {
-					filesize: 1024 * 50, // 50 KB
-					sizes: {},
-				},
-			} as MediaItem;
-
+		it.each( [
+			[ { media_details: { sizes: {} } }, 'when filesize is missing' ],
+			[ {}, 'when media_details is missing' ],
+		] )( 'returns empty string %s', ( item ) => {
 			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /^50\s+KB$/ );
-		} );
-
-		it( 'formats megabytes', () => {
-			const item = {
-				media_details: {
-					filesize: 1024 * 1024 * 5, // 5 MB
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /^5\s+MB$/ );
-		} );
-
-		it( 'formats gigabytes', () => {
-			const item = {
-				media_details: {
-					filesize: 1024 * 1024 * 1024 * 2.5, // 2.5 GB
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /^2\.5\s+GB$/ );
-		} );
-
-		it( 'formats terabytes', () => {
-			const item = {
-				media_details: {
-					filesize: 1024 * 1024 * 1024 * 1024 * 1.5, // 1.5 TB
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /^1\.5\s+TB$/ );
-		} );
-
-		it( 'formats with proper decimals for fractional sizes', () => {
-			const item = {
-				media_details: {
-					filesize: 1024 * 1024 * 3.14159, // ~3.14 MB
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			// Should have at most 2 decimal places
-			expect( result ).toMatch( /^3\.14\s+MB$/ );
-		} );
-
-		it( 'uses correct unit for boundary values', () => {
-			const item = {
-				media_details: {
-					filesize: 1024, // Exactly 1 KB
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /^1\s+KB$/ );
-		} );
-
-		it( 'returns empty string when filesize is missing', () => {
-			const item = {
-				media_details: {
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when media_details is missing', () => {
-			const item = {} as MediaItem;
-
-			const result = filesizeField.getValue?.( {
-				item,
+				item: item as MediaItem,
 			} );
 
 			expect( result ).toBe( '' );
@@ -166,50 +72,15 @@ describe( 'filesizeField', () => {
 	} );
 
 	describe( 'isVisible', () => {
-		it( 'returns true when filesize exists', () => {
-			const item = {
-				media_details: {
-					filesize: 1024,
-					sizes: {},
-				},
-			} as MediaItem;
+		it.each( [
+			[ { media_details: { filesize: 1024, sizes: {} } }, true ],
+			[ { media_details: { filesize: 0, sizes: {} } }, false ],
+			[ { media_details: { sizes: {} } }, false ],
+			[ {}, false ],
+		] )( 'returns %s for item %#', ( item, expected ) => {
+			const result = filesizeField.isVisible?.( item as MediaItem );
 
-			const result = filesizeField.isVisible?.( item );
-
-			expect( result ).toBe( true );
-		} );
-
-		it( 'returns false when filesize is 0', () => {
-			const item = {
-				media_details: {
-					filesize: 0,
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when filesize is missing', () => {
-			const item = {
-				media_details: {
-					sizes: {},
-				},
-			} as MediaItem;
-
-			const result = filesizeField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when media_details is missing', () => {
-			const item = {} as MediaItem;
-
-			const result = filesizeField.isVisible?.( item );
-
-			expect( result ).toBe( false );
+			expect( result ).toBe( expected );
 		} );
 	} );
 } );

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -29,7 +29,8 @@ describe( 'filesizeField', () => {
 				item,
 			} );
 
-			// 0 bytes returns empty string because the truthy check in getValue treats 0 as falsy
+			// 0 bytes returns empty string because getValue uses a truthy check on filesize
+			// Note: formatFileSize would return "0 B" if called with 0, but it's never reached
 			expect( result ).toBe( '' );
 		} );
 

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -90,6 +90,54 @@ describe( 'mediaDimensionsField', () => {
 
 			expect( result ).toBe( '' );
 		} );
+
+		it( 'returns empty string when width is 0', () => {
+			const item = {
+				media_details: {
+					width: 0,
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when height is 0', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					height: 0,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when both width and height are 0', () => {
+			const item = {
+				media_details: {
+					width: 0,
+					height: 0,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
 	} );
 
 	describe( 'isVisible', () => {
@@ -163,6 +211,20 @@ describe( 'mediaDimensionsField', () => {
 			const item = {
 				media_details: {
 					width: 1920,
+					height: 0,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when both width and height are 0', () => {
+			const item = {
+				media_details: {
+					width: 0,
 					height: 0,
 					sizes: {},
 				},

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -23,11 +23,7 @@ describe( 'mediaDimensionsField', () => {
 	describe( 'getValue - dimension formatting', () => {
 		it( 'formats dimensions with × separator', () => {
 			const item = {
-				media_details: {
-					width: 1920,
-					height: 1080,
-					sizes: {},
-				},
+				media_details: { width: 1920, height: 1080, sizes: {} },
 			} as Updatable< Attachment >;
 
 			const result = mediaDimensionsField.getValue?.( {
@@ -37,103 +33,35 @@ describe( 'mediaDimensionsField', () => {
 			expect( result ).toMatch( /1920\s*×\s*1080/ );
 		} );
 
-		it( 'returns empty string when width is missing', () => {
-			const item = {
-				media_details: {
-					height: 1080,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
+		it.each( [
+			[
+				{ media_details: { height: 1080, sizes: {} } },
+				'when width is missing',
+			],
+			[
+				{ media_details: { width: 1920, sizes: {} } },
+				'when height is missing',
+			],
+			[
+				{ media_details: { sizes: {} } },
+				'when both dimensions are missing',
+			],
+			[ {}, 'when media_details is missing' ],
+			[
+				{ media_details: { width: 0, height: 1080, sizes: {} } },
+				'when width is 0',
+			],
+			[
+				{ media_details: { width: 1920, height: 0, sizes: {} } },
+				'when height is 0',
+			],
+			[
+				{ media_details: { width: 0, height: 0, sizes: {} } },
+				'when both width and height are 0',
+			],
+		] )( 'returns empty string %s', ( item ) => {
 			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when height is missing', () => {
-			const item = {
-				media_details: {
-					width: 1920,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when both dimensions are missing', () => {
-			const item = {
-				media_details: {
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when media_details is missing', () => {
-			const item = {} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when width is 0', () => {
-			const item = {
-				media_details: {
-					width: 0,
-					height: 1080,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when height is 0', () => {
-			const item = {
-				media_details: {
-					width: 1920,
-					height: 0,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toBe( '' );
-		} );
-
-		it( 'returns empty string when both width and height are 0', () => {
-			const item = {
-				media_details: {
-					width: 0,
-					height: 0,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
+				item: item as Updatable< Attachment >,
 			} );
 
 			expect( result ).toBe( '' );
@@ -141,98 +69,48 @@ describe( 'mediaDimensionsField', () => {
 	} );
 
 	describe( 'isVisible', () => {
-		it( 'returns true when both dimensions exist', () => {
-			const item = {
-				media_details: {
-					width: 1920,
-					height: 1080,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
+		it.each( [
+			[
+				{ media_details: { width: 1920, height: 1080, sizes: {} } },
+				true,
+				'when both dimensions exist',
+			],
+			[
+				{ media_details: { height: 1080, sizes: {} } },
+				false,
+				'when width is missing',
+			],
+			[
+				{ media_details: { width: 1920, sizes: {} } },
+				false,
+				'when height is missing',
+			],
+			[
+				{ media_details: { sizes: {} } },
+				false,
+				'when both dimensions are missing',
+			],
+			[
+				{ media_details: { width: 0, height: 1080, sizes: {} } },
+				false,
+				'when width is 0 (due to truthy check)',
+			],
+			[
+				{ media_details: { width: 1920, height: 0, sizes: {} } },
+				false,
+				'when height is 0 (due to truthy check)',
+			],
+			[
+				{ media_details: { width: 0, height: 0, sizes: {} } },
+				false,
+				'when both width and height are 0',
+			],
+		] )( 'returns %s %s', ( item, expected ) => {
+			const result = mediaDimensionsField.isVisible?.(
+				item as Updatable< Attachment >
+			);
 
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( true );
-		} );
-
-		it( 'returns false when width is missing', () => {
-			const item = {
-				media_details: {
-					height: 1080,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when height is missing', () => {
-			const item = {
-				media_details: {
-					width: 1920,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when both dimensions are missing', () => {
-			const item = {
-				media_details: {
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when width is 0 (due to truthy check)', () => {
-			const item = {
-				media_details: {
-					width: 0,
-					height: 1080,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when height is 0 (due to truthy check)', () => {
-			const item = {
-				media_details: {
-					width: 1920,
-					height: 0,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns false when both width and height are 0', () => {
-			const item = {
-				media_details: {
-					width: 0,
-					height: 0,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.isVisible?.( item );
-
-			expect( result ).toBe( false );
+			expect( result ).toBe( expected );
 		} );
 	} );
 } );

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -145,8 +145,28 @@ describe( 'mediaDimensionsField', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it( 'returns false when media_details is missing', () => {
-			const item = {} as Updatable< Attachment >;
+		it( 'returns false when width is 0 (due to truthy check)', () => {
+			const item = {
+				media_details: {
+					width: 0,
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when height is 0 (due to truthy check)', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					height: 0,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
 
 			const result = mediaDimensionsField.isVisible?.( item );
 

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -37,38 +37,6 @@ describe( 'mediaDimensionsField', () => {
 			expect( result ).toMatch( /1920\s*×\s*1080/ );
 		} );
 
-		it( 'formats small dimensions', () => {
-			const item = {
-				media_details: {
-					width: 100,
-					height: 50,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /100\s*×\s*50/ );
-		} );
-
-		it( 'formats large dimensions', () => {
-			const item = {
-				media_details: {
-					width: 4096,
-					height: 2160,
-					sizes: {},
-				},
-			} as Updatable< Attachment >;
-
-			const result = mediaDimensionsField.getValue?.( {
-				item,
-			} );
-
-			expect( result ).toMatch( /4096\s*×\s*2160/ );
-		} );
-
 		it( 'returns empty string when width is missing', () => {
 			const item = {
 				media_details: {

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -144,5 +144,13 @@ describe( 'mediaDimensionsField', () => {
 
 			expect( result ).toBe( false );
 		} );
+
+		it( 'returns false when media_details is missing', () => {
+			const item = {} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
 	} );
 } );

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -59,12 +59,20 @@ describe( 'mediaDimensionsField', () => {
 				{ media_details: { width: 0, height: 0, sizes: {} } },
 				'when both width and height are 0',
 			],
-		] )( 'returns empty string %s', ( item ) => {
+		] )( 'returns empty string %s', ( item, description ) => {
 			const result = mediaDimensionsField.getValue?.( {
 				item: item as Updatable< Attachment >,
 			} );
 
-			expect( result ).toBe( '' );
+			try {
+				expect( result ).toBe( '' );
+			} catch ( error ) {
+				const message =
+					error instanceof Error ? error.message : String( error );
+				throw new Error(
+					`Failed getValue test (${ description }): ${ message }`
+				);
+			}
 		} );
 	} );
 
@@ -105,12 +113,20 @@ describe( 'mediaDimensionsField', () => {
 				false,
 				'when both width and height are 0',
 			],
-		] )( 'returns %s %s', ( item, expected ) => {
+		] )( 'returns %s %s', ( item, expected, description ) => {
 			const result = mediaDimensionsField.isVisible?.(
 				item as Updatable< Attachment >
 			);
 
-			expect( result ).toBe( expected );
+			try {
+				expect( result ).toBe( expected );
+			} catch ( error ) {
+				const message =
+					error instanceof Error ? error.message : String( error );
+				throw new Error(
+					`Failed isVisible test (${ description }): ${ message }`
+				);
+			}
 		} );
 	} );
 } );

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -1,0 +1,180 @@
+/**
+ * WordPress dependencies
+ */
+import type { Attachment, Updatable } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import mediaDimensionsField from '../index';
+
+describe( 'mediaDimensionsField', () => {
+	it( 'has correct field configuration', () => {
+		expect( mediaDimensionsField ).toMatchObject( {
+			id: 'media_dimensions',
+			type: 'text',
+			label: 'Dimensions',
+			enableSorting: false,
+			filterBy: false,
+			readOnly: true,
+		} );
+	} );
+
+	describe( 'getValue - dimension formatting', () => {
+		it( 'formats dimensions with × separator', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /1920\s*×\s*1080/ );
+		} );
+
+		it( 'formats small dimensions', () => {
+			const item = {
+				media_details: {
+					width: 100,
+					height: 50,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /100\s*×\s*50/ );
+		} );
+
+		it( 'formats large dimensions', () => {
+			const item = {
+				media_details: {
+					width: 4096,
+					height: 2160,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toMatch( /4096\s*×\s*2160/ );
+		} );
+
+		it( 'returns empty string when width is missing', () => {
+			const item = {
+				media_details: {
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when height is missing', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when both dimensions are missing', () => {
+			const item = {
+				media_details: {
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+
+		it( 'returns empty string when media_details is missing', () => {
+			const item = {} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.getValue?.( {
+				item,
+			} );
+
+			expect( result ).toBe( '' );
+		} );
+	} );
+
+	describe( 'isVisible', () => {
+		it( 'returns true when both dimensions exist', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns false when width is missing', () => {
+			const item = {
+				media_details: {
+					height: 1080,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when height is missing', () => {
+			const item = {
+				media_details: {
+					width: 1920,
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when both dimensions are missing', () => {
+			const item = {
+				media_details: {
+					sizes: {},
+				},
+			} as Updatable< Attachment >;
+
+			const result = mediaDimensionsField.isVisible?.( item );
+
+			expect( result ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Related to https://github.com/WordPress/gutenberg/issues/72612#issuecomment-3615224611 and partial follow up to https://github.com/WordPress/gutenberg/pull/73071

Add unit tests for media fields: filename, filesize, media dimensions.

- **filename field** (7 tests): Field configuration, filename extraction via `getValue`, and view component rendering (short/long filenames, edge cases)
- **filesize field** (20 tests): Field configuration, byte formatting logic (B → KB → MB → GB → TB with proper decimal handling), and `isVisible` behavior
- **media_dimensions field** (8 tests): Field configuration, dimension formatting (width × height), and `isVisible` behavior

I think the media thumbnail could an E2E test? Happy to try to mock that up too if required.



## Testing Instructions

Tests should pass!
