### PR TITLE
Media Fields: add ThumbnailView fallback

### DIFF
--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -85,7 +85,9 @@ export default function MediaThumbnailView( {
 		imageError ||
 		getMediaTypeFromMimeType( featuredMedia.mime_type ).type !== 'image'
 	) {
-		return <FallbackView item={ item } filename={ filename || '' } />;
+		return (
+			<FallbackView item={ featuredMedia } filename={ filename || '' } />
+		);
 	}
 
 	return (

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 	Icon,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import type { Attachment } from '@wordpress/core-data';
 import { getFilename } from '@wordpress/url';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
@@ -17,10 +18,44 @@ import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 import { getMediaTypeFromMimeType } from '../utils/get-media-type-from-mime-type';
 import type { MediaItem } from '../types';
 
+function FallbackView( {
+	item,
+	filename,
+}: {
+	item: MediaItem;
+	filename: string;
+} ) {
+	return (
+		<div className="dataviews-media-field__media-thumbnail">
+			<VStack
+				justify="center"
+				alignment="center"
+				className="dataviews-media-field__media-thumbnail__stack"
+				spacing={ 0 }
+			>
+				<Icon
+					className="dataviews-media-field__media-thumbnail--icon"
+					icon={ getMediaTypeFromMimeType( item.mime_type ).icon }
+					size={ 24 }
+				/>
+				{ !! filename && (
+					<div className="dataviews-media-field__media-thumbnail__filename">
+						<Truncate className="dataviews-media-field__media-thumbnail__filename__truncate">
+							{ filename }
+						</Truncate>
+					</div>
+				) }
+			</VStack>
+		</div>
+	);
+}
+
 export default function MediaThumbnailView( {
 	item,
 	config,
 }: DataViewRenderFieldProps< MediaItem > ) {
+	const [ imageError, setImageError ] = useState( false );
+
 	const _featuredMedia = useSelect(
 		( select ) => {
 			// Avoid the network request if it's not needed. `featured_media` is
@@ -45,60 +80,40 @@ export default function MediaThumbnailView( {
 
 	const filename = getFilename( featuredMedia.source_url || '' );
 
+	// Show fallback if image failed to load or if not an image type.
 	if (
-		// Ensure the featured media is an image.
-		getMediaTypeFromMimeType( featuredMedia.mime_type ).type === 'image'
+		imageError ||
+		getMediaTypeFromMimeType( featuredMedia.mime_type ).type !== 'image'
 	) {
-		return (
-			<div className="dataviews-media-field__media-thumbnail">
-				<img
-					className="dataviews-media-field__media-thumbnail--image"
-					src={ featuredMedia.source_url }
-					srcSet={
-						featuredMedia?.media_details?.sizes
-							? (
-									Object.values(
-										featuredMedia.media_details.sizes
-									) as Array< {
-										source_url: string;
-										width: number;
-									} >
-							   )
-									.map(
-										( size ) =>
-											`${ size.source_url } ${ size.width }w`
-									)
-									.join( ', ' )
-							: undefined
-					}
-					sizes={ config?.sizes || '100vw' }
-					alt={ featuredMedia.alt_text || featuredMedia.title.raw }
-				/>
-			</div>
-		);
+		return <FallbackView item={ item } filename={ filename || '' } />;
 	}
 
 	return (
 		<div className="dataviews-media-field__media-thumbnail">
-			<VStack
-				justify="center"
-				alignment="center"
-				className="dataviews-media-field__media-thumbnail__stack"
-				spacing={ 0 }
-			>
-				<Icon
-					className="dataviews-media-field__media-thumbnail--icon"
-					icon={ getMediaTypeFromMimeType( item.mime_type ).icon }
-					size={ 24 }
-				/>
-				{ !! filename && (
-					<div className="dataviews-media-field__media-thumbnail__filename">
-						<Truncate className="dataviews-media-field__media-thumbnail__filename__truncate">
-							{ filename }
-						</Truncate>
-					</div>
-				) }
-			</VStack>
+			<img
+				className="dataviews-media-field__media-thumbnail--image"
+				src={ featuredMedia.source_url }
+				srcSet={
+					featuredMedia?.media_details?.sizes
+						? (
+								Object.values(
+									featuredMedia.media_details.sizes
+								) as Array< {
+									source_url: string;
+									width: number;
+								} >
+						   )
+								.map(
+									( size ) =>
+										`${ size.source_url } ${ size.width }w`
+								)
+								.join( ', ' )
+						: undefined
+				}
+				sizes={ config?.sizes || '100vw' }
+				alt={ featuredMedia.alt_text || featuredMedia.title.raw }
+				onError={ () => setImageError( true ) }
+			/>
 		</div>
 	);
 }

--- a/packages/media-fields/src/stories/index.story.tsx
+++ b/packages/media-fields/src/stories/index.story.tsx
@@ -175,6 +175,57 @@ const sampleMediaItemZip: MediaItem = {
 	missing_image_sizes: [],
 };
 
+// Sample data for a broken image (demonstrates error fallback)
+const sampleMediaItemBrokenImage: MediaItem = {
+	id: 124,
+	date: '2024-01-16T10:30:00',
+	date_gmt: '2024-01-16T10:30:00',
+	guid: {
+		raw: 'https://example.com/broken-image.jpg',
+		rendered: 'https://example.com/broken-image.jpg',
+	},
+	modified: '2024-01-16T10:30:00',
+	modified_gmt: '2024-01-16T10:30:00',
+	slug: 'broken-image',
+	status: 'publish',
+	type: 'attachment',
+	link: 'https://example.com/broken-image/',
+	title: {
+		raw: 'Broken Image',
+		rendered: 'Broken Image',
+	},
+	author: 1,
+	featured_media: 0,
+	comment_status: 'open',
+	ping_status: 'closed',
+	template: '',
+	meta: {},
+	permalink_template: 'https://example.com/?attachment_id=124',
+	generated_slug: 'broken-image',
+	class_list: [ 'post-124', 'attachment' ],
+	alt_text: 'This image will fail to load',
+	caption: {
+		raw: 'Image that demonstrates error handling',
+		rendered: '<p>Image that demonstrates error handling</p>\n',
+	},
+	description: {
+		raw: '',
+		rendered: '',
+	},
+	mime_type: 'image/jpeg',
+	media_type: 'image',
+	post: null,
+	source_url: 'https://example.com/this-image-does-not-exist.jpg',
+	media_details: {
+		file: 'broken-image.jpg',
+		width: 1920,
+		height: 1080,
+		filesize: 0,
+		sizes: {},
+	},
+	missing_image_sizes: [],
+};
+
 // Create a showcase of all media fields.
 const showcaseFields = [
 	mediaThumbnailField,
@@ -256,10 +307,11 @@ export const DataViewsPreview = () => {
 	const [ data ] = useState< MediaItem[] >( [
 		sampleMediaItem,
 		sampleMediaItemZip,
+		sampleMediaItemBrokenImage,
 	] );
 
 	const paginationInfo = {
-		totalItems: 2,
+		totalItems: 3,
 		totalPages: 1,
 	};
 


### PR DESCRIPTION

## What?

Related to https://github.com/WordPress/gutenberg/issues/72612#issuecomment-3615224611 and partial follow up to https://github.com/WordPress/gutenberg/pull/73071

Update `MediaThumbnailView` to gracefully handle images that fail to load by falling back to icon + filename display.

The fallback handles existing non-image file types, which is the current behaviour.


## Why?

Just in case the image doesn't load, yo!

## How?

Using the existing mediaType icon as fallback.

## Testing Instructions

Fire up StoryBook 

`npm run storybook:dev`

Head to http://localhost:50240/?path=/story/fields-media-fields--data-views-preview

<img width="1135" height="384" alt="Screenshot 2025-12-16 at 2 05 05 pm" src="https://github.com/user-attachments/assets/6489a900-aeb6-4dc1-812e-dacaf80086e6" />

Check that non-image icons are present (see the file icon above)

