### PR TITLE
Block visibility based on screen size: basic clientside state

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -612,7 +612,9 @@ function BlockListBlockProvider( props ) {
 				isPreviewMode,
 				__experimentalBlockBindingsSupportedAttributes,
 			} = getSettings();
-
+			const { isBlockHidden: _isBlockHidden } = unlock(
+				select( blockEditorStore )
+			);
 			const bindableAttributes =
 				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
 
@@ -633,7 +635,7 @@ function BlockListBlockProvider( props ) {
 					? getBlockDefaultClassName( blockName )
 					: undefined,
 				blockTitle: blockType?.title,
-				isBlockHidden: attributes?.metadata?.blockVisibility === false,
+				isBlockHidden: _isBlockHidden( clientId ),
 				bindableAttributes,
 			};
 
@@ -642,10 +644,6 @@ function BlockListBlockProvider( props ) {
 			if ( isPreviewMode ) {
 				return previewContext;
 			}
-
-			const { isBlockHidden: _isBlockHidden } = unlock(
-				select( blockEditorStore )
-			);
 			const _isSelected = isBlockSelected( clientId );
 			const canRemove = canRemoveBlock( clientId );
 			const canMove = canMoveBlock( clientId );
@@ -722,7 +720,6 @@ function BlockListBlockProvider( props ) {
 				originalBlockClientId: isInvalid
 					? blocksWithSameName[ 0 ]
 					: false,
-				isBlockHidden: _isBlockHidden( clientId ),
 			};
 		},
 		[ clientId, rootClientId ]

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -108,6 +108,8 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		height: 0;
 		border: none !important;
 		padding: 0 !important;
+		opacity: 0;
+		margin: 0 !important;
 	}
 
 	&.is-layout-flex:not(.is-vertical) > .is-block-hidden {

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -42,6 +42,7 @@ import {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	deviceTypeKey,
 	isIsolatedEditorKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
@@ -113,6 +114,7 @@ lock( privateApis, {
 	mediaEditKey,
 	getMediaSelectKey,
 	essentialFormatKey,
+	deviceTypeKey,
 	isIsolatedEditorKey,
 	useBlockElement,
 	useBlockElementRef,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -7,3 +7,4 @@ export const mediaEditKey = Symbol( 'mediaEditKey' );
 export const getMediaSelectKey = Symbol( 'getMediaSelect' );
 export const essentialFormatKey = Symbol( 'essentialFormat' );
 export const isIsolatedEditorKey = Symbol( 'isIsolatedEditor' );
+export const deviceTypeKey = Symbol( 'deviceTypeKey' );

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -36,6 +36,7 @@ import {
 	reusableBlocksSelectKey,
 	sectionRootClientIdKey,
 	isIsolatedEditorKey,
+	deviceTypeKey,
 } from './private-keys';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
@@ -700,6 +701,10 @@ export function getInsertionPoint( state ) {
 /**
  * Returns true if the block is hidden, or false otherwise.
  *
+ * A block is considered hidden if:
+ * - blockVisibility is false (hidden everywhere)
+ * - blockVisibility is an object with the current device preview set to false
+ *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
  *
@@ -711,7 +716,67 @@ export const isBlockHidden = ( state, clientId ) => {
 		return false;
 	}
 	const attributes = state.blocks.attributes.get( clientId );
-	return attributes?.metadata?.blockVisibility === false;
+	const blockVisibility = attributes?.metadata?.blockVisibility;
+
+	if ( blockVisibility === false ) {
+		return true;
+	}
+
+	if ( ! window.__experimentalHideBlocksBasedOnScreenSize ) {
+		return false;
+	}
+
+	// Check viewport-specific hiding based on current device preview
+	// Only apply when a device is explicitly selected.
+	if ( typeof blockVisibility === 'object' && blockVisibility !== null ) {
+		const settings = getSettings( state );
+		const viewportType = settings[ deviceTypeKey ] ?? 'Desktop';
+		const viewportKey = viewportType.toLowerCase();
+		return blockVisibility?.[ viewportKey ] === false;
+	}
+
+	return false;
+};
+
+/**
+ * Returns true if the block is hidden on any device/viewport, or false otherwise.
+ *
+ * A block is considered to have visibility restrictions if it's hidden everywhere
+ * or has any breakpoint-specific visibility settings (mobile, tablet, or desktop).
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client ID of the block.
+ *
+ * @return {boolean} Whether the block has visibility restrictions.
+ */
+export const isHiddenInAnyDevice = ( state, clientId ) => {
+	// Gate behind experimental flag
+	if ( ! window.__experimentalHideBlocksBasedOnScreenSize ) {
+		return false;
+	}
+
+	const blockName = getBlockName( state, clientId );
+	if ( ! hasBlockSupport( state, blockName, 'visibility', true ) ) {
+		return false;
+	}
+	const attributes = state.blocks.attributes.get( clientId );
+	const blockVisibility = attributes?.metadata?.blockVisibility;
+
+	// Hidden everywhere
+	if ( blockVisibility === false ) {
+		return true;
+	}
+
+	// Check if any breakpoint has visibility set to false
+	if ( typeof blockVisibility === 'object' && blockVisibility !== null ) {
+		return (
+			blockVisibility.mobile === false ||
+			blockVisibility.tablet === false ||
+			blockVisibility.desktop === false
+		);
+	}
+
+	return false;
 };
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -739,47 +739,6 @@ export const isBlockHidden = ( state, clientId ) => {
 };
 
 /**
- * Returns true if the block is hidden on any device/viewport, or false otherwise.
- *
- * A block is considered to have visibility restrictions if it's hidden everywhere
- * or has any breakpoint-specific visibility settings (mobile, tablet, or desktop).
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId Client ID of the block.
- *
- * @return {boolean} Whether the block has visibility restrictions.
- */
-export const isHiddenInAnyDevice = ( state, clientId ) => {
-	// Gate behind experimental flag
-	if ( ! window.__experimentalHideBlocksBasedOnScreenSize ) {
-		return false;
-	}
-
-	const blockName = getBlockName( state, clientId );
-	if ( ! hasBlockSupport( state, blockName, 'visibility', true ) ) {
-		return false;
-	}
-	const attributes = state.blocks.attributes.get( clientId );
-	const blockVisibility = attributes?.metadata?.blockVisibility;
-
-	// Hidden everywhere
-	if ( blockVisibility === false ) {
-		return true;
-	}
-
-	// Check if any breakpoint has visibility set to false
-	if ( typeof blockVisibility === 'object' && blockVisibility !== null ) {
-		return (
-			blockVisibility.mobile === false ||
-			blockVisibility.tablet === false ||
-			blockVisibility.desktop === false
-		);
-	}
-
-	return false;
-};
-
-/**
  * Returns true if there is a spotlighted block.
  *
  * The spotlight is also active when a contentOnly section is being edited, the selector

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -20,8 +20,10 @@ import {
 	isRemoveLockedBlock,
 	isLockedBlock,
 	isBlockHidden,
+	isHiddenInAnyDevice,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
+import { deviceTypeKey } from '../private-keys';
 
 describe( 'private selectors', () => {
 	describe( 'isBlockInterfaceHidden', () => {
@@ -1147,6 +1149,202 @@ describe( 'private selectors', () => {
 			expect( isBlockHidden( state, 'non-existent-block' ) ).toBe(
 				false
 			);
+		} );
+	} );
+
+	describe( 'isBlockHidden in different devices', () => {
+		const originalExperimentalFlag =
+			window.__experimentalHideBlocksBasedOnScreenSize;
+
+		beforeEach( () => {
+			window.__experimentalHideBlocksBasedOnScreenSize = true;
+		} );
+
+		afterEach( () => {
+			window.__experimentalHideBlocksBasedOnScreenSize =
+				originalExperimentalFlag;
+		} );
+
+		const createState = ( blockVisibility, deviceType = 'Desktop' ) => ( {
+			settings: {
+				[ deviceTypeKey ]: deviceType,
+			},
+			blocks: {
+				byClientId: new Map( [
+					[
+						'test-block',
+						{
+							name: 'core/paragraph',
+							attributes: {
+								metadata: {
+									blockVisibility,
+								},
+							},
+						},
+					],
+				] ),
+				attributes: new Map( [
+					[
+						'test-block',
+						{
+							metadata: {
+								blockVisibility,
+							},
+						},
+					],
+				] ),
+			},
+		} );
+
+		it( 'returns false when experimental flag is disabled and block has breakpoint visibility', () => {
+			window.__experimentalHideBlocksBasedOnScreenSize = false;
+			const state = createState( { mobile: false, tablet: true } );
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns false when Desktop is selected and block has breakpoint visibility', () => {
+			const state = createState(
+				{ mobile: false, tablet: true },
+				'Desktop'
+			);
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns true when Desktop is selected and block is hidden on desktop', () => {
+			const state = createState( { desktop: false }, 'Desktop' );
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns true when Tablet is selected and block is hidden on tablet', () => {
+			const state = createState(
+				{ mobile: true, tablet: false },
+				'Tablet'
+			);
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns true when Mobile is selected and block is hidden on mobile', () => {
+			const state = createState(
+				{ mobile: false, tablet: true },
+				'Mobile'
+			);
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns false when Tablet is selected and block is visible on tablet', () => {
+			const state = createState(
+				{ mobile: false, tablet: true },
+				'Tablet'
+			);
+			const result = isBlockHidden( state, 'test-block' );
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	describe( 'isHiddenInAnyDevice', () => {
+		const originalExperimentalFlag =
+			window.__experimentalHideBlocksBasedOnScreenSize;
+
+		beforeEach( () => {
+			window.__experimentalHideBlocksBasedOnScreenSize = true;
+		} );
+
+		afterEach( () => {
+			window.__experimentalHideBlocksBasedOnScreenSize =
+				originalExperimentalFlag;
+		} );
+
+		const createState = ( blockVisibility ) => ( {
+			settings: {},
+			blocks: {
+				byClientId: new Map( [
+					[
+						'test-block',
+						{
+							name: 'core/paragraph',
+							attributes: {
+								metadata: {
+									blockVisibility,
+								},
+							},
+						},
+					],
+				] ),
+				attributes: new Map( [
+					[
+						'test-block',
+						{
+							metadata: {
+								blockVisibility,
+							},
+						},
+					],
+				] ),
+			},
+		} );
+
+		it( 'returns false when experimental flag is disabled', () => {
+			window.__experimentalHideBlocksBasedOnScreenSize = false;
+			const state = createState( false );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
+		} );
+
+		it( 'returns false for block without visibility support', () => {
+			// This test verifies that hasBlockSupport check works correctly
+			// Since hasBlockSupport is imported and used directly, we test the behavior
+			// by using a block type that doesn't support visibility
+			const state = {
+				settings: {},
+				blocks: {
+					byClientId: new Map( [
+						[ 'test-block', { name: 'core/html' } ],
+					] ),
+					attributes: new Map( [ [ 'test-block', {} ] ] ),
+				},
+			};
+
+			const result = isHiddenInAnyDevice( state, 'test-block' );
+			// Should return false because core/html doesn't support visibility
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns true when blockVisibility is false', () => {
+			const state = createState( false );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
+		} );
+
+		it( 'returns false when blockVisibility is undefined', () => {
+			const state = createState( undefined );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
+		} );
+
+		it( 'returns true when block is hidden on mobile', () => {
+			const state = createState( { mobile: false, tablet: true } );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
+		} );
+
+		it( 'returns true when block is hidden on tablet', () => {
+			const state = createState( { mobile: true, tablet: false } );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
+		} );
+
+		it( 'returns true when block is hidden on desktop', () => {
+			const state = createState( { mobile: true, desktop: false } );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
+		} );
+
+		it( 'returns false when block is visible on all devices', () => {
+			const state = createState( {
+				mobile: true,
+				tablet: true,
+				desktop: true,
+			} );
+			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -20,7 +20,6 @@ import {
 	isRemoveLockedBlock,
 	isLockedBlock,
 	isBlockHidden,
-	isHiddenInAnyDevice,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -1243,108 +1242,6 @@ describe( 'private selectors', () => {
 			);
 			const result = isBlockHidden( state, 'test-block' );
 			expect( result ).toBe( false );
-		} );
-	} );
-
-	describe( 'isHiddenInAnyDevice', () => {
-		const originalExperimentalFlag =
-			window.__experimentalHideBlocksBasedOnScreenSize;
-
-		beforeEach( () => {
-			window.__experimentalHideBlocksBasedOnScreenSize = true;
-		} );
-
-		afterEach( () => {
-			window.__experimentalHideBlocksBasedOnScreenSize =
-				originalExperimentalFlag;
-		} );
-
-		const createState = ( blockVisibility ) => ( {
-			settings: {},
-			blocks: {
-				byClientId: new Map( [
-					[
-						'test-block',
-						{
-							name: 'core/paragraph',
-							attributes: {
-								metadata: {
-									blockVisibility,
-								},
-							},
-						},
-					],
-				] ),
-				attributes: new Map( [
-					[
-						'test-block',
-						{
-							metadata: {
-								blockVisibility,
-							},
-						},
-					],
-				] ),
-			},
-		} );
-
-		it( 'returns false when experimental flag is disabled', () => {
-			window.__experimentalHideBlocksBasedOnScreenSize = false;
-			const state = createState( false );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
-		} );
-
-		it( 'returns false for block without visibility support', () => {
-			// This test verifies that hasBlockSupport check works correctly
-			// Since hasBlockSupport is imported and used directly, we test the behavior
-			// by using a block type that doesn't support visibility
-			const state = {
-				settings: {},
-				blocks: {
-					byClientId: new Map( [
-						[ 'test-block', { name: 'core/html' } ],
-					] ),
-					attributes: new Map( [ [ 'test-block', {} ] ] ),
-				},
-			};
-
-			const result = isHiddenInAnyDevice( state, 'test-block' );
-			// Should return false because core/html doesn't support visibility
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns true when blockVisibility is false', () => {
-			const state = createState( false );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
-		} );
-
-		it( 'returns false when blockVisibility is undefined', () => {
-			const state = createState( undefined );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
-		} );
-
-		it( 'returns true when block is hidden on mobile', () => {
-			const state = createState( { mobile: false, tablet: true } );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
-		} );
-
-		it( 'returns true when block is hidden on tablet', () => {
-			const state = createState( { mobile: true, tablet: false } );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
-		} );
-
-		it( 'returns true when block is hidden on desktop', () => {
-			const state = createState( { mobile: true, desktop: false } );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( true );
-		} );
-
-		it( 'returns false when block is visible on all devices', () => {
-			const state = createState( {
-				mobile: true,
-				tablet: true,
-				desktop: true,
-			} );
-			expect( isHiddenInAnyDevice( state, 'test-block' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -98,6 +98,7 @@ const {
 	mediaEditKey,
 	getMediaSelectKey,
 	isIsolatedEditorKey,
+	deviceTypeKey,
 } = unlock( privateApis );
 
 /**
@@ -128,6 +129,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		userPatternCategories,
 		restBlockPatternCategories,
 		sectionRootClientId,
+		deviceType,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -139,6 +141,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
+			const { getDeviceType } = unlock( select( editorStore ) );
 			const { getBlocksByName, getBlockAttributes } =
 				select( blockEditorStore );
 			const siteSettings = canUser( 'read', {
@@ -192,6 +195,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatternCategories: getBlockPatternCategories(),
 				sectionRootClientId: getSectionRootBlock(),
+				deviceType: getDeviceType(),
 			};
 		},
 		[ postType, postId, isLargeViewport, renderingMode ]
@@ -383,6 +387,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				'wp_block',
 				'wp_navigation',
 			].includes( postType ),
+			...( window.__experimentalHideBlocksBasedOnScreenSize && deviceType
+				? { [ deviceTypeKey ]: deviceType }
+				: {} ),
 		};
 
 		return blockEditorSettings;
@@ -413,6 +420,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		renderingMode,
 		editMediaEntity,
 		wrappedOnNavigateToEntityRecord,
+		deviceType,
 	] );
 }
 


### PR DESCRIPTION
## What?

Related to:

- https://github.com/WordPress/gutenberg/issues/72502

This PR makes blocks "aware" of their visibility settings and renders/hides them on the canvas according to their attributes.

Blocks are hidden in the editor when they have visibility restrictions for the active device preview via the existing `is-block-hidden` classname.

To test the backend:

- https://github.com/WordPress/gutenberg/pull/73994

> [!NOTE]
> This PR does not add any UI changes or provision to update block attributes with visibility settings; it only allows "telling the block how to render itself on the canvas. The basic UI interface is in https://github.com/WordPress/gutenberg/pull/74249. 

## How?

- **Selectors**: Updated `isBlockHidden` to be viewport-aware
- **Settings**: Pass `deviceType` from editor store to block editor settings using private key

## Testing Instructions

For starters, the JS unit tests should pass 🍏 

To test manually, enable the experiment:

<img width="998" height="90" alt="Screenshot 2025-12-15 at 10 53 52 am" src="https://github.com/user-attachments/assets/ec7052f1-3758-4f2c-8ad1-93ddd50fd0c5" />

Then copy and paste this into your post editor, then toggle the device menu.

```html


<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false}}} -->
<p>🔴 Hidden on MOBILE (≤599px) - You should see this on tablet and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false}}} -->
<p>🟡 Hidden on TABLET (600-959px) - You should see this on mobile and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"desktop":false}}} -->
<p>🟢 Hidden on DESKTOP (≥960px) - You should see this on mobile and tablet only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"desktop":false}}} -->
<p>🟣 Hidden on MOBILE and DESKTOP - You should only see this on tablet (600-959px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"tablet":false}}} -->
<p>🔵 Hidden on MOBILE and TABLET - You should only see this on desktop (≥960px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false,"desktop":false}}} -->
<p>🟠 Hidden on TABLET and DESKTOP - You should only see this on mobile (≤599px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":true,"tablet":true,"desktop":true}}} -->
<p>✅ Visible on ALL breakpoints - You should always see this</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
<p>❌ Completely HIDDEN (boolean false) - You should never see this</p>
<!-- /wp:paragraph -->
```

https://github.com/user-attachments/assets/ece3b033-4909-41b9-8d75-d616ccab9974




Make sure to test with the experiment off as well. The last item should never show with the experiment on and off.

