### PR TITLE
Block Library: Fix discussion settings data selection

### DIFF
--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -40,11 +40,12 @@ export default function Edit( {
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 	const maxSizeBuffer = Math.floor( maxSize * 2.5 );
-	const { avatarURL } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
-	} );
+	const avatarURL = useSelect( ( select ) => {
+		const { __experimentalDiscussionSettings } =
+			select( blockEditorStore ).getSettings();
+
+		return __experimentalDiscussionSettings?.avatarURL;
+	}, [] );
 
 	const inspectorControls = (
 		<InspectorControls>

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -252,8 +252,8 @@ export default function CommentTemplateEdit( {
 		pageComments,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		return getSettings().__experimentalDiscussionSettings;
-	} );
+		return getSettings().__experimentalDiscussionSettings ?? {};
+	}, [] );
 
 	const commentQuery = useCommentQueryArgs( {
 		postId,

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -38,7 +38,7 @@ export const useCommentQueryArgs = ( { postId } ) => {
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
+		return __experimentalDiscussionSettings ?? {};
 	} );
 
 	// WP REST API doesn't allow fetching more than max items limit set per single page of data.

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -39,7 +39,7 @@ export const useCommentQueryArgs = ( { postId } ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
 		return __experimentalDiscussionSettings ?? {};
-	} );
+	}, [] );
 
 	// WP REST API doesn't allow fetching more than max items limit set per single page of data.
 	// As for the editor performance is more important than completeness of data and fetching only the

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -59,8 +59,8 @@ export default function Edit( {
 		pageComments,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		return getSettings().__experimentalDiscussionSettings;
-	} );
+		return getSettings().__experimentalDiscussionSettings ?? {};
+	}, [] );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 

--- a/packages/block-library/src/comments/edit/placeholder.js
+++ b/packages/block-library/src/comments/edit/placeholder.js
@@ -16,10 +16,11 @@ export default function PostCommentsPlaceholder( { postType, postId } ) {
 	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	postTitle = postTitle || __( 'Post Title' );
 
-	const { avatarURL } = useSelect(
+	const avatarURL = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings()
-				.__experimentalDiscussionSettings
+				.__experimentalDiscussionSettings?.avatarURL,
+		[]
 	);
 
 	return (

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -68,10 +68,11 @@ const CommentsForm = ( { postId, postType } ) => {
 
 	const isSiteEditor = postType === undefined || postId === undefined;
 
-	const { defaultCommentStatus } = useSelect(
+	const defaultCommentStatus = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings()
-				.__experimentalDiscussionSettings
+				.__experimentalDiscussionSettings?.defaultCommentStatus,
+		[]
 	);
 
 	const postTypeSupportsComments = useSelect( ( select ) =>

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -94,12 +94,12 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 }
 
 export function useDefaultAvatar() {
-	const { avatarURL: defaultAvatarUrl } = useSelect( ( select ) => {
+	const avatarURL = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
-	} );
-	return defaultAvatarUrl;
+		return __experimentalDiscussionSettings?.avatarURL ?? '';
+	}, [] );
+	return avatarURL;
 }
 
 export function useToolsPanelDropdownMenuProps() {


### PR DESCRIPTION
## What?
Part of #73869.

PR hardens `useSelect` hooks only returning the `__experimentalDiscussionSettings` values and avoids errors when the setting isn't defined.

I've also added missing dependency arrays in a couple of places.

## Testing Instructions
1. Navigate to `wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks&preview=stylebook`.
2. Open the DevTools console and observe no errors.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1195" height="616" alt="Image" src="https://github.com/user-attachments/assets/e8190581-455b-4681-8d4c-4567653e97bd" />