### PR TITLE
Fix document title html entities

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
 
@@ -38,7 +38,9 @@ function BlockBreadcrumb( { rootLabelText } ) {
 			hasSelection: !! getSelectionStart().clientId,
 		};
 	}, [] );
-	const rootLabel = rootLabelText || __( 'Document' );
+
+	// translators: Default label for the Document in the Block Breadcrumb.
+	const rootLabel = rootLabelText || _x( 'Document', 'noun, breadcrumb' );
 
 	// We don't care about this specific ref, but this is a way
 	// to get a ref within the editor canvas so we can focus it later.

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -9,6 +9,7 @@
 	li {
 		display: inline-flex;
 		margin: 0;
+		white-space: nowrap;
 
 		.block-editor-block-breadcrumb__separator {
 			fill: currentColor;

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -8,11 +8,12 @@ import clsx from 'clsx';
  */
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
 import { useSelect } from '@wordpress/data';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { BlockBreadcrumb, BlockToolbar } from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { useState, useCallback } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ export default function EditorInterface( {
 		isDistractionFree,
 		isPreviewMode,
 		showBlockBreadcrumbs,
-		documentLabel,
+		postTypeLabel,
 		stylesPath,
 		showStylebook,
 	} = useSelect( ( select ) => {
@@ -70,7 +71,6 @@ export default function EditorInterface( {
 			select( editorStore )
 		);
 		const editorSettings = getEditorSettings();
-		const postTypeLabel = getPostTypeLabel();
 
 		let _mode = select( editorStore ).getEditorMode();
 		if ( ! editorSettings.richEditingEnabled && _mode === 'visual' ) {
@@ -87,9 +87,7 @@ export default function EditorInterface( {
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isPreviewMode: editorSettings.isPreviewMode,
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
-			documentLabel:
-				// translators: Default label for the Document in the Block Breadcrumb.
-				postTypeLabel || _x( 'Document', 'noun, breadcrumb' ),
+			postTypeLabel: getPostTypeLabel(),
 			stylesPath: getStylesPath(),
 			showStylebook: getShowStylebook(),
 		};
@@ -192,7 +190,9 @@ export default function EditorInterface( {
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				mode === 'visual' && (
-					<BlockBreadcrumb rootLabelText={ documentLabel } />
+					<BlockBreadcrumb
+						rootLabelText={ decodeEntities( postTypeLabel ) }
+					/>
 				)
 			}
 			actions={

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -191,7 +191,11 @@ export default function EditorInterface( {
 				showBlockBreadcrumbs &&
 				mode === 'visual' && (
 					<BlockBreadcrumb
-						rootLabelText={ decodeEntities( postTypeLabel ) }
+						rootLabelText={
+							postTypeLabel
+								? decodeEntities( postTypeLabel )
+								: undefined
+						}
 					/>
 				)
 			}

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -4,7 +4,8 @@
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -16,15 +17,19 @@ import { sidebars } from './constants';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SidebarHeader = ( _, ref ) => {
-	const { documentLabel } = useSelect( ( select ) => {
-		const { getPostTypeLabel } = select( editorStore );
+	const postTypeLabel = useSelect(
+		( select ) => select( editorStore ).getPostTypeLabel(),
+		[]
+	);
 
-		return {
-			documentLabel:
-				// translators: Default label for the Document sidebar tab, not selected.
-				getPostTypeLabel() || _x( 'Document', 'noun, panel' ),
-		};
-	}, [] );
+	const documentLabel = useMemo(
+		() =>
+			postTypeLabel
+				? decodeEntities( postTypeLabel )
+				: // translators: Default label for the Document sidebar tab, not selected.
+				  _x( 'Document', 'noun, panel' ),
+		[ postTypeLabel ]
+	);
 
 	return (
 		<Tabs.TabList ref={ ref }>

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -4,7 +4,7 @@
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { forwardRef, useMemo } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -22,14 +22,10 @@ const SidebarHeader = ( _, ref ) => {
 		[]
 	);
 
-	const documentLabel = useMemo(
-		() =>
-			postTypeLabel
-				? decodeEntities( postTypeLabel )
-				: // translators: Default label for the Document sidebar tab, not selected.
-				  _x( 'Document', 'noun, panel' ),
-		[ postTypeLabel ]
-	);
+	const documentLabel = postTypeLabel
+		? decodeEntities( postTypeLabel )
+		: // translators: Default label for the Document sidebar tab, not selected.
+		  _x( 'Document', 'noun, panel' );
 
 	return (
 		<Tabs.TabList ref={ ref }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #28558

When registering a postType, devs might add html entities in the postType label. These were being rendered verbatim in two places in the UI - the document tab title and the block breadcrumbs. The 'Address Bar' area also shows the postType label, but already handles decoding the entities.

## How?
This PR uses decodeEntities to convert any entities.

## Testing Instructions
1. Add a small snippet of code to register a custom post type:
```php
add_action( 'init', function() {
	register_post_type(
		'shy_guy,
		array(
			'label' => '&shy; guy',
			'public' => true,
			'show_in_rest' => true,
		)
	);
});
```
2. Create a new post of the custom post type
3. Open the Inspector sidebar

Expected: The post title doesn't render HTML entities in the Block Breadcrumbs (in the editor footer) or the document tab title (in the inspector)
In trunk: `&shy;` is rendered in the text

4. Now change the `label` value for the post type to an empty string `''`.
5. Reload the editor.
6. Check that the fallback to the default value of 'Document' works in both places.

## Screenshots or screencast <!-- if applicable -->

#### Before
<img width="198" height="65" alt="Screenshot 2025-12-16 at 12 52 16 pm" src="https://github.com/user-attachments/assets/c369fa36-0a08-426e-990e-942dd39d41b7" />
<br>
<img width="194" height="31" alt="Screenshot 2025-12-16 at 12 52 21 pm" src="https://github.com/user-attachments/assets/486ec9a6-4348-424d-905a-9ca3b5e67a4b" />

#### After
<img width="146" height="51" alt="Screenshot 2025-12-16 at 12 51 42 pm" src="https://github.com/user-attachments/assets/c4673e63-c406-4a85-9567-61bd96b8776a" />
<br>
<img width="170" height="37" alt="Screenshot 2025-12-16 at 12 51 51 pm" src="https://github.com/user-attachments/assets/c70eeca6-5e45-48e6-bdfc-e13b73b5f6bb" />


