### PR TITLE
Table block: Improve table block typing performance

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -208,36 +208,31 @@ function BlockListBlock( {
 	}
 
 	const { 'data-align': dataAlign, ...restWrapperProps } = wrapperProps ?? {};
+	const updatedWrapperProps = {
+		...restWrapperProps,
+		className: clsx(
+			restWrapperProps.className,
+			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
+			! ( dataAlign && isSticky ) && className
+		),
+	};
 
 	// We set a new context with the adjusted and filtered wrapperProps (through
 	// `editor.BlockListBlock`), which the `BlockListBlockProvider` did not have
 	// access to.
-	const newPrivateBlockContext = useMemo(
-		() => ( {
-			wrapperProps: {
-				...restWrapperProps,
-				className: clsx(
-					restWrapperProps.className,
-					dataAlign && themeSupportsLayout && `align${ dataAlign }`,
-					! ( dataAlign && isSticky ) && className
-				),
-			},
-			isAligned,
-			...context,
-		} ),
-		[
-			className,
-			context,
-			dataAlign,
-			isAligned,
-			isSticky,
-			restWrapperProps,
-			themeSupportsLayout,
-		]
-	);
-
+	// Note that the context value doesn't have to be memoized in this case
+	// because when it changes, this component will be re-rendered anyway, and
+	// none of the consumers (BlockListBlock and useBlockProps) are memoized or
+	// "pure". This is different from the public BlockEditContext, where
+	// consumers might be memoized or "pure".
 	return (
-		<PrivateBlockContext.Provider value={ newPrivateBlockContext }>
+		<PrivateBlockContext.Provider
+			value={ {
+				wrapperProps: updatedWrapperProps,
+				isAligned,
+				...context,
+			} }
+		>
 			<BlockCrashBoundary
 				fallback={
 					<Block className="has-warning">

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -208,31 +208,36 @@ function BlockListBlock( {
 	}
 
 	const { 'data-align': dataAlign, ...restWrapperProps } = wrapperProps ?? {};
-	const updatedWrapperProps = {
-		...restWrapperProps,
-		className: clsx(
-			restWrapperProps.className,
-			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
-			! ( dataAlign && isSticky ) && className
-		),
-	};
 
 	// We set a new context with the adjusted and filtered wrapperProps (through
 	// `editor.BlockListBlock`), which the `BlockListBlockProvider` did not have
 	// access to.
-	// Note that the context value doesn't have to be memoized in this case
-	// because when it changes, this component will be re-rendered anyway, and
-	// none of the consumers (BlockListBlock and useBlockProps) are memoized or
-	// "pure". This is different from the public BlockEditContext, where
-	// consumers might be memoized or "pure".
+	const newPrivateBlockContext = useMemo(
+		() => ( {
+			wrapperProps: {
+				...restWrapperProps,
+				className: clsx(
+					restWrapperProps.className,
+					dataAlign && themeSupportsLayout && `align${ dataAlign }`,
+					! ( dataAlign && isSticky ) && className
+				),
+			},
+			isAligned,
+			...context,
+		} ),
+		[
+			className,
+			context,
+			dataAlign,
+			isAligned,
+			isSticky,
+			restWrapperProps,
+			themeSupportsLayout,
+		]
+	);
+
 	return (
-		<PrivateBlockContext.Provider
-			value={ {
-				wrapperProps: updatedWrapperProps,
-				isAligned,
-				...context,
-			} }
-		>
+		<PrivateBlockContext.Provider value={ newPrivateBlockContext }>
 			<BlockCrashBoundary
 				fallback={
 					<Block className="has-warning">

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -41,7 +41,6 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
-import { PrivateBlockContext } from '../block-list/private-block-context';
 
 export const keyboardShortcutContext = createContext();
 keyboardShortcutContext.displayName = 'keyboardShortcutContext';
@@ -125,10 +124,9 @@ export function RichTextWrapper(
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
 	const context = useBlockEditContext();
-	const { clientId, isSelected: isBlockSelected } = context;
+	const { clientId, isSelected: isBlockSelected, name: blockName } = context;
 	const blockBindings = context[ blockBindingsKey ];
 	const blockContext = useContext( BlockContext );
-	const { bindableAttributes } = useContext( PrivateBlockContext );
 	const registry = useRegistry();
 	const selector = ( select ) => {
 		// Avoid subscribing to the block editor store if the block is not
@@ -137,8 +135,12 @@ export function RichTextWrapper(
 			return { isSelected: false };
 		}
 
-		const { getSelectionStart, getSelectionEnd, getBlockEditingMode } =
-			select( blockEditorStore );
+		const {
+			getSelectionStart,
+			getSelectionEnd,
+			getBlockEditingMode,
+			getSettings,
+		} = select( blockEditorStore );
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
 
@@ -155,21 +157,32 @@ export function RichTextWrapper(
 			isSelected = selectionStart.clientId === clientId;
 		}
 
+		const { __experimentalBlockBindingsSupportedAttributes } =
+			getSettings();
+
 		return {
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
 			isContentOnly: getBlockEditingMode( clientId ) === 'contentOnly',
+			bindableAttributes:
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ],
 		};
 	};
-	const { selectionStart, selectionEnd, isSelected, isContentOnly } =
-		useSelect( selector, [
-			clientId,
-			identifier,
-			instanceId,
-			originalIsSelected,
-			isBlockSelected,
-		] );
+	const {
+		selectionStart,
+		selectionEnd,
+		isSelected,
+		isContentOnly,
+		bindableAttributes,
+	} = useSelect( selector, [
+		clientId,
+		blockName,
+		identifier,
+		instanceId,
+		originalIsSelected,
+		isBlockSelected,
+	] );
 
 	const { disableBoundBlock, bindingsPlaceholder, bindingsLabel } = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -41,7 +41,6 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
-import { PrivateBlockContext } from '../block-list/private-block-context';
 
 export const keyboardShortcutContext = createContext();
 keyboardShortcutContext.displayName = 'keyboardShortcutContext';
@@ -50,6 +49,8 @@ export const inputEventContext = createContext();
 inputEventContext.displayName = 'inputEventContext';
 
 const instanceIdKey = Symbol( 'instanceId' );
+
+const EMPTY_OBJECT = {};
 
 /**
  * Removes props used for the native version of RichText so that they are not
@@ -128,7 +129,8 @@ export function RichTextWrapper(
 	const { clientId, isSelected: isBlockSelected } = context;
 	const blockBindings = context[ blockBindingsKey ];
 	const blockContext = useContext( BlockContext );
-	const { bindableAttributes } = useContext( PrivateBlockContext );
+	// const { bindableAttributes } = useContext( PrivateBlockContext );
+	const bindableAttributes = EMPTY_OBJECT;
 	const registry = useRegistry();
 	const selector = ( select ) => {
 		// Avoid subscribing to the block editor store if the block is not

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -41,6 +41,7 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 export const keyboardShortcutContext = createContext();
 keyboardShortcutContext.displayName = 'keyboardShortcutContext';
@@ -49,8 +50,6 @@ export const inputEventContext = createContext();
 inputEventContext.displayName = 'inputEventContext';
 
 const instanceIdKey = Symbol( 'instanceId' );
-
-const EMPTY_OBJECT = {};
 
 /**
  * Removes props used for the native version of RichText so that they are not
@@ -129,8 +128,7 @@ export function RichTextWrapper(
 	const { clientId, isSelected: isBlockSelected } = context;
 	const blockBindings = context[ blockBindingsKey ];
 	const blockContext = useContext( BlockContext );
-	// const { bindableAttributes } = useContext( PrivateBlockContext );
-	const bindableAttributes = EMPTY_OBJECT;
+	const { bindableAttributes } = useContext( PrivateBlockContext );
 	const registry = useRegistry();
 	const selector = ( select ) => {
 		// Avoid subscribing to the block editor store if the block is not

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -416,25 +416,32 @@ function TableEdit( {
 		<TSection name={ name } key={ name }>
 			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
 				<tr key={ rowIndex }>
-					{ cells.map( ( cellProps, columnIndex ) => (
+					{ cells.map( ( cellProps, columnIndex ) => {
+						const isSelected =
+							selectedCell?.sectionName === name &&
+							selectedCell?.rowIndex === rowIndex &&
+							selectedCell?.columnIndex === columnIndex;
+
 						// Important - the Cell component is memoized to improve typing performance.
 						// ensure all props passed have stable references.
-						<Cell
-							key={ columnIndex }
-							name={ name }
-							rowIndex={ rowIndex }
-							columnIndex={ columnIndex }
-							onChange={
-								// Only pass the `onChange` handler to the selectedCell.
-								// Cell components are memoized, so it's best to avoid
-								// passing in a value that will cause all cells to re-render
-								// whenever it changes.
-								selectedCell === 'text' ? onChange : undefined
-							}
-							setSelectedCell={ setSelectedCell }
-							{ ...cellProps }
-						/>
-					) ) }
+						return (
+							<Cell
+								key={ columnIndex }
+								name={ name }
+								rowIndex={ rowIndex }
+								columnIndex={ columnIndex }
+								onChange={
+									// Only pass the `onChange` handler to the selectedCell.
+									// Cell components are memoized, so it's best to avoid
+									// passing in a value that will cause all cells to re-render
+									// whenever it changes.
+									isSelected ? onChange : undefined
+								}
+								setSelectedCell={ setSelectedCell }
+								{ ...cellProps }
+							/>
+						);
+					} ) }
 				</tr>
 			) ) }
 		</TSection>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -6,7 +6,13 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	memo,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
@@ -161,22 +167,25 @@ function TableEdit( {
 	 *
 	 * @param {Array} content A RichText content value.
 	 */
-	function onChange( content ) {
-		if ( ! selectedCell ) {
-			return;
-		}
+	const onChange = useCallback(
+		function ( content ) {
+			if ( ! selectedCell ) {
+				return;
+			}
 
-		setAttributes(
-			updateSelectedCell(
-				attributes,
-				selectedCell,
-				( cellAttributes ) => ( {
-					...cellAttributes,
-					content,
-				} )
-			)
-		);
-	}
+			setAttributes(
+				updateSelectedCell(
+					attributes,
+					selectedCell,
+					( cellAttributes ) => ( {
+						...cellAttributes,
+						content,
+					} )
+				)
+			);
+		},
+		[ attributes, selectedCell, setAttributes ]
+	);
 
 	/**
 	 * Align text within the a column.
@@ -407,47 +416,25 @@ function TableEdit( {
 		<TSection name={ name } key={ name }>
 			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
 				<tr key={ rowIndex }>
-					{ cells.map(
-						(
-							{
-								content,
-								tag: CellTag,
-								scope,
-								align,
-								colspan,
-								rowspan,
-							},
-							columnIndex
-						) => (
-							<CellTag
-								key={ columnIndex }
-								scope={ CellTag === 'th' ? scope : undefined }
-								colSpan={ colspan }
-								rowSpan={ rowspan }
-								className={ clsx(
-									{
-										[ `has-text-align-${ align }` ]: align,
-									},
-									'wp-block-table__cell-content'
-								) }
-							>
-								<RichText
-									value={ content }
-									onChange={ onChange }
-									onFocus={ () => {
-										setSelectedCell( {
-											sectionName: name,
-											rowIndex,
-											columnIndex,
-											type: 'cell',
-										} );
-									} }
-									aria-label={ cellAriaLabel[ name ] }
-									placeholder={ placeholder[ name ] }
-								/>
-							</CellTag>
-						)
-					) }
+					{ cells.map( ( cellProps, columnIndex ) => (
+						// Important - the Cell component is memoized to improve typing performance.
+						// ensure all props passed have stable references.
+						<Cell
+							key={ columnIndex }
+							name={ name }
+							rowIndex={ rowIndex }
+							columnIndex={ columnIndex }
+							onChange={
+								// Only pass the `onChange` handler to the selectedCell.
+								// Cell components are memoized, so it's best to avoid
+								// passing in a value that will cause all cells to re-render
+								// whenever it changes.
+								selectedCell === 'text' ? onChange : undefined
+							}
+							setSelectedCell={ setSelectedCell }
+							{ ...cellProps }
+						/>
+					) ) }
 				</tr>
 			) ) }
 		</TSection>
@@ -613,5 +600,48 @@ function TableEdit( {
 		</figure>
 	);
 }
+
+const Cell = memo( function ( {
+	tag: CellTag,
+	name,
+	scope,
+	colspan,
+	rowspan,
+	rowIndex,
+	columnIndex,
+	align,
+	content,
+	onChange,
+	setSelectedCell,
+} ) {
+	return (
+		<CellTag
+			scope={ CellTag === 'th' ? scope : undefined }
+			colSpan={ colspan }
+			rowSpan={ rowspan }
+			className={ clsx(
+				{
+					[ `has-text-align-${ align }` ]: align,
+				},
+				'wp-block-table__cell-content'
+			) }
+		>
+			<RichText
+				value={ content }
+				onChange={ onChange }
+				onFocus={ () => {
+					setSelectedCell( {
+						sectionName: name,
+						rowIndex,
+						columnIndex,
+						type: 'cell',
+					} );
+				} }
+				aria-label={ cellAriaLabel[ name ] }
+				placeholder={ placeholder[ name ] }
+			/>
+		</CellTag>
+	);
+} );
 
 export default TableEdit;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the typing performance part of #30091. I still see quite slow performance when creating big tables, so that can be a separate perf challenge.

As noted in that issue, for large tables typing performance degrades significantly.

@t-hamano kindly diagnosed one of the problems in that issue - all cells are re-rendered whenever a change is made to a single cell, this can involve quite a large number of cells and RichText components.

After solving that, there were still some issues causing every RichText in the table to update at the same time. I narrowed this down usage of `PrivateBlockContext` in Rich Text.

## How?
I've extracted Cell into a separate component that's memoized.

Memoization seems like a good solution to me, as the majority of the elements in the table don't change, only one cell does at a time.

For the PrivateBlockContext issue - this is an unmemoized context provider, and seems to update on any change to a block. I've removed that usage and switched to getting bindableAttributes via RichText's own useSelect call. After that change, only the RichText being typed into updates.

## Testing Instructions
One way to test this is to use the React Developer Tools, from the options menu toggle on 'Highlight updates when components render'. Then compare trunk to this PR.

1. Create a table block with multiple rows and columns (don't be that person that creates a single cell table block, you won't be able to test this!)
2. Click between the cells and type in cells

In this PR: Only the selected cell (and the deselected cell) re-render
In trunk: Every cell re-renders whenever changing selection or typing 😬 

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/user-attachments/assets/909ebfc5-1f4a-4137-9b5d-35f7802e0434

#### After

https://github.com/user-attachments/assets/d0142144-cc46-4639-b2c3-8ab881355060
