### PR TITLE
Docs: Fix API Versions link in Block API reference

### DIFF
--- a/docs/reference-guides/README.md
+++ b/docs/reference-guides/README.md
@@ -3,7 +3,7 @@
 ## [Block API Reference](/docs/reference-guides/block-api/README.md)
 
 -   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
--   [API Versions](/docs/reference-guides/block-api/block-api-versions.md)
+-   [API Versions](/docs/reference-guides/block-api/block-api-versions/README.md)
 -   [Attributes](/docs/reference-guides/block-api/block-attributes.md)
 -   [Context](/docs/reference-guides/block-api/block-context.md)
 -   [Deprecation](/docs/reference-guides/block-api/block-deprecation.md)

--- a/docs/reference-guides/block-api/README.md
+++ b/docs/reference-guides/block-api/README.md
@@ -5,7 +5,7 @@ Blocks are the fundamental element of the editor. They are the primary way in wh
 The following sections will walk you through the existing block APIs:
 
 -   [Annotations](/docs/reference-guides/block-api/block-annotations.md)
--   [API Versions](/docs/reference-guides/block-api/block-api-versions.md)
+-   [API Versions](/docs/reference-guides/block-api/block-api-versions/README.md)
 -   [Attributes](/docs/reference-guides/block-api/block-attributes.md)
 -   [Bindings](/docs/reference-guides/block-api/block-bindings.md)
 -   [Context](/docs/reference-guides/block-api/block-context.md)

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -100,7 +100,7 @@ This section describes all the properties that can be added to the `block.json` 
 
 The version of the Block API used by the block. The most recent version is `3` and it was introduced in WordPress 6.3.
 
-See [the API versions documentation](/docs/reference-guides/block-api/block-api-versions.md) for more details.
+See [the API versions documentation](/docs/reference-guides/block-api/block-api-versions/README.md) for more details.
 
 ### Name
 


### PR DESCRIPTION
### What
Fixes the "API Versions" link in the Block API reference to point to the correct documentation entry point.

### Why
The previous link pointed to a directory instead of a specific document, making it inconsistent with other Block API links and less explicit for readers.

### How
Updated the link to reference `block-api-versions/README.md` directly.

No behavioral or API changes.
