### PR TITLE
WordPress Build: Use stable content hashes when building scripts

### DIFF
--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -3,15 +3,42 @@
 /**
  * External dependencies
  */
-import { copyFile, mkdir, writeFile } from 'fs/promises';
+import { copyFile, mkdir, writeFile, readFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
+import { createHash } from 'crypto';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const ROOT_DIR = path.resolve( __dirname, '../..' );
 const BUILD_DIR = path.join( ROOT_DIR, 'build', 'scripts' );
 const VENDORS_DIR = path.join( BUILD_DIR, 'vendors' );
+
+/**
+ * Generate a content hash from file contents.
+ * Uses SHA256 algorithm for broad compatibility across Node.js versions.
+ *
+ * @param {string[]} filePaths - Absolute paths to files to hash
+ * @param {string}   algorithm - Hash algorithm (default: 'sha256')
+ * @param {number}   length    - Hash length (default: 20)
+ * @return {Promise<string>} Content hash string
+ */
+async function generateContentHash( filePaths, algorithm = 'sha256', length = 20 ) {
+	const hashBuilder = createHash( algorithm );
+
+	// Sort paths for deterministic ordering
+	const sortedPaths = [ ...filePaths ].sort();
+
+	// Read and hash each file
+	for ( const filePath of sortedPaths ) {
+		const content = await readFile( filePath );
+		hashBuilder.update( content );
+	}
+
+	// Generate hash as hex string and truncate
+	const fullHash = hashBuilder.digest( 'hex' );
+	return fullHash.slice( 0, length );
+}
 
 /**
  * Copy React and ReactDOM UMD files from node_modules.
@@ -131,7 +158,9 @@ async function bundleReactRefresh() {
 	} );
 
 	// Generate asset file for react-refresh-entry
-	const entryAssetContent = `<?php return array('dependencies' => array('wp-react-refresh-runtime'), 'version' => '${ Date.now() }');`;
+	const entryOutputFile = path.join( entryDir, 'index.min.js' );
+	const entryVersion = await generateContentHash( [ entryOutputFile ] );
+	const entryAssetContent = `<?php return array('dependencies' => array('wp-react-refresh-runtime'), 'version' => '${ entryVersion }');`;
 	await writeFile(
 		path.join( entryDir, 'index.min.asset.php' ),
 		entryAssetContent
@@ -153,7 +182,9 @@ async function bundleReactRefresh() {
 	} );
 
 	// Generate asset file for react-refresh-runtime
-	const runtimeAssetContent = `<?php return array('dependencies' => array(), 'version' => '${ Date.now() }');`;
+	const runtimeOutputFile = path.join( runtimeDir, 'index.min.js' );
+	const runtimeVersion = await generateContentHash( [ runtimeOutputFile ] );
+	const runtimeAssetContent = `<?php return array('dependencies' => array(), 'version' => '${ runtimeVersion }');`;
 	await writeFile(
 		path.join( runtimeDir, 'index.min.asset.php' ),
 		runtimeAssetContent

--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -23,7 +23,11 @@ const VENDORS_DIR = path.join( BUILD_DIR, 'vendors' );
  * @param {number}   length    - Hash length (default: 20)
  * @return {Promise<string>} Content hash string
  */
-async function generateContentHash( filePaths, algorithm = 'sha256', length = 20 ) {
+async function generateContentHash(
+	filePaths,
+	algorithm = 'sha256',
+	length = 20
+) {
 	const hashBuilder = createHash( algorithm );
 
 	// Sort paths for deterministic ordering

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -20,7 +20,11 @@ import { getPackageInfo } from './package-utils.mjs';
  * @param {number}   length    - Hash length (default: 20)
  * @return {Promise<string>} Content hash string
  */
-async function generateContentHash( filePaths, algorithm = 'sha256', length = 20 ) {
+async function generateContentHash(
+	filePaths,
+	algorithm = 'sha256',
+	length = 20
+) {
 	const hashBuilder = createHash( algorithm );
 
 	// Sort paths for deterministic ordering
@@ -359,7 +363,8 @@ export function createWordpressExternalsPlugin(
 						}
 
 						// Generate content-based version hash
-						const version = await generateContentHash( filesToHash );
+						const version =
+							await generateContentHash( filesToHash );
 
 						const parts = [
 							`'dependencies' => array(${ dependenciesString })`,

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -1,14 +1,41 @@
 /**
  * External dependencies
  */
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile, mkdir, readFile } from 'fs/promises';
 import path from 'path';
 import { camelCase } from 'change-case';
+import { createHash } from 'crypto';
 
 /**
  * Internal dependencies
  */
 import { getPackageInfo } from './package-utils.mjs';
+
+/**
+ * Generate a content hash from file contents.
+ * Uses SHA256 algorithm for broad compatibility across Node.js versions.
+ *
+ * @param {string[]} filePaths - Absolute paths to files to hash
+ * @param {string}   algorithm - Hash algorithm (default: 'sha256')
+ * @param {number}   length    - Hash length (default: 20)
+ * @return {Promise<string>} Content hash string
+ */
+async function generateContentHash( filePaths, algorithm = 'sha256', length = 20 ) {
+	const hashBuilder = createHash( algorithm );
+
+	// Sort paths for deterministic ordering
+	const sortedPaths = [ ...filePaths ].sort();
+
+	// Read and hash each file
+	for ( const filePath of sortedPaths ) {
+		const content = await readFile( filePath );
+		hashBuilder.update( content );
+	}
+
+	// Generate hash as hex string and truncate
+	const fullHash = hashBuilder.digest( 'hex' );
+	return fullHash.slice( 0, length );
+}
 
 /**
  * Create WordPress externals plugin for esbuild.
@@ -307,7 +334,32 @@ export function createWordpressExternalsPlugin(
 								? moduleDependenciesArray.join( ', ' )
 								: '';
 
-						const version = Date.now();
+						// Determine output file path from build config
+						let outputFilePath;
+						if ( build.initialOptions.outfile ) {
+							outputFilePath = build.initialOptions.outfile;
+						} else if ( build.initialOptions.outdir ) {
+							// Construct expected output filename from assetName
+							// e.g., assetName='index.min' -> 'index.min.js'
+							outputFilePath = path.join(
+								build.initialOptions.outdir,
+								`${ assetName }.js`
+							);
+						}
+
+						// Collect files to hash
+						const filesToHash = [];
+						if ( outputFilePath ) {
+							filesToHash.push( outputFilePath );
+
+							// Include source map if enabled
+							if ( build.initialOptions.sourcemap ) {
+								filesToHash.push( `${ outputFilePath }.map` );
+							}
+						}
+
+						// Generate content-based version hash
+						const version = await generateContentHash( filesToHash );
 
 						const parts = [
 							`'dependencies' => array(${ dependenciesString })`,


### PR DESCRIPTION
### Summary

Replaces `Date.now()` timestamps with SHA256 content hashes in build asset versioning to enable reproducible builds. 
Core has a job that auto-commits on each "diff" discovered and this creates an infinite loop since each commit triggers the job which rebuilds and since we were using timestamps the build was slightly different each time.

This PR ensures wp-build generates the same "version" hashes if the content of the scripts didn't change.

### Testing

  Verified that:
  - Clean rebuilds produce identical hashes
  - Source changes trigger version updates for affected packages only
  - Unmodified packages maintain stable versions

  ### Example
  **Before:** `'version' => '1765880436119'` (timestamp)
  **After:** `'version' => 'a5b3a20a3d22575549c7'` (content hash)