### PR TITLE
Prevent start page options modal from opening when navigating back from template parts

### DIFF
--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -17,7 +17,10 @@ import { store as interfaceStore } from '@wordpress/interface';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../store/constants';
 import { store as editorStore } from '../../store';
 
 export function useStartPatterns() {
@@ -152,7 +155,8 @@ export default function StartPageOptions() {
 			postId: getCurrentPostId(),
 			enabled:
 				choosePatternModalEnabled &&
-				TEMPLATE_POST_TYPE !== getCurrentPostType(),
+				TEMPLATE_POST_TYPE !== getCurrentPostType() &&
+				TEMPLATE_PART_POST_TYPE !== getCurrentPostType(),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -151,12 +151,13 @@ export default function StartPageOptions() {
 			'core',
 			'enableChoosePatternModal'
 		);
+		const currentPostType = getCurrentPostType();
 		return {
 			postId: getCurrentPostId(),
 			enabled:
 				choosePatternModalEnabled &&
-				TEMPLATE_POST_TYPE !== getCurrentPostType() &&
-				TEMPLATE_PART_POST_TYPE !== getCurrentPostType(),
+				TEMPLATE_POST_TYPE !== currentPostType &&
+				TEMPLATE_PART_POST_TYPE !== currentPostType,
 		};
 	}, [] );
 


### PR DESCRIPTION
## What

Fixes a bug where the start page options modal opens when navigating to or back from empty template parts. The modal should only appear for pages, not template parts.

This bug was uncovered as part of #73919.

## Why

The start page options modal is intended for pages. When navigating back from an empty template part, the component treated it as a "fresh page" because it was empty and not dirty, causing the modal to open. Template parts should be excluded from this auto-open behavior, similar to how templates (`wp_template`) are already excluded.

## How

Adds `TEMPLATE_PART_POST_TYPE` to the exclusion list in the `StartPageOptions` component, alongside the existing `TEMPLATE_POST_TYPE` exclusion. This prevents the modal from auto-opening when editing template parts.

## Testing Instructions

1. Add a new template part block
2. Click "Start blank"
3. Click the "Edit" button on the template part to go to focused editing mode
4. Save the blank template part
5. Click Back
6. Verify the start page options modal does not appear



## Screenshots

#### Before

https://github.com/user-attachments/assets/de95cb20-5952-4c62-8f19-894f213277f4

#### After

https://github.com/user-attachments/assets/fad4128a-939c-42ba-9d7d-8ae8c813642b





