### PR TITLE
Format library: visualise non-breaking spaces

### DIFF
--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -54,3 +54,9 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 .rich-text [contenteditable="false"]::selection {
 	background-color: transparent;
 }
+
+.is-selected .non-breaking-space {
+	outline: 1px solid currentColor;
+	outline-offset: -1px;
+	opacity: 0.8;
+}

--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -52,3 +52,9 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 .rich-text [contenteditable="false"]::selection {
 	background-color: transparent;
 }
+
+.is-selected .non-breaking-space {
+	outline: 1px solid currentColor;
+	outline-offset: -1px;
+	opacity: 0.8;
+}

--- a/packages/format-library/src/non-breaking-space/index.js
+++ b/packages/format-library/src/non-breaking-space/index.js
@@ -2,28 +2,75 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { insert } from '@wordpress/rich-text';
+import { applyFormat, insert, useAnchor } from '@wordpress/rich-text';
 import { RichTextShortcut } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
 
 const name = 'core/non-breaking-space';
 const title = __( 'Non breaking space' );
 
+function PopoverAnchor( { contentRef } ) {
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		settings: nonBreakingSpace,
+	} );
+
+	return (
+		<Popover anchor={ popoverAnchor }>
+			<div style={ { whiteSpace: 'nowrap', padding: '4px' } }>
+				{ __( 'Non-breaking space' ) }
+			</div>
+		</Popover>
+	);
+}
+
 export const nonBreakingSpace = {
 	name,
 	title,
-	tagName: 'nbsp',
-	className: null,
-	edit( { value, onChange } ) {
+	tagName: 'span',
+	className: 'non-breaking-space',
+	edit( { value, onChange, contentRef } ) {
 		function addNonBreakingSpace() {
 			onChange( insert( value, '\u00a0' ) );
 		}
 
+		const selectedValue =
+			value.start && value.end
+				? value.text.slice( value.start, value.end )
+				: null;
+
 		return (
-			<RichTextShortcut
-				type="primaryShift"
-				character=" "
-				onUse={ addNonBreakingSpace }
-			/>
+			<>
+				<RichTextShortcut
+					type="primaryShift"
+					character=" "
+					onUse={ addNonBreakingSpace }
+				/>
+				{ selectedValue === '\u00a0' && (
+					<PopoverAnchor contentRef={ contentRef } />
+				) }
+			</>
 		);
+	},
+	__experimentalCreatePrepareEditableTree() {
+		return ( formats, text ) => {
+			const NBSP = '\u00a0';
+			let record = { formats, text };
+			let index = -1;
+
+			do {
+				index = text.indexOf( NBSP, index + 1 );
+				if ( index !== -1 ) {
+					record = applyFormat(
+						record,
+						{ type: name },
+						index,
+						index + 1
+					);
+				}
+			} while ( index !== -1 );
+
+			return record.formats;
+		};
 	},
 };

--- a/packages/format-library/src/non-breaking-space/index.jsx
+++ b/packages/format-library/src/non-breaking-space/index.jsx
@@ -1,26 +1,73 @@
 import { __ } from '@wordpress/i18n';
-import { insert } from '@wordpress/rich-text';
+import { applyFormat, insert, useAnchor } from '@wordpress/rich-text';
 import { RichTextShortcut } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
 
 const name = 'core/non-breaking-space';
 const title = __( 'Non breaking space' );
 
+function PopoverAnchor( { contentRef } ) {
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		settings: nonBreakingSpace,
+	} );
+
+	return (
+		<Popover anchor={ popoverAnchor }>
+			<div style={ { whiteSpace: 'nowrap', padding: '4px' } }>
+				{ __( 'Non-breaking space' ) }
+			</div>
+		</Popover>
+	);
+}
+
 export const nonBreakingSpace = {
 	name,
 	title,
-	tagName: 'nbsp',
-	className: null,
-	edit( { value, onChange } ) {
+	tagName: 'span',
+	className: 'non-breaking-space',
+	edit( { value, onChange, contentRef } ) {
 		function addNonBreakingSpace() {
 			onChange( insert( value, '\u00a0' ) );
 		}
 
+		const selectedValue =
+			value.start && value.end
+				? value.text.slice( value.start, value.end )
+				: null;
+
 		return (
-			<RichTextShortcut
-				type="primaryShift"
-				character=" "
-				onUse={ addNonBreakingSpace }
-			/>
+			<>
+				<RichTextShortcut
+					type="primaryShift"
+					character=" "
+					onUse={ addNonBreakingSpace }
+				/>
+				{ selectedValue === '\u00a0' && (
+					<PopoverAnchor contentRef={ contentRef } />
+				) }
+			</>
 		);
+	},
+	__experimentalCreatePrepareEditableTree() {
+		return ( formats, text ) => {
+			const NBSP = '\u00a0';
+			let record = { formats, text };
+			let index = -1;
+
+			do {
+				index = text.indexOf( NBSP, index + 1 );
+				if ( index !== -1 ) {
+					record = applyFormat(
+						record,
+						{ type: name },
+						index,
+						index + 1
+					);
+				}
+			} while ( index !== -1 );
+
+			return record.formats;
+		};
 	},
 };

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -7620,6 +7620,9 @@
 		}
 	},
 	"packages/format-library/src/non-breaking-space/index.jsx": {
+		"react-hooks/refs": {
+			"count": 2
+		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Visualises non breaking spaces in rich text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Non-breaking spaces can sneak in from all sorts of places (paste, browser inserting them). These characters affect the layout and users might be confused about why a sentence is breaking to a new line much earlier. 

Non-breaking spaces are also often used to fine-tune the way sentences wrap. For example, in a heading, you might not want a single word on a second new line, so it's possible "glue" them together on a new line. Regardless of the reason, when  making use of them there's currently no way to know if a space is a normal space or a non-breaking space.

See also #72232. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We visualize them in rich text by wrapping them in a span (format). These formats are editor-only, they are not serialized.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add a non breaking space, for example by pressing Alt+Space.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="741" height="362" alt="image" src="https://github.com/user-attachments/assets/3670fddd-a115-45cc-a0de-10c2eaa38c45" />
<img width="754" height="375" alt="image" src="https://github.com/user-attachments/assets/1c08f5f6-09f1-4aae-bd9a-960c480b804b" />
