### PR TITLE
Fix: Unset line heights on stretch text

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -511,7 +511,7 @@ export default function TypographyPanel( {
 					/>
 				</ToolsPanelItem>
 			) }
-			{ hasLineHeightEnabled && (
+			{ hasLineHeightEnabled && ! fitText && (
 				<ToolsPanelItem
 					className="single-column"
 					label={ __( 'Line height' ) }

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -21,9 +21,14 @@ export const LINE_HEIGHT_SUPPORT_KEY = 'typography.lineHeight';
  */
 export function LineHeightEdit( props ) {
 	const {
-		attributes: { style },
+		attributes: { style, fitText },
 		setAttributes,
 	} = props;
+
+	// Hide line height UI when fitText is enabled
+	if ( fitText ) {
+		return null;
+	}
 
 	const onChange = ( newLineHeightValue ) => {
 		const newStyle = {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -53,6 +53,7 @@
 // Fit Text
 .has-fit-text {
 	white-space: nowrap !important;
+	line-height: unset !important;
 }
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/73806

Line heights limits the height of a text block, on fit text we try to maximize the size of a given text block inside its available dimensions. Both options are fundamentally against each other, in the same way fit text is fundamentally against white-space wrapping and line heigh. Having fit text together with a line height at the block does makes sense adn could have unpredictable results.

This PR adds change to make sure line heigh is removed when fit text is enable.

cc: @iamtakashi

## Testing
Paste the following on the code editor:
```
<!-- wp:paragraph {"style":{"typography":{"lineHeight":"40px"}}} -->
<p style="line-height:40px">Stretch Text</p>
<!-- /wp:paragraph -->
```
Covert the block to Stretch Paragraph.
Verify text stretches (trunk it does not).