### PR TITLE
Fix typo in Tutorial: Build your first block

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -919,7 +919,7 @@ Save both the `block.json` and `save.js` files; you won't need to make any more 
 
 The `save()` function now uses the new `fallbackCurrentYear`, so it needs to be set somewhere. Let's use the `Edit()` function.
 
-Open the `edit.js` file and start by defining the `fallbackCurrentYear` variable at the top of the `Edit()` functional alongside the other attributes. Next, review what's happening in the function.
+Open the `edit.js` file and start by defining the `fallbackCurrentYear` variable at the top of the `Edit()` function alongside the other attributes. Next, review what's happening in the function.
 
 When the block loads in the Editor, the `currentYear` variable is defined. The function then uses this variable to set the content of the block.
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Documentation update for [WordPress Developer Resources > Tutorial: Build your first block (Section Setting the attribute in edit.js) ](https://developer.wordpress.org/block-editor/getting-started/tutorial/#setting-the-attribute-in-edit-js)

Changing "Edit() functional" to "Edit() function" to help with readability.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was originally reported in the Documentation Issue Tracker: https://github.com/WordPress/Documentation-Issue-Tracker/issues/1915 by @cent-kanayo

## Testing Instructions
View page: https://developer.wordpress.org/block-editor/getting-started/tutorial/#setting-the-attribute-in-edit-js 
