### PR TITLE
Build: Only generate asset file once and keep version consistent

### DIFF
--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -64,12 +64,14 @@ export function createWordpressExternalsPlugin(
 	 * @param {string}        assetName         Base name for the asset file (e.g., 'index.min').
 	 * @param {string}        buildFormat       Build format: 'iife' for classic scripts, 'esm' for modules.
 	 * @param {Array<string>} extraDependencies Additional dependencies to include in the asset file.
+	 * @param {boolean}       generateAssetFile Whether to generate the .asset.php file. Default true.
 	 * @return {Object} esbuild plugin object.
 	 */
 	return function wordpressExternalsPlugin(
 		assetName = 'index.min',
 		buildFormat = 'iife',
-		extraDependencies = []
+		extraDependencies = [],
+		generateAssetFile = true
 	) {
 		return {
 			name: 'wordpress-externals',
@@ -312,17 +314,6 @@ export function createWordpressExternalsPlugin(
 							return;
 						}
 
-						// Merge discovered dependencies with extra dependencies
-						const allDependencies = new Set( [
-							...dependencies,
-							...extraDependencies,
-						] );
-
-						const dependenciesString = Array.from( allDependencies )
-							.sort()
-							.map( ( dep ) => `'${ dep }'` )
-							.join( ', ' );
-
 						// Format module dependencies as array of arrays with 'id' and 'import' keys
 						const moduleDependenciesArray = Array.from(
 							moduleDependencies.entries()
@@ -337,6 +328,22 @@ export function createWordpressExternalsPlugin(
 							moduleDependenciesArray.length > 0
 								? moduleDependenciesArray.join( ', ' )
 								: '';
+
+						// Only generate asset file if requested
+						if ( ! generateAssetFile ) {
+							return;
+						}
+
+						// Merge discovered dependencies with extra dependencies
+						const allDependencies = new Set( [
+							...dependencies,
+							...extraDependencies,
+						] );
+
+						const dependenciesString = Array.from( allDependencies )
+							.sort()
+							.map( ( dep ) => `'${ dep }'` )
+							.join( ', ' );
 
 						// Determine output file path from build config
 						let outputFilePath;


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/10638

### Problem

Both minified and non-minified builds were generating the same `.asset.php` file concurrently, causing a race condition. The hash would alternate between two values depending on which build finished last:
  - Minified build: hash of `index.min.js` + `index.min.js.map`
  - Non-minified build: hash of `index.js` + `index.js.map`

  This made builds non-deterministic, causing unnecessary git diffs on every rebuild.

### Solution
  - Added `generateAssetFile` parameter to `wordpressExternalsPlugin()` (defaults to `true`)
  - Only the **minified build** now generates the `.asset.php` file
  - Non-minified build skips asset file generation entirely

  This ensures each `.asset.php` file is written exactly once with a consistent hash.

### Testing

Verified multiple consecutive builds produce identical `.asset.php` files with stable hashes.