### PR TITLE
SelectControl: Deprecate bottom margin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -276,7 +276,7 @@ module.exports = {
 					...restrictedSyntax,
 					...restrictedSyntaxComponents,
 					// Temporary rules until we're ready to officially deprecate the bottom margins.
-					...[ 'BaseControl', 'SearchControl', 'SelectControl' ].map(
+					...[ 'BaseControl', 'SearchControl' ].map(
 						( componentName ) => ( {
 							selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,
 							message:

--- a/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
@@ -93,7 +93,6 @@ export default function AspectRatioTool( {
 				options={ options ?? aspectRatioOptions }
 				onChange={ onChange }
 				size="__unstable-large"
-				__nextHasNoMarginBottom
 			/>
 		</ToolsPanelItem>
 	);

--- a/packages/block-editor/src/components/html-element-control/index.js
+++ b/packages/block-editor/src/components/html-element-control/index.js
@@ -88,7 +88,6 @@ export default function HTMLElementControl( {
 	return (
 		<VStack spacing={ 2 } className="block-editor-html-element-control">
 			<SelectControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'HTML element' ) }
 				options={ modifiedOptions }

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -91,7 +91,6 @@ export default function ImageSizeControl( {
 		<VStack className="block-editor-image-size-control" spacing="4">
 			{ imageSizeOptions && imageSizeOptions.length > 0 && (
 				<SelectControl
-					__nextHasNoMarginBottom
 					label={ __( 'Resolution' ) }
 					value={ slug }
 					options={ imageSizeOptions }

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -128,7 +128,6 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 						/>
 
 						<SelectControl
-							__nextHasNoMarginBottom
 							label="Select Control"
 							value={ selectField }
 							options={ [

--- a/packages/block-editor/src/components/resolution-tool/index.js
+++ b/packages/block-editor/src/components/resolution-tool/index.js
@@ -46,7 +46,6 @@ export default function ResolutionTool( {
 			resetAllFilter={ resetAllFilter }
 		>
 			<SelectControl
-				__nextHasNoMarginBottom
 				label={ __( 'Resolution' ) }
 				value={ displayValue }
 				options={ options }

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -43,7 +43,6 @@ const renderTestDefaultControlComponent = ( labelComponent, device ) => {
 				__next40pxDefaultSize
 				label={ labelComponent }
 				options={ sizeOptions }
-				__nextHasNoMarginBottom
 			/>
 			<p id={ device.id }>
 				{ device.label } is used here for testing purposes to ensure we

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -106,7 +106,6 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Group by' ) }
 							options={ [
 								{ label: __( 'Year' ), value: 'yearly' },

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -224,7 +224,6 @@ function AudioEdit( {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ _x(
 								'Preload',
 								'noun; Audio block parameter'

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -235,7 +235,6 @@ export default function CategoriesEdit( {
 							isShownByDefault
 						>
 							<SelectControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'Taxonomy' ) }
 								options={ taxonomies.map( ( t ) => ( {

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -111,7 +111,6 @@ export default function FileBlockInspector( {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Link to' ) }
 							value={ textLinkHref }
 							options={ linkDestinationOptions }

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -108,7 +108,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						isShownByDefault
 					>
 						<SelectControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label={ __( 'Submissions method' ) }
 							options={ [
@@ -176,7 +175,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 				<InspectorControls group="advanced">
 					<SelectControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Method' ) }
 						options={ [
 							{ label: 'Get', value: 'get' },

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -704,7 +704,6 @@ export default function GalleryEdit( props ) {
 								}
 							>
 								<SelectControl
-									__nextHasNoMarginBottom
 									label={ __( 'Resolution' ) }
 									help={ __(
 										'Select the size of the source images.'
@@ -770,7 +769,6 @@ export default function GalleryEdit( props ) {
 							>
 								<SelectControl
 									__next40pxDefaultSize
-									__nextHasNoMarginBottom
 									label={ __( 'Aspect ratio' ) }
 									help={ __(
 										'Set a consistent aspect ratio for all images in the gallery.'
@@ -803,7 +801,6 @@ export default function GalleryEdit( props ) {
 						) }
 						{ imageSizeOptions?.length > 0 && (
 							<SelectControl
-								__nextHasNoMarginBottom
 								label={ __( 'Resolution' ) }
 								help={ __(
 									'Select the size of the source images.'
@@ -816,7 +813,6 @@ export default function GalleryEdit( props ) {
 							/>
 						) }
 						<SelectControl
-							__nextHasNoMarginBottom
 							label={ __( 'Link' ) }
 							value={ linkTo }
 							onChange={ setLinkTo }
@@ -843,7 +839,6 @@ export default function GalleryEdit( props ) {
 						) }
 						{ aspectRatioOptions.length > 1 && (
 							<SelectControl
-								__nextHasNoMarginBottom
 								label={ __( 'Aspect Ratio' ) }
 								help={ __(
 									'Set a consistent aspect ratio for all images in the gallery.'

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -105,7 +105,6 @@ export default function LatestComments( { attributes, setAttributes } ) {
 						isShownByDefault
 					>
 						<SelectControl
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							label={ __( 'Display content' ) }
 							value={ displayContent }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -50,7 +50,6 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 				<PanelBody title={ __( 'Settings' ) }>
 					<SelectControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'List style' ) }
 						options={ LIST_STYLE_OPTIONS }
 						value={ type }
@@ -113,7 +112,6 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'List style' ) }
 							options={ LIST_STYLE_OPTIONS }
 							value={ type || 'decimal' }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -194,7 +194,6 @@ export default function OverlayTemplatePartSelector( {
 			/>
 			<SelectControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label={ __( 'Overlay template' ) }
 				value={ overlay || '' }
 				options={ options }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -247,7 +247,6 @@ function PostAuthorEdit( {
 						>
 							<SelectControl
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 								label={ __( 'Avatar size' ) }
 								value={ avatarSize }
 								options={ avatarSizes }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -117,7 +117,6 @@ const DimensionControls = ( {
 			>
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Aspect ratio' ) }
 					value={ aspectRatio }
 					options={ aspectRatioOptions }

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -207,7 +207,6 @@ export default function PostNavigationLinkEdit( {
 			<InspectorControls group="advanced">
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Filter by taxonomy' ) }
 					value={ taxonomy }
 					options={ getTaxonomyOptions() }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -269,7 +269,6 @@ export default function QueryInspectorControls( props ) {
 						>
 							{ postTypesSelectOptions.length > 2 ? (
 								<SelectControl
-									__nextHasNoMarginBottom
 									__next40pxDefaultSize
 									options={ postTypesSelectOptions }
 									value={ postType }

--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -33,7 +33,6 @@ function OrderControl( {
 } ) {
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Order by' ) }
 			value={ `${ orderBy }/${ order }` }

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -14,7 +14,6 @@ const stickyOptions = [
 export default function StickyControl( { value, onChange } ) {
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Sticky posts' ) }
 			options={ stickyOptions }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -390,7 +390,6 @@ export default function SearchEdit( {
 						<SelectControl
 							value={ buttonPosition }
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Button position' ) }
 							onChange={ ( value ) => {
 								setAttributes( {
@@ -490,7 +489,6 @@ export default function SearchEdit( {
 								} }
 								isBlock
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 							>
 								{ PERCENTAGE_WIDTHS.map( ( widthValue ) => {
 									return (

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -40,7 +40,6 @@ const HtmlElementControl = ( { tagName, setAttributes } ) => {
 					  )
 			}
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 		/>
 	);
 };

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -182,7 +182,6 @@ export function SocialLinksEdit( props ) {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Icon size' ) }
 							onChange={ ( newSize ) => {
 								setAttributes( {

--- a/packages/block-library/src/tab/controls.js
+++ b/packages/block-library/src/tab/controls.js
@@ -45,7 +45,6 @@ export default function Controls( {
 							} );
 						} }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Default Tab' ) }

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -190,7 +190,6 @@ export default function TableOfContentsEdit( {
 					isShownByDefault
 				>
 					<SelectControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Include headings down to level' ) }
 						value={ maxLevel || '' }

--- a/packages/block-library/src/tabs/controls.js
+++ b/packages/block-library/src/tabs/controls.js
@@ -169,7 +169,6 @@ export default function Controls( {
 								metadata: { ...metadata, name: value },
 							} );
 						} }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 				</PanelBody>

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -146,7 +146,6 @@ function TagCloudEdit( { attributes, setAttributes } ) {
 					isShownByDefault
 				>
 					<SelectControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Taxonomy' ) }
 						options={ getTaxonomyOptions() }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -67,7 +67,6 @@ export function TemplatePartAdvancedControls( {
 					/>
 					<SelectControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label={ __( 'Area' ) }
 						labelPosition="top"
 						options={ areaOptions }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -148,7 +148,6 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 						onChange={ ( value ) => setSelectedSidebar( value ) }
 						disabled={ ! options.length }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					/>
 				</FlexBlock>
 				<FlexItem

--- a/packages/block-library/src/terms-query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/order-control.js
@@ -7,7 +7,6 @@ import { SelectControl } from '@wordpress/components';
 export default function OrderControl( { orderBy, order, onChange, ...props } ) {
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			options={ [
 				{

--- a/packages/block-library/src/terms-query/edit/inspector-controls/taxonomy-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/taxonomy-control.js
@@ -17,7 +17,6 @@ export default function TaxonomyControl( { value, onChange, ...props } ) {
 
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			options={ taxonomyOptions }
 			value={ value }

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -154,7 +154,6 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			>
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Preload' ) }
 					value={ preload }
 					onChange={ onChangePreload }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -147,7 +147,6 @@ function SingleTrackEditor( {
 			<VStack spacing="4">
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					className="block-library-video-tracks-editor__single-track-editor-kind-select"
 					options={ KIND_OPTIONS }
 					value={ kind }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `TreeSelect`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74014](https://github.com/WordPress/gutenberg/pull/74014)).
 -   `RangeControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74033](https://github.com/WordPress/gutenberg/pull/74033)).
 -   `ComboboxControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74034](https://github.com/WordPress/gutenberg/pull/74034)).
+-   `SelectControl`: The `__nextHasNoMarginBottom` prop is now true by default. The prop can be safely removed ([#74052](https://github.com/WordPress/gutenberg/pull/74052)).
 -   `DimensionControl`: Completely remove deprecated component ([#73944](https://github.com/WordPress/gutenberg/pull/73944)).
 
 ### Enhancements

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -135,7 +135,6 @@ const UnconnectedColorPicker = (
 			<AuxiliaryColorArtefactWrapper>
 				<AuxiliaryColorArtefactHStackHeader justify="space-between">
 					<SelectControl
-						__nextHasNoMarginBottom
 						size="compact"
 						options={ options }
 						value={ colorType }

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -104,7 +104,6 @@ const GradientTypePicker = ( {
 
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			className="components-custom-gradient-picker__type-picker"
 			label={ __( 'Type' ) }
 			labelPosition="top"

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -164,7 +164,6 @@ export function TimePicker( {
 				label={ __( 'Month' ) }
 				hideLabelFromVision
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				value={ month }
 				options={ monthOptions }
 				onChange={ ( value ) => {

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -52,7 +52,6 @@ const Form = () => {
 				onChange={ setTextAreaValue }
 			/>
 			<SelectControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label="Select Control"
 				onChange={ () => {} }

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -103,7 +103,6 @@ export function QueryControls( {
 			{ [
 				onOrderChange && onOrderByChange && (
 					<SelectControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						key="query-controls-order-select"
 						label={ __( 'Order by' ) }

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -93,7 +93,6 @@ const MySelectControl = () => {
 			] }
 			onChange={ ( newSize ) => setSize( newSize ) }
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 		/>
 	);
 };
@@ -116,7 +115,6 @@ Render a user interface to select multiple users from a list.
 		{ value: 'c', label: 'User c' },
 	] }
 	__next40pxDefaultSize
-	__nextHasNoMarginBottom
 />
 ```
 
@@ -132,7 +130,6 @@ const [ item, setItem ] = useState( '' );
     value={ item } // e.g: value = 'a'
     onChange={ ( selection ) => { setItem( selection ) } }
     __next40pxDefaultSize
-    __nextHasNoMarginBottom
 >
 	<optgroup label="Theropods">
 		<option value="Tyrannosaurus">Tyrannosaurus</option>
@@ -235,14 +232,6 @@ The style variant of the control.
 ### __next40pxDefaultSize
 
 Start opting into the larger default height that will become the default size in a future version.
-
--   Type: `Boolean`
--   Required: No
--   Default: `false`
-
-### __nextHasNoMarginBottom
-
-Start opting into the new margin-free styles that will become the default in a future version.
 
 -   Type: `Boolean`
 -   Required: No

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -65,7 +65,7 @@ function UnforwardedSelectControl< V extends string >(
 		suffix,
 		variant = 'default',
 		__next40pxDefaultSize = false,
-		__nextHasNoMarginBottom = false,
+		__nextHasNoMarginBottom: _, // Prevent passing to internal component
 		__shouldNotWarnDeprecated36pxSize,
 		...restProps
 	} = useDeprecated36pxDefaultSizeProp( props );
@@ -107,8 +107,7 @@ function UnforwardedSelectControl< V extends string >(
 			help={ help }
 			id={ id }
 			className={ classes }
-			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-			__associatedWPComponentName="SelectControl"
+			__nextHasNoMarginBottom
 		>
 			<StyledInputBase
 				disabled={ disabled }
@@ -163,7 +162,6 @@ function UnforwardedSelectControl< V extends string >(
  *   return (
  *     <SelectControl
  *       __next40pxDefaultSize
- *       __nextHasNoMarginBottom
  *       label="Size"
  *       value={ size }
  *       options={ [

--- a/packages/components/src/select-control/stories/index.story.tsx
+++ b/packages/components/src/select-control/stories/index.story.tsx
@@ -69,7 +69,6 @@ const SelectControlWithState: StoryFn< typeof SelectControl > = ( props ) => {
 export const Default = SelectControlWithState.bind( {} );
 Default.args = {
 	__next40pxDefaultSize: true,
-	__nextHasNoMarginBottom: true,
 	label: 'Label',
 	options: [
 		{ value: '', label: 'Select an Option', disabled: true },
@@ -92,7 +91,6 @@ WithLabelAndHelpText.args = {
 export const WithCustomChildren = SelectControlWithState.bind( {} );
 WithCustomChildren.args = {
 	__next40pxDefaultSize: true,
-	__nextHasNoMarginBottom: true,
 	label: 'Label',
 	children: (
 		<>

--- a/packages/components/src/select-control/test/select-control.tsx
+++ b/packages/components/src/select-control/test/select-control.tsx
@@ -12,13 +12,7 @@ import _SelectControl from '..';
 const SelectControl = (
 	props: React.ComponentProps< typeof _SelectControl >
 ) => {
-	return (
-		<_SelectControl
-			{ ...props }
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-		/>
-	);
+	return <_SelectControl { ...props } __next40pxDefaultSize />;
 };
 
 describe( 'SelectControl', () => {

--- a/packages/components/src/select-control/types.ts
+++ b/packages/components/src/select-control/types.ts
@@ -22,7 +22,14 @@ type SelectControlBaseProps< V extends string > = Pick<
 	| 'size'
 	| 'suffix'
 > &
-	Pick< BaseControlProps, 'help' | '__nextHasNoMarginBottom' > & {
+	Pick< BaseControlProps, 'help' > & {
+		/**
+		 * Start opting into the new margin-free styles that will become the default in a future version.
+		 *
+		 * @deprecated Default behavior since WordPress 7.0. Prop can be safely removed.
+		 * @ignore
+		 */
+		__nextHasNoMarginBottom?: boolean;
 		/**
 		 * An array of option property objects to be rendered,
 		 * each with a `label` and `value` property, as well as any other

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -104,7 +104,6 @@ export function TreeSelect( props: TreeSelectProps ) {
 			{ ...{ label, options, onChange } }
 			value={ selectedId }
 			{ ...restProps }
-			__nextHasNoMarginBottom
 		/>
 	);
 }

--- a/packages/components/src/tree-select/types.ts
+++ b/packages/components/src/tree-select/types.ts
@@ -18,15 +18,8 @@ export interface Tree {
 export interface TreeSelectProps
 	extends Omit<
 		SelectControlSingleSelectionProps,
-		'value' | 'multiple' | 'onChange' | '__nextHasNoMarginBottom'
+		'value' | 'multiple' | 'onChange'
 	> {
-	/**
-	 * Start opting into the new margin-free styles that will become the default in a future version.
-	 *
-	 * @deprecated Default behavior since WordPress 7.0. Prop can be safely removed.
-	 * @ignore
-	 */
-	__nextHasNoMarginBottom?: boolean;
 	/**
 	 * If this property is added, an option will be added with this label to represent empty selection.
 	 */

--- a/packages/components/src/validated-form-controls/components/select-control.tsx
+++ b/packages/components/src/validated-form-controls/components/select-control.tsx
@@ -19,11 +19,7 @@ const UnforwardedValidatedSelectControl = (
 		...restProps
 	}: Omit<
 		React.ComponentProps< typeof SelectControl >,
-		| '__next40pxDefaultSize'
-		| '__nextHasNoMarginBottom'
-		| 'multiple'
-		| 'onChange'
-		| 'value'
+		'__next40pxDefaultSize' | 'multiple' | 'onChange' | 'value'
 	> & {
 		value?: string;
 		onChange: ( value: string ) => void;
@@ -41,7 +37,6 @@ const UnforwardedValidatedSelectControl = (
 			getValidityTarget={ () => validityTargetRef.current }
 		>
 			<SelectControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				ref={ mergedRefs }
 				{ ...restProps }

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -169,7 +169,6 @@ function OperatorSelector( {
 					} }
 					size="small"
 					variant="minimal"
-					__nextHasNoMarginBottom
 					hideLabelFromVision
 				/>
 			</HStack>

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -85,7 +85,6 @@ export function DataViewsPagination() {
 										} );
 									} }
 									size="small"
-									__nextHasNoMarginBottom
 									variant="minimal"
 								/>
 							),

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -128,7 +128,6 @@ function SortFieldControl() {
 
 	return (
 		<SelectControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			label={ __( 'Sort by' ) }
 			value={ view.sort?.field }

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -51,7 +51,6 @@ export default function Select< Item >( {
 			options={ elements }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
 			multiple={ isMultiple }
 		/>

--- a/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
@@ -106,7 +106,6 @@ export default function RelativeDateControl< Item >( {
 				<SelectControl
 					className="dataviews-controls__relative-date-unit"
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Unit' ) }
 					value={ unit }
 					options={ options }

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -23,7 +23,6 @@ export default function PostAuthorSelect() {
 	return (
 		<SelectControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			className="post-author-selector"
 			label={ __( 'Author' ) }
 			options={ authorOptions }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -160,7 +160,6 @@ function PostTemplateDropdownContent( { onClose } ) {
 			) : (
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					hideLabelFromVision
 					label={ __( 'Template' ) }
 					value={ selectedOption?.value ?? '' }

--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -108,7 +108,6 @@ function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 				/>
 				<SelectControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Text direction' ) }
 					value={ dir }
 					options={ [

--- a/packages/global-styles-ui/src/font-library/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library/font-collection.tsx
@@ -315,7 +315,6 @@ function FontCollection( { slug }: { slug: string } ) {
 									hideLabelFromVision={ false }
 								/>
 								<SelectControl
-									__nextHasNoMarginBottom
 									__next40pxDefaultSize
 									label={ __( 'Category' ) }
 									value={ filters.category }
@@ -534,7 +533,6 @@ function FontCollection( { slug }: { slug: string } ) {
 													)
 												}
 												size="small"
-												__nextHasNoMarginBottom
 												variant="minimal"
 											/>
 										),

--- a/packages/image-cropper/src/stories/index.story.tsx
+++ b/packages/image-cropper/src/stories/index.story.tsx
@@ -199,7 +199,6 @@ const WithControlsContent = ( args: ImageCropperProps ) => {
 						options={ aspectRatioOptions }
 						onChange={ handleAspectRatioChange }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					/>
 				</VStack>
 				<HStack style={ { marginBottom: '20px' } } spacing={ 2 }>

--- a/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
@@ -28,7 +28,6 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 	return (
 		<SelectControl
 			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			label={ __( 'Legacy widget' ) }
 			value={ selectedId ?? '' }
 			options={ [


### PR DESCRIPTION
## What?

Part of #73848

Remove the deprecated `__nextHasNoMarginBottom` prop from `SelectControl`, making the margin-free styles the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0. This removes the prop, completing the deprecation cycle.

## How?

- Remove the `__nextHasNoMarginBottom` prop from `SelectControl` and its types and docs.
- Remove all usages of the prop across the codebase.

## Testing Instructions

Smoke test the affected components in Storybook and the app.


