### PR TITLE
Navigation Link: Clarify Link To invalid and draft states

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -37,7 +37,7 @@ import {
 	Controls,
 	LinkUI,
 	useEntityBinding,
-	InvalidLinkHelpText,
+	getInvalidLinkHelpText,
 	useHandleLinkChange,
 	useIsInvalidLink,
 	InvalidDraftDisplay,
@@ -366,6 +366,7 @@ export default function NavigationLinkEdit( {
 	} );
 
 	const missingText = getMissingText( type );
+	const invalidLinkHelpText = getInvalidLinkHelpText();
 
 	return (
 		<>
@@ -400,7 +401,7 @@ export default function NavigationLinkEdit( {
 			<div { ...blockProps }>
 				{ hasMissingEntity && (
 					<VisuallyHidden id={ missingEntityDescriptionId }>
-						<InvalidLinkHelpText />
+						{ invalidLinkHelpText }
 					</VisuallyHidden>
 				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -400,10 +400,7 @@ export default function NavigationLinkEdit( {
 			<div { ...blockProps }>
 				{ hasMissingEntity && (
 					<VisuallyHidden id={ missingEntityDescriptionId }>
-						<InvalidLinkHelpText
-							invalid={ isInvalid }
-							draft={ isDraft }
-						/>
+						<InvalidLinkHelpText />
 					</VisuallyHidden>
 				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -37,7 +37,7 @@ import {
 	Controls,
 	LinkUI,
 	useEntityBinding,
-	MissingEntityHelpText,
+	InvalidLinkHelpText,
 	useHandleLinkChange,
 	useIsInvalidLink,
 	InvalidDraftDisplay,
@@ -400,7 +400,10 @@ export default function NavigationLinkEdit( {
 			<div { ...blockProps }>
 				{ hasMissingEntity && (
 					<VisuallyHidden id={ missingEntityDescriptionId }>
-						<MissingEntityHelpText type={ type } kind={ kind } />
+						<InvalidLinkHelpText
+							invalid={ isInvalid }
+							draft={ isDraft }
+						/>
 					</VisuallyHidden>
 				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -90,9 +90,12 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	let helpText = '';
 
 	if ( isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ) ) {
-		helpText = InvalidLinkHelpText();
+		// Show invalid link help text for:
+		// 1. Invalid post-type links (trashed/deleted posts/pages) - via useIsInvalidLink
+		// 2. Missing bound taxonomy entities (deleted categories/tags) - useIsInvalidLink only checks post-types
+		helpText = getInvalidLinkHelpText();
 	} else if ( isDraft ) {
-		helpText = DraftHelpText( {
+		helpText = getDraftHelpText( {
 			type: attributes.type,
 			kind: attributes.kind,
 		} );
@@ -251,30 +254,30 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	);
 }
 /**
- * Returns help text for invalid or draft navigation links.
+ * Returns help text for invalid links.
  *
  * @return {string} Error help text string (empty string if valid).
  */
-export function InvalidLinkHelpText() {
+export function getInvalidLinkHelpText() {
 	return __(
 		'This link is invalid and will not appear on your site. Please update the link.'
 	);
 }
 
 /**
- * Component to display draft help text
+ * Returns the help text for links to draft entities
  *
- * @param {Object} props      - Component props
+ * @param {Object} props      - Function props
  * @param {string} props.type - The entity type
  * @param {string} props.kind - The entity kind
- * @return {JSX.Element} Draft help text component
+ * @return {string} Draft help text
  */
-function DraftHelpText( { type, kind } ) {
+function getDraftHelpText( { type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
 	return sprintf(
-		/* translators: %s is the entity type (e.g., "page", "post", "category") */
+		/* translators: %1$s is the entity type (e.g., "page", "post", "category") */
 		__(
-			'This link is to a draft %s, and will not appear on your site until it is published.'
+			'This link is to a draft %1$s and will not appear on your site until the %1$s is published.'
 		),
 		entityType
 	);

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -8,7 +8,7 @@ import {
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -22,40 +22,10 @@ import { useHandleLinkChange } from './use-handle-link-change';
 import { useEntityBinding } from './use-entity-binding';
 import { getSuggestionsQuery } from '../link-ui';
 import { useLinkPreview } from './use-link-preview';
+import { useIsInvalidLink } from './use-is-invalid-link';
 import { unlock } from '../../lock-unlock';
 
 const { LinkPicker } = unlock( blockEditorPrivateApis );
-
-/**
- * Get a human-readable entity type name.
- *
- * @param {string} type - The entity type
- * @param {string} kind - The entity kind
- * @return {string} Human-readable entity type name
- */
-function getEntityTypeName( type, kind ) {
-	if ( kind === 'post-type' ) {
-		switch ( type ) {
-			case 'post':
-				return __( 'post' );
-			case 'page':
-				return __( 'page' );
-			default:
-				return type || __( 'post' );
-		}
-	}
-	if ( kind === 'taxonomy' ) {
-		switch ( type ) {
-			case 'category':
-				return __( 'category' );
-			case 'tag':
-				return __( 'tag' );
-			default:
-				return type || __( 'term' );
-		}
-	}
-	return type || __( 'item' );
-}
 
 /**
  * Shared Controls component for Navigation Link and Navigation Submenu blocks.
@@ -79,16 +49,17 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			attributes,
 		} );
 
-	const needsHelpText = hasUrlBinding;
-	const helpText = isBoundEntityAvailable
-		? BindingHelpText( {
-				type: attributes.type,
-				kind: attributes.kind,
-		  } )
-		: MissingEntityHelpText( {
-				type: attributes.type,
-				kind: attributes.kind,
-		  } );
+	const [ isInvalid, isDraft ] = useIsInvalidLink(
+		attributes.kind,
+		attributes.type,
+		entityRecord?.id,
+		hasUrlBinding
+	);
+
+	const helpText = InvalidLinkHelpText( {
+		invalid: isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ),
+		draft: isDraft,
+	} );
 
 	// Get the link change handler with built-in binding management
 	const handleLinkChange = useHandleLinkChange( {
@@ -184,7 +155,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						attributes.kind
 					) }
 					label={ __( 'Link to' ) }
-					help={ needsHelpText ? helpText : undefined }
+					help={ helpText ? helpText : undefined }
 				/>
 			</ToolsPanelItem>
 
@@ -243,37 +214,24 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		</ToolsPanel>
 	);
 }
-
 /**
- * Component to display help text for bound URL attributes.
+ * Returns help text for invalid or draft navigation links.
  *
- * @param {Object} props      - Component props
- * @param {string} props.type - The entity type
- * @param {string} props.kind - The entity kind
- * @return {string} Help text for the bound URL
+ * @param {Object}  props         - Component props
+ * @param {boolean} props.invalid - Whether the link is invalid (deleted or trashed).
+ * @param {boolean} props.draft   - Whether the link is a draft.
+ * @return {string} Error help text string (empty string if valid).
  */
-export function BindingHelpText( { type, kind } ) {
-	const entityType = getEntityTypeName( type, kind );
-	return sprintf(
-		/* translators: %s is the entity type (e.g., "page", "post", "category") */
-		__( 'Synced with the selected %s.' ),
-		entityType
-	);
-}
+export function InvalidLinkHelpText( { invalid, draft } ) {
+	if ( invalid ) {
+		return __(
+			'This link is invalid and will not appear on your site. Please update the link.'
+		);
+	} else if ( draft ) {
+		return __(
+			'This link is to a draft page, and will not appear on your site until it is published.'
+		);
+	}
 
-/**
- * Component to display error help text for missing entity bindings.
- *
- * @param {Object} props      - Component props
- * @param {string} props.type - The entity type
- * @param {string} props.kind - The entity kind
- * @return {JSX.Element} Error help text component
- */
-export function MissingEntityHelpText( { type, kind } ) {
-	const entityType = getEntityTypeName( type, kind );
-	return sprintf(
-		/* translators: %s is the entity type (e.g., "page", "post", "category") */
-		__( 'Synced %s is missing. Please update or remove this link.' ),
-		entityType
-	);
+	return '';
 }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -261,6 +261,14 @@ export function InvalidLinkHelpText() {
 	);
 }
 
+/**
+ * Component to display draft help text
+ *
+ * @param {Object} props      - Component props
+ * @param {string} props.type - The entity type
+ * @param {string} props.kind - The entity kind
+ * @return {JSX.Element} Draft help text component
+ */
 function DraftHelpText( { type, kind } ) {
 	const entityType = getEntityTypeName( type, kind );
 	return sprintf(

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -8,7 +8,7 @@ import {
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -26,6 +26,37 @@ import { useIsInvalidLink } from './use-is-invalid-link';
 import { unlock } from '../../lock-unlock';
 
 const { LinkPicker } = unlock( blockEditorPrivateApis );
+
+/**
+ * Get a human-readable entity type name.
+ *
+ * @param {string} type - The entity type
+ * @param {string} kind - The entity kind
+ * @return {string} Human-readable entity type name
+ */
+function getEntityTypeName( type, kind ) {
+	if ( kind === 'post-type' ) {
+		switch ( type ) {
+			case 'post':
+				return __( 'post' );
+			case 'page':
+				return __( 'page' );
+			default:
+				return type || __( 'post' );
+		}
+	}
+	if ( kind === 'taxonomy' ) {
+		switch ( type ) {
+			case 'category':
+				return __( 'category' );
+			case 'tag':
+				return __( 'tag' );
+			default:
+				return type || __( 'term' );
+		}
+	}
+	return type || __( 'item' );
+}
 
 /**
  * Shared Controls component for Navigation Link and Navigation Submenu blocks.
@@ -56,11 +87,16 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		hasUrlBinding
 	);
 
-	const helpText = InvalidLinkHelpText( {
-		invalid: isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ),
-		draft: isDraft,
-	} );
+	let helpText = '';
 
+	if ( isInvalid || ( hasUrlBinding && ! isBoundEntityAvailable ) ) {
+		helpText = InvalidLinkHelpText();
+	} else if ( isDraft ) {
+		helpText = DraftHelpText( {
+			type: attributes.type,
+			kind: attributes.kind,
+		} );
+	}
 	// Get the link change handler with built-in binding management
 	const handleLinkChange = useHandleLinkChange( {
 		clientId,
@@ -217,21 +253,21 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 /**
  * Returns help text for invalid or draft navigation links.
  *
- * @param {Object}  props         - Component props
- * @param {boolean} props.invalid - Whether the link is invalid (deleted or trashed).
- * @param {boolean} props.draft   - Whether the link is a draft.
  * @return {string} Error help text string (empty string if valid).
  */
-export function InvalidLinkHelpText( { invalid, draft } ) {
-	if ( invalid ) {
-		return __(
-			'This link is invalid and will not appear on your site. Please update the link.'
-		);
-	} else if ( draft ) {
-		return __(
-			'This link is to a draft page, and will not appear on your site until it is published.'
-		);
-	}
+export function InvalidLinkHelpText() {
+	return __(
+		'This link is invalid and will not appear on your site. Please update the link.'
+	);
+}
 
-	return '';
+function DraftHelpText( { type, kind } ) {
+	const entityType = getEntityTypeName( type, kind );
+	return sprintf(
+		/* translators: %s is the entity type (e.g., "page", "post", "category") */
+		__(
+			'This link is to a draft %s, and will not appear on your site until it is published.'
+		),
+		entityType
+	);
 }

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -5,7 +5,7 @@
  * to reduce code duplication and ensure consistent behavior.
  */
 
-export { Controls, InvalidLinkHelpText } from './controls';
+export { Controls, getInvalidLinkHelpText } from './controls';
 export { updateAttributes } from './update-attributes';
 export {
 	useEntityBinding,

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -5,7 +5,7 @@
  * to reduce code duplication and ensure consistent behavior.
  */
 
-export { Controls, BindingHelpText, MissingEntityHelpText } from './controls';
+export { Controls, InvalidLinkHelpText } from './controls';
 export { updateAttributes } from './update-attributes';
 export {
 	useEntityBinding,

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -179,7 +179,7 @@ describe( 'Controls', () => {
 
 			expect(
 				screen.getByText(
-					'This link is to a draft page, and will not appear on your site until it is published.'
+					'This link is to a draft page and will not appear on your site until the page is published.'
 				)
 			).toBeInTheDocument();
 		} );
@@ -201,7 +201,7 @@ describe( 'Controls', () => {
 
 			expect(
 				screen.getByText(
-					'This link is to a draft post, and will not appear on your site until it is published.'
+					'This link is to a draft post and will not appear on your site until the post is published.'
 				)
 			).toBeInTheDocument();
 		} );

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -32,6 +32,11 @@ jest.mock( '../use-entity-binding', () => ( {
 	} ) ),
 } ) );
 
+// Mock the useIsInvalidLink hook
+jest.mock( '../use-is-invalid-link', () => ( {
+	useIsInvalidLink: jest.fn( () => [ false, false ] ),
+} ) );
+
 describe( 'Controls', () => {
 	// Initialize the mock function
 	beforeAll( () => {
@@ -54,6 +59,18 @@ describe( 'Controls', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockUpdateAttributes.mockClear();
+
+		// Reset useEntityBinding mock to default
+		const { useEntityBinding } = require( '../use-entity-binding' );
+		useEntityBinding.mockReturnValue( {
+			hasUrlBinding: false,
+			isBoundEntityAvailable: false,
+			clearBinding: jest.fn(),
+		} );
+
+		// Reset useIsInvalidLink mock to default
+		const { useIsInvalidLink } = require( '../use-is-invalid-link' );
+		useIsInvalidLink.mockReturnValue( [ false, false ] );
 	} );
 
 	it( 'renders all form controls', () => {
@@ -119,35 +136,11 @@ describe( 'Controls', () => {
 	} );
 
 	describe( 'URL binding help text', () => {
-		it( 'shows help text when URL is bound to an entity', () => {
+		it( 'shows invalid link help text when bound entity is not available', () => {
 			const { useEntityBinding } = require( '../use-entity-binding' );
 			useEntityBinding.mockReturnValue( {
 				hasUrlBinding: true,
-				isBoundEntityAvailable: true,
-				clearBinding: jest.fn(),
-			} );
-
-			const propsWithBinding = {
-				...defaultProps,
-				attributes: {
-					...defaultProps.attributes,
-					type: 'page',
-					kind: 'post-type',
-				},
-			};
-
-			render( <Controls { ...propsWithBinding } /> );
-
-			expect(
-				screen.getByText( 'Synced with the selected page.' )
-			).toBeInTheDocument();
-		} );
-
-		it( 'shows help text for different entity types', () => {
-			const { useEntityBinding } = require( '../use-entity-binding' );
-			useEntityBinding.mockReturnValue( {
-				hasUrlBinding: true,
-				isBoundEntityAvailable: true,
+				isBoundEntityAvailable: false,
 				clearBinding: jest.fn(),
 			} );
 
@@ -163,33 +156,39 @@ describe( 'Controls', () => {
 			render( <Controls { ...propsWithCategoryBinding } /> );
 
 			expect(
-				screen.getByText( 'Synced with the selected category.' )
+				screen.getByText(
+					'This link is invalid and will not appear on your site. Please update the link.'
+				)
 			).toBeInTheDocument();
 		} );
 
-		it( 'does not show help text when URL is not bound', () => {
-			const { useEntityBinding } = require( '../use-entity-binding' );
-			useEntityBinding.mockReturnValue( {
-				hasUrlBinding: false,
-				clearBinding: jest.fn(),
-			} );
+		it( 'shows draft help text for draft entities', () => {
+			const { useIsInvalidLink } = require( '../use-is-invalid-link' );
+			useIsInvalidLink.mockReturnValue( [ false, true ] ); // isInvalid: false, isDraft: true
 
-			render( <Controls { ...defaultProps } /> );
+			const propsWithDraftPage = {
+				...defaultProps,
+				attributes: {
+					...defaultProps.attributes,
+					type: 'page',
+					kind: 'post-type',
+				},
+			};
+
+			render( <Controls { ...propsWithDraftPage } /> );
 
 			expect(
-				screen.queryByText( /Synced with the selected/ )
-			).not.toBeInTheDocument();
+				screen.getByText(
+					'This link is to a draft page, and will not appear on your site until it is published.'
+				)
+			).toBeInTheDocument();
 		} );
 
-		it( 'shows help text for post entity type', () => {
-			const { useEntityBinding } = require( '../use-entity-binding' );
-			useEntityBinding.mockReturnValue( {
-				hasUrlBinding: true,
-				isBoundEntityAvailable: true,
-				clearBinding: jest.fn(),
-			} );
+		it( 'shows draft help text for different entity types', () => {
+			const { useIsInvalidLink } = require( '../use-is-invalid-link' );
+			useIsInvalidLink.mockReturnValue( [ false, true ] );
 
-			const propsWithPostBinding = {
+			const propsWithDraftPost = {
 				...defaultProps,
 				attributes: {
 					...defaultProps.attributes,
@@ -198,35 +197,30 @@ describe( 'Controls', () => {
 				},
 			};
 
-			render( <Controls { ...propsWithPostBinding } /> );
+			render( <Controls { ...propsWithDraftPost } /> );
 
 			expect(
-				screen.getByText( 'Synced with the selected post.' )
+				screen.getByText(
+					'This link is to a draft post, and will not appear on your site until it is published.'
+				)
 			).toBeInTheDocument();
 		} );
 
-		it( 'shows help text for tag entity type', () => {
-			const { useEntityBinding } = require( '../use-entity-binding' );
-			useEntityBinding.mockReturnValue( {
-				hasUrlBinding: true,
-				isBoundEntityAvailable: true,
-				clearBinding: jest.fn(),
-			} );
-
-			const propsWithTagBinding = {
+		it( 'does not show help text for valid link', () => {
+			const propsWithValidLink = {
 				...defaultProps,
 				attributes: {
 					...defaultProps.attributes,
-					type: 'tag',
-					kind: 'taxonomy',
+					url: 'https://example.com',
+					type: 'page',
+					kind: 'post-type',
 				},
 			};
 
-			render( <Controls { ...propsWithTagBinding } /> );
+			render( <Controls { ...propsWithValidLink } /> );
 
-			expect(
-				screen.getByText( 'Synced with the selected tag.' )
-			).toBeInTheDocument();
+			// When link is valid (not invalid, not draft, no binding issues), no help text should be shown
+			expect( screen.queryByText( /This link/ ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
+++ b/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
@@ -6,16 +6,25 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useBlockEditingMode } from '@wordpress/block-editor';
 
 /**
- * A React hook to determine if a navigation link or submenu's parent link is invalid.
+ * Custom hook to check if a navigation link points to an invalid or deleted entity.
  *
- * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
- * @param {string}  type    The type of post (post, page, etc).
- * @param {number}  id      The post or term id.
- * @param {boolean} enabled Whether to enable the validation check.
+ * Checks if a post-type link is:
+ * - Deleted (entity no longer exists)
+ * - Trashed (post status is 'trash')
+ * - Draft (post status is 'draft')
  *
- * @return {Array} Array containing [isInvalid, isDraft] booleans.
+ * This check is skipped when:
+ * - The block editing mode is 'disabled' (e.g., in templates)
+ * - The `enabled` parameter is false
+ * - The link is not a post-type link
+ *
+ * @param {string}  kind    The kind of entity (e.g., 'post-type', 'taxonomy').
+ * @param {string}  type    The entity type (e.g., 'post', 'page').
+ * @param {number}  id      The entity ID.
+ * @param {boolean} enabled Whether to perform the validation check.
+ * @return {Array} A tuple of [isInvalid, isDraft] booleans.
  */
-export const useIsInvalidLink = ( kind, type, id, enabled ) => {
+export function useIsInvalidLink( kind, type, id, enabled ) {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
 	const hasId = Number.isInteger( id );
@@ -69,4 +78,4 @@ export const useIsInvalidLink = ( kind, type, id, enabled ) => {
 	const isDraft = 'draft' === postStatus;
 
 	return [ isInvalid, isDraft ];
-};
+}

--- a/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
+++ b/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
@@ -6,25 +6,16 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useBlockEditingMode } from '@wordpress/block-editor';
 
 /**
- * Custom hook to check if a navigation link points to an invalid or deleted entity.
+ * A React hook to determine if a navigation link or submenu's parent link is invalid.
  *
- * Checks if a post-type link is:
- * - Deleted (entity no longer exists)
- * - Trashed (post status is 'trash')
- * - Draft (post status is 'draft')
+ * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
+ * @param {string}  type    The type of post (post, page, etc).
+ * @param {number}  id      The post or term id.
+ * @param {boolean} enabled Whether to enable the validation check.
  *
- * This check is skipped when:
- * - The block editing mode is 'disabled' (e.g., in templates)
- * - The `enabled` parameter is false
- * - The link is not a post-type link
- *
- * @param {string}  kind    The kind of entity (e.g., 'post-type', 'taxonomy').
- * @param {string}  type    The entity type (e.g., 'post', 'page').
- * @param {number}  id      The entity ID.
- * @param {boolean} enabled Whether to perform the validation check.
- * @return {Array} A tuple of [isInvalid, isDraft] booleans.
+ * @return {Array} Array containing [isInvalid, isDraft] booleans.
  */
-export function useIsInvalidLink( kind, type, id, enabled ) {
+export const useIsInvalidLink = ( kind, type, id, enabled ) => {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
 	const hasId = Number.isInteger( id );
@@ -78,4 +69,4 @@ export function useIsInvalidLink( kind, type, id, enabled ) {
 	const isDraft = 'draft' === postStatus;
 
 	return [ isInvalid, isDraft ];
-}
+};

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { safeDecodeURI } from '@wordpress/url';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -93,10 +93,17 @@ function computeBadges( {
 	}
 
 	// Status badge
-	if ( ! url ) {
+	if ( hasBinding && ! isEntityAvailable ) {
+		badges.push( {
+			label: sprintf(
+				/* translators: %s is the entity type (e.g., "page", "post", "category") */
+				__( 'Missing %s' ),
+				type
+			),
+			intent: 'error',
+		} );
+	} else if ( ! url ) {
 		badges.push( { label: __( 'No link selected' ), intent: 'error' } );
-	} else if ( hasBinding && ! isEntityAvailable ) {
-		badges.push( { label: __( 'Deleted' ), intent: 'error' } );
 	} else if ( entityStatus ) {
 		const statusMap = {
 			publish: { label: __( 'Published' ), intent: 'success' },

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1202,13 +1202,6 @@ test.describe( 'Navigation block', () => {
 				await expect( linkButton ).toContainText(
 					url.pathname.replace( /\/$/, '' )
 				);
-
-				// Verify help text
-				await expect(
-					settingsControls.getByText(
-						'Synced with the selected page.'
-					)
-				).toBeVisible();
 			} );
 
 			await test.step( 'Verify bound link works correctly on frontend', async () => {
@@ -1633,14 +1626,14 @@ test.describe( 'Navigation block', () => {
 
 				// With LinkControlInspector, unavailable entities show a button with error badge
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /No link selected/i,
+					name: /Missing page/i,
 				} );
 
 				// Button is enabled (can click to fix the link)
 				await expect( linkButton ).toBeEnabled();
 
-				// Button should show "No link selected" for unavailable entity
-				await expect( linkButton ).toContainText( 'No link selected' );
+				// Button should show "Missing page" for unavailable entity
+				await expect( linkButton ).toContainText( 'Missing page' );
 			} );
 
 			await test.step( 'Verify clicking button with error opens link control for fixing', async () => {
@@ -1649,7 +1642,7 @@ test.describe( 'Navigation block', () => {
 					.getByRole( 'tabpanel', { name: 'Settings' } );
 
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /No link selected/i,
+					name: /Missing page/i,
 				} );
 
 				// Click the button to open the link control and fix the link


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/72622

<!-- In a few words, what is the PR actually doing? -->
  Improves the user experience for navigation links by clarifying error states and fixing a bug that prevented the missing entity badge from displaying.                  


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Navigation links pointing to invalid or draft entities were showing unclear or missing error messages, making it difficult for users to understand why certain links wouldn't appear on their site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Invalid Entity: `This link is invalid and will not appear on your site. Please update the link.`
- Draft Entity: `This link is to a draft %s, and will not appear on your site until it is published.`
- Fixes condition where missing entity badge would never show

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a navigation menu to include:
  - A valid link
  - a draft page
    - no url: `<!-- wp:navigation-link {"label":"Empty Link"} /-->`
  - a missing entity: `<!-- wp:navigation-link {"label":"Missing Entity Page","type":"page","id":234234232,"url":"http://localhost:8888/?page_id=2","kind":"post-type","metadata":{"bindings":{"url":{"source":"core/post-data","args":{"field":"link"}}}}} /-->`
- Select each navigation link block and make sure the help text is sensible and the badges on the Link Preview are helpful

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

  **Before (Old Help Text)**                                                                                                                                                  
                                                                                                                                                                          
  For binding-related states: "Synced with the selected %s."                                                                                                                                        
                                                                                                                                                                          
  For missing entities: "Synced %s is missing. Please update or remove this link."                                                                                                            
                                                                                                                                                                          
  **After (New Help Text)**                                                                                                                                                   
                                                                                                                                                                          
  For invalid links:  "This link is invalid and will not appear on your site. Please update the link."                                                                                      
                                                                                                                                                                          
  For draft pages/posts: "This link is to a draft %s, and will not appear on your site until it is published."     
