### PR TITLE
Paragraph block: add RTL support for drop caps in paragraph block styles in the editor

### DIFF
--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -29,3 +29,11 @@
 		opacity: 0;
 	}
 }
+
+// This is the equivalent of the `body.rtl` style.scss rule for RTL,
+// but it's applied to the html element instead of the body element
+// since the `body.rtl` style is not applied to the iframe in the editor.
+html[dir="rtl"] .has-drop-cap:not(:focus)::first-letter {
+	float: initial;
+	margin-left: 0.1em;
+}


### PR DESCRIPTION


## What? How?

Noticed while testing https://github.com/WordPress/gutenberg/pull/73114#pullrequestreview-3585551700

Adds RTL-specific styling for paragraph drop caps in the editor canvas. The frontend uses `body.rtl` for RTL drop caps, but the editor iframe body doesn't receive the `rtl` class. This change uses `html[dir="rtl"]` to target RTL in the editor iframe, matching the frontend behavior.

## Why?

To make the editor styles match the frontend.

## Testing Instructions

1. Set site language to an RTL language (e.g., Arabic, Hebrew)
2. Create/edit a post in the block editor, add a Paragraph block and wnable "Drop cap" in block settings
3. Verify drop cap styling matches between editor and frontend
4. Verify drop caps still work correctly in LTR mode


## Screenshots or screencast <!-- if applicable -->

The frontend looks like this:

<img width="1446" height="712" alt="Screenshot 2025-12-17 at 12 46 41 pm" src="https://github.com/user-attachments/assets/d8fbac82-2dbf-43c4-91ed-65d6b5ab1a60" />

This PR relates to the editor:


|Before|After|
|-|-|
|<img width="1432" height="529" alt="Screenshot 2025-12-17 at 12 46 34 pm" src="https://github.com/user-attachments/assets/6c0a202c-3d2b-45e4-9578-485770f16e93" />
|<img width="1446" height="678" alt="Screenshot 2025-12-17 at 1 06 20 pm" src="https://github.com/user-attachments/assets/c98bad08-6867-4bed-a691-b2d60a84d98a" />|




