### PR TITLE
Global Styles: Remove orphaned get_svg_filters() method

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3467,40 +3467,6 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Converts all filter (duotone) presets into SVGs.
-	 *
-	 * @since 5.9.1
-	 *
-	 * @param array $origins List of origins to process.
-	 * @return string SVG filters.
-	 */
-	public function get_svg_filters( $origins ) {
-		$blocks_metadata = static::get_blocks_metadata();
-		$setting_nodes   = static::get_setting_nodes( $this->theme_json, $blocks_metadata );
-
-		$filters = '';
-		foreach ( $setting_nodes as $metadata ) {
-			$node = _wp_array_get( $this->theme_json, $metadata['path'], array() );
-			if ( empty( $node['color']['duotone'] ) ) {
-				continue;
-			}
-
-			$duotone_presets = $node['color']['duotone'];
-
-			foreach ( $origins as $origin ) {
-				if ( ! isset( $duotone_presets[ $origin ] ) ) {
-					continue;
-				}
-				foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
-					$filters .= wp_get_duotone_filter_svg( $duotone_preset );
-				}
-			}
-		}
-
-		return $filters;
-	}
-
-	/**
 	 * Determines whether a presets should be overridden or not.
 	 *
 	 * @since 5.9.0


### PR DESCRIPTION
## Summary
Removes the unused `get_svg_filters()` method from `WP_Theme_JSON_Gutenberg` that was left behind after PR #49103 moved duotone functionality to `WP_Duotone_Gutenberg`.

## What Changed
- Removed the orphaned `get_svg_filters()` method (34 lines) from `lib/class-wp-theme-json-gutenberg.php`

## Why
After PR #49103 consolidated duotone generation logic in `WP_Duotone_Gutenberg`, this method became orphaned:
- ❌ No callers exist in the codebase
- ❌ Calls a non-existent function (`wp_get_duotone_filter_svg`)
- ✅ Functionality fully replaced by `WP_Duotone_Gutenberg::get_svg_definitions()`

## Testing
- Verified no callers exist for this method
- Verified PHP syntax is valid after removal
- No tests reference this method

Closes #49213

🤖 Generated with [Claude Code](https://claude.com/claude-code)