### PR TITLE
Fix bindableAttributes only being returned for the selected block

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -137,12 +137,8 @@ export function RichTextWrapper(
 			return { isSelected: false };
 		}
 
-		const {
-			getSelectionStart,
-			getSelectionEnd,
-			getBlockEditingMode,
-			getSettings,
-		} = select( blockEditorStore );
+		const { getSelectionStart, getSelectionEnd, getBlockEditingMode } =
+			select( blockEditorStore );
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
 
@@ -159,36 +155,35 @@ export function RichTextWrapper(
 			isSelected = selectionStart.clientId === clientId;
 		}
 
-		const { __experimentalBlockBindingsSupportedAttributes } =
-			getSettings();
-
 		return {
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
 			isContentOnly: getBlockEditingMode( clientId ) === 'contentOnly',
-			bindableAttributes:
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ],
 		};
 	};
-	const {
-		selectionStart,
-		selectionEnd,
-		isSelected,
-		isContentOnly,
-		bindableAttributes,
-	} = useSelect( selector, [
-		clientId,
-		blockName,
-		identifier,
-		instanceId,
-		originalIsSelected,
-		isBlockSelected,
-	] );
+	const { selectionStart, selectionEnd, isSelected, isContentOnly } =
+		useSelect( selector, [
+			clientId,
+			identifier,
+			instanceId,
+			originalIsSelected,
+			isBlockSelected,
+		] );
 
 	const { disableBoundBlock, bindingsPlaceholder, bindingsLabel } = useSelect(
 		( select ) => {
-			if ( ! blockBindings?.[ identifier ] || ! bindableAttributes ) {
+			if ( ! blockBindings?.[ identifier ] ) {
+				return {};
+			}
+
+			const { __experimentalBlockBindingsSupportedAttributes } =
+				select( blockEditorStore ).getSettings();
+
+			const bindableAttributes =
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
+
+			if ( ! bindableAttributes ) {
 				return {};
 			}
 
@@ -261,7 +256,7 @@ export function RichTextWrapper(
 		[
 			blockBindings,
 			identifier,
-			bindableAttributes,
+			blockName,
 			adjustedValue,
 			clientId,
 			blockContext,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a logic error mentioned here - https://github.com/WordPress/gutenberg/pull/74029#discussion_r2625721931.

After that code change `bindableAttributes` would have only been return for the selected block due to the early return in the `useSelect` body.

## Why?
It looks like `bindingPlaceholder` and `bindingLabel` need the `bindableAttributes` for unselected blocks.

## How?
Moves it to a different useSelect. The concern is that it may regress previous performance improvements mentioned here:
https://github.com/WordPress/gutenberg/pull/74029#issuecomment-3661653780

Lets find out.

## Testing Instructions
I'm not sure how to test this, logically it should fix the issue.