### PR TITLE
Fix : Image caption blur in Gallery block

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -58,20 +58,6 @@ figure.wp-block-gallery.has-nested-images {
 			max-height: 100%;
 		}
 
-		// Create a background blur layer.
-		&:has(figcaption)::before {
-			content: "";
-			height: 100%;
-			max-height: 40%;
-			pointer-events: none;
-
-			// Blur the background under the gradient scrim.
-			backdrop-filter: blur(3px);
-
-			// Crop the caption so the blur is only on the edge.
-			mask-image: linear-gradient(0deg, $black 20%, transparent 100%);
-		}
-
 		// Place the caption at the bottom.
 		figcaption {
 			color: $white;
@@ -86,6 +72,9 @@ figure.wp-block-gallery.has-nested-images {
 
 			// Dark gradient scrim.
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
+
+			// Blur the background of the caption.
+			backdrop-filter: blur(3px);
 
 			img {
 				display: inline;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -58,6 +58,20 @@ figure.wp-block-gallery.has-nested-images {
 			max-height: 100%;
 		}
 
+		// Create a background blur layer.
+		&:has(figcaption)::before {
+			content: "";
+			height: 100%;
+			max-height: 3em;
+			pointer-events: none;
+
+			// Blur the background under the gradient scrim.
+			backdrop-filter: blur(3px);
+
+			// Crop the caption so the blur is only on the edge.
+			mask-image: linear-gradient(0deg, $black 20%, transparent 100%);
+		}
+
 		// Place the caption at the bottom.
 		figcaption {
 			color: $white;
@@ -72,9 +86,6 @@ figure.wp-block-gallery.has-nested-images {
 
 			// Dark gradient scrim.
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
-
-			// Blur the background of the caption.
-			backdrop-filter: blur(3px);
 
 			img {
 				display: inline;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
- https://github.com/WordPress/gutenberg/issues/74056
- When image caption is added, a pseudo element is added which blur large portions of the image.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Limits the blur to the image caption (figcaption) area.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Remove the pseudo style for figcaption
- Add `backdrop-filter: blur(3px);` directly to all figcaptions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a new post and add the gallery block.
- Select a single long vertical image.
- Add an image caption.
- Blur should be limited to the image caption.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="607" height="332" alt="Screenshot 2025-12-17 at 2 26 13 PM" src="https://github.com/user-attachments/assets/d0bef4da-0290-4ad7-bc90-07fa52d06f4f" />| <img width="695" height="105" alt="Screenshot 2025-12-17 at 2 25 06 PM" src="https://github.com/user-attachments/assets/30a88853-9cf9-4948-9ac5-41df681c3d6a" /> |
