### PR TITLE
Build: Avoid using the source maps file to compute the version hash

### DIFF
--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -362,11 +362,6 @@ export function createWordpressExternalsPlugin(
 						const filesToHash = [];
 						if ( outputFilePath ) {
 							filesToHash.push( outputFilePath );
-
-							// Include source map if enabled
-							if ( build.initialOptions.sourcemap ) {
-								filesToHash.push( `${ outputFilePath }.map` );
-							}
 						}
 
 						// Generate content-based version hash


### PR DESCRIPTION
This allows the hashes to be deterministic between operating systems as source maps contain potentially OS specific paths.