### PR TITLE
Template Activation: Make template edit test less flaky again

### DIFF
--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -86,13 +86,16 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		const editorTopBar = page.getByRole( 'region', {
-			name: 'Editor top bar',
-		} );
-		const saveButton = editorTopBar.getByRole( 'button', {
-			name: 'Save',
-			exact: true,
-		} );
+		// Find the correct save button to click.
+		const publishSaveButton = page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const topBarSaveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const saveButton = ( await publishSaveButton.isVisible() )
+			? publishSaveButton
+			: topBarSaveButton;
 		await saveButton.click();
 
 		await page

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -93,10 +93,7 @@ test.describe( 'Template ID Format', () => {
 		const topBarSaveButton = page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Save', exact: true } );
-		const saveButton = ( await publishSaveButton.isVisible() )
-			? publishSaveButton
-			: topBarSaveButton;
-		await saveButton.click();
+		await publishSaveButton.or( topBarSaveButton ).click();
 
 		await page
 			.getByRole( 'button', { name: 'Dismiss this notice' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73752
Follow-up to https://github.com/WordPress/gutenberg/pull/73975

<!-- In a few words, what is the PR actually doing? -->

## Why? / How?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Attempts to fix this test to make it less flaky again, this time by checking for the save button in both the Editor top bar and the publish area.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

All tests should pass first time.
