### PR TITLE
Comment Author Name: Migrate to text-align block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -179,8 +179,8 @@ Displays the name of the author of the comment. ([Source](https://github.com/Wor
 -	**Name:** core/comment-author-name
 -	**Category:** theme
 -	**Ancestor:** core/comment-template
--	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, linkTarget, textAlign
+-	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** isLink, linkTarget
 
 ## Comment Content
 

--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -15,9 +15,6 @@
 		"linkTarget": {
 			"type": "string",
 			"default": "_self"
-		},
-		"textAlign": {
-			"type": "string"
 		}
 	},
 	"usesContext": [ "commentId" ],
@@ -39,6 +36,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/comment-author-name/deprecated.js
+++ b/packages/block-library/src/comment-author-name/deprecated.js
@@ -2,6 +2,66 @@
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v2 = {
+	attributes: {
+		isLink: {
+			type: 'boolean',
+			default: true,
+		},
+		linkTarget: {
+			type: 'string',
+			default: '_self',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+	usesContext: [ 'commentId' ],
+	supports: {
+		html: false,
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		color: {
+			gradients: true,
+			link: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
 
 const v1 = {
 	attributes: {
@@ -47,4 +107,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/comment-author-name/edit.js
+++ b/packages/block-library/src/comment-author-name/edit.js
@@ -1,19 +1,9 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	ToggleControl,
@@ -25,6 +15,7 @@ import {
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 /**
  * Renders the `core/comment-author-name` block on the editor.
@@ -34,23 +25,20 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  * @param {Object} props.attributes            Block attributes.
  * @param {string} props.attributes.isLink     Whether the author name should be linked.
  * @param {string} props.attributes.linkTarget Target of the link.
- * @param {string} props.attributes.textAlign  Text alignment.
  * @param {Object} props.context               Inherited context.
  * @param {string} props.context.commentId     The comment ID.
  *
  * @return {JSX.Element} React element.
  */
-export default function Edit( {
-	attributes: { isLink, linkTarget, textAlign },
-	context: { commentId },
-	setAttributes,
-} ) {
+export default function Edit( props ) {
+	const {
+		attributes: { isLink, linkTarget },
+		context: { commentId },
+		setAttributes,
+	} = props;
+	useDeprecatedTextAlign( props );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 	let displayName = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
@@ -65,17 +53,6 @@ export default function Edit( {
 			return authorName ?? '';
 		},
 		[ commentId ]
-	);
-
-	const blockControls = (
-		<BlockControls group="block">
-			<AlignmentControl
-				value={ textAlign }
-				onChange={ ( newAlign ) =>
-					setAttributes( { textAlign: newAlign } )
-				}
-			/>
-		</BlockControls>
 	);
 
 	const inspectorControls = (
@@ -149,7 +126,6 @@ export default function Edit( {
 	return (
 		<>
 			{ inspectorControls }
-			{ blockControls }
 			<div { ...blockProps }>{ displayAuthor }</div>
 		</>
 	);

--- a/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.html
+++ b/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-author-name {"textAlign":"left"} /-->
+
+<!-- wp:comment-author-name {"textAlign":"center"} /-->
+
+<!-- wp:comment-author-name {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.json
@@ -1,0 +1,44 @@
+[
+	{
+		"name": "core/comment-author-name",
+		"isValid": true,
+		"attributes": {
+			"isLink": true,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-author-name",
+		"isValid": true,
+		"attributes": {
+			"isLink": true,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-author-name",
+		"isValid": true,
+		"attributes": {
+			"isLink": true,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.parsed.json
+++ b/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/comment-author-name",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-author-name",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-author-name",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__comment-author-name__deprecated-v2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-author-name {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:comment-author-name {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:comment-author-name {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the Comment Author Name block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the Comment Author Name block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Comment Author Name block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized Comment Author Name block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new Comment Author Name block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing Comment Author Name blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

