### PR TITLE
Add paragraph option to Accordion heading level

### DIFF
--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -18,7 +18,8 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		'core/accordion-show-icon': showIcon,
 		'core/accordion-heading-level': headingLevel,
 	} = context;
-	const TagName = 'h' + headingLevel;
+	const TagName = headingLevel === 0 ? 'p' : 'h' + headingLevel;
+
 
 	// Set icon attributes.
 	useEffect( () => {

--- a/packages/block-library/src/accordion-heading/save.js
+++ b/packages/block-library/src/accordion-heading/save.js
@@ -10,7 +10,7 @@ import {
 
 export default function save( { attributes } ) {
 	const { level, title, iconPosition, showIcon } = attributes;
-	const TagName = 'h' + ( level || 3 );
+	const TagName = level === 0 ? 'p' : 'h' + ( level || 3 );
 	const typographyProps = getTypographyClassesAndStyles( attributes );
 
 	const blockProps = useBlockProps.save();

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -75,7 +75,8 @@
 			"default": 3
 		},
 		"levelOptions": {
-			"type": "array"
+			"type": "array",
+			"default": [ 0, 1, 2, 3, 4, 5, 6 ]
 		}
 	},
 	"providesContext": {


### PR DESCRIPTION
## What?
Adds support for a Paragraph (`<p>`) option to the Accordion heading level selector.

Closes #74039

## Why?
Accordion headings are currently limited to H1–H6, which causes them to be included in Table of Contents plugins by default. This is not always desired, especially when accordion titles are meant to be purely presentational. Adding a paragraph option allows users to exclude accordion items from TOCs when needed.

## How?
- Added `0` (Paragraph) to the Accordion `levelOptions`
- Updated Accordion Heading edit logic to render `<p>` when the level is `0`
- Updated save logic to ensure frontend output matches editor behavior
- Preserved existing defaults for backward compatibility

## Testing Instructions
1. Open a post or page in the block editor
2. Insert an Accordion block
3. Select the Accordion and change the heading level to **Paragraph**
4. Confirm the accordion title renders as `<p>` instead of a heading
5. Verify that H1–H6 options continue to work as before

### Testing Instructions for Keyboard
1. Insert an Accordion block using the keyboard
2. Open block settings using keyboard navigation
3. Change the heading level using keyboard controls
4. Confirm focus, selection, and behavior remain unchanged