### PR TITLE
Table block: Improve 'onChange' callback memoization

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -173,9 +173,9 @@ function TableEdit( {
 				return;
 			}
 
-			setAttributes(
+			setAttributes( ( currentAttributes ) =>
 				updateSelectedCell(
-					attributes,
+					currentAttributes,
 					selectedCell,
 					( cellAttributes ) => ( {
 						...cellAttributes,
@@ -184,7 +184,7 @@ function TableEdit( {
 				)
 			);
 		},
-		[ attributes, selectedCell, setAttributes ]
+		[ selectedCell, setAttributes ]
 	);
 
 	/**


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/74029#discussion_r2625614714.

A micro-optimization, ensure `onChange` callback reference remains the same even when attributes change. PR changes to use a new attribute setter callback (https://github.com/WordPress/gutenberg/pull/69709), which makes attribute object merging easier.

## Testing Instructions
1. Open a post or page.
2. Confirm the Table block works as before.
