### PR TITLE
Build: Support custom url

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -1415,6 +1415,8 @@ async function buildAllRoutes() {
 
 /**
  * Main build function.
+ *
+ * @param {string?} baseUrlExpression
  */
 async function buildAll( baseUrlExpression ) {
 	console.log( '🔨 Building packages...\n' );
@@ -1571,7 +1573,10 @@ async function buildAll( baseUrlExpression ) {
 	}
 
 	console.log( '\n📄 Generating PHP registration files...\n' );
-	const phpReplacements = await getPhpReplacements( ROOT_DIR, baseUrlExpression );
+	const phpReplacements = await getPhpReplacements(
+		ROOT_DIR,
+		baseUrlExpression
+	);
 	await Promise.all( [
 		generateMainIndexPhp( phpReplacements ),
 		generateModuleRegistrationPhp( modules, phpReplacements ),

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -941,12 +941,6 @@ async function generatePagesPhp( pageData, replacements ) {
 				templateReplacements
 			),
 		] );
-
-		// Generate empty loader.js (dummy module for dependencies)
-		await writeFile(
-			path.join( BUILD_DIR, 'pages', page.slug, 'loader.js' ),
-			'// Empty module loader for page dependencies\n'
-		);
 	} );
 
 	await Promise.all( pageGenerationPromises );
@@ -1422,7 +1416,7 @@ async function buildAllRoutes() {
 /**
  * Main build function.
  */
-async function buildAll() {
+async function buildAll( baseUrlExpression ) {
 	console.log( '🔨 Building packages...\n' );
 
 	const startTime = Date.now();
@@ -1577,7 +1571,7 @@ async function buildAll() {
 	}
 
 	console.log( '\n📄 Generating PHP registration files...\n' );
-	const phpReplacements = await getPhpReplacements( ROOT_DIR );
+	const phpReplacements = await getPhpReplacements( ROOT_DIR, baseUrlExpression );
 	await Promise.all( [
 		generateMainIndexPhp( phpReplacements ),
 		generateModuleRegistrationPhp( modules, phpReplacements ),
@@ -1871,10 +1865,16 @@ async function main() {
 				short: 'w',
 				default: false,
 			},
+			'base-url': {
+				type: 'string',
+				default: "plugins_url( 'build', dirname( __FILE__ ) )",
+			},
 		},
 	} );
 
-	await buildAll();
+	const baseUrlExpression = values[ 'base-url' ];
+
+	await buildAll( baseUrlExpression );
 
 	if ( values.watch ) {
 		console.log( '\n👀 Watching for changes...\n' );

--- a/packages/wp-build/src/php-generator.mjs
+++ b/packages/wp-build/src/php-generator.mjs
@@ -15,10 +15,14 @@ const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 /**
  * Get PHP replacements from root package.json.
  *
- * @param {string} rootDir Root directory path.
- * @return {Promise<Record<string, string>>} Replacements object with {{PREFIX}}, {{VERSION}}, {{VERSION_CONSTANT}}.
+ * @param {string} rootDir           Root directory path.
+ * @param {string} baseUrlExpression PHP expression for base URL (e.g. "includes_url( 'build' )").
+ * @return {Promise<Record<string, string>>} Replacements object with {{PREFIX}}, {{VERSION}}, {{VERSION_CONSTANT}}, {{BASE_URL}}.
  */
-export async function getPhpReplacements( rootDir ) {
+export async function getPhpReplacements(
+	rootDir,
+	baseUrlExpression = "plugins_url( 'build', dirname( __FILE__ ) )"
+) {
 	const rootPackageJson = getPackageInfoFromFile(
 		path.join( rootDir, 'package.json' )
 	);
@@ -36,6 +40,7 @@ export async function getPhpReplacements( rootDir ) {
 		'{{PREFIX}}': name,
 		'{{VERSION}}': version,
 		'{{VERSION_CONSTANT}}': versionConstant,
+		'{{BASE_URL}}': baseUrlExpression,
 	};
 }
 

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -19,7 +19,7 @@ if ( ! function_exists( '{{PREFIX}}_register_script_modules' ) ) {
 		}
 
 		$modules = require $modules_file;
-		$base_url = plugins_url( 'build/modules/', dirname( __FILE__ ) );
+		$base_url = {{BASE_URL}} . '/modules/';
 		$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
 		foreach ( $modules as $module ) {

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -143,7 +143,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' ) ) 
 		$routes = get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes();
 
 		// Get boot module asset file for dependencies
-		$asset_file = plugin_dir_path( __FILE__ ) . '../../modules/boot/index.min.asset.php';
+		$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
 		if ( file_exists( $asset_file ) ) {
 			$asset = require $asset_file;
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -198,7 +198,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' ) ) 
 			// Dummy script module to ensure dependencies are loaded
 			wp_register_script_module(
 				'{{PAGE_SLUG}}-wp-admin',
-				plugin_dir_url( __FILE__ ) . 'loader.js',
+				'data:text/javascript,',
 				$boot_dependencies
 			);
 

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -152,7 +152,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 		$routes = get_{{PAGE_SLUG_UNDERSCORE}}_routes();
 
 		// Get boot module asset file for dependencies
-		$asset_file = plugin_dir_path( __FILE__ ) . '../../modules/boot/index.min.asset.php';
+		$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
 		if ( file_exists( $asset_file ) ) {
 			$asset = require $asset_file;
 

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -213,7 +213,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 			// Dummy script module to ensure dependencies are loaded
 			wp_register_script_module(
 				'{{PAGE_SLUG}}',
-				plugin_dir_url( __FILE__ ) . 'loader.js',
+				'data:text/javascript,',
 				$boot_dependencies
 			);
 

--- a/packages/wp-build/templates/routes-registration.php.template
+++ b/packages/wp-build/templates/routes-registration.php.template
@@ -41,7 +41,7 @@ $register_routes_callback = function ( $page_routes, $page_slug_underscore, $reg
 					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 					wp_register_script_module(
 						$content_handle,
-						plugins_url( 'build/routes/' . $route['name'] . '/content' . $extension, dirname( __FILE__ ) ),
+						{{BASE_URL}} . '/routes/' . $route['name'] . '/content' . $extension,
 						$content_asset['module_dependencies'] ?? array(),
 						$content_asset['version'] ?? false
 					);
@@ -57,7 +57,7 @@ $register_routes_callback = function ( $page_routes, $page_slug_underscore, $reg
 					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 					wp_register_script_module(
 						$route_handle,
-						plugins_url( 'build/routes/' . $route['name'] . '/route' . $extension, dirname( __FILE__ ) ),
+						{{BASE_URL}} . '/routes/' . $route['name'] . '/route' . $extension,
 						$route_asset['module_dependencies'] ?? array(),
 						$route_asset['version'] ?? false
 					);

--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -75,7 +75,7 @@ if ( ! function_exists( '{{PREFIX}}_register_package_scripts' ) ) {
 			{{PREFIX}}_override_script(
 				$scripts,
 				$script_data['handle'],
-				plugins_url( 'build/scripts/' . $script_data['path'] . $extension, $plugin_dir ),
+				{{BASE_URL}} . '/scripts/' . $script_data['path'] . $extension,
 				$dependencies,
 				$version,
 				true

--- a/packages/wp-build/templates/style-registration.php.template
+++ b/packages/wp-build/templates/style-registration.php.template
@@ -59,7 +59,7 @@ if ( ! function_exists( '{{PREFIX}}_register_package_styles' ) ) {
 			{{PREFIX}}_override_style(
 				$styles,
 				$style_data['handle'],
-				plugins_url( 'build/styles/' . $style_data['path'] . '.css', $plugin_dir ),
+				{{BASE_URL}} . '/styles/' . $style_data['path'] . '.css',
 				$style_data['dependencies'],
 				$default_version
 			);


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/10638

## What?

We're changing how we backport Gutenberg into Core to simplify things (see linked PR).
The current PR adapts wp-build to allow generating urls for pages when the build folder is included within WP Core.
It also removes the empty loader files and replace them with just inline empty registration.

There should be no impact on Gutenberg or third-party plugins as by default the build tool still assumes it's outputting a "build" folder within a plugin.