### PR TITLE
Build: Allow passing down arguments to wp-build

### DIFF
--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -123,7 +123,7 @@ async function build() {
 
 		// Step 7: Build packages
 		console.log( '\n📦 Building packages (production mode)...' );
-		await exec( 'wp-build', [], {
+		await exec( 'wp-build', process.argv.slice( 2 ), {
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );
 

--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -27,7 +27,6 @@ function exec( command, args = [], options = {} ) {
 		const childOptions = {
 			cwd: ROOT_DIR,
 			stdio: silent ? 'pipe' : 'inherit',
-			shell: true,
 			...spawnOptions,
 		};
 
@@ -125,7 +124,6 @@ async function build() {
 		console.log( '\n📦 Building packages (production mode)...' );
 		const buildArgs = process.argv.slice( 2 );
 		await exec( 'wp-build', buildArgs, {
-			shell: false,
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );
 

--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -123,7 +123,9 @@ async function build() {
 
 		// Step 7: Build packages
 		console.log( '\n📦 Building packages (production mode)...' );
-		await exec( 'wp-build', process.argv.slice( 2 ), {
+		const buildArgs = process.argv.slice( 2 );
+		await exec( 'wp-build', buildArgs, {
+			shell: false,
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );
 

--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -941,6 +941,12 @@ async function generatePagesPhp( pageData, replacements ) {
 				templateReplacements
 			),
 		] );
+
+		// Generate empty loader.js (dummy module for dependencies)
+		await writeFile(
+			path.join( BUILD_DIR, 'pages', page.slug, 'loader.js' ),
+			'// Empty module loader for page dependencies\n'
+		);
 	} );
 
 	await Promise.all( pageGenerationPromises );

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -198,7 +198,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' ) ) 
 			// Dummy script module to ensure dependencies are loaded
 			wp_register_script_module(
 				'{{PAGE_SLUG}}-wp-admin',
-				'data:text/javascript,',
+				{{BASE_URL}} . '/pages/{{PAGE_SLUG}}/loader.js',
 				$boot_dependencies
 			);
 

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -213,7 +213,7 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 			// Dummy script module to ensure dependencies are loaded
 			wp_register_script_module(
 				'{{PAGE_SLUG}}',
-				'data:text/javascript,',
+				{{BASE_URL}} . '/pages/{{PAGE_SLUG}}/loader.js',
 				$boot_dependencies
 			);
 


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/10638

## What?

This fixes an issue with `wp-build` when used in core, the arguments are not passed down to the build script.
It also restores the empty loader.js since it behaves better when WP appends versions.
