### PR TITLE
Autocomplete: Add offset to popover

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `ToolsPanel`: Remove line-height workaround for control labels ([#73892](https://github.com/WordPress/gutenberg/pull/73892)).
 -   `Notice`: Add right margin to content only when dismissible ([#73905](https://github.com/WordPress/gutenberg/pull/73905)).
 -   `Popover`: Update animation, also affecting `Autocomplete`, `BorderControl`, `CircularOptionPicker`, `ColorPalette`, `Dropdown`, `DropdownMenu`, and `PaletteEdit` ([#74082](https://github.com/WordPress/gutenberg/pull/74082)).
+-   `Autocomplete`: Add offset to popover ([#74084](https://github.com/WordPress/gutenberg/pull/74084)).
 
 ### Bug Fixes
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import { createPortal } from 'react-dom';
 
 /**
  * WordPress dependencies
@@ -24,7 +25,6 @@ import getDefaultUseItems from './get-default-use-items';
 import Button from '../button';
 import Popover from '../popover';
 import { VisuallyHidden } from '../visually-hidden';
-import { createPortal } from 'react-dom';
 import type { AutocompleterUIProps, KeyedOption, WPCompleter } from './types';
 
 type ListBoxProps = {
@@ -177,6 +177,7 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 		return (
 			<>
 				<Popover
+					offset={ 8 }
 					focusOnMount={ false }
 					onClose={ onReset }
 					placement="top-start"


### PR DESCRIPTION
Stacked on #74082

## What?

Adds a slight offset to the `Autocomplete` popover so it isn't uncomfortably close to the cursor.

## Why?

It's basically touching the cursor because there isn't any offset between the popover and the anchor.

## Testing Instructions

Try the `/` or `@` autocompleters in the block editor.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/a47426f9-5135-4b26-be25-0dadcaef7918

### After

https://github.com/user-attachments/assets/41b55d4c-1241-4fb4-8117-5af5c257dc94
