### PR TITLE
Site editor global styles settings: preserve non-global styles in default site editor settings

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -81,7 +81,6 @@ export function useSpecificEditorSettings() {
 		return {
 			...settings,
 			styles: [
-				...( settings?.defaultEditorStyles ?? [] ),
 				...nonGlobalStyles,
 				...globalStyles,
 				{

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -73,9 +73,16 @@ export function useSpecificEditorSettings() {
 	}, [ mergedConfig ] );
 
 	const defaultEditorSettings = useMemo( () => {
+		// Preserve non-global styles from settings.styles (e.g., editor styles from add_editor_style)
+		const nonGlobalStyles = ( settings?.styles ?? [] ).filter(
+			( style ) => ! style.isGlobalStyles
+		);
+
 		return {
 			...settings,
 			styles: [
+				...( settings?.defaultEditorStyles ?? [] ),
+				...nonGlobalStyles,
 				...globalStyles,
 				{
 					// Forming a "block formatting context" to prevent margin collapsing.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes https://github.com/WordPress/gutenberg/issues/74081

Follow up to:

- https://github.com/WordPress/gutenberg/pull/72681
- https://github.com/WordPress/gutenberg/pull/73952

Fixes an issue where editor styles added via `add_editor_style()` were not being applied in the site editor. The styles were being rendered in the HTML source (in the `wp.editSite.initializeEditor` variable) but were not actually applied to the editor canvas.



Props to @iamtakashi

## Why?

Any non-global styles from `settings.styles` were being discarded when the array was replaced.

~~There's also a missing `defaultEditorStyles` that I'm not sure about. I added it to be consistent with the post editor~~ removed.

## How?

Updated `useSpecificEditorSettings` to properly merge all style sources in the order that matches the pattern used in the post editor's `useEditorStyles` hook.


## Testing Instructions

1. Use a theme that has `add_editor_style()` configured (e.g., the `emptytheme` test theme)
2. Ensure the theme has an editor stylesheet (e.g., `style.css`)
3. Add test styles in the editor stylesheet (e.g., `style.css`), add a distinctive style:
   ```css
   h1 {
       background-color: red;
       color: white;
       padding: 10px;
   }
   ```
4. Test that the styles work in the site editor and the post editor

<img width="931" height="346" alt="Screenshot 2025-12-18 at 1 25 41 pm" src="https://github.com/user-attachments/assets/e040cee5-9eb1-4437-8ff0-5a5ab2cfe21a" />
<img width="702" height="464" alt="Screenshot 2025-12-18 at 1 25 31 pm" src="https://github.com/user-attachments/assets/a0203b8c-bb2a-4f85-96a3-b9ffad2cbf22" />

