### PR TITLE
Fix writing flow navigation for combobox and number inputs, allow arrow key use

### DIFF
--- a/packages/block-editor/src/components/writing-flow/test/index.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.js
@@ -22,11 +22,19 @@ describe( 'isNavigationCandidate', () => {
 		elements.inputNumber = document.createElement( 'input' );
 		elements.inputNumber.setAttribute( 'type', 'number' );
 
+		elements.inputListBox = document.createElement( 'input' );
+		elements.inputListBox.setAttribute( 'type', 'text' );
+		elements.inputListBox.setAttribute( 'role', 'listbox' );
+
+		elements.inputCombobox = document.createElement( 'input' );
+		elements.inputCombobox.setAttribute( 'type', 'text' );
+		elements.inputCombobox.setAttribute( 'role', 'combobox' );
+
 		elements.contentEditable = document.createElement( 'p' );
 		elements.contentEditable.contentEditable = true;
 	} );
 
-	it( 'should return true if vertically navigating input without modifier', () => {
+	it( 'returns true if vertically navigating input without modifier', () => {
 		[ UP, DOWN ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.inputText,
@@ -38,7 +46,7 @@ describe( 'isNavigationCandidate', () => {
 		} );
 	} );
 
-	it( 'should return false if vertically navigating input with modifier', () => {
+	it( 'returns false if vertically navigating input with modifier', () => {
 		[ UP, DOWN ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.inputText,
@@ -50,7 +58,31 @@ describe( 'isNavigationCandidate', () => {
 		} );
 	} );
 
-	it( 'should return false if vertically navigating inputs with vertical support like number', () => {
+	it( 'returns false if vertically navigating inputs with the listbox role', () => {
+		[ UP, DOWN ].forEach( ( keyCode ) => {
+			const result = isNavigationCandidate(
+				elements.inputListBox,
+				keyCode,
+				false
+			);
+
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	it( 'returns false if vertically navigating inputs with the combobox role', () => {
+		[ UP, DOWN ].forEach( ( keyCode ) => {
+			const result = isNavigationCandidate(
+				elements.inputCombobox,
+				keyCode,
+				false
+			);
+
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	it( 'returns false if vertically navigating inputs with vertical support like number', () => {
 		[ UP, DOWN ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.inputNumber,
@@ -62,7 +94,19 @@ describe( 'isNavigationCandidate', () => {
 		} );
 	} );
 
-	it( 'should return false if horizontally navigating input', () => {
+	it( 'returns false if horizontally navigating number inputs', () => {
+		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
+			const result = isNavigationCandidate(
+				elements.inputNumber,
+				keyCode,
+				false
+			);
+
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	it( 'returns false if horizontally navigating input', () => {
 		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.inputText,
@@ -74,7 +118,7 @@ describe( 'isNavigationCandidate', () => {
 		} );
 	} );
 
-	it( 'should return true if horizontally navigating simple inputs like checkboxes', () => {
+	it( 'returns true if horizontally navigating simple inputs like checkboxes', () => {
 		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.inputCheckbox,
@@ -86,7 +130,7 @@ describe( 'isNavigationCandidate', () => {
 		} );
 	} );
 
-	it( 'should return true if horizontally navigating non-input', () => {
+	it( 'returns true if horizontally navigating non-input', () => {
 		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
 				elements.contentEditable,

--- a/packages/block-editor/src/components/writing-flow/test/index.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.js
@@ -22,10 +22,6 @@ describe( 'isNavigationCandidate', () => {
 		elements.inputNumber = document.createElement( 'input' );
 		elements.inputNumber.setAttribute( 'type', 'number' );
 
-		elements.inputListBox = document.createElement( 'input' );
-		elements.inputListBox.setAttribute( 'type', 'text' );
-		elements.inputListBox.setAttribute( 'role', 'listbox' );
-
 		elements.inputCombobox = document.createElement( 'input' );
 		elements.inputCombobox.setAttribute( 'type', 'text' );
 		elements.inputCombobox.setAttribute( 'role', 'combobox' );
@@ -52,18 +48,6 @@ describe( 'isNavigationCandidate', () => {
 				elements.inputText,
 				keyCode,
 				true
-			);
-
-			expect( result ).toBe( false );
-		} );
-	} );
-
-	it( 'returns false if vertically navigating inputs with the listbox role', () => {
-		[ UP, DOWN ].forEach( ( keyCode ) => {
-			const result = isNavigationCandidate(
-				elements.inputListBox,
-				keyCode,
-				false
 			);
 
 			expect( result ).toBe( false );

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -29,7 +29,7 @@ const VERTICAL_INPUT_TYPES = [
 	'time',
 	'week',
 ];
-const VERTICAL_INPUT_ROLES = [ 'listbox', 'combobox' ];
+const VERTICAL_INPUT_ROLES = [ 'combobox' ];
 
 /**
  * Returns true if the element should consider edge navigation upon a keyboard

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -20,6 +20,17 @@ import { useRefEffect } from '@wordpress/compose';
 import { getBlockClientId, isInSameBlock } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
+const VERTICAL_INPUT_TYPES = [
+	'date',
+	'datetime-local',
+	'month',
+	'number',
+	'range',
+	'time',
+	'week',
+];
+const VERTICAL_INPUT_ROLES = [ 'listbox', 'combobox' ];
+
 /**
  * Returns true if the element should consider edge navigation upon a keyboard
  * event of the given directional key code, or false otherwise.
@@ -32,23 +43,18 @@ import { store as blockEditorStore } from '../../store';
  */
 export function isNavigationCandidate( element, keyCode, hasModifier ) {
 	const isVertical = keyCode === UP || keyCode === DOWN;
-	const { tagName } = element;
+	const { tagName, role } = element;
 	const elementType = element.getAttribute( 'type' );
 
 	// Native inputs should not navigate vertically, unless they are simple types that don't need up/down arrow keys.
 	if ( isVertical && ! hasModifier ) {
 		if ( tagName === 'INPUT' ) {
-			const verticalInputTypes = [
-				'date',
-				'datetime-local',
-				'month',
-				'number',
-				'range',
-				'time',
-				'week',
-			];
-			return ! verticalInputTypes.includes( elementType );
+			return (
+				! VERTICAL_INPUT_TYPES.includes( elementType ) &&
+				! VERTICAL_INPUT_ROLES.includes( role )
+			);
 		}
+
 		return true;
 	}
 

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -63,7 +63,6 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
 		const simpleInputTypes = [
 			'button',
 			'checkbox',
-			'number',
 			'color',
 			'file',
 			'image',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #38548
Fixes #48256

Allows up/down arrow key usage for boxes that implement combobox inputs.

## Why?
The combobox was barely usable with a keyboard. Number inputs are more usable but it's harder to edit large numbers.

## How?
There's some existing code that bypasses the writing flow arrow key navigation for certain types of element. The code I've added augments that by checking for role `combobox` as suggested in the issue.

Separately, I've reversed the decision in #43667 to disallow horizontal arrow key navigation for number inputs (cc @t-hamano). Number inputs work just like text inputs if you have more than one unit, so I personally don't think it was the right call.

## Testing Instructions
1. Make the following changes to the table block so that it has a combobox in its placeholder and build
<details><summary>Diff</summary>

```patch
diff --git a/packages/block-library/src/table/edit.js b/packages/block-library/src/table/edit.js
index 9f649b2901e..d37eebc3712 100644
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -34,6 +34,7 @@ import {
 	__experimentalHasSplitBorders as hasSplitBorders,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	ComboboxControl,
 } from '@wordpress/components';
 import {
 	alignLeft,
@@ -83,6 +84,28 @@ const ALIGNMENT_CONTROLS = [
 		align: 'right',
 	},
 ];
+const options = [
+	{
+		value: 'smallest',
+		label: 'Smallest',
+	},
+	{
+		value: 'small',
+		label: 'Small',
+	},
+	{
+		value: 'normal',
+		label: 'Normal',
+	},
+	{
+		value: 'large',
+		label: 'Large',
+	},
+	{
+		value: 'huge',
+		label: 'Huge',
+	},
+];
 
 const cellAriaLabel = {
 	head: __( 'Header cell text' ),
@@ -373,6 +396,9 @@ function TableEdit( {
 		( name ) => ! isEmptyTableSection( attributes[ name ] )
 	);
 
+	const [ fontSize, setFontSize ] = useState();
+	const [ filteredOptions, setFilteredOptions ] = useState( options );
+
 	const tableControls = [
 		{
 			icon: tableRowBefore,
@@ -580,6 +606,24 @@ function TableEdit( {
 							min="1"
 							className="blocks-table__placeholder-input"
 						/>
+						<ComboboxControl
+							__next40pxDefaultSize
+							label="Font Size"
+							value={ fontSize }
+							onChange={ setFontSize }
+							options={ filteredOptions }
+							onFilterValueChange={ ( inputValue ) =>
+								setFilteredOptions(
+									options.filter( ( option ) =>
+										option.label
+											.toLowerCase()
+											.startsWith(
+												inputValue.toLowerCase()
+											)
+									)
+								)
+							}
+						/>
 						<Button
 							__next40pxDefaultSize
 							variant="primary"
```

</details> 

2. Add a table block to a post
3. Use arrow keys to move focus to the navigation placeholder's column count input
4. Type a big number, then use left, right, up, down arrow keys to move the caret and edit the number (left/right doesn't work in trunk)
5. Tab to the row count input and try the same
6. Tab to the combox box input and type 'sm'. Left/right arrow keys should move the caret and up/down arrow keys should select different suggestions. (up/down doesn't work in trunk)

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e0badb49-7039-4ac4-bf2a-bf14a8b40926

