### PR TITLE
Add checkerboard pattern for background in featured image preview

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -681,3 +681,20 @@
 	left: 0;
 	@include selected-block-outline($widthRatio);
 }
+
+/**
+ * Creates a checkerboard pattern background to indicate transparency.
+ * @param {String} $size - The size of the squares in the checkerboard pattern. Default is 12px.
+ */
+@mixin checkerboard-background($size: 12px) {
+	// The background image creates a checkerboard pattern. Ignore rtlcss to
+	// make it work both in LTR and RTL.
+	// See https://github.com/WordPress/gutenberg/pull/42510
+	/*rtl:begin:ignore*/
+	background-image:
+		repeating-linear-gradient(45deg, colors.$gray-200 25%, transparent 25%, transparent 75%, colors.$gray-200 75%, colors.$gray-200),
+		repeating-linear-gradient(45deg, colors.$gray-200 25%, transparent 25%, transparent 75%, colors.$gray-200 75%, colors.$gray-200);
+	background-position: 0 0, $size $size;
+	/*rtl:end:ignore*/
+	background-size: calc(2 * $size) calc(2 * $size);
+}

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "../utils/theme-variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
 
 $border-as-box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 
@@ -32,17 +33,8 @@ $border-as-box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 		position: absolute;
 		inset: $border-width;
 		z-index: -1;
-		// The background image creates a checkerboard pattern. Ignore rtlcss to
-		// make it work both in LTR and RTL.
-		// See https://github.com/WordPress/gutenberg/pull/42510
-		/*rtl:begin:ignore*/
-		background-image:
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-		background-position: 0 0, 24px 24px;
-		/*rtl:end:ignore*/
-		background-size: calc(2 * 24px) calc(2 * 24px);
 		border-radius: $radius-medium - $border-width $radius-medium - $border-width 0 0;
+		@include checkerboard-background();
 	}
 }
 

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -34,7 +34,7 @@ $border-as-box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 		inset: $border-width;
 		z-index: -1;
 		border-radius: $radius-medium - $border-width $radius-medium - $border-width 0 0;
-		@include checkerboard-background();
+		@include checkerboard-background( 24px );
 	}
 }
 

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
 
 $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 16px handles inside, that leaves 32px padding, half of which is 1å6.
 
@@ -11,16 +12,7 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 	z-index: 1;
 
 	&.has-gradient {
-		// The background image creates a checkerboard pattern. Ignore rtlcss to
-		// make it work both in LTR and RTL.
-		// See https://github.com/WordPress/gutenberg/pull/42510
-		/*rtl:begin:ignore*/
-		background-image:
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-		background-position: 0 0, 12px 12px;
-		/*rtl:end:ignore*/
-		background-size: calc(2 * 12px) calc(2 * 12px);
+		@include checkerboard-background();
 	}
 
 	.components-custom-gradient-picker__gradient-bar-background {

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -12,7 +12,7 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 	z-index: 1;
 
 	&.has-gradient {
-		@include checkerboard-background();
+		@include checkerboard-background( 12px );
 	}
 
 	.components-custom-gradient-picker__gradient-bar-background {

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -83,7 +83,6 @@
 		object-position: 50% 50%;
 		aspect-ratio: 2/1;
 		position: relative;
-		z-index: 1;
 	}
 }
 

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -66,23 +66,13 @@
 .editor-post-featured-image__preview {
 	height: auto !important;
 	outline: $border-width solid rgba($black, 0.1);
-	position: relative;
-
-	// Add checkerboard pattern for transparent images
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		z-index: 0;
-		@include checkerboard-background( 12px );
-	}
+	@include checkerboard-background( 12px );
 
 	.editor-post-featured-image__preview-image {
 		object-fit: cover;
 		width: 100%;
 		object-position: 50% 50%;
 		aspect-ratio: 2/1;
-		position: relative;
 	}
 }
 

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
 
 .editor-post-featured-image {
 	padding: 0;
@@ -73,11 +74,7 @@
 		position: absolute;
 		inset: 0;
 		z-index: 0;
-		background-image:
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-		background-position: 0 0, 12px 12px;
-		background-size: calc(2 * 12px) calc(2 * 12px);
+		@include checkerboard-background();
 	}
 
 	.editor-post-featured-image__preview-image {

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -74,7 +74,7 @@
 		position: absolute;
 		inset: 0;
 		z-index: 0;
-		@include checkerboard-background();
+		@include checkerboard-background( 12px );
 	}
 
 	.editor-post-featured-image__preview-image {

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -65,12 +65,28 @@
 .editor-post-featured-image__preview {
 	height: auto !important;
 	outline: $border-width solid rgba($black, 0.1);
+	position: relative;
+
+	// Add checkerboard pattern for transparent images
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		background-image:
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+		background-position: 0 0, 12px 12px;
+		background-size: calc(2 * 12px) calc(2 * 12px);
+	}
 
 	.editor-post-featured-image__preview-image {
 		object-fit: cover;
 		width: 100%;
 		object-position: 50% 50%;
 		aspect-ratio: 2/1;
+		position: relative;
+		z-index: 1;
 	}
 }
 

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -1,12 +1,12 @@
 @use "@wordpress/base-styles/variables";
 @use "@wordpress/base-styles/colors";
 @use "@wordpress/base-styles/mixins";
+@use "@wordpress/base-styles/mixins" as *;
 @use "./font-library/style.scss" as *;
 @use "./pagination/style.scss" as *;
 @use "./screen-revisions/style.scss" as *;
 @use "./size-control/style.scss" as *;
 @use "./variations/style.scss" as *;
-
 
 .global-styles-ui-preview {
 	display: flex;
@@ -132,13 +132,7 @@
 	border: #ddd 1px solid;
 	border-radius: 2px;
 	overflow: auto;
-	background-image:
-		repeating-linear-gradient(45deg, #f5f5f5 25%, #0000 0, #0000 75%, #f5f5f5 0, #f5f5f5),
-		repeating-linear-gradient(45deg, #f5f5f5 25%, #0000 0, #0000 75%, #f5f5f5 0, #f5f5f5);
-	background-position:
-		0 0,
-		8px 8px;
-	background-size: 16px 16px;
+	@include checkerboard-background( 8px );
 
 	.global-styles-ui__shadow-preview-block {
 		border: #ddd 1px solid;

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -1,12 +1,12 @@
 @use "@wordpress/base-styles/variables";
 @use "@wordpress/base-styles/colors";
 @use "@wordpress/base-styles/mixins";
-@use "@wordpress/base-styles/mixins" as *;
 @use "./font-library/style.scss" as *;
 @use "./pagination/style.scss" as *;
 @use "./screen-revisions/style.scss" as *;
 @use "./size-control/style.scss" as *;
 @use "./variations/style.scss" as *;
+
 
 .global-styles-ui-preview {
 	display: flex;
@@ -132,7 +132,7 @@
 	border: #ddd 1px solid;
 	border-radius: 2px;
 	overflow: auto;
-	@include checkerboard-background( 8px );
+	@include mixins.checkerboard-background( 8px );
 
 	.global-styles-ui__shadow-preview-block {
 		border: #ddd 1px solid;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74006

<!-- In a few words, what is the PR actually doing? -->
- Add a checkerboard pattern background for the featured image preview in the editor
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- To identify the transparent images
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added css to add a checkerboard pattern background

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2f2dd078-3682-4429-bdbe-c3474ab7bf23
