### PR TITLE
[Tabs block] Button and Tab Styling options #73932

### DIFF
--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -91,6 +91,16 @@
 		"typography": {
 			"fontSize": true,
 			"__experimentalFontFamily": true
+		},
+		"__experimentalBorder": {
+			"color": false,
+			"radius": true,
+			"style": false,
+			"width": false,
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"radius": true
+			}
 		}
 	},
 	"example": {

--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -93,10 +93,7 @@
 			"__experimentalFontFamily": true
 		},
 		"__experimentalBorder": {
-			"color": false,
 			"radius": true,
-			"style": false,
-			"width": false,
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"radius": true

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -140,25 +140,25 @@ function block_core_tabs_generate_tabs_list_from_innerblocks( array $innerblocks
  * @return string Inline CSS string.
  */
 function block_core_tabs_generate_border_styles( array $attributes ): string {
-    if ( empty( $attributes['style']['border']['radius'] ) ) {
-        return '';
-    }
+	if ( empty( $attributes['style']['border']['radius'] ) ) {
+		return '';
+	}
 
-    $radius = $attributes['style']['border']['radius'];
+	$radius = $attributes['style']['border']['radius'];
 
-    if ( is_array( $radius ) ) {
-        $radius_value = wp_sprintf(
-            '%s %s %s %s',
-            $radius['topLeft'] ?? '0',
-            $radius['topRight'] ?? '0',
-            $radius['bottomRight'] ?? '0',
-            $radius['bottomLeft'] ?? '0'
-        );
-    } else {
-        $radius_value = (string) $radius;
-    }
+	if ( is_array( $radius ) ) {
+		$radius_value = wp_sprintf(
+			'%s %s %s %s',
+			$radius['topLeft'] ?? '0',
+			$radius['topRight'] ?? '0',
+			$radius['bottomRight'] ?? '0',
+			$radius['bottomLeft'] ?? '0'
+		);
+	} else {
+		$radius_value = (string) $radius;
+	}
 
-    return wp_sprintf( '--tab-border-radius: %s;', $radius_value );
+	return wp_sprintf( '--tab-border-radius: %s;', $radius_value );
 }
 
 /**

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -155,7 +155,7 @@ function block_core_tabs_generate_border_styles( array $attributes ): string {
 			$radius['bottomLeft'] ?? '0'
 		);
 	} else {
-		$radius_value = (string) $radius;
+		$radius_value = $radius;
 	}
 
 	return wp_sprintf( '--tab-border-radius: %s;', (string) $radius_value );

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -133,6 +133,35 @@ function block_core_tabs_generate_tabs_list_from_innerblocks( array $innerblocks
 }
 
 /**
+ * Build inline CSS custom properties for border settings.
+ *
+ * @param array $attributes Block attributes.
+ *
+ * @return string Inline CSS string.
+ */
+function block_core_tabs_generate_border_styles( array $attributes ): string {
+    if ( empty( $attributes['style']['border']['radius'] ) ) {
+        return '';
+    }
+
+    $radius = $attributes['style']['border']['radius'];
+
+    if ( is_array( $radius ) ) {
+        $radius_value = wp_sprintf(
+            '%s %s %s %s',
+            $radius['topLeft'] ?? '0',
+            $radius['topRight'] ?? '0',
+            $radius['bottomRight'] ?? '0',
+            $radius['bottomLeft'] ?? '0'
+        );
+    } else {
+        $radius_value = (string) $radius;
+    }
+
+    return wp_sprintf( '--tab-border-radius: %s;', $radius_value );
+}
+
+/**
  * Render callback for core/tabs.
  *
  * @param array     $attributes Block attributes.
@@ -185,6 +214,7 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 	$style  = (string) $tag_processor->get_attribute( 'style' );
 	$style .= block_core_tabs_generate_color_styles( $attributes );
 	$style .= block_core_tabs_generate_gap_styles( $attributes, $is_vertical );
+	$style .= block_core_tabs_generate_border_styles( $attributes );
 	$tag_processor->set_attribute( 'style', $style );
 
 	$updated_content = $tag_processor->get_updated_html();

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -140,11 +140,11 @@ function block_core_tabs_generate_tabs_list_from_innerblocks( array $innerblocks
  * @return string Inline CSS string.
  */
 function block_core_tabs_generate_border_styles( array $attributes ): string {
-	if ( empty( $attributes['style']['border']['radius'] ) ) {
+	$radius = $attributes['style']['border']['radius'] ?? null;
+
+	if ( empty( $radius ) ) {
 		return '';
 	}
-
-	$radius = $attributes['style']['border']['radius'];
 
 	if ( is_array( $radius ) ) {
 		$radius_value = wp_sprintf(
@@ -158,7 +158,7 @@ function block_core_tabs_generate_border_styles( array $attributes ): string {
 		$radius_value = (string) $radius;
 	}
 
-	return wp_sprintf( '--tab-border-radius: %s;', $radius_value );
+	return wp_sprintf( '--tab-border-radius: %s;', (string) $radius_value );
 }
 
 /**

--- a/packages/block-library/src/tabs/style-engine.js
+++ b/packages/block-library/src/tabs/style-engine.js
@@ -103,9 +103,7 @@ function getColorStyles( { attributes } ) {
  * @return {Object} CSS custom properties for border styles
  */
 function getBorderStyles( { attributes } ) {
-	const { style } = attributes || {};
-	const { border } = style || {};
-	const { radius } = border || {};
+	const { radius } = attributes?.style?.border || {};
 
 	if ( ! radius ) {
 		return {};

--- a/packages/block-library/src/tabs/style-engine.js
+++ b/packages/block-library/src/tabs/style-engine.js
@@ -96,6 +96,41 @@ function getColorStyles( { attributes } ) {
 }
 
 /**
+ * Gets the border styles for the tab block.
+ *
+ * @param {Object} props
+ * @param {Object} props.attributes Block attributes
+ * @return {Object} CSS custom properties for border styles
+ */
+function getBorderStyles( { attributes } ) {
+	const { style } = attributes || {};
+	const { border } = style || {};
+	const { radius } = border || {};
+
+	if ( ! radius ) {
+		return {};
+	}
+
+	let radiusValue = radius;
+
+	if ( typeof radius === 'object' ) {
+		const {
+			topLeft = '0',
+			topRight = '0',
+			bottomRight = '0',
+			bottomLeft = '0',
+		} = radius;
+		radiusValue = `${ topLeft } ${ topRight } ${ bottomRight } ${ bottomLeft }`;
+	}
+
+	const borderMap = {
+		'--tab-border-radius': radiusValue,
+	};
+
+	return borderMap;
+}
+
+/**
  * Injects color CSS custom properties for the tabs block, mirroring the pattern
  * used by gap-styles (scoped to `#block-{ clientId }`). This replaces the prior
  * inline-style object return value approach so that these values participate in
@@ -109,10 +144,12 @@ function getColorStyles( { attributes } ) {
 export default function StyleEngine( { attributes, clientId } ) {
 	const gapVarMap = getGapStyles( { attributes } );
 	const colorVarMap = getColorStyles( { attributes } );
+	const borderVarMap = getBorderStyles( { attributes } );
 
 	const styleVarMap = {
 		...gapVarMap,
 		...colorVarMap,
+		...borderVarMap,
 	};
 
 	// Build scoped CSS only for defined values to avoid unnecessary empty declarations.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73932

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Adds a radius control in the tabs block

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds radius controls for use to manually control the tab heading's radius

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a tabs block.
3. Select radius control from the block settings

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

None


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="400" src="https://github.com/user-attachments/assets/258d105f-696c-4e21-bc90-9bd696edd06f" />

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/2c56395e-6751-4e91-ab0d-cd109a8118f7" />

<img width="400" src="https://github.com/user-attachments/assets/17cb0cd4-b50b-4618-9fa5-a323d9dad464" />


