### PR TITLE
Widget Group: Optimize value returned by selector

### DIFF
--- a/packages/widgets/src/blocks/widget-group/edit.js
+++ b/packages/widgets/src/blocks/widget-group/edit.js
@@ -16,14 +16,14 @@ import { useSelect } from '@wordpress/data';
 
 export default function Edit( props ) {
 	const { clientId } = props;
-	const { innerBlocks } = useSelect(
-		( select ) => select( blockEditorStore ).getBlock( clientId ),
+	const hasInnerBlocks = useSelect(
+		( select ) => select( blockEditorStore ).getBlockCount( clientId ) > 0,
 		[ clientId ]
 	);
 
 	return (
 		<div { ...useBlockProps( { className: 'widget' } ) }>
-			{ innerBlocks.length === 0 ? (
+			{ ! hasInnerBlocks ? (
 				<PlaceholderContent { ...props } />
 			) : (
 				<PreviewContent { ...props } />


### PR DESCRIPTION
## What?
Noticed while testing #74062.

A micro-optimization for the Widget Group block. Return a boolean value for the inner blocks check instead of the whole inner blocks object.

## Testing Instructions
The code makes no behavioral changes. Confirm that Widgets Group continues to work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="690" height="147" alt="CleanShot 2025-12-18 at 17 11 44" src="https://github.com/user-attachments/assets/b431a885-1671-41b6-b00f-a4b9ce9bc109" />
