### PR TITLE
Field API: rename `text` to `string` to align with block.json API

### DIFF
--- a/packages/block-editor/src/hooks/generate-fields-from-attributes.js
+++ b/packages/block-editor/src/hooks/generate-fields-from-attributes.js
@@ -40,7 +40,6 @@ function createFieldFromAttribute( name, def ) {
 	const type = def.type;
 
 	// Skip unsupported types (object, union types, etc.)
-	// Supported: string→text, number, integer, boolean (1:1 with DataForm)
 	if ( ! [ 'string', 'number', 'integer', 'boolean' ].includes( type ) ) {
 		return null;
 	}
@@ -48,9 +47,7 @@ function createFieldFromAttribute( name, def ) {
 	const field = {
 		id: name,
 		label: def.label || name,
-		// Only 'string' needs mapping to 'text'; others are 1:1 with DataForm types.
-		// This mapping will be unnecessary once #74105 lands.
-		type: type === 'string' ? 'text' : type,
+		type,
 	};
 
 	// Add elements for enums (DataForm shows select UI when elements are present)

--- a/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
+++ b/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
@@ -33,7 +33,7 @@ describe( 'generateFieldsFromAttributes', () => {
 		expect( result.fields[ 0 ] ).toEqual( {
 			id: 'message',
 			label: 'message',
-			type: 'text',
+			type: 'string',
 		} );
 		expect( result.form.fields ).toContain( 'message' );
 	} );
@@ -108,7 +108,7 @@ describe( 'generateFieldsFromAttributes', () => {
 		expect( result.fields[ 0 ] ).toEqual( {
 			id: 'size',
 			label: 'size',
-			type: 'text',
+			type: 'string',
 			elements: [
 				{ value: 'small', label: 'small' },
 				{ value: 'medium', label: 'medium' },

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -59,7 +59,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -59,7 +59,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'text',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -48,7 +48,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Code' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -74,7 +74,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'summary',
 			label: __( 'Summary' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -59,13 +59,13 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'fileName',
 			label: __( 'Filename' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{
 			id: 'downloadButtonText',
 			label: __( 'Button Text' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -86,7 +86,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -112,13 +112,13 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{
 			id: 'alt',
 			label: __( 'Alt text' ),
-			type: 'text',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -57,7 +57,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -48,7 +48,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'customText',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -114,7 +114,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text',
 		},
 		{

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -60,7 +60,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', //TODO: replace with custom component
 		},
 		{

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -68,7 +68,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -48,7 +48,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -45,13 +45,13 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'value',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{
 			id: 'citation',
 			label: __( 'Citation' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -35,19 +35,19 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{
 			id: 'buttonText',
 			label: __( 'Button text' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 		{
 			id: 'placeholder',
 			label: __( 'Placeholder' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -45,7 +45,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'text',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -50,7 +50,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -64,7 +64,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'text',
+			type: 'string',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},
 	];

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - The design tokens stylesheet (`@wordpress/theme/design-tokens.css`) is no longer embedded in the DataViews stylesheet. Applications using DataViews outside of WordPress must now explicitly include the design tokens stylesheet. See the README for installation instructions. [#75182](https://github.com/WordPress/gutenberg/pull/75182)
+- Rename `text` field type to `string` to align with block.json API. [#74105](https://github.com/WordPress/gutenberg/pull/74105)
 
 ### Bug Fixes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -140,7 +140,7 @@ const AUTHORS = [
 const fields = [
 	{
 		id: 'title',
-		type: 'text',
+		type: 'string',
 		label: 'Title',
 		enableHiding: false,
 	},
@@ -165,7 +165,7 @@ const fields = [
 	},
 	{
 		id: 'status',
-		type: 'text',
+		type: 'string',
 		label: 'Status',
 		getValue: ( { item } ) =>
 			STATUSES.find( ( { value } ) => value === item.status )?.label ??
@@ -803,7 +803,7 @@ Example:
 const fields = [
 	{
 		id: 'title',
-		type: 'text',
+		type: 'string',
 		label: 'Title',
 	},
 	{
@@ -813,7 +813,7 @@ const fields = [
 	},
 	{
 		id: 'author',
-		type: 'text',
+		type: 'string',
 		label: 'Author',
 		elements: [
 			{ value: 1, label: 'Admin' },
@@ -1194,7 +1194,7 @@ Example:
 
 ### `type`
 
-Field type. One of `text`, `integer`, `number`, `datetime`, `date`, `media`, `boolean`, `email`, `password`, `telephone`, `color`, `url`, `array`.
+Field type. One of `string`, `integer`, `number`, `datetime`, `date`, `media`, `boolean`, `email`, `password`, `telephone`, `color`, `url`, `array`.
 
 -   Type: `string`.
 -   Optional.
@@ -1205,7 +1205,7 @@ Example:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 }
 ```
 
@@ -1222,7 +1222,7 @@ Example:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 }
 ```
@@ -1240,7 +1240,7 @@ Example:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	header: (
 		<Stack direction="row" gap="xs" justify="start">
 			<Icon icon={ icon } />
@@ -1305,7 +1305,7 @@ const item = {
 // Field definition
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title'
 	// getValue: automatically becomes ( { item } ) => item.title
 	// setValue: automatically becomes ( { value } ) => ( { title: value } )
@@ -1330,7 +1330,7 @@ const item = {
 // Field definition - using dot notation (automatic)
 {
 	id: 'user.profile.name',
-	type: 'text',
+	type: 'string',
 	label: 'User Name'
 	// getValue: automatically becomes ( { item } ) => item.user.profile.name
 	// setValue: automatically becomes ( { value } ) => ( { user: { profile: { name: value } } } )
@@ -1339,7 +1339,7 @@ const item = {
 // Alternative - using simple ID with custom functions
 {
 	id: 'userName',
-	type: 'text',
+	type: 'string',
 	label: 'User Name',
 	getValue: ( { item } ) => item.user.profile.name,
 	setValue: ( { value } ) => ( {
@@ -1459,7 +1459,7 @@ Example of a custom render function:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	render: ( { item, field, config } ) => {
 		/* React element to be displayed. */
@@ -1480,7 +1480,7 @@ Fields that provide a `type` will have a default Edit control:
 ```js
 {
 	id: 'categories',
-	type: 'text',
+	type: 'string',
 	label: 'Categories',
 }
 ```
@@ -1490,7 +1490,7 @@ Field authors can override the default Edit control by providing a string that m
 ```js
 {
 	id: 'categories',
-	type: 'text',
+	type: 'string',
 	label: 'Categories',
 	Edit: 'radio',
 }
@@ -1503,7 +1503,7 @@ Additionally, some of the bundled Edit controls are configurable via a config ob
 ```js
 {
 	id: 'description',
-	type: 'text',
+	type: 'string',
 	label: 'Description',
 	Edit: {
 		control: 'textarea',
@@ -1517,7 +1517,7 @@ Additionally, some of the bundled Edit controls are configurable via a config ob
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	Edit: {
 		control: 'text',
@@ -1585,7 +1585,7 @@ When the field declares a type, it gets a default sort function:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 }
 ```
@@ -1605,7 +1605,7 @@ It should return a number where:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	sort: ( a, b, direction ) => {
 		return direction === 'asc'
@@ -1681,7 +1681,7 @@ This can be useful to hide fields based on the state of other fields. For exampl
 ```js
 {
 	id: 'homepageDisplay',
-	type: 'text',
+	type: 'string',
 	label: 'Homepage display',
 	elements: [
 		{ value: 'latest', label: 'Latest post' },
@@ -1690,7 +1690,7 @@ This can be useful to hide fields based on the state of other fields. For exampl
 },
 {
 	id: 'staticHomepage',
-	type: 'text',
+	type: 'string',
 	label: 'Static homepage',
 	elements: [
 		{ value: 'welcome', label: 'Welcome to my website' },
@@ -1713,7 +1713,7 @@ Example to disable sorting by a field:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	enableSorting: false,
 }
@@ -1732,7 +1732,7 @@ Example to disable hiding of a field:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	enableHiding: false,
 }
@@ -1751,7 +1751,7 @@ Example to enable global search for a field:
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	enableGlobalSearch: true,
 }
@@ -1822,7 +1822,7 @@ By default, fields have filtering enabled by using the field's `Edit` function:
 ```js
 {
 	id: 'product',
-	type: 'text',
+	type: 'string',
 	label: 'Product',
 }
 ```
@@ -1832,7 +1832,7 @@ If the field provides `elements`, the filter will use those as predefined option
 ```js
 {
 	id: 'product',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	elements: [
 		{ value: 'a', label: 'Product A' },
@@ -1848,7 +1848,7 @@ A field can opt-out of filtering by setting `filterBy` to `false`:
 ```js
 {
 	id: 'product',
-	type: 'text',
+	type: 'string',
 	label: 'Product',
 	filterBy: false;
 }
@@ -1859,7 +1859,7 @@ Fields can declare its filter as primary, which means it'll always be visible an
 ```js
 {
 	id: 'title',
-	type: 'text',
+	type: 'string',
 	label: 'Title',
 	filterBy: {
 		isPrimary: true;
@@ -1872,7 +1872,7 @@ Filters come with default operators per field type, but this is configurable by 
 ```js
 {
 	id: 'product',
-	type: 'text',
+	type: 'string',
 	label: 'Product',
 	elements: [
 		{ value: 'a', label: 'Product A' },
@@ -1891,7 +1891,7 @@ Or multi-selection operators:
 ```js
 {
 	id: 'product',
-	type: 'text',
+	type: 'string',
 	label: 'Product',
 	elements: [
 		{ value: 'a', label: 'Product A' },

--- a/packages/dataviews/src/dataform/stories/content.story.tsx
+++ b/packages/dataviews/src/dataform/stories/content.story.tsx
@@ -43,7 +43,7 @@ export const Labels: Story = {
 				{
 					id: 'name',
 					label: 'Name',
-					type: 'text',
+					type: 'string',
 				},
 				{
 					id: 'email',
@@ -101,7 +101,7 @@ export const HelpText: Story = {
 				{
 					id: 'name',
 					label: 'Name',
-					type: 'text',
+					type: 'string',
 					placeholder: 'Jane Doe',
 					description:
 						'Enter your full legal name as it appears on official documents.',
@@ -168,7 +168,7 @@ export const ValidationMessages: Story = {
 				{
 					id: 'name',
 					label: 'Name',
-					type: 'text',
+					type: 'string',
 					placeholder: 'Jane Doe',
 					isValid: {
 						required: true,
@@ -275,7 +275,7 @@ export const HighLevelHelpText: Story = {
 				{
 					id: 'name',
 					label: 'Name',
-					type: 'text',
+					type: 'string',
 				},
 				{
 					id: 'email',
@@ -347,7 +347,7 @@ export const Placeholders: Story = {
 				{
 					id: 'name',
 					label: 'Name',
-					type: 'text',
+					type: 'string',
 					placeholder: 'Jane Doe',
 				},
 				{

--- a/packages/dataviews/src/dataform/stories/data-adapter.tsx
+++ b/packages/dataviews/src/dataform/stories/data-adapter.tsx
@@ -55,7 +55,7 @@ const DataAdapterComponent = () => {
 		{
 			id: 'user.profile.name',
 			label: 'User Name',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'user.profile.email',

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -45,12 +45,12 @@ const LayoutCardComponent = ( {
 		{
 			id: 'name',
 			label: 'Customer Name',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'phone',
 			label: 'Phone',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'email',
@@ -60,7 +60,7 @@ const LayoutCardComponent = ( {
 		{
 			id: 'plan',
 			label: 'Plan',
-			type: 'text',
+			type: 'string',
 			Edit: 'toggleGroup',
 			elements: [
 				{ value: 'basic', label: 'Basic' },
@@ -71,12 +71,12 @@ const LayoutCardComponent = ( {
 		{
 			id: 'shippingAddress',
 			label: 'Shipping Address',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'billingAddress',
 			label: 'Billing Address',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'displayPayments',
@@ -86,7 +86,7 @@ const LayoutCardComponent = ( {
 		{
 			id: 'payments',
 			label: 'Payments',
-			type: 'text',
+			type: 'string',
 			readOnly: true, // Triggers using the render method instead of Edit.
 			isVisible: ( item ) => item.displayPayments,
 			render: ( { item } ) => {
@@ -113,14 +113,14 @@ const LayoutCardComponent = ( {
 		{
 			id: 'dueDate',
 			label: 'Due Date',
-			type: 'text',
+			type: 'string',
 			render: ( { item } ) => {
 				return <Badge>Due on: { item.dueDate }</Badge>;
 			},
 		},
 		{
 			id: 'plan-summary',
-			type: 'text',
+			type: 'string',
 			readOnly: true,
 			render: ( { item } ) => {
 				return <Badge>{ item.plan }</Badge>;

--- a/packages/dataviews/src/dataform/stories/layout-details.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-details.tsx
@@ -38,7 +38,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'order',
@@ -77,7 +77,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'reviewer',
 		label: 'Reviewer',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'jane', label: 'Jane' },
@@ -89,7 +89,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'status',
 		label: 'Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'toggleGroup',
 		elements: [
 			{ value: 'draft', label: 'Draft' },
@@ -105,7 +105,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'password',
 		label: 'Password',
-		type: 'text',
+		type: 'string',
 		isVisible: ( item: SamplePost ) => {
 			return item.status !== 'private';
 		},
@@ -130,7 +130,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'dimensions',
 		label: 'Dimensions',
-		type: 'text',
+		type: 'string',
 		readOnly: true,
 	},
 	{
@@ -150,28 +150,28 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'address1',
 		label: 'Address 1',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'address2',
 		label: 'Address 2',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'city',
 		label: 'City',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'description',
 		label: 'Description',
-		type: 'text',
+		type: 'string',
 		Edit: 'textarea',
 	},
 	{
 		id: 'longDescription',
 		label: 'Long Description',
-		type: 'text',
+		type: 'string',
 		Edit: {
 			control: 'textarea',
 			rows: 5,
@@ -180,7 +180,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'comment_status',
 		label: 'Comment Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'open', label: 'Allow comments' },
@@ -195,7 +195,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'discussion',
 		label: 'Discussion',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			const commentLabel =
 				item.comment_status === 'open'
@@ -214,17 +214,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'origin',
 		label: 'Origin',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'destination',
 		label: 'Destination',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'flight_status',
 		label: 'Flight Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'on-time', label: 'On Time' },
@@ -235,17 +235,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'gate',
 		label: 'Gate',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'seat',
 		label: 'Seat',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'metadata_summary',
 		label: 'Metadata',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			return (
 				<span>

--- a/packages/dataviews/src/dataform/stories/layout-mixed.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-mixed.tsx
@@ -35,12 +35,12 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'status',
 		label: 'Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'toggleGroup',
 		elements: [
 			{ value: 'draft', label: 'Draft' },
@@ -51,12 +51,12 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'origin',
 		label: 'Origin',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'destination',
 		label: 'Destination',
-		type: 'text',
+		type: 'string',
 	},
 ];
 

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -44,7 +44,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'order',
@@ -83,7 +83,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'reviewer',
 		label: 'Reviewer',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'jane', label: 'Jane' },
@@ -95,7 +95,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'status',
 		label: 'Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'toggleGroup',
 		elements: [
 			{ value: 'draft', label: 'Draft' },
@@ -111,7 +111,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'password',
 		label: 'Password',
-		type: 'text',
+		type: 'string',
 		isVisible: ( item: SamplePost ) => {
 			return item.status !== 'private';
 		},
@@ -136,7 +136,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'dimensions',
 		label: 'Dimensions',
-		type: 'text',
+		type: 'string',
 		readOnly: true,
 	},
 	{
@@ -156,28 +156,28 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'address1',
 		label: 'Address 1',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'address2',
 		label: 'Address 2',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'city',
 		label: 'City',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'description',
 		label: 'Description',
-		type: 'text',
+		type: 'string',
 		Edit: 'textarea',
 	},
 	{
 		id: 'longDescription',
 		label: 'Long Description',
-		type: 'text',
+		type: 'string',
 		Edit: {
 			control: 'textarea',
 			rows: 5,
@@ -186,7 +186,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'comment_status',
 		label: 'Comment Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'open', label: 'Allow comments' },
@@ -201,7 +201,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'discussion',
 		label: 'Discussion',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			const commentLabel =
 				item.comment_status === 'open'
@@ -220,17 +220,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'origin',
 		label: 'Origin',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'destination',
 		label: 'Destination',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'flight_status',
 		label: 'Flight Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'on-time', label: 'On Time' },
@@ -241,17 +241,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'gate',
 		label: 'Gate',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'seat',
 		label: 'Seat',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'metadata_summary',
 		label: 'Metadata',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			return (
 				<span>

--- a/packages/dataviews/src/dataform/stories/layout-regular.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-regular.tsx
@@ -45,7 +45,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'order',
@@ -84,7 +84,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'reviewer',
 		label: 'Reviewer',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'jane', label: 'Jane' },
@@ -96,7 +96,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'status',
 		label: 'Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'toggleGroup',
 		elements: [
 			{ value: 'draft', label: 'Draft' },
@@ -112,7 +112,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'password',
 		label: 'Password',
-		type: 'text',
+		type: 'string',
 		isVisible: ( item: SamplePost ) => {
 			return item.status !== 'private';
 		},
@@ -137,7 +137,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'dimensions',
 		label: 'Dimensions',
-		type: 'text',
+		type: 'string',
 		readOnly: true,
 	},
 	{
@@ -157,28 +157,28 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'address1',
 		label: 'Address 1',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'address2',
 		label: 'Address 2',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'city',
 		label: 'City',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'description',
 		label: 'Description',
-		type: 'text',
+		type: 'string',
 		Edit: 'textarea',
 	},
 	{
 		id: 'longDescription',
 		label: 'Long Description',
-		type: 'text',
+		type: 'string',
 		Edit: {
 			control: 'textarea',
 			rows: 5,
@@ -187,7 +187,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'comment_status',
 		label: 'Comment Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'open', label: 'Allow comments' },
@@ -202,7 +202,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'discussion',
 		label: 'Discussion',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			const commentLabel =
 				item.comment_status === 'open'
@@ -221,17 +221,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'origin',
 		label: 'Origin',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'destination',
 		label: 'Destination',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'flight_status',
 		label: 'Flight Status',
-		type: 'text',
+		type: 'string',
 		Edit: 'radio',
 		elements: [
 			{ value: 'on-time', label: 'On Time' },
@@ -242,17 +242,17 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'gate',
 		label: 'Gate',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'seat',
 		label: 'Seat',
-		type: 'text',
+		type: 'string',
 	},
 	{
 		id: 'metadata_summary',
 		label: 'Metadata',
-		type: 'text',
+		type: 'string',
 		render: ( { item } ) => {
 			return (
 				<span>

--- a/packages/dataviews/src/dataform/stories/layout-row.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-row.tsx
@@ -43,12 +43,12 @@ const LayoutRowComponent = ( {
 		{
 			id: 'name',
 			label: 'Customer Name',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'phone',
 			label: 'Phone',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'email',
@@ -58,37 +58,37 @@ const LayoutRowComponent = ( {
 		{
 			id: 'shippingAddress',
 			label: 'Shipping Address',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'shippingCity',
 			label: 'Shipping City',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'shippingPostalCode',
 			label: 'Shipping Postal Code',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'shippingCountry',
 			label: 'Shipping Country',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'billingAddress',
 			label: 'Billing Address',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'billingCity',
 			label: 'Billing City',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'billingPostalCode',
 			label: 'Billing Postal Code',
-			type: 'text',
+			type: 'string',
 		},
 		{
 			id: 'vat',
@@ -108,7 +108,7 @@ const LayoutRowComponent = ( {
 		{
 			id: 'plan',
 			label: 'Plan',
-			type: 'text',
+			type: 'string',
 			Edit: 'toggleGroup',
 			elements: [
 				{ value: 'basic', label: 'Basic' },
@@ -119,7 +119,7 @@ const LayoutRowComponent = ( {
 		{
 			id: 'renewal',
 			label: 'Renewal',
-			type: 'text',
+			type: 'string',
 			Edit: 'radio',
 			elements: [
 				{ value: 'weekly', label: 'Weekly' },

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -510,7 +510,7 @@ const ValidationComponent = ( {
 		return [
 			{
 				id: 'text',
-				type: 'text',
+				type: 'string',
 				label: 'Text',
 				placeholder: getValidationPlaceholder(
 					'user_name (alphanumeric+underscore)',
@@ -533,7 +533,7 @@ const ValidationComponent = ( {
 			},
 			{
 				id: 'select',
-				type: 'text',
+				type: 'string',
 				label: 'Select',
 				elements:
 					elements === 'async'
@@ -552,7 +552,7 @@ const ValidationComponent = ( {
 			},
 			{
 				id: 'textWithRadio',
-				type: 'text',
+				type: 'string',
 				Edit: 'radio',
 				label: 'Text with radio',
 				elements:
@@ -574,7 +574,7 @@ const ValidationComponent = ( {
 			},
 			{
 				id: 'textarea',
-				type: 'text',
+				type: 'string',
 				Edit: 'textarea',
 				label: 'Textarea',
 				placeholder: minMax ? 'Min 10, max 200 characters' : undefined,
@@ -782,7 +782,7 @@ const ValidationComponent = ( {
 			},
 			{
 				id: 'toggleGroup',
-				type: 'text',
+				type: 'string',
 				label: 'Toggle Group',
 				Edit: 'toggleGroup',
 				elements:
@@ -805,7 +805,7 @@ const ValidationComponent = ( {
 			},
 			{
 				id: 'combobox',
-				type: 'text',
+				type: 'string',
 				Edit: 'combobox',
 				label: 'Combobox',
 				placeholder: 'Search and select a fruit',

--- a/packages/dataviews/src/dataform/stories/visibility.tsx
+++ b/packages/dataviews/src/dataform/stories/visibility.tsx
@@ -30,7 +30,7 @@ const VisibilityComponent = () => {
 		{
 			id: 'name',
 			label: 'Name',
-			type: 'text',
+			type: 'string',
 			isVisible: ( post ) => post.isActive === true,
 		},
 		{

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -15,17 +15,17 @@ const fields = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text' as const,
+		type: 'string',
 	},
 	{
 		id: 'order',
 		label: 'Order',
-		type: 'integer' as const,
+		type: 'integer',
 	},
 	{
 		id: 'author',
 		label: 'Author',
-		type: 'integer' as const,
+		type: 'integer',
 		elements: [
 			{ value: 1, label: 'Jane' },
 			{ value: 2, label: 'John' },
@@ -151,7 +151,7 @@ describe( 'DataForm component', () => {
 				{
 					id: 'price',
 					label: 'Price',
-					type: 'number' as const,
+					type: 'number',
 				},
 			];
 			const formWithNumber = {
@@ -213,7 +213,7 @@ describe( 'DataForm component', () => {
 			layout: {
 				type: 'panel',
 				labelPosition: 'side',
-			} as const,
+			},
 		};
 		it( 'should display fields', async () => {
 			render(
@@ -270,7 +270,7 @@ describe( 'DataForm component', () => {
 					type: 'panel',
 					labelPosition: 'side',
 					openAs: 'dropdown',
-				} as const,
+				},
 			};
 
 			render(
@@ -299,7 +299,7 @@ describe( 'DataForm component', () => {
 					type: 'panel',
 					labelPosition: 'side',
 					openAs: 'modal',
-				} as const,
+				},
 			};
 
 			render(
@@ -329,7 +329,7 @@ describe( 'DataForm component', () => {
 					type: 'panel',
 					labelPosition: 'side',
 					openAs: 'modal',
-				} as const,
+				},
 			};
 
 			render(
@@ -366,7 +366,7 @@ describe( 'DataForm component', () => {
 					type: 'panel',
 					labelPosition: 'side',
 					openAs: 'modal',
-				} as const,
+				},
 			};
 
 			render(

--- a/packages/dataviews/src/dataviews-picker/stories/fixtures.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/fixtures.tsx
@@ -332,7 +332,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Title',
 		id: 'title',
-		type: 'text',
+		type: 'string',
 		enableHiding: true,
 		enableGlobalSearch: true,
 		filterBy: {
@@ -404,7 +404,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Description',
 		id: 'description',
-		type: 'text',
+		type: 'string',
 		enableSorting: false,
 		enableGlobalSearch: true,
 		filterBy: {

--- a/packages/dataviews/src/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/dataviews/stories/fixtures.tsx
@@ -403,7 +403,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Title',
 		id: 'title',
-		type: 'text',
+		type: 'string',
 		enableHiding: true,
 		enableGlobalSearch: true,
 		filterBy: {
@@ -479,7 +479,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Description',
 		id: 'description',
-		type: 'text',
+		type: 'string',
 		enableSorting: false,
 		enableGlobalSearch: true,
 		filterBy: {
@@ -527,7 +527,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Author',
 		id: 'author',
-		type: 'text',
+		type: 'string',
 		enableHiding: false,
 		enableGlobalSearch: true,
 		elements: [

--- a/packages/dataviews/src/dataviews/stories/layout-activity.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-activity.tsx
@@ -372,14 +372,14 @@ export const orderEventFields: Field< OrderEvent >[] = [
 	{
 		label: 'Order',
 		id: 'orderNumber',
-		type: 'text',
+		type: 'string',
 		enableHiding: true,
 		enableSorting: false,
 	},
 	{
 		label: 'Title',
 		id: 'title',
-		type: 'text',
+		type: 'string',
 		enableHiding: true,
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name.title,
@@ -391,7 +391,7 @@ export const orderEventFields: Field< OrderEvent >[] = [
 	{
 		label: 'Description',
 		id: 'description',
-		type: 'text',
+		type: 'string',
 		enableSorting: false,
 		enableGlobalSearch: true,
 		getValue: ( { item } ) => item.name.description,

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -30,7 +30,7 @@ type Data = {
 };
 
 const DEFAULT_VIEW = {
-	type: 'table' as const,
+	type: 'table',
 	search: '',
 	page: 1,
 	perPage: 10,
@@ -49,17 +49,17 @@ const fields = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text' as const,
+		type: 'string',
 	},
 	{
 		id: 'order',
 		label: 'Order',
-		type: 'integer' as const,
+		type: 'integer',
 	},
 	{
 		id: 'author',
 		label: 'Author',
-		type: 'integer' as const,
+		type: 'integer',
 		elements: [
 			{ value: 1, label: 'Jane' },
 			{ value: 2, label: 'John' },
@@ -208,7 +208,7 @@ describe( 'DataViews component', () => {
 					{
 						id: 'author',
 						label: 'Author',
-						type: 'integer' as const,
+						type: 'integer',
 						elements: [
 							{ value: 1, label: 'Jane' },
 							{ value: 2, label: 'John' },
@@ -229,7 +229,7 @@ describe( 'DataViews component', () => {
 					{
 						id: 'title',
 						label: 'Title',
-						type: 'text' as const,
+						type: 'string',
 						render: ( { item }: { item: Data } ) => {
 							return item.title?.toUpperCase();
 						},

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -16,7 +16,7 @@ import setValueFromId from './utils/set-value-from-id';
 import { default as email } from './email';
 import { default as integer } from './integer';
 import { default as number } from './number';
-import { default as text } from './text';
+import { default as string } from './string';
 import { default as datetime } from './datetime';
 import { default as date } from './date';
 import { default as boolean } from './boolean';
@@ -42,7 +42,7 @@ function getFieldTypeByName< Item >( type?: FieldTypeName ): FieldType< Item > {
 		email,
 		integer,
 		number,
-		text,
+		string,
 		datetime,
 		date,
 		boolean,

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -197,13 +197,13 @@ function generateAdditionalElements(
 const fields: Field< DataType >[] = [
 	{
 		id: 'text',
-		type: 'text',
+		type: 'string',
 		label: 'Text',
 		description: 'Help for text.',
 	},
 	{
 		id: 'textWithElements',
-		type: 'text',
+		type: 'string',
 		label: 'Text (with elements)',
 		description: 'Help for text with elements.',
 		elements: [
@@ -214,7 +214,7 @@ const fields: Field< DataType >[] = [
 	},
 	{
 		id: 'textWithRadio',
-		type: 'text',
+		type: 'string',
 		label: 'Text (with radio)',
 		description: 'Help for text with radio.',
 		Edit: 'radio',
@@ -226,7 +226,7 @@ const fields: Field< DataType >[] = [
 	},
 	{
 		id: 'textWithTextarea',
-		type: 'text',
+		type: 'string',
 		label: 'Textarea',
 		description: 'Help for textarea.',
 		Edit: 'textarea',
@@ -510,7 +510,7 @@ const fields: Field< DataType >[] = [
 	{
 		id: 'priceWithPrefix',
 		label: 'Text with Prefix',
-		type: 'text',
+		type: 'string',
 		description: 'Text field with dollar sign prefix.',
 		Edit: {
 			control: 'text',
@@ -520,7 +520,7 @@ const fields: Field< DataType >[] = [
 	{
 		id: 'ratingWithIcon',
 		label: 'Text with Icon Prefix',
-		type: 'text',
+		type: 'string',
 		description: 'Text field with star icon prefix.',
 		Edit: {
 			control: 'text',
@@ -530,7 +530,7 @@ const fields: Field< DataType >[] = [
 	{
 		id: 'percentageWithSuffix',
 		label: 'Text with Suffix',
-		type: 'text',
+		type: 'string',
 		description: 'Text field with percent sign suffix.',
 		Edit: {
 			control: 'text',
@@ -540,7 +540,7 @@ const fields: Field< DataType >[] = [
 	{
 		id: 'priceWithBoth',
 		label: 'Text with Prefix and Suffix',
-		type: 'text',
+		type: 'string',
 		description: 'Text field with both dollar prefix and USD suffix.',
 		Edit: {
 			control: 'text',
@@ -774,7 +774,7 @@ export const TextComponent = ( {
 	manyElements: boolean;
 } ) => {
 	const textFields = useMemo(
-		() => fields.filter( ( field ) => field.type === 'text' ),
+		() => fields.filter( ( field ) => field.type === 'string' ),
 		[]
 	);
 
@@ -788,7 +788,7 @@ export const TextComponent = ( {
 		/>
 	);
 };
-TextComponent.storyName = 'text';
+TextComponent.storyName = 'string';
 
 export const IntegerComponent = ( {
 	type,

--- a/packages/dataviews/src/field-types/string.tsx
+++ b/packages/dataviews/src/field-types/string.tsx
@@ -23,7 +23,7 @@ import isValidElements from './utils/is-valid-elements';
 import getValueFormatted from './utils/get-value-formatted-default';
 
 export default {
-	type: 'text',
+	type: 'string',
 	render,
 	Edit: 'text',
 	sort,

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -376,7 +376,7 @@ describe( 'normalizeFields: default getValue', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 				},
 			];
 			const normalizedFields = normalizeFields( fields );

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -337,7 +337,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					elements: [
 						{ value: 'draft', label: 'Draft' },
 						{ value: 'published', label: 'Published' },
@@ -362,7 +362,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					elements: [
 						{ value: 'draft', label: 'Draft' },
 						{ value: 'published', label: 'Published' },
@@ -516,7 +516,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						pattern: '^[a-zA-Z0-9_]+$',
 					},
@@ -537,7 +537,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						pattern: '^[a-zA-Z0-9_]+$',
 					},
@@ -558,7 +558,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						pattern: '^[a-zA-Z0-9_]+$',
 					},
@@ -747,7 +747,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						pattern: '[invalid(regex',
 					},
@@ -1052,7 +1052,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						minLength: 5,
 					},
@@ -1073,7 +1073,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						minLength: 5,
 					},
@@ -1094,7 +1094,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						minLength: 5,
 					},
@@ -1115,7 +1115,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						minLength: 5,
 					},
@@ -1313,7 +1313,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						maxLength: 10,
 					},
@@ -1334,7 +1334,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						maxLength: 10,
 					},
@@ -1355,7 +1355,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						maxLength: 10,
 					},
@@ -1376,7 +1376,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'username',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						maxLength: 10,
 					},
@@ -1652,7 +1652,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< any >[] = [
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					getElements: async () =>
 						await new Promise( ( resolve ) => {
 							setTimeout( resolve, 5 );
@@ -1698,7 +1698,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						custom: async () =>
 							await new Promise( ( resolve ) =>
@@ -1708,7 +1708,7 @@ describe( 'useFormValidity', () => {
 				},
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						custom: async () =>
 							await new Promise( ( resolve ) =>
@@ -1739,7 +1739,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						// This promise is never resolved.
 						// Serves to test in flight behavior of validation.
@@ -1776,7 +1776,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						custom: async () =>
 							await new Promise( ( resolve ) =>
@@ -1814,7 +1814,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						// @ts-ignore returns wrong type for testing purposes
 						custom: async () =>
@@ -1853,7 +1853,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< {} >[] = [
 				{
 					id: 'title',
-					type: 'text',
+					type: 'string',
 					isValid: {
 						custom: async () =>
 							await new Promise( ( resolve, reject ) =>
@@ -1896,7 +1896,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< any >[] = [
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					getElements: async () =>
 						await new Promise( ( resolve ) => {
 							setTimeout( resolve, 5 );
@@ -1933,7 +1933,7 @@ describe( 'useFormValidity', () => {
 			const fields: Field< any >[] = [
 				{
 					id: 'status',
-					type: 'text',
+					type: 'string',
 					getElements: async () =>
 						await new Promise( ( resolve ) => {
 							setTimeout( resolve, 5 );

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -62,7 +62,7 @@ export type Operator =
 	| 'over';
 
 export type FieldTypeName =
-	| 'text'
+	| 'string'
 	| 'integer'
 	| 'number'
 	| 'datetime'
@@ -156,11 +156,32 @@ export type EditConfigText = {
 	suffix?: React.ComponentType;
 };
 
+export type ControlTypeName =
+	| 'adaptiveSelect'
+	| 'array'
+	| 'checkbox'
+	| 'color'
+	| 'combobox'
+	| 'datetime'
+	| 'date'
+	| 'email'
+	| 'telephone'
+	| 'url'
+	| 'integer'
+	| 'number'
+	| 'password'
+	| 'radio'
+	| 'select'
+	| 'text'
+	| 'toggle'
+	| 'textarea'
+	| 'toggleGroup';
+
 /**
  * Edit configuration for other control types (excluding 'text' and 'textarea').
  */
 export type EditConfigGeneric = {
-	control: Exclude< FieldTypeName, 'text' | 'textarea' >;
+	control: Exclude< ControlTypeName, 'text' | 'textarea' >;
 };
 
 /**

--- a/packages/fields/src/fields/comment-status/index.tsx
+++ b/packages/fields/src/fields/comment-status/index.tsx
@@ -12,7 +12,7 @@ import type { BasePost } from '../../types';
 const commentStatusField: Field< BasePost > = {
 	id: 'comment_status',
 	label: __( 'Comments' ),
-	type: 'text',
+	type: 'string',
 	Edit: 'radio',
 	enableSorting: false,
 	enableHiding: false,

--- a/packages/fields/src/fields/discussion/index.tsx
+++ b/packages/fields/src/fields/discussion/index.tsx
@@ -12,7 +12,7 @@ import type { BasePost } from '../../types';
 const discussionField: Field< BasePost > = {
 	id: 'discussion',
 	label: __( 'Discussion' ),
-	type: 'text',
+	type: 'string',
 	render: ( { item } ) => {
 		const commentsOpen = item.comment_status === 'open';
 		const pingsOpen = item.ping_status === 'open';

--- a/packages/fields/src/fields/page-title/index.ts
+++ b/packages/fields/src/fields/page-title/index.ts
@@ -12,7 +12,7 @@ import { getItemTitle } from '../../actions/utils';
 import PageTitleView from './view';
 
 const pageTitleField: Field< BasePost > = {
-	type: 'text',
+	type: 'string',
 	id: 'title',
 	label: __( 'Title' ),
 	placeholder: __( 'No title' ),

--- a/packages/fields/src/fields/parent/index.ts
+++ b/packages/fields/src/fields/parent/index.ts
@@ -13,7 +13,7 @@ import { ParentView } from './parent-view';
 
 const parentField: Field< BasePost > = {
 	id: 'parent',
-	type: 'text',
+	type: 'string',
 	label: __( 'Parent' ),
 	Edit: ParentEdit,
 	render: ParentView,

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -12,7 +12,7 @@ import PasswordEdit from './edit';
 
 const passwordField: Field< BasePost > = {
 	id: 'password',
-	type: 'text',
+	type: 'string',
 	label: __( 'Password' ),
 	Edit: PasswordEdit,
 	enableSorting: false,

--- a/packages/fields/src/fields/pattern-title/index.ts
+++ b/packages/fields/src/fields/pattern-title/index.ts
@@ -12,7 +12,7 @@ import { getItemTitle } from '../../actions/utils';
 import PatternTitleView from './view';
 
 const patternTitleField: Field< Pattern > = {
-	type: 'text',
+	type: 'string',
 	id: 'title',
 	label: __( 'Title' ),
 	placeholder: __( 'No title' ),

--- a/packages/fields/src/fields/ping-status/index.tsx
+++ b/packages/fields/src/fields/ping-status/index.tsx
@@ -44,7 +44,7 @@ function PingStatusEdit( {
 const pingStatusField: Field< BasePost > = {
 	id: 'ping_status',
 	label: __( 'Trackbacks & Pingbacks' ),
-	type: 'text',
+	type: 'string',
 	Edit: PingStatusEdit,
 	enableSorting: false,
 	enableHiding: false,

--- a/packages/fields/src/fields/slug/index.ts
+++ b/packages/fields/src/fields/slug/index.ts
@@ -13,7 +13,7 @@ import SlugView from './slug-view';
 
 const slugField: Field< BasePost > = {
 	id: 'slug',
-	type: 'text',
+	type: 'string',
 	label: __( 'Slug' ),
 	Edit: SlugEdit,
 	render: SlugView,

--- a/packages/fields/src/fields/status/index.tsx
+++ b/packages/fields/src/fields/status/index.tsx
@@ -16,7 +16,7 @@ const OPERATOR_IS_ANY = 'isAny';
 const statusField: Field< BasePost > = {
 	label: __( 'Status' ),
 	id: 'status',
-	type: 'text',
+	type: 'string',
 	elements: STATUSES,
 	render: StatusView,
 	Edit: 'radio',

--- a/packages/fields/src/fields/template-title/index.ts
+++ b/packages/fields/src/fields/template-title/index.ts
@@ -12,7 +12,7 @@ import { getItemTitle } from '../../actions/utils';
 import TitleView from '../title/view';
 
 const templateTitleField: Field< Template > = {
-	type: 'text',
+	type: 'string',
 	label: __( 'Template' ),
 	placeholder: __( 'No title' ),
 	id: 'title',

--- a/packages/fields/src/fields/template/index.ts
+++ b/packages/fields/src/fields/template/index.ts
@@ -12,7 +12,7 @@ import { TemplateEdit } from './template-edit';
 
 const templateField: Field< BasePost > = {
 	id: 'template',
-	type: 'text',
+	type: 'string',
 	label: __( 'Template' ),
 	Edit: TemplateEdit,
 	enableSorting: false,

--- a/packages/fields/src/fields/title/index.ts
+++ b/packages/fields/src/fields/title/index.ts
@@ -12,7 +12,7 @@ import { getItemTitle } from '../../actions/utils';
 import TitleView from './view';
 
 const titleField: Field< CommonPost > = {
-	type: 'text',
+	type: 'string',
 	id: 'title',
 	label: __( 'Title' ),
 	placeholder: __( 'No title' ),

--- a/packages/media-editor/README.md
+++ b/packages/media-editor/README.md
@@ -41,8 +41,8 @@ function MyMediaEditor( { mediaId } ) {
 
 	// Define fields using the Field type from @wordpress/dataviews
 	const fields: Field[] = [
-		{ id: 'title', label: 'Title', type: 'text' },
-		{ id: 'alt_text', label: 'Alt Text', type: 'text' },
+		{ id: 'title', label: 'Title', type: 'string' },
+		{ id: 'alt_text', label: 'Alt Text', type: 'string' },
 		{ id: 'caption', label: 'Caption', type: 'textarea' },
 		{ id: 'description', label: 'Description', type: 'textarea' },
 	];

--- a/packages/media-fields/src/alt_text/index.tsx
+++ b/packages/media-fields/src/alt_text/index.tsx
@@ -8,7 +8,7 @@ import type { Attachment, Updatable } from '@wordpress/core-data';
 
 const altTextField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'alt_text',
-	type: 'text',
+	type: 'string',
 	label: __( 'Alt text' ),
 	isVisible: ( item ) => item?.media_type === 'image',
 	render: ( { item } ) => item?.alt_text || '-',

--- a/packages/media-fields/src/attached_to/index.tsx
+++ b/packages/media-fields/src/attached_to/index.tsx
@@ -13,7 +13,7 @@ import MediaAttachedToEdit from './edit';
 
 const attachedToField: Partial< Field< MediaItem > > = {
 	id: 'attached_to',
-	type: 'text',
+	type: 'string',
 	label: __( 'Attached to' ),
 	Edit: MediaAttachedToEdit,
 	render: MediaAttachedToView,

--- a/packages/media-fields/src/caption/index.tsx
+++ b/packages/media-fields/src/caption/index.tsx
@@ -13,7 +13,7 @@ import { getRawContent } from '../utils/get-raw-content';
 
 const captionField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'caption',
-	type: 'text',
+	type: 'string',
 	label: __( 'Caption' ),
 	getValue: ( { item } ) => getRawContent( item?.caption ),
 	render: ( { item } ) => getRawContent( item?.caption ) || '-',

--- a/packages/media-fields/src/description/index.tsx
+++ b/packages/media-fields/src/description/index.tsx
@@ -13,7 +13,7 @@ import { getRawContent } from '../utils/get-raw-content';
 
 const descriptionField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'description',
-	type: 'text',
+	type: 'string',
 	label: __( 'Description' ),
 	getValue: ( { item } ) => getRawContent( item?.description ),
 	render: ( { item } ) => (

--- a/packages/media-fields/src/filename/index.ts
+++ b/packages/media-fields/src/filename/index.ts
@@ -13,7 +13,7 @@ import FileNameView from './view';
 
 const filenameField: Partial< Field< MediaItem > > = {
 	id: 'filename',
-	type: 'text',
+	type: 'string',
 	label: __( 'File name' ),
 	getValue: ( { item }: { item: MediaItem } ) =>
 		getFilename( item?.source_url || '' ),

--- a/packages/media-fields/src/filename/test/index.test.ts
+++ b/packages/media-fields/src/filename/test/index.test.ts
@@ -8,7 +8,7 @@ describe( 'filenameField', () => {
 	it( 'has correct field configuration', () => {
 		expect( filenameField ).toMatchObject( {
 			id: 'filename',
-			type: 'text',
+			type: 'string',
 			label: 'File name',
 			enableSorting: false,
 			filterBy: false,

--- a/packages/media-fields/src/filesize/index.tsx
+++ b/packages/media-fields/src/filesize/index.tsx
@@ -79,7 +79,7 @@ function formatFileSize( bytes: number, decimals = 2 ): string {
 
 const filesizeField: Partial< Field< MediaItem > > = {
 	id: 'filesize',
-	type: 'text',
+	type: 'string',
 	label: __( 'File size' ),
 	getValue: ( { item }: { item: MediaItem } ) =>
 		item?.media_details?.filesize

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -8,7 +8,7 @@ describe( 'filesizeField', () => {
 	it( 'has correct field configuration', () => {
 		expect( filesizeField ).toMatchObject( {
 			id: 'filesize',
-			type: 'text',
+			type: 'string',
 			label: 'File size',
 			enableSorting: false,
 			filterBy: false,

--- a/packages/media-fields/src/media_dimensions/index.ts
+++ b/packages/media-fields/src/media_dimensions/index.ts
@@ -7,7 +7,7 @@ import type { Field } from '@wordpress/dataviews';
 
 const mediaDimensionsField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'media_dimensions',
-	type: 'text',
+	type: 'string',
 	label: __( 'Dimensions' ),
 	getValue: ( { item } ) =>
 		item?.media_details?.width && item?.media_details?.height

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -12,7 +12,7 @@ describe( 'mediaDimensionsField', () => {
 	it( 'has correct field configuration', () => {
 		expect( mediaDimensionsField ).toMatchObject( {
 			id: 'media_dimensions',
-			type: 'text',
+			type: 'string',
 			label: 'Dimensions',
 			enableSorting: false,
 			filterBy: false,

--- a/packages/media-fields/src/mime_type/index.ts
+++ b/packages/media-fields/src/mime_type/index.ts
@@ -7,7 +7,7 @@ import type { Field } from '@wordpress/dataviews';
 
 const mimeTypeField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'mime_type',
-	type: 'text',
+	type: 'string',
 	label: __( 'File type' ),
 	getValue: ( { item } ) => item?.mime_type || '',
 	render: ( { item } ) => item?.mime_type || '-',

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -273,7 +273,7 @@ export function MediaUploadModal( {
 			},
 			{
 				id: 'title',
-				type: 'text' as const,
+				type: 'string',
 				label: __( 'Title' ),
 				getValue: ( { item }: { item: RestAttachment } ) => {
 					const titleValue = item.title.raw || item.title.rendered;


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/74102

## What?

This PR renames the `text` field type to be `string`. 

## Why?

So it's aligned with block.json and the block-based controls we create going forward (PHP-only, block fields), don't need any type mapping — both block.json and the Field API use `string`.

## How?

Before | After
--- | ---
Field type `text` | `string`

Not done:

- elements/getElements/useElements to enum/getEnum/useEnum.

While they reflect similar concerns, they have a different shape: `enum` is a list of values, `elements` is a list of options (object with value/label properties). If we were to do the rename, I argue we should support the block.json shape (a list of values) and we could remove this [code](https://github.com/WordPress/gutenberg/blob/0ff122fd3ba1300dd72045c1ddcb632e7bbce4b6/packages/block-editor/src/hooks/generate-fields-from-attributes.js#L55-L58).

## Testing Instructions

- Smoke test stories: DataViews, DataForm, DataviewsPicker, Fields.
- Smoke test the site editor: Pages, Templates, Patterns.
