### PR TITLE
Widget Group: Remove parent outline

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -202,11 +202,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		background-color: transparent;
 	}
 
-	// Reusable blocks parent border.
-	&.is-reusable.has-child-selected::after {
-		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
-	}
-
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;

--- a/packages/widgets/src/blocks/widget-group/editor.scss
+++ b/packages/widgets/src/blocks/widget-group/editor.scss
@@ -2,17 +2,6 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .wp-block-widget-group {
-	&.has-child-selected::after {
-		border-radius: $radius-small;
-		border: $border-width solid var(--wp-admin-theme-color);
-		bottom: 0;
-		content: "";
-		left: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
-
 	.widget-title {
 		font-family: $default-font;
 		font-size: 18px;


### PR DESCRIPTION
## What?
Closes #74062

PR removes parent block outline for Widget Group when child block is selected. This pseudo-element for outline intercepts clicks in some cases and moves the selection to the parent block, which can cause bugs as described in the issue.

## Testing Instructions
1. Enable classic theme.
2. Navigate to Widgets.
3. Add the Widget Group block and Social Icons as its child.
4. Add any social icon.
5. Clicking on the icon should open the URL popover.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5121852a-33dd-4f27-83d1-cbd470970a54


