### PR TITLE
LinkPicker: A11y: allow full url to be visible in link picker

### DIFF
--- a/packages/block-editor/src/components/link-picker/link-preview.js
+++ b/packages/block-editor/src/components/link-picker/link-preview.js
@@ -53,12 +53,9 @@ export function LinkPreview( { title, url, image, badges } ) {
 							{ title }
 						</Truncate>
 						{ url && (
-							<Truncate
-								numberOfLines={ 1 }
-								className="link-preview-button__hint"
-							>
+							<span className="link-preview-button__hint">
 								{ url }
-							</Truncate>
+							</span>
 						) }
 						{ badges && badges.length > 0 && (
 							<HStack

--- a/packages/block-editor/src/components/link-picker/style.scss
+++ b/packages/block-editor/src/components/link-picker/style.scss
@@ -38,8 +38,7 @@
 	flex: 1;
 }
 
-.link-preview-button__title,
-.link-preview-button__hint {
+.link-preview-button__title {
 	min-width: 0;
 	display: block;
 	width: 100%;
@@ -47,19 +46,23 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-
-.link-preview-button__title {
 	margin-top: $grid-unit-05;
 	font-weight: 500;
 	color: $gray-900;
-	display: block;
+	word-spacing: normal;
 }
 
 .link-preview-button__hint {
+	min-width: 0;
+	display: block;
+	width: 100%;
+	text-align: left;
 	font-size: $helptext-font-size;
 	color: $gray-700;
 	font-weight: 400;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	white-space: normal;
 }
 
 .link-preview-button__icon {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes an issue raised by @joedolson where [sighted users and screen users had different information](https://github.com/WordPress/gutenberg/pull/73830/#issuecomment-3671105132). Screen readers got the full url and sighted users only got truncated text. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Truncating the url doesn't allow for differentiation of the important part of the selected url. Often there are multiple similarly named pages, only differentiated by a number at the end. Showing the full url allows more confidence in the url you selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Rework CSS to not truncate the URL if it's long

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Turn on pretty permalinks with post-name or similar as the type
- Add a navigation link with a very long title
- View the inspector sidebar for this link
- The url should wrap and not be truncated within the link picker button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="280" height="150" alt="link picker with truncated url" src="https://github.com/user-attachments/assets/cd3a0701-85a3-459d-9bb0-845ada4042da" />|<img width="281" height="168" alt="link picker with full url" src="https://github.com/user-attachments/assets/057e6063-4cae-4c8b-b8f6-89211cd038e6" />
|

