### PR TITLE
Notes: use standard dark canvas background instead of global styles background

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -23,7 +23,6 @@ import { Comments } from './comments';
 import { store as editorStore } from '../../store';
 import AddCommentMenuItem from './comment-menu-item';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
-import { useGlobalStylesContext } from '../global-styles-provider';
 import {
 	useBlockComments,
 	useBlockCommentsActions,
@@ -122,10 +121,6 @@ function NotesSidebar( { postId, mode } ) {
 				newNoteFormState !== 'closed' )
 	);
 
-	// Get the global styles to set the background color of the sidebar.
-	const { merged: GlobalStyles } = useGlobalStylesContext();
-	const backgroundColor = GlobalStyles?.styles?.color?.background;
-
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
@@ -207,7 +202,6 @@ function NotesSidebar( { postId, mode } ) {
 					identifier={ collabSidebarName }
 					className="editor-collab-sidebar"
 					headerClassName="editor-collab-sidebar__header"
-					backgroundColor={ backgroundColor }
 				>
 					<NotesSidebarContent
 						comments={ unresolvedSortedThreads }
@@ -216,9 +210,6 @@ function NotesSidebar( { postId, mode } ) {
 						commentSidebarRef={ commentSidebarRef }
 						reflowComments={ reflowComments }
 						commentLastUpdated={ commentLastUpdated }
-						styles={ {
-							backgroundColor,
-						} }
 						isFloating
 					/>
 				</PluginSidebar>

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -3,8 +3,6 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .interface-interface-skeleton__sidebar:has(.editor-collab-sidebar) {
-	box-shadow: none;
-
 	.interface-complementary-area-header {
 		display: none;
 	}
@@ -19,6 +17,7 @@
 	padding: $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	height: 100%;
 	overflow: hidden;
+	background-color: var(--wp-editor-canvas-background);
 }
 
 .editor-collab-sidebar-panel__thread {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -17,7 +17,10 @@
 	padding: $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	height: 100%;
 	overflow: hidden;
-	background-color: var(--wp-editor-canvas-background);
+
+	.editor-collab-sidebar & {
+		background-color: var(--wp-editor-canvas-background);
+	}
 }
 
 .editor-collab-sidebar-panel__thread {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Context: https://wordpress.slack.com/archives/C02RQBWTW/p1764321679209489?thread_ts=1764321433.920779&cid=C02RQBWTW

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Filling in the theme backgound color outside the canvas feels buggy. 
* It makes it look like the sidebar is part of the canvas, but it's not. People think that this is part of their site, but it's not. 
* When comments are below the fold, it can be even more difficult to understand what's going on.
* On top of that, the scrollbar for the site content will feel out of place.

|Before|After|
|-|-|
|<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/5a6465cc-5e03-4de9-ac7c-4b9f6bb1e851" />|<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/dd8ed173-b411-496e-a449-75505ff729dd" />|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the, what is now standard, dark canvas background. It's the same background we use for all canvas padding:

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/70cc0b13-0014-424b-b915-76240bf9e5ff" />
<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/04c807e6-c259-44da-9639-80e93f2f2938" />
<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/bbe5b1be-446f-4c00-812e-559c1e7836d4" />
<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/28492bc1-e400-433b-bc38-634829cd1c66" />


