### PR TITLE
Build: Support Core *.php pages (screen id) when rendering single separate pages

### DIFF
--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -128,8 +128,16 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' ) ) 
 	 * @param string $hook_suffix The current admin page.
 	 */
 	function {{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
-		// Only enqueue on our page
-		if ( ! isset( $_GET['page'] ) || '{{PAGE_SLUG}}-wp-admin' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// Check all possible ways this page can be accessed:
+		// 1. Menu page via admin.php?page={{PAGE_SLUG}}-wp-admin (plugin)
+		// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
+		$current_screen = get_current_screen();
+		$is_our_page = (
+			( isset( $_GET['page'] ) && '{{PAGE_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
+		);
+
+		if ( ! $is_our_page ) {
 			return;
 		}
 


### PR DESCRIPTION
Related #72032 
Related https://github.com/WordPress/wordpress-develop/pull/10638

## What?

Use get_current_screen() for generic page detection in wp-admin pages                                   
This PR updates the page-wp-admin.php template to check both $_GET['page'] and get_current_screen()->id for page detection. This allows the same code to work in both Gutenberg plugin context (menu page access) and WordPress Core context (direct file access) without requiring transformations.