### PR TITLE
Real-time collaboration: Apply only detected changes from the persisted CRDT document

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -301,6 +301,7 @@ export function createSyncManager(): SyncManager {
 
 		targetDoc.transact( () => {
 			if ( ! supports?.crdtPersistence ) {
+				// Apply the current record as changes.
 				applyChangesToCRDTDoc( targetDoc, record );
 				return;
 			}
@@ -309,8 +310,11 @@ export function createSyncManager(): SyncManager {
 			const tempDoc = getPersistedCrdtDoc( record );
 
 			if ( ! tempDoc ) {
+				// Apply the current record as changes and trigger a save, which will
+				// persist the CRDT document. (The entity should call `createEntityMeta`
+				// via its pre-persist hook.)
 				applyChangesToCRDTDoc( targetDoc, record );
-				handlers.saveRecord(); // persist the current CRDT document
+				handlers.saveRecord();
 				return;
 			}
 
@@ -322,9 +326,16 @@ export function createSyncManager(): SyncManager {
 			Y.applyUpdateV2( targetDoc, update );
 
 			// Compute the differences between the persisted doc and the current
-			// record. This can happen when there are "out-of-band" updates (e.g., a
-			// WP-CLI command or direct database update) or when unsaved changes are
-			// synced from a peer.
+			// record. This can happen when:
+			//
+			// 1. The server makes updates on save that mutate the entity. Example: On
+			//    initial save, the server adds the "Uncategorized" category to the
+			//    post.
+			// 2. An "out-of-band" update occurs. Example: a WP-CLI command or direct
+			//    database update mutates the entity.
+			// 3. Unsaved changes are synced from a peer _before_ this code runs. We
+			//    can't control when (or if) remote changes are synced, so this is a
+			//    race condition.
 			const invalidations = getChangesFromCRDTDoc( tempDoc, record );
 			const invalidatedKeys = Object.keys( invalidations );
 
@@ -332,7 +343,7 @@ export function createSyncManager(): SyncManager {
 			tempDoc.destroy();
 
 			if ( 0 === invalidatedKeys.length ) {
-				// No invalidations.
+				// The persisted CRDT document is valid. There are no updates to apply.
 				return;
 			}
 
@@ -345,10 +356,10 @@ export function createSyncManager(): SyncManager {
 				{}
 			);
 
+			// Apply the changes and trigger a save, which will persist the CRDT
+			// document. (The entity should call `createEntityMeta` via its pre-persist
+			// hook.)
 			applyChangesToCRDTDoc( targetDoc, changes );
-
-			// Trigger a save to update the persisted CRDT document. The entity should
-			// call `createEntityMeta` via its pre-persist hook.
 			handlers.saveRecord();
 		}, LOCAL_SYNC_MANAGER_ORIGIN );
 	}

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -164,23 +164,7 @@ export function createSyncManager(): SyncManager {
 		recordMetaMap.observe( onRecordMetaUpdate );
 
 		// Get and apply the persisted CRDT document, if it exists.
-		const isInvalid = applyPersistedCrdtDoc( syncConfig, ydoc, record );
-
-		// If there is no persisted document or if it has been invalidated by out-of-
-		// band updates, apply changes from the current entity record to the CRDT
-		// document. This ensures that the CRDT document reflects the latest state of
-		// the entity record.
-		if ( isInvalid ) {
-			ydoc.transact( () => {
-				syncConfig.applyChangesToCRDTDoc( ydoc, record );
-			}, LOCAL_SYNC_MANAGER_ORIGIN );
-
-			// If the entity support CRDT persistence, trigger a save. The entity
-			// will call `createEntityMeta` via its pre-persist hook.
-			if ( syncConfig.supports?.crdtPersistence ) {
-				handlers.saveRecord();
-			}
-		}
+		applyPersistedCrdtDoc( objectType, objectId, record );
 	}
 
 	/**
@@ -285,52 +269,88 @@ export function createSyncManager(): SyncManager {
 	}
 
 	/**
-	 * Apply a persisted CRDT document to the current document, if it exists.
-	 * Return true if the document exists and is valid, otherwise false. Returning
-	 * a boolean allows us to destroy the temporary document and prevent it from
-	 * leaking out.
+	 * Load and inspect the persisted CRDT document. If supported and it exists,
+	 * compare it against the current entity record. If there are differences,
+	 * apply the changes from the entity record.
 	 *
-	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
-	 * @param {CRDTDoc}    targetDoc  Target CRDT doc.
+	 * @param {ObjectType} objectType Object type.
+	 * @param {ObjectID}   objectId   Object ID.
 	 * @param {ObjectData} record     Entity record representing this object type.
-	 * @return {boolean} Whether the persisted document is non-existent or invalid.
 	 */
 	function applyPersistedCrdtDoc(
-		syncConfig: SyncConfig,
-		targetDoc: CRDTDoc,
+		objectType: ObjectType,
+		objectId: ObjectID,
 		record: ObjectData
-	): boolean {
-		if ( ! syncConfig.supports?.crdtPersistence ) {
-			return true;
+	): void {
+		const entityId = getEntityId( objectType, objectId );
+		const entityState = entityStates.get( entityId );
+
+		if ( ! entityState ) {
+			return;
 		}
 
-		// Get the persisted CRDT document, if it exists.
-		const tempDoc = getPersistedCrdtDoc( record );
+		const {
+			handlers,
+			syncConfig: {
+				applyChangesToCRDTDoc,
+				getChangesFromCRDTDoc,
+				supports,
+			},
+			ydoc: targetDoc,
+		} = entityState;
 
-		if ( ! tempDoc ) {
-			return true;
-		}
-
-		// Apply the persisted document to the current document as a singular update.
-		// This is done even if the persisted document has been invalidated. This
-		// prevents a newly joining peer (or refreshing user) from re-initializing
-		// the CRDT document (the "initialization problem").
-		const update = Y.encodeStateAsUpdateV2( tempDoc );
 		targetDoc.transact( () => {
+			if ( ! supports?.crdtPersistence ) {
+				applyChangesToCRDTDoc( targetDoc, record );
+				return;
+			}
+
+			// Get the persisted CRDT document, if it exists.
+			const tempDoc = getPersistedCrdtDoc( record );
+
+			if ( ! tempDoc ) {
+				applyChangesToCRDTDoc( targetDoc, record );
+				handlers.saveRecord(); // persist the current CRDT document
+				return;
+			}
+
+			// Apply the persisted document to the current document as a single update.
+			// This is done even if the persisted document has been invalidated. This
+			// prevents a newly joining peer (or refreshing user) from re-initializing
+			// the CRDT document (the "initialization problem").
+			const update = Y.encodeStateAsUpdateV2( tempDoc );
 			Y.applyUpdateV2( targetDoc, update );
+
+			// Compute the differences between the persisted doc and the current
+			// record. This can happen when there are "out-of-band" updates (e.g., a
+			// WP-CLI command or direct database update) or when unsaved changes are
+			// synced from a peer.
+			const invalidations = getChangesFromCRDTDoc( tempDoc, record );
+			const invalidatedKeys = Object.keys( invalidations );
+
+			// Destroy the temporary document to prevent leaks.
+			tempDoc.destroy();
+
+			if ( 0 === invalidatedKeys.length ) {
+				// No invalidations.
+				return;
+			}
+
+			// Use the invalidated keys to get the updated values from the entity.
+			const changes = invalidatedKeys.reduce(
+				( acc, key ) =>
+					Object.assign( acc, {
+						[ key ]: record[ key ],
+					} ),
+				{}
+			);
+
+			applyChangesToCRDTDoc( targetDoc, changes );
+
+			// Trigger a save to update the persisted CRDT document. The entity should
+			// call `createEntityMeta` via its pre-persist hook.
+			handlers.saveRecord();
 		}, LOCAL_SYNC_MANAGER_ORIGIN );
-
-		// Check if the persisted doc has been invalidated by out-of-band updates
-		// (e.g., a WP CLI command or direct database update) by determining if the
-		// persisted document introduces any changes that are not present in the
-		// current record. If it has been invalidated, then we return true as a
-		// signal that we need to apply the entity record to the target document.
-		const changes = syncConfig.getChangesFromCRDTDoc( tempDoc, record );
-
-		// Destroy the temporary document to prevent leaks.
-		tempDoc.destroy();
-
-		return Object.keys( changes ).length > 0;
 	}
 
 	/**

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -95,11 +95,13 @@ describe( 'SyncManager', () => {
 		};
 
 		mockHandlers = {
+			addUndoMeta: jest.fn(),
 			editRecord: jest.fn(),
 			getEditedRecord: jest.fn( async () =>
 				Promise.resolve( mockRecord )
 			),
 			refetchRecord: jest.fn( async () => Promise.resolve() ),
+			restoreUndoMeta: jest.fn(),
 			saveRecord: jest.fn( async () => Promise.resolve() ),
 		};
 	} );
@@ -276,16 +278,6 @@ describe( 'SyncManager', () => {
 					mockSyncConfig.applyChangesToCRDTDoc
 				).toHaveBeenCalledWith( expect.any( Y.Doc ), mockRecord );
 
-				// Changes should be correctly applied.
-				const mockCall =
-					mockSyncConfig.applyChangesToCRDTDoc.mock.calls[ 0 ];
-				const targetDoc = mockCall[ 0 ] as Y.Doc;
-				const appliedChanges = mockCall[ 1 ] as ObjectData;
-				expect(
-					targetDoc.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
-				).toBeUndefined();
-				expect( appliedChanges.title ).toStrictEqual( 'Test Post' );
-
 				// getChangesFromCRDTDoc should not be called since there was no persisted doc.
 				expect(
 					mockSyncConfig.getChangesFromCRDTDoc
@@ -295,7 +287,7 @@ describe( 'SyncManager', () => {
 				expect( mockHandlers.saveRecord ).toHaveBeenCalledTimes( 1 );
 			} );
 
-			it( 'applies a valid persisted CRDT doc without applying the current record', async () => {
+			it( 'accepts a valid persisted CRDT doc without applying changes', async () => {
 				const record = createRecordWithPersistedCRDTDoc( mockRecord );
 
 				mockSyncConfig = {
@@ -313,7 +305,7 @@ describe( 'SyncManager', () => {
 					mockHandlers
 				);
 
-				// Current record should NOT be applied since the persisted doc is valid.
+				// Changes should NOT be applied since the persisted doc is valid.
 				expect(
 					mockSyncConfig.applyChangesToCRDTDoc
 				).not.toHaveBeenCalled();
@@ -331,9 +323,10 @@ describe( 'SyncManager', () => {
 				expect( mockHandlers.saveRecord ).not.toHaveBeenCalled();
 			} );
 
-			it( 'applies an invalid persisted CRDT doc, then applies the current record', async () => {
+			it( 'applies an invalid CRDT doc, then applies changes', async () => {
 				const record = createRecordWithPersistedCRDTDoc( mockRecord, {
-					title: 'Title from persisted CRDT doc',
+					...mockRecord,
+					title: 'Invalidated title from persisted CRDT doc',
 				} );
 
 				mockSyncConfig = {
@@ -351,23 +344,17 @@ describe( 'SyncManager', () => {
 					mockHandlers
 				);
 
-				// Current record should be applied since the persisted doc is invalid.
+				// Changes should be applied for the invalidated properties.
+				const expectedChanges = {
+					title: mockRecord.title,
+				};
+
 				expect(
 					mockSyncConfig.applyChangesToCRDTDoc
 				).toHaveBeenCalledTimes( 1 );
 				expect(
 					mockSyncConfig.applyChangesToCRDTDoc
-				).toHaveBeenCalledWith( expect.any( Y.Doc ), record );
-
-				// Changes should be correctly applied.
-				const mockCall =
-					mockSyncConfig.applyChangesToCRDTDoc.mock.calls[ 0 ];
-				const targetDoc = mockCall[ 0 ] as Y.Doc;
-				const appliedChanges = mockCall[ 1 ] as ObjectData;
-				expect(
-					targetDoc.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
-				).toStrictEqual( 'Title from persisted CRDT doc' );
-				expect( appliedChanges.title ).toStrictEqual( 'Test Post' );
+				).toHaveBeenCalledWith( expect.any( Y.Doc ), expectedChanges );
 
 				// getChangesFromCRDTDoc should be called with the persisted doc and record.
 				expect(
@@ -383,6 +370,7 @@ describe( 'SyncManager', () => {
 
 			it( 'ignores a persisted CRDT doc when CRDT persistence is not supported', async () => {
 				const record = createRecordWithPersistedCRDTDoc( mockRecord, {
+					...mockRecord,
 					title: 'Persisted Title',
 				} );
 
@@ -403,16 +391,6 @@ describe( 'SyncManager', () => {
 				expect(
 					mockSyncConfig.applyChangesToCRDTDoc
 				).toHaveBeenCalledWith( expect.any( Y.Doc ), record );
-
-				// Changes should be correctly applied.
-				const mockCall =
-					mockSyncConfig.applyChangesToCRDTDoc.mock.calls[ 0 ];
-				const targetDoc = mockCall[ 0 ] as Y.Doc;
-				const appliedChanges = mockCall[ 1 ] as ObjectData;
-				expect(
-					targetDoc.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
-				).toBeUndefined();
-				expect( appliedChanges.title ).toStrictEqual( 'Test Post' );
 
 				// getChangesFromCRDTDoc should not be called since the persisted doc is igored.
 				expect(


### PR DESCRIPTION
## What?

When loading and validating the persisted CRDT document, apply only the changes detected between the persisted document and the current entity record.

## Why?

When even a single difference exists between a persisted CRDT document and the current entity record, we pass the entire `record` to `applyChangesToCRDTDoc`. 

1. This is wasteful, since we already know which properties have changed.
2. It causes issues with transient properties like `blocks`—which produce different `clientId`s (UUIDs) each time they are instantiated in memory. We make a special comparison of `blocks` that effectively ignores `clientId`s in `getChangesFromCRDTDoc`, but we are unable to do the same in `applyChangesToCRDTDoc`. As a result, our syncronization of block `clientId`s is unnecessarily reset whenever a persisted CRDT document is invalided—even when the blocks are effectively identical.

## How?

Update `applyPersistedCRDTDoc` to find which entity properties have been invalidated, then pass only those changes to `applyChangesToCRDTDoc`.

## Testing Instructions

1. Check out this branch.
2. Run unit tests, which cover persisted CRDT doc invalidation.

### Testing Instructions for Keyboard
n/a
