### PR TITLE
Global Fonts: Convert relative font URLs to absolute theme URLs in font-face styles

### DIFF
--- a/lib/compat/wordpress-7.0/global-styles.php
+++ b/lib/compat/wordpress-7.0/global-styles.php
@@ -62,6 +62,17 @@ function gutenberg_get_font_face_styles() {
 				// Add the font-family property to the font-face.
 				$font_face['font-family'] = $font_family_name;
 
+				// Convert relative font URLs to absolute theme URLs.
+				if ( ! empty( $font_face['src'] ) ) {
+					$srcs = (array) $font_face['src'];
+					foreach ( $srcs as $i => $src ) {
+						if ( ! wp_parse_url( $src, PHP_URL_HOST ) ) {
+							$srcs[ $i ] = get_theme_file_uri( wp_parse_url( $src, PHP_URL_PATH ) );
+						}
+					}
+					$font_face['src'] = $srcs;
+				}
+
 				// Convert camelCase to kebab-case.
 				$converted_face = array();
 				foreach ( $font_face as $key => $value ) {

--- a/lib/compat/wordpress-7.0/global-styles.php
+++ b/lib/compat/wordpress-7.0/global-styles.php
@@ -64,13 +64,18 @@ function gutenberg_get_font_face_styles() {
 
 				// Convert relative font URLs to absolute theme URLs.
 				if ( ! empty( $font_face['src'] ) ) {
-					$srcs = (array) $font_face['src'];
-					foreach ( $srcs as $i => $src ) {
-						if ( ! wp_parse_url( $src, PHP_URL_HOST ) ) {
-							$srcs[ $i ] = get_theme_file_uri( wp_parse_url( $src, PHP_URL_PATH ) );
+					$src         = (array) $font_face['src'];
+					$placeholder = 'file:./';
+
+					foreach ( $src as $src_key => $src_url ) {
+						// Skip if the src doesn't start with the placeholder
+						if ( ! str_starts_with( $src_url, $placeholder ) ) {
+							continue;
 						}
+
+						$src_file        = str_replace( $placeholder, '', $src_url );
+						$src[ $src_key ] = get_theme_file_uri( $src_file );
 					}
-					$font_face['src'] = $srcs;
 				}
 
 				// Convert camelCase to kebab-case.


### PR DESCRIPTION
Closes #74087

After https://github.com/WordPress/gutenberg/commit/0a447bcc907383071906ab64bf15145d4a94dabb
It seems that fonts are being loaded with relative paths

This is reporting:
https://github.com/WordPress/gutenberg/blob/35b21cd6c12c03e625e290b6f4f9d61dadf16d2d/lib/compat/wordpress-7.0/global-styles.php#L117

```css
"@font-face{font-family:Inter;font-style:normal;font-weight:300 900;font-display:fallback;font-stretch:normal;src:url('file:./assets/fonts/inter/Inter-VariableFont_slnt,wght.woff2') format('woff2');}@font-face{font-family:Cardo;font-style:normal;font-weight:400;font-display:fallback;src:url('file:./assets/fonts/cardo/cardo_normal_400.woff2') format('woff2');}@font-face{font-family:Cardo;font-style:italic;font-weight:400;font-display:fallback;src:url('file:./assets/fonts/cardo/cardo_italic_400.woff2') format('woff2');}@font-face{font-family:Cardo;font-style:normal;font-weight:700;font-display:fallback;src:url('file:./assets/fonts/cardo/cardo_normal_700.woff2') format('woff2');}"
```

When using a block theme like TT4

If we are willing to maintain the same code, I can only see two solutions:
1. Converting in `gutenberg_get_font_face_styles`  relative paths back to absolute
2. Parsing the CSS and doing this in `gutenberg_print_font_faces`

But still I'm a little bit uncertain because this file was not meant to be modified and was going to be merged in #10623

So knowing where is the problem, feel free to add anything on top of this. 

cc @youknowriad