### PR TITLE
Editor: Cleanup active post as needed

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -325,6 +325,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				// Clear any notices dependent on the post context.
 				removeNotice( 'template-activate-notice' );
 			}
+
+			return () => setEditedPost( null, null );
 		}, [ post.type, post.id, setEditedPost, removeNotice ] );
 
 		// Synchronize the editor settings as they change.

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -51,9 +51,6 @@ test.describe( 'Preload', () => {
 			'/wp-abilities/v1/abilities?per_page=100&context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
-			// There are two separate settings OPTIONS requests. We should fix
-			// so the one for canUser and getEntityRecord are reused.
-			'/wp/v2/settings',
 		] );
 	} );
 } );


### PR DESCRIPTION
## What?
Closes #70570.
Alternative to #70571.

PR adds a cleanup method for the effect responsible for synchronizing the active post for the Editor. This fixes stale editor state values when navigating to non-editor pages.

## Why?
Previously, it wasn't possible to navigate between entities or different React pages from the editor. When navigating away, all the states were pruned. Now that this become possible with the new routing system, we should clean up the state as needed.

## Testing Instructions
1. Open the default template in the Site Editor.
2. Check the current post ID and confirm it's returned correctly - `wp.data.select( 'core/editor' ).getCurrentPostId();`.
3. Navigate to the Template list page.
4. Run the selector from step two. Confirm that it returns `null`.

### Testing Instructions for Keyboard
Same.