### PR TITLE
Allow for themes to define the overlay attribute without using a theme slug

### DIFF
--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -10,11 +10,14 @@ import { close, Icon } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import OverlayMenuIcon from './overlay-menu-icon';
+import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
 
 export default function ResponsiveWrapper( {
 	children,
@@ -30,6 +33,11 @@ export default function ResponsiveWrapper( {
 	overlay,
 	onNavigateToEntityRecord,
 } ) {
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+
 	if ( ! isResponsive ) {
 		return children;
 	}
@@ -80,8 +88,11 @@ export default function ResponsiveWrapper( {
 	const handleToggleClick = () => {
 		// If an overlay template part is selected, navigate to it instead of toggling
 		if ( overlay && onNavigateToEntityRecord ) {
+			const theme = currentTheme;
+			const templatePartId = createTemplatePartId( theme, overlay );
+
 			onNavigateToEntityRecord( {
-				postId: overlay,
+				postId: templatePartId,
 				postType: 'wp_template_part',
 			} );
 			return;

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -88,8 +88,10 @@ export default function ResponsiveWrapper( {
 	const handleToggleClick = () => {
 		// If an overlay template part is selected, navigate to it instead of toggling
 		if ( overlay && onNavigateToEntityRecord ) {
-			const theme = currentTheme;
-			const templatePartId = createTemplatePartId( theme, overlay );
+			const templatePartId = createTemplatePartId(
+				currentTheme,
+				overlay
+			);
 
 			onNavigateToEntityRecord( {
 				postId: templatePartId,

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -28,9 +28,10 @@ jest.mock( '../use-create-overlay', () => ( {
 	default: jest.fn(),
 } ) );
 
-// Mock useDispatch specifically to avoid needing to set up full data store
+// Mock useDispatch and useSelect specifically to avoid needing to set up full data store
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
 	createSelector: jest.fn( ( fn ) => fn ),
 	createRegistrySelector: jest.fn( ( fn ) => fn ),
 	createReduxStore: jest.fn( () => ( {} ) ),
@@ -92,6 +93,7 @@ const allTemplateParts = [
 describe( 'OverlayTemplatePartSelector', () => {
 	const mockCreateOverlayTemplatePart = jest.fn();
 	const mockCreateErrorNotice = jest.fn();
+	const { useSelect } = require( '@wordpress/data' );
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -106,6 +108,19 @@ describe( 'OverlayTemplatePartSelector', () => {
 		// Mock useDispatch to return createErrorNotice for noticesStore
 		useDispatch.mockReturnValue( {
 			createErrorNotice: mockCreateErrorNotice,
+		} );
+		// Mock useSelect to return current theme
+		// The component calls: select( coreStore ).getCurrentTheme()?.stylesheet
+		useSelect.mockImplementation( ( selector ) => {
+			if ( typeof selector === 'function' ) {
+				const mockSelect = () => ( {
+					getCurrentTheme: () => ( {
+						stylesheet: 'twentytwentyfive',
+					} ),
+				} );
+				return selector( mockSelect );
+			}
+			return 'twentytwentyfive';
 		} );
 	} );
 
@@ -195,7 +210,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should call set the overlay attribute when an overlay is selected', async () => {
+		it( 'should store slug only when an overlay is selected', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -210,10 +225,10 @@ describe( 'OverlayTemplatePartSelector', () => {
 				name: 'Overlay template',
 			} );
 
-			await user.selectOptions( select, 'twentytwentyfive//my-overlay' );
+			await user.selectOptions( select, 'my-overlay' );
 
 			expect( mockSetAttributes ).toHaveBeenCalledWith( {
-				overlay: 'twentytwentyfive//my-overlay',
+				overlay: 'my-overlay',
 			} );
 		} );
 
@@ -229,7 +244,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 				/>
 			);
 
@@ -244,7 +259,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			} );
 		} );
 
-		it( 'should display selected overlay', () => {
+		it( 'should display selected overlay by slug', () => {
 			useEntityRecords.mockReturnValue( {
 				records: [ templatePart1 ],
 				isResolving: false,
@@ -254,7 +269,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 				/>
 			);
 
@@ -262,7 +277,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 				name: 'Overlay template',
 			} );
 
-			expect( select ).toHaveValue( 'twentytwentyfive//my-overlay' );
+			expect( select ).toHaveValue( 'my-overlay' );
 		} );
 	} );
 
@@ -293,7 +308,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 				/>
 			);
 
@@ -322,7 +337,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 				/>
 			);
 
@@ -345,7 +360,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 					onNavigateToEntityRecord={ undefined }
 				/>
 			);
@@ -359,7 +374,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			expect( editButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
-		it( 'should navigate to focused overlay editor when edit button is clicked', async () => {
+		it( 'should navigate to focused overlay editor with full ID when edit button is clicked', async () => {
 			const user = userEvent.setup();
 
 			useEntityRecords.mockReturnValue( {
@@ -371,7 +386,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 				/>
 			);
 
@@ -382,6 +397,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			await user.click( editButton );
 
+			// Should construct full ID from theme and slug
 			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
 				postId: 'twentytwentyfive//my-overlay',
 				postType: 'wp_template_part',
@@ -400,7 +416,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render(
 				<OverlayTemplatePartSelector
 					{ ...defaultProps }
-					overlay="twentytwentyfive//my-overlay"
+					overlay="my-overlay"
 					onNavigateToEntityRecord={ undefined }
 				/>
 			);
@@ -461,7 +477,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 	} );
 
 	describe( 'Create overlay', () => {
-		it( 'should call createOverlayTemplatePart when create button is clicked', async () => {
+		it( 'should store slug only and navigate with full ID when creating overlay', async () => {
 			const user = userEvent.setup();
 			const newOverlay = {
 				id: 'twentytwentyfive//overlay',
@@ -490,9 +506,11 @@ describe( 'OverlayTemplatePartSelector', () => {
 			await user.click( createButton );
 
 			expect( mockCreateOverlayTemplatePart ).toHaveBeenCalled();
+			// Should store slug only
 			expect( mockSetAttributes ).toHaveBeenCalledWith( {
-				overlay: 'twentytwentyfive//overlay',
+				overlay: 'overlay',
 			} );
+			// Should navigate with full ID constructed from theme and slug
 			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
 				postId: 'twentytwentyfive//overlay',
 				postType: 'wp_template_part',

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -111,17 +111,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 		} );
 		// Mock useSelect to return current theme
 		// The component calls: select( coreStore ).getCurrentTheme()?.stylesheet
-		useSelect.mockImplementation( ( selector ) => {
-			if ( typeof selector === 'function' ) {
-				const mockSelect = () => ( {
-					getCurrentTheme: () => ( {
-						stylesheet: 'twentytwentyfive',
-					} ),
-				} );
-				return selector( mockSelect );
-			}
-			return 'twentytwentyfive';
-		} );
+		useSelect.mockReturnValue( 'twentytwentyfive' );
 	} );
 
 	describe( 'Loading state', () => {

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import ResponsiveWrapper from '../responsive-wrapper';
+
+// Mock block-editor to avoid private API issues
+jest.mock( '@wordpress/block-editor', () => ( {
+	getColorClassName: jest.fn( () => '' ),
+} ) );
+
+// Mock core-data store
+jest.mock( '@wordpress/core-data', () => ( {
+	store: {},
+} ) );
+
+// Mock useSelect
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	createSelector: jest.fn( ( fn ) => fn ),
+	createRegistrySelector: jest.fn( ( fn ) => fn ),
+	createReduxStore: jest.fn( () => ( {} ) ),
+	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+		const newState = {};
+		Object.keys( reducers ).forEach( ( key ) => {
+			newState[ key ] = reducers[ key ]( state[ key ], action );
+		} );
+		return newState;
+	} ),
+	register: jest.fn(),
+} ) );
+
+describe( 'ResponsiveWrapper', () => {
+	const mockOnToggle = jest.fn();
+	const mockOnNavigateToEntityRecord = jest.fn();
+
+	const defaultProps = {
+		id: 'test-navigation',
+		isOpen: false,
+		isResponsive: true,
+		onToggle: mockOnToggle,
+		isHiddenByDefault: false,
+		overlayBackgroundColor: {},
+		overlayTextColor: {},
+		hasIcon: false,
+		icon: null,
+		overlay: undefined,
+		onNavigateToEntityRecord: undefined,
+		children: <div>Navigation content</div>,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Mock useSelect - component calls: select( coreStore ).getCurrentTheme()?.stylesheet
+		useSelect.mockImplementation( ( selector ) => {
+			if ( typeof selector === 'function' ) {
+				const mockSelect = () => ( {
+					getCurrentTheme: () => ( {
+						stylesheet: 'twentytwentyfive',
+					} ),
+				} );
+				return selector( mockSelect );
+			}
+			return 'twentytwentyfive';
+		} );
+	} );
+
+	describe( 'Overlay navigation', () => {
+		it( 'should navigate to custom overlay template part when custom overlay slug is provided', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					overlay="my-overlay"
+					onNavigateToEntityRecord={ mockOnNavigateToEntityRecord }
+				/>
+			);
+
+			const openButton = screen.getByRole( 'button', {
+				name: 'Menu',
+			} );
+
+			await user.click( openButton );
+
+			// Should construct full ID from current theme and slug
+			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
+				postId: 'twentytwentyfive//my-overlay',
+				postType: 'wp_template_part',
+			} );
+			// Should not open default overlay when custom overlay is present
+			expect( mockOnToggle ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should open the default overlay when no custom overlay is provided', async () => {
+			const user = userEvent.setup();
+
+			render( <ResponsiveWrapper { ...defaultProps } /> );
+
+			const openButton = screen.getByRole( 'button', {
+				name: 'Menu',
+			} );
+
+			await user.click( openButton );
+
+			// Should open the default overlay when no custom overlay
+			expect( mockOnToggle ).toHaveBeenCalledWith( true );
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should open the default overlay when custom overlay is provided but navigation is not available', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					overlay="my-overlay"
+					onNavigateToEntityRecord={ undefined }
+				/>
+			);
+
+			const openButton = screen.getByRole( 'button', {
+				name: 'Menu',
+			} );
+
+			await user.click( openButton );
+
+			expect( mockOnToggle ).toHaveBeenCalledWith( true );
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should construct template part ID using current theme from useSelect', async () => {
+			const user = userEvent.setup();
+
+			// Mock different theme
+			useSelect.mockImplementation( ( selector ) => {
+				if ( typeof selector === 'function' ) {
+					const mockSelect = () => ( {
+						getCurrentTheme: () => ( {
+							stylesheet: 'custom-theme',
+						} ),
+					} );
+					return selector( mockSelect );
+				}
+				return 'custom-theme';
+			} );
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					overlay="my-overlay"
+					onNavigateToEntityRecord={ mockOnNavigateToEntityRecord }
+				/>
+			);
+
+			const openButton = screen.getByRole( 'button', {
+				name: 'Menu',
+			} );
+
+			await user.click( openButton );
+
+			// Should use the current theme from useSelect
+			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
+				postId: 'custom-theme//my-overlay',
+				postType: 'wp_template_part',
+			} );
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -351,13 +351,17 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Parse the template part ID (format: "theme//slug").
+		// If it's just a slug, construct the full ID using the current theme.
 		$parts = explode( '//', $overlay_template_part_id, 2 );
-		if ( count( $parts ) !== 2 ) {
-			return new WP_Block_List( array(), $attributes );
+		if ( count( $parts ) === 2 ) {
+			// Already in "theme//slug" format (backward compatibility).
+			$theme = $parts[0];
+			$slug  = $parts[1];
+		} else {
+			// Just a slug, use current theme.
+			$theme = get_stylesheet();
+			$slug  = $overlay_template_part_id;
 		}
-
-		$theme = $parts[0];
-		$slug  = $parts[1];
 
 		// Only query for template parts from the active theme.
 		if ( get_stylesheet() !== $theme ) {
@@ -387,7 +391,9 @@ class WP_Navigation_Block_Renderer {
 
 		if ( ! $template_part_post ) {
 			// Try to get from theme file if not in database.
-			$block_template = get_block_file_template( $overlay_template_part_id, 'wp_template_part' );
+			// Construct the full template part ID for get_block_file_template.
+			$full_template_part_id = $theme . '//' . $slug;
+			$block_template        = get_block_file_template( $full_template_part_id, 'wp_template_part' );
 			if ( isset( $block_template->content ) ) {
 				$parsed_blocks = parse_blocks( $block_template->content );
 				$blocks        = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes https://github.com/WordPress/gutenberg/issues/74101
Closes https://github.com/WordPress/gutenberg/issues/74100

Refactor Navigation block overlay template part storage to use slug instead of full template part ID.

## Why?

Previously, the Navigation block stored the full template part ID (format: `theme//slug`) in the `overlay` attribute. This created issues when themes live ina  subfolder or change or when template parts need to resolve to the current theme context. This is also how the header and footer template parts work, we used to store the theme slug too but that caused issues when a theme didn't live in the root of the themes folder.

By storing only the slug and resolving the full template part ID dynamically when needed (using the current theme), we:
- Simplify the stored data model (slug is theme-agnostic)
- Ensure template parts always resolve correctly to the current theme when navigating
- Reduce coupling between stored attributes and theme-specific identifiers
- Improve maintainability and consistency with how template parts are handled elsewhere

## How?

- **Changed storage format**: The `overlay` attribute now stores only the template part slug instead of the full `theme//slug` ID format
- **Added theme resolution**: Both `OverlayTemplatePartSelector` and `ResponsiveWrapper` components now use `useSelect` to get the current theme from the core data store
- **Dynamic ID construction**: When navigating to edit a template part (via `onNavigateToEntityRecord`), the full template part ID is constructed using `createTemplatePartId(theme, slug)` where:
  - `theme` comes from the template part's theme property, or defaults to the current theme if not set
  - `slug` is the stored overlay value
- **Updated matching logic**: Changed from matching by full ID to matching by slug when finding the selected template part
- **Updated SelectControl options**: Options now use slug as the value instead of the full template part ID

## Testing Instructions

1. Checkout this PR for a theme that defines a nav block with an overlay https://github.com/WordPress/community-themes/pull/263 (the slug is "overlay"). Bonus points if you store this theme in a subfolder.
2. Activate the theme and navigate to the header template part
3. Click on the nav block and under Overlay you should see the "overlay" one selected (it's the active for this menu)
4. Create a new overlay using the "+" button and verify that the new overlay is selected. Try and use the same name too.
5. Check that a user created overlay works as intended.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1255" height="782" alt="Screenshot 2025-12-19 at 10 16 55" src="https://github.com/user-attachments/assets/7d8f2d03-f71c-456f-9aa5-1e56947019fe" />
