### PR TITLE
Add list view tab to the buttons, list and social icons blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -112,7 +112,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Allowed Blocks:** core/button
--	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Calendar
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -466,7 +466,7 @@ An organized collection of items displayed in a specific order. ([Source](https:
 -	**Name:** core/list
 -	**Category:** text
 -	**Allowed Blocks:** core/list-item
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item
@@ -953,7 +953,7 @@ Display icons linking to your social profiles or sites. ([Source](https://github
 -	**Name:** core/social-links
 -	**Category:** widgets
 -	**Allowed Blocks:** core/social-link
--	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, margin, padding, units), ~~html~~
+-	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
 -	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -77,7 +77,6 @@ export function BlockSettingsDropdown( {
 	...props
 } ) {
 	// Get the client id of the current block for this menu, if one is set.
-	const currentClientId = block?.clientId;
 	const count = clientIds.length;
 	const firstBlockClientId = clientIds[ 0 ];
 
@@ -86,7 +85,6 @@ export function BlockSettingsDropdown( {
 		parentBlockType,
 		previousBlockClientId,
 		selectedBlockClientIds,
-		openedBlockSettingsMenu,
 		isContentOnly,
 		isZoomOut,
 	} = useSelect(
@@ -97,7 +95,6 @@ export function BlockSettingsDropdown( {
 				getPreviousBlockClientId,
 				getSelectedBlockClientIds,
 				getBlockAttributes,
-				getOpenedBlockSettingsMenu,
 				getBlockEditingMode,
 				isZoomOut: _isZoomOut,
 			} = unlock( select( blockEditorStore ) );
@@ -121,7 +118,6 @@ export function BlockSettingsDropdown( {
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				selectedBlockClientIds: getSelectedBlockClientIds(),
-				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
 				isZoomOut: _isZoomOut(),
@@ -132,10 +128,6 @@ export function BlockSettingsDropdown( {
 
 	const { getBlockOrder, getSelectedBlockClientIds } =
 		useSelect( blockEditorStore );
-
-	const { setOpenedBlockSettingsMenu } = unlock(
-		useDispatch( blockEditorStore )
-	);
 
 	const shortcuts = useSelect( ( select ) => {
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
@@ -191,29 +183,6 @@ export function BlockSettingsDropdown( {
 	const parentBlockIsSelected =
 		selectedBlockClientIds?.includes( firstParentClientId );
 
-	// When a currentClientId is in use, treat the menu as a controlled component.
-	// This ensures that only one block settings menu is open at a time.
-	// This is a temporary solution to work around an issue with `onFocusOutside`
-	// where it does not allow a dropdown to be closed if focus was never within
-	// the dropdown to begin with. Examples include a user either CMD+Clicking or
-	// right clicking into an inactive window.
-	// See: https://github.com/WordPress/gutenberg/pull/54083
-	const open = ! currentClientId
-		? undefined
-		: openedBlockSettingsMenu === currentClientId || false;
-
-	function onToggle( localOpen ) {
-		if ( localOpen && openedBlockSettingsMenu !== currentClientId ) {
-			setOpenedBlockSettingsMenu( currentClientId );
-		} else if (
-			! localOpen &&
-			openedBlockSettingsMenu &&
-			openedBlockSettingsMenu === currentClientId
-		) {
-			setOpenedBlockSettingsMenu( undefined );
-		}
-	}
-
 	const shouldShowBlockParentMenuItem =
 		! parentBlockIsSelected && !! firstParentClientId;
 
@@ -254,8 +223,6 @@ export function BlockSettingsDropdown( {
 						label={ __( 'Options' ) }
 						className="block-editor-block-settings-menu"
 						popoverProps={ POPOVER_PROPS }
-						open={ open }
-						onToggle={ onToggle }
 						noIcons
 						{ ...props }
 					>

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -8,7 +8,6 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import InspectorControlsGroups from '../inspector-controls/groups';
-import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
 import { InspectorAdvancedControls } from '../inspector-controls';
 import { TAB_LIST_VIEW, TAB_SETTINGS, TAB_STYLES, TAB_CONTENT } from './utils';
 import { store as blockEditorStore } from '../../store';
@@ -50,9 +49,8 @@ export default function useInspectorControlsTabs(
 	} = InspectorControlsGroups;
 
 	// List View Tab: If there are any fills for the list group add that tab.
-	const listViewDisabled = useIsListViewTabDisabled( blockName );
 	const listFills = useSlotFills( listGroup.name );
-	const hasListFills = ! listViewDisabled && !! listFills && listFills.length;
+	const hasListFills = !! listFills && listFills.length;
 
 	// Styles Tab: Add this tab if there are any fills for block supports
 	// e.g. border, color, spacing, typography, etc.

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-is-list-view-tab-disabled.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-is-list-view-tab-disabled.js
@@ -1,9 +1,0 @@
-// List view tab restricts the blocks that may render to it via the
-// allowlist below.
-const allowlist = [ 'core/navigation' ];
-
-export const useIsListViewTabDisabled = ( blockName ) => {
-	return ! allowlist.includes( blockName );
-};
-
-export default useIsListViewTabDisabled;

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -96,7 +96,6 @@ function ListViewBlock( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
-		setOpenedBlockSettingsMenu,
 		updateBlockAttributes,
 	} = unlock( useDispatch( blockEditorStore ) );
 	const debouncedToggleBlockHighlight = useDebounce(
@@ -298,7 +297,6 @@ function ListViewBlock( {
 			const newlySelectedBlocks = getSelectedBlockClientIds();
 
 			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
-			setOpenedBlockSettingsMenu( undefined );
 			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 		} else if ( isMatch( 'core/block-editor/insert-after', event ) ) {
 			event.preventDefault();
@@ -308,7 +306,6 @@ function ListViewBlock( {
 			const newlySelectedBlocks = getSelectedBlockClientIds();
 
 			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
-			setOpenedBlockSettingsMenu( undefined );
 			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
 			event.preventDefault();
@@ -368,7 +365,6 @@ function ListViewBlock( {
 				speak( __( 'Selected blocks are grouped.' ) );
 				const newlySelectedBlocks = getSelectedBlockClientIds();
 				// Focus the first block of the newly inserted blocks, to keep focus within the list view.
-				setOpenedBlockSettingsMenu( undefined );
 				updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 			}
 		} else if (

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -445,6 +445,11 @@ function ListViewBlock( {
 	// Allow right-clicking an item in the List View to open up the block settings dropdown.
 	const onContextMenu = useCallback(
 		( event ) => {
+			const { ownerDocument } = settingsRef?.current || {};
+			if ( ! ownerDocument || ! ownerDocument.hasFocus() ) {
+				return;
+			}
+
 			if ( showBlockActions && allowRightClickOverrides ) {
 				settingsRef.current?.click();
 				// Ensure the position of the settings dropdown is at the cursor.

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -33,6 +33,7 @@ import contentLockUI from './content-lock-ui';
 import './metadata';
 import blockHooks from './block-hooks';
 import blockBindingsPanel from './block-bindings';
+import listView from './list-view';
 import './block-renaming';
 import './grid-visualizer';
 
@@ -52,6 +53,7 @@ createBlockEditFilter(
 		blockBindingsPanel,
 		childLayout,
 		allowedBlocks,
+		listView,
 	].filter( Boolean )
 );
 createBlockListBlockFilter( [

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as blocksStore, hasBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../components/inspector-controls';
+import { store as blockEditorStore } from '../store';
+import { privateApis } from '../private-apis';
+import { unlock } from '../lock-unlock';
+
+const { PrivateListView } = unlock( privateApis );
+
+export const LIST_VIEW_SUPPORT_KEY = 'listView';
+
+/**
+ * Check if the block has list view support.
+ *
+ * @param {string|Object} nameOrType Block name or block type object.
+ * @return {boolean} Whether the block has list view support.
+ */
+export function hasListViewSupport( nameOrType ) {
+	return hasBlockSupport( nameOrType, LIST_VIEW_SUPPORT_KEY );
+}
+
+/**
+ * Inspector controls panel for list view.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId Block client ID.
+ * @param {string} props.name     Block name.
+ * @return {Element|null} List view inspector controls or null.
+ */
+export function ListViewPanel( { clientId, name } ) {
+	const isEnabled = hasListViewSupport( name );
+	const { hasChildren, blockTitle } = useSelect(
+		( select ) => ( {
+			hasChildren:
+				!! select( blockEditorStore ).getBlockCount( clientId ),
+			blockTitle: select( blocksStore ).getBlockType( name )?.title,
+		} ),
+		[ clientId, name ]
+	);
+
+	if ( ! isEnabled ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls group="list">
+			<PanelBody title={ null }>
+				{ ! hasChildren && (
+					<p className="block-editor-block-inspector__no-blocks">
+						{ __( 'No items yet.' ) }
+					</p>
+				) }
+				<PrivateListView
+					rootClientId={ clientId }
+					isExpanded
+					description={ blockTitle }
+					showAppender
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
+/**
+ * Export block support definition.
+ */
+export default {
+	edit: ListViewPanel,
+	hasSupport: hasListViewSupport,
+	attributeKeys: [],
+};

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -275,19 +275,6 @@ export function setBlockRemovalRules( rules = false ) {
 	};
 }
 
-/**
- * Sets the client ID of the block settings menu that is currently open.
- *
- * @param {?string} clientId The block client ID.
- * @return {Object} Action object.
- */
-export function setOpenedBlockSettingsMenu( clientId ) {
-	return {
-		type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
-		clientId,
-	};
-}
-
 export function setStyleOverride( id, style ) {
 	return {
 		type: 'SET_STYLE_OVERRIDE',

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -199,16 +199,6 @@ export function getBlockRemovalRules( state ) {
 }
 
 /**
- * Returns the client ID of the block settings menu that is currently open.
- *
- * @param {Object} state Global application state.
- * @return {string|null} The client ID of the block menu that is currently open.
- */
-export function getOpenedBlockSettingsMenu( state ) {
-	return state.openedBlockSettingsMenu;
-}
-
-/**
  * Returns all style overrides, intended to be merged with global editor styles.
  *
  * Overrides are sorted to match the order of the blocks they relate to. This

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2010,21 +2010,6 @@ export function blockEditingModes( state = new Map(), action ) {
 }
 
 /**
- * Reducer returning the clientId of the block settings menu that is currently open.
- *
- * @param {string|null} state  Current state.
- * @param {Object}      action Dispatched action.
- *
- * @return {string|null} Updated state.
- */
-export function openedBlockSettingsMenu( state = null, action ) {
-	if ( 'SET_OPENED_BLOCK_SETTINGS_MENU' === action.type ) {
-		return action?.clientId ?? null;
-	}
-	return state;
-}
-
-/**
  * Reducer returning a map of style IDs to style overrides.
  *
  * @param {Map}    state  Current state.
@@ -2145,7 +2130,6 @@ const combinedReducers = combineReducers( {
 	styleOverrides,
 	removalPromptData,
 	blockRemovalRules,
-	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	zoomLevel,
 	hasBlockSpotlight,

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -7,7 +7,6 @@ import {
 	expandBlock,
 	__experimentalUpdateSettings,
 	setInsertionPoint,
-	setOpenedBlockSettingsMenu,
 	startDragging,
 	stopDragging,
 } from '../private-actions';
@@ -80,22 +79,6 @@ describe( 'private actions', () => {
 					baz: 'baz',
 				},
 				reset: false,
-			} );
-		} );
-	} );
-
-	describe( 'setOpenedBlockSettingsMenu', () => {
-		it( 'should return the SET_OPENED_BLOCK_SETTINGS_MENU action', () => {
-			expect( setOpenedBlockSettingsMenu() ).toEqual( {
-				clientId: undefined,
-				type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
-			} );
-		} );
-
-		it( 'should return the SET_OPENED_BLOCK_SETTINGS_MENU action with client id if provided', () => {
-			expect( setOpenedBlockSettingsMenu( 'abcd' ) ).toEqual( {
-				clientId: 'abcd',
-				type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -38,7 +38,6 @@ import {
 	lastBlockAttributesChange,
 	lastBlockInserted,
 	blockEditingModes,
-	openedBlockSettingsMenu,
 	expandedBlock,
 	zoomLevel,
 	editedContentOnlySection,
@@ -3483,30 +3482,6 @@ describe( 'state', () => {
 					[ '', 'disabled' ],
 				] )
 			);
-		} );
-	} );
-
-	describe( 'openedBlockSettingsMenu', () => {
-		it( 'should return null by default', () => {
-			expect( openedBlockSettingsMenu( undefined, {} ) ).toBe( null );
-		} );
-
-		it( 'should set client id for opened block settings menu', () => {
-			const state = openedBlockSettingsMenu( null, {
-				type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
-				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
-			} );
-			expect( state ).toBe( '14501cc2-90a6-4f52-aa36-ab6e896135d1' );
-		} );
-
-		it( 'should clear the state when no client id is passed', () => {
-			const state = openedBlockSettingsMenu(
-				'14501cc2-90a6-4f52-aa36-ab6e896135d1',
-				{
-					type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
-				}
-			);
-			expect( state ).toBe( null );
 		} );
 	} );
 

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -63,6 +63,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
+		"listView": true,
 		"contentRole": true
 	},
 	"editorStyle": "wp-block-buttons-editor",

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,9 +6,24 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { PrivateListView } = unlock( blockEditorPrivateApis );
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
@@ -25,22 +40,27 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className } ) {
+function ButtonsEdit( { attributes, className, clientId } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const { hasButtonVariations } = useSelect( ( select ) => {
-		const buttonVariations = select( blocksStore ).getBlockVariations(
-			'core/button',
-			'inserter'
-		);
-		return {
-			hasButtonVariations: buttonVariations.length > 0,
-		};
-	}, [] );
+	const { hasButtonVariations, hasChildren } = useSelect(
+		( select ) => {
+			const buttonVariations = select( blocksStore ).getBlockVariations(
+				'core/button',
+				'inserter'
+			);
+			return {
+				hasButtonVariations: buttonVariations.length > 0,
+				hasChildren:
+					!! select( blockEditorStore ).getBlockCount( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
@@ -51,7 +71,26 @@ function ButtonsEdit( { attributes, className } ) {
 		orientation: layout?.orientation ?? 'horizontal',
 	} );
 
-	return <div { ...innerBlocksProps } />;
+	return (
+		<>
+			<InspectorControls group="list">
+				<PanelBody title={ null }>
+					{ ! hasChildren && (
+						<p className="block-editor-block-inspector__no-blocks">
+							{ __( 'No buttons yet.' ) }
+						</p>
+					) }
+					<PrivateListView
+						rootClientId={ clientId }
+						isExpanded
+						description={ __( 'Buttons' ) }
+						showAppender
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...innerBlocksProps } />
+		</>
+	);
 }
 
 export default ButtonsEdit;

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,24 +6,9 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	useInnerBlocksProps,
-	InspectorControls,
-	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
-import { PanelBody } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { PrivateListView } = unlock( blockEditorPrivateApis );
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
@@ -40,27 +25,22 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className, clientId } ) {
+function ButtonsEdit( { attributes, className } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const { hasButtonVariations, hasChildren } = useSelect(
-		( select ) => {
-			const buttonVariations = select( blocksStore ).getBlockVariations(
-				'core/button',
-				'inserter'
-			);
-			return {
-				hasButtonVariations: buttonVariations.length > 0,
-				hasChildren:
-					!! select( blockEditorStore ).getBlockCount( clientId ),
-			};
-		},
-		[ clientId ]
-	);
+	const { hasButtonVariations } = useSelect( ( select ) => {
+		const buttonVariations = select( blocksStore ).getBlockVariations(
+			'core/button',
+			'inserter'
+		);
+		return {
+			hasButtonVariations: buttonVariations.length > 0,
+		};
+	}, [] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
@@ -71,26 +51,7 @@ function ButtonsEdit( { attributes, className, clientId } ) {
 		orientation: layout?.orientation ?? 'horizontal',
 	} );
 
-	return (
-		<>
-			<InspectorControls group="list">
-				<PanelBody title={ null }>
-					{ ! hasChildren && (
-						<p className="block-editor-block-inspector__no-blocks">
-							{ __( 'No buttons yet.' ) }
-						</p>
-					) }
-					<PrivateListView
-						rootClientId={ clientId }
-						isExpanded
-						description={ __( 'Buttons' ) }
-						showAppender
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<div { ...innerBlocksProps } />
-		</>
-	);
+	return <div { ...innerBlocksProps } />;
 }
 
 export default ButtonsEdit;

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -78,7 +78,8 @@
 		"__experimentalSlashInserter": true,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"listView": true
 	},
 	"selectors": {
 		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)"

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -95,7 +95,8 @@
 				"style": true
 			}
 		},
-		"contentRole": true
+		"contentRole": true,
+		"listView": true
 	},
 	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -11,6 +11,20 @@ jest.mock( '@wordpress/compose', () => {
 	};
 } );
 
+jest.mock( '@wordpress/block-editor/src/hooks/list-view', () => {
+	return {
+		__esModule: true,
+		LIST_VIEW_SUPPORT_KEY: 'listView',
+		hasListViewSupport: jest.fn( () => false ),
+		ListViewPanel: jest.fn( () => null ),
+		default: {
+			edit: jest.fn( () => null ),
+			hasSupport: jest.fn( () => false ),
+			attributeKeys: [],
+		},
+	};
+} );
+
 /**
  * client-zip is meant to be used in a browser and is therefore released as an ES6 module only,
  * in order to use it in node environment, we need to mock it.


### PR DESCRIPTION
Related #73845 

Fixes #73866

## What?                                                                                                                                                     
                                                                                                                                                               
Removes the allowlist restriction for the List View inspector tab, making it available to any block that provides list group fills. The Buttons block now includes list view support, allowing users to reorder buttons through a hierarchical interface in the sidebar.
                                                                                                                                                               
## Why?                                                                                                                              
                                                                                                                                                               
Previously, only the Navigation block could show the List View tab due to a hardcoded allowlist. This prevented other container blocks like Buttons, Social Icons, and List from benefiting from the same reordering and management interface. This limitation was inconsistent with how other inspector tabs (Settings, Styles, Content) work, which appear automatically based on available fills.
                                                                                                                                                               
## Testing Instructions                                                                                                                                      
                                                                                                                                                               
Select a Buttons block and verify the List View tab appears in the inspector sidebar and is selected by default. Confirm you can reorder buttons via drag-and-drop in the list view and add new buttons using the appender. Select a Paragraph block and verify it defaults to the Settings tab. Select a Navigation block and confirm it still defaults to List View as before.
