### PR TITLE
Site Editor: Add extensible site editor experiment

### DIFF
--- a/lib/experimental/extensible-site-editor.php
+++ b/lib/experimental/extensible-site-editor.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Extensible Site Editor experiment integration.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Redirect the Appearance > Design menu to the extensible site editor
+ * when both experiments are enabled.
+ */
+function gutenberg_redirect_to_extensible_site_editor() {
+	// Only proceed if both required experiments are enabled.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ||
+		! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
+		return;
+	}
+
+	// Update the Design submenu item to point to the extensible site editor.
+	global $submenu;
+	if ( $submenu && isset( $submenu['themes.php'] ) ) {
+		foreach ( $submenu['themes.php'] as $key => $item ) {
+			// Find the Design/site-editor menu item and update its URL.
+			if ( isset( $item[2] ) && 'site-editor.php' === $item[2] ) {
+				$submenu['themes.php'][ $key ][2] = 'admin.php?page=site-editor';
+				break;
+			}
+		}
+	}
+}
+add_action( 'admin_menu', 'gutenberg_redirect_to_extensible_site_editor', 100 );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -247,6 +247,19 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-extensible-site-editor',
+		__( 'Extensible Site Editor', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label'    => __( 'Redirects the default site editor (Appearance > Design) to use the extensible site editor page. Requires "Template Activation" experiment to be enabled.', 'gutenberg' ),
+			'id'       => 'gutenberg-extensible-site-editor',
+			'requires' => 'active_templates',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/load.php
+++ b/lib/load.php
@@ -117,6 +117,7 @@ require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/synchronization.php';
 require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/site-editor.php';
+require __DIR__ . '/experimental/extensible-site-editor.php';
 require __DIR__ . '/experimental/fonts/load.php';
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-workflow-palette' ) ) {


### PR DESCRIPTION
Related #70862

## What?

This PR adds an explicit experiment to the experiments screen to take over the "Appearance > Design" menu item with the new extensible site editor.

This will allow more folks to provide feedback and move this forward. I enabled it for all themes, although right now the experience for classic themes is not optimal yet. I'll improve that separately.

The "template activation" is right now mandatory to use this separate screen though because I didn't implement the "classic templates" behavior in the templates route yet.