### PR TITLE
Theme_JSON_Resolver: defensively cover against situations where the post is null

### DIFF
--- a/backport-changelog/7.0/10648.md
+++ b/backport-changelog/7.0/10648.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10648
+
+* https://github.com/WordPress/gutenberg/pull/74124

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -483,7 +483,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$global_style_query = new WP_Query();
 		$recent_posts       = $global_style_query->query( $args );
-		if ( count( $recent_posts ) === 1 ) {
+		if ( count( $recent_posts ) === 1 && is_object( $recent_posts[0] ) ) {
 			$user_cpt = get_object_vars( $recent_posts[0] );
 		} elseif ( $create_post ) {
 			$cpt_post_id = wp_insert_post(
@@ -500,7 +500,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				true
 			);
 			if ( ! is_wp_error( $cpt_post_id ) ) {
-				$user_cpt = get_object_vars( get_post( $cpt_post_id ) );
+				$post = get_post( $cpt_post_id );
+				if ( is_object( $post ) ) {
+					$user_cpt = get_object_vars( $post );
+				}
 			}
 		}
 


### PR DESCRIPTION
Backported to core at https://github.com/WordPress/wordpress-develop/pull/10648

## What?

This PR adds defensive checks to prevent some errors we've seen in hosts.

In certain scenarios, get_post function returns null after the wp_insert_post function is called. Although the post is saved, it's assumed that it can be immediately accessed, which is not always true.

## Why?

See https://github.com/WordPress/gutenberg/issues/70161

## How?

Check if it's an object before passing it to `get_object_vars`.


## How to reproduce

Unfortunately, there's no steps to reproduce it consistently. We've just seen reports by hosts that this happens occassionally in certain transition states for the site (creation, migration, etc.).
