### PR TITLE
Extensible Site Editor: The Canvas should share the same ThemeProvider as all the surfaces

### DIFF
--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -144,40 +144,44 @@ export default function Root() {
 						<div className="boot-layout__surfaces">
 							<UserThemeProvider color={ { bg: '#ffffff' } }>
 								<Outlet />
+								{ /* Render Canvas in Root to prevent remounting on route changes */ }
+								{ ( canvas || canvas === null ) && (
+									<div
+										className={ clsx(
+											'boot-layout__canvas',
+											{
+												'has-mobile-drawer':
+													canvas?.isPreview &&
+													isMobileViewport,
+											}
+										) }
+									>
+										{ canvas?.isPreview &&
+											isMobileViewport && (
+												<div className="boot-layout__mobile-sidebar-drawer">
+													<Button
+														icon={ menu }
+														onClick={ () =>
+															setIsMobileSidebarOpen(
+																true
+															)
+														}
+														label={ __(
+															'Open navigation panel'
+														) }
+														size="compact"
+													/>
+												</div>
+											) }
+										<CanvasRenderer
+											canvas={ canvas }
+											routeContentModule={
+												routeContentModule
+											}
+										/>
+									</div>
+								) }
 							</UserThemeProvider>
-							{ /* Render Canvas in Root to prevent remounting on route changes */ }
-							{ ( canvas || canvas === null ) && (
-								<div
-									className={ clsx( 'boot-layout__canvas', {
-										'has-mobile-drawer':
-											canvas?.isPreview &&
-											isMobileViewport,
-									} ) }
-								>
-									{ canvas?.isPreview && isMobileViewport && (
-										<div className="boot-layout__mobile-sidebar-drawer">
-											<Button
-												icon={ menu }
-												onClick={ () =>
-													setIsMobileSidebarOpen(
-														true
-													)
-												}
-												label={ __(
-													'Open navigation panel'
-												) }
-												size="compact"
-											/>
-										</div>
-									) }
-									<CanvasRenderer
-										canvas={ canvas }
-										routeContentModule={
-											routeContentModule
-										}
-									/>
-								</div>
-							) }
 						</div>
 					</div>
 				</UserThemeProvider>

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -56,16 +56,18 @@ export default function RootSinglePage() {
 					<div className="boot-layout__surfaces">
 						<UserThemeProvider color={ { bg: '#ffffff' } }>
 							<Outlet />
+							{ /* Render Canvas in Root to prevent remounting on route changes */ }
+							{ ( canvas || canvas === null ) && (
+								<div className="boot-layout__canvas">
+									<CanvasRenderer
+										canvas={ canvas }
+										routeContentModule={
+											routeContentModule
+										}
+									/>
+								</div>
+							) }
 						</UserThemeProvider>
-						{ /* Render Canvas in Root to prevent remounting on route changes */ }
-						{ ( canvas || canvas === null ) && (
-							<div className="boot-layout__canvas">
-								<CanvasRenderer
-									canvas={ canvas }
-									routeContentModule={ routeContentModule }
-								/>
-							</div>
-						) }
 					</div>
 				</div>
 			</UserThemeProvider>


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/70862

At some point I refactored the rendering of the "Canvas" surface to move it from the Route component into the root. I did that to avoid remounting the canvas on navigation and keeping transitions smooth. 

The issue is that I inadvertently moved the Canvas under a separate ThemeProvider which cause the different buttons to render with a light color (be unreadable)

This PR moves the canvas under the same theme provider as the other surfaces fixing the color issue.

You can test by opening the separate site editor and going to the editor `admin.php?page=site-editor`