### PR TITLE
Feature proposal/docker compose override

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
-const { v2: dockerCompose } = require( 'docker-compose' );
+const fs = require( 'fs' ).promises;
 const util = require( 'util' );
 const path = require( 'path' );
-const fs = require( 'fs' ).promises;
 const { confirm } = require( '@inquirer/prompts' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 
 /**
  * Promisified dependencies
@@ -236,6 +236,14 @@ module.exports = async function start( {
 		// Set the cache key once everything has been configured.
 		await setCache( CONFIG_CACHE_KEY, configHash, {
 			workDirectoryPath,
+		} );
+	}
+
+	if ( config.detectedLocalDockerOverride ) {
+		spinner.text = 'Starting custom services.';
+		await dockerCompose.upAll( {
+			...dockerComposeConfig,
+			commandOptions: [ '--no-recreate' ],
 		} );
 	}
 

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -56,18 +56,29 @@ module.exports = async function loadConfig( configDirectoryPath ) {
 	// consumption elsewhere in the tool.
 	config = postProcessConfig( config );
 
+	const isLocalDockerOverride = await hasLocalConfig( [
+		path.resolve( cacheDirectoryPath, 'docker-compose.override.yml' ),
+	] );
+	console.log( isLocalDockerOverride );
+
 	return {
 		name: path.basename( configDirectoryPath ),
-		dockerComposeConfigPath: path.resolve(
-			cacheDirectoryPath,
-			'docker-compose.yml'
-		),
+		dockerComposeConfigPath: isLocalDockerOverride
+			? [
+					path.resolve( cacheDirectoryPath, 'docker-compose.yml' ),
+					path.resolve(
+						cacheDirectoryPath,
+						'docker-compose.override.yml'
+					),
+			  ]
+			: [ path.resolve( cacheDirectoryPath, 'docker-compose.yml' ) ],
 		configDirectoryPath,
 		workDirectoryPath: cacheDirectoryPath,
 		detectedLocalConfig: await hasLocalConfig( [
 			configFilePath,
 			getConfigFilePath( configDirectoryPath, 'override' ),
 		] ),
+		detectedLocalDockerOverride: isLocalDockerOverride,
 		lifecycleScripts: config.lifecycleScripts,
 		env: config.env,
 	};

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -59,7 +59,6 @@ module.exports = async function loadConfig( configDirectoryPath ) {
 	const isLocalDockerOverride = await hasLocalConfig( [
 		path.resolve( cacheDirectoryPath, 'docker-compose.override.yml' ),
 	] );
-	console.log( isLocalDockerOverride );
 
 	return {
 		name: path.basename( configDirectoryPath ),

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -83,7 +83,7 @@ module.exports = async function initConfig( {
 		await mkdir( config.workDirectoryPath, { recursive: true } );
 
 		await writeFile(
-			config.dockerComposeConfigPath,
+			config.dockerComposeConfigPath[ 0 ],
 			yaml.dump( dockerComposeConfig )
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/72838 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
This PR introduces a way to override or add additional docker-compose without changing the default file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/issues/72838
Easier to extend the base docker-compose.yml file.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changes in load-config to set the place where we look for the override file.
Changes in docker start command to run the extra configs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
In a WordPress plugin or theme directory, run wp-env start.

Create a file named docker-compose.override.yml in your root directory:

```YAML

services:
  mailpit:
    image: axllent/mailpit:latest
    restart: unless-stopped
    ports:
      - "1025:1025"
      - "8025:8025"
 ```
Run ./wp-env start

Expected Result: Mailpit will start alongside WordPress

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
