### PR TITLE
Terms Query Block: Fix Max terms for non-hierarchical taxonomies

### DIFF
--- a/packages/block-library/src/term-template/index.php
+++ b/packages/block-library/src/term-template/index.php
@@ -59,7 +59,7 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 			$query_args['include'] = array_unique( array_map( 'intval', $query['include'] ) );
 			$query_args['orderby'] = 'include';
 			$query_args['order']   = 'asc';
-		} elseif ( empty( $query['showNested'] ) ) {
+		} elseif ( is_taxonomy_hierarchical( $query['taxonomy'] ) && empty( $query['showNested'] ) ) {
 			// We set parent only when inheriting from the taxonomy archive context or not
 			// showing nested terms, otherwise nested terms are not displayed.
 			$query_args['parent'] = 0;


### PR DESCRIPTION
## What?

Fix Max terms for non-hierarchical taxonomies.

## Why?

In Terms Query block, "Max terms" currently only works for non-hierarchical taxonomies.

## How?

We do not need to set `$query_args['parent']` for non-hierarchical taxonomies.

## Testing Instructions

* create 3 tags
* on an empty page, add a Terms Query block select Tags taxonomy and Max terms = 2

Without the fix : 3 tags are displayed
With the fix : 2 tags a displayed