### PR TITLE
Forms Block: Add hidden input field variation

### DIFF
--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -115,6 +115,20 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 						'Affects the "name" attribute of the input element, and is used as a name for the form submission results.'
 					) }
 				/>
+				{ 'hidden' === type && (
+					<TextControl
+						__next40pxDefaultSize
+						autoComplete="off"
+						label={ __( 'Value' ) }
+						value={ value }
+						onChange={ ( newVal ) =>
+							setAttributes( { value: newVal } )
+						}
+						help={ __(
+							'Sets the stored value for this hidden field.'
+						) }
+					/>
+				) }
 			</InspectorControls>
 		</>
 	);
@@ -133,23 +147,13 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 
 	if ( 'hidden' === type ) {
 		return (
-			<>
+			<div { ...blockProps }>
 				{ controls }
-				<input
-					type="hidden"
-					className={ clsx(
-						className,
-						'wp-block-form-input__input',
-						colorProps.className,
-						borderProps.className
-					) }
-					aria-label={ __( 'Value' ) }
-					value={ value }
-					onChange={ ( event ) =>
-						setAttributes( { value: event.target.value } )
-					}
+				<span
+					className="wp-block-form-input__label is-input-hidden"
+					data-message={ __( 'Hidden field' ) }
 				/>
-			</>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/form-input/editor.scss
+++ b/packages/block-library/src/form-input/editor.scss
@@ -1,24 +1,24 @@
 .wp-block-form-input {
 	.is-input-hidden {
+		display: flex;
+		position: relative;
 		font-size: 0.85em;
 		opacity: 0.3;
 		border: 1px dashed;
 		padding: 0.5em;
 		box-sizing: border-box;
 		background: repeating-linear-gradient(45deg, transparent, transparent 5px, currentColor 5px, currentColor 6px);
+		justify-content: center;
+		align-items: center;
 
-		input[type="text"] {
-			background: transparent;
+		&::after {
+			content: attr(data-message);
 		}
 	}
 	&.is-selected {
 		.is-input-hidden {
 			opacity: 1;
 			background: none;
-
-			input[type="text"] {
-				background: unset;
-			}
 		}
 	}
 }

--- a/packages/block-library/src/form-input/variations.js
+++ b/packages/block-library/src/form-input/variations.js
@@ -77,6 +77,16 @@ const variations = [
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => blockAttributes?.type === 'number',
 	},
+	{
+		name: 'hidden',
+		title: __( 'Hidden Input' ),
+		icon: 'visibility',
+		description: __( 'A hidden input field.' ),
+		attributes: { type: 'hidden' },
+		isDefault: true,
+		scope: [ 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) => blockAttributes?.type === 'hidden',
+	},
 ];
 
 export default variations;


### PR DESCRIPTION
Closes #57610

## Why?
One of the most important fields in any form is the `hidden` type. This PR aims to add this.

## How?
Part of the logic and styles were already implemented but not being used. This PR takes advantage of this with the following additions:

1. Advanced Text Control, next to `Name` to set `Value`. To some extent this mimics the same behavior as Elementor forms.
2. There was a field template for the component that was targeting the `hidden` input (but adding hidden in the editor, which made 0 sense). I simply took advantage of it and styled a little bit to resemble the `Form Submission Notification` block, which happens to have two hidden fields (that only appear on submission). This way, it's clear that there are hidden inputs set in the form, they are selectable without needing to unfold the `Document Overview`.

## Testing Instructions
Very easy to test. 
1. Enable the form experiments in Gutenberg > Experiments > Blocks: add Form and Input blocks
2. Create a new post
3. Add a new `Form block`
4. Add the `Hidden Input` block inside the form.
5. Add a value (in the right controls Block > Advanced)
6. Save and check the front end
7. Check the HTML code, and look for the hidden field; it should have the value you set.

## Screenshots

<img width="1227" height="1027" alt="image" src="https://github.com/user-attachments/assets/c6cba3a5-ec03-4258-9d85-8aa04a9b537a" />