### PR TITLE
wp-env: Add git installation to Dockerfile for GHA

### DIFF
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -230,6 +230,9 @@ RUN apk update
 # Install some basic PHP dependencies.
 RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
+# Install git
+RUN apk --no-cache add git
+
 # Set up sudo so they can have root access.
 RUN apk --no-cache add sudo linux-headers
 RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;


### PR DESCRIPTION
## What?
I've noted that many GHA playground tests fail during `wp-env` setup.

## Why?
It appears that the problem is that it's trying to run `git` but git is not being installed in the `cli` image of `wp-env`. Generally it tries to run it when it can download from sources. 

The error generally looks something like this

```
#38 2.198  25/26 [==========================>-]  96%    Failed to download sebastian/cli-parser from dist: curl error 28 while downloading https://codeload.github.com/sebastianbergmann/cli-parser/legacy.zip/c34583b87e7b7a8055bf6c450c2c77ce32a24084: Connection timed out after 10004 milliseconds
#38 11.18     Now trying to download from source
#38 11.18 
#38 11.18  26/26 [============================] 100%
#38 11.18 In GitDownloader.php line 82:
#38 11.18                                                             
#38 11.18   git was not found in your PATH, skipping source download  
```

An example like this job: https://github.com/WordPress/gutenberg/actions/runs/20342219366/job/58444497388

Failures in builds are generally due to a rate limitation. This is why its not happening consistently

## How?
The solution is to add `git` to the `cli` containers.