### PR TITLE
Classic Block: Open modal only when block is inserted

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -85,6 +85,11 @@ export default function ModalEdit( props ) {
 	const [ isModalFullScreen, setIsModalFullScreen ] = useState( false );
 	const id = `editor-${ clientId }`;
 
+	const wasBlockJustInserted = useSelect(
+		( select ) => select( store ).wasBlockJustInserted( clientId ),
+		[ clientId ]
+	);
+
 	const onClose = () => ( content ? setOpen( false ) : onReplace( [] ) );
 
 	return (
@@ -97,7 +102,7 @@ export default function ModalEdit( props ) {
 				</ToolbarGroup>
 			</BlockControls>
 			{ content && <RawHTML>{ content }</RawHTML> }
-			{ ( isOpen || ! content ) && (
+			{ ( isOpen || wasBlockJustInserted ) && (
 				<Modal
 					title={ __( 'Classic Editor' ) }
 					onRequestClose={ onClose }

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { BlockControls, store } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
 	ToolbarButton,
@@ -40,7 +43,7 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 
 function ClassicEdit( props ) {
 	const styles = useSelect(
-		( select ) => select( store ).getSettings().styles
+		( select ) => select( blockEditorStore ).getSettings().styles
 	);
 	useEffect( () => {
 		const { baseURL, suffix, settings } = window.wpEditorL10n.tinymce;
@@ -86,7 +89,8 @@ export default function ModalEdit( props ) {
 	const id = `editor-${ clientId }`;
 
 	const wasBlockJustInserted = useSelect(
-		( select ) => select( store ).wasBlockJustInserted( clientId ),
+		( select ) =>
+			select( blockEditorStore ).wasBlockJustInserted( clientId ),
 		[ clientId ]
 	);
 


### PR DESCRIPTION
Fixes #73891

## What?

Opens the classic editor modal when the block is inserted, instead of when there is no content.

## Why?

I believe the current behavior is not ideal in certain scenarios. See https://github.com/WordPress/gutenberg/issues/73891#issuecomment-3677802851 for more details.

## Testing Instructions

Here's one scenario where this PR would be useful:

Use the following code to temporarily register a block:

```javascript
wp.blocks.registerBlockType(
	'test/classic-container-block',
	{
		apiVersion: 3,
		title: 'Test Block',
		edit: function( props ) {
			const innerBlocksProps = wp.blockEditor.useInnerBlocksProps( wp.blockEditor.useBlockProps(), {
				template: [[ 'core/freeform' ]],
			} );
			return wp.element.createElement( 'div', innerBlocksProps );
		},
	}
);
```

- Insert a block:
  - ❌ trunk: The Classic editor modal opens, but if the block is an inner block, this behavior may not be ideal.
  - ✅ This PR: The Classic editor modal doesn't open. I was surprised, but `wasBlockJustInserted` might not work if it's an inner block. This might technically be a bug, but I think it's acceptable behavior.
- Enable the Code editor and back to the Visual editor:
  - ❌ trunk: The Classic editor modal opens,
  - ✅ This PR: The Classic editor modal doesn't open.