### PR TITLE
Global Fonts: Correctly convert relative font URLs to absolute theme URLs in font-face styles

### DIFF
--- a/lib/compat/wordpress-7.0/global-styles.php
+++ b/lib/compat/wordpress-7.0/global-styles.php
@@ -76,6 +76,8 @@ function gutenberg_get_font_face_styles() {
 						$src_file        = str_replace( $placeholder, '', $src_url );
 						$src[ $src_key ] = get_theme_file_uri( $src_file );
 					}
+
+					$font_face['src'] = $src;
 				}
 
 				// Convert camelCase to kebab-case.


### PR DESCRIPTION
Follow-up to #74115

## What?

We forgot to actually use the font URL converted to absolute theme URL 😄


## Testing Instructions

Check the source code on the front end:

Before:

```html
<style id='wp-fonts-local'>
@font-face{font-family:Manrope;font-style:normal;font-weight:200 800;font-display:fallback;src:url('file:./assets/fonts/manrope/Manrope-VariableFont_wght.woff2') format('woff2');}
@font-face{font-family:"Fira Code";font-style:normal;font-weight:300 700;font-display:fallback;src:url('file:./assets/fonts/fira-code/FiraCode-VariableFont_wght.woff2') format('woff2');}
</style>
```

After:

```html
<style id='wp-fonts-local'>
@font-face{font-family:Manrope;font-style:normal;font-weight:200 800;font-display:fallback;src:url('http://localhost:8888/wp-content/themes/twentytwentyfive/assets/fonts/manrope/Manrope-VariableFont_wght.woff2') format('woff2');}
@font-face{font-family:"Fira Code";font-style:normal;font-weight:300 700;font-display:fallback;src:url('http://localhost:8888/wp-content/themes/twentytwentyfive/assets/fonts/fira-code/FiraCode-VariableFont_wght.woff2') format('woff2');}
</style>
```
