### PR TITLE
Tests: Add check for absolute URLs in font face styles

### DIFF
--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1438,4 +1438,17 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $actual, 'Merged variation styles do not match.' );
 	}
+
+	/**
+	 * Test that font face styles rendered in wp_head contain absolute URLs, not relative file:// URLs.
+	 */
+	public function test_font_face_styles_in_head_should_have_absolute_urls() {
+		switch_theme( 'fonts-block-theme' );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head_output = ob_get_clean();
+
+		$this->assertStringNotContainsString( "url('file:", $head_output, 'Font face URLs in wp_head should not contain relative file:// paths.' );
+	}
 }


### PR DESCRIPTION
Test to cover the possibility of font mismatching. 

#74137 and #74115 could have been avoided with this test.


