### PR TITLE
GHA: Fix action.yml for flaky tests action CommonJS file

### DIFF
--- a/packages/report-flaky-tests/action.yml
+++ b/packages/report-flaky-tests/action.yml
@@ -14,4 +14,4 @@ inputs:
         default: 'flaky-tests'
 runs:
     using: 'node20'
-    main: 'build/index.js'
+    main: 'build/index.cjs'


### PR DESCRIPTION
I've found a common error like this for a while:
https://github.com/WordPress/gutenberg/actions/runs/20396304494/job/58612923539?pr=74138

Whenever Flaky Tests step in Report to Github GHA action is reached, it will fail

```
Run ./packages/report-flaky-tests
Error: File not found: '/home/runner/work/gutenberg/gutenberg/./packages/report-flaky-tests/build/index.js'
```

Problem is that this file is being called wrongly, it's being compiled in commonJS in `tsconfig.json`

Two options:
1. Use the `cjs` file, which is the fastest to sort it
2. Switch to modules. 

Here I propose the first option.

<img width="880" height="516" alt="image" src="https://github.com/user-attachments/assets/db095340-b513-44b9-a486-b701398352cf" />