### PR TITLE
Post Excerpt Block: Fix length limits for both Editor and Front and fix ellipsis consistency.

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -45,7 +45,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 * wp_trim_words is used instead.
 	 *
 	 * To ensure the block's excerptLength setting works correctly for auto-generated
-	 * excerpts, we temporarily override excerpt_length to 100 (the max block setting)
+	 * excerpts, we temporarily override excerpt_length to 101 (the max block setting)
 	 * so that wp_trim_excerpt doesn't pre-trim the content before wp_trim_words can
 	 * apply the user's desired length.
 	 */

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -39,7 +39,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	add_filter( 'excerpt_more', $filter_excerpt_more );
 	$filter_excerpt_length = static function () {
 		return 100;
-	};	
+	};
 	add_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
 
 	/*
@@ -52,8 +52,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
 
 	remove_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
-	
-	$is_trimmed     = false;
+
+	$is_trimmed = false;
 	if ( isset( $excerpt_length ) ) {
 		$original_excerpt = $excerpt;
 		$excerpt          = wp_trim_words( $excerpt, $excerpt_length, '' );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -37,27 +37,27 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 * Otherwise, the read more link filter from the theme is not removed.
 	 */
 	add_filter( 'excerpt_more', $filter_excerpt_more );
-	$filter_excerpt_length = static function () {
-		return 100;
-	};
-	add_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
 
 	/*
-	* The purpose of the excerpt length setting is to limit the length of both
-	* automatically generated and user-created excerpts.
-	* Because the excerpt_length filter only applies to auto generated excerpts,
-	* wp_trim_words is used instead.
-	*/
+	 * The purpose of the excerpt length setting is to limit the length of both
+	 * automatically generated and user-created excerpts.
+	 * Because the excerpt_length filter only applies to auto generated excerpts,
+	 * wp_trim_words is used instead.
+	 *
+	 * To ensure the block's excerptLength setting works correctly for auto-generated
+	 * excerpts, we temporarily override excerpt_length to 100 (the max block setting)
+	 * so that wp_trim_excerpt doesn't pre-trim the content before wp_trim_words can
+	 * apply the user's desired length.
+	 */
 	$excerpt_length = $attributes['excerptLength'];
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	add_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
 
-	remove_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
+	$excerpt = get_the_excerpt( $block->context['postId'] );
 
-	$is_trimmed = false;
+	remove_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
+
 	if ( isset( $excerpt_length ) ) {
-		$original_excerpt = $excerpt;
-		$excerpt          = wp_trim_words( $excerpt, $excerpt_length, '' );
-		$is_trimmed       = $original_excerpt !== $excerpt;
+		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}
 
 	$classes = array();
@@ -72,9 +72,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$content               = '<p class="wp-block-post-excerpt__excerpt">' . $excerpt;
 	$show_more_on_new_line = ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'];
 	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
-		$content .= ( $is_trimmed ? '&hellip;' : '' ) . '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
+		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
-		$content .= ( $is_trimmed ? '&hellip; ' : '' ) . $more_text . '</p>';
+		$content .= " $more_text</p>";
 	}
 	remove_filter( 'excerpt_more', $filter_excerpt_more );
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
@@ -96,18 +96,31 @@ function register_block_core_post_excerpt() {
 add_action( 'init', 'register_block_core_post_excerpt' );
 
 /**
+ * Callback for the excerpt_length filter to override the excerpt length.
+ *
  * If themes or plugins filter the excerpt_length, we need to
  * override the filter in the editor, otherwise
  * the excerpt length block setting has no effect.
- * Returns 100 because 100 is the max length in the setting.
+ * Returns 101 (one more than the max block setting of 100) to ensure
+ * wp_trim_words can detect when trimming is needed and add the ellipsis.
+ *
+ * For REST API requests, the filter is added on 'rest_api_init'
+ * because REST_REQUEST is not defined until 'parse_request'.
+ *
+ * @since 7.0.0
+ *
+ * @return int The excerpt length.
  */
-if ( is_admin() ||
-	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-	add_filter(
-		'excerpt_length',
-		static function () {
-			return 100;
-		},
-		PHP_INT_MAX
-	);
+function block_core_post_excerpt_excerpt_length() {
+	return 101;
 }
+
+if ( is_admin() ) {
+	add_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
+}
+add_action(
+	'rest_api_init',
+	static function () {
+		add_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
+	}
+);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -37,6 +37,10 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 * Otherwise, the read more link filter from the theme is not removed.
 	 */
 	add_filter( 'excerpt_more', $filter_excerpt_more );
+	$filter_excerpt_length = static function () {
+		return 100;
+	};	
+	add_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
 
 	/*
 	* The purpose of the excerpt length setting is to limit the length of both
@@ -46,6 +50,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	*/
 	$excerpt_length = $attributes['excerptLength'];
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
+
+	remove_filter( 'excerpt_length', $filter_excerpt_length, PHP_INT_MAX );
+	
 	$is_trimmed     = false;
 	if ( isset( $excerpt_length ) ) {
 		$original_excerpt = $excerpt;

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -65,7 +65,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$content               = '<p class="wp-block-post-excerpt__excerpt">' . $excerpt;
 	$show_more_on_new_line = ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'];
 	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
-		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
+		$content .= ( $is_trimmed ? '&hellip;' : '' ) . '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
 		$content .= ( $is_trimmed ? '&hellip; ' : '' ) . $more_text . '</p>';
 	}

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -46,8 +46,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	*/
 	$excerpt_length = $attributes['excerptLength'];
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	$is_trimmed     = false;
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+		$original_excerpt = $excerpt;
+		$excerpt          = wp_trim_words( $excerpt, $excerpt_length, '' );
+		$is_trimmed       = $original_excerpt !== $excerpt;
 	}
 
 	$classes = array();
@@ -64,7 +67,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
 		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
-		$content .= " $more_text</p>";
+		$content .= ( $is_trimmed ? '&hellip; ' : '' ) . $more_text . '</p>';
 	}
 	remove_filter( 'excerpt_more', $filter_excerpt_more );
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );

--- a/phpunit/blocks/render-post-template-test.php
+++ b/phpunit/blocks/render-post-template-test.php
@@ -54,13 +54,13 @@ class Tests_Blocks_RenderPostTemplateBlock extends WP_UnitTestCase {
 	<li class="wp-block-post post-$other_post_id post type-post status-publish format-standard hentry category-uncategorized">
 		<h2 class="wp-block-post-title">Ceiling Cat</h2>
 		<div class="wp-block-post-excerpt">
-			<p class="wp-block-post-excerpt__excerpt">Ceiling Cat </p>
+			<p class="wp-block-post-excerpt__excerpt">Ceiling Cat</p>
 		</div>
 	</li>
 	<li class="wp-block-post post-$post_id post type-post status-publish format-standard hentry category-uncategorized">
 		<h2 class="wp-block-post-title">Metal Dog</h2>
 		<div class="wp-block-post-excerpt">
-			<p class="wp-block-post-excerpt__excerpt">Metal Dog </p>
+			<p class="wp-block-post-excerpt__excerpt">Metal Dog</p>
 		</div>
 	</li>
 </ul>

--- a/phpunit/blocks/render-post-template-test.php
+++ b/phpunit/blocks/render-post-template-test.php
@@ -54,13 +54,13 @@ class Tests_Blocks_RenderPostTemplateBlock extends WP_UnitTestCase {
 	<li class="wp-block-post post-$other_post_id post type-post status-publish format-standard hentry category-uncategorized">
 		<h2 class="wp-block-post-title">Ceiling Cat</h2>
 		<div class="wp-block-post-excerpt">
-			<p class="wp-block-post-excerpt__excerpt">Ceiling Cat</p>
+			<p class="wp-block-post-excerpt__excerpt">Ceiling Cat </p>
 		</div>
 	</li>
 	<li class="wp-block-post post-$post_id post type-post status-publish format-standard hentry category-uncategorized">
 		<h2 class="wp-block-post-title">Metal Dog</h2>
 		<div class="wp-block-post-excerpt">
-			<p class="wp-block-post-excerpt__excerpt">Metal Dog</p>
+			<p class="wp-block-post-excerpt__excerpt">Metal Dog </p>
 		</div>
 	</li>
 </ul>


### PR DESCRIPTION
Fixes #74133

## What?
Closes #74133

Adds the missing ellipsis (…) to the Post Excerpt block on the frontend when the excerpt is trimmed and a read more link is present.

## Why?
The ellipsis was correctly displayed in the editor but missing on the frontend, creating an inconsistent user experience. When users add a "read more" link to a trimmed excerpt, the ellipsis should appear to indicate the content continues, matching the editor preview.

## How?
- Track whether the excerpt was actually trimmed by storing the original excerpt and comparing it with the trimmed version
- Pass an empty string as the third parameter to `wp_trim_words()` to prevent it from automatically adding its own ellipsis
- Manually add `&hellip;` when the excerpt is trimmed and displayed inline with the read more link

## Testing Instructions
1. Use TT4 or any block theme
2. Create a new post with long content (more than 55 words in the excerpt or content)
3. Go to the Site Editor and edit a template that displays posts (e.g., Home or Archive template)
4. Add or locate the Post Excerpt block
5. In the block settings, add "Read more" text (e.g., "Continue reading")
6. Test with "Show link on new line" disabled (inline mode)
7. Save the template and view the frontend
8. Verify the ellipsis (…) now appears before the "Read more" link
9. Also test with "Show link on new line" enabled to ensure no regression

### Testing Instructions for Keyboard
1. Navigate to the Post Excerpt block using Tab key
2. Press Enter to select the block
3. Use Tab to navigate to the block settings sidebar
4. Use arrow keys to navigate to "Read more" text field
5. Type "Read more" text
6. Tab to "Show link on new line" toggle and test both states with Space key
7. Save and verify on frontend using keyboard navigation


