### PR TITLE
LinkPicker: conditionally truncate URL

### DIFF
--- a/packages/block-editor/src/components/link-picker/link-preview.js
+++ b/packages/block-editor/src/components/link-picker/link-preview.js
@@ -54,7 +54,13 @@ export function LinkPreview( { title, url, image, badges } ) {
 						</Truncate>
 						{ url && (
 							<span className="link-preview-button__hint">
-								{ url }
+								{ /^https?:\/\//.test( url ) ? (
+									<Truncate numberOfLines={ 1 }>
+										{ url }
+									</Truncate>
+								) : (
+									url
+								) }
 							</span>
 						) }
 						{ badges && badges.length > 0 && (


### PR DESCRIPTION
Adding over #74110

Conditionally truncate or not if the URL is internal or external using an `http(s)` regex (by default all externals should have full URI while internals shouldn't).

More testing/preview info directly in #74110 