### PR TITLE
Storybook: Update DataView free composition story.

### DIFF
--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -17,7 +17,6 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	__experimentalGrid as Grid,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
@@ -318,67 +317,69 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 			<Heading className="free-composition-heading" level={ 2 }>
 				{ __( 'Solar System numbers' ) }
 			</Heading>
-			<Grid
-				templateColumns="repeat(auto-fit, minmax(330px, 1fr))"
-				align="flex-start"
-				className="free-composition-header"
-			>
-				<Card variant="secondary">
-					<CardBody>
-						<VStack>
-							<Text size={ 18 } as="p">
-								{ createInterpolateElement(
-									_n(
-										'<PlanetsNumber /> planet',
-										'<PlanetsNumber /> planets',
-										planets.length
-									),
-									{
-										PlanetsNumber: (
-											<strong>{ planets.length } </strong>
-										),
-									}
-								) }
-							</Text>
-
-							<Text size={ 18 } as="p">
-								{ createInterpolateElement(
-									_n(
-										'<SatellitesNumber /> moon',
-										'<SatellitesNumber /> moons',
-										moons
-									),
-									{
-										SatellitesNumber: (
-											<strong>{ moons } </strong>
-										),
-									}
-								) }
-							</Text>
-						</VStack>
-					</CardBody>
-				</Card>
-
-				<VStack>
-					<HStack justify="start">
+			<div className="free-composition-header">
+				<VStack spacing={ 4 }>
+					<HStack justify="start" spacing={ 2 }>
+						<DataViews.Search label={ __( 'Search content' ) } />
 						<DataViews.FiltersToggle />
-						<DataViews.Search label={ __( 'moons by planet' ) } />
+						<HStack justify="end" spacing={ 2 }>
+							<DataViews.ViewConfig />
+							<DataViews.LayoutSwitcher />
+						</HStack>
 					</HStack>
 					<DataViews.FiltersToggled />
+					<Card variant="secondary">
+						<CardBody>
+							<VStack>
+								<Text size={ 18 } as="p">
+									{ createInterpolateElement(
+										_n(
+											'<PlanetsNumber /> planet',
+											'<PlanetsNumber /> planets',
+											planets.length
+										),
+										{
+											PlanetsNumber: (
+												<strong>
+													{ planets.length }{ ' ' }
+												</strong>
+											),
+										}
+									) }
+								</Text>
+
+								<Text size={ 18 } as="p">
+									{ createInterpolateElement(
+										_n(
+											'<SatellitesNumber /> moon',
+											'<SatellitesNumber /> moons',
+											moons
+										),
+										{
+											SatellitesNumber: (
+												<strong>{ moons } </strong>
+											),
+										}
+									) }
+								</Text>
+							</VStack>
+						</CardBody>
+					</Card>
+					<Card style={ { width: '100%' } }>
+						<CardBody>
+							<HStack
+								justify="space-between"
+								alignment="center"
+								spacing={ 2 }
+							>
+								<DataViews.BulkActionToolbar />
+								<DataViews.Pagination />
+							</HStack>
+						</CardBody>
+					</Card>
+					<DataViews.Layout className="free-composition-dataviews-layout" />
 				</VStack>
-
-				<VStack>
-					<HStack justify="end">
-						<DataViews.Pagination />
-						<DataViews.ViewConfig />
-						<DataViews.LayoutSwitcher />
-					</HStack>
-
-					<DataViews.BulkActionToolbar />
-				</VStack>
-			</Grid>
-
-			<DataViews.Layout className="free-composition-dataviews-layout" />
+			</div>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
Related to: https://github.com/WordPress/gutenberg/pull/73969.

This PR improves the look for the free composition example to make it more like a world-real example. It also kind of looked broken before.

| Before | After |
|--------|--------|
| <img width="2882" height="1926" alt="wordpress github io_gutenberg__path=_story_dataviews-dataviews--free-composition" src="https://github.com/user-attachments/assets/18e2c621-0cd5-418a-b45d-b6856b3af4b9" /> | <img width="2882" height="1926" alt="localhost_50240__path=_story_dataviews-dataviews--free-composition" src="https://github.com/user-attachments/assets/16547af0-9694-4929-b5df-6f14e8a4131a" /> | 


## Testing Instructions
- `npm run storybook:dev`
- Visit: http://localhost:50240/?path=/story/dataviews-dataviews--free-composition
