### PR TITLE
Media Modal experiment: Always show thumbnail field

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -222,6 +222,12 @@ export function MediaUploadModal( {
 
 	const fields: Field< RestAttachment >[] = useMemo(
 		() => [
+			// Media field definitions from @wordpress/media-fields
+			// Cast is safe because RestAttachment has the same properties as Attachment
+			{
+				...( mediaThumbnailField as Field< RestAttachment > ),
+				enableHiding: false, // Within the modal, the thumbnail should always be shown.
+			},
 			{
 				id: 'title',
 				type: 'text' as const,
@@ -231,9 +237,6 @@ export function MediaUploadModal( {
 					return titleValue || __( '(no title)' );
 				},
 			},
-			// Media field definitions from @wordpress/media-fields
-			// Cast is safe because RestAttachment has the same properties as Attachment
-			mediaThumbnailField as Field< RestAttachment >,
 			altTextField as Field< RestAttachment >,
 			captionField as Field< RestAttachment >,
 			descriptionField as Field< RestAttachment >,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #73085

In the media modal experiment, ensure the media thumbnail field cannot be hidden.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Within the context of the media modal, we should always show the media thumbnail in both the grid and table layouts. This PR enforces this at the consumer level (within the modal) because other consumers of the media fields (e.g. a media editor) may need the ability to allow hiding things.

This guardrail makes it slightly less likely for someone to reach a state where the different views of the media modal look not-quite-right.

Note: this PR is intentionally very granular. Other visual tasks will be tackled in separate PRs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* When importing the media thumbnail field for the media modal, override the `enableHiding` flag and set it to `false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the media modal experiment in Gutenberg's experiments page:

<img width="959" height="70" alt="image" src="https://github.com/user-attachments/assets/68b1a4d5-f05d-4d39-b69e-50faff702c1d" />

Open up the post editor and go to set a featured image for the post. You should not be able to hide the thumbnail field in either the grid or table layouts.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

With this PR, the thumbnail field cannot be hidden, but the title field can be toggled. Please excuse my fumbling clicks in the following video, but I get stage fright when recording these and click way too frequently:

https://github.com/user-attachments/assets/4db23e82-a758-436a-bde0-24d7f57595ad


