### PR TITLE
[Throw away] Scroll to preview block after isolated editor, store destination in session storage

### DIFF
--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -4,13 +4,14 @@
 import { useCallback, useReducer } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore, privateApis } from '@wordpress/editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
 
-const { useGenerateBlockPath } = unlock( privateApis );
+const { useGenerateBlockPath, saveBlockSelection } = unlock( privateApis );
 
 /**
  * A hook that records the 'entity' history in the post editor as a user
@@ -34,19 +35,9 @@ export default function useNavigateToEntityRecord(
 ) {
 	const generateBlockPath = useGenerateBlockPath();
 	const [ postHistory, dispatch ] = useReducer(
-		(
-			historyState,
-			{ type, post, previousRenderingMode, selectedBlockPath }
-		) => {
+		( historyState, { type, post, previousRenderingMode } ) => {
 			if ( type === 'push' ) {
-				// Update the current item with the selected block path before pushing new item
-				const updatedHistory = [ ...historyState ];
-				const currentIndex = updatedHistory.length - 1;
-				updatedHistory[ currentIndex ] = {
-					...updatedHistory[ currentIndex ],
-					selectedBlockPath,
-				};
-				return [ ...updatedHistory, { post, previousRenderingMode } ];
+				return [ ...historyState, { post, previousRenderingMode } ];
 			}
 			if ( type === 'pop' ) {
 				// Remove the current item from history
@@ -62,33 +53,55 @@ export default function useNavigateToEntityRecord(
 			},
 		]
 	);
-	const { post, previousRenderingMode, selectedBlockPath } =
+	const { post, previousRenderingMode } =
 		postHistory[ postHistory.length - 1 ];
 
-	const { getRenderingMode } = useSelect( editorStore );
+	const { getRenderingMode, getSelectedBlockClientId } = useSelect(
+		( select ) => {
+			return {
+				getRenderingMode: select( editorStore ).getRenderingMode,
+				getSelectedBlockClientId:
+					select( blockEditorStore ).getSelectedBlockClientId,
+			};
+		},
+		[]
+	);
 	const { setRenderingMode } = useDispatch( editorStore );
 
 	const onNavigateToEntityRecord = useCallback(
 		( params ) => {
-			// Generate block path from clientId if provided
-			const blockPath = params.selectedBlockClientId
-				? generateBlockPath( params.selectedBlockClientId )
-				: null;
+			// Save current selection to sessionStorage for restoration on back navigation
+			const selectedBlockClientId =
+				params.selectedBlockClientId || getSelectedBlockClientId();
+
+			if ( selectedBlockClientId ) {
+				const blockPath = generateBlockPath( selectedBlockClientId );
+				if ( blockPath ) {
+					saveBlockSelection(
+						post.postType,
+						post.postId,
+						selectedBlockClientId,
+						blockPath
+					);
+				}
+			}
 
 			dispatch( {
 				type: 'push',
 				post: { postId: params.postId, postType: params.postType },
 				// Save the current rendering mode so we can restore it when navigating back.
 				previousRenderingMode: getRenderingMode(),
-				selectedBlockPath: blockPath,
 			} );
 			setRenderingMode( defaultRenderingMode );
 		},
 		[
+			post.postType,
+			post.postId,
+			getSelectedBlockClientId,
+			generateBlockPath,
 			getRenderingMode,
 			setRenderingMode,
 			defaultRenderingMode,
-			generateBlockPath,
 		]
 	);
 
@@ -108,7 +121,5 @@ export default function useNavigateToEntityRecord(
 			postHistory.length > 1
 				? onNavigateToPreviousEntityRecord
 				: undefined,
-		// Return the selected block path from the current history item
-		previousSelectedBlockPath: selectedBlockPath,
 	};
 }

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -5,60 +5,56 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useCallback } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 
-const { useHistory, useLocation } = unlock( routerPrivateApis );
-const { useGenerateBlockPath } = unlock( editorPrivateApis );
+const { useHistory } = unlock( routerPrivateApis );
+const { useGenerateBlockPath, saveBlockSelection } =
+	unlock( editorPrivateApis );
 
 /**
- * Hook to handle navigation to entity records and retrieve initial block selection.
+ * Hook to handle navigation to entity records.
  *
- * @return {Array} A tuple containing:
- *   - onNavigateToEntityRecord: Function to navigate to an entity record
- *   - initialBlockSelection: The block path or clientId to restore selection, or null if none stored
+ * @param {string} currentPostType Current post type.
+ * @param {number} currentPostId   Current post ID.
+ *
+ * @return {Function} Function to navigate to an entity record.
  */
-export default function useNavigateToEntityRecord() {
+export default function useNavigateToEntityRecord(
+	currentPostType,
+	currentPostId
+) {
 	const history = useHistory();
-	const { query, path } = useLocation();
 	const generateBlockPath = useGenerateBlockPath();
-
-	// Get the selected block from URL parameters and decode the block path
-	let initialBlockSelection = null;
-	if ( query.selectedBlock ) {
-		try {
-			initialBlockSelection = JSON.parse(
-				decodeURIComponent( query.selectedBlock )
-			);
-		} catch ( e ) {
-			// Invalid JSON, ignore
-			initialBlockSelection = null;
-		}
-	}
+	const getSelectedBlockClientId = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockClientId,
+		[]
+	);
 
 	const onNavigateToEntityRecord = useCallback(
 		( params ) => {
-			// First, update the current URL to include the selected block path for when we navigate back
-			if ( params.selectedBlockClientId ) {
-				const blockPath = generateBlockPath(
-					params.selectedBlockClientId
-				);
+			// Save current selection to sessionStorage for restoration on back navigation
+			const selectedBlockClientId =
+				params.selectedBlockClientId || getSelectedBlockClientId();
+
+			if ( selectedBlockClientId && currentPostType && currentPostId ) {
+				const blockPath = generateBlockPath( selectedBlockClientId );
 				if ( blockPath ) {
-					// Encode the block path as JSON in the URL
-					const currentUrl = addQueryArgs( path, {
-						...query,
-						selectedBlock: encodeURIComponent(
-							JSON.stringify( blockPath )
-						),
-					} );
-					history.navigate( currentUrl, { replace: true } );
+					saveBlockSelection(
+						currentPostType,
+						currentPostId,
+						selectedBlockClientId,
+						blockPath
+					);
 				}
 			}
 
-			// Then navigate to the new entity record
+			// Navigate to the new entity record
 			const url = addQueryArgs(
 				`/${ params.postType }/${ params.postId }`,
 				{
@@ -69,8 +65,14 @@ export default function useNavigateToEntityRecord() {
 
 			history.navigate( url );
 		},
-		[ history, path, query, generateBlockPath ]
+		[
+			currentPostType,
+			currentPostId,
+			getSelectedBlockClientId,
+			generateBlockPath,
+			history,
+		]
 	);
 
-	return [ onNavigateToEntityRecord, initialBlockSelection ];
+	return onNavigateToEntityRecord;
 }

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -38,11 +38,13 @@ function useNavigateToPreviousEntityRecord() {
 	return goBack;
 }
 
-export function useSpecificEditorSettings() {
+export function useSpecificEditorSettings( postType, postId ) {
 	const { query } = useLocation();
 	const { canvas = 'view' } = query;
-	const [ onNavigateToEntityRecord, initialBlockSelection ] =
-		useNavigateToEntityRecord();
+	const onNavigateToEntityRecord = useNavigateToEntityRecord(
+		postType,
+		postId
+	);
 
 	/*
 	 * Generate global styles directly to avoid circular dependency with GlobalStylesRenderer
@@ -97,7 +99,6 @@ export function useSpecificEditorSettings() {
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			isPreviewMode: canvas === 'view',
-			initialBlockSelection,
 		};
 	}, [
 		settings,
@@ -107,7 +108,6 @@ export function useSpecificEditorSettings() {
 		currentPostIsTrashed,
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,
-		initialBlockSelection,
 	] );
 
 	return defaultEditorSettings;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -142,8 +142,10 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 		'edit-site-editor__loading-progress'
 	);
 
-	const settings = useSpecificEditorSettings();
-	const { initialBlockSelection, ...editorSettings } = settings;
+	const settings = useSpecificEditorSettings(
+		postWithTemplate ? context.postType : postType,
+		postWithTemplate ? context.postId : postId
+	);
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
@@ -223,8 +225,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 					postType={ postWithTemplate ? context.postType : postType }
 					postId={ postWithTemplate ? context.postId : postId }
 					templateId={ postWithTemplate ? postId : undefined }
-					settings={ editorSettings }
-					initialSelection={ initialBlockSelection }
+					settings={ settings }
 					className="edit-site-editor__editor-interface"
 					customSaveButton={
 						_isPreviewingTheme && <SaveButton size="compact" />

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -25,7 +25,6 @@ function Editor( {
 	settings,
 	children,
 	initialEdits,
-	initialSelection,
 
 	// This could be part of the settings.
 	onActionPerformed,
@@ -115,7 +114,6 @@ function Editor( {
 					__unstableTemplate={ template }
 					settings={ settings }
 					initialEdits={ initialEdits }
-					initialSelection={ initialSelection }
 					useSubRegistry={ false }
 				>
 					<EditorInterface { ...props }>

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -1,19 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
-import { useRestoreBlockFromPath } from '../../utils/block-selection-path';
 import EditorInterface from '../editor-interface';
 import { ExperimentalEditorProvider } from '../provider';
 import Sidebar from '../sidebar';
@@ -98,32 +95,6 @@ function Editor( {
 		[ postType, postId, templateId ]
 	);
 
-	const { selectBlock } = useDispatch( blockEditorStore );
-	const restoreBlockFromPath = useRestoreBlockFromPath();
-
-	// Restore initial block selection if provided (e.g., from navigation)
-	useEffect( () => {
-		if ( ! initialSelection || ! hasLoadedPost || ! post ) {
-			return;
-		}
-
-		// Use setTimeout to ensure blocks are fully rendered before selecting
-		const timeoutId = setTimeout( () => {
-			const clientId = restoreBlockFromPath( initialSelection );
-			if ( clientId ) {
-				selectBlock( clientId );
-			}
-		}, 0 );
-
-		return () => clearTimeout( timeoutId );
-	}, [
-		initialSelection,
-		hasLoadedPost,
-		post,
-		selectBlock,
-		restoreBlockFromPath,
-	] );
-
 	return (
 		<>
 			{ hasLoadedPost && ! post && (
@@ -144,6 +115,7 @@ function Editor( {
 					__unstableTemplate={ template }
 					settings={ settings }
 					initialEdits={ initialEdits }
+					initialSelection={ initialSelection }
 					useSubRegistry={ false }
 				>
 					<EditorInterface { ...props }>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -13,6 +13,7 @@ import {
 	BlockEditorProvider,
 	BlockContextProvider,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
@@ -37,6 +38,7 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
+import { useRestoreBlockFromPath } from '../../utils/block-selection-path';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -158,6 +160,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		settings,
 		recovery,
 		initialEdits,
+		initialSelection,
 		children,
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
@@ -348,6 +351,20 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Register the editor commands.
 		useCommands();
+
+		// Handle initial selection restoration from navigation (e.g., editor back button)
+		const restoreBlockFromPath = useRestoreBlockFromPath();
+		const { selectBlock } = useDispatch( blockEditorStore );
+		useEffect( () => {
+			if ( ! initialSelection || ! blocks || blocks.length === 0 ) {
+				return;
+			}
+
+			const clientId = restoreBlockFromPath( initialSelection );
+			if ( clientId ) {
+				selectBlock( clientId );
+			}
+		}, [ initialSelection, blocks, selectBlock, restoreBlockFromPath ] );
 
 		if ( ! isReady || ! mode ) {
 			return null;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -38,7 +38,7 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
-import { useRestoreBlockFromPath } from '../../utils/block-selection-path';
+import { useRestoreBlockSelectionFromSession } from '../../utils/block-selection-path';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -160,7 +160,6 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		settings,
 		recovery,
 		initialEdits,
-		initialSelection,
 		children,
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
@@ -353,18 +352,27 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useCommands();
 
 		// Handle initial selection restoration from navigation (e.g., editor back button)
-		const restoreBlockFromPath = useRestoreBlockFromPath();
+		// Restore from sessionStorage using fast path (clientId) with fallback to block path
+		const restoreSelectionFromSession =
+			useRestoreBlockSelectionFromSession();
 		const { selectBlock } = useDispatch( blockEditorStore );
 		useEffect( () => {
-			if ( ! initialSelection || ! blocks || blocks.length === 0 ) {
+			if ( ! blocks || blocks.length === 0 ) {
 				return;
 			}
 
-			const clientId = restoreBlockFromPath( initialSelection );
+			// Try to restore selection from sessionStorage
+			const clientId = restoreSelectionFromSession( post.type, post.id );
 			if ( clientId ) {
 				selectBlock( clientId );
 			}
-		}, [ initialSelection, blocks, selectBlock, restoreBlockFromPath ] );
+		}, [
+			blocks,
+			post.type,
+			post.id,
+			restoreSelectionFromSession,
+			selectBlock,
+		] );
 
 		if ( ! isReady || ! mode ) {
 			return null;

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -1,6 +1,11 @@
 /**
  * WordPress dependencies
  */
+import {
+	CreateTemplatePartModal,
+	patternTitleField,
+	templateTitleField,
+} from '@wordpress/fields';
 import * as interfaceApis from '@wordpress/interface';
 
 /**
@@ -18,11 +23,6 @@ import usePostFields from './components/post-fields';
 import ToolsMoreMenuGroup from './components/more-menu/tools-more-menu-group';
 import ViewMoreMenuGroup from './components/more-menu/view-more-menu-group';
 import ResizableEditor from './components/resizable-editor';
-import {
-	CreateTemplatePartModal,
-	patternTitleField,
-	templateTitleField,
-} from '@wordpress/fields';
 import { registerCoreBlockBindingsSources } from './bindings/api';
 import { getTemplateInfo } from './utils/get-template-info';
 import GlobalStylesUIWrapper from './components/global-styles';
@@ -32,6 +32,9 @@ import { GlobalStylesActionMenu } from './components/global-styles/menu';
 import {
 	useGenerateBlockPath,
 	useRestoreBlockFromPath,
+	saveBlockSelection,
+	getAndClearBlockSelection,
+	useRestoreBlockSelectionFromSession,
 } from './utils/block-selection-path';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
@@ -63,6 +66,9 @@ lock( privateApis, {
 	// Block selection
 	useGenerateBlockPath,
 	useRestoreBlockFromPath,
+	saveBlockSelection,
+	getAndClearBlockSelection,
+	useRestoreBlockSelectionFromSession,
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	interfaceStore,
 	...remainingInterfaceApis,

--- a/packages/editor/src/utils/block-selection-path.js
+++ b/packages/editor/src/utils/block-selection-path.js
@@ -6,6 +6,84 @@ import { useCallback } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
+ * Creates a sessionStorage key for storing block selection.
+ *
+ * @param {string} postType Post type.
+ * @param {number} postId   Post ID.
+ * @return {string} SessionStorage key.
+ */
+function getSelectionStorageKey( postType, postId ) {
+	return `wp-block-editor-selection-${ postType }-${ postId }`;
+}
+
+/**
+ * Saves the current block selection to sessionStorage.
+ * Stores both clientId (for fast restoration) and blockPath (for reliability).
+ *
+ * @param {string} postType Post type.
+ * @param {number} postId   Post ID.
+ * @param {string} clientId Selected block's clientId.
+ * @param {Array}  path     Block path from useGenerateBlockPath.
+ */
+export function saveBlockSelection( postType, postId, clientId, path ) {
+	if ( typeof window === 'undefined' || ! window.sessionStorage ) {
+		return;
+	}
+
+	try {
+		const data = {
+			clientId,
+			path,
+			timestamp: Date.now(),
+		};
+		window.sessionStorage.setItem(
+			getSelectionStorageKey( postType, postId ),
+			JSON.stringify( data )
+		);
+	} catch ( error ) {
+		// Silently fail if sessionStorage is full or unavailable
+	}
+}
+
+/**
+ * Retrieves and clears the stored block selection from sessionStorage.
+ *
+ * @param {string} postType Post type.
+ * @param {number} postId   Post ID.
+ * @return {Object|null} Stored selection data or null if not found.
+ */
+export function getAndClearBlockSelection( postType, postId ) {
+	if ( typeof window === 'undefined' || ! window.sessionStorage ) {
+		return null;
+	}
+
+	try {
+		const key = getSelectionStorageKey( postType, postId );
+		const stored = window.sessionStorage.getItem( key );
+
+		if ( ! stored ) {
+			return null;
+		}
+
+		// Clear immediately to prevent reuse
+		window.sessionStorage.removeItem( key );
+
+		const data = JSON.parse( stored );
+
+		// Ignore stored selections older than 5 minutes
+		const FIVE_MINUTES = 5 * 60 * 1000;
+		if ( Date.now() - data.timestamp > FIVE_MINUTES ) {
+			return null;
+		}
+
+		return data;
+	} catch ( error ) {
+		// Silently fail if parsing fails
+		return null;
+	}
+}
+
+/**
  * Hook that returns a function to generate a block path for a given block clientId.
  * The path is an array of steps from root to the target block,
  * where each step contains the block name and index within its parent.
@@ -123,5 +201,42 @@ export function useRestoreBlockFromPath() {
 			return null;
 		},
 		[ registry ]
+	);
+}
+
+/**
+ * Hook that returns a function to restore a block selection from sessionStorage.
+ * Attempts to use the stored clientId first (fast path), then falls back to
+ * resolving the block path (reliable path).
+ *
+ * @return {Function} Function that takes postType and postId, returns the clientId or null.
+ */
+export function useRestoreBlockSelectionFromSession() {
+	const registry = useRegistry();
+	const restoreFromPath = useRestoreBlockFromPath();
+
+	return useCallback(
+		( postType, postId ) => {
+			const stored = getAndClearBlockSelection( postType, postId );
+
+			if ( ! stored ) {
+				return null;
+			}
+
+			const { getBlock } = registry.select( blockEditorStore );
+
+			// Fast path: Try the stored clientId first
+			if ( stored.clientId && getBlock( stored.clientId ) ) {
+				return stored.clientId;
+			}
+
+			// Fallback: Resolve using the block path
+			if ( stored.path ) {
+				return restoreFromPath( stored.path );
+			}
+
+			return null;
+		},
+		[ registry, restoreFromPath ]
 	);
 }


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
