### PR TITLE
Block visibility: incorrect argument passed to hasBlockSupport in isBlockHidden

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -717,7 +717,7 @@ export function getInsertionPoint( state ) {
  */
 export const isBlockHidden = ( state, clientId ) => {
 	const blockName = getBlockName( state, clientId );
-	if ( ! hasBlockSupport( state, blockName, 'visibility', true ) ) {
+	if ( ! hasBlockSupport( blockName, 'visibility', true ) ) {
 		return false;
 	}
 	const attributes = state.blocks.attributes.get( clientId );


### PR DESCRIPTION
## What

The `isBlockHidden` selector was incorrectly passing the `state` object as the first argument to `hasBlockSupport`, when it should only pass the block name. The `hasBlockSupport` function from `@wordpress/blocks` expects `(nameOrType, feature, defaultSupports)`, not a state object.

## Why

In unit tests (can't see any manual bugs so far) this caused incorrect behavior when checking if a block supports the visibility feature, potentially leading to blocks being incorrectly identified as hidden or visible.

## How

Removed the `state` argument from the `hasBlockSupport` call in `isBlockHidden`.

## Testing

Run tests with:
```bash
npm run test:unit -- packages/block-editor/src/store/test/private-selectors.js --testNamePattern="isBlockHidden"
```

You can try running the tests with the current code (there'll be a fail in `should return false when block does not have visibility support`).

```diff
diff --git a/packages/block-editor/src/store/private-selectors.js b/packages/block-editor/src/store/private-selectors.js
index b11cb081e5..5c4ab1bf8e 100644
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -717,7 +717,7 @@ export function getInsertionPoint( state ) {
  */
 export const isBlockHidden = ( state, clientId ) => {
 	const blockName = getBlockName( state, clientId );
-	if ( ! hasBlockSupport( blockName, 'visibility', true ) ) {
+	if ( ! hasBlockSupport( state, blockName, 'visibility', true ) ) {
 		return false;
 	}
 	const attributes = state.blocks.attributes.get( clientId );
```

### Manual Testing Steps

1. **Test block visibility with visibility support:**
   - Create a new post/page
   - Add a paragraph block
   - Open the block options menu (three dots)
   - Verify "Hide block" option is available
   - Click "Hide block"
   - Verify the block is hidden in the editor
   - Click "Show block" to unhide
   - Verify the block is visible again

2. **Test block without visibility support:**
   - Add a block that doesn't support visibility (if any exist)
   - Verify the "Hide block" option is not available in the block options menu

3. **Verify no regressions:**
   - Test other block operations (insert, move, delete)
   - Verify block visibility state persists after save/reload
   - Test with multiple blocks of different types
