### PR TITLE
Update report-flaky-tests action to use CommonJS module format

### DIFF
--- a/packages/report-flaky-tests/action.yml
+++ b/packages/report-flaky-tests/action.yml
@@ -14,4 +14,4 @@ inputs:
         default: 'flaky-tests'
 runs:
     using: 'node20'
-    main: 'build/index.js'
+    main: 'build/index.cjs'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The report flakey e2e test job failed because :
```
Run ./packages/report-flaky-tests
  with:
    repo-token: ***
    label: [Type] Flaky Test
    artifact-path: flaky-tests
Error: File not found: '/home/runner/work/gutenberg/gutenberg/./packages/report-flaky-tests/build/index.js'
```

I guess it was after this PR?

- https://github.com/WordPress/gutenberg/pull/73822

I don't know. 

Anyway this PR updates the test run path from index.js to index.cjs because that's what's now being built.

