### PR TITLE
Media Modal experiment: Tweak padding of the modal for consistency

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -349,6 +349,7 @@ export function MediaUploadModal( {
 			onRequestClose={ handleModalClose }
 			isDismissible={ isDismissible }
 			className={ modalClass }
+			overlayClassName="media-upload-modal"
 			size="fill"
 			headerActions={
 				<FormFileUpload

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -1,0 +1,13 @@
+.media-upload-modal {
+	.components-modal__content {
+		padding: 0;
+	}
+
+	.dataviews-picker-wrapper > .dataviews__view-actions {
+		padding-top: 0;
+	}
+
+	.dataviews-footer {
+		padding-bottom: 0;
+	}
+}

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -1,13 +1,23 @@
+@use "@wordpress/base-styles/variables" as *;
+
 .media-upload-modal {
+	.components-modal__header {
+		padding-bottom: $grid-unit-10;
+	}
+
+	.components-modal__frame.is-full-screen .components-modal__content {
+		margin-bottom: $grid-unit-20;
+	}
+
 	.components-modal__content {
 		padding: 0;
 	}
 
 	.dataviews-picker-wrapper > .dataviews__view-actions {
-		padding-top: 0;
+		padding-top: $grid-unit-10;
 	}
 
 	.dataviews-footer {
-		padding-bottom: 0;
+		padding-bottom: $grid-unit-10;
 	}
 }

--- a/packages/media-utils/src/style.scss
+++ b/packages/media-utils/src/style.scss
@@ -1,1 +1,2 @@
 @use "@wordpress/media-fields/build-style/style.css" as *;
+@use "./components/media-upload-modal/style.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #73085 and follows #73334

Update the padding for the media modal experiment to make the DataViewsPicker feel more at home within the UI (get closer to a consistent visual `24px` padding).

Note: this PR is not the final answer for how padding for pickers should work. It seeks to take a pragmatic approach and add a few rules to get things looking good enough for now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While #73334 updated DataViews to use a more consistent `24px` padding, it did so while deferring to the consumer to make sure things are zeroed out correctly or placed how they should in order for things to look good. For the media modal, that's this PR.

However, it isn't _totally_ straightforward. We need to still give things a little breathing room so that focus styles aren't cut off, because the overall content area has an `overflow` rule that causes these things to be... cut off.

I'd _also_ like to revisit the overflow rules, but that's a little more complex. So for now, I'm proposing we add these rules in to get things looking better in the shorter-term, and in the longer-term, (as part of #73085) we can continue to polish these UIs to get them working a little smoother.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a classname to the media upload modal
* Zero out the modal's content area padding so that we can defer to DataViewsPicker for its padding
* Adjust the top and bottom paddings so that they play nicely with each other — we still need a little breathing room for DataViewsPicker focus styles, but we also want things to line up nicely. My proposal here is to go with these changes for now, and we can continue to polish in follow-ups.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the media modal experiment:

<img width="1918" height="140" alt="image" src="https://github.com/user-attachments/assets/09fe1079-5d6b-496a-b5ce-78b16dc21227" />

Open up the post editor and go to add a featured image. Take a look at how the padding looks in the modal. Does this feel a bit better and seem good enough for now?

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1600" alt="image" src="https://github.com/user-attachments/assets/6a0c11d7-3717-4f64-8c6b-72d50c9c27a0" />

### After

<img width="1600" alt="image" src="https://github.com/user-attachments/assets/e7e73a89-c9da-405d-a04f-c956c18541d5" />