### PR TITLE
Font Library: fix help text position in Upload tab

### DIFF
--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -212,7 +211,7 @@ function UploadFonts() {
 	return (
 		<div className="font-library__tabpanel-layout">
 			<DropZone onFilesDrop={ handleDropZone } />
-			<VStack className="font-library__local-fonts">
+			<VStack className="font-library__local-fonts" justify="start">
 				{ notice && (
 					<Notice
 						status={ notice.type }
@@ -254,7 +253,6 @@ function UploadFonts() {
 						) }
 					/>
 				) }
-				<Spacer margin={ 2 } />
 				<Text className="font-library__upload-area__text">
 					{ __(
 						'Uploaded fonts appear in your library and can be used in your theme. Supported formats: .ttf, .otf, .woff, and .woff2.'


### PR DESCRIPTION
## What?

| Before | After |
|--------|--------|
| <img width="887" height="854" alt="image" src="https://github.com/user-attachments/assets/b29e18b9-5732-412c-a598-8800acd0999d" /> | <img width="890" height="851" alt="image" src="https://github.com/user-attachments/assets/123dd294-7fb0-4c92-aa52-f2396ab53f3e" /> |

## Why?

Perhaps the following two PRs are related to this problem:

- https://github.com/WordPress/gutenberg/pull/72599
- https://github.com/WordPress/gutenberg/pull/73150

## How?

Remove unnecessary components.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
