### PR TITLE
Query Loop: Hide `change design` or `choose pattern` when is locked

### DIFF
--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -10,7 +10,6 @@ import {
 	store as blockEditorStore,
 	useInnerBlocksProps,
 	privateApis as blockEditorPrivateApis,
-	BlockControls,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
@@ -130,13 +129,11 @@ export default function QueryContent( {
 
 	return (
 		<>
-			<BlockControls group="other">
-				<QueryToolbar
-					clientId={ clientId }
-					attributes={ attributes }
-					hasInnerBlocks
-				/>
-			</BlockControls>
+			<QueryToolbar
+				clientId={ clientId }
+				attributes={ attributes }
+				hasInnerBlocks
+			/>
 			<EnhancedPaginationModal
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -35,6 +35,7 @@ export default function QueryContent( {
 	clientId,
 	context,
 	name,
+	isSelected,
 } ) {
 	const {
 		queryId,
@@ -129,11 +130,13 @@ export default function QueryContent( {
 
 	return (
 		<>
-			<QueryToolbar
-				clientId={ clientId }
-				attributes={ attributes }
-				hasInnerBlocks
-			/>
+			{ isSelected && (
+				<QueryToolbar
+					clientId={ clientId }
+					attributes={ attributes }
+					hasInnerBlocks
+				/>
+			) }
 			<EnhancedPaginationModal
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -10,7 +10,6 @@ import { useState } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	__experimentalBlockVariationPicker,
-	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Button, Placeholder } from '@wordpress/components';
@@ -29,6 +28,7 @@ export default function QueryPlaceholder( {
 	clientId,
 	name,
 	openPatternSelectionModal,
+	isSelected,
 } ) {
 	const [ isStartingBlank, setIsStartingBlank ] = useState( false );
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
@@ -79,13 +79,13 @@ export default function QueryPlaceholder( {
 	}
 	return (
 		<div { ...blockProps }>
-			<BlockControls>
+			{ isSelected && (
 				<QueryToolbar
 					clientId={ clientId }
 					attributes={ attributes }
 					hasInnerBlocks={ false }
 				/>
-			</BlockControls>
+			) }
 			<Placeholder
 				className="block-editor-media-placeholder"
 				icon={ ! isSmallContainer && icon }

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -7,11 +7,17 @@ import {
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import PatternSelection, { useBlockPatterns } from './pattern-selection';
+import { unlock } from '../../lock-unlock';
 
 export default function QueryToolbar( {
 	clientId,
@@ -19,7 +25,14 @@ export default function QueryToolbar( {
 	hasInnerBlocks,
 } ) {
 	const hasPatterns = useBlockPatterns( clientId, attributes ).length;
-	if ( ! hasPatterns ) {
+	const isLocked = useSelect(
+		( select ) => {
+			const { isLockedBlock } = unlock( select( blockEditorStore ) );
+			return isLockedBlock( clientId );
+		},
+		[ clientId ]
+	);
+	if ( ! hasPatterns || isLocked ) {
 		return null;
 	}
 
@@ -28,29 +41,31 @@ export default function QueryToolbar( {
 		: __( 'Choose pattern' );
 
 	return (
-		<DropdownContentWrapper>
-			<Dropdown
-				contentClassName="block-editor-block-settings-menu__popover"
-				focusOnMount="firstElement"
-				expandOnMobile
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<ToolbarButton
-						aria-haspopup="true"
-						aria-expanded={ isOpen }
-						onClick={ onToggle }
-					>
-						{ buttonLabel }
-					</ToolbarButton>
-				) }
-				renderContent={ () => (
-					<PatternSelection
-						clientId={ clientId }
-						attributes={ attributes }
-						showSearch={ false }
-						showTitlesAsTooltip
-					/>
-				) }
-			/>
-		</DropdownContentWrapper>
+		<BlockControls group="other">
+			<DropdownContentWrapper>
+				<Dropdown
+					contentClassName="block-editor-block-settings-menu__popover"
+					focusOnMount="firstElement"
+					expandOnMobile
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<ToolbarButton
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							onClick={ onToggle }
+						>
+							{ buttonLabel }
+						</ToolbarButton>
+					) }
+					renderContent={ () => (
+						<PatternSelection
+							clientId={ clientId }
+							attributes={ attributes }
+							showSearch={ false }
+							showTitlesAsTooltip
+						/>
+					) }
+				/>
+			</DropdownContentWrapper>
+		</BlockControls>
 	);
 }

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -19,27 +19,14 @@ import {
 import PatternSelection, { useBlockPatterns } from './pattern-selection';
 import { unlock } from '../../lock-unlock';
 
-export default function QueryToolbar( {
-	clientId,
-	attributes,
-	hasInnerBlocks,
-} ) {
+function PatternPicker( { clientId, attributes, hasInnerBlocks } ) {
 	const hasPatterns = useBlockPatterns( clientId, attributes ).length;
-	const isLocked = useSelect(
-		( select ) => {
-			const { isLockedBlock } = unlock( select( blockEditorStore ) );
-			return isLockedBlock( clientId );
-		},
-		[ clientId ]
-	);
-	if ( ! hasPatterns || isLocked ) {
+	if ( ! hasPatterns ) {
 		return null;
 	}
-
 	const buttonLabel = hasInnerBlocks
 		? __( 'Change design' )
 		: __( 'Choose pattern' );
-
 	return (
 		<BlockControls group="other">
 			<DropdownContentWrapper>
@@ -68,4 +55,18 @@ export default function QueryToolbar( {
 			</DropdownContentWrapper>
 		</BlockControls>
 	);
+}
+
+export default function QueryToolbar( props ) {
+	const isLocked = useSelect(
+		( select ) => {
+			const { isLockedBlock } = unlock( select( blockEditorStore ) );
+			return isLockedBlock( props.clientId );
+		},
+		[ props.clientId ]
+	);
+	if ( isLocked ) {
+		return null;
+	}
+	return <PatternPicker { ...props } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/39908

This PR handles this part:
> Remove the "change design" option when the block is locked as being able to switch designs removes the locking

Additionally it hides the `choose pattern` toolbar button if it's in set up mode.

The root cause for this issue is [this](https://github.com/WordPress/gutenberg/issues/39908#issuecomment-1084637108).
> When we perform one of the above `replace/choose` actions, we replace a single Query Loop block with a pattern. What this means is there could be any blocks, from a wrapper Group block to a paragraph and then a Query Loop(or even multiple ones), so we can't even rely on the first replaced block etc..


This small patch is not ideal but maybe it's fine for this specific case when is locked.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Insert Query Loop block and lock it in its setup state
2. The `choose pattern` should not be visible
3. Insert another Query Loop and add some inner blocks
4. Lock the block and observe that the `change design` toolbar button shouldn't be visible

### Screenshots

https://github.com/user-attachments/assets/2325c694-d43a-4d17-bdd9-7b53088c3128




https://github.com/user-attachments/assets/261389e5-a49a-4c9f-81a1-b56f3deb27f1





