### PR TITLE
DataViews: Add groupBy.showLabel config option to control group header label visibility

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Enhancements
 
+- DataViews: Add `groupBy.showLabel` config option to control whether the field label is shown in group headers. [#74161](https://github.com/WordPress/gutenberg/pull/74161)
 - DataViews table layout: remove row click-to-select behavior and hover styles. Selection is now only possible via checkboxes, or by ctrl/cmd clicking. [#73873](https://github.com/WordPress/gutenberg/pull/73873)
 - Better labels for operators and deprecate the `isNotAll` operator. [#73671](https://github.com/WordPress/gutenberg/pull/73671)
 - DataForm: add support for `min`/`max` and `minLength`/`maxLength` validation for relevant controls. [#73465](https://github.com/WordPress/gutenberg/pull/73465)

--- a/packages/dataviews/src/dataviews-layouts/activity/activity-group.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/activity-group.tsx
@@ -14,6 +14,7 @@ interface ActivityGroupProps< Item > {
 	groupName: string;
 	groupData: Item[];
 	groupField: NormalizedField< Item >;
+	showLabel?: boolean;
 	children: React.ReactNode;
 }
 
@@ -21,20 +22,25 @@ export default function ActivityGroup< Item >( {
 	groupName,
 	groupData,
 	groupField,
+	showLabel = true,
 	children,
 }: ActivityGroupProps< Item > ) {
-	// Determine if we should show the field label
-	const groupHeader = createInterpolateElement(
-		// translators: %s: The label of the field e.g. "Status".
-		sprintf( __( '%s: <groupName />' ), groupField.label ).trim(),
-		{
-			groupName: (
-				<groupField.render
-					item={ groupData[ 0 ] }
-					field={ groupField }
-				/>
-			),
-		}
+	// Render group header content - either with or without field label
+	const groupHeader = showLabel ? (
+		createInterpolateElement(
+			// translators: %s: The label of the field e.g. "Status".
+			sprintf( __( '%s: <groupName />' ), groupField.label ).trim(),
+			{
+				groupName: (
+					<groupField.render
+						item={ groupData[ 0 ] }
+						field={ groupField }
+					/>
+				),
+			}
+		)
+	) : (
+		<groupField.render item={ groupData[ 0 ] } field={ groupField } />
 	);
 
 	return (

--- a/packages/dataviews/src/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/index.tsx
@@ -67,6 +67,7 @@ export default function ViewActivity< Item >(
 							groupName={ groupName }
 							groupData={ groupData }
 							groupField={ groupField }
+							showLabel={ view.groupBy?.showLabel !== false }
 						>
 							<ActivityItems< Item >
 								{ ...props }

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -60,12 +60,14 @@ function ViewGrid< Item >( {
 							( [ groupName, groupItems ] ) => (
 								<VStack key={ groupName } spacing={ 2 }>
 									<h3 className="dataviews-view-grid__group-header">
-										{ sprintf(
-											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-											__( '%1$s: %2$s' ),
-											groupField.label,
-											groupName
-										) }
+										{ view.groupBy?.showLabel === false
+											? groupName
+											: sprintf(
+													// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+													__( '%1$s: %2$s' ),
+													groupField.label,
+													groupName
+											  ) }
 									</h3>
 									<CompositeGrid
 										{ ...gridProps }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -546,12 +546,14 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 						( [ groupName, groupItems ] ) => (
 							<VStack key={ groupName } spacing={ 2 }>
 								<h3 className="dataviews-view-list__group-header">
-									{ sprintf(
-										// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-										__( '%1$s: %2$s' ),
-										groupField.label,
-										groupName
-									) }
+									{ view.groupBy?.showLabel === false
+										? groupName
+										: sprintf(
+												// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+												__( '%1$s: %2$s' ),
+												groupField.label,
+												groupName
+										  ) }
 								</h3>
 								{ groupItems.map( ( item ) => {
 									const id =

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -218,10 +218,12 @@ function GridItem< Item >( {
 function GridGroup< Item >( {
 	groupName,
 	groupField,
+	showLabel = true,
 	children,
 }: {
 	groupName: string;
 	groupField: NormalizedField< Item >;
+	showLabel?: boolean;
 	children: ReactNode;
 } ) {
 	const headerId = useInstanceId(
@@ -239,12 +241,14 @@ function GridGroup< Item >( {
 				className="dataviews-view-picker-grid-group__header"
 				id={ headerId }
 			>
-				{ sprintf(
-					// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-					__( '%1$s: %2$s' ),
-					groupField.label,
-					groupName
-				) }
+				{ showLabel
+					? sprintf(
+							// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+							__( '%1$s: %2$s' ),
+							groupField.label,
+							groupName
+					  )
+					: groupName }
 			</h3>
 			{ children }
 		</VStack>
@@ -346,6 +350,9 @@ function ViewPickerGrid< Item >( {
 									key={ groupName }
 									groupName={ groupName }
 									groupField={ groupField }
+									showLabel={
+										view.groupBy?.showLabel !== false
+									}
 								>
 									<GridItems
 										previewSize={ usedPreviewSize }

--- a/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-table/index.tsx
@@ -402,12 +402,14 @@ function ViewPickerTable< Item >( {
 										className="dataviews-view-table__group-header-cell"
 										role="presentation"
 									>
-										{ sprintf(
-											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-											__( '%1$s: %2$s' ),
-											groupField.label,
-											groupName
-										) }
+										{ view.groupBy?.showLabel === false
+											? groupName
+											: sprintf(
+													// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+													__( '%1$s: %2$s' ),
+													groupField.label,
+													groupName
+											  ) }
 									</td>
 								</tr>
 								{ groupItems.map( ( item, index ) => (

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -541,12 +541,14 @@ function ViewTable< Item >( {
 										}
 										className="dataviews-view-table__group-header-cell"
 									>
-										{ sprintf(
-											// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
-											__( '%1$s: %2$s' ),
-											groupField.label,
-											groupName
-										) }
+										{ view.groupBy?.showLabel === false
+											? groupName
+											: sprintf(
+													// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+													__( '%1$s: %2$s' ),
+													groupField.label,
+													groupName
+											  ) }
 									</td>
 								</tr>
 								{ groupItems.map( ( item, index ) => (

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -485,7 +485,11 @@ export const WithCard = () => {
 	);
 };
 
-export const GroupByLayout = () => {
+const GroupByLayoutComponent = ( {
+	showLabel = true,
+}: {
+	showLabel: boolean;
+} ) => {
 	const [ view, setView ] = useState< View >( {
 		type: LAYOUT_GRID,
 		search: '',
@@ -496,11 +500,19 @@ export const GroupByLayout = () => {
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'image',
-		groupBy: { field: 'type', direction: 'asc' },
+		groupBy: { field: 'type', direction: 'asc', showLabel },
 		layout: {
 			badgeFields: [ 'satellites' ],
 		},
 	} );
+
+	useEffect( () => {
+		setView( ( prevView ) => ( {
+			...prevView,
+			groupBy: { field: 'type', direction: 'asc', showLabel },
+		} ) );
+	}, [ showLabel ] );
+
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
@@ -516,6 +528,20 @@ export const GroupByLayout = () => {
 			defaultLayouts={ defaultLayouts }
 		/>
 	);
+};
+
+export const GroupByLayout = {
+	render: GroupByLayoutComponent,
+	args: {
+		showLabel: true,
+	},
+	argTypes: {
+		showLabel: {
+			control: 'boolean',
+			description:
+				'Whether to show the field label in group headers (e.g., "Type: Planet" vs just "Planet")',
+		},
+	},
 };
 
 export const InfiniteScroll = () => {
@@ -643,9 +669,11 @@ export const InfiniteScroll = () => {
 const ActivityComponent = ( {
 	showMedia = true,
 	grouping = true,
+	showLabel = true,
 }: {
 	showMedia: boolean;
 	grouping: boolean;
+	showLabel: boolean;
 } ) => {
 	const [ view, setView ] = useState< View >( {
 		type: LAYOUT_ACTIVITY,
@@ -666,6 +694,7 @@ const ActivityComponent = ( {
 			? {
 					field: 'date',
 					direction: 'asc',
+					showLabel,
 			  }
 			: undefined,
 	} );
@@ -674,12 +703,12 @@ const ActivityComponent = ( {
 			return {
 				...prevView,
 				groupBy: grouping
-					? { field: 'date', direction: 'asc' }
+					? { field: 'date', direction: 'asc', showLabel }
 					: undefined,
 				showMedia,
 			};
 		} );
-	}, [ showMedia, grouping ] );
+	}, [ showMedia, grouping, showLabel ] );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( orderEventData, view, orderEventFields );
@@ -711,6 +740,7 @@ export const Activity = {
 	args: {
 		showMedia: true,
 		grouping: true,
+		showLabel: true,
 	},
 	argTypes: {
 		showMedia: {
@@ -725,6 +755,11 @@ export const Activity = {
 			defaultValue: true,
 			description:
 				'Whether items are grouped by date in the activity list',
+		},
+		showLabel: {
+			control: 'boolean',
+			description:
+				'Whether to show the field label in group headers (e.g., "Date: Dec 15" vs just "Dec 15")',
 		},
 	},
 };

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -190,6 +190,13 @@ interface ViewBase {
 		 * The direction to sort by.
 		 */
 		direction: SortDirection;
+
+		/**
+		 * Whether to show the field label in the group header.
+		 *
+		 * @default true
+		 */
+		showLabel?: boolean;
 	};
 
 	/**


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74126

Introduces a new `showLabel` configuration option for the `groupBy` feature in DataViews layouts

## Why?
The groupBy feature currently always displays the field label in group headers (e.g., "Type: Planet", "Date: Dec 15, 2024"). However, this is not always necessary or desirable because some groupBy values are self-explanatory and the label adds visual noise. This option gives consumers control over whether the label is visible.

## How?
- Added `showLabel?: boolean` property to the `groupBy` configuration in the `ViewBase` type definition (defaults to `true` for backward compatibility)
  - Updated all 6 layout components to conditionally render the label based on this option:       
    - Table layout                                                                                
    - Grid layout                                                                                 
    - List layout                                                                                 
    - Activity layout                                                                             
    - Picker Grid layout                                                                          
    - Picker Table layout                                                                         
  - Added Storybook controls to the `GroupByLayout` and `Activity` stories to demonstrate the feature
                                                                                                  
  ### Usage                                                                                       
                                                                                                  
  ```typescript                                                                                   
  const view = {                                                                                  
    type: 'table',                                                                                
    groupBy: {                                                                                    
      field: 'status',                                                                            
      direction: 'asc',                                                                           
      showLabel: false  // Only shows "Published" instead of "Status: Published"                  
    }                                                                                             
  };                  

## Testing Instructions
 1. Run Storybook: npm run storybook:dev                                                         
  2. Navigate to DataViews → GroupByLayout                                                        
  3. In the Controls panel, toggle the showLabel checkbox                                         
  4. Observe the group headers change:                                                            
    - showLabel: true → "Type: Planet", "Type: Moon", etc.                                        
    - showLabel: false → "Planet", "Moon", etc.                                                   
  5. Switch between different layouts (Grid, Table, List) to verify it works across all           
  6. Navigate to DataViews → Activity and repeat with grouping enabled  

### Testing Instructions for Keyboard
  1. Use Tab to navigate to the Storybook Controls panel                                          
  2. Use Space/Enter to toggle the showLabel checkbox                                             
  3. Verify the group headers update correctly in the preview   

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5ab7c870-69ee-4df6-a2a2-3467571e18dc

