### PR TITLE
Button: Improve the label of the button block in list view

### DIFF
--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -36,6 +36,14 @@ export const settings = {
 		...a,
 		text: ( a.text || '' ) + text,
 	} ),
+	__experimentalLabel( attributes ) {
+		const customName = attributes?.metadata?.name;
+		if ( customName ) {
+			return customName;
+		}
+		const { text } = attributes;
+		return ! text || text.length === 0 ? __( 'Button' ) : text;
+	},
 };
 
 if ( window.__experimentalContentOnlyInspectorFields ) {

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -36,13 +36,17 @@ export const settings = {
 		...a,
 		text: ( a.text || '' ) + text,
 	} ),
-	__experimentalLabel( attributes ) {
-		const customName = attributes?.metadata?.name;
-		if ( customName ) {
-			return customName;
-		}
+	__experimentalLabel( attributes, { context } ) {
 		const { text } = attributes;
-		return ! text || text.length === 0 ? __( 'Button' ) : text;
+
+		const customName = attributes?.metadata?.name;
+		const hasContent = text?.trim().length > 0;
+
+		// In the list view, use the block's text as the label.
+		// If the text is empty, fall back to the default label.
+		if ( context === 'list-view' && ( customName || hasContent ) ) {
+			return customName || text;
+		}
 	},
 };
 


### PR DESCRIPTION
This PR updates the Button block to use a label based on its content. 
The need for this is more visible in #74120

## Testing instructions

 - Add a buttons block with some buttons
 - Open the list view
 - Check the label of the nested button blocks.