### PR TITLE
Block Card: Make the parent block navigation generic, supports any block with list view support

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -15,13 +15,14 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	chevronLeft,
 	chevronRight,
 	arrowRight,
 	arrowLeft,
 } from '@wordpress/icons';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ import {
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
+import { hasListViewSupport } from '../../hooks/list-view';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -103,18 +105,32 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
-	const parentNavBlockClientId = useSelect(
+	const { parentNavBlockClientId, parentBlockName } = useSelect(
 		( select ) => {
 			if ( parentClientId || isChild || ! allowParentNavigation ) {
-				return;
+				return {};
 			}
-			const { getBlockParentsByBlockName } = select( blockEditorStore );
+			const { getBlockParents, getBlockName } =
+				select( blockEditorStore );
 
-			return getBlockParentsByBlockName(
-				clientId,
-				'core/navigation',
-				true
-			)[ 0 ];
+			// Find the closest parent block that is either:
+			// 1. A navigation block (special case for ad-hoc list view support)
+			// 2. Any block with listView support
+			const parents = getBlockParents( clientId, true );
+			const foundParentId = parents.find( ( parentId ) => {
+				const parentName = getBlockName( parentId );
+				return (
+					parentName === 'core/navigation' ||
+					hasListViewSupport( parentName )
+				);
+			} );
+
+			return {
+				parentNavBlockClientId: foundParentId,
+				parentBlockName: foundParentId
+					? getBlockName( foundParentId )
+					: null,
+			};
 		},
 		[ clientId, allowParentNavigation, isChild, parentClientId ]
 	);
@@ -134,14 +150,17 @@ function BlockCard( {
 				className
 			) }
 		>
-			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
+			{ parentNavBlockClientId && (
 				<Button
 					onClick={ () => selectBlock( parentNavBlockClientId ) }
 					label={
-						parentNavBlockClientId
-							? __( 'Go to parent Navigation block' )
-							: // TODO - improve copy, not sure that we should use the term 'section'
-							  __( 'Go to parent section' )
+						parentBlockName
+							? sprintf(
+									/* translators: %s: The name of the parent block. */
+									__( 'Go to "%s" block' ),
+									getBlockType( parentBlockName )?.title
+							  )
+							: __( 'Go to parent block' )
 					}
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -11,6 +11,7 @@ import {
 	Icon,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -105,7 +106,7 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId, parentBlockName } = useSelect(
+	const { parentBlockClientId, parentBlockName } = useSelect(
 		( select ) => {
 			if ( parentClientId || isChild || ! allowParentNavigation ) {
 				return {};
@@ -126,7 +127,7 @@ function BlockCard( {
 			} );
 
 			return {
-				parentNavBlockClientId: foundParentId,
+				parentBlockClientId: foundParentId,
 				parentBlockName: foundParentId
 					? getBlockName( foundParentId )
 					: null,
@@ -150,59 +151,66 @@ function BlockCard( {
 				className
 			) }
 		>
-			{ parentNavBlockClientId && (
-				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
-					label={
-						parentBlockName
-							? sprintf(
-									/* translators: %s: The name of the parent block. */
-									__( 'Go to "%s" block' ),
-									getBlockType( parentBlockName )?.title
-							  )
-							: __( 'Go to parent block' )
-					}
-					style={
-						// TODO: This style override is also used in ToolsPanelHeader.
-						// It should be supported out-of-the-box by Button.
-						{ minWidth: 24, padding: 0 }
-					}
-					icon={ isRTL() ? chevronRight : chevronLeft }
-					size="small"
-				/>
-			) }
-			{ isChild && (
-				<span className="block-editor-block-card__child-indicator-icon">
-					<Icon icon={ isRTL() ? arrowLeft : arrowRight } />
-				</span>
-			) }
-			<OptionalParentSelectButton
-				onClick={
-					parentClientId
-						? () => {
-								selectBlock( parentClientId );
-						  }
-						: undefined
-				}
-			>
-				<BlockIcon icon={ icon } showColors />
-				<VStack spacing={ 1 }>
-					<TitleElement className="block-editor-block-card__title">
-						<span className="block-editor-block-card__name">
-							{ !! name?.length ? name : title }
-						</span>
-						{ ! parentClientId && ! isChild && !! name?.length && (
-							<Badge>{ title }</Badge>
-						) }
-					</TitleElement>
-					{ ! parentClientId && ! isChild && description && (
-						<Text className="block-editor-block-card__description">
-							{ description }
-						</Text>
+			<VStack>
+				<HStack justify="flex-start" spacing={ 0 }>
+					{ parentBlockClientId && (
+						<Button
+							onClick={ () => selectBlock( parentBlockClientId ) }
+							label={
+								parentBlockName
+									? sprintf(
+											/* translators: %s: The name of the parent block. */
+											__( 'Go to "%s" block' ),
+											getBlockType( parentBlockName )
+												?.title
+									  )
+									: __( 'Go to parent block' )
+							}
+							style={
+								// TODO: This style override is also used in ToolsPanelHeader.
+								// It should be supported out-of-the-box by Button.
+								{ minWidth: 24, padding: 0 }
+							}
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							size="small"
+						/>
 					) }
-					{ children }
-				</VStack>
-			</OptionalParentSelectButton>
+					{ isChild && (
+						<span className="block-editor-block-card__child-indicator-icon">
+							<Icon icon={ isRTL() ? arrowLeft : arrowRight } />
+						</span>
+					) }
+					<OptionalParentSelectButton
+						onClick={
+							parentClientId
+								? () => {
+										selectBlock( parentClientId );
+								  }
+								: undefined
+						}
+					>
+						<BlockIcon icon={ icon } showColors />
+						<VStack spacing={ 1 }>
+							<TitleElement className="block-editor-block-card__title">
+								<span className="block-editor-block-card__name">
+									{ !! name?.length ? name : title }
+								</span>
+								{ ! parentClientId &&
+									! isChild &&
+									!! name?.length && (
+										<Badge>{ title }</Badge>
+									) }
+							</TitleElement>
+							{ children }
+						</VStack>
+					</OptionalParentSelectButton>
+				</HStack>
+				{ ! parentClientId && ! isChild && description && (
+					<Text className="block-editor-block-card__description">
+						{ description }
+					</Text>
+				) }
+			</VStack>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -23,7 +23,7 @@ import {
 	arrowRight,
 	arrowLeft,
 } from '@wordpress/icons';
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,7 +31,6 @@ import { getBlockType } from '@wordpress/blocks';
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
-import { hasListViewSupport } from '../../hooks/list-view';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -122,7 +121,7 @@ function BlockCard( {
 				const parentName = getBlockName( parentId );
 				return (
 					parentName === 'core/navigation' ||
-					hasListViewSupport( parentName )
+					hasBlockSupport( parentName, 'listView' )
 				);
 			} );
 

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -2,9 +2,7 @@
 @use "@wordpress/base-styles/colors" as *;
 
 .block-editor-block-card {
-	align-items: flex-start;
 	color: $gray-900;
-	display: flex;
 	padding: $grid-unit-20;
 
 	&.is-parent {

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -338,7 +338,7 @@ test.describe( 'Navigation block - List view editing', () => {
 		// Click the back button to go back to the Nav block.
 		await blockSettings
 			.getByRole( 'button', {
-				name: 'Go to parent Navigation block',
+				name: 'Go to "Navigation" block',
 			} )
 			.click();
 


### PR DESCRIPTION
Builds on top of #74120 

## What?

Makes the inspector sidebar "back" button generic for any block with `listView` support, not just Navigation blocks.

## Why?

Buttons, Social Links, and List blocks now have listView support and should show the same back button behavior when their children are selected.

## How?
  - Updated `BlockCard` component to check for `listView` support in addition to the Navigation block special case
  - Changed button label from "Go to parent Navigation block" to "Go to [Block Title] block" for better clarity
  - Examples: "Go to Buttons block", "Go to Navigation block", "Go to Social Links block"

## Testing
Select a child block within Buttons, Social Links, or List blocks and verify the back button appears in the block inspector with the correct parent block title.