### PR TITLE
Breadcrumbs: Stabilize block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -87,10 +87,9 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 
 ## Breadcrumbs
 
-Display a breadcrumb trail for hierarchical post types or based on taxonomy terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
+Display a breadcrumb trail showing the path to the current page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
 
 -	**Name:** core/breadcrumbs
--	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -3,9 +3,8 @@
 	"apiVersion": 3,
 	"name": "core/breadcrumbs",
 	"title": "Breadcrumbs",
-	"__experimental": true,
 	"category": "theme",
-	"description": "Display a breadcrumb trail for hierarchical post types or based on taxonomy terms.",
+	"description": "Display a breadcrumb trail showing the path to the current page.",
 	"textdomain": "default",
 	"attributes": {
 		"prefersTaxonomy": {

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -26,6 +26,7 @@ const separatorDefaultValue = '/';
 export default function BreadcrumbEdit( {
 	attributes,
 	setAttributes,
+	name,
 	context: { postId, postType, templateSlug },
 } ) {
 	const {
@@ -104,7 +105,7 @@ export default function BreadcrumbEdit( {
 	const { content } = useServerSideRender( {
 		attributes,
 		skipBlockSupportAttributes: true,
-		block: 'core/breadcrumbs',
+		block: name,
 		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -435,7 +435,9 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 			$post_type = reset( $post_type );
 		}
 		$post_type_object = get_post_type_object( $post_type );
-		$title            = apply_filters( 'post_type_archive_title', $post_type_object->labels->archives, $post_type );
+
+		/** This filter is documented in wp-includes/general-template.php */
+		$title = apply_filters( 'post_type_archive_title', $post_type_object->labels->archives, $post_type ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		if ( $post_type_object ) {
 			// Add post type (current if not paginated, link if paginated).

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -262,10 +262,10 @@ const getAllBlocks = () => {
 		termTemplate,
 		queryTitle,
 		postAuthorBiography,
+		breadcrumbs,
 	];
 
 	if ( window?.__experimentalEnableBlockExperiments ) {
-		blocks.push( breadcrumbs );
 		blocks.push( tab );
 		blocks.push( tabs );
 	}

--- a/test/integration/fixtures/blocks/core__breadcrumbs.json
+++ b/test/integration/fixtures/blocks/core__breadcrumbs.json
@@ -1,11 +1,13 @@
 [
 	{
-		"name": "core/missing",
+		"name": "core/breadcrumbs",
 		"isValid": true,
 		"attributes": {
-			"originalName": "core/breadcrumbs",
-			"originalUndelimitedContent": "",
-			"originalContent": "<!-- wp:breadcrumbs /-->"
+			"prefersTaxonomy": false,
+			"separator": "/",
+			"showHomeItem": true,
+			"showCurrentItem": true,
+			"showOnHomePage": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: https://github.com/WordPress/gutenberg/issues/72649

This PR stabilizes the Breadcrumbs block as it supports most use cases seamlessly. You can add this block in a single place like a theme's header and have good results.


## Testing Instructions
1. Insert the block in your theme's header and visit any kind of page (posts, pages, search, taxonomies, author pages, etc..)
2. The displayed breadcrumbs trail should be the one that is expected. For example in a post with categories, it should also add the terms breadcrumbs.
