### PR TITLE
Add `block_core_breadcrumbs_items` filter to Breadcrumbs allowing to filter final items array

### DIFF
--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -167,10 +167,12 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 * @since 7.0.0
 	 *
 	 * @param array    $breadcrumb_items Array of breadcrumb item data. Each item is an array with:
-	 *                                   - 'label' (string) The breadcrumb text
-	 *                                   - 'url' (string, optional) The breadcrumb link URL
-	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in label
-	 * @param array    $attributes       Block attributes.
+	 *                                   - 'label' (string) The breadcrumb text.
+	 *                                   - 'url' (string, optional) The breadcrumb link URL.
+	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in the label.
+	 *                                     When true, the label will be sanitized with wp_kses_post(),
+	 *                                     allowing only safe HTML tags. When false or omitted, all HTML
+	 *                                     will be escaped with esc_html(). Default false.
 	 */
 	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items );
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -166,7 +166,16 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array    $breadcrumb_items Array of breadcrumb item data. Each item is an array with:
+ * @param array[] $breadcrumb_items {
+ *     Array of breadcrumb item data.
+ *
+ *     @type string $label      The breadcrumb text.
+ *     @type string $url        Optional. The breadcrumb link URL.
+ *     @type bool   $allow_html Optional. Whether to allow HTML in the label.
+ *                              When true, the label will be sanitized with wp_kses_post(),
+ *                              allowing only safe HTML tags. When false or omitted, all HTML
+ *                              will be escaped with esc_html(). Default false.
+ * }
 	 *                                   - 'label' (string) The breadcrumb text.
 	 *                                   - 'url' (string, optional) The breadcrumb link URL.
 	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in the label.

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -173,7 +173,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 * @param array    $attributes       Block attributes.
 	 * @param WP_Block $block            Block instance.
 	 */
-	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items, $attributes, $block );
+	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items, $attributes );
 
 	if ( empty( $breadcrumb_items ) ) {
 		return '';

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -172,7 +172,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in label
 	 * @param array    $attributes       Block attributes.
 	 */
-	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items, $attributes );
+	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items );
 
 	if ( empty( $breadcrumb_items ) ) {
 		return '';

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -166,22 +166,16 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 *
 	 * @since 7.0.0
 	 *
- * @param array[] $breadcrumb_items {
- *     Array of breadcrumb item data.
- *
- *     @type string $label      The breadcrumb text.
- *     @type string $url        Optional. The breadcrumb link URL.
- *     @type bool   $allow_html Optional. Whether to allow HTML in the label.
- *                              When true, the label will be sanitized with wp_kses_post(),
- *                              allowing only safe HTML tags. When false or omitted, all HTML
- *                              will be escaped with esc_html(). Default false.
- * }
-	 *                                   - 'label' (string) The breadcrumb text.
-	 *                                   - 'url' (string, optional) The breadcrumb link URL.
-	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in the label.
-	 *                                     When true, the label will be sanitized with wp_kses_post(),
-	 *                                     allowing only safe HTML tags. When false or omitted, all HTML
-	 *                                     will be escaped with esc_html(). Default false.
+	 * @param array[] $breadcrumb_items {
+	 *     Array of breadcrumb item data.
+	 *
+	 *     @type string $label      The breadcrumb text.
+	 *     @type string $url        Optional. The breadcrumb link URL.
+	 *     @type bool   $allow_html Optional. Whether to allow HTML in the label.
+	 *                              When true, the label will be sanitized with wp_kses_post(),
+	 *                              allowing only safe HTML tags. When false or omitted, all HTML
+	 *                              will be escaped with esc_html(). Default false.
+	 * }
 	 */
 	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items );
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -171,7 +171,6 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	 *                                   - 'url' (string, optional) The breadcrumb link URL
 	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in label
 	 * @param array    $attributes       Block attributes.
-	 * @param WP_Block $block            Block instance.
 	 */
 	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items, $attributes );
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -159,6 +159,22 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		array_pop( $breadcrumb_items );
 	}
 
+	/**
+	 * Filters the breadcrumb items array before rendering.
+	 *
+	 * Allows developers to modify, add, or remove breadcrumb items.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array    $breadcrumb_items Array of breadcrumb item data. Each item is an array with:
+	 *                                   - 'label' (string) The breadcrumb text
+	 *                                   - 'url' (string, optional) The breadcrumb link URL
+	 *                                   - 'allow_html' (bool, optional) Whether to allow HTML in label
+	 * @param array    $attributes       Block attributes.
+	 * @param WP_Block $block            Block instance.
+	 */
+	$breadcrumb_items = apply_filters( 'block_core_breadcrumbs_items', $breadcrumb_items, $attributes, $block );
+
 	if ( empty( $breadcrumb_items ) ) {
 		return '';
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Add a `block_core_breadcrumbs_items` filter to filter the final crumbs array.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This will allow to alter the final list of crumbs, e.g. by adding, removing, formatting or updating specific crumb.

This will also help to provide extensibility parity so core block can be used in WooCommerce as eventual Store Breadcrumbs replacement (equivalent of `woocommerce_get_breadcrumb `).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Apply filter with final breadcrumbs array just before rendering items.

## Testing Instructions

1. Add Breadcrumbs block to Header
2. Add snippet to your `functions.php`:

```
add_filter( 'block_core_breadcrumbs_items', function( $breadcrumb_items ) {
    // Add a test breadcrumb at the beginning
    array_unshift( $breadcrumb_items, array(
        'label' => 'TEST CRUMB',
        'url'   => home_url( '/' ),
    ) );
    
    return $breadcrumb_items;
} );
```

3. Visit frontend
4. **Expected:** TEST CRUMB appears as a first crumb

<img width="230" height="113" alt="image" src="https://github.com/user-attachments/assets/875bfc02-3035-464d-808d-c1fcd4467fc3" />

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
