### PR TITLE
wp-build: Replace import.meta.resolve with createRequire in getPackageInfo

### DIFF
--- a/packages/wp-build/src/package-utils.mjs
+++ b/packages/wp-build/src/package-utils.mjs
@@ -2,13 +2,11 @@
  * External dependencies
  */
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
 /**
- * Shared cache for package.json files to avoid redundant reads.
- * Cache is keyed by the full package name from package.json's name field.
+ * Cache for package.json files to avoid redundant reads.
  */
-const packageJsonCache = new Map();
 const packagePathCache = new Map();
 
 /**
@@ -42,21 +40,20 @@ const packagePathCache = new Map();
 
 /**
  * Get package.json info using Node's module resolution.
- * Resolves the package using import.meta.resolve and reads its package.json.
  *
  * @param {string} fullPackageName The full package name (e.g., '@wordpress/blocks').
+ * @param {string} [resolveDir]    Directory to resolve from. Defaults to process.cwd().
  * @return {PackageJson|null} Package.json object or null if not found.
  */
-export function getPackageInfo( fullPackageName ) {
-	if ( packageJsonCache.has( fullPackageName ) ) {
-		return packageJsonCache.get( fullPackageName );
+export function getPackageInfo( fullPackageName, resolveDir = process.cwd() ) {
+	const require = createRequire( resolveDir + '/package.json' );
+	try {
+		return getPackageInfoFromFile(
+			require.resolve( `${ fullPackageName }/package.json` )
+		);
+	} catch {
+		return null;
 	}
-
-	const resolved = import.meta.resolve( `${ fullPackageName }/package.json` );
-	const result = getPackageInfoFromFile( fileURLToPath( resolved ) );
-	packageJsonCache.set( fullPackageName, result );
-
-	return result;
 }
 
 /**

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -213,7 +213,7 @@ export function createWordpressExternalsPlugin(
 							const shortName = parts[ 1 ];
 							const handle = `${ externalConfig.handlePrefix }-${ shortName }`;
 
-							const packageJson = getPackageInfo( packageName );
+							const packageJson = getPackageInfo( packageName, args.resolveDir );
 
 							if ( ! packageJson ) {
 								return undefined;


### PR DESCRIPTION
Refactors package resolution in getPackageInfo to use Node's createRequire and require.resolve instead of import.meta.resolve and fileURLToPath. This improves compatibility and reliability when resolving package.json files.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
