### PR TITLE
Theme_JSON_Resolver: check for `WP_Post` instance

### DIFF
--- a/backport-changelog/7.0/10648.md
+++ b/backport-changelog/7.0/10648.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10648
 
 * https://github.com/WordPress/gutenberg/pull/74124
+* https://github.com/WordPress/gutenberg/pull/74172

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -483,7 +483,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$global_style_query = new WP_Query();
 		$recent_posts       = $global_style_query->query( $args );
-		if ( count( $recent_posts ) === 1 && is_object( $recent_posts[0] ) ) {
+		if ( count( $recent_posts ) === 1 && $recent_posts[0] instanceof WP_Post ) {
 			$user_cpt = get_object_vars( $recent_posts[0] );
 		} elseif ( $create_post ) {
 			$cpt_post_id = wp_insert_post(
@@ -501,7 +501,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			);
 			if ( ! is_wp_error( $cpt_post_id ) ) {
 				$post = get_post( $cpt_post_id );
-				if ( is_object( $post ) ) {
+				if ( $post instanceof WP_Post ) {
 					$user_cpt = get_object_vars( $post );
 				}
 			}


### PR DESCRIPTION
## What?

https://github.com/WordPress/gutenberg/pull/74124 added some guardrails to `WP_Theme_JSON_Resolver` and was backported to core at https://github.com/WordPress/wordpress-develop/pull/10648

Core contributors suggested other changes, that this PR bring back to Gutenberg.

## Why?

To keep core and gutenberg in sync.

## How?

Brings back core changes verbatim.

