### PR TITLE
Fix color palette dropdown not closing on custom color selection

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -47,6 +47,7 @@ function ColorGradientControlInner( {
 	showTitle = true,
 	enableAlpha,
 	headingLevel,
+	onClose,
 } ) {
 	const canChooseAColor =
 		onColorChange &&
@@ -68,8 +69,12 @@ function ColorGradientControlInner( {
 						? ( newColor ) => {
 								onColorChange( newColor );
 								onGradientChange();
+								onClose?.();
 						  }
-						: onColorChange
+						: ( newColor ) => {
+								onColorChange( newColor );
+								onClose?.();
+						  }
 				}
 				{ ...{ colors, disableCustomColors } }
 				__experimentalIsRenderedInSidebar={
@@ -88,8 +93,12 @@ function ColorGradientControlInner( {
 						? ( newGradient ) => {
 								onGradientChange( newGradient );
 								onColorChange();
+								onClose?.();
 						  }
-						: onGradientChange
+						: ( newGradient ) => {
+								onGradientChange( newGradient );
+								onClose?.();
+						  }
 				}
 				{ ...{ gradients, disableCustomGradients } }
 				__experimentalIsRenderedInSidebar={

--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -209,11 +209,12 @@ export default function ColorGradientSettingsDropdown( {
 								popoverProps={ popoverProps }
 								className="block-editor-tools-panel-color-gradient-settings__dropdown"
 								renderToggle={ renderToggle( toggleSettings ) }
-								renderContent={ () => (
+								renderContent={ ( { onClose } ) => (
 									<DropdownContentWrapper paddingSize="none">
 										<div className="block-editor-panel-color-gradient-settings__dropdown-content">
 											<ColorGradientControl
 												{ ...controlProps }
+												onClose={ onClose }
 											/>
 										</div>
 									</DropdownContentWrapper>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixed #74154

<!-- In a few words, what is the PR actually doing? -->

## Why?
Selecting a custom color might prevent the color palette from closing.

## How?
- Updated renderContent to receive and pass the onClose callback to ColorGradientControl
- Added onClose parameter to ColorGradientControlInner function
- Updated both color and gradient onChange handlers to call onClose?.() after setting the new value

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
