### PR TITLE
`wordpress/dataviews`: migrate to Stack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54188,6 +54188,8 @@
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/theme": "file:../theme",
+				"@wordpress/ui": "file:../ui",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
 				"clsx": "^2.1.1",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Code Quality
 
+- Replace HStack/VStack from `wordpress/components` by Stack from `wordpress/ui`. [#74174](https://github.com/WordPress/gutenberg/pull/74174)
 - DataViews: Remove extra wrapper for GridItem. [#73665](https://github.com/WordPress/gutenberg/pull/73665)
 - Field API: move validation to the field type. [#73642](https://github.com/WordPress/gutenberg/pull/73642)
 - Field API: move format logic to the field type. [#73922](https://github.com/WordPress/gutenberg/pull/73922)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1071,14 +1071,14 @@ Component to render UI in a modal for the action.
 		return (
 			<form onSubmit={ onSubmit }>
 				<p>Modal UI</p>
-				<HStack>
+				<Stack direction="row">
 					<Button variant="tertiary" onClick={ closeModal }>
 						Cancel
 					</Button>
 					<Button variant="primary" type="submit">
 						Submit
 					</Button>
-				</HStack>
+				</Stack>
 			</form>
 		);
 	};
@@ -1202,10 +1202,10 @@ Example:
 	id: 'title',
 	type: 'text',
 	header: (
-		<HStack spacing={ 1 } justify="start">
+		<Stack direction="row" gap="2xs" justify="start">
 			<Icon icon={ icon } />
 			<span>Title</span>
-		</HStack>
+		</Stack>
 	),
 }
 ```

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -67,6 +67,8 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/theme": "file:../theme",
+		"@wordpress/ui": "file:../ui",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"clsx": "^2.1.1",

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -13,7 +13,6 @@ import { useRegistry } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -6,16 +6,14 @@ import type { ReactElement } from 'react';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	CheckboxControl,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { useMemo, useState, useRef, useContext } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -263,10 +261,10 @@ function renderFooterContent< Item >(
 					data.length
 			  );
 	return (
-		<HStack
-			expanded={ false }
+		<Stack
+			direction="row"
 			className="dataviews-bulk-actions-footer__container"
-			spacing={ 3 }
+			gap="sm"
 		>
 			<BulkSelectionCheckbox
 				selection={ selection }
@@ -278,10 +276,10 @@ function renderFooterContent< Item >(
 			<span className="dataviews-bulk-actions-footer__item-count">
 				{ message }
 			</span>
-			<HStack
+			<Stack
+				direction="row"
 				className="dataviews-bulk-actions-footer__action-buttons"
-				expanded={ false }
-				spacing={ 1 }
+				gap="2xs"
 			>
 				{ actionsToShow.map( ( action ) => {
 					return (
@@ -308,8 +306,8 @@ function renderFooterContent< Item >(
 						} }
 					/>
 				) }
-			</HStack>
-		</HStack>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -264,6 +264,7 @@ function renderFooterContent< Item >(
 			direction="row"
 			className="dataviews-bulk-actions-footer__container"
 			gap="sm"
+			align="center"
 		>
 			<BulkSelectionCheckbox
 				selection={ selection }

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -18,7 +18,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -9,8 +9,6 @@ import type { RefObject } from 'react';
  */
 import {
 	Dropdown,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	FlexItem,
 	SelectControl,
 	Tooltip,
@@ -19,6 +17,8 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -93,8 +93,9 @@ function OperatorSelector( {
 	const value = currentFilter?.operator || filter.operators[ 0 ];
 	return (
 		operatorOptions.length > 1 && (
-			<HStack
-				spacing={ 2 }
+			<Stack
+				direction="row"
+				gap="xs"
 				justify="flex-start"
 				className="dataviews-filters__summary-operators-container"
 			>
@@ -164,7 +165,7 @@ function OperatorSelector( {
 					variant="minimal"
 					hideLabelFromVision
 				/>
-			</HStack>
+			</Stack>
 		)
 	);
 }
@@ -348,7 +349,7 @@ export default function Filter( {
 			) }
 			renderContent={ () => {
 				return (
-					<VStack spacing={ 0 } justify="flex-start">
+					<Stack direction="column" justify="flex-start">
 						<OperatorSelector { ...commonProps } />
 						{ commonProps.filter.hasElements ? (
 							<SearchWidget
@@ -361,7 +362,7 @@ export default function Filter( {
 						) : (
 							<InputWidget { ...commonProps } fields={ fields } />
 						) }
-					</VStack>
+					</Stack>
 				);
 			} }
 		/>

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -97,6 +97,7 @@ function OperatorSelector( {
 				gap="xs"
 				justify="flex-start"
 				className="dataviews-filters__summary-operators-container"
+				align="center"
 			>
 				<FlexItem className="dataviews-filters__summary-operators-filter-name">
 					{ filter.name }

--- a/packages/dataviews/src/components/dataviews-filters/filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filters.tsx
@@ -62,6 +62,7 @@ function Filters( { className }: { className?: string } ) {
 		<Stack
 			direction="row"
 			justify="flex-start"
+			gap="xs"
 			style={ { width: 'fit-content' } }
 			wrap="wrap"
 			className={ className }

--- a/packages/dataviews/src/components/dataviews-filters/filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filters.tsx
@@ -3,7 +3,6 @@
  */
 import { memo, useContext, useRef } from '@wordpress/element';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-filters/filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filters.tsx
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { memo, useContext, useRef } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -59,14 +60,15 @@ function Filters( { className }: { className?: string } ) {
 	);
 
 	return (
-		<HStack
+		<Stack
+			direction="row"
 			justify="flex-start"
 			style={ { width: 'fit-content' } }
-			wrap
+			wrap="wrap"
 			className={ className }
 		>
 			{ filterComponents }
-		</HStack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -3,7 +3,6 @@
  */
 import { useContext } from '@wordpress/element';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -37,7 +37,12 @@ export default function DataViewsFooter() {
 	}
 	return (
 		!! totalItems && (
-			<Stack direction="row" justify="end" className="dataviews-footer">
+			<Stack
+				direction="row"
+				justify="end"
+				align="center"
+				className="dataviews-footer"
+			>
 				{ hasBulkActions && <BulkActionsFooter /> }
 				<DataViewsPagination />
 			</Stack>

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -42,6 +42,7 @@ export default function DataViewsFooter() {
 				justify="end"
 				align="center"
 				className="dataviews-footer"
+				gap="xs"
 			>
 				{ hasBulkActions && <BulkActionsFooter /> }
 				<DataViewsPagination />

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -37,14 +38,10 @@ export default function DataViewsFooter() {
 	}
 	return (
 		!! totalItems && (
-			<HStack
-				expanded={ false }
-				justify="end"
-				className="dataviews-footer"
-			>
+			<Stack direction="row" justify="end" className="dataviews-footer">
 				{ hasBulkActions && <BulkActionsFooter /> }
 				<DataViewsPagination />
-			</HStack>
+			</Stack>
 		)
 	);
 }

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -9,7 +9,6 @@ import type { MouseEventHandler } from 'react';
 import {
 	Button,
 	Modal,
-	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -17,6 +16,8 @@ import { useMemo, useState } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -212,8 +213,8 @@ export default function ItemActions< Item >( {
 	}
 
 	return (
-		<HStack
-			spacing={ 0 }
+		<Stack
+			direction="row"
 			justify="flex-end"
 			className="dataviews-item-actions"
 			style={ {
@@ -233,7 +234,7 @@ export default function ItemActions< Item >( {
 					registry={ registry }
 				/>
 			) }
-		</HStack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -17,7 +17,6 @@ import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -50,11 +50,13 @@ export function DataViewsPagination() {
 				direction="row"
 				className="dataviews-pagination"
 				justify="end"
+				align="center"
 				gap="lg"
 			>
 				<Stack
 					direction="row"
 					justify="flex-start"
+					align="center"
 					gap="2xs"
 					className="dataviews-pagination__page-select"
 				>
@@ -88,7 +90,7 @@ export function DataViewsPagination() {
 						}
 					) }
 				</Stack>
-				<Stack direction="row" gap="2xs">
+				<Stack direction="row" gap="2xs" align="center">
 					<Button
 						onClick={ () =>
 							onChangeView( {

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -6,7 +6,6 @@ import { createInterpolateElement, memo, useContext } from '@wordpress/element';
 import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -1,14 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	__experimentalHStack as HStack,
-	SelectControl,
-} from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { createInterpolateElement, memo, useContext } from '@wordpress/element';
 import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -49,16 +47,16 @@ export function DataViewsPagination() {
 	return (
 		!! totalItems &&
 		totalPages !== 1 && (
-			<HStack
-				expanded={ false }
+			<Stack
+				direction="row"
 				className="dataviews-pagination"
 				justify="end"
-				spacing={ 6 }
+				gap="lg"
 			>
-				<HStack
+				<Stack
+					direction="row"
 					justify="flex-start"
-					expanded={ false }
-					spacing={ 1 }
+					gap="2xs"
 					className="dataviews-pagination__page-select"
 				>
 					{ createInterpolateElement(
@@ -90,8 +88,8 @@ export function DataViewsPagination() {
 							),
 						}
 					) }
-				</HStack>
-				<HStack expanded={ false } spacing={ 1 }>
+				</Stack>
+				<Stack direction="row" gap="2xs">
 					<Button
 						onClick={ () =>
 							onChangeView( {
@@ -119,8 +117,8 @@ export function DataViewsPagination() {
 						size="compact"
 						tooltipPosition="top"
 					/>
-				</HStack>
-			</HStack>
+				</Stack>
+			</Stack>
 		)
 	);
 }

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -166,12 +166,14 @@ export function DataViewsPickerFooter() {
 		<Stack
 			direction="row"
 			justify="space-between"
+			align="center"
 			className="dataviews-footer"
 		>
 			<Stack
 				direction="row"
 				className="dataviews-picker-footer__bulk-selection"
 				gap="sm"
+				align="center"
 			>
 				{ isMultiselect && (
 					<BulkSelectionCheckbox

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -168,6 +168,7 @@ export function DataViewsPickerFooter() {
 			justify="space-between"
 			align="center"
 			className="dataviews-footer"
+			gap="xs"
 		>
 			<Stack
 				direction="row"

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -1,14 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	CheckboxControl,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { useRegistry } from '@wordpress/data';
 import { useContext, useMemo, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -90,7 +88,7 @@ function ActionButtons< Item >( {
 	);
 
 	return (
-		<HStack expanded={ false } spacing={ 1 }>
+		<Stack direction="row" gap="2xs">
 			{ actions.map( ( action ) => {
 				// Only support actions with callbacks for DataViewsPicker.
 				// This is because many use cases of the picker will be already within modals.
@@ -126,7 +124,7 @@ function ActionButtons< Item >( {
 					</Button>
 				);
 			} ) }
-		</HStack>
+		</Stack>
 	);
 }
 
@@ -166,15 +164,15 @@ export function DataViewsPickerFooter() {
 	);
 
 	return (
-		<HStack
-			expanded={ false }
+		<Stack
+			direction="row"
 			justify="space-between"
 			className="dataviews-footer"
 		>
-			<HStack
+			<Stack
+				direction="row"
 				className="dataviews-picker-footer__bulk-selection"
-				expanded={ false }
-				spacing={ 3 }
+				gap="sm"
 			>
 				{ isMultiselect && (
 					<BulkSelectionCheckbox
@@ -188,7 +186,7 @@ export function DataViewsPickerFooter() {
 				<span className="dataviews-bulk-actions-footer__item-count">
 					{ message }
 				</span>
-			</HStack>
+			</Stack>
 			<DataViewsPagination />
 			{ Boolean( actions?.length ) && (
 				<div className="dataviews-picker-footer__actions">
@@ -199,6 +197,6 @@ export function DataViewsPickerFooter() {
 					/>
 				</div>
 			) }
-		</HStack>
+		</Stack>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -6,7 +6,6 @@ import { useRegistry } from '@wordpress/data';
 import { useContext, useMemo, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/index.tsx
@@ -91,6 +91,7 @@ function DefaultUI( {
 			>
 				<Stack
 					direction="row"
+					gap="xs"
 					justify="start"
 					className="dataviews__search"
 				>

--- a/packages/dataviews/src/components/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/index.tsx
@@ -9,7 +9,6 @@ import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/index.tsx
@@ -6,9 +6,10 @@ import type { ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -81,28 +82,25 @@ function DefaultUI( {
 }: DefaultUIProps ) {
 	return (
 		<>
-			<HStack
-				alignment="top"
+			<Stack
+				direction="row"
+				align="top"
 				justify="space-between"
 				className="dataviews__view-actions"
-				spacing={ 1 }
+				gap="2xs"
 			>
-				<HStack
+				<Stack
+					direction="row"
 					justify="start"
-					expanded={ false }
 					className="dataviews__search"
 				>
 					{ search && <DataViewsSearch label={ searchLabel } /> }
 					<FiltersToggle />
-				</HStack>
-				<HStack
-					spacing={ 1 }
-					expanded={ false }
-					style={ { flexShrink: 0 } }
-				>
+				</Stack>
+				<Stack direction="row" gap="2xs" style={ { flexShrink: 0 } }>
 					<DataViewsViewConfig />
-				</HStack>
-			</HStack>
+				</Stack>
+			</Stack>
 			<FiltersToggled className="dataviews-filters__container" />
 			<DataViewsLayout />
 			<DataViewsPickerFooter />

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -25,7 +25,6 @@ import { cog } from '@wordpress/icons';
 import warning from '@wordpress/warning';
 import { useInstanceId } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -326,6 +326,7 @@ export function DataviewsViewConfigDropdown() {
 						<SettingsSection title={ __( 'Appearance' ) }>
 							<Stack
 								direction="row"
+								gap="xs"
 								className="is-divided-in-two"
 							>
 								<SortFieldControl />

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -15,8 +15,6 @@ import {
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	SelectControl,
 	__experimentalGrid as Grid,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
@@ -26,6 +24,8 @@ import { memo, useContext, useMemo } from '@wordpress/element';
 import { cog } from '@wordpress/icons';
 import warning from '@wordpress/warning';
 import { useInstanceId } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -319,12 +319,19 @@ export function DataviewsViewConfigDropdown() {
 					paddingSize="medium"
 					className="dataviews-config__popover-content-wrapper"
 				>
-					<VStack className="dataviews-view-config" spacing={ 6 }>
+					<Stack
+						direction="column"
+						className="dataviews-view-config"
+						gap="lg"
+					>
 						<SettingsSection title={ __( 'Appearance' ) }>
-							<HStack expanded className="is-divided-in-two">
+							<Stack
+								direction="row"
+								className="is-divided-in-two"
+							>
 								<SortFieldControl />
 								<SortDirectionControl />
-							</HStack>
+							</Stack>
 							{ !! activeLayout?.viewConfigOptions && (
 								<activeLayout.viewConfigOptions />
 							) }
@@ -332,7 +339,7 @@ export function DataviewsViewConfigDropdown() {
 							<ItemsPerPageControl />
 							<PropertiesSection />
 						</SettingsSection>
-					</VStack>
+					</Stack>
 				</DropdownContentWrapper>
 			) }
 		/>

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -86,6 +86,7 @@ export function PropertiesSection( {
 
 	let visibleLockedFields = lockedFields.filter(
 		( { field, isVisibleFlag } ) =>
+			// @ts-expect-error
 			isDefined( field ) && ( view[ isVisibleFlag ] ?? true )
 	) as Array< {
 		field: NormalizedField< any >;
@@ -106,6 +107,7 @@ export function PropertiesSection( {
 
 	const hiddenLockedFields = lockedFields.filter(
 		( { field, isVisibleFlag } ) =>
+			// @ts-expect-error
 			isDefined( field ) && ! ( view[ isVisibleFlag ] ?? true )
 	) as Array< {
 		field: NormalizedField< any >;

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -4,14 +4,14 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	BaseControl,
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import { check } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -31,14 +31,14 @@ function FieldItem( {
 } ) {
 	return (
 		<Item onClick={ field.enableHiding ? onToggleVisibility : undefined }>
-			<HStack expanded justify="flex-start" alignment="center">
+			<Stack direction="row" justify="flex-start" align="center">
 				<div style={ { height: 24, width: 24 } }>
 					{ isVisible && <Icon icon={ check } /> }
 				</div>
 				<span className="dataviews-view-config__label">
 					{ field.label }
 				</span>
-			</HStack>
+			</Stack>
 		</Item>
 	);
 }
@@ -116,13 +116,16 @@ export function PropertiesSection( {
 	} >;
 
 	return (
-		<VStack className="dataviews-field-control" spacing={ 0 }>
+		<Stack direction="column" className="dataviews-field-control">
 			{ showLabel && (
 				<BaseControl.VisualLabel>
 					{ __( 'Properties' ) }
 				</BaseControl.VisualLabel>
 			) }
-			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
+			<Stack
+				direction="column"
+				className="dataviews-view-config__properties"
+			>
 				<ItemGroup isBordered isSeparated size="medium">
 					{ visibleLockedFields.map( ( { field, isVisibleFlag } ) => {
 						return (
@@ -185,7 +188,7 @@ export function PropertiesSection( {
 						);
 					} ) }
 				</ItemGroup>
-			</VStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -86,7 +86,6 @@ export function PropertiesSection( {
 
 	let visibleLockedFields = lockedFields.filter(
 		( { field, isVisibleFlag } ) =>
-			// @ts-expect-error
 			isDefined( field ) && ( view[ isVisibleFlag ] ?? true )
 	) as Array< {
 		field: NormalizedField< any >;
@@ -107,7 +106,6 @@ export function PropertiesSection( {
 
 	const hiddenLockedFields = lockedFields.filter(
 		( { field, isVisibleFlag } ) =>
-			// @ts-expect-error
 			isDefined( field ) && ! ( view[ isVisibleFlag ] ?? true )
 	) as Array< {
 		field: NormalizedField< any >;

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -30,7 +30,7 @@ function FieldItem( {
 } ) {
 	return (
 		<Item onClick={ field.enableHiding ? onToggleVisibility : undefined }>
-			<Stack direction="row" justify="flex-start" align="center">
+			<Stack direction="row" gap="xs" justify="flex-start" align="center">
 				<div style={ { height: 24, width: 24 } }>
 					{ isVisible && <Icon icon={ check } /> }
 				</div>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -6,9 +6,10 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -90,29 +91,26 @@ function DefaultUI( {
 }: DefaultUIProps ) {
 	return (
 		<>
-			<HStack
-				alignment="top"
+			<Stack
+				direction="row"
+				align="top"
 				justify="space-between"
 				className="dataviews__view-actions"
-				spacing={ 1 }
+				gap="2xs"
 			>
-				<HStack
+				<Stack
+					direction="row"
 					justify="start"
-					expanded={ false }
 					className="dataviews__search"
 				>
 					{ search && <DataViewsSearch label={ searchLabel } /> }
 					<FiltersToggle />
-				</HStack>
-				<HStack
-					spacing={ 1 }
-					expanded={ false }
-					style={ { flexShrink: 0 } }
-				>
+				</Stack>
+				<Stack direction="row" gap="2xs" style={ { flexShrink: 0 } }>
 					<DataViewsViewConfig />
 					{ header }
-				</HStack>
-			</HStack>
+				</Stack>
+			</Stack>
 			<FiltersToggled className="dataviews-filters__container" />
 			<DataViewsLayout />
 			<DataViewsFooter />

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -101,6 +101,7 @@ function DefaultUI( {
 				<Stack
 					direction="row"
 					justify="start"
+					gap="xs"
 					className="dataviews__search"
 				>
 					{ search && <DataViewsSearch label={ searchLabel } /> }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -9,7 +9,6 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useResizeObserver, throttle } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -33,7 +33,6 @@ import { __ } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
 import { error as errorIcon } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -21,8 +21,6 @@ import {
 	Icon,
 	privateApis as componentsPrivateApis,
 	__experimentalInputControl as InputControl,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import {
 	useCallback,
@@ -34,6 +32,8 @@ import {
 import { __ } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
 import { error as errorIcon } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -352,9 +352,14 @@ function CalendarDateControl< Item >( {
 				label={ displayLabel }
 				hideLabelFromVision={ hideLabelFromVision }
 			>
-				<VStack spacing={ 4 }>
+				<Stack direction="column" gap="md">
 					{ /* Preset buttons */ }
-					<HStack spacing={ 2 } wrap justify="flex-start">
+					<Stack
+						direction="row"
+						gap="xs"
+						wrap="wrap"
+						justify="flex-start"
+					>
 						{ DATE_PRESETS.map( ( preset ) => {
 							const isSelected = selectedPresetId === preset.id;
 							return (
@@ -382,7 +387,7 @@ function CalendarDateControl< Item >( {
 						>
 							{ __( 'Custom' ) }
 						</Button>
-					</HStack>
+					</Stack>
 
 					{ /* Manual date input */ }
 					<InputControl
@@ -408,7 +413,7 @@ function CalendarDateControl< Item >( {
 						timeZone={ timezoneString || undefined }
 						weekStartsOn={ weekStartsOn }
 					/>
-				</VStack>
+				</Stack>
 			</BaseControl>
 		</ValidatedDateControl>
 	);
@@ -555,9 +560,14 @@ function CalendarDateRangeControl< Item >( {
 				label={ displayLabel }
 				hideLabelFromVision={ hideLabelFromVision }
 			>
-				<VStack spacing={ 4 }>
+				<Stack direction="column" gap="md">
 					{ /* Preset buttons */ }
-					<HStack spacing={ 2 } wrap justify="flex-start">
+					<Stack
+						direction="row"
+						gap="xs"
+						wrap="wrap"
+						justify="flex-start"
+					>
 						{ DATE_RANGE_PRESETS.map( ( preset ) => {
 							const isSelected = selectedPresetId === preset.id;
 							return (
@@ -585,10 +595,10 @@ function CalendarDateRangeControl< Item >( {
 						>
 							{ __( 'Custom' ) }
 						</Button>
-					</HStack>
+					</Stack>
 
 					{ /* Manual date range inputs */ }
-					<HStack spacing={ 2 }>
+					<Stack direction="row" gap="xs">
 						<InputControl
 							__next40pxDefaultSize
 							ref={ fromInputRef }
@@ -613,7 +623,7 @@ function CalendarDateRangeControl< Item >( {
 							}
 							required={ !! field.isValid?.required }
 						/>
-					</HStack>
+					</Stack>
 
 					<DateRangeCalendar
 						style={ { width: '100%' } }
@@ -624,7 +634,7 @@ function CalendarDateRangeControl< Item >( {
 						timeZone={ timezone.string || undefined }
 						weekStartsOn={ weekStartsOn }
 					/>
-				</VStack>
+				</Stack>
 			</BaseControl>
 		</ValidatedDateControl>
 	);

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -600,6 +600,7 @@ function CalendarDateRangeControl< Item >( {
 					<Stack
 						direction="row"
 						gap="xs"
+						justify="space-between"
 						className="dataviews-controls__date-range-inputs"
 					>
 						<InputControl

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -597,7 +597,11 @@ function CalendarDateRangeControl< Item >( {
 					</Stack>
 
 					{ /* Manual date range inputs */ }
-					<Stack direction="row" gap="xs">
+					<Stack
+						direction="row"
+						gap="xs"
+						className="dataviews-controls__date-range-inputs"
+					>
 						<InputControl
 							__next40pxDefaultSize
 							ref={ fromInputRef }

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -9,11 +9,12 @@ import { format } from 'date-fns';
 import {
 	BaseControl,
 	privateApis as componentsPrivateApis,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getSettings } from '@wordpress/date';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -167,7 +168,7 @@ function CalendarDateTimeControl< Item >( {
 			help={ description }
 			hideLabelFromVision={ hideLabelFromVision }
 		>
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="md">
 				{ /* Calendar widget */ }
 				<DateCalendar
 					style={ { width: '100%' } }
@@ -198,7 +199,7 @@ function CalendarDateTimeControl< Item >( {
 					}
 					onChange={ handleManualDateTimeChange }
 				/>
-			</VStack>
+			</Stack>
 		</BaseControl>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -14,7 +14,6 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getSettings } from '@wordpress/date';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-controls/style.scss
+++ b/packages/dataviews/src/dataform-controls/style.scss
@@ -19,6 +19,11 @@
 	}
 }
 
+.dataviews-controls__date-range-inputs > * {
+	flex: 1 1 50%;
+	min-width: 0;
+}
+
 .dataviews-controls__date-preset {
 	border: 1px solid #ddd;
 

--- a/packages/dataviews/src/dataform-controls/style.scss
+++ b/packages/dataviews/src/dataform-controls/style.scss
@@ -20,7 +20,6 @@
 }
 
 .dataviews-controls__date-range-inputs > * {
-	flex: 1 1 50%;
 	min-width: 0;
 }
 

--- a/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
@@ -14,7 +14,6 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
@@ -10,10 +10,11 @@ import {
 	BaseControl,
 	SelectControl,
 	__experimentalNumberControl as NumberControl,
-	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -92,7 +93,7 @@ export default function RelativeDateControl< Item >( {
 			label={ label }
 			hideLabelFromVision={ hideLabelFromVision }
 		>
-			<HStack spacing={ 2.5 }>
+			<Stack direction="row" gap="xs">
 				<NumberControl
 					__next40pxDefaultSize
 					className="dataviews-controls__relative-date-number"
@@ -111,7 +112,7 @@ export default function RelativeDateControl< Item >( {
 					onChange={ onChangeUnit }
 					hideLabelFromVision
 				/>
-			</HStack>
+			</Stack>
 		</BaseControl>
 	);
 }

--- a/packages/dataviews/src/dataform-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataform-layouts/data-form-layout.tsx
@@ -3,7 +3,6 @@
  */
 import { useContext } from '@wordpress/element';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataform-layouts/data-form-layout.tsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -17,9 +18,9 @@ import { getFormFieldLayout } from './index';
 import DataFormContext from '../components/dataform-context';
 
 const DEFAULT_WRAPPER = ( { children }: { children: React.ReactNode } ) => (
-	<VStack className="dataforms-layouts__wrapper" spacing={ 4 }>
+	<Stack direction="column" className="dataforms-layouts__wrapper" gap="md">
 		{ children }
-	</VStack>
+	</Stack>
 );
 
 export function DataFormLayout< Item >( {

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -1,10 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -21,27 +19,39 @@ const FORM_FIELD_LAYOUTS = [
 		type: 'regular',
 		component: FormRegularField,
 		wrapper: ( { children }: { children: React.ReactNode } ) => (
-			<VStack className="dataforms-layouts__wrapper" spacing={ 4 }>
+			<Stack
+				direction="column"
+				className="dataforms-layouts__wrapper"
+				gap="md"
+			>
 				{ children }
-			</VStack>
+			</Stack>
 		),
 	},
 	{
 		type: 'panel',
 		component: FormPanelField,
 		wrapper: ( { children }: { children: React.ReactNode } ) => (
-			<VStack className="dataforms-layouts__wrapper" spacing={ 2 }>
+			<Stack
+				direction="column"
+				className="dataforms-layouts__wrapper"
+				gap="xs"
+			>
 				{ children }
-			</VStack>
+			</Stack>
 		),
 	},
 	{
 		type: 'card',
 		component: FormCardField,
 		wrapper: ( { children }: { children: React.ReactNode } ) => (
-			<VStack className="dataforms-layouts__wrapper" spacing={ 6 }>
+			<Stack
+				direction="column"
+				className="dataforms-layouts__wrapper"
+				gap="lg"
+			>
 				{ children }
-			</VStack>
+			</Stack>
 		),
 	},
 	{
@@ -54,18 +64,21 @@ const FORM_FIELD_LAYOUTS = [
 			children: React.ReactNode;
 			layout: NormalizedLayout;
 		} ) => (
-			<VStack className="dataforms-layouts__wrapper" spacing={ 4 }>
+			<Stack
+				direction="column"
+				className="dataforms-layouts__wrapper"
+				gap="md"
+			>
 				<div className="dataforms-layouts-row__field">
-					<HStack
-						spacing={ 4 }
-						alignment={
-							( layout as NormalizedRowLayout ).alignment
-						}
+					<Stack
+						direction="row"
+						gap="md"
+						align={ ( layout as NormalizedRowLayout ).alignment }
 					>
 						{ children }
-					</HStack>
+					</Stack>
 				</div>
-			</VStack>
+			</Stack>
 		),
 	},
 	{

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	__experimentalSpacer as Spacer,
 	Dropdown,
@@ -13,6 +11,8 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -36,11 +36,12 @@ function DropdownHeader( {
 	onClose: () => void;
 } ) {
 	return (
-		<VStack
+		<Stack
+			direction="column"
 			className="dataforms-layouts-panel__dropdown-header"
-			spacing={ 4 }
+			gap="md"
 		>
-			<HStack alignment="center">
+			<Stack direction="row" align="center">
 				{ title && (
 					<Heading level={ 2 } size={ 13 }>
 						{ title }
@@ -55,8 +56,8 @@ function DropdownHeader( {
 						size="small"
 					/>
 				) }
-			</HStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -40,7 +40,7 @@ function DropdownHeader( {
 			className="dataforms-layouts-panel__dropdown-header"
 			gap="md"
 		>
-			<Stack direction="row" align="center">
+			<Stack direction="row" gap="xs" align="center">
 				{ title && (
 					<Heading level={ 2 } size={ 13 }>
 						{ title }

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -12,7 +12,6 @@ import { useMemo } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/dropdown.tsx
@@ -46,7 +46,7 @@ function DropdownHeader( {
 						{ title }
 					</Heading>
 				) }
-				<Spacer />
+				<Spacer style={ { flex: 1 } } />
 				{ onClose && (
 					<Button
 						label={ __( 'Close' ) }

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -172,6 +172,7 @@ export default function FormPanelField< Item >( {
 		<Tooltip text={ errorMessage } placement="top">
 			<Stack
 				direction="row"
+				gap="xs"
 				className="dataforms-layouts-panel__field-label-error-content"
 				justify="flex-start"
 			>
@@ -231,6 +232,7 @@ export default function FormPanelField< Item >( {
 		return (
 			<Stack
 				direction="row"
+				gap="xs"
 				className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none"
 			>
 				{ showError && (
@@ -253,6 +255,7 @@ export default function FormPanelField< Item >( {
 	return (
 		<Stack
 			direction="row"
+			gap="xs"
 			ref={ setPopoverAnchor }
 			className="dataforms-layouts-panel__field"
 		>

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -10,7 +10,6 @@ import { Icon, Tooltip } from '@wordpress/components';
 import { useState, useContext } from '@wordpress/element';
 import { error as errorIcon } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/index.tsx
@@ -6,14 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	Icon,
-	Tooltip,
-} from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { useState, useContext } from '@wordpress/element';
 import { error as errorIcon } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -174,13 +171,14 @@ export default function FormPanelField< Item >( {
 
 	const labelContent = showError ? (
 		<Tooltip text={ errorMessage } placement="top">
-			<HStack
+			<Stack
+				direction="row"
 				className="dataforms-layouts-panel__field-label-error-content"
 				justify="flex-start"
 			>
 				<Icon icon={ errorIcon } size={ 16 } />
 				<>{ fieldLabel }</>
-			</HStack>
+			</Stack>
 		</Tooltip>
 	) : (
 		fieldLabel
@@ -213,7 +211,10 @@ export default function FormPanelField< Item >( {
 
 	if ( labelPosition === 'top' ) {
 		return (
-			<VStack className="dataforms-layouts-panel__field" spacing={ 0 }>
+			<Stack
+				direction="column"
+				className="dataforms-layouts-panel__field"
+			>
 				<div
 					className={ labelClassName }
 					style={ { paddingBottom: 0 } }
@@ -223,13 +224,16 @@ export default function FormPanelField< Item >( {
 				<div className="dataforms-layouts-panel__field-control">
 					{ renderedControl }
 				</div>
-			</VStack>
+			</Stack>
 		);
 	}
 
 	if ( labelPosition === 'none' ) {
 		return (
-			<HStack className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none">
+			<Stack
+				direction="row"
+				className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none"
+			>
 				{ showError && (
 					<Tooltip text={ errorMessage } placement="top">
 						<Icon
@@ -242,13 +246,14 @@ export default function FormPanelField< Item >( {
 				<div className="dataforms-layouts-panel__field-control">
 					{ renderedControl }
 				</div>
-			</HStack>
+			</Stack>
 		);
 	}
 
 	// Defaults to label position side.
 	return (
-		<HStack
+		<Stack
+			direction="row"
 			ref={ setPopoverAnchor }
 			className="dataforms-layouts-panel__field"
 		>
@@ -256,6 +261,6 @@ export default function FormPanelField< Item >( {
 			<div className="dataforms-layouts-panel__field-control">
 				{ renderedControl }
 			</div>
-		</HStack>
+		</Stack>
 	);
 }

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -7,7 +7,6 @@ import deepMerge from 'deepmerge';
  * WordPress dependencies
  */
 import {
-	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 	Button,
 	Modal,
@@ -15,6 +14,8 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useContext, useState, useMemo } from '@wordpress/element';
 import { useFocusOnMount } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -120,9 +121,10 @@ function ModalContent< Item >( {
 					) }
 				</DataFormLayout>
 			</div>
-			<HStack
+			<Stack
+				direction="row"
 				className="dataforms-layouts-panel__modal-footer"
-				spacing={ 3 }
+				gap="sm"
 			>
 				<Spacer />
 				<Button
@@ -139,7 +141,7 @@ function ModalContent< Item >( {
 				>
 					{ __( 'Apply' ) }
 				</Button>
-			</HStack>
+			</Stack>
 		</Modal>
 	);
 }

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -15,7 +15,6 @@ import { __ } from '@wordpress/i18n';
 import { useContext, useState, useMemo } from '@wordpress/element';
 import { useFocusOnMount } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataform-layouts/panel/modal.tsx
@@ -125,7 +125,7 @@ function ModalContent< Item >( {
 				className="dataforms-layouts-panel__modal-footer"
 				gap="sm"
 			>
-				<Spacer />
+				<Spacer style={ { flex: 1 } } />
 				<Button
 					variant="tertiary"
 					onClick={ onClose }

--- a/packages/dataviews/src/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/regular/index.tsx
@@ -86,7 +86,11 @@ export default function FormRegularField< Item >( {
 
 	if ( labelPosition === 'side' ) {
 		return (
-			<Stack direction="row" className="dataforms-layouts-regular__field">
+			<Stack
+				direction="row"
+				className="dataforms-layouts-regular__field"
+				gap="xs"
+			>
 				<div
 					className={ clsx(
 						'dataforms-layouts-regular__field-label',

--- a/packages/dataviews/src/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/regular/index.tsx
@@ -8,12 +8,12 @@ import clsx from 'clsx';
  */
 import { useContext, useMemo } from '@wordpress/element';
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	__experimentalSpacer as Spacer,
 	BaseControl,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -29,14 +29,18 @@ import { DEFAULT_LAYOUT } from '../normalize-form';
 
 function Header( { title }: { title: string } ) {
 	return (
-		<VStack className="dataforms-layouts-regular__header" spacing={ 4 }>
-			<HStack alignment="center">
+		<Stack
+			direction="column"
+			className="dataforms-layouts-regular__header"
+			gap="md"
+		>
+			<Stack direction="row" align="center">
 				<Heading level={ 2 } size={ 13 }>
 					{ title }
 				</Heading>
 				<Spacer />
-			</HStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }
 
@@ -85,7 +89,7 @@ export default function FormRegularField< Item >( {
 
 	if ( labelPosition === 'side' ) {
 		return (
-			<HStack className="dataforms-layouts-regular__field">
+			<Stack direction="row" className="dataforms-layouts-regular__field">
 				<div
 					className={ clsx(
 						'dataforms-layouts-regular__field-label',
@@ -111,7 +115,7 @@ export default function FormRegularField< Item >( {
 						/>
 					) }
 				</div>
-			</HStack>
+			</Stack>
 		);
 	}
 

--- a/packages/dataviews/src/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/regular/index.tsx
@@ -13,7 +13,6 @@ import {
 	BaseControl,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/regular/index.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { useContext, useMemo } from '@wordpress/element';
 import {
 	__experimentalHeading as Heading,
-	__experimentalSpacer as Spacer,
 	BaseControl,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
@@ -37,7 +36,6 @@ function Header( { title }: { title: string } ) {
 				<Heading level={ 2 } size={ 13 }>
 					{ title }
 				</Heading>
-				<Spacer />
 			</Stack>
 		</Stack>
 	);

--- a/packages/dataviews/src/dataform-layouts/row/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/row/index.tsx
@@ -6,7 +6,6 @@ import {
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataform-layouts/row/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/row/index.tsx
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { __experimentalHeading as Heading } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -31,7 +28,6 @@ function Header( { title }: { title: string } ) {
 				<Heading level={ 2 } size={ 13 }>
 					{ title }
 				</Heading>
-				<Spacer />
 			</Stack>
 		</Stack>
 	);

--- a/packages/dataviews/src/dataform-layouts/row/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/row/index.tsx
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import {
-	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
-	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -23,14 +23,18 @@ import { getFormFieldLayout } from '..';
 
 function Header( { title }: { title: string } ) {
 	return (
-		<VStack className="dataforms-layouts-row__header" spacing={ 4 }>
-			<HStack alignment="center">
+		<Stack
+			direction="column"
+			className="dataforms-layouts-row__header"
+			gap="md"
+		>
+			<Stack direction="row" align="center">
 				<Heading level={ 2 } size={ 13 }>
 					{ title }
 				</Heading>
 				<Spacer />
-			</HStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }
 
@@ -58,7 +62,7 @@ export default function FormRowField< Item >( {
 				{ ! hideLabelFromVision && field.label && (
 					<Header title={ field.label } />
 				) }
-				<HStack alignment={ layout.alignment } spacing={ 4 }>
+				<Stack direction="row" align={ layout.alignment } gap="md">
 					<DataFormLayout
 						data={ data }
 						form={ form }
@@ -82,7 +86,7 @@ export default function FormRowField< Item >( {
 							</div>
 						) }
 					</DataFormLayout>
-				</HStack>
+				</Stack>
 			</div>
 		);
 	}

--- a/packages/dataviews/src/dataviews-layouts/activity/activity-group.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/activity-group.tsx
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -44,15 +44,15 @@ export default function ActivityGroup< Item >( {
 	);
 
 	return (
-		<VStack
+		<Stack
 			key={ groupName }
-			spacing={ 0 }
+			direction="column"
 			className="dataviews-view-activity__group"
 		>
 			<h3 className="dataviews-view-activity__group-header">
 				{ groupHeader }
 			</h3>
 			{ children }
-		</VStack>
+		</Stack>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/activity/activity-item.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/activity-item.tsx
@@ -6,13 +6,10 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	VisuallyHidden,
-} from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/components';
 import { useRef, useContext, useMemo } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -100,12 +97,12 @@ function ActivityItem< Item >(
 			<titleField.render item={ item } field={ titleField } />
 		) : null;
 
-	const verticalSpacing = useMemo( () => {
+	const verticalGap = useMemo( () => {
 		switch ( density ) {
 			case 'comfortable':
-				return '3';
+				return 'sm';
 			default:
-				return '2';
+				return 'xs';
 		}
 	}, [ density ] );
 
@@ -124,17 +121,19 @@ function ActivityItem< Item >(
 				density === 'comfortable' && 'is-comfortable'
 			) }
 		>
-			<HStack spacing={ 4 } justify="start" alignment="flex-start">
-				<VStack
-					spacing={ 1 }
-					alignment="center"
+			<Stack direction="row" gap="md" justify="start" align="flex-start">
+				<Stack
+					direction="column"
+					gap="2xs"
+					align="center"
 					className="dataviews-view-activity__item-type"
 				>
 					{ renderedMediaField }
-				</VStack>
-				<VStack
-					spacing={ verticalSpacing }
-					alignment="flex-start"
+				</Stack>
+				<Stack
+					direction="column"
+					gap={ verticalGap }
+					align="flex-start"
 					className="dataviews-view-activity__item-content"
 				>
 					{ renderedTitleField && (
@@ -185,7 +184,7 @@ function ActivityItem< Item >(
 							buttonVariant="secondary"
 						/>
 					) }
-				</VStack>
+				</Stack>
 				{ primaryActions.length < eligibleActions.length && (
 					<div className="dataviews-view-activity__item-actions">
 						<ItemActions
@@ -195,7 +194,7 @@ function ActivityItem< Item >(
 						/>
 					</div>
 				) }
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/index.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { Spinner } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/activity/index.tsx
@@ -6,7 +6,9 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -59,7 +61,7 @@ export default function ViewActivity< Item >(
 	// Render grouped activity
 	if ( hasData && groupField && dataByGroup ) {
 		return (
-			<VStack spacing={ 2 } className={ wrapperClassName }>
+			<Stack direction="column" gap="xs" className={ wrapperClassName }>
 				{ groupedEntries.map(
 					( [ groupName, groupData ]: [ string, Item[] ] ) => (
 						<ActivityGroup< Item >
@@ -76,7 +78,7 @@ export default function ViewActivity< Item >(
 						</ActivityGroup>
 					)
 				) }
-			</VStack>
+			</Stack>
 		);
 	}
 

--- a/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
@@ -189,7 +189,7 @@ const GridItem = forwardRef( function GridItem< Item >(
 			{ showTitle && (
 				<Stack
 					direction="row"
-					justify="space-between"
+					gap="xs"
 					className="dataviews-view-grid__title-actions"
 				>
 					<ItemClickWrapper

--- a/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/composite-grid.tsx
@@ -8,14 +8,13 @@ import type { ComponentProps, ReactElement, HTMLAttributes } from 'react';
  * WordPress dependencies
  */
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	Flex,
 	FlexItem,
 	Tooltip,
 	Composite,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { isAppleOS } from '@wordpress/keycodes';
@@ -132,10 +131,10 @@ const GridItem = forwardRef( function GridItem< Item >(
 		}
 	}
 	return (
-		<VStack
+		<Stack
+			direction="column"
 			{ ...props }
 			ref={ ref }
-			spacing={ 0 }
 			className={ clsx(
 				props.className,
 				'dataviews-view-grid__row__gridcell',
@@ -188,7 +187,8 @@ const GridItem = forwardRef( function GridItem< Item >(
 				</div>
 			) }
 			{ showTitle && (
-				<HStack
+				<Stack
+					direction="row"
 					justify="space-between"
 					className="dataviews-view-grid__title-actions"
 				>
@@ -209,9 +209,9 @@ const GridItem = forwardRef( function GridItem< Item >(
 							isCompact
 						/>
 					) }
-				</HStack>
+				</Stack>
 			) }
-			<VStack spacing={ 1 }>
+			<Stack direction="column" gap="2xs">
 				{ showDescription && descriptionField?.render && (
 					<descriptionField.render
 						item={ item }
@@ -219,11 +219,12 @@ const GridItem = forwardRef( function GridItem< Item >(
 					/>
 				) }
 				{ !! badgeFields?.length && (
-					<HStack
+					<Stack
+						direction="row"
 						className="dataviews-view-grid__badge-fields"
-						spacing={ 2 }
-						wrap
-						alignment="top"
+						gap="xs"
+						wrap="wrap"
+						align="top"
 						justify="flex-start"
 					>
 						{ badgeFields.map( ( field ) => {
@@ -239,12 +240,13 @@ const GridItem = forwardRef( function GridItem< Item >(
 								</Badge>
 							);
 						} ) }
-					</HStack>
+					</Stack>
 				) }
 				{ !! regularFields?.length && (
-					<VStack
+					<Stack
+						direction="column"
 						className="dataviews-view-grid__fields"
-						spacing={ 1 }
+						gap="2xs"
 					>
 						{ regularFields.map( ( field ) => {
 							return (
@@ -276,10 +278,10 @@ const GridItem = forwardRef( function GridItem< Item >(
 								</Flex>
 							);
 						} ) }
-					</VStack>
+					</Stack>
 				) }
-			</VStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 } ) as < Item >(
 	props: GridItemProps< Item > & {

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -6,8 +6,10 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -55,10 +57,14 @@ function ViewGrid< Item >( {
 			{
 				// Render multiple groups.
 				hasData && groupField && dataByGroup && (
-					<VStack spacing={ 4 }>
+					<Stack direction="column" gap="md">
 						{ Array.from( dataByGroup.entries() ).map(
 							( [ groupName, groupItems ] ) => (
-								<VStack key={ groupName } spacing={ 2 }>
+								<Stack
+									direction="column"
+									key={ groupName }
+									gap="xs"
+								>
 									<h3 className="dataviews-view-grid__group-header">
 										{ view.groupBy?.showLabel === false
 											? groupName
@@ -74,10 +80,10 @@ function ViewGrid< Item >( {
 										data={ groupItems }
 										isInfiniteScroll={ false }
 									/>
-								</VStack>
+								</Stack>
 							)
 						) }
-					</VStack>
+					</Stack>
 				)
 			}
 			{

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -326,7 +326,7 @@ function ListItem< Item >( {
 						gap="2xs"
 						className="dataviews-view-list__field-wrapper"
 					>
-						<Stack direction="row">
+						<Stack direction="row" align="center">
 							<div
 								className="dataviews-title-field"
 								id={ labelId }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -26,7 +26,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -8,8 +8,6 @@ import clsx from 'clsx';
  */
 import { useInstanceId, usePrevious } from '@wordpress/compose';
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	Button,
 	privateApis as componentsPrivateApis,
 	Spinner,
@@ -27,6 +25,8 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -221,7 +221,11 @@ function ListItem< Item >( {
 		) : null;
 
 	const usedActions = eligibleActions?.length > 0 && (
-		<HStack spacing={ 3 } className="dataviews-view-list__item-actions">
+		<Stack
+			direction="row"
+			gap="sm"
+			className="dataviews-view-list__item-actions"
+		>
 			{ primaryAction && (
 				<PrimaryActionGridCell
 					idPrefix={ idPrefix }
@@ -271,7 +275,7 @@ function ListItem< Item >( {
 					) }
 				</div>
 			) }
-		</HStack>
+		</Stack>
 	);
 
 	return (
@@ -296,7 +300,10 @@ function ListItem< Item >( {
 			onMouseEnter={ handleHover }
 			onMouseLeave={ handleHover }
 		>
-			<HStack className="dataviews-view-list__item-wrapper" spacing={ 0 }>
+			<Stack
+				direction="row"
+				className="dataviews-view-list__item-wrapper"
+			>
 				<div role="gridcell">
 					<Composite.Item
 						id={ generateItemWrapperCompositeId( idPrefix ) }
@@ -307,13 +314,19 @@ function ListItem< Item >( {
 						onClick={ () => onSelect( item ) }
 					/>
 				</div>
-				<HStack spacing={ 3 } justify="start" alignment="flex-start">
+				<Stack
+					direction="row"
+					gap="sm"
+					justify="start"
+					align="flex-start"
+				>
 					{ renderedMediaField }
-					<VStack
-						spacing={ 1 }
+					<Stack
+						direction="column"
+						gap="2xs"
 						className="dataviews-view-list__field-wrapper"
 					>
-						<HStack spacing={ 0 }>
+						<Stack direction="row">
 							<div
 								className="dataviews-title-field"
 								id={ labelId }
@@ -321,7 +334,7 @@ function ListItem< Item >( {
 								{ renderedTitleField }
 							</div>
 							{ usedActions }
-						</HStack>
+						</Stack>
 						{ showDescription && descriptionField?.render && (
 							<div className="dataviews-view-list__field">
 								<descriptionField.render
@@ -354,9 +367,9 @@ function ListItem< Item >( {
 								</div>
 							) ) }
 						</div>
-					</VStack>
-				</HStack>
-			</HStack>
+					</Stack>
+				</Stack>
+			</Stack>
 		</Composite.Row>
 	);
 }
@@ -538,13 +551,18 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				activeId={ activeCompositeId }
 				setActiveId={ setActiveCompositeId }
 			>
-				<VStack
-					spacing={ 4 }
+				<Stack
+					direction="column"
+					gap="md"
 					className={ clsx( 'dataviews-view-list', className ) }
 				>
 					{ Array.from( dataByGroup.entries() ).map(
 						( [ groupName, groupItems ] ) => (
-							<VStack key={ groupName } spacing={ 2 }>
+							<Stack
+								direction="column"
+								key={ groupName }
+								gap="xs"
+							>
 								<h3 className="dataviews-view-list__group-header">
 									{ view.groupBy?.showLabel === false
 										? groupName
@@ -579,10 +597,10 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 										/>
 									);
 								} ) }
-							</VStack>
+							</Stack>
 						)
 					) }
-				</VStack>
+				</Stack>
 			</Composite>
 		);
 	}

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -318,6 +318,7 @@ function ListItem< Item >( {
 					gap="sm"
 					justify="start"
 					align="flex-start"
+					style={ { flex: 1 } }
 				>
 					{ renderedMediaField }
 					<Stack
@@ -329,6 +330,7 @@ function ListItem< Item >( {
 							<div
 								className="dataviews-title-field"
 								id={ labelId }
+								style={ { flex: 1 } }
 							>
 								{ renderedTitleField }
 							</div>

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -18,7 +18,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { useContext } from '@wordpress/element';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -8,8 +8,6 @@ import type { ReactNode } from 'react';
  * WordPress dependencies
  */
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	Spinner,
 	Flex,
 	FlexItem,
@@ -19,6 +17,8 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { useContext } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -96,7 +96,7 @@ function GridItem< Item >( {
 			}
 			key={ id }
 			render={ ( { children, ...props } ) => (
-				<VStack spacing={ 0 } children={ children } { ...props } />
+				<Stack direction="column" children={ children } { ...props } />
 			) }
 			role="option"
 			aria-posinset={ posinset }
@@ -136,16 +136,17 @@ function GridItem< Item >( {
 				/>
 			) }
 			{ showTitle && (
-				<HStack
+				<Stack
+					direction="row"
 					justify="space-between"
 					className="dataviews-view-picker-grid__title-actions"
 				>
 					<div className="dataviews-view-picker-grid__title-field dataviews-title-field">
 						{ renderedTitleField }
 					</div>
-				</HStack>
+				</Stack>
 			) }
-			<VStack spacing={ 1 }>
+			<Stack direction="column" gap="2xs">
 				{ showDescription && descriptionField?.render && (
 					<descriptionField.render
 						item={ item }
@@ -153,11 +154,12 @@ function GridItem< Item >( {
 					/>
 				) }
 				{ !! badgeFields?.length && (
-					<HStack
+					<Stack
+						direction="row"
 						className="dataviews-view-picker-grid__badge-fields"
-						spacing={ 2 }
-						wrap
-						alignment="top"
+						gap="xs"
+						wrap="wrap"
+						align="top"
 						justify="flex-start"
 					>
 						{ badgeFields.map( ( field ) => {
@@ -173,12 +175,13 @@ function GridItem< Item >( {
 								</Badge>
 							);
 						} ) }
-					</HStack>
+					</Stack>
 				) }
 				{ !! regularFields?.length && (
-					<VStack
+					<Stack
+						direction="column"
 						className="dataviews-view-picker-grid__fields"
-						spacing={ 1 }
+						gap="2xs"
 					>
 						{ regularFields.map( ( field ) => {
 							return (
@@ -208,9 +211,9 @@ function GridItem< Item >( {
 								</Flex>
 							);
 						} ) }
-					</VStack>
+					</Stack>
 				) }
-			</VStack>
+			</Stack>
 		</Composite.Item>
 	);
 }
@@ -231,9 +234,10 @@ function GridGroup< Item >( {
 		'dataviews-view-picker-grid-group__header'
 	);
 	return (
-		<VStack
+		<Stack
+			direction="column"
 			key={ groupName }
-			spacing={ 2 }
+			gap="xs"
 			role="group"
 			aria-labelledby={ headerId }
 		>
@@ -251,7 +255,7 @@ function GridGroup< Item >( {
 					: groupName }
 			</h3>
 			{ children }
-		</VStack>
+		</Stack>
 	);
 }
 
@@ -337,8 +341,9 @@ function ViewPickerGrid< Item >( {
 						) }
 						aria-label={ itemListLabel }
 						render={ ( { children, ...props } ) => (
-							<VStack
-								spacing={ 4 }
+							<Stack
+								direction="column"
+								gap="md"
 								children={ children }
 								{ ...props }
 							/>

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/style.scss
@@ -69,6 +69,7 @@
 	.dataviews-view-picker-grid__media {
 		width: 100%;
 		aspect-ratio: 1/1;
+		min-height: 0;
 		background-color: $white;
 		border-radius: $radius-medium;
 		position: relative;

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -7,7 +7,6 @@ import type { ComponentProps, ReactElement } from 'react';
  * WordPress dependencies
  */
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -6,10 +6,8 @@ import type { ComponentProps, ReactElement } from 'react';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -41,7 +39,7 @@ function ColumnPrimary< Item >( {
 	isItemClickable: ( item: Item ) => boolean;
 } ) {
 	return (
-		<HStack spacing={ 3 } alignment="flex-start" justify="flex-start">
+		<Stack direction="row" gap="sm" align="flex-start" justify="flex-start">
 			{ mediaField && (
 				<ItemClickWrapper
 					item={ item }
@@ -64,9 +62,9 @@ function ColumnPrimary< Item >( {
 					/>
 				</ItemClickWrapper>
 			) }
-			<VStack
-				spacing={ 0 }
-				alignment="flex-start"
+			<Stack
+				direction="column"
+				align="flex-start"
 				className="dataviews-view-table__primary-column-content"
 			>
 				{ titleField && (
@@ -91,8 +89,8 @@ function ColumnPrimary< Item >( {
 						field={ descriptionField }
 					/>
 				) }
-			</VStack>
-		</HStack>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -9,7 +9,6 @@ import deepMerge from 'deepmerge';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { Button, privateApis } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1391,7 +1391,7 @@ const ValidationComponent = ( {
 
 	return (
 		<form>
-			<Stack direction="column" align="left">
+			<Stack direction="column" align="start" gap="xl">
 				<DataForm< ValidatedItem >
 					data={ post }
 					fields={ _fields }

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -7,11 +7,9 @@ import deepMerge from 'deepmerge';
  * WordPress dependencies
  */
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import {
-	Button,
-	__experimentalVStack as VStack,
-	privateApis,
-} from '@wordpress/components';
+import { Button, privateApis } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -1393,7 +1391,7 @@ const ValidationComponent = ( {
 
 	return (
 		<form>
-			<VStack alignment="left" spacing={ 8 }>
+			<Stack direction="column" align="left">
 				<DataForm< ValidatedItem >
 					data={ post }
 					fields={ _fields }
@@ -1414,7 +1412,7 @@ const ValidationComponent = ( {
 				>
 					Submit
 				</Button>
-			</VStack>
+			</Stack>
 		</form>
 	);
 };

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -239,7 +239,7 @@ export const WithModal = ( {
 
 	return (
 		<>
-			<Stack direction="row" justify="left">
+			<Stack direction="row" justify="left" gap="xs">
 				<Button
 					variant="primary"
 					onClick={ () => setIsModalOpen( true ) }

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -9,7 +9,6 @@ import type { Meta } from '@storybook/react';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { Modal, Button } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -7,11 +7,9 @@ import type { Meta } from '@storybook/react';
  * WordPress dependencies
  */
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
-import {
-	Modal,
-	Button,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -241,7 +239,7 @@ export const WithModal = ( {
 
 	return (
 		<>
-			<HStack justify="left">
+			<Stack direction="row" justify="left">
 				<Button
 					variant="primary"
 					onClick={ () => setIsModalOpen( true ) }
@@ -255,7 +253,7 @@ export const WithModal = ( {
 				>
 					Clear Selection
 				</Button>
-			</HStack>
+			</Stack>
 			{ selectedItems.length > 0 && (
 				<p>
 					Selected:{ ' ' }

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -15,12 +15,9 @@ import {
 	pin,
 	link,
 } from '@wordpress/icons';
-import {
-	Button,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, __experimentalText as Text } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -793,9 +790,9 @@ export const actions: Action< SpaceObject >[] = [
 					? `Are you sure you want to delete ${ items.length } items?`
 					: `Are you sure you want to delete "${ items[ 0 ].name.title }"?`;
 			return (
-				<VStack spacing="5">
+				<Stack direction="column">
 					<Text>{ label }</Text>
-					<HStack justify="right">
+					<Stack direction="row" justify="right">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -810,8 +807,8 @@ export const actions: Action< SpaceObject >[] = [
 						>
 							Delete
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			);
 		},
 	},
@@ -1283,10 +1280,10 @@ export const orderEventFields: Field< OrderEvent >[] = [
 		label: 'Categories',
 		id: 'categories',
 		header: (
-			<HStack spacing={ 1 } justify="start">
+			<Stack direction="row" gap="2xs" justify="start">
 				<Icon icon={ category } />
 				<span>Categories</span>
-			</HStack>
+			</Stack>
 		),
 		elements: [
 			{ value: 'Order', label: 'Order' },
@@ -1353,9 +1350,9 @@ export const orderEventActions: Action< OrderEvent >[] = [
 				closeModal?.();
 			};
 			return (
-				<VStack spacing="5">
+				<Stack direction="column">
 					<Text>{ label }</Text>
-					<HStack justify="right">
+					<Stack direction="row" justify="right">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -1370,8 +1367,8 @@ export const orderEventActions: Action< OrderEvent >[] = [
 						>
 							Delete
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			);
 		},
 	},
@@ -1383,10 +1380,10 @@ export const fields: Field< SpaceObject >[] = [
 		id: 'image',
 		type: 'media',
 		header: (
-			<HStack spacing={ 1 } justify="start">
+			<Stack direction="row" gap="2xs" justify="start">
 				<Icon icon={ image } />
 				<span>Image</span>
-			</HStack>
+			</Stack>
 		),
 		render: ( { item } ) => {
 			return (
@@ -1491,10 +1488,10 @@ export const fields: Field< SpaceObject >[] = [
 		label: 'Categories',
 		id: 'categories',
 		header: (
-			<HStack spacing={ 1 } justify="start">
+			<Stack direction="row" gap="2xs" justify="start">
 				<Icon icon={ category } />
 				<span>Categories</span>
-			</HStack>
+			</Stack>
 		),
 		elements: [
 			{ value: 'Solar system', label: 'Solar system' },

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -1282,7 +1282,7 @@ export const orderEventFields: Field< OrderEvent >[] = [
 		header: (
 			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ category } />
-				<span>Categories</span>
+				<span style={ { minWidth: 0 } }>Categories</span>
 			</Stack>
 		),
 		elements: [
@@ -1382,7 +1382,7 @@ export const fields: Field< SpaceObject >[] = [
 		header: (
 			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ image } />
-				<span>Image</span>
+				<span style={ { minWidth: 0 } }>Image</span>
 			</Stack>
 		),
 		render: ( { item } ) => {
@@ -1490,7 +1490,7 @@ export const fields: Field< SpaceObject >[] = [
 		header: (
 			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ category } />
-				<span>Categories</span>
+				<span style={ { minWidth: 0 } }>Categories</span>
 			</Stack>
 		),
 		elements: [

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/icons';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -789,9 +789,9 @@ export const actions: Action< SpaceObject >[] = [
 					? `Are you sure you want to delete ${ items.length } items?`
 					: `Are you sure you want to delete "${ items[ 0 ].name.title }"?`;
 			return (
-				<Stack direction="column">
+				<Stack direction="column" gap="lg">
 					<Text>{ label }</Text>
-					<Stack direction="row" justify="right">
+					<Stack direction="row" gap="xs" justify="right">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -1349,9 +1349,9 @@ export const orderEventActions: Action< OrderEvent >[] = [
 				closeModal?.();
 			};
 			return (
-				<Stack direction="column">
+				<Stack direction="column" gap="lg">
 					<Text>{ label }</Text>
-					<Stack direction="row" justify="right">
+					<Stack direction="row" gap="xs" justify="right">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"

--- a/packages/dataviews/src/stories/dataviews.fixtures.tsx
+++ b/packages/dataviews/src/stories/dataviews.fixtures.tsx
@@ -1280,7 +1280,7 @@ export const orderEventFields: Field< OrderEvent >[] = [
 		label: 'Categories',
 		id: 'categories',
 		header: (
-			<Stack direction="row" gap="2xs" justify="start">
+			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ category } />
 				<span>Categories</span>
 			</Stack>
@@ -1380,7 +1380,7 @@ export const fields: Field< SpaceObject >[] = [
 		id: 'image',
 		type: 'media',
 		header: (
-			<Stack direction="row" gap="2xs" justify="start">
+			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ image } />
 				<span>Image</span>
 			</Stack>
@@ -1488,7 +1488,7 @@ export const fields: Field< SpaceObject >[] = [
 		label: 'Categories',
 		id: 'categories',
 		header: (
-			<Stack direction="row" gap="2xs" justify="start">
+			<Stack direction="row" gap="2xs" justify="start" align="center">
 				<Icon icon={ category } />
 				<span>Categories</span>
 			</Stack>

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -19,11 +19,11 @@ import {
 	CardBody,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies
@@ -182,10 +182,10 @@ const PlanetIllustration = () => (
 );
 
 const CustomEmptyComponent = () => (
-	<VStack alignment="center" justify="center" spacing={ 3 }>
+	<Stack direction="column" align="center" justify="center" gap="sm">
 		<PlanetIllustration />
 		<Text>No celestial bodies found</Text>
-	</VStack>
+	</Stack>
 );
 
 const EmptyComponent = ( {
@@ -318,19 +318,19 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 				{ __( 'Solar System numbers' ) }
 			</Heading>
 			<div className="free-composition-header">
-				<VStack spacing={ 4 }>
-					<HStack justify="start" spacing={ 2 }>
+				<Stack direction="column" gap="md">
+					<Stack direction="row" justify="start" gap="xs">
 						<DataViews.Search label={ __( 'Search content' ) } />
 						<DataViews.FiltersToggle />
-						<HStack justify="end" spacing={ 2 }>
+						<Stack direction="row" justify="end" gap="xs">
 							<DataViews.ViewConfig />
 							<DataViews.LayoutSwitcher />
-						</HStack>
-					</HStack>
+						</Stack>
+					</Stack>
 					<DataViews.FiltersToggled />
 					<Card variant="secondary">
 						<CardBody>
-							<VStack>
+							<Stack direction="column">
 								<Text size={ 18 } as="p">
 									{ createInterpolateElement(
 										_n(
@@ -362,23 +362,24 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 										}
 									) }
 								</Text>
-							</VStack>
+							</Stack>
 						</CardBody>
 					</Card>
 					<Card style={ { width: '100%' } }>
 						<CardBody>
-							<HStack
+							<Stack
+								direction="row"
 								justify="space-between"
-								alignment="center"
-								spacing={ 2 }
+								align="center"
+								gap="xs"
 							>
 								<DataViews.BulkActionToolbar />
 								<DataViews.Pagination />
-							</HStack>
+							</Stack>
 						</CardBody>
 					</Card>
 					<DataViews.Layout className="free-composition-dataviews-layout" />
-				</VStack>
+				</Stack>
 			</div>
 		</>
 	);
@@ -434,17 +435,18 @@ export const FreeComposition = () => {
 					grid: {},
 				} }
 				empty={
-					<VStack
+					<Stack
+						direction="column"
 						justify="space-around"
-						alignment="center"
+						align="center"
 						className="free-composition-dataviews-empty"
 					>
 						<Text size={ 18 } as="p">
 							No planets
 						</Text>
-						<Text variant="muted">{ `Try a different search because “${ view.search }” returned no results.` }</Text>
+						<Text variant="muted">{ `Try a different search because "${ view.search }" returned no results.` }</Text>
 						<Button variant="secondary">Create new planet</Button>
-					</VStack>
+					</Stack>
 				}
 			>
 				<PlanetOverview planets={ planets } />

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -448,7 +448,7 @@ export const FreeComposition = () => {
 						<Text size={ 18 } as="p">
 							No planets
 						</Text>
-						<Text variant="muted">{ `Try a different search because "${ view.search }" returned no results.` }</Text>
+						<Text variant="muted">{ `Try a different search because “${ view.search }” returned no results.` }</Text>
 						<Button variant="secondary">Create new planet</Button>
 					</Stack>
 				}

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -23,7 +23,6 @@ import {
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -322,7 +322,12 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					<Stack direction="row" justify="start" gap="xs">
 						<DataViews.Search label={ __( 'Search content' ) } />
 						<DataViews.FiltersToggle />
-						<Stack direction="row" justify="end" gap="xs">
+						<Stack
+							direction="row"
+							justify="end"
+							gap="xs"
+							style={ { flex: 1 } }
+						>
 							<DataViews.ViewConfig />
 							<DataViews.LayoutSwitcher />
 						</Stack>
@@ -330,7 +335,7 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					<DataViews.FiltersToggled />
 					<Card variant="secondary">
 						<CardBody>
-							<Stack direction="column">
+							<Stack direction="column" gap="xs">
 								<Text size={ 18 } as="p">
 									{ createInterpolateElement(
 										_n(

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -441,6 +441,7 @@ export const FreeComposition = () => {
 				empty={
 					<Stack
 						direction="column"
+						gap="xs"
 						justify="space-around"
 						align="center"
 						className="free-composition-dataviews-empty"

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -3,12 +3,12 @@
  */
 import { useState, useMemo } from '@wordpress/element';
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import '@wordpress/theme/design-tokens.css';
 import { starFilled } from '@wordpress/icons';
 
 /**
@@ -618,7 +618,7 @@ const FieldTypeStory = ( {
 		null;
 
 	return (
-		<HStack alignment="stretch">
+		<Stack direction="row" align="stretch">
 			<div style={ { flex: 2 } }>
 				<DataViews
 					getItemId={ ( item ) => item.id.toString() }
@@ -648,7 +648,7 @@ const FieldTypeStory = ( {
 				/>
 			</div>
 			{ selectedItem ? (
-				<VStack alignment="top">
+				<Stack direction="column" align="top">
 					<DataForm
 						data={ selectedItem }
 						form={ form }
@@ -668,9 +668,9 @@ const FieldTypeStory = ( {
 							);
 						} }
 					/>
-				</VStack>
+				</Stack>
 			) : (
-				<VStack alignment="center">
+				<Stack direction="column" align="center">
 					<span
 						style={ {
 							color: '#888',
@@ -678,9 +678,9 @@ const FieldTypeStory = ( {
 					>
 						Please, select a single item.
 					</span>
-				</VStack>
+				</Stack>
 			) }
-		</HStack>
+		</Stack>
 	);
 };
 

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -670,7 +670,7 @@ const FieldTypeStory = ( {
 					/>
 				</Stack>
 			) : (
-				<Stack direction="column" align="center">
+				<Stack direction="column" align="center" justify="center">
 					<span
 						style={ {
 							color: '#888',

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -8,7 +8,6 @@ import {
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import '@wordpress/theme/design-tokens.css';
 import { starFilled } from '@wordpress/icons';
 
 /**

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -617,7 +617,7 @@ const FieldTypeStory = ( {
 		null;
 
 	return (
-		<Stack direction="row" align="stretch">
+		<Stack direction="row" gap="xs" align="stretch">
 			<div style={ { flex: 2 } }>
 				<DataViews
 					getItemId={ ( item ) => item.id.toString() }
@@ -647,7 +647,7 @@ const FieldTypeStory = ( {
 				/>
 			</div>
 			{ selectedItem ? (
-				<Stack direction="column" align="top">
+				<Stack direction="column" gap="xs" align="top">
 					<DataForm
 						data={ selectedItem }
 						form={ form }
@@ -669,7 +669,12 @@ const FieldTypeStory = ( {
 					/>
 				</Stack>
 			) : (
-				<Stack direction="column" align="center" justify="center">
+				<Stack
+					direction="column"
+					gap="xs"
+					align="center"
+					justify="center"
+				>
 					<span
 						style={ {
 							color: '#888',

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/theme/src/prebuilt/css/design-tokens.css" as *;
+
 @use "./components/dataviews/style.scss" as *;
 @use "./components/dataviews-bulk-actions/style.scss" as *;
 @use "./components/dataviews-filters/style.scss" as *;

--- a/packages/dataviews/src/test/dataform.tsx
+++ b/packages/dataviews/src/test/dataform.tsx
@@ -180,26 +180,6 @@ describe( 'DataForm component', () => {
 			expect( priceInput ).toHaveValue( 3.75 );
 		} );
 
-		it( 'should wrap fields in HStack when labelPosition is set to side', async () => {
-			const { container } = render(
-				<Dataform
-					onChange={ noop }
-					fields={ fields }
-					form={ {
-						...form,
-						layout: { type: 'regular', labelPosition: 'side' },
-					} }
-					data={ data }
-				/>
-			);
-
-			expect(
-				// It is used here to ensure that the fields are wrapped in HStack. This happens when the labelPosition is set to side.
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				container.querySelectorAll( "[data-wp-component='HStack']" )
-			).toHaveLength( 3 );
-		} );
-
 		it( 'should render combined fields correctly', async () => {
 			const formWithCombinedFields = {
 				fields: [
@@ -447,25 +427,6 @@ describe( 'DataForm component', () => {
 					title: newValue.slice( 0, i + 1 ),
 				} );
 			}
-		} );
-
-		it( 'should wrap fields in HStack when labelPosition is set to side', async () => {
-			const { container } = render(
-				<Dataform
-					onChange={ noop }
-					fields={ fields }
-					form={ {
-						...formPanelMode,
-						layout: { type: 'panel', labelPosition: 'side' },
-					} }
-					data={ data }
-				/>
-			);
-
-			expect(
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				container.querySelectorAll( "[data-wp-component='HStack']" )
-			).toHaveLength( 3 );
 		} );
 
 		it( 'should render combined fields correctly', async () => {

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -22,6 +22,8 @@
 		{ "path": "../keycodes" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
+		{ "path": "../theme" },
+		{ "path": "../ui" },
 		{ "path": "../url" },
 		{ "path": "../warning" }
 	],


### PR DESCRIPTION
## What?

This PR migrates from HStack/VStack (wordpress/components) to Stack (wordpress/ui package).

## Why?

To give early feedback on the new Stack component.

## How?

Migration Guide: HStack/VStack to Stack

 Overview

 This guide covers migrating from HStack/VStack components in @wordpress/components to the unified Stack component from @wordpress/ui.

 Import Changes

 Before

```tsx
 import {
     __experimentalHStack as HStack,
     __experimentalVStack as VStack,
 } from '@wordpress/components';
```

 After

```tsx
 import { Stack } from '@wordpress/ui';
 import '@wordpress/theme/design-tokens.css'; // Required for design tokens
```

 Component Mapping

 | Before   | After                      |
 |----------|----------------------------|
 | `<HStack>` | `<Stack direction="row">`   |
 | `<VStack>` | `<Stack direction="column">` |

 Prop Changes

 Direction

 - HStack → direction="row"
 - VStack → direction="column"

 Spacing → Gap

 The spacing numeric prop maps to semantic gap tokens:

 | Old spacing | New gap      |
 |-------------|--------------|
 | 0           | (omit prop)  |
 | 1           | "2xs"        |
 | 2           | "xs"         |
 | 2.5         | "xs"         |
 | 3           | "sm"         |
 | 4           | "md"         |
 | 5           | "md" or "lg" |
 | 6           | "lg"         |
 | 8           | "xl"         |

 Alignment

 - alignment="center" → align="center"
 - alignment="top" → align="top"
 - alignment="flex-start" → align="flex-start"
 - alignment="flex-end" → align="flex-end"
 - alignment="left" → align="start"

 Wrap

 - wrap (boolean) → wrap="wrap"

 Removed Props

 - expanded - No equivalent in Stack. Use CSS flex: 1 if needed.
 - expanded={false} - Simply remove (Stack doesn't expand by default)

 Unchanged Props

 - justify - Works the same way
 - className - Works the same way
 - style - Works the same way

 Examples

 HStack Basic

```tsx
 // Before
 <HStack spacing={ 3 } justify="flex-start">
     <Child1 />
     <Child2 />
 </HStack>

 // After
 <Stack direction="row" gap="sm" justify="flex-start">
     <Child1 />
     <Child2 />
 </Stack>
```

 VStack Basic

```tsx
 // Before
 <VStack spacing={ 4 } alignment="center">
     <Child1 />
     <Child2 />
 </VStack>

 // After
 <Stack direction="column" gap="md" align="center">
     <Child1 />
     <Child2 />
 </Stack>
```

 HStack with expanded={false}

```tsx
 // Before
 <HStack expanded={ false } spacing={ 1 }>
     <Child />
 </HStack>

 // After
 <Stack direction="row" gap="2xs">
     <Child />
 </Stack>
```

 With wrap

```tsx
 // Before
 <HStack spacing={ 2 } wrap justify="flex-start">
     <Child />
 </HStack>

 // After
 <Stack direction="row" gap="xs" wrap="wrap" justify="flex-start">
     <Child />
 </Stack>
```tsx

 Complex Example

```tsx
 // Before
 <HStack
     expanded={ false }
     justify="space-between"
     alignment="center"
     spacing={ 3 }
 >
     <VStack spacing={ 1 } alignment="flex-start">
         <Title />
         <Description />
     </VStack>
     <Actions />
 </HStack>

 // After
 <Stack
     direction="row"
     justify="space-between"
     align="center"
     gap="sm"
 >
     <Stack direction="column" gap="2xs" align="flex-start">
         <Title />
         <Description />
     </Stack>
     <Actions />
 </Stack>
```

 Notes

 1. Design tokens CSS: Import @wordpress/theme/design-tokens.css at the entry point of components using Stack
 2. No spacing={0}: When spacing was 0, simply omit the gap prop
 3. Spacer component: The Spacer component from @wordpress/components may need style={{ flex: 1 }} when used inside Stack
 4. min-width considerations: Some child elements may need min-width: 0 for proper flex behavior```

## Testing Instructions

- Compare the DataViews story.
- Check the site editor pages (site, templates, patterns).

