### PR TITLE
Block visibility: add visibility notice for hidden blocks in the block inspector

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -29,6 +29,7 @@ import PositionControls from '../inspector-controls-tabs/position-controls-panel
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
 import { useBorderPanelLabel } from '../../hooks/border';
 import ContentTab from '../inspector-controls-tabs/content-tab';
+import BlockVisibilityInfo from '../block-visibility/block-visibility-info';
 import { unlock } from '../../lock-unlock';
 
 function StyleInspectorSlots( {
@@ -354,6 +355,7 @@ const BlockInspectorSingleBlock = ( {
 				isChild={ hasParentChildBlockCards }
 				clientId={ renderedBlockClientId }
 			/>
+			<BlockVisibilityInfo clientId={ renderedBlockClientId } />
 			{ window?.__experimentalContentOnlyPatternInsertion && (
 				<EditContents clientId={ renderedBlockClientId } />
 			) }

--- a/packages/block-editor/src/components/block-visibility/block-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/block-visibility-info.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Icon,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { unseen } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as blockEditorStore } from '../../store';
+import './styles.scss';
+
+const { Badge } = unlock( componentsPrivateApis );
+
+export default function BlockVisibilityInfo( { clientId } ) {
+	const { isBlockHidden, hasHiddenParent } = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return { isBlockHidden: false, hasHiddenParent: false };
+			}
+			const { isBlockHidden: _isBlockHidden, getBlockParents } = unlock(
+				select( blockEditorStore )
+			);
+
+			const blockHidden = _isBlockHidden( clientId );
+			const parents = getBlockParents( clientId );
+			const parentHidden = parents.some( ( parentId ) =>
+				_isBlockHidden( parentId )
+			);
+
+			return {
+				isBlockHidden: blockHidden,
+				hasHiddenParent: parentHidden,
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! ( isBlockHidden || hasHiddenParent ) ) {
+		return null;
+	}
+
+	return (
+		<Badge className="block-editor-block-visibility-info">
+			<HStack spacing={ 2 } justify="start">
+				<Icon icon={ unseen } />
+				<Text>
+					{ isBlockHidden
+						? __( 'Block is hidden' )
+						: __( 'Parent block is hidden' ) }
+				</Text>
+			</HStack>
+		</Badge>
+	);
+}

--- a/packages/block-editor/src/components/block-visibility/styles.scss
+++ b/packages/block-editor/src/components/block-visibility/styles.scss
@@ -1,0 +1,10 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.block-editor-block-visibility-info {
+	padding-top: $grid-unit-05;
+	padding-bottom: $grid-unit-05;
+	margin: 0 $grid-unit-20 $grid-unit-20;
+	display: flex;
+	align-items: center;
+	justify-content: start;
+}


### PR DESCRIPTION
## What?

Related to:

- https://github.com/WordPress/gutenberg/issues/72502

https://github.com/WordPress/gutenberg/pull/73888 proposed a block visibility notice in the block inspector 

> When a block is hidden on the current viewport, the block inspector displays a visibility notice at the top of the block inspector. This is also present when a block is hidden everywhere.

This PR implements the "hidden everywhere" aspect with the intention to extend the notice to display viewports later.

This will be a series of little PRs to implement https://github.com/WordPress/gutenberg/issues/72502

## Why?

For discoverability mainly. Hidden blocks are not displayed on the canvas, though they can be selected. 

The notice informs the user that a block is hidden.

## How?

By checking if a block, or one of its parents, is hidden.

## Testing Instructions

<details>

<summary>Example block HTML</summary>

```html
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"className":"is-style-section-3","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
<div class="wp-block-column is-style-section-3" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"metadata":{"blockVisibility":false}} -->
<h2 class="wp-block-heading">Smash burger</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Extra everything</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"metadata":{"blockVisibility":false},"className":"is-style-section-4","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
<div class="wp-block-column is-style-section-4" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading -->
<h2 class="wp-block-heading">Toasted sarnie</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Be one with the cheese.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"className":"is-style-section-5","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
<div class="wp-block-column is-style-section-5" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading -->
<h2 class="wp-block-heading">Lasagne</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Layers of fun.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

```

</details>

1. Add a few blocks to a post, including nested blocks
2. Hide a block 
3. Hide a parent block
4. Check that the block inspector shows the visibility notice

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Hidden block|Block whose parent is hidden|
|-|-|
|<img width="1440" height="669" alt="Screenshot 2025-12-23 at 3 20 27 pm" src="https://github.com/user-attachments/assets/7bf498c8-6c6a-456a-a68a-95cc724f0a86" />|<img width="1441" height="670" alt="Screenshot 2025-12-23 at 3 20 34 pm" src="https://github.com/user-attachments/assets/b64eb815-ac13-462b-9fd6-f3a72de14914" />|


