### PR TITLE
DataViewsPicker Table Layout: Ensure checkbox column is always 48px wide

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Enhancements
 
+- DataViewsPicker: Ensure checkbox column in table picker layout is always `48px` wide. [#74181](https://github.com/WordPress/gutenberg/pull/74181)
 - DataViews: improve how hierarchy is displayed in table layout. [#74199](https://github.com/WordPress/gutenberg/pull/74199)
 - DataViews: Add `groupBy.showLabel` config option to control whether the field label is shown in group headers. [#74161](https://github.com/WordPress/gutenberg/pull/74161)
 - DataViews table layout: remove row click-to-select behavior and hover styles. Selection is now only possible via checkboxes, or by ctrl/cmd clicking. [#73873](https://github.com/WordPress/gutenberg/pull/73873)

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
@@ -1,9 +1,16 @@
+@use "@wordpress/base-styles/variables" as *;
+
 // Picker-specific table styles
 // The table picker mainly reuses the regular table styles from ../table/style.scss
 // Add any picker-specific overrides here if needed in the future.
 
 .dataviews-view-picker-table {
 	background-color: inherit;
+
+	// Constrain checkbox column to fixed width while other columns share remaining space.
+	.dataviews-view-table__checkbox-column {
+		width: $grid-unit-60;
+	}
 
 	tbody:focus-visible {
 		// Only show one focus outline at a time. When focus is on a child element,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of: #73085

Constrain the checkbox column of the DataViewsPicker table layout to `48px`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the table layout of the DataViewsPicker results in columns expanding to fill their area in the way that table columns do. This results in an unpleasing amount of space between the checkbox column and the next available column.

Over in `DataViews` this kind of issue was addressed for the general case of the table layout in #72969 by using a `colgroup`. At first I tried this for the picker case, too, but for the picker this (IMO) winds up resulting in the title field being far too wide. For the picker use case, I think it looks more balanced if we set the checkbox to an explicit `48px` (which matches the effective checkbox size used in DataViews) and then allow the other columns to do their thing.

<details>
<summary>In case you're curious here's how it would have looked using `colgroup` instead</summary>

IMO this would have looked very unbalanced for the DataViewsPicker use case:

<img width="1275" height="452" alt="image" src="https://github.com/user-attachments/assets/13bab612-25ce-4017-a721-cf27a1ed85d3" />

</details>

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* For the DataViewsPicker case, set an explicit `48px` on the checkbox column

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the media modal experiment:

<img width="1918" height="140" alt="image" src="https://github.com/user-attachments/assets/b7c5fb12-9afe-4783-bcc1-0d5ecb67e476" />

Open up the post editor and go to add a featured image. Switch to the table layout. Notice that in `trunk` there's too much spacing on the checkbox column. With this PR applied, it'll always conform to a `48px` size. Try toggling other fields' visibility to ensure that the checkbox column continues to look correct.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="3168" height="1428" alt="image" src="https://github.com/user-attachments/assets/d1a337dc-cb48-4d06-a59d-ede0347912cf" />

### After

<img width="3170" height="1432" alt="image" src="https://github.com/user-attachments/assets/4507c60b-e045-409f-a5b7-fca37800f67c" />