### PR TITLE
Accordion Header: Fix potential undo trap

### DIFF
--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -9,7 +9,9 @@ import {
 	RichText,
 	getTypographyClassesAndStyles as useTypographyProps,
 	useSettings,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 
 export default function Edit( { attributes, setAttributes, context } ) {
 	const { title } = attributes;
@@ -19,16 +21,24 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		'core/accordion-heading-level': headingLevel,
 	} = context;
 	const TagName = 'h' + headingLevel;
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	// Set icon attributes.
 	useEffect( () => {
 		if ( iconPosition !== undefined && showIcon !== undefined ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				iconPosition,
 				showIcon,
 			} );
 		}
-	}, [ iconPosition, showIcon, setAttributes ] );
+	}, [
+		iconPosition,
+		showIcon,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	const [ fluidTypographySettings, layout ] = useSettings(
 		'typography.fluid',


### PR DESCRIPTION
## What?
PR fixes the potential undo trap issue with the Accordion Header block. Attribute synchronization via effects should always be marked as non-persistent.

## Testing Instructions
1. Open a post or page.
2. Insert an Accordion block.
3. Change the icon settings.
4. Confirm they're synced with Accordion Header as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="283" height="627" alt="CleanShot 2025-12-23 at 10 21 29" src="https://github.com/user-attachments/assets/6669ab13-7a18-47a8-9184-d5a686b0a977" />

