### PR TITLE
Tests: Add unit tests for Button block __experimentalLabel functionality

### DIFF
--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -27,4 +27,9 @@ describe( 'Button block __experimentalLabel', () => {
 		};
 		expect( getLabel( attributes ) ).toBe( 'Button' );
 	} );
+
+	it( 'returns "Button" when text is undefined', () => {
+		const attributes = {};
+		expect( getLabel( attributes ) ).toBe( 'Button' );
+	} );
 } );

--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -27,17 +27,4 @@ describe( 'Button block __experimentalLabel', () => {
 		};
 		expect( getLabel( attributes ) ).toBe( 'Button' );
 	} );
-
-	it( 'returns "Button" when text is undefined', () => {
-		const attributes = {};
-		expect( getLabel( attributes ) ).toBe( 'Button' );
-	} );
-
-	it( 'returns "Button" when attributes is null', () => {
-		expect( getLabel( null ) ).toBe( 'Button' );
-	} );
-
-	it( 'returns "Button" when attributes is undefined', () => {
-		expect( getLabel( undefined ) ).toBe( 'Button' );
-	} );
 } );

--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { settings } from '..';
+
+describe( 'Button block __experimentalLabel', () => {
+	const { __experimentalLabel: getLabel } = settings;
+
+	it( 'returns custom name when metadata.name exists', () => {
+		const attributes = {
+			metadata: { name: 'My Custom Button' },
+			text: 'Click me',
+		};
+		expect( getLabel( attributes ) ).toBe( 'My Custom Button' );
+	} );
+
+	it( 'returns text when no custom name is set', () => {
+		const attributes = {
+			text: 'My Custom Button',
+		};
+		expect( getLabel( attributes ) ).toBe( 'My Custom Button' );
+	} );
+
+	it( 'returns "Button" when text is empty', () => {
+		const attributes = {
+			text: '',
+		};
+		expect( getLabel( attributes ) ).toBe( 'Button' );
+	} );
+
+	it( 'returns "Button" when text is undefined', () => {
+		const attributes = {};
+		expect( getLabel( attributes ) ).toBe( 'Button' );
+	} );
+
+	it( 'returns "Button" when attributes is null', () => {
+		expect( getLabel( null ) ).toBe( 'Button' );
+	} );
+
+	it( 'returns "Button" when attributes is undefined', () => {
+		expect( getLabel( undefined ) ).toBe( 'Button' );
+	} );
+} );

--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -11,25 +11,40 @@ describe( 'Button block __experimentalLabel', () => {
 			metadata: { name: 'My Custom Button' },
 			text: 'Click me',
 		};
-		expect( getLabel( attributes ) ).toBe( 'My Custom Button' );
+		expect( getLabel( attributes, { context: 'list-view' } ) ).toBe(
+			'My Custom Button'
+		);
 	} );
 
 	it( 'returns text when no custom name is set', () => {
 		const attributes = {
 			text: 'My Custom Button',
 		};
-		expect( getLabel( attributes ) ).toBe( 'My Custom Button' );
+		expect( getLabel( attributes, { context: 'list-view' } ) ).toBe(
+			'My Custom Button'
+		);
 	} );
 
-	it( 'returns "Button" when text is empty', () => {
+	it( 'returns undefined when text is empty', () => {
 		const attributes = {
 			text: '',
 		};
-		expect( getLabel( attributes ) ).toBe( 'Button' );
+		expect(
+			getLabel( attributes, { context: 'list-view' } )
+		).toBeUndefined();
 	} );
 
-	it( 'returns "Button" when empty attributes', () => {
+	it( 'returns undefined when empty attributes', () => {
 		const attributes = {};
-		expect( getLabel( attributes ) ).toBe( 'Button' );
+		expect(
+			getLabel( attributes, { context: 'list-view' } )
+		).toBeUndefined();
+	} );
+
+	it( 'returns undefined when context is not list-view', () => {
+		const attributes = {
+			text: 'Click me',
+		};
+		expect( getLabel( attributes, { context: 'other' } ) ).toBeUndefined();
 	} );
 } );

--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -28,7 +28,7 @@ describe( 'Button block __experimentalLabel', () => {
 		expect( getLabel( attributes ) ).toBe( 'Button' );
 	} );
 
-	it( 'returns "Button" when text is undefined', () => {
+	it( 'returns "Button" when empty attributes', () => {
 		const attributes = {};
 		expect( getLabel( attributes ) ).toBe( 'Button' );
 	} );


### PR DESCRIPTION
Adding some unit tests for https://github.com/WordPress/gutenberg/pull/74163

For some reason they have not been merged in https://github.com/WordPress/gutenberg/commit/c1e52cdbdb6b0a78f14a6d54f20f6c94f805dbda
But no problem, we can merge them now.

I have removed the `undefined` and `null` tests as Riad suggested.

cc @youknowriad 
