### PR TITLE
Accordion: Passthrough 'openByDefault' value via context

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -47,7 +47,7 @@ Contains the hidden or revealed content beneath the heading. ([Source](https://g
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
--	**Attributes:** isSelected, openByDefault, templateLock
+-	**Attributes:** isSelected, templateLock
 
 ## Archives
 

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -55,6 +55,9 @@
 			"default": false
 		}
 	},
+	"providesContext": {
+		"core/accordion-open-by-default": "openByDefault"
+	},
 	"textdomain": "default",
 	"style": "wp-block-accordion-item"
 }

--- a/packages/block-library/src/accordion-item/edit.js
+++ b/packages/block-library/src/accordion-item/edit.js
@@ -102,11 +102,6 @@ export default function Edit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( { openByDefault: false } );
-						if ( contentBlockClientId ) {
-							updateBlockAttributes( contentBlockClientId, {
-								openByDefault: false,
-							} );
-						}
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
@@ -116,11 +111,6 @@ export default function Edit( {
 						hasValue={ () => !! openByDefault }
 						onDeselect={ () => {
 							setAttributes( { openByDefault: false } );
-							if ( contentBlockClientId ) {
-								updateBlockAttributes( contentBlockClientId, {
-									openByDefault: false,
-								} );
-							}
 						} }
 					>
 						<ToggleControl
@@ -129,14 +119,6 @@ export default function Edit( {
 								setAttributes( {
 									openByDefault: value,
 								} );
-								if ( contentBlockClientId ) {
-									updateBlockAttributes(
-										contentBlockClientId,
-										{
-											openByDefault: value,
-										}
-									);
-								}
 							} }
 							checked={ openByDefault }
 							help={ __(

--- a/packages/block-library/src/accordion-item/edit.js
+++ b/packages/block-library/src/accordion-item/edit.js
@@ -25,12 +25,9 @@ import clsx from 'clsx';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-export default function Edit( {
-	attributes,
-	clientId,
-	setAttributes,
-	context,
-} ) {
+const TEMPLATE = [ [ 'core/accordion-heading' ], [ 'core/accordion-panel' ] ];
+
+export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -75,21 +72,8 @@ export default function Edit( {
 		} ),
 	} );
 
-	// Get heading level from context.
-	const headingLevel = context && context[ 'core/accordion-heading-level' ];
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: [
-			[
-				'core/accordion-heading',
-				headingLevel ? { level: headingLevel } : {},
-			],
-			[
-				'core/accordion-panel',
-				{
-					openByDefault,
-				},
-			],
-		],
+		template: TEMPLATE,
 		templateLock: 'all',
 		directInsert: true,
 		templateInsertUpdatesSelection: true,

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -6,6 +6,7 @@
 	"category": "design",
 	"description": "Contains the hidden or revealed content beneath the heading.",
 	"parent": [ "core/accordion-item" ],
+	"usesContext": [ "core/accordion-open-by-default" ],
 	"supports": {
 		"html": false,
 		"color": {
@@ -59,10 +60,6 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ],
-			"default": false
-		},
-		"openByDefault": {
-			"type": "boolean",
 			"default": false
 		},
 		"isSelected": {

--- a/packages/block-library/src/accordion-panel/edit.js
+++ b/packages/block-library/src/accordion-panel/edit.js
@@ -3,10 +3,9 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function Edit( { attributes } ) {
-	const { allowedBlocks, templateLock, openByDefault, isSelected } =
-		attributes;
-
+export default function Edit( { attributes, context } ) {
+	const { allowedBlocks, templateLock, isSelected } = attributes;
+	const openByDefault = context[ 'core/accordion-open-by-default' ];
 	const blockProps = useBlockProps( {
 		'aria-hidden': ! isSelected && ! openByDefault,
 		role: 'region',

--- a/test/integration/fixtures/blocks/core__accordion-item.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.json
@@ -22,7 +22,6 @@
 				"isValid": true,
 				"attributes": {
 					"templateLock": false,
-					"openByDefault": false,
 					"isSelected": false
 				},
 				"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__accordion-panel.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.json
@@ -4,7 +4,6 @@
 		"isValid": true,
 		"attributes": {
 			"templateLock": false,
-			"openByDefault": false,
 			"isSelected": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__accordion.json
+++ b/test/integration/fixtures/blocks/core__accordion.json
@@ -32,7 +32,6 @@
 						"isValid": true,
 						"attributes": {
 							"templateLock": false,
-							"openByDefault": false,
 							"isSelected": false
 						},
 						"innerBlocks": [


### PR DESCRIPTION
## What?
PR updates the Accordion block to passdown and consume `openByDefault` value via [block context](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/), which is more suitable for this use case.

## Why?
* The Accordion Panel only uses the `openByDefault` value in the editor; this attribute isn't used when the content is serialized.
*  Using the context also simplifies the attribute controls.
* This also helps to promote better patterns in the core.

P.S. I have some ideas to improve how the `isSelected` state is handled, will create a separate PR for it.

## Testing Instructions
1. Open a post or page.
2. Insert the Accordion block.
3. Toggle "Open by default" setting.
4. Confirm that the Accordion Panel remains open even after the block is deselected.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="922" height="573" alt="CleanShot 2025-12-24 at 10 50 09" src="https://github.com/user-attachments/assets/c4874aa0-cac3-405a-b016-617926e5fa47" />

