### PR TITLE
feat: consistent vertical tabs behavior

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1003,7 +1003,7 @@ Display content in a tabbed interface to help users navigate detailed content wi
 -	**Category:** design
 -	**Allowed Blocks:** core/tab
 -	**Supports:** align, color (~~background~~, ~~text~~), interactivity, spacing (blockGap, margin, ~~padding~~), typography (fontSize), ~~html~~
--	**Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
+-	**Attributes:** activeTabIndex, customTabActiveColor, customTabActiveTextColor, customTabDividerColor, customTabHoverColor, customTabHoverTextColor, customTabInactiveColor, customTabTextColor, orientation, tabActiveColor, tabActiveTextColor, tabDividerColor, tabHoverColor, tabHoverTextColor, tabInactiveColor, tabTextColor, tabsId
 
 ## Tag Cloud
 

--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -58,6 +58,12 @@
 		},
 		"customTabHoverTextColor": {
 			"type": "string"
+		},
+		"tabDividerColor": {
+			"type": "string"
+		},
+		"customTabDividerColor": {
+			"type": "string"
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/tabs/controls.js
+++ b/packages/block-library/src/tabs/controls.js
@@ -119,6 +119,8 @@ export default function Controls( {
 	setTabActiveTextColor,
 	tabHoverTextColor,
 	setTabHoverTextColor,
+	tabDividerColor,
+	setTabDividerColor,
 } ) {
 	const {
 		customTabInactiveColor,
@@ -127,6 +129,7 @@ export default function Controls( {
 		customTabTextColor,
 		customTabActiveTextColor,
 		customTabHoverTextColor,
+		customTabDividerColor,
 		orientation,
 		metadata = {
 			name: '',
@@ -242,6 +245,17 @@ export default function Controls( {
 								setTabHoverTextColor( value );
 								setAttributes( {
 									customTabHoverTextColor: value,
+								} );
+							},
+						},
+						{
+							label: __( 'Divider Color' ),
+							colorValue:
+								tabDividerColor?.color ?? customTabDividerColor,
+							onColorChange: ( value ) => {
+								setTabDividerColor( value );
+								setAttributes( {
+									customTabDividerColor: value,
 								} );
 							},
 						},

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -41,6 +41,8 @@ function Edit( {
 	setTabActiveTextColor,
 	tabHoverTextColor,
 	setTabHoverTextColor,
+	tabDividerColor,
+	setTabDividerColor,
 } ) {
 	const { style, orientation } = attributes;
 
@@ -91,6 +93,8 @@ function Edit( {
 						setTabActiveTextColor,
 						tabHoverTextColor,
 						setTabHoverTextColor,
+						tabDividerColor,
+						setTabDividerColor,
 					} }
 				/>
 			</div>
@@ -104,5 +108,6 @@ export default withColors(
 	'tabActiveColor',
 	'tabTextColor',
 	'tabActiveTextColor',
-	'tabHoverTextColor'
+	'tabHoverTextColor',
+	'tabDividerColor'
 )( Edit );

--- a/packages/block-library/src/tabs/style-engine.js
+++ b/packages/block-library/src/tabs/style-engine.js
@@ -66,6 +66,7 @@ function getColorStyles( { attributes } ) {
 		customTabTextColor,
 		customTabActiveTextColor,
 		customTabHoverTextColor,
+		customTabDividerColor,
 	} = attributes || {};
 
 	// Helper to normalize color objects (preset { slug } vs direct value).
@@ -90,6 +91,7 @@ function getColorStyles( { attributes } ) {
 		'--custom-tab-hover-text-color': getColorValue(
 			customTabHoverTextColor
 		),
+		'--custom-tab-divider-color': getColorValue( customTabDividerColor ),
 	};
 
 	return colorVarMap;

--- a/packages/block-library/src/tabs/style.scss
+++ b/packages/block-library/src/tabs/style.scss
@@ -23,7 +23,7 @@
 	--tab-padding-block: var(--wp--preset--spacing--20, 0.5em);
 	--tab-padding-inline: var(--wp--preset--spacing--30, 1em);
 	--tab-border-radius: 0;
-	--tabs-divider-color: var(--custom-tab-active-color, #000);
+	--tabs-divider-color: var(--custom-tab-divider-color, var(--custom-tab-active-color, #000));
 
 	.tabs__title {
 		display: none;
@@ -95,9 +95,10 @@
 	&.is-vertical {
 		flex-wrap: nowrap;
 		.tabs__list {
-			flex-grow: 0;
 			flex-direction: column;
-			max-width: 30%;
+			align-items: flex-start;
+			flex: 0 0 var(--wp--style--tabs-vertical-nav-width, 16rem);
+			max-width: fit-content;
 			border-inline-end: 1px solid var(--tabs-divider-color);
 			border-block-end: none;
 			overflow-x: hidden;
@@ -183,7 +184,7 @@
 		.tabs__list {
 			border-block-end: none;
 			border-inline-end: none;
-			align-items: flex-end;
+			align-items: flex-start;
 		}
 	}
 }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73935 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Fixed the tab navigation jumping/moving around when switching between vertical tabs
- Keeps the left column (vertical tab navigation) fixed in position
- Added ability to change the color of the vertical divider line between tabs and content
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- To fix the navigation jumps, I have adjusted the styling to fix the position of the tabs
- I have added an block control to adjust the color of the separator line with other color controls
## Testing Instructions
### Testing the navigation jump fix:
1. Add a new page
2. Add the tabs block with a few tabs
3. Set the toggle for the Vertical tab to on
4. Switch between tabs to see that the navigation stays fixed

### Testing the separator color:
1. Add a new page
2. Add the tabs block with a few tabs
3. Set the toggle for the Vertical tab to on
4. Go to styles tab of block controls and set the divider color
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="690" height="531" alt="Screenshot 2025-12-24 at 3 55 55 PM" src="https://github.com/user-attachments/assets/208e7ad0-8ade-494f-9f8f-d0b75f01f25c" />
<img width="241" height="326" alt="Screenshot 2025-12-24 at 3 56 21 PM" src="https://github.com/user-attachments/assets/41ed77e8-17f6-4bcf-9268-bd5597bb901e" />
