### PR TITLE
Build: Support pnpm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16108,12 +16108,6 @@
 				"@types/jest": "*"
 			}
 		},
-		"node_modules/@types/toposort": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/toposort/-/toposort-2.0.7.tgz",
-			"integrity": "sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==",
-			"license": "MIT"
-		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -48621,12 +48615,6 @@
 				"node": ">=0.6"
 			}
 		},
-		"node_modules/toposort": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-			"integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-			"license": "MIT"
-		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -56223,7 +56211,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@emotion/babel-plugin": "11.11.0",
-				"@types/toposort": "2.0.7",
 				"autoprefixer": "10.4.21",
 				"browserslist-to-esbuild": "2.1.1",
 				"change-case": "4.1.2",
@@ -56235,8 +56222,7 @@
 				"fast-glob": "^3.2.7",
 				"postcss": "8.4.38",
 				"postcss-modules": "6.0.1",
-				"rtlcss": "4.3.0",
-				"toposort": "2.0.2"
+				"rtlcss": "4.3.0"
 			},
 			"bin": {
 				"wp-build": "src/build.mjs"

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -36,7 +36,6 @@
 	},
 	"dependencies": {
 		"@emotion/babel-plugin": "11.11.0",
-		"@types/toposort": "2.0.7",
 		"autoprefixer": "10.4.21",
 		"browserslist-to-esbuild": "2.1.1",
 		"change-case": "4.1.2",
@@ -48,8 +47,7 @@
 		"fast-glob": "^3.2.7",
 		"postcss": "8.4.38",
 		"postcss-modules": "6.0.1",
-		"rtlcss": "4.3.0",
-		"toposort": "2.0.2"
+		"rtlcss": "4.3.0"
 	},
 	"peerDependencies": {
 		"@wordpress/boot": "^0.3.0",

--- a/packages/wp-build/src/package-utils.mjs
+++ b/packages/wp-build/src/package-utils.mjs
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFileSync, existsSync } from 'fs';
+import { createRequire } from 'module';
+import path from 'path';
 
 /**
  * Shared cache for package.json files to avoid redundant reads.
@@ -41,20 +42,54 @@ const packagePathCache = new Map();
  */
 
 /**
- * Get package.json info using Node's module resolution.
- * Resolves the package using import.meta.resolve and reads its package.json.
+ * Find the nearest package root directory by walking up from the given directory.
+ * Looks for a directory containing package.json.
  *
- * @param {string} fullPackageName The full package name (e.g., '@wordpress/blocks').
- * @return {PackageJson|null} Package.json object or null if not found.
+ * @param {string} startDir The directory to start searching from.
+ * @return {string} The package root directory, or the start directory if no package.json found.
  */
-export function getPackageInfo( fullPackageName ) {
-	if ( packageJsonCache.has( fullPackageName ) ) {
-		return packageJsonCache.get( fullPackageName );
+function findPackageRoot( startDir ) {
+	let current = startDir;
+	const root = path.parse( current ).root;
+
+	while ( current !== root ) {
+		const packageJsonPath = path.join( current, 'package.json' );
+		if ( existsSync( packageJsonPath ) ) {
+			return current;
+		}
+		current = path.dirname( current );
 	}
 
-	const resolved = import.meta.resolve( `${ fullPackageName }/package.json` );
-	const result = getPackageInfoFromFile( fileURLToPath( resolved ) );
-	packageJsonCache.set( fullPackageName, result );
+	// Fallback to the start directory if no package.json found
+	return startDir;
+}
+
+/**
+ * Get package.json info using Node's module resolution.
+ * Resolves packages from the appropriate context to support both workspace packages
+ * and external dependencies in pnpm/yarn/npm workspaces.
+ *
+ * @param {string}      fullPackageName The full package name (e.g., '@wordpress/blocks').
+ * @param {string|null} resolveDir      Optional directory context for resolution (from esbuild).
+ * @return {PackageJson|null} Package.json object or null if not found.
+ */
+export function getPackageInfo( fullPackageName, resolveDir = null ) {
+	// Determine the package root for cache keying
+	const packageRoot = resolveDir
+		? findPackageRoot( resolveDir )
+		: process.cwd();
+	const cacheKey = `${ fullPackageName }@${ packageRoot }`;
+
+	if ( packageJsonCache.has( cacheKey ) ) {
+		return packageJsonCache.get( cacheKey );
+	}
+
+	// Resolve from the package root context to get correct versions
+	const contextPath = path.join( packageRoot, 'package.json' );
+	const require = createRequire( contextPath );
+	const resolved = require.resolve( `${ fullPackageName }/package.json` );
+	const result = getPackageInfoFromFile( resolved );
+	packageJsonCache.set( cacheKey, result );
 
 	return result;
 }

--- a/packages/wp-build/src/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/src/wordpress-externals-plugin.mjs
@@ -213,7 +213,10 @@ export function createWordpressExternalsPlugin(
 							const shortName = parts[ 1 ];
 							const handle = `${ externalConfig.handlePrefix }-${ shortName }`;
 
-							const packageJson = getPackageInfo( packageName );
+							const packageJson = getPackageInfo(
+								packageName,
+								args.resolveDir
+							);
 
 							if ( ! packageJson ) {
 								return undefined;


### PR DESCRIPTION
Related #72032
Alternative to #74171

Fixes wp-build to support pnpm's strict hoisting mode by implementing context-aware package resolution.

## Problem

wp-build failed when used in pnpm workspaces because it resolved packages from a single global context. In pnpm's strict hoisting mode, workspace packages and their dependencies aren't hoisted to the root, causing resolution failures.

## Solution

Implemented context-aware package resolution:

  1. **`package-utils.mjs`**: Updated `getPackageInfo()` to accept optional `resolveDir` parameter and resolve packages from the importing package's context rather than workspace root
  2. **`dependency-graph.mjs`**: Changed functions to accept `Map<packageName, packageJson>` instead of resolving packages dynamically
  3. **`build.mjs`**: Created `fullToPackageJson` map and passed it to dependency graph functions
  4. **`wordpress-externals-plugin.mjs`**: Pass `args.resolveDir` from esbuild to `getPackageInfo()` for context-aware resolution

## Testing

Tested with pnpm workspace containing: (https://github.com/lezama/wp-build-pnpm-test) 
  - Workspace packages with external dependencies
  - Routes importing from workspace packages
  - Build completes successfully with all phases
