### PR TITLE
Accordion: Remove 'isSelected' attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -47,7 +47,7 @@ Contains the hidden or revealed content beneath the heading. ([Source](https://g
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~lock~~, ~~visibility~~
--	**Attributes:** isSelected, templateLock
+-	**Attributes:** templateLock
 
 ## Archives
 

--- a/packages/block-library/src/accordion-item/edit.js
+++ b/packages/block-library/src/accordion-item/edit.js
@@ -29,14 +29,14 @@ const TEMPLATE = [ [ 'core/accordion-heading' ], [ 'core/accordion-panel' ] ];
 export default function Edit( {
 	attributes,
 	clientId,
-	isBlockSelected,
 	setAttributes,
+	isSelected: isSingleSelected,
 } ) {
 	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { isSelected } = useSelect(
 		( select ) => {
-			if ( isBlockSelected || openByDefault ) {
+			if ( isSingleSelected || openByDefault ) {
 				return { isSelected: true };
 			}
 
@@ -47,7 +47,7 @@ export default function Edit( {
 				),
 			};
 		},
-		[ clientId, isBlockSelected, openByDefault ]
+		[ clientId, isSingleSelected, openByDefault ]
 	);
 
 	const blockProps = useBlockProps( {

--- a/packages/block-library/src/accordion-item/edit.js
+++ b/packages/block-library/src/accordion-item/edit.js
@@ -8,8 +8,7 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -27,44 +26,29 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const TEMPLATE = [ [ 'core/accordion-heading' ], [ 'core/accordion-panel' ] ];
 
-export default function Edit( { attributes, clientId, setAttributes } ) {
+export default function Edit( {
+	attributes,
+	clientId,
+	isBlockSelected,
+	setAttributes,
+} ) {
 	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
-	const { isSelected, getBlockOrder } = useSelect(
+	const { isSelected } = useSelect(
 		( select ) => {
-			const {
-				isBlockSelected,
-				hasSelectedInnerBlock,
-				getBlockOrder: getBlockOrderSelector,
-			} = select( blockEditorStore );
+			if ( isBlockSelected || openByDefault ) {
+				return { isSelected: true };
+			}
+
 			return {
-				isSelected:
-					isBlockSelected( clientId ) ||
-					hasSelectedInnerBlock( clientId, true ),
-				getBlockOrder: getBlockOrderSelector,
+				isSelected: select( blockEditorStore ).hasSelectedInnerBlock(
+					clientId,
+					true
+				),
 			};
 		},
-		[ clientId ]
+		[ clientId, isBlockSelected, openByDefault ]
 	);
-
-	const contentBlockClientId = getBlockOrder( clientId )[ 1 ];
-	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-
-	useEffect( () => {
-		if ( contentBlockClientId ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			updateBlockAttributes( contentBlockClientId, {
-				isSelected,
-			} );
-		}
-	}, [
-		isSelected,
-		contentBlockClientId,
-		__unstableMarkNextChangeAsNotPersistent,
-		updateBlockAttributes,
-	] );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -61,10 +61,6 @@
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ],
 			"default": false
-		},
-		"isSelected": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "default",

--- a/packages/block-library/src/accordion-panel/edit.js
+++ b/packages/block-library/src/accordion-panel/edit.js
@@ -1,13 +1,38 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
-export default function Edit( { attributes, context } ) {
-	const { allowedBlocks, templateLock, isSelected } = attributes;
+export default function Edit( { attributes, context, clientId, isSelected } ) {
+	const { allowedBlocks, templateLock } = attributes;
 	const openByDefault = context[ 'core/accordion-open-by-default' ];
+	const { hasSelection } = useSelect(
+		( select ) => {
+			if ( isSelected || openByDefault ) {
+				return { hasSelection: true };
+			}
+
+			const {
+				getBlockRootClientId,
+				isBlockSelected,
+				hasSelectedInnerBlock,
+			} = select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			return {
+				hasSelection:
+					isBlockSelected( rootClientId ) ||
+					hasSelectedInnerBlock( rootClientId, true ),
+			};
+		},
+		[ clientId, isSelected, openByDefault ]
+	);
 	const blockProps = useBlockProps( {
-		'aria-hidden': ! isSelected && ! openByDefault,
+		'aria-hidden': ! hasSelection,
 		role: 'region',
 	} );
 

--- a/test/integration/fixtures/blocks/core__accordion-item.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.json
@@ -21,8 +21,7 @@
 				"name": "core/accordion-panel",
 				"isValid": true,
 				"attributes": {
-					"templateLock": false,
-					"isSelected": false
+					"templateLock": false
 				},
 				"innerBlocks": [
 					{

--- a/test/integration/fixtures/blocks/core__accordion-panel.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.json
@@ -3,8 +3,7 @@
 		"name": "core/accordion-panel",
 		"isValid": true,
 		"attributes": {
-			"templateLock": false,
-			"isSelected": false
+			"templateLock": false
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__accordion.json
+++ b/test/integration/fixtures/blocks/core__accordion.json
@@ -31,8 +31,7 @@
 						"name": "core/accordion-panel",
 						"isValid": true,
 						"attributes": {
-							"templateLock": false,
-							"isSelected": false
+							"templateLock": false
 						},
 						"innerBlocks": [
 							{


### PR DESCRIPTION
## What?
PR removes hack for passing down `isSelected` state as attribute from Accordion Item to Accordion Panel. The same state can be selected and derived in both blocks.

The attributes are primarily for rendering block data, not for maintaining a similar internal state.

## Testing Instructions
1. Open a post or page.
2. Insert the Accordion block.
3. Confirm it works as before.
4. Selecting an accordion item or its children should expand the panel.
5. The panel should remain open if `openByDefault` is set to `true`.

### Testing Instructions for Keyboard
Same.