### PR TITLE
DataViews: display a separate `—` for each level

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Enhancements
 
+- DataViews: improve how hierarchy is displayed in table layout. [#74199](https://github.com/WordPress/gutenberg/pull/74199)
 - DataViews: Add `groupBy.showLabel` config option to control whether the field label is shown in group headers. [#74161](https://github.com/WordPress/gutenberg/pull/74161)
 - DataViews table layout: remove row click-to-select behavior and hover styles. Selection is now only possible via checkboxes, or by ctrl/cmd clicking. [#73873](https://github.com/WordPress/gutenberg/pull/73873)
 - Better labels for operators and deprecate the `isNotAll` operator. [#73671](https://github.com/WordPress/gutenberg/pull/73671)

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
@@ -76,7 +76,7 @@ function ColumnPrimary< Item >( {
 					>
 						{ level !== undefined && level > 0 && (
 							<span className="dataviews-view-table__level">
-								{ '— '.repeat( level ) }&nbsp;
+								{ Array( level ).fill( '—' ).join( ' ' ) }&nbsp;
 							</span>
 						) }
 						<titleField.render item={ item } field={ titleField } />

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
@@ -76,7 +76,7 @@ function ColumnPrimary< Item >( {
 					>
 						{ level !== undefined && level > 0 && (
 							<span className="dataviews-view-table__level">
-								{ '—'.repeat( level ) }&nbsp;
+								{ '— '.repeat( level ) }&nbsp;
 							</span>
 						) }
 						<titleField.render item={ item } field={ titleField } />


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/74072

## What?

Display a separate `—` for each level.

Before | After 
--- | ---
<img width="2262" height="1225" alt="Screenshot 2025-12-24 at 13 54 04" src="https://github.com/user-attachments/assets/224f083e-6f2d-4cde-a124-c926cf62ab9e" /> | <img width="2262" height="1225" alt="Screenshot 2025-12-24 at 13 52 25" src="https://github.com/user-attachments/assets/242de313-013a-4060-b797-6d506712027c" />

## Why?

I ran this by design, and they wanted to try separate `—`. The rationale being that it's easier to understand the level of an item.

## How?

Changes how it's rendered.

## Testing Instructions

How to the Site Editor > Pages screen and verify that the level is represented by separate `—`.