### PR TITLE
Image Block: Add content tab and reorganize inspector controls

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -97,6 +97,7 @@ export default function InspectorControlsTabs( {
 					/>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
+					<InspectorControls.Slot group="content" />
 					<ContentTab
 						rootClientId={ clientId }
 						contentClientIds={ contentClientIds }

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -39,6 +39,7 @@ export default function useInspectorControlsTabs(
 		bindings: bindingsGroup,
 		border: borderGroup,
 		color: colorGroup,
+		content: contentGroup,
 		default: defaultGroup,
 		dimensions: dimensionsGroup,
 		list: listGroup,
@@ -51,6 +52,10 @@ export default function useInspectorControlsTabs(
 	// List View Tab: If there are any fills for the list group add that tab.
 	const listFills = useSlotFills( listGroup.name );
 	const hasListFills = !! listFills && listFills.length;
+
+	// Content Tab: If there are any fills for the content group add that tab.
+	const contentFills = useSlotFills( contentGroup.name );
+	const hasContentFills = !! contentFills && contentFills.length;
 
 	// Styles Tab: Add this tab if there are any fills for block supports
 	// e.g. border, color, spacing, typography, etc.
@@ -79,9 +84,9 @@ export default function useInspectorControlsTabs(
 		...( hasListFills && hasStyleFills > 1 ? advancedFills : [] ),
 	];
 
-	const hasContentTab = !! (
-		contentClientIds && contentClientIds.length > 0
-	);
+	const hasContentTab =
+		hasContentFills ||
+		!! ( contentClientIds && contentClientIds.length > 0 );
 
 	// Add the tabs in the order that they will default to if available.
 	// List View > Content > Settings > Styles.

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -88,9 +88,11 @@ export default function useInspectorControlsTabs(
 		hasContentFills ||
 		!! ( contentClientIds && contentClientIds.length > 0 );
 
+	const hasListTab = hasListFills && ! isSectionBlock;
+
 	// Add the tabs in the order that they will default to if available.
 	// List View > Content > Settings > Styles.
-	if ( hasListFills && ! isSectionBlock ) {
+	if ( hasListTab ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 
@@ -98,7 +100,12 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_CONTENT );
 	}
 
-	if ( settingsFills.length && ! isSectionBlock ) {
+	if (
+		( settingsFills.length ||
+			// Advanded fills who up in settings tab if available or they blend into the default tab, if there's only one tab.
+			( advancedFills.length && ( hasContentTab || hasListTab ) ) ) &&
+		! isSectionBlock
+	) {
 		tabs.push( TAB_SETTINGS );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -22,6 +22,7 @@ const InspectorControlsTypography = createSlotFill(
 const InspectorControlsListView = createSlotFill( 'InspectorControlsListView' );
 const InspectorControlsStyles = createSlotFill( 'InspectorControlsStyles' );
 const InspectorControlsEffects = createSlotFill( 'InspectorControlsEffects' );
+const InspectorControlsContent = createSlotFill( 'InspectorControlsContent' );
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -30,6 +31,7 @@ const groups = {
 	bindings: InspectorControlsBindings,
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
+	content: InspectorControlsContent,
 	dimensions: InspectorControlsDimensions,
 	effects: InspectorControlsEffects,
 	filter: InspectorControlsFilter,

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
@@ -55,6 +60,7 @@ const MediaReplaceFlow = ( {
 	multiple = false,
 	addToGallery,
 	handleUpload = true,
+	variant,
 	popoverProps,
 	renderToggle,
 	className,
@@ -148,11 +154,19 @@ const MediaReplaceFlow = ( {
 
 	const gallery = multiple && onlyAllowsImages();
 
+	const mergedPopoverProps = {
+		...popoverProps,
+		variant,
+	};
+
 	return (
 		<Dropdown
-			popoverProps={ popoverProps }
+			popoverProps={ mergedPopoverProps }
 			className={ className }
-			contentClassName="block-editor-media-replace-flow__options"
+			contentClassName={ clsx(
+				'block-editor-media-replace-flow__options',
+				variant && `is-variant-${ variant }`
+			) }
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				if ( renderToggle ) {
 					return renderToggle( {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -13,9 +13,16 @@
 }
 
 .block-editor-media-replace-flow__media-upload-menu:not(:empty) + .block-editor-media-flow__url-input {
-	border-top: $border-width solid $gray-900;
+	border-top: $border-width solid $gray-300;
 	margin-top: $grid-unit-10;
 	padding-bottom: $grid-unit-10;
+}
+
+// Toolbar variant: Dark border (high contrast)
+.block-editor-media-replace-flow__options.is-variant-toolbar {
+	.block-editor-media-replace-flow__media-upload-menu:not(:empty) + .block-editor-media-flow__url-input {
+		border-top-color: $gray-900;
+	}
 }
 
 .block-editor-media-flow__url-input {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -164,6 +164,7 @@ function AudioEdit( {
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 						onReset={ () => onSelectAudio( undefined ) }
+						variant="toolbar"
 					/>
 				</BlockControls>
 			) }

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -112,6 +112,7 @@ export default function CoverBlockControls( {
 					useFeaturedImage={ useFeaturedImage }
 					name={ ! url ? __( 'Add media' ) : __( 'Replace' ) }
 					onReset={ onClearMedia }
+					variant="toolbar"
 				>
 					{ ( { onClose } ) => (
 						<MenuItem

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/mixins" as *;
+@use "./utils/media-control.scss" as *;
 @use "./archives/editor.scss" as *;
 @use "./audio/editor.scss" as *;
 @use "./avatar/editor.scss" as *;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -907,6 +907,7 @@ export default function GalleryEdit( props ) {
 									.filter( ( image ) => image.id )
 									.map( ( image ) => image.id ) }
 								addToGallery={ hasImageIds }
+								variant="toolbar"
 							/>
 						</BlockControls>
 					) }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -158,3 +158,4 @@ figure.wp-block-image:not(.wp-block) {
 	// Corresponds to the size of the textarea in the block inspector.
 	width: 250px;
 }
+

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -861,22 +861,22 @@ export default function Image( {
 			>
 				{ dimensionsControl }
 			</InspectorControls>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ resetSettings }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					{ !! imageSizeOptions.length && (
+			{ !! imageSizeOptions.length && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ resetSettings }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
 						<ResolutionTool
 							value={ sizeSlug }
 							defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
 							onChange={ updateImage }
 							options={ imageSizeOptions }
 						/>
-					) }
-				</ToolsPanel>
-			</InspectorControls>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -592,12 +592,6 @@ export default function Image( {
 			/>
 		) );
 
-	const resetContentAttributes = () => {
-		setAttributes( {
-			alt: undefined,
-		} );
-	};
-
 	const resetSettings = () => {
 		setAttributes( {
 			lightbox: undefined,
@@ -783,13 +777,14 @@ export default function Image( {
 			<InspectorControls group="content">
 				<ToolsPanel
 					label={ __( 'Media' ) }
-					resetAll={ resetContentAttributes }
+					resetAll={ () => onSelectImage( undefined ) }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					{ isSingleSelected && ! lockUrlControls && (
 						<ToolsPanelItem
 							label={ __( 'Image' ) }
 							hasValue={ () => !! url }
+							onDeselect={ () => onSelectImage( undefined ) }
 							isShownByDefault
 						>
 							<MediaControl

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -53,6 +53,7 @@ import { unlock } from '../lock-unlock';
 import { createUpgradedEmbedBlock } from '../embed/util';
 import { isExternalImage } from './edit';
 import { Caption } from '../utils/caption';
+import { MediaControl } from '../utils/media-control';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
 	MIN_SIZE,
@@ -549,6 +550,7 @@ export default function Image( {
 		isResizable &&
 		( SIZED_LAYOUTS.includes( parentLayoutType ) ? (
 			<DimensionsTool
+				panelId={ clientId }
 				value={ { aspectRatio } }
 				onChange={ ( { aspectRatio: newAspectRatio } ) => {
 					setAttributes( {
@@ -561,6 +563,7 @@ export default function Image( {
 			/>
 		) : (
 			<DimensionsTool
+				panelId={ clientId }
 				value={ { width, height, scale, aspectRatio } }
 				onChange={ ( {
 					width: newWidth,
@@ -589,29 +592,18 @@ export default function Image( {
 			/>
 		) );
 
-	const resetAll = () => {
+	const resetContentAttributes = () => {
 		setAttributes( {
 			alt: undefined,
-			width: undefined,
-			height: undefined,
-			scale: undefined,
-			aspectRatio: undefined,
+		} );
+	};
+
+	const resetSettings = () => {
+		setAttributes( {
 			lightbox: undefined,
 		} );
 		updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 	};
-
-	const sizeControls = (
-		<InspectorControls>
-			<ToolsPanel
-				label={ __( 'Settings' ) }
-				resetAll={ resetAll }
-				dropdownMenuProps={ dropdownMenuProps }
-			>
-				{ dimensionsControl }
-			</ToolsPanel>
-		</InspectorControls>
-	);
 
 	const arePatternOverridesEnabled =
 		metadata?.bindings?.__default?.source === 'core/pattern-overrides';
@@ -721,6 +713,7 @@ export default function Image( {
 					onError={ onUploadError }
 					name={ ! url ? __( 'Add image' ) : __( 'Replace' ) }
 					onReset={ () => onSelectImage( undefined ) }
+					variant="toolbar"
 				/>
 			</BlockControls>
 		);
@@ -787,12 +780,37 @@ export default function Image( {
 					/>
 				</BlockControls>
 			) }
-			<InspectorControls>
+			<InspectorControls group="content">
 				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ resetAll }
+					label={ __( 'Media' ) }
+					resetAll={ resetContentAttributes }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
+					{ isSingleSelected && ! lockUrlControls && (
+						<ToolsPanelItem
+							label={ __( 'Image' ) }
+							hasValue={ () => !! url }
+							isShownByDefault
+						>
+							<MediaControl
+								mediaId={ id }
+								mediaUrl={ url }
+								alt={ alt }
+								filename={
+									image?.media_details?.sizes?.full?.file ||
+									image?.slug ||
+									getFilename( url )
+								}
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								onSelect={ onSelectImage }
+								onSelectURL={ onSelectURL }
+								onError={ onUploadError }
+								onReset={ () => onSelectImage( undefined ) }
+								isUploading={ !! temporaryURL }
+								emptyLabel={ __( 'Add image' ) }
+							/>
+						</ToolsPanelItem>
+					) }
 					{ isSingleSelected && (
 						<ToolsPanelItem
 							label={ __( 'Alternative text' ) }
@@ -834,7 +852,26 @@ export default function Image( {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ dimensionsControl }
+				</ToolsPanel>
+			</InspectorControls>
+			<InspectorControls
+				group="dimensions"
+				resetAllFilter={ ( attrs ) => ( {
+					...attrs,
+					aspectRatio: undefined,
+					width: undefined,
+					height: undefined,
+					scale: undefined,
+				} ) }
+			>
+				{ dimensionsControl }
+			</InspectorControls>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ resetSettings }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
 					{ !! imageSizeOptions.length && (
 						<ResolutionTool
 							value={ sizeSlug }
@@ -1086,8 +1123,7 @@ export default function Image( {
 		return (
 			<>
 				{ mediaReplaceFlow }
-				{ /* Add all controls if the image attributes are connected. */ }
-				{ metadata?.bindings ? controls : sizeControls }
+				{ controls }
 			</>
 		);
 	}

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -112,30 +112,8 @@
 }
 
 .block-library-site-logo__inspector-media-replace-container {
-	// Ensure the dropzone is positioned to the size of the item.
+	// For readonly preview: ensure proper positioning
 	position: relative;
-
-	// Since there is no option to skip rendering the drag'n'drop icon in drop
-	// zone, we hide it for now.
-	.components-drop-zone__content-icon {
-		display: none;
-	}
-
-	button.components-button {
-		color: $gray-900;
-		box-shadow: inset 0 0 0 1px $gray-400;
-		width: 100%;
-		display: block;
-		height: $grid-unit-50;
-
-		&:hover {
-			color: var(--wp-admin-theme-color);
-		}
-
-		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
-	}
 
 	.block-library-site-logo__inspector-media-replace-title {
 		word-break: break-all;
@@ -147,16 +125,12 @@
 		text-align-last: center;
 	}
 
-	.components-dropdown {
-		display: block;
-	}
-
 	img {
 		width: 20px;
 		min-width: 20px;
 		aspect-ratio: 1;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-		border-radius: 50% !important;
+		border-radius: 2px;
 	}
 
 	.block-library-site-logo__inspector-readonly-logo-preview {

--- a/packages/block-library/src/utils/media-control.js
+++ b/packages/block-library/src/utils/media-control.js
@@ -79,14 +79,9 @@ export function MediaControl( {
 	isUploading = false,
 	emptyLabel = __( 'Add media' ),
 } ) {
-	const { mediaUpload } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return {
-			mediaUpload: getSettings().mediaUpload,
-		};
-	}, [] );
-
+	const { getSettings } = useSelect( blockEditorStore );
 	const onFilesDrop = ( filesList ) => {
+		const { mediaUpload } = getSettings();
 		if ( ! mediaUpload ) {
 			return;
 		}

--- a/packages/block-library/src/utils/media-control.js
+++ b/packages/block-library/src/utils/media-control.js
@@ -1,0 +1,134 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	DropZone,
+	FlexItem,
+	Spinner,
+	__experimentalItemGroup as ItemGroup,
+	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
+} from '@wordpress/components';
+import {
+	MediaReplaceFlow,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * MediaControlPreview - Preview component showing media thumbnail and filename
+ *
+ * @param {Object} props
+ * @param {string} props.url            Media URL for thumbnail
+ * @param {string} props.alt            Alt text for image
+ * @param {string} props.filename       Filename to display
+ * @param {Object} props.itemGroupProps Optional props to pass to ItemGroup
+ * @param {string} props.className      Optional className for Truncate
+ * @return {Element} Preview component
+ */
+export function MediaControlPreview( {
+	url,
+	alt,
+	filename,
+	itemGroupProps,
+	className,
+} ) {
+	return (
+		<ItemGroup { ...itemGroupProps } as="span">
+			<HStack justify="flex-start" as="span">
+				<img src={ url } alt={ alt } />
+				<FlexItem as="span">
+					<Truncate numberOfLines={ 1 } className={ className }>
+						{ filename }
+					</Truncate>
+				</FlexItem>
+			</HStack>
+		</ItemGroup>
+	);
+}
+
+/**
+ * MediaControl - Complete media selection control for inspector panels
+ *
+ * @param {Object}   props
+ * @param {number}   props.mediaId      Media attachment ID
+ * @param {string}   props.mediaUrl     Media URL
+ * @param {string}   props.alt          Alt text for preview
+ * @param {string}   props.filename     Filename to display
+ * @param {Array}    props.allowedTypes Allowed media types
+ * @param {Function} props.onSelect     Callback when media selected
+ * @param {Function} props.onSelectURL  Callback when URL entered
+ * @param {Function} props.onError      Error callback
+ * @param {Function} props.onReset      Reset/remove callback
+ * @param {boolean}  props.isUploading  Whether upload in progress
+ * @param {string}   props.emptyLabel   Label when no media (default: 'Add media')
+ * @return {Element} Media control component
+ */
+export function MediaControl( {
+	mediaId,
+	mediaUrl,
+	alt = '',
+	filename,
+	allowedTypes,
+	onSelect,
+	onSelectURL,
+	onError,
+	onReset,
+	isUploading = false,
+	emptyLabel = __( 'Add media' ),
+} ) {
+	const { mediaUpload } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return {
+			mediaUpload: getSettings().mediaUpload,
+		};
+	}, [] );
+
+	const onFilesDrop = ( filesList ) => {
+		if ( ! mediaUpload ) {
+			return;
+		}
+		mediaUpload( {
+			allowedTypes,
+			filesList,
+			onFileChange( [ media ] ) {
+				onSelect( media );
+			},
+			onError,
+			multiple: false,
+		} );
+	};
+
+	return (
+		<div className="block-library-utils__media-control">
+			<MediaReplaceFlow
+				mediaId={ mediaId }
+				mediaURL={ mediaUrl }
+				allowedTypes={ allowedTypes }
+				onSelect={ onSelect }
+				onSelectURL={ onSelectURL }
+				onError={ onError }
+				name={
+					mediaUrl ? (
+						<MediaControlPreview
+							url={ mediaUrl }
+							alt={ alt }
+							filename={ filename }
+						/>
+					) : (
+						emptyLabel
+					)
+				}
+				renderToggle={ ( props ) => (
+					<Button { ...props } __next40pxDefaultSize>
+						{ isUploading ? <Spinner /> : props.children }
+					</Button>
+				) }
+				onReset={ onReset }
+			/>
+			<DropZone onFilesDrop={ onFilesDrop } />
+		</div>
+	);
+}

--- a/packages/block-library/src/utils/media-control.scss
+++ b/packages/block-library/src/utils/media-control.scss
@@ -1,0 +1,41 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.block-library-utils__media-control {
+	// Ensure the dropzone is positioned to the size of the item.
+	position: relative;
+
+	// Since there is no option to skip rendering the drag'n'drop icon in drop
+	// zone, we hide it for now.
+	.components-drop-zone__content-icon {
+		display: none;
+	}
+
+	button.components-button {
+		color: $gray-900;
+		box-shadow: inset 0 0 0 1px $gray-400;
+		width: 100%;
+		display: block;
+		height: $grid-unit-50;
+
+		&:hover {
+			color: var(--wp-admin-theme-color);
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+
+	.components-dropdown {
+		display: block;
+	}
+
+	img {
+		width: 20px;
+		min-width: 20px;
+		aspect-ratio: 1;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		border-radius: 2px;
+	}
+}

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -197,6 +197,7 @@ function VideoEdit( {
 							onSelectURL={ onSelectURL }
 							onError={ onUploadError }
 							onReset={ () => onSelectVideo( undefined ) }
+							variant="toolbar"
 						/>
 					</BlockControls>
 				</>

--- a/test/e2e/specs/editor/plugins/image-size.spec.js
+++ b/test/e2e/specs/editor/plugins/image-size.spec.js
@@ -46,6 +46,7 @@ test.describe( 'changing image size', () => {
 
 		// Select the new size updated with the plugin.
 		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
 		await page.selectOption( 'role=combobox[name="Resolution"i]', {
 			label: 'Custom Size One',
 		} );
@@ -54,6 +55,7 @@ test.describe( 'changing image size', () => {
 		await expect(
 			editor.canvas.locator( `role=img[name="${ fileName }"]` )
 		).toHaveCSS( 'width', '499px' );
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 		await expect(
 			page.locator( 'role=spinbutton[name="Width"i]' )
 		).toHaveValue( '' );

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -81,6 +81,7 @@ test.describe( 'Registered sources', () => {
 					},
 				},
 			} );
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', { name: 'Show id' } )
@@ -239,12 +240,12 @@ test.describe( 'Registered sources', () => {
 
 			// Alt textarea should have the custom field value.
 			const altValue = await page
-				.getByRole( 'tabpanel', { name: 'Settings' } )
-				.getByLabel( 'Alternative text' )
+				.getByRole( 'textbox', { name: 'Alternative text' } )
 				.inputValue();
 			expect( altValue ).toBe( 'Text Field Value' );
 
 			// Title input should have the original value.
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			const advancedButton = page
 				.getByRole( 'tabpanel', { name: 'Settings' } )
 				.getByRole( 'button', {
@@ -531,18 +532,15 @@ test.describe( 'Registered sources', () => {
 				).toBeHidden();
 
 				// Alt textarea is disabled and with the custom field value.
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Alternative text' )
-				).toHaveAttribute( 'readonly' );
-				const altValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Alternative text' )
-					.inputValue();
+				const altInput = page.getByRole( 'textbox', {
+					name: 'Alternative text',
+				} );
+				await expect( altInput ).toHaveAttribute( 'readonly' );
+				const altValue = await altInput.inputValue();
 				expect( altValue ).toBe( 'Text Field Value' );
 
 				// Title input is enabled and with the original value.
+				await page.getByRole( 'tab', { name: 'Settings' } ).click();
 				await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByRole( 'button', { name: 'Advanced' } )
@@ -802,9 +800,9 @@ test.describe( 'Registered sources', () => {
 			await imageBlockImg.click( { force: true } );
 
 			// Edit the custom field value in the alt textarea.
-			const altInputArea = page
-				.getByRole( 'tabpanel', { name: 'Settings' } )
-				.getByLabel( 'Alternative text' );
+			const altInputArea = page.getByRole( 'textbox', {
+				name: 'Alternative text',
+			} );
 			await expect( altInputArea ).not.toHaveAttribute( 'readonly' );
 			await altInputArea.fill( 'new value' );
 
@@ -930,6 +928,7 @@ test.describe( 'Registered sources', () => {
 			await editor.insertBlock( {
 				name: 'core/image',
 			} );
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			await page
 				.getByRole( 'tabpanel', {
 					name: 'Settings',
@@ -1284,6 +1283,7 @@ test.describe( 'Registered sources', () => {
 			page,
 		} ) => {
 			await editor.insertBlock( { name: 'core/image' } );
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', { name: 'Show id' } )


### PR DESCRIPTION
Related #73845

## What?

This PR starts the initial work for the "content" tab based on  #73845. It focuses on the Image block.

It reorganizes the Image block's inspector controls by introducing a new "Content" tab and properly distributing controls across dedicated tabs. It also adds variant support to MediaReplaceFlow for context-appropriate styling and extracts a reusable MediaControl component (kept it under block-library and might merge later with the ongoing MediaEdit efforts).

The MediaControl is basically extracted from what we already do for the SiteLogo block.

## Why?

The Image block's inspector controls were previously all grouped in a single "Settings" panel, making it difficult for users to find specific controls. With the introduction of the content tab feature in the block editor, it makes sense to organize controls by their purpose: content-related controls (image selection, alt text) should be in the Content tab, dimension controls (width, height, aspect ratio) should be in the Dimensions tab, and technical settings (resolution) should remain in Settings.

Additionally, MediaReplaceFlow was displaying dark borders everywhere, assuming it was always used in a toolbar context. However, with the introduction of MediaControl for inspector panels, we needed a way to apply lighter borders for standard popover styling in non-toolbar contexts.

## Testing Instructions

 - Insert an Image block and open the inspector sidebar. You should see a Content tab containing the image picker and alternative text field. The Dimensions tab should contain width, height, aspect ratio, and scale controls. The Settings tab should contain the resolution picker (if multiple sizes are available). Verify that the "Reset all" button works correctly in each tab.
-  Test MediaReplaceFlow styling by opening the media picker from both the toolbar (should have dark border on URL input) and the inspector Content tab (should have light border). Test this in the Image block, Site Logo block, and other blocks that support media selection.
- You can also test the SiteLogo block to ensure there's no regression there.

<img width="277" height="334" alt="Screenshot 2025-12-24 at 3 31 59 PM" src="https://github.com/user-attachments/assets/a7c4b8ed-f203-4da3-85e3-c52a9cabcac2" />
