### PR TITLE
Changelog: Fix `block-library` and `date` package entries after failed release action

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   Post Date Block: Improve semantic HTML to add `<time>` inside link element.
 
+## 9.37.0 (2025-12-23)
+
 ## 9.36.0 (2025-11-26)
 
 ## 9.35.0 (2025-11-12)

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
-## Bug Fixes
+### Bug Fixes
 
 -   Fixed incorrect spacing for the time format. It was `g: i` (`14: 30`), and it's now `g:i` (`14:30`). ([#73924](https://github.com/WordPress/gutenberg/pull/73924))
 -   Fixed `timezone` argument handling to properly treat `0` numeric timezone values as a valid UTC offset (UTC+0). Previously, these were treated as if the `timezone` argument was not passed. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
+
+## 5.37.0 (2025-12-23)
 
 ## 5.36.0 (2025-11-26)
 


### PR DESCRIPTION
## What

Updates the CHANGELOGs for `@wordpress/block-library` and `@wordpress/date` packages to include the 9.37.0 and 5.37.0 version headers, respectively.

## Why

The [npm publish workflow](https://github.com/WordPress/gutenberg/actions/runs/20462309747/job/58797649853) failed during the backporting step due to merge conflicts in these CHANGELOG files. While the packages were successfully published to npm, the version headers were not properly merged back to trunk, leaving the CHANGELOGs in an inconsistent state.

## How

- Adding the missing version headers to the respective CHANGELOGs
- It also fixes a markdown heading level in `@wordpress/date` CHANGELOG where `##` should be `###`, as it's a subsection under `Unreleased`.

## Testing Instructions

1. Review the CHANGELOG files to verify the version headers are up to date
2. Confirm the markdown heading levels are correct (## for versions, ### for subsections)
