### PR TITLE
`@wordpress/keycodes`: add `ariaKeyShortcut` and  `shortcutFormats ` exports

### DIFF
--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -150,6 +150,7 @@ function KeyboardShortcutsRegister() {
 			description: __( 'Select text across multiple blocks.' ),
 			keyCombination: {
 				modifier: 'shift',
+				// Spotted during my own research — invalid character?
 				character: 'arrow',
 			},
 		} );

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New features
+
+-   Add new `ariaKeyShortcut` export as an alias of the existing `rawShortcut` export ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
+-   Add new `shortcutFormats` export ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
+
 ## 4.36.0 (2025-11-26)
 
 ## 4.35.0 (2025-11-12)

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### New features
 
--   Add new `ariaKeyShortcut` export as an alias of the existing `rawShortcut` export ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
--   Add new `shortcutFormats` export ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
+-   Add new `ariaKeyShortcut` function ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
+-   Add new `shortcutFormats` function ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
 
 ## 4.36.0 (2025-11-26)
 

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### New features
 
 -   Add new `ariaKeyShortcut` function ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
--   Add new `shortcutFormats` function ([#74205](https://github.com/WordPress/gutenberg/pull/74205)).
 
 ## 4.36.0 (2025-11-26)
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -229,19 +229,6 @@ shortcutAriaLabel.primary( '.' );
 
 Keyed map of functions to shortcut ARIA labels.
 
-### shortcutFormats
-
-An object containing all the various formats for a given shortcut.
-
-_Parameters_
-
--   _modifier_ `WPKeycodeModifier`: The modifier key combination to use, as a string.
--   _character_ `string`: The character key to combine with the modifier.
-
-_Returns_
-
--   Object containing the shortcut in different formats (as an ARIA label, as a string to be displayed to the end user, and as a value for the aria-keyshortcuts attribute).
-
 ### SPACE
 
 Keycode for SPACE key.

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -42,6 +42,18 @@ onKeyDown( event ) {
 
 Keycode for ALT key.
 
+### ariaKeyShortcut
+
+An object that contains functions to get shortcuts in a format compatible with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
+
+_Usage_
+
+```js
+// Assuming macOS:
+ariaKeyShortcut.primary( 'c' );
+// "meta+c"
+```
+
 ### BACKSPACE
 
 Keycode for BACKSPACE key.
@@ -167,7 +179,7 @@ _Usage_
 ```js
 // Assuming macOS:
 rawShortcut.primary( 'm' );
-// "meta+m""
+// "meta+m"
 ```
 
 ### RIGHT

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -46,12 +46,37 @@ Keycode for ALT key.
 
 An object that contains functions to get shortcuts in a format compatible with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
 
+The output follows the WAI-ARIA 1.2 specification:
+
+-   Modifier keys use standard names: "Alt", "AltGraph" (Option on Mac), "Control", "Shift", "Meta" (Command on Mac)
+-   Keys are joined with "+"
+-   Non-modifier keys are normalized to their `KeyboardEvent.key` equivalents
+-   Special characters are HTML-escaped for safe use in HTML attributes
+
+_Related_
+
+-   <https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts>
+-   <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts>
+
 _Usage_
 
 ```js
 // Assuming macOS:
-ariaKeyShortcut.primary( 'c' );
-// "meta+c"
+ariaKeyShortcut.primary( 'm' );
+// "Meta+M"
+
+ariaKeyShortcut.primaryAlt( 'm' );
+// "AltGraph+Meta+M"
+
+// Assuming Windows:
+ariaKeyShortcut.primary( 'm' );
+// "Control+M"
+
+ariaKeyShortcut.primaryAlt( 'm' );
+// "Control+Alt+M"
+
+ariaKeyShortcut.primaryShift( 'del' );
+// "Control+Shift+Delete"
 ```
 
 ### BACKSPACE

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -46,17 +46,13 @@ Keycode for ALT key.
 
 An object that contains functions to get shortcuts in a format compatible with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
 
-The output follows the WAI-ARIA 1.2 specification:
-
--   Modifier keys use standard names: "Alt", "AltGraph" (Option on Mac), "Control", "Shift", "Meta" (Command on Mac)
--   Keys are joined with "+"
--   Non-modifier keys are normalized to their `KeyboardEvent.key` equivalents
--   Special characters are HTML-escaped for safe use in HTML attributes
+**Note**: The provided shortcut character strings (ie. not the modifiers) should follow the values specified in the [UI Events KeyboardEvent key Values spec](https://www.w3.org/TR/uievents-key/) — for example, "Enter", "Tab", "ArrowRight", "PageDown", "Escape", "Plus", or "F1". The spacebar key should be represented with the "Space" string (an exception to the UI Events KeyboardEvent key Values spec).
 
 _Related_
 
 -   <https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts>
 -   <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts>
+-   <https://www.w3.org/TR/uievents-key/>
 
 _Usage_
 
@@ -66,7 +62,7 @@ ariaKeyShortcut.primary( 'm' );
 // "Meta+M"
 
 ariaKeyShortcut.primaryAlt( 'm' );
-// "AltGraph+Meta+M"
+// "Meta+Alt+M"
 
 // Assuming Windows:
 ariaKeyShortcut.primary( 'm' );

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -204,6 +204,19 @@ shortcutAriaLabel.primary( '.' );
 
 Keyed map of functions to shortcut ARIA labels.
 
+### shortcutFormats
+
+An object containing all the various formats for a given shortcut.
+
+_Parameters_
+
+-   _modifier_ `WPKeycodeModifier`: The modifier key combination to use, as a string.
+-   _character_ `string`: The character key to combine with the modifier.
+
+_Returns_
+
+-   Object containing the shortcut in different formats (as an ARIA label, as a string to be displayed to the end user, and as a value for the aria-keyshortcuts attribute).
+
 ### SPACE
 
 Keycode for SPACE key.

--- a/packages/keycodes/src/index.ts
+++ b/packages/keycodes/src/index.ts
@@ -244,7 +244,7 @@ export const rawShortcut: WPModifierHandler< WPKeyHandler< string > > =
  * An object that contains functions to get shortcuts in a format compatible
  * with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
  *
- * The provided shortcut character strings (ie. not the modifiers) should follow
+ * **Note**: The provided shortcut character strings (ie. not the modifiers) should follow
  * the values specified in the [UI Events KeyboardEvent key Values spec](https://www.w3.org/TR/uievents-key/) — for example, "Enter", "Tab", "ArrowRight", "PageDown",
  * "Escape", "Plus", or "F1". The spacebar key should be represented with the
  * "Space" string (an exception to the UI Events KeyboardEvent key Values spec).
@@ -398,22 +398,6 @@ export const shortcutAriaLabel: WPModifierHandler< WPKeyHandler< string > > =
 				.join( isApple ? ' ' : ' + ' );
 		};
 	} );
-
-/**
- * An object containing all the various formats for a given shortcut.
- *
- * @param modifier  The modifier key combination to use, as a string.
- * @param character The character key to combine with the modifier.
- * @return Object containing the shortcut in different formats (as an ARIA label, as a string to be displayed to the end user, and as a value for the aria-keyshortcuts attribute).
- */
-export const shortcutFormats = (
-	modifier: WPKeycodeModifier,
-	character: string
-) => ( {
-	shortcutAriaLabel: shortcutAriaLabel[ modifier ]( character ),
-	displayShortcut: displayShortcut[ modifier ]( character ),
-	ariaKeyShortcut: ariaKeyShortcut[ modifier ]( character ),
-} );
 
 /**
  * From a given KeyboardEvent, returns an array of active modifier constants for

--- a/packages/keycodes/src/index.ts
+++ b/packages/keycodes/src/index.ts
@@ -176,6 +176,169 @@ function capitaliseFirstCharacter( string: string ): string {
 }
 
 /**
+ * Map of key names to their `aria-keyshortcuts` compliant equivalents.
+ *
+ * This includes:
+ * - Shorthand key names (e.g., 'del' → 'Delete')
+ * - Special characters that need named representations per the spec
+ *   (e.g., ' ' → 'Space', '+' → 'Plus')
+ * - Named keys from the UI Events KeyboardEvent key Values specification
+ *
+ * The space key is a special case: per the WAI-ARIA spec, the spacebar
+ * should be represented as "Space" (not ' ') since the space character
+ * would be treated as whitespace.
+ *
+ * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
+ * @see https://www.w3.org/TR/uievents-key/
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+ */
+const ARIA_KEY_SHORTCUT_KEY_MAP: Record< string, string > = {
+	/*
+	 * Shorthand mappings (lowercase keys for case-insensitive lookup).
+	 * These are common abbreviations used in the codebase that need to be
+	 * converted to their full KeyboardEvent.key equivalents.
+	 */
+	del: 'Delete',
+	esc: 'Escape',
+
+	/*
+	 * Special characters that need named representations.
+	 * Per the spec, certain characters must be written out as words.
+	 */
+	' ': 'Space',
+	'+': 'Plus',
+
+	/*
+	 * Whitespace keys.
+	 * @see https://www.w3.org/TR/uievents-key/#keys-whitespace
+	 */
+	enter: 'Enter',
+	tab: 'Tab',
+
+	/*
+	 * Navigation keys.
+	 * @see https://www.w3.org/TR/uievents-key/#keys-navigation
+	 */
+	arrowdown: 'ArrowDown',
+	arrowleft: 'ArrowLeft',
+	arrowright: 'ArrowRight',
+	arrowup: 'ArrowUp',
+	end: 'End',
+	home: 'Home',
+	pagedown: 'PageDown',
+	pageup: 'PageUp',
+
+	/*
+	 * Editing keys.
+	 * @see https://www.w3.org/TR/uievents-key/#keys-editing
+	 */
+	backspace: 'Backspace',
+	clear: 'Clear',
+	copy: 'Copy',
+	cut: 'Cut',
+	delete: 'Delete',
+	insert: 'Insert',
+	paste: 'Paste',
+	redo: 'Redo',
+	undo: 'Undo',
+
+	/*
+	 * UI keys.
+	 * @see https://www.w3.org/TR/uievents-key/#keys-ui
+	 */
+	escape: 'Escape',
+	help: 'Help',
+	contextmenu: 'ContextMenu',
+	pause: 'Pause',
+	printscreen: 'PrintScreen',
+	scrolllock: 'ScrollLock',
+
+	/*
+	 * Function keys.
+	 * @see https://www.w3.org/TR/uievents-key/#keys-function
+	 */
+	f1: 'F1',
+	f2: 'F2',
+	f3: 'F3',
+	f4: 'F4',
+	f5: 'F5',
+	f6: 'F6',
+	f7: 'F7',
+	f8: 'F8',
+	f9: 'F9',
+	f10: 'F10',
+	f11: 'F11',
+	f12: 'F12',
+
+	/*
+	 * Numpad keys (when NumLock is off, these produce navigation actions).
+	 * @see https://www.w3.org/TR/uievents-key/#keys-numpad-section
+	 */
+	numlock: 'NumLock',
+};
+
+/**
+ * Map of characters that need HTML entity escaping for use in HTML attributes.
+ *
+ * Per the WAI-ARIA spec, character values in aria-keyshortcuts should be
+ * HTML escaped to prevent issues with special characters in HTML attributes.
+ *
+ * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
+ */
+const HTML_ENTITY_MAP: Record< string, string > = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+
+/**
+ * Escape special HTML characters in a string for use in HTML attributes.
+ *
+ * @param str The string to escape.
+ * @return The escaped string.
+ */
+function escapeHtmlForAriaShortcut( str: string ): string {
+	return str.replace( /[&<>"']/g, ( char ) => HTML_ENTITY_MAP[ char ] );
+}
+
+/**
+ * Normalize a key for use in the `aria-keyshortcuts` attribute.
+ *
+ * This function:
+ * 1. Converts shorthand key names (like 'del') to their standard
+ *    `KeyboardEvent.key` equivalents (like 'Delete')
+ * 2. Converts special characters to their named equivalents
+ *    (like ' ' to 'Space', '+' to 'Plus')
+ * 3. Ensures proper capitalization for character keys
+ * 4. HTML-escapes special characters that could cause issues in HTML attributes
+ *
+ * @param key The key to normalize.
+ * @return The normalized and escaped key name.
+ */
+function normalizeKeyForAriaShortcut( key: string ): string {
+	// Check for exact character mappings first (like ' ' for space)
+	if ( ARIA_KEY_SHORTCUT_KEY_MAP[ key ] ) {
+		return ARIA_KEY_SHORTCUT_KEY_MAP[ key ];
+	}
+
+	// Check for case-insensitive shorthand mappings (like 'del', 'esc')
+	const lowerKey = key.toLowerCase();
+	if ( ARIA_KEY_SHORTCUT_KEY_MAP[ lowerKey ] ) {
+		return ARIA_KEY_SHORTCUT_KEY_MAP[ lowerKey ];
+	}
+
+	// For single characters, uppercase and escape if needed
+	if ( key.length === 1 ) {
+		return escapeHtmlForAriaShortcut( key.toUpperCase() );
+	}
+
+	// Multi-character keys get capitalized (e.g., 'enter' -> 'Enter')
+	return capitaliseFirstCharacter( key );
+}
+
+/**
  * Map the values of an object with a specified callback and return the result object.
  *
  * @template T The object type
@@ -241,17 +404,90 @@ export const rawShortcut: WPModifierHandler< WPKeyHandler< string > > =
 	} );
 
 /**
+ * Get the aria-keyshortcuts compliant name for a modifier key.
+ *
+ * Per the WAI-ARIA spec, modifier keys are written as:
+ * - "Alt" (on Windows/Linux)
+ * - "AltGraph" (Option key on Mac)
+ * - "Control"
+ * - "Shift"
+ * - "Meta" (Command key on Mac)
+ *
+ * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+ *
+ * @param key     The internal modifier key constant.
+ * @param isApple Whether the current platform is Apple (macOS/iOS).
+ * @return The WAI-ARIA compliant modifier key name.
+ */
+function getAriaShortcutModifierName(
+	key: WPModifierPart,
+	isApple: boolean
+): string {
+	switch ( key ) {
+		case ALT:
+			// On macOS, the Option key is represented as "AltGraph"
+			// per the aria-keyshortcuts specification.
+			return isApple ? 'AltGraph' : 'Alt';
+		case CTRL:
+			return 'Control';
+		case COMMAND:
+			return 'Meta';
+		case SHIFT:
+			return 'Shift';
+		default:
+			return key;
+	}
+}
+
+/**
  * An object that contains functions to get shortcuts in a format compatible
  * with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
+ *
+ * The output follows the WAI-ARIA 1.2 specification:
+ * - Modifier keys use standard names: "Alt", "AltGraph" (Option on Mac),
+ *   "Control", "Shift", "Meta" (Command on Mac)
+ * - Keys are joined with "+"
+ * - Non-modifier keys are normalized to their `KeyboardEvent.key` equivalents
+ * - Special characters are HTML-escaped for safe use in HTML attributes
+ *
+ * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
  *
  * @example
  * ```js
  * // Assuming macOS:
- * ariaKeyShortcut.primary( 'c' )
- * // "meta+c"
+ * ariaKeyShortcut.primary( 'm' )
+ * // "Meta+M"
+ *
+ * ariaKeyShortcut.primaryAlt( 'm' )
+ * // "AltGraph+Meta+M"
+ *
+ * // Assuming Windows:
+ * ariaKeyShortcut.primary( 'm' )
+ * // "Control+M"
+ *
+ * ariaKeyShortcut.primaryAlt( 'm' )
+ * // "Control+Alt+M"
+ *
+ * ariaKeyShortcut.primaryShift( 'del' )
+ * // "Control+Shift+Delete"
  * ```
  */
-export const ariaKeyShortcut = rawShortcut;
+export const ariaKeyShortcut: WPModifierHandler< WPKeyHandler< string > > =
+	/* @__PURE__ */
+	mapValues( modifiers, ( modifier: WPModifier ) => {
+		return ( character: string, _isApple = isAppleOS ) => {
+			const isApple = _isApple();
+			const modifierKeys = modifier( _isApple ).map( ( key ) =>
+				getAriaShortcutModifierName( key, isApple )
+			);
+			const normalizedCharacter =
+				normalizeKeyForAriaShortcut( character );
+
+			return [ ...modifierKeys, normalizedCharacter ].join( '+' );
+		};
+	} );
 
 /**
  * Return an array of the parts of a keyboard shortcut chord for display.

--- a/packages/keycodes/src/index.ts
+++ b/packages/keycodes/src/index.ts
@@ -366,6 +366,22 @@ export const shortcutAriaLabel: WPModifierHandler< WPKeyHandler< string > > =
 	} );
 
 /**
+ * An object containing all the various formats for a given shortcut.
+ *
+ * @param modifier  The modifier key combination to use, as a string.
+ * @param character The character key to combine with the modifier.
+ * @return Object containing the shortcut in different formats (as an ARIA label, as a string to be displayed to the end user, and as a value for the aria-keyshortcuts attribute).
+ */
+export const shortcutFormats = (
+	modifier: WPKeycodeModifier,
+	character: string
+) => ( {
+	shortcutAriaLabel: shortcutAriaLabel[ modifier ]( character ),
+	displayShortcut: displayShortcut[ modifier ]( character ),
+	ariaKeyShortcut: ariaKeyShortcut[ modifier ]( character ),
+} );
+
+/**
  * From a given KeyboardEvent, returns an array of active modifier constants for
  * the event.
  *

--- a/packages/keycodes/src/index.ts
+++ b/packages/keycodes/src/index.ts
@@ -227,7 +227,7 @@ export const modifiers: WPModifierHandler< WPModifier > = {
  * ```js
  * // Assuming macOS:
  * rawShortcut.primary( 'm' )
- * // "meta+m""
+ * // "meta+m"
  * ```
  */
 export const rawShortcut: WPModifierHandler< WPKeyHandler< string > > =
@@ -239,6 +239,19 @@ export const rawShortcut: WPModifierHandler< WPKeyHandler< string > > =
 			);
 		};
 	} );
+
+/**
+ * An object that contains functions to get shortcuts in a format compatible
+ * with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
+ *
+ * @example
+ * ```js
+ * // Assuming macOS:
+ * ariaKeyShortcut.primary( 'c' )
+ * // "meta+c"
+ * ```
+ */
+export const ariaKeyShortcut = rawShortcut;
 
 /**
  * Return an array of the parts of a keyboard shortcut chord for display.

--- a/packages/keycodes/src/index.ts
+++ b/packages/keycodes/src/index.ts
@@ -176,169 +176,6 @@ function capitaliseFirstCharacter( string: string ): string {
 }
 
 /**
- * Map of key names to their `aria-keyshortcuts` compliant equivalents.
- *
- * This includes:
- * - Shorthand key names (e.g., 'del' → 'Delete')
- * - Special characters that need named representations per the spec
- *   (e.g., ' ' → 'Space', '+' → 'Plus')
- * - Named keys from the UI Events KeyboardEvent key Values specification
- *
- * The space key is a special case: per the WAI-ARIA spec, the spacebar
- * should be represented as "Space" (not ' ') since the space character
- * would be treated as whitespace.
- *
- * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
- * @see https://www.w3.org/TR/uievents-key/
- * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
- */
-const ARIA_KEY_SHORTCUT_KEY_MAP: Record< string, string > = {
-	/*
-	 * Shorthand mappings (lowercase keys for case-insensitive lookup).
-	 * These are common abbreviations used in the codebase that need to be
-	 * converted to their full KeyboardEvent.key equivalents.
-	 */
-	del: 'Delete',
-	esc: 'Escape',
-
-	/*
-	 * Special characters that need named representations.
-	 * Per the spec, certain characters must be written out as words.
-	 */
-	' ': 'Space',
-	'+': 'Plus',
-
-	/*
-	 * Whitespace keys.
-	 * @see https://www.w3.org/TR/uievents-key/#keys-whitespace
-	 */
-	enter: 'Enter',
-	tab: 'Tab',
-
-	/*
-	 * Navigation keys.
-	 * @see https://www.w3.org/TR/uievents-key/#keys-navigation
-	 */
-	arrowdown: 'ArrowDown',
-	arrowleft: 'ArrowLeft',
-	arrowright: 'ArrowRight',
-	arrowup: 'ArrowUp',
-	end: 'End',
-	home: 'Home',
-	pagedown: 'PageDown',
-	pageup: 'PageUp',
-
-	/*
-	 * Editing keys.
-	 * @see https://www.w3.org/TR/uievents-key/#keys-editing
-	 */
-	backspace: 'Backspace',
-	clear: 'Clear',
-	copy: 'Copy',
-	cut: 'Cut',
-	delete: 'Delete',
-	insert: 'Insert',
-	paste: 'Paste',
-	redo: 'Redo',
-	undo: 'Undo',
-
-	/*
-	 * UI keys.
-	 * @see https://www.w3.org/TR/uievents-key/#keys-ui
-	 */
-	escape: 'Escape',
-	help: 'Help',
-	contextmenu: 'ContextMenu',
-	pause: 'Pause',
-	printscreen: 'PrintScreen',
-	scrolllock: 'ScrollLock',
-
-	/*
-	 * Function keys.
-	 * @see https://www.w3.org/TR/uievents-key/#keys-function
-	 */
-	f1: 'F1',
-	f2: 'F2',
-	f3: 'F3',
-	f4: 'F4',
-	f5: 'F5',
-	f6: 'F6',
-	f7: 'F7',
-	f8: 'F8',
-	f9: 'F9',
-	f10: 'F10',
-	f11: 'F11',
-	f12: 'F12',
-
-	/*
-	 * Numpad keys (when NumLock is off, these produce navigation actions).
-	 * @see https://www.w3.org/TR/uievents-key/#keys-numpad-section
-	 */
-	numlock: 'NumLock',
-};
-
-/**
- * Map of characters that need HTML entity escaping for use in HTML attributes.
- *
- * Per the WAI-ARIA spec, character values in aria-keyshortcuts should be
- * HTML escaped to prevent issues with special characters in HTML attributes.
- *
- * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
- */
-const HTML_ENTITY_MAP: Record< string, string > = {
-	'&': '&amp;',
-	'<': '&lt;',
-	'>': '&gt;',
-	'"': '&quot;',
-	"'": '&#39;',
-};
-
-/**
- * Escape special HTML characters in a string for use in HTML attributes.
- *
- * @param str The string to escape.
- * @return The escaped string.
- */
-function escapeHtmlForAriaShortcut( str: string ): string {
-	return str.replace( /[&<>"']/g, ( char ) => HTML_ENTITY_MAP[ char ] );
-}
-
-/**
- * Normalize a key for use in the `aria-keyshortcuts` attribute.
- *
- * This function:
- * 1. Converts shorthand key names (like 'del') to their standard
- *    `KeyboardEvent.key` equivalents (like 'Delete')
- * 2. Converts special characters to their named equivalents
- *    (like ' ' to 'Space', '+' to 'Plus')
- * 3. Ensures proper capitalization for character keys
- * 4. HTML-escapes special characters that could cause issues in HTML attributes
- *
- * @param key The key to normalize.
- * @return The normalized and escaped key name.
- */
-function normalizeKeyForAriaShortcut( key: string ): string {
-	// Check for exact character mappings first (like ' ' for space)
-	if ( ARIA_KEY_SHORTCUT_KEY_MAP[ key ] ) {
-		return ARIA_KEY_SHORTCUT_KEY_MAP[ key ];
-	}
-
-	// Check for case-insensitive shorthand mappings (like 'del', 'esc')
-	const lowerKey = key.toLowerCase();
-	if ( ARIA_KEY_SHORTCUT_KEY_MAP[ lowerKey ] ) {
-		return ARIA_KEY_SHORTCUT_KEY_MAP[ lowerKey ];
-	}
-
-	// For single characters, uppercase and escape if needed
-	if ( key.length === 1 ) {
-		return escapeHtmlForAriaShortcut( key.toUpperCase() );
-	}
-
-	// Multi-character keys get capitalized (e.g., 'enter' -> 'Enter')
-	return capitaliseFirstCharacter( key );
-}
-
-/**
  * Map the values of an object with a specified callback and return the result object.
  *
  * @template T The object type
@@ -404,55 +241,17 @@ export const rawShortcut: WPModifierHandler< WPKeyHandler< string > > =
 	} );
 
 /**
- * Get the aria-keyshortcuts compliant name for a modifier key.
- *
- * Per the WAI-ARIA spec, modifier keys are written as:
- * - "Alt" (on Windows/Linux)
- * - "AltGraph" (Option key on Mac)
- * - "Control"
- * - "Shift"
- * - "Meta" (Command key on Mac)
- *
- * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
- * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
- *
- * @param key     The internal modifier key constant.
- * @param isApple Whether the current platform is Apple (macOS/iOS).
- * @return The WAI-ARIA compliant modifier key name.
- */
-function getAriaShortcutModifierName(
-	key: WPModifierPart,
-	isApple: boolean
-): string {
-	switch ( key ) {
-		case ALT:
-			// On macOS, the Option key is represented as "AltGraph"
-			// per the aria-keyshortcuts specification.
-			return isApple ? 'AltGraph' : 'Alt';
-		case CTRL:
-			return 'Control';
-		case COMMAND:
-			return 'Meta';
-		case SHIFT:
-			return 'Shift';
-		default:
-			return key;
-	}
-}
-
-/**
  * An object that contains functions to get shortcuts in a format compatible
  * with the [`aria-keyshortcuts` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts).
  *
- * The output follows the WAI-ARIA 1.2 specification:
- * - Modifier keys use standard names: "Alt", "AltGraph" (Option on Mac),
- *   "Control", "Shift", "Meta" (Command on Mac)
- * - Keys are joined with "+"
- * - Non-modifier keys are normalized to their `KeyboardEvent.key` equivalents
- * - Special characters are HTML-escaped for safe use in HTML attributes
+ * The provided shortcut character strings (ie. not the modifiers) should follow
+ * the values specified in the [UI Events KeyboardEvent key Values spec](https://www.w3.org/TR/uievents-key/) — for example, "Enter", "Tab", "ArrowRight", "PageDown",
+ * "Escape", "Plus", or "F1". The spacebar key should be represented with the
+ * "Space" string (an exception to the UI Events KeyboardEvent key Values spec).
  *
  * @see https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts
  * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+ * @see https://www.w3.org/TR/uievents-key/
  *
  * @example
  * ```js
@@ -461,7 +260,7 @@ function getAriaShortcutModifierName(
  * // "Meta+M"
  *
  * ariaKeyShortcut.primaryAlt( 'm' )
- * // "AltGraph+Meta+M"
+ * // "Meta+Alt+M"
  *
  * // Assuming Windows:
  * ariaKeyShortcut.primary( 'm' )
@@ -478,14 +277,13 @@ export const ariaKeyShortcut: WPModifierHandler< WPKeyHandler< string > > =
 	/* @__PURE__ */
 	mapValues( modifiers, ( modifier: WPModifier ) => {
 		return ( character: string, _isApple = isAppleOS ) => {
-			const isApple = _isApple();
-			const modifierKeys = modifier( _isApple ).map( ( key ) =>
-				getAriaShortcutModifierName( key, isApple )
-			);
-			const normalizedCharacter =
-				normalizeKeyForAriaShortcut( character );
-
-			return [ ...modifierKeys, normalizedCharacter ].join( '+' );
+			return [
+				...modifier( _isApple )
+					// Swap 'ctrl' for 'control' (spec-compliant)
+					.map( ( key ) => ( key === CTRL ? 'Control' : key ) )
+					.map( ( key ) => capitaliseFirstCharacter( key ) ),
+				capitaliseFirstCharacter( character ),
+			].join( '+' );
 		};
 	} );
 

--- a/packages/keycodes/src/test/index.ts
+++ b/packages/keycodes/src/test/index.ts
@@ -273,207 +273,52 @@ describe( 'rawShortcut', () => {
 } );
 
 describe( 'ariaKeyShortcut', () => {
-	describe( 'primary', () => {
-		it( 'should output "Control+M" on Windows', () => {
+	describe( 'modifier key formatting', () => {
+		it( 'should use "Control" (not "ctrl") on Windows', () => {
 			const shortcut = ariaKeyShortcut.primary( 'm', isAppleOSFalse );
 			expect( shortcut ).toEqual( 'Control+M' );
 		} );
 
-		it( 'should output "Meta+M" on MacOS', () => {
+		it( 'should use "Meta" for Command key on MacOS', () => {
 			const shortcut = ariaKeyShortcut.primary( 'm', isAppleOSTrue );
 			expect( shortcut ).toEqual( 'Meta+M' );
 		} );
 
-		it( 'should normalize "del" to "Delete"', () => {
-			const shortcut = ariaKeyShortcut.primary( 'del', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Delete' );
-		} );
-
-		it( 'should normalize "esc" to "Escape"', () => {
-			const shortcut = ariaKeyShortcut.primary( 'esc', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Escape' );
-		} );
-	} );
-
-	describe( 'primaryShift', () => {
-		it( 'should output "Control+Shift+M" on Windows', () => {
-			const shortcut = ariaKeyShortcut.primaryShift(
-				'm',
-				isAppleOSFalse
-			);
-			expect( shortcut ).toEqual( 'Control+Shift+M' );
-		} );
-
-		it( 'should output "Shift+Meta+M" on MacOS', () => {
-			const shortcut = ariaKeyShortcut.primaryShift( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+Meta+M' );
-		} );
-	} );
-
-	describe( 'primaryAlt', () => {
-		it( 'should output "Control+Alt+M" on Windows', () => {
-			const shortcut = ariaKeyShortcut.primaryAlt( 'm', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Alt+M' );
-		} );
-
-		it( 'should output "AltGraph+Meta+M" on MacOS (Option key is AltGraph)', () => {
-			const shortcut = ariaKeyShortcut.primaryAlt( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'AltGraph+Meta+M' );
-		} );
-	} );
-
-	describe( 'secondary', () => {
-		it( 'should output "Control+Shift+Alt+M" on Windows', () => {
+		it( 'should capitalize modifier keys (Shift, Alt)', () => {
 			const shortcut = ariaKeyShortcut.secondary( 'm', isAppleOSFalse );
 			expect( shortcut ).toEqual( 'Control+Shift+Alt+M' );
 		} );
 
-		it( 'should output "Shift+AltGraph+Meta+M" on MacOS (Option key is AltGraph)', () => {
+		it( 'should handle multiple modifiers on MacOS', () => {
 			const shortcut = ariaKeyShortcut.secondary( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+AltGraph+Meta+M' );
+			expect( shortcut ).toEqual( 'Shift+Alt+Meta+M' );
 		} );
 	} );
 
-	describe( 'access', () => {
-		it( 'should output "Shift+Alt+M" on Windows', () => {
-			const shortcut = ariaKeyShortcut.access( 'm', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Shift+Alt+M' );
+	describe( 'character handling', () => {
+		it( 'should uppercase single letter characters', () => {
+			const shortcut = ariaKeyShortcut.primary( 'k', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+K' );
 		} );
 
-		it( 'should output "Control+AltGraph+M" on MacOS (Option key is AltGraph)', () => {
-			const shortcut = ariaKeyShortcut.access( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Control+AltGraph+M' );
-		} );
-	} );
-
-	describe( 'alt', () => {
-		it( 'should output "Alt+M" on Windows', () => {
-			const shortcut = ariaKeyShortcut.alt( 'm', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Alt+M' );
+		it( 'should pass through number characters', () => {
+			const shortcut = ariaKeyShortcut.primary( '1', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+1' );
 		} );
 
-		it( 'should output "AltGraph+M" on MacOS (Option key is AltGraph)', () => {
-			const shortcut = ariaKeyShortcut.alt( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'AltGraph+M' );
-		} );
-	} );
-
-	describe( 'shiftAlt', () => {
-		it( 'should output "Shift+Alt+M" on Windows', () => {
-			const shortcut = ariaKeyShortcut.shiftAlt( 'm', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Shift+Alt+M' );
-		} );
-
-		it( 'should output "Shift+AltGraph+M" on MacOS (Option key is AltGraph)', () => {
-			const shortcut = ariaKeyShortcut.shiftAlt( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+AltGraph+M' );
-		} );
-	} );
-
-	describe( 'special characters and key normalization', () => {
-		it( 'should preserve special characters like period', () => {
-			const shortcut = ariaKeyShortcut.primary( '.', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+.' );
-		} );
-
-		it( 'should convert space to "Space"', () => {
-			const shortcut = ariaKeyShortcut.primary( ' ', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Space' );
-		} );
-
-		it( 'should convert plus sign to "Plus"', () => {
-			const shortcut = ariaKeyShortcut.primary( '+', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Plus' );
-		} );
-	} );
-
-	describe( 'named key normalization', () => {
-		it( 'should normalize "enter" to "Enter"', () => {
+		it( 'should capitalize multi-character key names', () => {
 			const shortcut = ariaKeyShortcut.primary( 'enter', isAppleOSFalse );
 			expect( shortcut ).toEqual( 'Control+Enter' );
 		} );
 
-		it( 'should normalize "tab" to "Tab"', () => {
-			const shortcut = ariaKeyShortcut.primary( 'tab', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+Tab' );
+		it( 'should pass through special characters unchanged', () => {
+			const shortcut = ariaKeyShortcut.primary( '.', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+.' );
 		} );
 
-		it( 'should normalize arrow keys', () => {
-			expect(
-				ariaKeyShortcut.primary( 'arrowup', isAppleOSFalse )
-			).toEqual( 'Control+ArrowUp' );
-			expect(
-				ariaKeyShortcut.primary( 'arrowdown', isAppleOSFalse )
-			).toEqual( 'Control+ArrowDown' );
-			expect(
-				ariaKeyShortcut.primary( 'arrowleft', isAppleOSFalse )
-			).toEqual( 'Control+ArrowLeft' );
-			expect(
-				ariaKeyShortcut.primary( 'arrowright', isAppleOSFalse )
-			).toEqual( 'Control+ArrowRight' );
-		} );
-
-		it( 'should normalize navigation keys', () => {
-			expect(
-				ariaKeyShortcut.primary( 'pageup', isAppleOSFalse )
-			).toEqual( 'Control+PageUp' );
-			expect(
-				ariaKeyShortcut.primary( 'pagedown', isAppleOSFalse )
-			).toEqual( 'Control+PageDown' );
-			expect( ariaKeyShortcut.primary( 'home', isAppleOSFalse ) ).toEqual(
-				'Control+Home'
-			);
-			expect( ariaKeyShortcut.primary( 'end', isAppleOSFalse ) ).toEqual(
-				'Control+End'
-			);
-		} );
-
-		it( 'should normalize editing keys', () => {
-			expect(
-				ariaKeyShortcut.primary( 'backspace', isAppleOSFalse )
-			).toEqual( 'Control+Backspace' );
-			expect(
-				ariaKeyShortcut.primary( 'insert', isAppleOSFalse )
-			).toEqual( 'Control+Insert' );
-		} );
-
-		it( 'should normalize function keys', () => {
-			expect( ariaKeyShortcut.undefined( 'f1', isAppleOSFalse ) ).toEqual(
-				'F1'
-			);
-			expect(
-				ariaKeyShortcut.undefined( 'f10', isAppleOSFalse )
-			).toEqual( 'F10' );
-			expect(
-				ariaKeyShortcut.undefined( 'f12', isAppleOSFalse )
-			).toEqual( 'F12' );
-		} );
-	} );
-
-	describe( 'HTML entity escaping', () => {
-		it( 'should escape double quote character', () => {
-			const shortcut = ariaKeyShortcut.shift( '"', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Shift+&quot;' );
-		} );
-
-		it( 'should escape single quote character', () => {
-			const shortcut = ariaKeyShortcut.primary( "'", isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+&#39;' );
-		} );
-
-		it( 'should escape ampersand character', () => {
-			const shortcut = ariaKeyShortcut.primary( '&', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+&amp;' );
-		} );
-
-		it( 'should escape less-than character', () => {
-			const shortcut = ariaKeyShortcut.primary( '<', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+&lt;' );
-		} );
-
-		it( 'should escape greater-than character', () => {
-			const shortcut = ariaKeyShortcut.primary( '>', isAppleOSFalse );
-			expect( shortcut ).toEqual( 'Control+&gt;' );
+		it( 'should output just the character when no modifier is used', () => {
+			const shortcut = ariaKeyShortcut.undefined( 'F1', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'F1' );
 		} );
 	} );
 } );

--- a/packages/keycodes/src/test/index.ts
+++ b/packages/keycodes/src/test/index.ts
@@ -272,9 +272,209 @@ describe( 'rawShortcut', () => {
 	} );
 } );
 
-describe( 'ariaKeyShortcut alias verification', () => {
-	it( 'should be identical to rawShortcut', () => {
-		expect( ariaKeyShortcut ).toBe( rawShortcut );
+describe( 'ariaKeyShortcut', () => {
+	describe( 'primary', () => {
+		it( 'should output "Control+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.primary( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+M' );
+		} );
+
+		it( 'should output "Meta+M" on MacOS', () => {
+			const shortcut = ariaKeyShortcut.primary( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'Meta+M' );
+		} );
+
+		it( 'should normalize "del" to "Delete"', () => {
+			const shortcut = ariaKeyShortcut.primary( 'del', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Delete' );
+		} );
+
+		it( 'should normalize "esc" to "Escape"', () => {
+			const shortcut = ariaKeyShortcut.primary( 'esc', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Escape' );
+		} );
+	} );
+
+	describe( 'primaryShift', () => {
+		it( 'should output "Control+Shift+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.primaryShift(
+				'm',
+				isAppleOSFalse
+			);
+			expect( shortcut ).toEqual( 'Control+Shift+M' );
+		} );
+
+		it( 'should output "Shift+Meta+M" on MacOS', () => {
+			const shortcut = ariaKeyShortcut.primaryShift( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'Shift+Meta+M' );
+		} );
+	} );
+
+	describe( 'primaryAlt', () => {
+		it( 'should output "Control+Alt+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.primaryAlt( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Alt+M' );
+		} );
+
+		it( 'should output "AltGraph+Meta+M" on MacOS (Option key is AltGraph)', () => {
+			const shortcut = ariaKeyShortcut.primaryAlt( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'AltGraph+Meta+M' );
+		} );
+	} );
+
+	describe( 'secondary', () => {
+		it( 'should output "Control+Shift+Alt+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.secondary( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Shift+Alt+M' );
+		} );
+
+		it( 'should output "Shift+AltGraph+Meta+M" on MacOS (Option key is AltGraph)', () => {
+			const shortcut = ariaKeyShortcut.secondary( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'Shift+AltGraph+Meta+M' );
+		} );
+	} );
+
+	describe( 'access', () => {
+		it( 'should output "Shift+Alt+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.access( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Shift+Alt+M' );
+		} );
+
+		it( 'should output "Control+AltGraph+M" on MacOS (Option key is AltGraph)', () => {
+			const shortcut = ariaKeyShortcut.access( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'Control+AltGraph+M' );
+		} );
+	} );
+
+	describe( 'alt', () => {
+		it( 'should output "Alt+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.alt( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Alt+M' );
+		} );
+
+		it( 'should output "AltGraph+M" on MacOS (Option key is AltGraph)', () => {
+			const shortcut = ariaKeyShortcut.alt( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'AltGraph+M' );
+		} );
+	} );
+
+	describe( 'shiftAlt', () => {
+		it( 'should output "Shift+Alt+M" on Windows', () => {
+			const shortcut = ariaKeyShortcut.shiftAlt( 'm', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Shift+Alt+M' );
+		} );
+
+		it( 'should output "Shift+AltGraph+M" on MacOS (Option key is AltGraph)', () => {
+			const shortcut = ariaKeyShortcut.shiftAlt( 'm', isAppleOSTrue );
+			expect( shortcut ).toEqual( 'Shift+AltGraph+M' );
+		} );
+	} );
+
+	describe( 'special characters and key normalization', () => {
+		it( 'should preserve special characters like period', () => {
+			const shortcut = ariaKeyShortcut.primary( '.', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+.' );
+		} );
+
+		it( 'should convert space to "Space"', () => {
+			const shortcut = ariaKeyShortcut.primary( ' ', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Space' );
+		} );
+
+		it( 'should convert plus sign to "Plus"', () => {
+			const shortcut = ariaKeyShortcut.primary( '+', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Plus' );
+		} );
+	} );
+
+	describe( 'named key normalization', () => {
+		it( 'should normalize "enter" to "Enter"', () => {
+			const shortcut = ariaKeyShortcut.primary( 'enter', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Enter' );
+		} );
+
+		it( 'should normalize "tab" to "Tab"', () => {
+			const shortcut = ariaKeyShortcut.primary( 'tab', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+Tab' );
+		} );
+
+		it( 'should normalize arrow keys', () => {
+			expect(
+				ariaKeyShortcut.primary( 'arrowup', isAppleOSFalse )
+			).toEqual( 'Control+ArrowUp' );
+			expect(
+				ariaKeyShortcut.primary( 'arrowdown', isAppleOSFalse )
+			).toEqual( 'Control+ArrowDown' );
+			expect(
+				ariaKeyShortcut.primary( 'arrowleft', isAppleOSFalse )
+			).toEqual( 'Control+ArrowLeft' );
+			expect(
+				ariaKeyShortcut.primary( 'arrowright', isAppleOSFalse )
+			).toEqual( 'Control+ArrowRight' );
+		} );
+
+		it( 'should normalize navigation keys', () => {
+			expect(
+				ariaKeyShortcut.primary( 'pageup', isAppleOSFalse )
+			).toEqual( 'Control+PageUp' );
+			expect(
+				ariaKeyShortcut.primary( 'pagedown', isAppleOSFalse )
+			).toEqual( 'Control+PageDown' );
+			expect( ariaKeyShortcut.primary( 'home', isAppleOSFalse ) ).toEqual(
+				'Control+Home'
+			);
+			expect( ariaKeyShortcut.primary( 'end', isAppleOSFalse ) ).toEqual(
+				'Control+End'
+			);
+		} );
+
+		it( 'should normalize editing keys', () => {
+			expect(
+				ariaKeyShortcut.primary( 'backspace', isAppleOSFalse )
+			).toEqual( 'Control+Backspace' );
+			expect(
+				ariaKeyShortcut.primary( 'insert', isAppleOSFalse )
+			).toEqual( 'Control+Insert' );
+		} );
+
+		it( 'should normalize function keys', () => {
+			expect( ariaKeyShortcut.undefined( 'f1', isAppleOSFalse ) ).toEqual(
+				'F1'
+			);
+			expect(
+				ariaKeyShortcut.undefined( 'f10', isAppleOSFalse )
+			).toEqual( 'F10' );
+			expect(
+				ariaKeyShortcut.undefined( 'f12', isAppleOSFalse )
+			).toEqual( 'F12' );
+		} );
+	} );
+
+	describe( 'HTML entity escaping', () => {
+		it( 'should escape double quote character', () => {
+			const shortcut = ariaKeyShortcut.shift( '"', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Shift+&quot;' );
+		} );
+
+		it( 'should escape single quote character', () => {
+			const shortcut = ariaKeyShortcut.primary( "'", isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+&#39;' );
+		} );
+
+		it( 'should escape ampersand character', () => {
+			const shortcut = ariaKeyShortcut.primary( '&', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+&amp;' );
+		} );
+
+		it( 'should escape less-than character', () => {
+			const shortcut = ariaKeyShortcut.primary( '<', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+&lt;' );
+		} );
+
+		it( 'should escape greater-than character', () => {
+			const shortcut = ariaKeyShortcut.primary( '>', isAppleOSFalse );
+			expect( shortcut ).toEqual( 'Control+&gt;' );
+		} );
 	} );
 } );
 
@@ -285,7 +485,7 @@ describe( 'shortcutFormats', () => {
 		expect( result ).toEqual( {
 			shortcutAriaLabel: 'Control + M',
 			displayShortcut: 'Ctrl+M',
-			ariaKeyShortcut: 'ctrl+m',
+			ariaKeyShortcut: 'Control+M',
 		} );
 	} );
 
@@ -295,7 +495,7 @@ describe( 'shortcutFormats', () => {
 		expect( result ).toEqual( {
 			shortcutAriaLabel: 'Control + Shift + K',
 			displayShortcut: 'Ctrl+Shift+K',
-			ariaKeyShortcut: 'ctrl+shift+k',
+			ariaKeyShortcut: 'Control+Shift+K',
 		} );
 	} );
 
@@ -305,7 +505,7 @@ describe( 'shortcutFormats', () => {
 		expect( result ).toEqual( {
 			shortcutAriaLabel: 'Shift + Alt + H',
 			displayShortcut: 'Shift+Alt+H',
-			ariaKeyShortcut: 'shift+alt+h',
+			ariaKeyShortcut: 'Shift+Alt+H',
 		} );
 	} );
 
@@ -315,7 +515,7 @@ describe( 'shortcutFormats', () => {
 		expect( result ).toEqual( {
 			shortcutAriaLabel: 'Control + Period',
 			displayShortcut: 'Ctrl+.',
-			ariaKeyShortcut: 'ctrl+.',
+			ariaKeyShortcut: 'Control+.',
 		} );
 	} );
 

--- a/packages/keycodes/src/test/index.ts
+++ b/packages/keycodes/src/test/index.ts
@@ -323,6 +323,193 @@ describe( 'ariaKeyShortcut', () => {
 	} );
 } );
 
+/**
+ * Tests for handling KeyboardEvent.key-style values.
+ *
+ * These tests document how each shortcut function handles named keys
+ * (like "Enter", "Tab", "Delete") as opposed to single character keys.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+ */
+describe( 'KeyboardEvent.key value handling', () => {
+	const namedKeys = [
+		// Whitespace keys
+		'Tab',
+		'Enter',
+		'Space',
+		// Navigation keys
+		'ArrowUp',
+		'ArrowDown',
+		'ArrowLeft',
+		'ArrowRight',
+		'End',
+		'Home',
+		'PageDown',
+		'PageUp',
+		// Editing keys
+		'Backspace',
+		'Delete',
+		'Insert',
+		// UI keys
+		'Escape',
+		// Function keys
+		'F1',
+		'F10',
+	];
+
+	// Also test the lowercase/shorthand versions commonly used in the codebase
+	const shorthandKeys = [ 'del', 'esc', 'enter', 'tab', 'space' ];
+
+	describe( 'rawShortcut', () => {
+		it( 'lowercases named keys', () => {
+			expect( rawShortcut.primary( 'Enter', isAppleOSFalse ) ).toEqual(
+				'ctrl+enter'
+			);
+			expect( rawShortcut.primary( 'Delete', isAppleOSFalse ) ).toEqual(
+				'ctrl+delete'
+			);
+			expect( rawShortcut.primary( 'ArrowUp', isAppleOSFalse ) ).toEqual(
+				'ctrl+arrowup'
+			);
+		} );
+
+		it( 'passes through shorthand keys lowercased', () => {
+			expect( rawShortcut.primary( 'del', isAppleOSFalse ) ).toEqual(
+				'ctrl+del'
+			);
+			expect( rawShortcut.primary( 'esc', isAppleOSFalse ) ).toEqual(
+				'ctrl+esc'
+			);
+		} );
+
+		it.each( namedKeys )(
+			'outputs %s lowercased with modifier',
+			( key ) => {
+				const shortcut = rawShortcut.primary( key, isAppleOSFalse );
+				expect( shortcut ).toEqual( `ctrl+${ key.toLowerCase() }` );
+			}
+		);
+	} );
+
+	describe( 'displayShortcut', () => {
+		it( 'capitalizes first letter of named keys', () => {
+			expect(
+				displayShortcut.primary( 'enter', isAppleOSFalse )
+			).toEqual( 'Ctrl+Enter' );
+			expect( displayShortcut.primary( 'del', isAppleOSFalse ) ).toEqual(
+				'Ctrl+Del'
+			);
+			expect(
+				displayShortcut.primary( 'arrowup', isAppleOSFalse )
+			).toEqual( 'Ctrl+Arrowup' );
+		} );
+
+		it( 'preserves casing of already-capitalized keys', () => {
+			expect(
+				displayShortcut.primary( 'Enter', isAppleOSFalse )
+			).toEqual( 'Ctrl+Enter' );
+			expect(
+				displayShortcut.primary( 'ArrowUp', isAppleOSFalse )
+			).toEqual( 'Ctrl+ArrowUp' );
+		} );
+
+		it.each( namedKeys )(
+			'outputs %s with capitalized first letter',
+			( key ) => {
+				const shortcut = displayShortcut.primary( key, isAppleOSFalse );
+				// capitaliseFirstCharacter keeps the rest of the string as-is
+				const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+				expect( shortcut ).toEqual( `Ctrl+${ expected }` );
+			}
+		);
+
+		it.each( shorthandKeys )( 'capitalizes shorthand key %s', ( key ) => {
+			const shortcut = displayShortcut.primary( key, isAppleOSFalse );
+			const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+			expect( shortcut ).toEqual( `Ctrl+${ expected }` );
+		} );
+	} );
+
+	describe( 'displayShortcutList', () => {
+		it( 'capitalizes first letter of named keys in list', () => {
+			expect(
+				displayShortcutList.primary( 'enter', isAppleOSFalse )
+			).toEqual( [ 'Ctrl', '+', 'Enter' ] );
+			expect(
+				displayShortcutList.primary( 'PageDown', isAppleOSFalse )
+			).toEqual( [ 'Ctrl', '+', 'PageDown' ] );
+		} );
+	} );
+
+	describe( 'shortcutAriaLabel', () => {
+		it( 'capitalizes first letter of named keys', () => {
+			expect(
+				shortcutAriaLabel.primary( 'enter', isAppleOSFalse )
+			).toEqual( 'Control + Enter' );
+			expect(
+				shortcutAriaLabel.primary( 'Delete', isAppleOSFalse )
+			).toEqual( 'Control + Delete' );
+		} );
+
+		it( 'does not have special mappings for most named keys', () => {
+			// Unlike period/comma which are mapped, named keys are just capitalized
+			expect(
+				shortcutAriaLabel.primary( 'ArrowUp', isAppleOSFalse )
+			).toEqual( 'Control + ArrowUp' );
+			expect(
+				shortcutAriaLabel.primary( 'Escape', isAppleOSFalse )
+			).toEqual( 'Control + Escape' );
+		} );
+
+		it.each( namedKeys )(
+			'outputs %s with capitalized first letter',
+			( key ) => {
+				const shortcut = shortcutAriaLabel.primary(
+					key,
+					isAppleOSFalse
+				);
+				const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+				expect( shortcut ).toEqual( `Control + ${ expected }` );
+			}
+		);
+	} );
+
+	describe( 'ariaKeyShortcut', () => {
+		it( 'capitalizes first letter of named keys', () => {
+			expect(
+				ariaKeyShortcut.primary( 'enter', isAppleOSFalse )
+			).toEqual( 'Control+Enter' );
+			expect(
+				ariaKeyShortcut.primary( 'Delete', isAppleOSFalse )
+			).toEqual( 'Control+Delete' );
+		} );
+
+		it( 'preserves casing after first character', () => {
+			expect(
+				ariaKeyShortcut.primary( 'ArrowUp', isAppleOSFalse )
+			).toEqual( 'Control+ArrowUp' );
+			expect(
+				ariaKeyShortcut.primary( 'PageDown', isAppleOSFalse )
+			).toEqual( 'Control+PageDown' );
+		} );
+
+		it.each( namedKeys )(
+			'outputs %s with capitalized first letter',
+			( key ) => {
+				const shortcut = ariaKeyShortcut.primary( key, isAppleOSFalse );
+				const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+				expect( shortcut ).toEqual( `Control+${ expected }` );
+			}
+		);
+
+		it.each( shorthandKeys )( 'capitalizes shorthand key %s', ( key ) => {
+			const shortcut = ariaKeyShortcut.primary( key, isAppleOSFalse );
+			const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+			expect( shortcut ).toEqual( `Control+${ expected }` );
+		} );
+	} );
+} );
+
 describe( 'shortcutFormats', () => {
 	it( 'should return all three shortcut formats for primary modifier on Windows', () => {
 		const result = shortcutFormats( 'primary', 'm' );

--- a/packages/keycodes/src/test/index.ts
+++ b/packages/keycodes/src/test/index.ts
@@ -7,7 +7,6 @@ import {
 	rawShortcut,
 	ariaKeyShortcut,
 	shortcutAriaLabel,
-	shortcutFormats,
 	isKeyboardEvent,
 } from '..';
 
@@ -507,64 +506,6 @@ describe( 'KeyboardEvent.key value handling', () => {
 			const expected = key.charAt( 0 ).toUpperCase() + key.slice( 1 );
 			expect( shortcut ).toEqual( `Control+${ expected }` );
 		} );
-	} );
-} );
-
-describe( 'shortcutFormats', () => {
-	it( 'should return all three shortcut formats for primary modifier on Windows', () => {
-		const result = shortcutFormats( 'primary', 'm' );
-
-		expect( result ).toEqual( {
-			shortcutAriaLabel: 'Control + M',
-			displayShortcut: 'Ctrl+M',
-			ariaKeyShortcut: 'Control+M',
-		} );
-	} );
-
-	it( 'should return all three shortcut formats for primaryShift modifier', () => {
-		const result = shortcutFormats( 'primaryShift', 'k' );
-
-		expect( result ).toEqual( {
-			shortcutAriaLabel: 'Control + Shift + K',
-			displayShortcut: 'Ctrl+Shift+K',
-			ariaKeyShortcut: 'Control+Shift+K',
-		} );
-	} );
-
-	it( 'should return all three shortcut formats for access modifier', () => {
-		const result = shortcutFormats( 'access', 'h' );
-
-		expect( result ).toEqual( {
-			shortcutAriaLabel: 'Shift + Alt + H',
-			displayShortcut: 'Shift+Alt+H',
-			ariaKeyShortcut: 'Shift+Alt+H',
-		} );
-	} );
-
-	it( 'should handle special characters like period', () => {
-		const result = shortcutFormats( 'primary', '.' );
-
-		expect( result ).toEqual( {
-			shortcutAriaLabel: 'Control + Period',
-			displayShortcut: 'Ctrl+.',
-			ariaKeyShortcut: 'Control+.',
-		} );
-	} );
-
-	it( 'should return consistent results with individual functions', () => {
-		const modifier = 'primary';
-		const character = 'z';
-		const result = shortcutFormats( modifier, character );
-
-		expect( result.shortcutAriaLabel ).toEqual(
-			shortcutAriaLabel[ modifier ]( character )
-		);
-		expect( result.displayShortcut ).toEqual(
-			displayShortcut[ modifier ]( character )
-		);
-		expect( result.ariaKeyShortcut ).toEqual(
-			ariaKeyShortcut[ modifier ]( character )
-		);
 	} );
 } );
 

--- a/packages/keycodes/src/test/index.ts
+++ b/packages/keycodes/src/test/index.ts
@@ -5,7 +5,9 @@ import {
 	displayShortcutList,
 	displayShortcut,
 	rawShortcut,
+	ariaKeyShortcut,
 	shortcutAriaLabel,
+	shortcutFormats,
 	isKeyboardEvent,
 } from '..';
 
@@ -267,6 +269,70 @@ describe( 'rawShortcut', () => {
 			const shortcut = rawShortcut.access( 'm', isAppleOSTrue );
 			expect( shortcut ).toEqual( 'ctrl+alt+m' );
 		} );
+	} );
+} );
+
+describe( 'ariaKeyShortcut alias verification', () => {
+	it( 'should be identical to rawShortcut', () => {
+		expect( ariaKeyShortcut ).toBe( rawShortcut );
+	} );
+} );
+
+describe( 'shortcutFormats', () => {
+	it( 'should return all three shortcut formats for primary modifier on Windows', () => {
+		const result = shortcutFormats( 'primary', 'm' );
+
+		expect( result ).toEqual( {
+			shortcutAriaLabel: 'Control + M',
+			displayShortcut: 'Ctrl+M',
+			ariaKeyShortcut: 'ctrl+m',
+		} );
+	} );
+
+	it( 'should return all three shortcut formats for primaryShift modifier', () => {
+		const result = shortcutFormats( 'primaryShift', 'k' );
+
+		expect( result ).toEqual( {
+			shortcutAriaLabel: 'Control + Shift + K',
+			displayShortcut: 'Ctrl+Shift+K',
+			ariaKeyShortcut: 'ctrl+shift+k',
+		} );
+	} );
+
+	it( 'should return all three shortcut formats for access modifier', () => {
+		const result = shortcutFormats( 'access', 'h' );
+
+		expect( result ).toEqual( {
+			shortcutAriaLabel: 'Shift + Alt + H',
+			displayShortcut: 'Shift+Alt+H',
+			ariaKeyShortcut: 'shift+alt+h',
+		} );
+	} );
+
+	it( 'should handle special characters like period', () => {
+		const result = shortcutFormats( 'primary', '.' );
+
+		expect( result ).toEqual( {
+			shortcutAriaLabel: 'Control + Period',
+			displayShortcut: 'Ctrl+.',
+			ariaKeyShortcut: 'ctrl+.',
+		} );
+	} );
+
+	it( 'should return consistent results with individual functions', () => {
+		const modifier = 'primary';
+		const character = 'z';
+		const result = shortcutFormats( modifier, character );
+
+		expect( result.shortcutAriaLabel ).toEqual(
+			shortcutAriaLabel[ modifier ]( character )
+		);
+		expect( result.displayShortcut ).toEqual(
+			displayShortcut[ modifier ]( character )
+		);
+		expect( result.ariaKeyShortcut ).toEqual(
+			ariaKeyShortcut[ modifier ]( character )
+		);
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Adds a new `ariaKeyShortcut` function as a public export of the `@wordpress/keycodes` package, a utility that helps creating a shortcut representation that can be used as the value for the `aria-keyshortcuts` attribute


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As we want to have a more widespread support for communicating (both visually and via assistive technology) the existence of keyboard shortcuts across our UIs, we wanted to expose the existing functionality in a more ergonomic and discoverable manner to the consumers of the Gutenberg platform.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See code changes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Review code changes
- Run unit tests
- Test them locally

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Assign the value returned by the `ariaKeyShortcut[modifier](character)` function to an HTML element's `aria-keyshortcuts`
- Verify that the values produced by that function are compatible with the format expected for that HTML attribute

