### PR TITLE
Remove outdated vendor prefix properties in CSS

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove outdated vendor prefix properties ([#74213](https://github.com/WordPress/gutenberg/pull/74213)).
+
 ## 6.12.0 (2025-11-26)
 
 ## 6.11.0 (2025-11-12)

--- a/packages/base-styles/_long-content-fade.scss
+++ b/packages/base-styles/_long-content-fade.scss
@@ -10,10 +10,6 @@
 	display: block;
 	position: absolute;
 	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	pointer-events: none;
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -283,15 +283,7 @@
 	}
 
 	// Use opacity to work in various editor styles.
-	&::-webkit-input-placeholder {
-		color: colors.$dark-gray-placeholder;
-	}
-
-	&::-moz-placeholder {
-		color: colors.$dark-gray-placeholder;
-	}
-
-	&:-ms-input-placeholder {
+	&::placeholder {
 		color: colors.$dark-gray-placeholder;
 	}
 }
@@ -313,11 +305,6 @@
 	&:checked {
 		background: var(--wp-admin-theme-color);
 		border-color: var(--wp-admin-theme-color);
-
-		// Hide default checkbox styles in IE.
-		&::-ms-check {
-			opacity: 0;
-		}
 	}
 
 	&:checked::before,

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -95,7 +95,7 @@
 
 	select {
 		font-family: system-ui;
-		-webkit-appearance: revert;
+		appearance: revert;
 		color: revert;
 		border: revert;
 		border-radius: revert;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 -   `AlignmentMatrixControl`: Migrate styles from Emotion to a CSS module ([#73714](https://github.com/WordPress/gutenberg/pull/73714) and [#73757](https://github.com/WordPress/gutenberg/pull/73757)).
 -   `AnglePickerControl`: Migrate styles from Emotion to a CSS module ([#73786](https://github.com/WordPress/gutenberg/pull/73786)).
+-   `Button`, `DateCalendar`, `DateRangeCalendar`, `CheckboxControl`, `Panel`, `Placeholder`: Remove outdated vendor prefix properties in CSS ([#74213](https://github.com/WordPress/gutenberg/pull/74213)).
 
 ## 30.9.0 (2025-11-26)
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -19,7 +19,7 @@
 	margin: 0;
 	border: 0;
 	cursor: pointer;
-	-webkit-appearance: none;
+	appearance: none;
 	background: none;
 
 	@media not ( prefers-reduced-motion ) {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -126,13 +126,11 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	padding: 0;
 	margin: 0;
 	cursor: pointer;
-	-moz-appearance: none;
-	-webkit-appearance: none;
+	appearance: none;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	position: relative;
-	appearance: none;
 
 	width: $wp-components-calendar-button-width;
 	height: $wp-components-calendar-button-height;

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -50,11 +50,6 @@
 	&:indeterminate {
 		background: $components-color-accent;
 		border-color: $components-color-accent;
-
-		// Hide default checkbox styles in IE.
-		&::-ms-check {
-			opacity: 0;
-		}
 	}
 
 	&:checked::before {

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -123,8 +123,6 @@
 	/* rtl:begin:ignore */
 	body.rtl & .dashicons-arrow-right {
 		transform: scaleX(-1);
-		-ms-filter: fliph;
-		filter: FlipH;
 		margin-top: -10px;
 	}
 	/* rtl:end:ignore */

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -18,7 +18,6 @@
 	gap: $grid-unit-20;
 
 	// Some editor styles unset this.
-	-moz-font-smoothing: subpixel-antialiased;
 	-webkit-font-smoothing: subpixel-antialiased;
 
 

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -9,7 +9,6 @@
 			body:has(&) {
 				cursor: col-resize;
 				user-select: none;
-				-webkit-user-select: none;
 			}
 		}
 

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -39,15 +39,7 @@ textarea.editor-post-text-editor {
 		position: relative;
 	}
 
-	&::-webkit-input-placeholder {
-		color: $dark-gray-placeholder;
-	}
-
-	&::-moz-placeholder {
-		color: $dark-gray-placeholder;
-	}
-
-	&:-ms-input-placeholder {
+	&::placeholder {
 		color: $dark-gray-placeholder;
 	}
 }

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -9,10 +9,6 @@
 	height: 100%;
 	overflow: auto;
 
-	@include break-small() {
-		-webkit-overflow-scrolling: touch;
-	}
-
 	@include break-medium() {
 		width: $sidebar-width;
 	}


### PR DESCRIPTION
## What?

Removes old vendor-prefixed CSS properties that are no longer necessary.

## Why?

Clean up the codebase. These styles also tend to be copied into newer things, keeping the old properties alive.

## Testing Instructions

Smoke test some affected components. There should be no regressions.
