### PR TITLE
Template Activation: Try fixing still flaky test

### DIFF
--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -4,31 +4,59 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 async function navigateToTemplateEditor( { admin, editor, page }, pageId ) {
-	await admin.editPost( pageId );
-	await expect(
-		page.locator( 'iframe[name="editor-canvas"]' )
-	).toBeVisible();
+	await test.step( 'navigate to template editor', async () => {
+		await admin.editPost( pageId );
+		await expect(
+			page.locator( 'iframe[name="editor-canvas"]' )
+		).toBeVisible();
 
-	// Close pattern chooser dialog.
-	const patternDialog = page.getByRole( 'dialog', {
-		name: 'Choose a pattern',
+		// Close pattern chooser dialog.
+		const patternDialog = page.getByRole( 'dialog', {
+			name: 'Choose a pattern',
+		} );
+		await expect( patternDialog ).toBeVisible( { timeout: 2000 } );
+		await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
+
+		await editor.openDocumentSettingsSidebar();
+		const settingsPanel = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsPanel.getByRole( 'tab', { name: 'Page' } ).click();
+		await settingsPanel
+			.getByRole( 'button', { name: 'Template options' } )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
+		await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuideTemplate: false,
+		} );
 	} );
-	await expect( patternDialog ).toBeVisible( { timeout: 2000 } );
-	await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
+}
 
-	await editor.openDocumentSettingsSidebar();
-	const settingsPanel = page.getByRole( 'region', {
-		name: 'Editor settings',
-	} );
-	await settingsPanel.getByRole( 'tab', { name: 'Page' } ).click();
-	await settingsPanel
-		.getByRole( 'button', { name: 'Template options' } )
-		.click();
-	await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
-	await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
+async function saveEntities( { page } ) {
+	await test.step( 'save entities', async () => {
+		const publishSaveButton = page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const topBarSaveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		// Initiate save.
+		await topBarSaveButton.click();
+		const publishPanelVisible = await publishSaveButton.isVisible();
+		// If the publish panel is visible, click the save button there.
+		// Sometimes template parts trigger the publish panel to appear due to navigation fallback.
+		if ( publishPanelVisible ) {
+			await publishSaveButton.click();
+		}
 
-	await editor.setPreferences( 'core/edit-post', {
-		welcomeGuideTemplate: false,
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText( /(updated|published)\./ )
+				.first()
+		).toBeVisible();
 	} );
 }
 
@@ -72,9 +100,7 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: false,
-		} );
+		await saveEntities( { page } );
 		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		// Make a second edit to the template to ensure wp_id is not 0.
@@ -85,27 +111,7 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		const publishSaveButton = page
-			.getByRole( 'region', { name: 'Editor publish' } )
-			.getByRole( 'button', { name: 'Save', exact: true } );
-		const topBarSaveButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save', exact: true } );
-		// Initiate save.
-		await topBarSaveButton.click();
-		const publishPanelVisible = await publishSaveButton.isVisible();
-		// If the publish panel is visible, click the save button there.
-		// Sometimes template parts trigger the publish panel to appear due to navigation fallback.
-		if ( publishPanelVisible ) {
-			await publishSaveButton.click();
-		}
-
-		await expect(
-			page
-				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.getByText( /(updated|published)\./ )
-				.first()
-		).toBeVisible();
+		await saveEntities( { page } );
 	} );
 
 	test( 'should open and edit templates correctly when active_templates experiment is disabled', async ( {
@@ -124,9 +130,7 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await saveEntities( { page } );
 		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		// Make a second edit to the template to ensure wp_id is not 0.
@@ -137,15 +141,6 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
-
-		await expect(
-			page
-				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.getByText( /(updated|published)\./ )
-				.first()
-		).toBeVisible();
+		await saveEntities( { page } );
 	} );
 } );

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -85,14 +85,20 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		// Find the correct save button to click.
 		const publishSaveButton = page
 			.getByRole( 'region', { name: 'Editor publish' } )
 			.getByRole( 'button', { name: 'Save', exact: true } );
 		const topBarSaveButton = page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Save', exact: true } );
-		await publishSaveButton.or( topBarSaveButton ).click();
+		// Initiate save.
+		await topBarSaveButton.click();
+		const publishPanelVisible = await publishSaveButton.isVisible();
+		// If the publish panel is visible, click the save button there.
+		// Sometimes template parts trigger the publish panel to appear due to navigation fallback.
+		if ( publishPanelVisible ) {
+			await publishSaveButton.click();
+		}
 
 		await expect(
 			page
@@ -131,14 +137,9 @@ test.describe( 'Template ID Format', () => {
 		} );
 		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
 
-		// Find the correct save button to click.
-		const publishSaveButton = page
-			.getByRole( 'region', { name: 'Editor publish' } )
-			.getByRole( 'button', { name: 'Save', exact: true } );
-		const topBarSaveButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Save', exact: true } );
-		await publishSaveButton.or( topBarSaveButton ).click();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await expect(
 			page

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -56,13 +56,14 @@ test.describe( 'Template ID Format', () => {
 		await requestUtils.setGutenbergExperiments( [] );
 	} );
 
-	const testTemplateEditing = async (
-		{ admin, editor, page, requestUtils },
-		experiments,
-		contentText
-	) => {
-		await requestUtils.setGutenbergExperiments( experiments );
-
+	test( 'should open and edit templates correctly when active_templates experiment is enabled', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const contentText = 'Test content with experiment enabled';
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		await editor.insertBlock( {
@@ -72,10 +73,8 @@ test.describe( 'Template ID Format', () => {
 		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
 
 		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty:
-				! experiments.includes( 'active_templates' ),
+			isOnlyCurrentEntityDirty: false,
 		} );
-
 		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
 		// Make a second edit to the template to ensure wp_id is not 0.
@@ -95,27 +94,12 @@ test.describe( 'Template ID Format', () => {
 			.getByRole( 'button', { name: 'Save', exact: true } );
 		await publishSaveButton.or( topBarSaveButton ).click();
 
-		await page
-			.getByRole( 'button', { name: 'Dismiss this notice' } )
-			.getByText( /(updated|published)\./ )
-			.first()
-			.waitFor();
-	};
-
-	test( 'should open and edit templates correctly when active_templates experiment is enabled', async ( {
-		admin,
-		editor,
-		page,
-		requestUtils,
-	} ) => {
-		await testTemplateEditing(
-			{ admin, editor, page, requestUtils },
-			[ 'active_templates' ],
-			'Test content with experiment enabled'
-		);
-
-		// Verify test completed successfully.
-		expect( true ).toBe( true );
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText( /(updated|published)\./ )
+				.first()
+		).toBeVisible();
 	} );
 
 	test( 'should open and edit templates correctly when active_templates experiment is disabled', async ( {
@@ -124,13 +108,43 @@ test.describe( 'Template ID Format', () => {
 		page,
 		requestUtils,
 	} ) => {
-		await testTemplateEditing(
-			{ admin, editor, page, requestUtils },
-			[],
-			'Test content with experiment disabled'
-		);
+		const contentText = 'Test content with experiment disabled';
+		await requestUtils.setGutenbergExperiments( [] );
+		await navigateToTemplateEditor( { admin, editor, page }, pageId );
 
-		// Verify test completed successfully.
-		expect( true ).toBe( true );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: contentText },
+		} );
+		await expect( editor.canvas.getByText( contentText ) ).toBeVisible();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await navigateToTemplateEditor( { admin, editor, page }, pageId );
+
+		// Make a second edit to the template to ensure wp_id is not 0.
+		const secondEditText = `Second edit: ${ contentText }`;
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: secondEditText },
+		} );
+		await expect( editor.canvas.getByText( secondEditText ) ).toBeVisible();
+
+		// Find the correct save button to click.
+		const publishSaveButton = page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const topBarSaveButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		await publishSaveButton.or( topBarSaveButton ).click();
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText( /(updated|published)\./ )
+				.first()
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
Tries to fix #73752 and fix #73743.
Previous attempts: #73975, #74066.

Yet another attempt to fix the flaky Template Activation e2e test.

## How?
* Don't use the shared test function for both tests. IMO, it's better to repeat yourself in test bodies and only extract actions in local helpers. Makes it easier to change a single test without affecting others.
* Try to improve saving fallback logic when Template Activation is enabled. After investigating flaky test traces, I noticed that multi-entity saving is triggered due to Template Part modifications, which can be caused by navigation fallback.

## Testing Instructions
CI checks are green and flaky test isn't reported after multiple runs.

## Screenshot
<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/d7f86bc9-f40a-4ba0-87e5-f1b6609eaca8" />
