### PR TITLE
iAPI: Preserves boolean attributes during navigation.

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve boolean HTML attributes during router navigation. ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+
 ## 6.36.0 (2025-11-26)
 
 ### Bug Fixes

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Preserve boolean HTML attributes during router navigation. ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+-   Preserve boolean HTML attributes during router navigation. ([#74217](https://github.com/WordPress/gutenberg/pull/74217))
 
 ## 6.36.0 (2025-11-26)
 

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -220,6 +220,37 @@ describe( 'toVdom', () => {
 		} );
 	} );
 
+	describe( 'Boolean attributes', () => {
+		it( 'should convert empty string boolean attributes to true', () => {
+			const element = createElementFromHTML(
+				'<details open><summary>Test</summary></details>'
+			);
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'details' as any, { open: true }, [
+					h( 'summary' as any, {}, [ 'Test' ] ),
+				] )
+			);
+		} );
+
+		it( 'should handle multiple boolean attributes', () => {
+			const element = createElementFromHTML(
+				'<input type="checkbox" checked disabled readonly/>'
+			);
+			expect( toVdom( element ) ).toMatchVNode(
+				h(
+					'input' as any,
+					{
+						type: 'checkbox',
+						checked: true,
+						disabled: true,
+						readonly: true,
+					},
+					[]
+				)
+			);
+		} );
+	} );
+
 	describe( 'Directive processing', () => {
 		it( 'should process simple directives', () => {
 			const element = createElementFromHTML(

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -14,6 +14,19 @@ const currentNamespace = () => namespaces[ namespaces.length - 1 ] ?? null;
 const isObject = ( item: unknown ): item is Record< string, unknown > =>
 	Boolean( item && typeof item === 'object' && item.constructor === Object );
 const invalidCharsRegex = /[^a-z0-9-_]/i;
+const booleanAttributes: readonly string[] = [
+	'open',
+	'checked',
+	'disabled',
+	'hidden',
+	'selected',
+	'readonly',
+	'required',
+	'autoplay',
+	'controls',
+	'loop',
+	'muted',
+];
 
 function parseDirectiveName( directiveName: string ): {
 	prefix: string;
@@ -160,7 +173,14 @@ export function toVdom( root: Node ): ComponentChild {
 			} else if ( attributeName === 'ref' ) {
 				continue;
 			}
-			props[ attributeName ] = attributeValue;
+			if (
+				attributeValue === '' &&
+				booleanAttributes.includes( attributeName )
+			) {
+				props[ attributeName ] = true;
+			} else {
+				props[ attributeName ] = attributeValue;
+			}
 		}
 
 		if ( ignore && ! island ) {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/74148

<!-- In a few words, what is the PR actually doing? -->

## Why?
Boolean attributes were being ignored during navigation via the iAPI router.

## How?
This PR adds checks for boolean attributes and ensures they are preserved in the VDOM.

## Testing Instructions

1. Create a new test page.
2. Add a Query Loop to that test page. It should be Custom query type, taget Posts, and show 1 item per page (to force pagination; a single item is enough to demonstrate the issue).
3. Enable enhanced pagination on the Query Loop (disable "Reload full page" under the Advanced panel).
4. Configure the Post Template such that it has a Details block, that Details block has contents to be shown when the details block is expanded, and that the Details block is configured to "Open by default". You can also add other blocks with such attributes like video and turn on autoplay.
5. Publish the page, and review the rendered results. Verify the Details block expanded on first load, as well as on any pagination operations.

## Screenshots or screencast 

https://github.com/user-attachments/assets/cbcdecaf-e2a6-4d9e-8aee-d92b40b79b98



