### PR TITLE
Block Editor: Make TextIndentControl component internal

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -54,7 +54,6 @@ export { default as __experimentalFontAppearanceControl } from './font-appearanc
 export { default as __experimentalFontFamilyControl } from './font-family';
 export { default as __experimentalLetterSpacingControl } from './letter-spacing-control';
 export { default as __experimentalTextDecorationControl } from './text-decoration-control';
-export { default as __experimentalTextIndentControl } from './text-indent-control';
 export { default as __experimentalTextTransformControl } from './text-transform-control';
 export { default as __experimentalWritingModeControl } from './writing-mode-control';
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -61,6 +61,7 @@ import {
 } from './components/block-list/use-block-props/use-block-refs';
 import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
+import TextIndentControl from './components/text-indent-control';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -90,6 +91,7 @@ lock( privateApis, {
 	ResolutionTool,
 	TabbedSidebar,
 	TextAlignmentControl,
+	TextIndentControl,
 	usesContextKey,
 	useFlashEditableBlocks,
 	HTMLElementControl,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -61,7 +61,6 @@ import {
 } from './components/block-list/use-block-props/use-block-refs';
 import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
-import TextIndentControl from './components/text-indent-control';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -91,7 +90,6 @@ lock( privateApis, {
 	ResolutionTool,
 	TabbedSidebar,
 	TextAlignmentControl,
-	TextIndentControl,
 	usesContextKey,
 	useFlashEditableBlocks,
 	HTMLElementControl,


### PR DESCRIPTION
Related to #73114

## Why?

The `TextIndentControl` component is simply a combination of the `UnitControl` and `RangeControl` components, and I believe that such a concrete component should not be exposed.

While there is certainly a need for such a UI, I believe it should be exposed as an abstract component in the future. In the meantime, I propose making the `TextIndentControl` component private.

See the following resources:

- https://github.com/WordPress/gutenberg/pull/40462
- https://github.com/WordPress/gutenberg/issues/40507

## Testing Instructions

Confirm that the Line Indent support works correctly as before.