### PR TITLE
Build: Rename extensible site editor page to avoid conflicts

### DIFF
--- a/lib/experimental/extensible-site-editor.php
+++ b/lib/experimental/extensible-site-editor.php
@@ -21,7 +21,7 @@ function gutenberg_redirect_to_extensible_site_editor() {
 		foreach ( $submenu['themes.php'] as $key => $item ) {
 			// Find the Design/site-editor menu item and update its URL.
 			if ( isset( $item[2] ) && 'site-editor.php' === $item[2] ) {
-				$submenu['themes.php'][ $key ][2] = 'admin.php?page=site-editor';
+				$submenu['themes.php'][ $key ][2] = 'admin.php?page=site-editor-v2';
 				break;
 			}
 		}

--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -14,8 +14,8 @@ function gutenberg_register_site_editor_admin_page() {
 		__( 'Site Editor', 'gutenberg' ),
 		__( 'Site Editor', 'gutenberg' ),
 		'manage_options',
-		'site-editor',
-		'site_editor_render_page'
+		'site-editor-v2',
+		'site_editor_v2_render_page'
 	);
 }
 add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
@@ -24,13 +24,13 @@ add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
  * Register default menu items for the site editor page.
  */
 function gutenberg_site_editor_register_default_menu_items() {
-	register_site_editor_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
-	register_site_editor_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
-	register_site_editor_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
-	register_site_editor_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
-	register_site_editor_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );
-	register_site_editor_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
-	register_site_editor_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
-	register_site_editor_menu_item( 'fontList', __( 'Fonts', 'gutenberg' ), '/font-list', '' );
+	register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
+	register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
+	register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
+	register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
+	register_site_editor_v2_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );
+	register_site_editor_v2_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
+	register_site_editor_v2_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
+	register_site_editor_v2_menu_item( 'fontList', __( 'Fonts', 'gutenberg' ), '/font-list', '' );
 }
-add_action( 'site-editor_init', 'gutenberg_site_editor_register_default_menu_items', 5 );
+add_action( 'site-editor-v2_init', 'gutenberg_site_editor_register_default_menu_items', 5 );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"handlePrefix": "wp",
 		"pages": [
 			{
-				"id": "site-editor",
+				"id": "site-editor-v2",
 				"init": [
 					"@wordpress/edit-site-init"
 				]

--- a/routes/home/package.json
+++ b/routes/home/package.json
@@ -1,7 +1,7 @@
 {
 	"route": {
 		"path": "/",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/i18n": "file:../i18n"

--- a/routes/navigation-edit/package.json
+++ b/routes/navigation-edit/package.json
@@ -1,7 +1,7 @@
 {
 	"route": {
 		"path": "/navigation/edit/$id",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/navigation-list/package.json
+++ b/routes/navigation-list/package.json
@@ -1,7 +1,7 @@
 {
 	"route": {
 		"path": "/navigation/list",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/navigation/package.json
+++ b/routes/navigation/package.json
@@ -1,7 +1,7 @@
 {
 	"route": {
 		"path": "/navigation",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/route": "file:../../packages/route"

--- a/routes/pattern-list/package.json
+++ b/routes/pattern-list/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/patterns/list/$type",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/pattern/package.json
+++ b/routes/pattern/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/patterns",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/route": "file:../../packages/route"

--- a/routes/post-edit/package.json
+++ b/routes/post-edit/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/types/$type/edit/$id",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/core-data": "file:../../packages/core-data",

--- a/routes/post-list/package.json
+++ b/routes/post-list/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/types/$type/list/$slug",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/post-new/package.json
+++ b/routes/post-new/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/types/$type/new",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/core-data": "file:../../packages/core-data",

--- a/routes/post/package.json
+++ b/routes/post/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/types/$type",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/route": "file:../../packages/route"

--- a/routes/styles/package.json
+++ b/routes/styles/package.json
@@ -1,7 +1,7 @@
 {
 	"route": {
 		"path": "/styles",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/template-list/package.json
+++ b/routes/template-list/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/templates/list/$activeView",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/template-part-list/package.json
+++ b/routes/template-part-list/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/template-parts/list/$area",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/template-part/package.json
+++ b/routes/template-part/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/template-parts",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/route": "file:../../packages/route"

--- a/routes/template/package.json
+++ b/routes/template/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"route": {
 		"path": "/templates",
-		"page": "site-editor"
+		"page": "site-editor-v2"
 	},
 	"dependencies": {
 		"@wordpress/route": "file:../../packages/route"

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -51,6 +51,9 @@ test.describe( 'Preload', () => {
 			'/wp-abilities/v1/abilities?per_page=100&context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
+			// There are two separate settings OPTIONS requests. We should fix
+			// so the one for canUser and getEntityRecord are reused.
+			'/wp/v2/settings',
 		] );
 	} );
 } );


### PR DESCRIPTION
To support WordPress Core rendering and Gutenberg rendering, the new build tool for pages, support both "mypage.php" or "admin.php?page=mypage"

in both of these cases, the scripts are enqueued... and since our experimental page's id was "site-editor", it mean that its scripts and modules were being enqueued even in the regular "site-editor.php". This is probably what we want long term but since it's experimental for now, I removed the experimental page to "site-editor-v2" temporarily to avoid script enqueuing conflicts.