### PR TITLE
Use a stable npm version on static checks job

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -10,4 +10,4 @@ paths:
     .github/workflows/end2end-test.yml:
         ignore:
             # This file gets created in the step prior.
-            - 'file "build/index.js" does not exist.+'
+            - 'file "build/index.cjs" does not exist.+'

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -38,8 +38,6 @@ jobs:
                     - event: 'pull_request'
                       node: '22'
                     - event: 'pull_request'
-                      node: '24'
-                    - event: 'pull_request'
                       os: 'macos-15'
 
         steps:
@@ -52,6 +50,9 @@ jobs:
               uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
               with:
                   node-version: ${{ matrix.node }}
+
+            - name: Pin npm version for consistency
+              run: npm install -g npm@10
 
             - name: Npm install
               # A "full" install is executed, since `npm ci` does not always exit


### PR DESCRIPTION
This should solve the issues on trunk where npm install on npm 11 is producing a different package-lock.json file than the one we generated on npm 10.