### PR TITLE
Block Inspector: Update the design of the style variation to use ToolsPanel

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -7,7 +7,7 @@ import {
 	getUnregisteredTypeHandlerName,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { PanelBody, __unstableMotion as motion } from '@wordpress/components';
+import { __unstableMotion as motion } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -30,14 +30,6 @@ import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSett
 import { useBorderPanelLabel } from '../../hooks/border';
 import ContentTab from '../inspector-controls-tabs/content-tab';
 import { unlock } from '../../lock-unlock';
-
-function BlockStylesPanel( { clientId } ) {
-	return (
-		<PanelBody title={ __( 'Styles' ) }>
-			<BlockStyles clientId={ clientId } />
-		</PanelBody>
-	);
-}
 
 function StyleInspectorSlots( {
 	blockName,
@@ -379,7 +371,7 @@ const BlockInspectorSingleBlock = ( {
 			{ ! shouldShowTabs && (
 				<>
 					{ hasBlockStyles && (
-						<BlockStylesPanel clientId={ renderedBlockClientId } />
+						<BlockStyles clientId={ renderedBlockClientId } />
 					) }
 					<ContentTab
 						rootClientId={ renderedBlockClientId }

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -12,13 +12,18 @@ import {
 	Button,
 	__experimentalTruncate as Truncate,
 	Popover,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockStylesPreviewPanel from './preview-panel';
 import useStylesForBlocks from './use-styles-for-block';
+import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
+import { getDefaultStyle } from './utils';
 
 const noop = () => {};
 
@@ -36,6 +41,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	} );
 	const [ hoveredStyle, setHoveredStyle ] = useState( null );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( ! stylesToRender || stylesToRender.length === 0 ) {
 		return null;
@@ -59,62 +65,96 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		onHoverClassName( item?.name ?? null );
 	};
 
-	return (
-		<div className="block-editor-block-styles">
-			<div className="block-editor-block-styles__variants">
-				{ stylesToRender.map( ( style ) => {
-					const buttonText = style.label || style.name;
+	const defaultStyle = getDefaultStyle( stylesToRender );
 
-					return (
-						<Button
-							__next40pxDefaultSize
-							className={ clsx(
-								'block-editor-block-styles__item',
-								{
-									'is-active':
-										activeStyle.name === style.name,
-								}
-							) }
-							key={ style.name }
-							variant="secondary"
-							label={ buttonText }
-							onMouseEnter={ () => styleItemHandler( style ) }
-							onFocus={ () => styleItemHandler( style ) }
-							onMouseLeave={ () => styleItemHandler( null ) }
-							onBlur={ () => styleItemHandler( null ) }
-							onClick={ () => onSelectStylePreview( style ) }
-							aria-current={ activeStyle.name === style.name }
-						>
-							<Truncate
-								numberOfLines={ 1 }
-								className="block-editor-block-styles__item-text"
-							>
-								{ buttonText }
-							</Truncate>
-						</Button>
-					);
-				} ) }
-			</div>
-			{ hoveredStyle && ! isMobileViewport && (
-				<Popover
-					placement="left-start"
-					offset={ 34 }
-					focusOnMount={ false }
-				>
-					<div
-						className="block-editor-block-styles__preview-panel"
-						onMouseLeave={ () => styleItemHandler( null ) }
-					>
-						<BlockStylesPreviewPanel
-							activeStyle={ activeStyle }
-							className={ previewClassName }
-							genericPreviewBlock={ genericPreviewBlock }
-							style={ hoveredStyle }
-						/>
+	const hasValue = () => {
+		return activeStyle?.name !== defaultStyle?.name;
+	};
+
+	const onDeselect = () => {
+		onSelectStylePreview( defaultStyle );
+	};
+
+	return (
+		<ToolsPanel
+			label={ __( 'Styles' ) }
+			resetAll={ onDeselect }
+			panelId={ clientId }
+			hasInnerWrapper
+			dropdownMenuProps={ dropdownMenuProps }
+		>
+			<ToolsPanelItem
+				hasValue={ hasValue }
+				label={ __( 'Variation' ) }
+				onDeselect={ onDeselect }
+				isShownByDefault
+				panelId={ clientId }
+			>
+				<div className="block-editor-block-styles">
+					<div className="block-editor-block-styles__variants">
+						{ stylesToRender.map( ( style ) => {
+							const buttonText = style.label || style.name;
+
+							return (
+								<Button
+									__next40pxDefaultSize
+									className={ clsx(
+										'block-editor-block-styles__item',
+										{
+											'is-active':
+												activeStyle.name === style.name,
+										}
+									) }
+									key={ style.name }
+									variant="secondary"
+									label={ buttonText }
+									onMouseEnter={ () =>
+										styleItemHandler( style )
+									}
+									onFocus={ () => styleItemHandler( style ) }
+									onMouseLeave={ () =>
+										styleItemHandler( null )
+									}
+									onBlur={ () => styleItemHandler( null ) }
+									onClick={ () =>
+										onSelectStylePreview( style )
+									}
+									aria-current={
+										activeStyle.name === style.name
+									}
+								>
+									<Truncate
+										numberOfLines={ 1 }
+										className="block-editor-block-styles__item-text"
+									>
+										{ buttonText }
+									</Truncate>
+								</Button>
+							);
+						} ) }
 					</div>
-				</Popover>
-			) }
-		</div>
+					{ hoveredStyle && ! isMobileViewport && (
+						<Popover
+							placement="left-start"
+							offset={ 34 }
+							focusOnMount={ false }
+						>
+							<div
+								className="block-editor-block-styles__preview-panel"
+								onMouseLeave={ () => styleItemHandler( null ) }
+							>
+								<BlockStylesPreviewPanel
+									activeStyle={ activeStyle }
+									className={ previewClassName }
+									genericPreviewBlock={ genericPreviewBlock }
+									style={ hoveredStyle }
+								/>
+							</div>
+						</Popover>
+					) }
+				</div>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 }
 

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -18,6 +18,10 @@
 	}
 }
 
+.block-editor-block-styles {
+	grid-column: 1 / -1;
+}
+
 .block-editor-block-styles__variants {
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -71,13 +70,7 @@ const StylesTab = ( {
 
 	return (
 		<>
-			{ hasBlockStyles && (
-				<div>
-					<PanelBody title={ __( 'Styles' ) }>
-						<BlockStyles clientId={ clientId } />
-					</PanelBody>
-				</div>
-			) }
+			{ hasBlockStyles && <BlockStyles clientId={ clientId } /> }
 			{ isSectionBlock &&
 				window?.__experimentalContentOnlyPatternInsertion && (
 					<SectionBlockColorControls

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -619,7 +619,7 @@ test.describe( 'Synced pattern', () => {
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Styles', exact: true } )
+				.getByRole( 'heading', { name: 'Styles', exact: true } )
 		).toBeVisible();
 
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );


### PR DESCRIPTION
Every panel in the block inspector uses "ToolsPanel" component as a wrapper except "Styles" and "Advanced" that are still using the old "PanelBody" wrapper.

The current PR updates the "styles" panel to move to "ToolsPanel" for consistency. We should consider "Advanced" separately. 

<img width="266" height="743" alt="Screenshot 2025-12-25 at 5 34 13 PM" src="https://github.com/user-attachments/assets/9b6363f9-7d7f-47d5-a35c-bba3e5f4522a" />
