### PR TITLE
Tabs: Reset focus styles to avoid visual glitch

### DIFF
--- a/packages/block-library/src/tabs/style.scss
+++ b/packages/block-library/src/tabs/style.scss
@@ -66,6 +66,9 @@
 			border-block-end: var(--tab-underline-width) solid var(--tab-border-color);
 			border-inline-end: var(--tab-side-border-width) solid var(--tab-border-color);
 			border-radius: var(--tab-border-radius);
+			&:focus {
+				outline: none;
+			}
 			&:focus-visible {
 				outline: 2px solid var(--tab-border-color-active);
 				outline-offset: 2px;


### PR DESCRIPTION
## What?
Closes #73935

## Why?
There is a visual glitch when clicking the tabs caused by the global WordPress `:focus` style that is applying the outline on click. 

## How?
Since the tabs already have a `:focus-visible` style for keyboard accessibility, we need to reset the :focus outline to prevent this.

## Testing Instructions
1. Enable Tabs in the Gutenberg > Experiments > Blocks: add experimental blocks
2. Create a new post
3. Add the tabs block and add a couple tabs
4. Use a block theme like TT5
5. Go to the front end and click on the Tabs (click and hold)
6. 🐞 You will see that visual glitch

## Screencast

### Before
https://github.com/user-attachments/assets/48c5c4f3-2e1d-40ed-861e-4468af16840a

### After
https://github.com/user-attachments/assets/a3a62d31-cb88-4d47-be92-a39862009b89