### PR TITLE
theme.json: Add breadcrumbs block schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -897,6 +897,9 @@
 			"description": "Settings defined on a per-block basis.",
 			"type": "object",
 			"properties": {
+				"core/breadcrumbs": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/accordion": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -1955,6 +1958,9 @@
 			"description": "Styles defined on a per-block basis using the block's selector.",
 			"type": "object",
 			"properties": {
+				"core/breadcrumbs": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
 				"core/accordion": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2406,6 +2412,9 @@
 		"stylesVariationBlocksPropertiesComplete": {
 			"type": "object",
 			"properties": {
+				"core/breadcrumbs": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
 				"core/accordion": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -897,9 +897,6 @@
 			"description": "Settings defined on a per-block basis.",
 			"type": "object",
 			"properties": {
-				"core/breadcrumbs": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
 				"core/accordion": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -922,6 +919,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/block": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/breadcrumbs": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/button": {
@@ -1958,9 +1958,6 @@
 			"description": "Styles defined on a per-block basis using the block's selector.",
 			"type": "object",
 			"properties": {
-				"core/breadcrumbs": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
 				"core/accordion": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -1983,6 +1980,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/block": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/breadcrumbs": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/button": {
@@ -2412,9 +2412,6 @@
 		"stylesVariationBlocksPropertiesComplete": {
 			"type": "object",
 			"properties": {
-				"core/breadcrumbs": {
-					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
-				},
 				"core/accordion": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
@@ -2437,6 +2434,9 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/block": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/breadcrumbs": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/button": {


### PR DESCRIPTION
## What?
I have added the `core/breadcrumbs` block to the `theme.json` schema definitions. This ensures the block is recognized correctly in theme configuration files.

## Why?
The Breadcrumbs block was recently stabilized but was missing from the `theme.json` schema list. This fixes the omission reported in issue #74203.

## How?
I added `"core/breadcrumbs"` to the following definitions in `schemas/json/theme.json`:
- `settingsBlocksPropertiesComplete`
- `stylesPropertiesComplete`
- `stylesProperties`

## Testing Instructions
1. Open `schemas/json/theme.json`.
2. Search for `core/breadcrumbs`.
3. Confirm it exists in the three locations mentioned above.

Fixes #74203