### PR TITLE
Tag Cloud: Use new HtmlRenderer component to remove extra div wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29754,6 +29754,114 @@
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
 			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
 		},
+		"node_modules/html-dom-parser": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
+			"integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "5.0.3",
+				"htmlparser2": "10.0.0"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/dom-serializer/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/html-dom-parser/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/html-dom-parser/node_modules/htmlparser2": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.1",
+				"entities": "^6.0.0"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -29813,6 +29921,54 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/html-react-parser": {
+			"version": "5.2.11",
+			"resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
+			"integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "5.0.3",
+				"html-dom-parser": "5.1.2",
+				"react-property": "2.0.2",
+				"style-to-js": "1.1.21"
+			},
+			"peerDependencies": {
+				"@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+				"react": "0.14 || 15 || 16 || 17 || 18 || 19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/html-react-parser/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/html-react-parser/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
 			}
 		},
 		"node_modules/html-tags": {
@@ -30480,6 +30636,12 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
+		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.5",
@@ -42914,6 +43076,12 @@
 				"async-limiter": "~1.0.0"
 			}
 		},
+		"node_modules/react-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+			"integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+			"license": "MIT"
+		},
 		"node_modules/react-refresh": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -47039,6 +47207,24 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
+		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
+			}
 		},
 		"node_modules/stylehacks": {
 			"version": "6.0.0",
@@ -53499,6 +53685,7 @@
 				"escape-html": "^1.0.3",
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
+				"html-react-parser": "5.2.11",
 				"memize": "^2.1.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -135,6 +135,7 @@
 		"escape-html": "^1.0.3",
 		"fast-average-color": "^9.1.1",
 		"fast-deep-equal": "^3.1.3",
+		"html-react-parser": "5.2.11",
 		"memize": "^2.1.0",
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -47,7 +47,6 @@
 @use "./spacer/editor.scss" as *;
 @use "./table/editor.scss" as *;
 @use "./tabs/editor.scss" as *;
-@use "./tag-cloud/editor.scss" as *;
 @use "./template-part/editor.scss" as *;
 @use "./term-template/editor.scss" as *;
 @use "./text-columns/editor.scss" as *;

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -29,7 +29,7 @@ import { useDisabled } from '@wordpress/compose';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import BlockFromHtml from '../utils/block-from-html';
+import HtmlRenderer from '../utils/html-renderer';
 
 /**
  * Minimum number of tags a user can show using this block.
@@ -262,7 +262,7 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	return (
 		<>
 			{ inspectorControls }
-			<BlockFromHtml wrapperProps={ blockProps } html={ content } />
+			<HtmlRenderer wrapperProps={ blockProps } html={ content } />
 		</>
 	);
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -260,7 +260,7 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	return (
 		<>
 			{ inspectorControls }
-			<BlockFromHtml content={ content } />
+			<BlockFromHtml html={ content } />
 		</>
 	);
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -23,6 +23,7 @@ import {
 } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useServerSideRender } from '@wordpress/server-side-render';
+import { useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -239,7 +240,8 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 		block: name,
 	} );
 
-	const blockProps = useBlockProps();
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
 
 	if ( status === 'loading' ) {
 		return (
@@ -260,7 +262,7 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	return (
 		<>
 			{ inspectorControls }
-			<BlockFromHtml html={ content } />
+			<BlockFromHtml wrapperProps={ blockProps } html={ content } />
 		</>
 	);
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -6,13 +6,13 @@ import {
 	FlexItem,
 	ToggleControl,
 	SelectControl,
+	Spinner,
 	RangeControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	Disabled,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -21,13 +21,14 @@ import {
 	useBlockProps,
 	useSettings,
 } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
 import { store as coreStore } from '@wordpress/core-data';
+import { useServerSideRender } from '@wordpress/server-side-render';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import BlockFromHtml from '../utils/block-from-html';
 
 /**
  * Minimum number of tags a user can show using this block.
@@ -46,7 +47,7 @@ const MAX_TAGS = 100;
 const MIN_FONT_SIZE = 0.1;
 const MAX_FONT_SIZE = 100;
 
-function TagCloudEdit( { attributes, setAttributes } ) {
+function TagCloudEdit( { attributes, setAttributes, name } ) {
 	const {
 		taxonomy,
 		showTagCounts,
@@ -111,15 +112,6 @@ function TagCloudEdit( { attributes, setAttributes } ) {
 			}
 		} );
 		setAttributes( updateObj );
-	};
-
-	// Remove border styles from the server-side attributes to prevent duplicate border.
-	const serverSideAttributes = {
-		...attributes,
-		style: {
-			...attributes?.style,
-			border: undefined,
-		},
 	};
 
 	const inspectorControls = (
@@ -241,18 +233,34 @@ function TagCloudEdit( { attributes, setAttributes } ) {
 		</InspectorControls>
 	);
 
+	const { content, status, error } = useServerSideRender( {
+		attributes,
+		skipBlockSupportAttributes: true,
+		block: name,
+	} );
+
+	const blockProps = useBlockProps();
+
+	if ( status === 'loading' ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div { ...blockProps }>
+				<p>Error: { error }</p>
+			</div>
+		);
+	}
+
 	return (
 		<>
 			{ inspectorControls }
-			<div { ...useBlockProps() }>
-				<Disabled>
-					<ServerSideRender
-						skipBlockSupportAttributes
-						block="core/tag-cloud"
-						attributes={ serverSideAttributes }
-					/>
-				</Disabled>
-			</div>
+			<BlockFromHtml content={ content } />
 		</>
 	);
 }

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -1,3 +1,0 @@
-.wp-block-tag-cloud a {
-	pointer-events: none;
-}

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -1,11 +1,3 @@
-// The following styles are to prevent duplicate spacing and border for the tag cloud
-// block in the editor given it uses server side rendering. The specificity
-// must be higher than `0-1-0` to override global styles. Targeting the
-// inner use of the .wp-block-tag-cloud class should minimize impact on
-// other 3rd party styles targeting the block.
-.wp-block-tag-cloud .wp-block-tag-cloud {
-	margin: 0;
-	padding: 0;
-	border: none;
-	border-radius: inherit;
+.wp-block-tag-cloud a {
+	pointer-events: none;
 }

--- a/packages/block-library/src/utils/block-from-html.js
+++ b/packages/block-library/src/utils/block-from-html.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import parse, { attributesToProps, domToReact } from 'html-react-parser';
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Generates an Edit component that works in the block editor
+ * from the given HTML content.
+ *
+ * @param {Object} props         - The props for the component.
+ * @param {string} props.content - The content to render.
+ * @return {JSX.Element} The Edit component.
+ */
+const BlockFromHtml = ( { content = '' } ) => {
+	const blockProps = useBlockProps();
+	const options = {
+		replace: ( { name, type, attribs, parent, children } ) => {
+			if ( type === 'tag' && name ) {
+				const parsedProps = attributesToProps( attribs || {} );
+				const TagName = name;
+				if ( ! parent ) {
+					const mergedProps = {
+						...parsedProps,
+						...blockProps,
+					};
+					return (
+						<TagName { ...mergedProps }>
+							{ domToReact( children, options ) }
+						</TagName>
+					);
+				}
+			}
+		},
+	};
+	const parsedContent = parse( content, options );
+	return parsedContent;
+};
+
+export default BlockFromHtml;

--- a/packages/block-library/src/utils/block-from-html.js
+++ b/packages/block-library/src/utils/block-from-html.js
@@ -7,16 +7,17 @@ import parse, { attributesToProps, domToReact } from 'html-react-parser';
  * WordPress dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import { safeHTML } from '@wordpress/dom';
 
 /**
  * Generates an Edit component that works in the block editor
  * from the given HTML content.
  *
- * @param {Object} props         - The props for the component.
- * @param {string} props.content - The content to render.
+ * @param {Object} props      - The props for the component.
+ * @param {string} props.html - The HTML content to render.
  * @return {JSX.Element} The Edit component.
  */
-const BlockFromHtml = ( { content = '' } ) => {
+const BlockFromHtml = ( { html = '' } ) => {
 	const blockProps = useBlockProps();
 	const options = {
 		replace: ( { name, type, attribs, parent, children } ) => {
@@ -37,7 +38,8 @@ const BlockFromHtml = ( { content = '' } ) => {
 			}
 		},
 	};
-	const parsedContent = parse( content, options );
+	const sanitizedContent = safeHTML( html );
+	const parsedContent = parse( sanitizedContent, options );
 	return parsedContent;
 };
 

--- a/packages/block-library/src/utils/block-from-html.js
+++ b/packages/block-library/src/utils/block-from-html.js
@@ -6,22 +6,18 @@ import parse, { attributesToProps, domToReact } from 'html-react-parser';
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
 import { safeHTML } from '@wordpress/dom';
-import { useDisabled } from '@wordpress/compose';
 
 /**
  * Generates an Edit component that works in the block editor
  * from the given HTML content.
  *
- * @param {Object} props      - The props for the component.
- * @param {string} props.html - The HTML content to render.
+ * @param {Object} props              - The props for the component.
+ * @param {Object} props.wrapperProps - The props for the block wrapper.
+ * @param {string} props.html         - The HTML content to render.
  * @return {JSX.Element} The Edit component.
  */
-const BlockFromHtml = ( { html = '' } ) => {
-	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( { ref: disabledRef } );
-
+const BlockFromHtml = ( { wrapperProps = {}, html = '' } ) => {
 	const options = {
 		replace: ( { name, type, attribs, parent, children } ) => {
 			if ( type === 'tag' && name ) {
@@ -30,7 +26,7 @@ const BlockFromHtml = ( { html = '' } ) => {
 				if ( ! parent ) {
 					const mergedProps = {
 						...parsedProps,
-						...blockProps,
+						...wrapperProps,
 					};
 					return (
 						<TagName { ...mergedProps }>

--- a/packages/block-library/src/utils/block-from-html.js
+++ b/packages/block-library/src/utils/block-from-html.js
@@ -8,6 +8,7 @@ import parse, { attributesToProps, domToReact } from 'html-react-parser';
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { safeHTML } from '@wordpress/dom';
+import { useDisabled } from '@wordpress/compose';
 
 /**
  * Generates an Edit component that works in the block editor
@@ -18,7 +19,9 @@ import { safeHTML } from '@wordpress/dom';
  * @return {JSX.Element} The Edit component.
  */
 const BlockFromHtml = ( { html = '' } ) => {
-	const blockProps = useBlockProps();
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
+
 	const options = {
 		replace: ( { name, type, attribs, parent, children } ) => {
 			if ( type === 'tag' && name ) {
@@ -38,8 +41,10 @@ const BlockFromHtml = ( { html = '' } ) => {
 			}
 		},
 	};
+
 	const sanitizedContent = safeHTML( html );
 	const parsedContent = parse( sanitizedContent, options );
+
 	return parsedContent;
 };
 

--- a/packages/block-library/src/utils/html-renderer.js
+++ b/packages/block-library/src/utils/html-renderer.js
@@ -9,15 +9,14 @@ import parse, { attributesToProps, domToReact } from 'html-react-parser';
 import { safeHTML } from '@wordpress/dom';
 
 /**
- * Generates an Edit component that works in the block editor
- * from the given HTML content.
+ * Renders HTML content as React elements with optional wrapper props.
  *
  * @param {Object} props              - The props for the component.
- * @param {Object} props.wrapperProps - The props for the block wrapper.
+ * @param {Object} props.wrapperProps - The props to merge with the root element.
  * @param {string} props.html         - The HTML content to render.
- * @return {JSX.Element} The Edit component.
+ * @return {JSX.Element} The rendered React elements.
  */
-const BlockFromHtml = ( { wrapperProps = {}, html = '' } ) => {
+const HtmlRenderer = ( { wrapperProps = {}, html = '' } ) => {
 	const options = {
 		replace: ( { name, type, attribs, parent, children } ) => {
 			if ( type === 'tag' && name ) {
@@ -44,4 +43,4 @@ const BlockFromHtml = ( { wrapperProps = {}, html = '' } ) => {
 	return parsedContent;
 };
 
-export default BlockFromHtml;
+export default HtmlRenderer;


### PR DESCRIPTION
- Fixes: #49226
- Alternatives to #49248

## What?

This PR is an experiment to remove the extra div wrapper in the editor, making the HTML in the front end and editor consistent.

This ensures that the same CSS selectors will correctly style the front end and editor, eliminating the need for special style overrides for the editor.

Before:

```html
<div tabindex="0" draggable="true" class="block-editor-block-list__block wp-block wp-block-tag-cloud" id="" role="document" aria-label="Block: Tag Cloud" data-block="" data-type="core/tag-cloud" data-title="Tag Cloud">
  <div inert="true">
    <div>
      <p class="wp-block-tag-cloud">
        <a href="" class="tag-cloud-link tag-link-1 tag-link-position-1" style="font-size: 8pt;" aria-label="Tag A (1 item)">Tag A</a>
        <a href="" class="tag-cloud-link tag-link-2 tag-link-position-2" style="font-size: 8pt;" aria-label="Tag B (1 item)">Tag B</a>
        <a href="" class="tag-cloud-link tag-link-3 tag-link-position-3" style="font-size: 8pt;" aria-label="Tag C (1 item)">Tag C</a>
      </p>
    </div>
  </div>
</div>
```

After:

```html
<p class="block-editor-block-list__block wp-block wp-block-tag-cloud" tabindex="0" draggable="true" id="" role="document" aria-label="Block: Tag Cloud" data-block="" data-type="core/tag-cloud" data-title="Tag Cloud">
  <a href="" class="tag-cloud-link tag-link-1 tag-link-position-1" aria-label="Tag A (1 item)" style="font-size: 8pt;">Tag A</a>
  <a href="" class="tag-cloud-link tag-link-2 tag-link-position-2" aria-label="Tag B (1 item)" style="font-size: 8pt;">Tag B</a>
  <a href="" class="tag-cloud-link tag-link-3 tag-link-position-3" aria-label="Tag C (1 item)" style="font-size: 8pt;">Tag C</a>
</p>
```


## Why?

The current specification requires at least two div wrappers to render a server-side rendered block's HTML as an Edit component:

- The div with the blockProps applied
- The div output by the `RawHTML` component

These extra div elements may require special CSS overrides for the editor.

## How?

I tried the following approach to generate a component that works in the block editor based on an HTML string:

- The HTML string is converted into a React element using [html-react-parser](https://www.npmjs.com/package/html-react-parser).
- The attributes that the HTML root element originally has are converted into props.
- These props are merged with the blockProps, which are required for the block to function.
- The HTML child elements are rendered as is.

This new component currently only accepts HTML content as props. As such, this component is primarily expected to work in conjunction with the `useServerSideRender` hook, but it's also possible to create blocks directly from arbitrary strings.

## Testing Instructions

- Insert a Tag Cloud block and verify that you can navigate the block toolbar and drag it around.
- The block sidebar settings work correctly.
- You can apply a default style to this block via global styles.

## Next Step

If this approach makes sense, I plan to:

- Apply this component to other dynamic blocks:
  - Breadcrumb
  - Calendar
  - Latest Comments
  - RSS
  - PHP-only blocks
- Expose `BlockFromHtml` as a public component