### PR TITLE
Query Loop: Add Random order option

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -23,6 +23,10 @@ const defaultOrderByOptions = [
 		label: __( 'Z → A' ),
 		value: 'title/desc',
 	},
+	{
+		label: __( 'Random' ),
+		value: 'rand/desc',
+	},
 ];
 
 function OrderControl( {

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -223,6 +223,10 @@ export function useOrderByOptions( postType ) {
 				label: __( 'Z → A' ),
 				value: 'title/desc',
 			},
+			{
+				label: __( 'Random' ),
+				value: 'rand/desc',
+			},
 		];
 
 		if ( supportsCustomOrder ) {


### PR DESCRIPTION
## What?
Add "Random" to the "Order by" dropdown options in the Query Loop block.

## Why?
Fixes #40481

Users often need to display dynamic content using random post order (e.g., featured posts on homepage, random recommendations). The ability to randomly order posts is a common requirement in WordPress themes.

## How?

### Files Modified:

| File | Change |
|------|--------|
| [packages/block-library/src/query/utils.js](cci:7://file:///Users/noruzzamanrubel/Local%20Sites/core/app/public/wp-content/plugins/gutenberg/packages/block-library/src/query/utils.js:0:0-0:0) | Added `{ label: 'Random', value: 'rand/desc' }` to [useOrderByOptions()](cci:1://file:///Users/noruzzamanrubel/Local%20Sites/core/app/public/wp-content/plugins/gutenberg/packages/block-library/src/query/utils.js:190:0-248:1) |
| [packages/block-library/src/query/edit/inspector-controls/order-control.js](cci:7://file:///Users/noruzzamanrubel/Local%20Sites/core/app/public/wp-content/plugins/gutenberg/packages/block-library/src/query/edit/inspector-controls/order-control.js:0:0-0:0) | Added `{ label: 'Random', value: 'rand/desc' }` to `defaultOrderByOptions` |

## Testing Instructions
1. Add a Query Loop block to a page
2. Set Query type to "Custom"
3. Open the "Order by" dropdown
4. Select "Random"
5. Save/Publish the page
6. View the page on frontend - posts should display in random order
7. Refresh the page - order should change

## Known Limitation

⚠️ **Editor preview shows "No results" or loading spinner when Random is selected.** This is a known REST API limitation - the WordPress REST API does not support `orderby=rand`. However, the **frontend works correctly** as it uses `WP_Query` which fully supports random ordering.

This is consistent with how WordPress handles random ordering in other contexts.
