### PR TITLE
Extensible Site Editor: Fix the dashboard link

### DIFF
--- a/packages/boot/src/components/app/index.tsx
+++ b/packages/boot/src/components/app/index.tsx
@@ -23,11 +23,13 @@ export async function init( {
 	menuItems,
 	routes,
 	initModules,
+	dashboardLink,
 }: {
 	mountId: string;
 	menuItems?: MenuItem[];
 	routes?: Route[];
 	initModules?: string[];
+	dashboardLink?: string;
 } ) {
 	( menuItems ?? [] ).forEach( ( menuItem ) => {
 		dispatch( store ).registerMenuItem( menuItem.id, menuItem );
@@ -36,6 +38,10 @@ export async function init( {
 	( routes ?? [] ).forEach( ( route ) => {
 		dispatch( store ).registerRoute( route );
 	} );
+
+	if ( dashboardLink ) {
+		dispatch( store ).setDashboardLink( dashboardLink );
+	}
 
 	for ( const moduleId of initModules ?? [] ) {
 		const module = await import( moduleId );

--- a/packages/boot/src/components/site-hub/index.tsx
+++ b/packages/boot/src/components/site-hub/index.tsx
@@ -22,16 +22,18 @@ import type { UnstableBase } from '@wordpress/core-data';
  * Internal dependencies
  */
 import SiteIconLink from '../site-icon-link';
+import { store as bootStore } from '../../store';
 import './style.scss';
 
 function SiteHub() {
-	const { homeUrl, siteTitle } = useSelect( ( select ) => {
+	const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
 		const { getEntityRecord } = select( coreStore );
 		const _base = getEntityRecord< UnstableBase >(
 			'root',
 			'__unstableBase'
 		);
 		return {
+			dashboardLink: select( bootStore ).getDashboardLink(),
 			homeUrl: _base?.home,
 			siteTitle:
 				! _base?.name && !! _base?.url
@@ -43,7 +45,10 @@ function SiteHub() {
 
 	return (
 		<div className="boot-site-hub">
-			<SiteIconLink to="/" aria-label={ __( 'Go to the Dashboard' ) } />
+			<SiteIconLink
+				to={ dashboardLink || '/' }
+				aria-label={ __( 'Go to the Dashboard' ) }
+			/>
 			<ExternalLink
 				href={ homeUrl ?? '/' }
 				className="boot-site-hub__title"

--- a/packages/boot/src/components/site-icon-link/index.tsx
+++ b/packages/boot/src/components/site-icon-link/index.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Link, privateApis as routePrivateApis } from '@wordpress/route';
+import { Tooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,21 +26,23 @@ function SiteIconLink( {
 	const canGoBack = useCanGoBack();
 
 	return (
-		<Link
-			to={ to }
-			aria-label={ props[ 'aria-label' ] }
-			className="boot-site-icon-link"
-			onClick={ ( event ) => {
-				// If possible, restore the previous page with
-				// filters etc.
-				if ( canGoBack && isBackButton ) {
-					event.preventDefault();
-					router.history.back();
-				}
-			} }
-		>
-			<SiteIcon />
-		</Link>
+		<Tooltip text={ props[ 'aria-label' ] } placement="right">
+			<Link
+				to={ to }
+				aria-label={ props[ 'aria-label' ] }
+				className="boot-site-icon-link"
+				onClick={ ( event ) => {
+					// If possible, restore the previous page with
+					// filters etc.
+					if ( canGoBack && isBackButton ) {
+						event.preventDefault();
+						router.history.back();
+					}
+				} }
+			>
+				<SiteIcon />
+			</Link>
+		</Tooltip>
 	);
 }
 

--- a/packages/boot/src/components/site-icon/style.scss
+++ b/packages/boot/src/components/site-icon/style.scss
@@ -7,7 +7,7 @@
 .boot-site-icon__icon {
 	width: variables.$grid-unit-40;
 	height: variables.$grid-unit-40;
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	fill: var(--wpds-color-fg-content-neutral, #1e1e1e);
 }
 
 .boot-site-icon__image {

--- a/packages/boot/src/store/actions.ts
+++ b/packages/boot/src/store/actions.ts
@@ -26,7 +26,15 @@ export function registerRoute( route: Route ) {
 	};
 }
 
+export function setDashboardLink( dashboardLink: string ) {
+	return {
+		type: 'SET_DASHBOARD_LINK' as const,
+		dashboardLink,
+	};
+}
+
 export type Action =
 	| ReturnType< typeof registerMenuItem >
 	| ReturnType< typeof updateMenuItem >
-	| ReturnType< typeof registerRoute >;
+	| ReturnType< typeof registerRoute >
+	| ReturnType< typeof setDashboardLink >;

--- a/packages/boot/src/store/reducer.ts
+++ b/packages/boot/src/store/reducer.ts
@@ -7,6 +7,7 @@ import type { State } from './types';
 const initialState: State = {
 	menuItems: {},
 	routes: [],
+	dashboardLink: undefined,
 };
 
 export function reducer( state: State = initialState, action: Action ): State {
@@ -36,6 +37,12 @@ export function reducer( state: State = initialState, action: Action ): State {
 			return {
 				...state,
 				routes: [ ...state.routes, action.route ],
+			};
+
+		case 'SET_DASHBOARD_LINK':
+			return {
+				...state,
+				dashboardLink: action.dashboardLink,
 			};
 	}
 

--- a/packages/boot/src/store/selectors.ts
+++ b/packages/boot/src/store/selectors.ts
@@ -10,3 +10,7 @@ export function getMenuItems( state: State ) {
 export function getRoutes( state: State ) {
 	return state.routes;
 }
+
+export function getDashboardLink( state: State ) {
+	return state.dashboardLink;
+}

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -163,4 +163,5 @@ export interface Route {
 export interface State {
 	menuItems: Record< string, MenuItem >;
 	routes: Route[];
+	dashboardLink?: string;
 }

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -169,11 +169,12 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 			wp_add_inline_script(
 				'{{PAGE_SLUG}}-prerequisites',
 				sprintf(
-					'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s}));',
+					'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"}));',
 					'{{PAGE_SLUG}}-app',
 					wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 					wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-					wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+					wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+					esc_url( admin_url( '/' ) )
 				)
 			);
 


### PR DESCRIPTION
## What?

Add dashboard link support to the boot package's SiteHub component, matching the functionality in edit-site.

## Testing
 - Enable the "extensible site editor" experiment
 - Navigate to the site editor
 - Ensure that you can can navigate back to the dashboard by clicking the logo.
