### PR TITLE
Command Palette: Fix in the font library page and site editor experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -47,10 +47,13 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalTemplateActivate = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalExtensibleSiteEditor = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );
-add_action( 'site-editor_init', 'gutenberg_enable_experiments' );
+add_action( 'site-editor-v2_init', 'gutenberg_enable_experiments' );
 
 /**
  * Sets a global JS variable used to trigger the availability of form & input blocks.

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -7,8 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { privateApis as routePrivateApis } from '@wordpress/route';
-// @ts-expect-error Commands is not typed properly.
-import { CommandMenu } from '@wordpress/commands';
 import { EditorSnackbars } from '@wordpress/editor';
 import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
 import {
@@ -69,7 +67,6 @@ export default function Root() {
 							'has-full-canvas': isFullScreen,
 						} ) }
 					>
-						<CommandMenu />
 						<SavePanel />
 						<EditorSnackbars />
 						{ isMobileViewport && (

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -7,9 +7,8 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { privateApis as routePrivateApis } from '@wordpress/route';
-// @ts-expect-error Commands is not typed properly.
-import { CommandMenu } from '@wordpress/commands';
 import { EditorSnackbars } from '@wordpress/editor';
+import { SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -42,35 +41,39 @@ export default function RootSinglePage() {
 	useRouteTitle();
 
 	return (
-		<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
-			<UserThemeProvider color={ { bg: '#1d2327' } }>
-				<div
-					className={ clsx( 'boot-layout boot-layout--single-page', {
-						'has-canvas': !! canvas || canvas === null,
-						'has-full-canvas': isFullScreen,
-					} ) }
-				>
-					<CommandMenu />
-					<SavePanel />
-					<EditorSnackbars />
-					<div className="boot-layout__surfaces">
-						<UserThemeProvider color={ { bg: '#ffffff' } }>
-							<Outlet />
-							{ /* Render Canvas in Root to prevent remounting on route changes */ }
-							{ ( canvas || canvas === null ) && (
-								<div className="boot-layout__canvas">
-									<CanvasRenderer
-										canvas={ canvas }
-										routeContentModule={
-											routeContentModule
-										}
-									/>
-								</div>
-							) }
-						</UserThemeProvider>
+		<SlotFillProvider>
+			<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
+				<UserThemeProvider color={ { bg: '#1d2327' } }>
+					<div
+						className={ clsx(
+							'boot-layout boot-layout--single-page',
+							{
+								'has-canvas': !! canvas || canvas === null,
+								'has-full-canvas': isFullScreen,
+							}
+						) }
+					>
+						<SavePanel />
+						<EditorSnackbars />
+						<div className="boot-layout__surfaces">
+							<UserThemeProvider color={ { bg: '#ffffff' } }>
+								<Outlet />
+								{ /* Render Canvas in Root to prevent remounting on route changes */ }
+								{ ( canvas || canvas === null ) && (
+									<div className="boot-layout__canvas">
+										<CanvasRenderer
+											canvas={ canvas }
+											routeContentModule={
+												routeContentModule
+											}
+										/>
+									</div>
+								) }
+							</UserThemeProvider>
+						</div>
 					</div>
-				</div>
+				</UserThemeProvider>
 			</UserThemeProvider>
-		</UserThemeProvider>
+		</SlotFillProvider>
 	);
 }

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -147,6 +147,11 @@ if ( ! function_exists( '{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
 		// Fire init action for extensions to register routes and menu items
 		do_action( '{{PAGE_SLUG}}_init' );
 
+		// Enqueue command palette assets for boot-based pages
+		if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
+			wp_enqueue_command_palette_assets();
+		}
+
 		// Preload REST API data
 		{{PAGE_SLUG_UNDERSCORE}}_preload_data();
 


### PR DESCRIPTION
This PR fixes the core command palette in both the fonts page and also on the same occasion fixes it in the extensible site editor experiment (enables core commands).

## Testing instructions

 - Navigate to the fonts page
 - cmd+k triggers the command palette and you can navigate to any wp-admin page.