### PR TITLE
tsconfig: Replace `skipDefaultLibCheck` with `skipLibCheck`

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,7 @@
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 
-		"skipDefaultLibCheck": true,
+		"skipLibCheck": true,
 
 		/* Strict Type-Checking Options */
 		"strict": true,


### PR DESCRIPTION
Extracting from https://github.com/WordPress/gutenberg/pull/74143#discussion_r2646099175, inspired by #74309

## What?
Update `tsconfig.base.json` to replace `skipDefaultLibCheck` with `skipLibCheck`

## Why?
`skipDefaultLibCheck` is deprecated, and it's recommended to use `skipLibCheck`. See [TS Docs](https://www.typescriptlang.org/tsconfig/#skipDefaultLibCheck)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- CI should be happy

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
