### PR TITLE
Docs: Fix Gutenberg Release Process link

### DIFF
--- a/docs/contributors/code/README.md
+++ b/docs/contributors/code/README.md
@@ -22,6 +22,6 @@ Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find 
 -   [Testing Overview](/docs/contributors/code/testing-overview.md) for PHP and JavaScript development in Gutenberg.
 -   [Accessibility Testing](/docs/contributors/accessibility-testing.md) documents the process of testing accessibility in Gutenberg.
 -   [Managing Packages](/docs/contributors/code/managing-packages.md) documents the process for managing the npm packages.
--   [Gutenberg Release Process](/docs/contributors/code/release/) - a checklist for the different types of releases for the Gutenberg project.
+-   [Gutenberg Release Process](/docs/contributors/code/release/README.md) - a checklist for the different types of releases for the Gutenberg project.
 -   [React Native mobile editor](/docs/contributors/code/react-native/README.md) - a guide on contributing to the React Native mobile editor.
 -   [React Native Integration Test Guide](/docs/contributors/code/react-native/integration-test-guide.md) - a guide on creating integration tests for the mobile editor.

--- a/docs/contributors/code/README.md
+++ b/docs/contributors/code/README.md
@@ -22,6 +22,6 @@ Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find 
 -   [Testing Overview](/docs/contributors/code/testing-overview.md) for PHP and JavaScript development in Gutenberg.
 -   [Accessibility Testing](/docs/contributors/accessibility-testing.md) documents the process of testing accessibility in Gutenberg.
 -   [Managing Packages](/docs/contributors/code/managing-packages.md) documents the process for managing the npm packages.
--   [Gutenberg Release Process](/docs/contributors/code/release.md) - a checklist for the different types of releases for the Gutenberg project.
+-   [Gutenberg Release Process](/docs/contributors/code/release/) - a checklist for the different types of releases for the Gutenberg project.
 -   [React Native mobile editor](/docs/contributors/code/react-native/README.md) - a guide on contributing to the React Native mobile editor.
 -   [React Native Integration Test Guide](/docs/contributors/code/react-native/integration-test-guide.md) - a guide on creating integration tests for the mobile editor.


### PR DESCRIPTION
Fixes a broken link to the Gutenberg Release Process documentation.
