### PR TITLE
Button: Migrate to width block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -101,8 +101,8 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url, width
+-	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2855,13 +2855,17 @@ class WP_Theme_JSON_Gutenberg {
 				$percentage = (float) $value;
 			}
 
-			// Case 2: Preset CSS var e.g. "var(--wp--preset--dimension--quarter)".
+			// Case 2: Preset CSS var e.g. "var(--wp--preset--dimension--50)".
 			if ( null === $percentage && is_string( $value ) && str_starts_with( $value, 'var(--wp--preset--dimension--' ) ) {
 				// Extract the slug from the var name.
 				$slug = substr( $value, strlen( 'var(--wp--preset--dimension--' ), -1 );
 
-				// Look up the preset size across all origins.
-				$dimension_sizes = $settings['dimensions']['dimensionSizes'] ?? array();
+				/*
+				 * Look up the preset size across all origins.
+				 * Check block-level settings first (core/button), then top-level settings.
+				 */
+				$dimension_sizes = ( $settings['blocks']['core/button']['dimensions']['dimensionSizes'] ?? array() )
+					+ ( $settings['dimensions']['dimensionSizes'] ?? array() );
 				foreach ( $dimension_sizes as $origin_sizes ) {
 					if ( ! is_array( $origin_sizes ) ) {
 						continue;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2822,6 +2822,84 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Updates button width declarations to use a calc() formula for percentage values.
+	 *
+	 * When a percentage width is set on the Button block via Global Styles, the
+	 * resulting CSS needs to account for block gap spacing so that buttons tile
+	 * correctly on a row (e.g. 4 buttons at 25% width all fit on one row).
+	 *
+	 * This mirrors the dynamic calc() formula applied at the block instance level
+	 * in the button block's stylesheet (style.scss).
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $feature_declarations The feature declarations keyed by selector.
+	 * @param array $settings             The theme.json settings.
+	 * @return array The updated feature declarations.
+	 */
+	private static function update_button_width_declarations( $feature_declarations, $settings ) {
+		if ( ! isset( $feature_declarations['.wp-block-button'] ) ) {
+			return $feature_declarations;
+		}
+
+		foreach ( $feature_declarations['.wp-block-button'] as &$declaration ) {
+			if ( 'width' !== $declaration['name'] || ! isset( $declaration['value'] ) ) {
+				continue;
+			}
+
+			$value      = $declaration['value'];
+			$percentage = null;
+
+			// Case 1: Direct percentage value e.g. "25%".
+			if ( is_string( $value ) && str_ends_with( $value, '%' ) ) {
+				$percentage = (float) $value;
+			}
+
+			// Case 2: Preset CSS var e.g. "var(--wp--preset--dimension--quarter)".
+			if ( null === $percentage && is_string( $value ) && str_starts_with( $value, 'var(--wp--preset--dimension--' ) ) {
+				// Extract the slug from the var name.
+				$slug = substr( $value, strlen( 'var(--wp--preset--dimension--' ), -1 );
+
+				// Look up the preset size across all origins.
+				$dimension_sizes = $settings['dimensions']['dimensionSizes'] ?? array();
+				foreach ( $dimension_sizes as $origin_sizes ) {
+					if ( ! is_array( $origin_sizes ) ) {
+						continue;
+					}
+					foreach ( $origin_sizes as $preset ) {
+						if ( isset( $preset['slug'] ) && $slug === $preset['slug'] && isset( $preset['size'] ) ) {
+							$size = $preset['size'];
+							if ( is_string( $size ) && str_ends_with( $size, '%' ) ) {
+								$percentage = (float) $size;
+							}
+							break 2;
+						}
+					}
+				}
+			}
+
+			if ( null === $percentage ) {
+				continue;
+			}
+
+			/*
+			 * Apply the same calc() formula as the block instance level (style.scss).
+			 * The numeric percentage value is used as a unitless number:
+			 * - Multiplied by 1% to get the percentage width.
+			 * - Divided by 100 to calculate the gap adjustment proportion.
+			 */
+			$declaration['value'] = sprintf(
+				'calc(%s * 1%% - (var(--wp--style--block-gap, 0.5em) * (1 - %s / 100)))',
+				$percentage,
+				$percentage
+			);
+		}
+		unset( $declaration );
+
+		return $feature_declarations;
+	}
+
+	/**
 	 * Updates the text indent selector for paragraph blocks based on the textIndent setting.
 	 *
 	 * The textIndent setting can be 'subsequent' (default), 'all', or false.
@@ -3029,6 +3107,9 @@ class WP_Theme_JSON_Gutenberg {
 		$block_name           = $block_metadata['name'] ?? null;
 		$feature_declarations = static::update_paragraph_text_indent_selector( $feature_declarations, $settings, $block_name );
 
+		// Update button width declarations for percentage values to use calc() with block gap.
+		$feature_declarations = static::update_button_width_declarations( $feature_declarations, $settings );
+
 		// If there are style variations, generate the declarations for them, including any feature selectors the block may have.
 		$style_variation_declarations    = array();
 		$style_variation_custom_css      = array();
@@ -3043,6 +3124,9 @@ class WP_Theme_JSON_Gutenberg {
 
 				// Update text indent selector for paragraph blocks based on the textIndent setting.
 				$variation_declarations = static::update_paragraph_text_indent_selector( $variation_declarations, $settings, $block_name );
+
+				// Update button width declarations for percentage values to use calc() with block gap.
+				$variation_declarations = static::update_button_width_declarations( $variation_declarations, $settings );
 
 				// Combine selectors with style variation's selector and add to overall style variation declarations.
 				foreach ( $variation_declarations as $current_selector => $new_declarations ) {

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -316,6 +316,30 @@
 			"core/button": {
 				"border": {
 					"radius": true
+				},
+				"dimensions": {
+					"dimensionSizes": [
+						{
+							"name": "25%",
+							"slug": "25",
+							"size": "25%"
+						},
+						{
+							"name": "50%",
+							"slug": "50",
+							"size": "50%"
+						},
+						{
+							"name": "75%",
+							"slug": "75",
+							"size": "75%"
+						},
+						{
+							"name": "100%",
+							"slug": "100",
+							"size": "100%"
+						}
+					]
 				}
 			},
 			"core/image": {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -406,6 +406,7 @@ _Parameters_
 -   _props.label_ `?string`: A label for the control.
 -   _props.onChange_ `( value: string ) => void`: Called when the dimension value changes.
 -   _props.value_ `string`: The current dimension value.
+-   _props.dimensionSizes_ `?Object`: Optional dimension size presets. Falls back to settings from the store.
 
 _Returns_
 

--- a/packages/block-editor/src/components/dimension-control/index.js
+++ b/packages/block-editor/src/components/dimension-control/index.js
@@ -55,9 +55,10 @@ function useDimensionSizes( presets ) {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/dimension-control/README.md
  *
  * @param {Object}                     props
- * @param {?string}                    props.label    A label for the control.
- * @param {( value: string ) => void } props.onChange Called when the dimension value changes.
- * @param {string}                     props.value    The current dimension value.
+ * @param {?string}                    props.label          A label for the control.
+ * @param {( value: string ) => void } props.onChange       Called when the dimension value changes.
+ * @param {string}                     props.value          The current dimension value.
+ * @param {?Object}                    props.dimensionSizes Optional dimension size presets. Falls back to settings from the store.
  *
  * @return {Component} The component to be rendered.
  */
@@ -65,11 +66,13 @@ export default function DimensionControl( {
 	label = __( 'Dimension' ),
 	onChange,
 	value,
+	dimensionSizes: dimensionSizesProp,
 } ) {
-	const [ dimensionSizes, availableUnits ] = useSettings(
+	const [ dimensionSizesFromSettings, availableUnits ] = useSettings(
 		'dimensions.dimensionSizes',
 		'spacing.units'
 	);
+	const dimensionSizes = dimensionSizesProp ?? dimensionSizesFromSettings;
 
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -735,6 +735,7 @@ export default function DimensionsPanel( {
 						label={ __( 'Minimum height' ) }
 						value={ minHeightValue }
 						onChange={ setMinHeightValue }
+						dimensionSizes={ dimensions?.dimensionSizes }
 					/>
 				</ToolsPanelItem>
 			) }
@@ -752,6 +753,7 @@ export default function DimensionsPanel( {
 						label={ __( 'Height' ) }
 						value={ heightValue }
 						onChange={ setHeightValue }
+						dimensionSizes={ dimensions?.dimensionSizes }
 					/>
 				</ToolsPanelItem>
 			) }
@@ -769,6 +771,7 @@ export default function DimensionsPanel( {
 						label={ __( 'Width' ) }
 						value={ widthValue }
 						onChange={ setWidthValue }
+						dimensionSizes={ dimensions?.dimensionSizes }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/hooks/test/dimensions.js
+++ b/packages/block-editor/src/hooks/test/dimensions.js
@@ -93,4 +93,20 @@ describe( 'getDimensionsClassesAndStyles', () => {
 			},
 		} );
 	} );
+
+	it( 'should convert preset width value to CSS var', () => {
+		const attributes = {
+			style: {
+				dimensions: {
+					width: 'var:preset|dimension|custom-width',
+				},
+			},
+		};
+		expect( getDimensionsClassesAndStyles( attributes ) ).toEqual( {
+			className: undefined,
+			style: {
+				width: 'var(--wp--preset--dimension--custom-width)',
+			},
+		} );
+	} );
 } );

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -11,6 +11,7 @@ export {
 	useColorProps as __experimentalUseColorProps,
 	useCustomSides as __experimentalUseCustomSides,
 	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
+	getDimensionsClassesAndStyles as __experimentalGetDimensionsClassesAndStyles,
 	getGapCSSValue as __experimentalGetGapCSSValue,
 	getShadowClassesAndStyles as __experimentalGetShadowClassesAndStyles,
 	useCachedTruthy,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -63,9 +63,6 @@
 		},
 		"gradient": {
 			"type": "string"
-		},
-		"width": {
-			"type": "number"
 		}
 	},
 	"supports": {
@@ -79,6 +76,13 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
+			}
+		},
+		"dimensions": {
+			"width": true,
+			"__experimentalSkipSerialization": [ "width" ],
+			"__experimentalDefaultControls": {
+				"width": true
 			}
 		},
 		"typography": {
@@ -145,6 +149,10 @@
 		"root": ".wp-block-button .wp-block-button__link",
 		"typography": {
 			"writingMode": ".wp-block-button"
+		},
+		"dimensions": {
+			"root": ".wp-block-button",
+			"width": ".wp-block-button"
 		}
 	}
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -312,7 +312,7 @@ function ButtonEdit( props ) {
 		}
 		if ( isPercentageWidth( resolvedWidth ) ) {
 			return {
-				'--wp--block-button--width': parseInt( resolvedWidth, 10 ),
+				'--wp--block-button--width': parseFloat( resolvedWidth ),
 			};
 		}
 		return dimensionsProps.style;

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -12,10 +12,6 @@ import {
 	ToolbarButton,
 	Popover,
 	ExternalLink,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -27,6 +23,7 @@ import {
 	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	__experimentalGetShadowClassesAndStyles as useShadowProps,
+	__experimentalGetDimensionsClassesAndStyles as useDimensionsProps,
 	__experimentalGetElementClassName,
 	store as blockEditorStore,
 	useBlockEditingMode,
@@ -47,9 +44,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { unlock } from '../lock-unlock';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
+import { getWidthClasses, isPercentageWidth } from './utils';
 
 const { HTMLElementControl } = unlock( blockEditorPrivateApis );
 
@@ -117,49 +114,6 @@ function useEnter( props ) {
 	}, [] );
 }
 
-function WidthPanel( { selectedWidth, setAttributes } ) {
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
-	return (
-		<ToolsPanel
-			label={ __( 'Settings' ) }
-			resetAll={ () => setAttributes( { width: undefined } ) }
-			dropdownMenuProps={ dropdownMenuProps }
-		>
-			<ToolsPanelItem
-				label={ __( 'Width' ) }
-				isShownByDefault
-				hasValue={ () => !! selectedWidth }
-				onDeselect={ () => setAttributes( { width: undefined } ) }
-			>
-				<ToggleGroupControl
-					label={ __( 'Width' ) }
-					value={ selectedWidth }
-					onChange={ ( newWidth ) =>
-						setAttributes( { width: newWidth } )
-					}
-					isBlock
-					__next40pxDefaultSize
-				>
-					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-						return (
-							<ToggleGroupControlOption
-								key={ widthValue }
-								value={ widthValue }
-								label={ sprintf(
-									/* translators: %d: Percentage value. */
-									__( '%d%%' ),
-									widthValue
-								) }
-							/>
-						);
-					} ) }
-				</ToggleGroupControl>
-			</ToolsPanelItem>
-		</ToolsPanel>
-	);
-}
-
 function ButtonEdit( props ) {
 	const {
 		attributes,
@@ -179,9 +133,10 @@ function ButtonEdit( props ) {
 		style,
 		text,
 		url,
-		width,
 		metadata,
 	} = attributes;
+	const width = style?.dimensions?.width;
+
 	useDeprecatedTextAlign( props );
 
 	const TagName = tagName || 'a';
@@ -203,6 +158,7 @@ function ButtonEdit( props ) {
 	const colorProps = useColorProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
 	const shadowProps = useShadowProps( attributes );
+	const dimensionsProps = useDimensionsProps( attributes );
 	const ref = useRef();
 	const richTextRef = useRef();
 	const blockProps = useBlockProps( {
@@ -304,10 +260,21 @@ function ButtonEdit( props ) {
 	const useEnterRef = useEnter( { content: text, clientId } );
 	const mergedRef = useMergeRefs( [ useEnterRef, richTextRef ] );
 
-	const [ fluidTypographySettings, layout ] = useSettings(
+	const [ fluidTypographySettings, layout, dimensionSizes ] = useSettings(
 		'typography.fluid',
-		'layout'
+		'layout',
+		'dimensions.dimensionSizes'
 	);
+	const dimensionPresets = useMemo( () => {
+		if ( ! dimensionSizes ) {
+			return [];
+		}
+		return [
+			...( dimensionSizes?.custom ?? [] ),
+			...( dimensionSizes?.theme ?? [] ),
+			...( dimensionSizes?.default ?? [] ),
+		];
+	}, [ dimensionSizes ] );
 	const typographyProps = useTypographyProps( attributes, {
 		typography: {
 			fluid: fluidTypographySettings,
@@ -317,18 +284,46 @@ function ButtonEdit( props ) {
 		},
 	} );
 
+	// Resolve preset dimension references to their actual values.
+	const resolvedWidth = useMemo( () => {
+		if ( ! width ) {
+			return undefined;
+		}
+		const presetPrefix = 'var:preset|dimension|';
+		if ( width.startsWith( presetPrefix ) ) {
+			const slug = width.slice( presetPrefix.length );
+			const preset = dimensionPresets?.find( ( p ) => p.slug === slug );
+			return preset?.size ?? width;
+		}
+		return width;
+	}, [ width, dimensionPresets ] );
+
 	const hasNonContentControls = blockEditingMode === 'default';
 	const hasBlockControls =
 		hasNonContentControls || ( isLinkTag && ! lockUrlControls );
+	const classes = clsx(
+		blockProps.className,
+		getWidthClasses( resolvedWidth )
+	);
+
+	const widthStyle = useMemo( () => {
+		if ( ! width ) {
+			return {};
+		}
+		if ( isPercentageWidth( resolvedWidth ) ) {
+			return {
+				'--wp--block-button--width': parseInt( resolvedWidth, 10 ),
+			};
+		}
+		return dimensionsProps.style;
+	}, [ width, resolvedWidth, dimensionsProps.style ] );
 
 	return (
 		<>
 			<div
 				{ ...blockProps }
-				className={ clsx( blockProps.className, {
-					[ `has-custom-width wp-block-button__width-${ width }` ]:
-						width,
-				} ) }
+				className={ classes }
+				style={ { ...blockProps.style, ...widthStyle } }
 			>
 				<RichText
 					ref={ mergedRef }
@@ -432,12 +427,6 @@ function ButtonEdit( props ) {
 						/>
 					</Popover>
 				) }
-			<InspectorControls>
-				<WidthPanel
-					selectedWidth={ width }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
 			<InspectorControls group="advanced">
 				<HTMLElementControl
 					tagName={ tagName }

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -60,6 +60,67 @@ function render_block_core_button( $attributes, $content ) {
 		return '';
 	}
 
+	$width = $attributes['style']['dimensions']['width'] ?? null;
+
+	if ( $width ) {
+		// Resolve preset references to their actual values.
+		$resolved_width = $width;
+		$is_preset      = str_starts_with( $width, 'var:preset|dimension|' );
+
+		if ( $is_preset ) {
+			$slug              = substr( $width, strlen( 'var:preset|dimension|' ) );
+			$dimension_presets = wp_get_global_settings(
+				array( 'dimensions', 'dimensionSizes' ),
+				array( 'block_name' => 'core/button' )
+			);
+
+			// Search origins in priority order: custom > theme > default.
+			if ( is_array( $dimension_presets ) ) {
+				foreach ( array( 'custom', 'theme', 'default' ) as $origin ) {
+					if ( empty( $dimension_presets[ $origin ] ) || ! is_array( $dimension_presets[ $origin ] ) ) {
+						continue;
+					}
+					foreach ( $dimension_presets[ $origin ] as $preset ) {
+						if ( isset( $preset['slug'] ) && $preset['slug'] === $slug ) {
+							$resolved_width = $preset['size'] ?? $width;
+							break 2;
+						}
+					}
+				}
+			}
+		}
+
+		$is_percentage = str_ends_with( $resolved_width, '%' );
+
+		$p = new WP_HTML_Tag_Processor( $content );
+		// Target the outer wrapper div.
+		if ( $p->next_tag( array( 'class_name' => 'wp-block-button' ) ) ) {
+			if ( $is_percentage ) {
+				$numeric_width = (int) $resolved_width;
+				$p->add_class( 'wp-block-button__width' );
+
+				// Maintain legacy class for the standard percentage widths.
+				$legacy_widths = array( 25, 50, 75, 100 );
+				if ( in_array( $numeric_width, $legacy_widths, true ) ) {
+					$p->add_class( 'wp-block-button__width-' . $numeric_width );
+				}
+
+				$existing_style = $p->get_attribute( 'style' ) ?? '';
+				$width_style    = "--wp--block-button--width: $numeric_width;";
+				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
+			} else {
+				$css_value      = $is_preset
+					? 'var(--wp--preset--dimension--' . $slug . ')'
+					: $resolved_width;
+				$existing_style = $p->get_attribute( 'style' ) ?? '';
+				$width_style    = "width: $css_value;";
+				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
+			}
+
+			$content = $p->get_updated_html();
+		}
+	}
+
 	return $content;
 }
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -95,6 +95,9 @@ function render_block_core_button( $attributes, $content ) {
 		$p = new WP_HTML_Tag_Processor( $content );
 		// Target the outer wrapper div.
 		if ( $p->next_tag( array( 'class_name' => 'wp-block-button' ) ) ) {
+			$p->add_class( 'has-custom-width' );
+			$existing_style = $p->get_attribute( 'style' ) ?? '';
+
 			if ( $is_percentage ) {
 				$numeric_width = (int) $resolved_width;
 				$p->add_class( 'wp-block-button__width' );
@@ -105,15 +108,10 @@ function render_block_core_button( $attributes, $content ) {
 					$p->add_class( 'wp-block-button__width-' . $numeric_width );
 				}
 
-				$existing_style = $p->get_attribute( 'style' ) ?? '';
 				$width_style    = "--wp--block-button--width: $numeric_width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			} else {
-				$css_value      = $is_preset
-					? 'var(--wp--preset--dimension--' . $slug . ')'
-					: $resolved_width;
-				$existing_style = $p->get_attribute( 'style' ) ?? '';
-				$width_style    = "width: $css_value;";
+				$width_style    = "width: $width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -99,13 +99,18 @@ function render_block_core_button( $attributes, $content ) {
 			$existing_style = $p->get_attribute( 'style' ) ?? '';
 
 			if ( $is_percentage ) {
-				$numeric_width = (int) $resolved_width;
+				$numeric_width = (float) $resolved_width;
 				$p->add_class( 'wp-block-button__width' );
 
 				// Maintain legacy class for the standard percentage widths.
-				$legacy_widths = array( 25, 50, 75, 100 );
-				if ( in_array( $numeric_width, $legacy_widths, true ) ) {
-					$p->add_class( 'wp-block-button__width-' . $numeric_width );
+				$legacy_widths = array(
+					'25%'  => 'wp-block-button__width-25',
+					'50%'  => 'wp-block-button__width-50',
+					'75%'  => 'wp-block-button__width-75',
+					'100%' => 'wp-block-button__width-100',
+				);
+				if ( isset( $legacy_widths[ $resolved_width ] ) ) {
+					$p->add_class( $legacy_widths[ $resolved_width ] );
 				}
 
 				$width_style    = "--wp--block-button--width: $numeric_width;";

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -113,10 +113,10 @@ function render_block_core_button( $attributes, $content ) {
 					$p->add_class( $legacy_widths[ $resolved_width ] );
 				}
 
-				$width_style    = "--wp--block-button--width: $numeric_width;";
+				$width_style = "--wp--block-button--width: $numeric_width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			} else {
-				$width_style    = "width: $width;";
+				$width_style = "width: $width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -92,15 +92,16 @@ function render_block_core_button( $attributes, $content ) {
 
 		$is_percentage = str_ends_with( $resolved_width, '%' );
 
-		$p = new WP_HTML_Tag_Processor( $content );
+		$processor = new WP_HTML_Tag_Processor( $content );
 		// Target the outer wrapper div.
-		if ( $p->next_tag( array( 'class_name' => 'wp-block-button' ) ) ) {
-			$p->add_class( 'has-custom-width' );
-			$existing_style = $p->get_attribute( 'style' ) ?? '';
+		if ( $processor->next_tag( array( 'class_name' => 'wp-block-button' ) ) ) {
+			$processor->add_class( 'has-custom-width' );
+			$existing_style = $processor->get_attribute( 'style' );
+			$existing_style = is_string( $existing_style ) ? $existing_style : '';
 
 			if ( $is_percentage ) {
 				$numeric_width = (float) $resolved_width;
-				$p->add_class( 'wp-block-button__width' );
+				$processor->add_class( 'wp-block-button__width' );
 
 				// Maintain legacy class for the standard percentage widths.
 				$legacy_widths = array(
@@ -110,20 +111,20 @@ function render_block_core_button( $attributes, $content ) {
 					'100%' => 'wp-block-button__width-100',
 				);
 				if ( isset( $legacy_widths[ $resolved_width ] ) ) {
-					$p->add_class( $legacy_widths[ $resolved_width ] );
+					$processor->add_class( $legacy_widths[ $resolved_width ] );
 				}
 
 				$width_style = "--wp--block-button--width: $numeric_width;";
-				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
+				$processor->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			} else {
 				$css_value   = $is_preset
 					? 'var(--wp--preset--dimension--' . _wp_to_kebab_case( $slug ) . ')'
 					: $width;
 				$width_style = "width: $css_value;";
-				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
+				$processor->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			}
 
-			$content = $p->get_updated_html();
+			$content = $processor->get_updated_html();
 		}
 	}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -116,10 +116,10 @@ function render_block_core_button( $attributes, $content ) {
 				$width_style = "--wp--block-button--width: $numeric_width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			} else {
-			    $css_value   = $is_preset
-			        ? 'var(--wp--preset--dimension--' . _wp_to_kebab_case( $slug ) . ')'
-			        : $width;
-			    $width_style = "width: $css_value;";
+				$css_value   = $is_preset
+					? 'var(--wp--preset--dimension--' . _wp_to_kebab_case( $slug ) . ')'
+					: $width;
+				$width_style = "width: $css_value;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -116,7 +116,10 @@ function render_block_core_button( $attributes, $content ) {
 				$width_style = "--wp--block-button--width: $numeric_width;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			} else {
-				$width_style = "width: $width;";
+			    $css_value   = $is_preset
+			        ? 'var(--wp--preset--dimension--' . _wp_to_kebab_case( $slug ) . ')'
+			        : $width;
+			    $width_style = "width: $css_value;";
 				$p->set_attribute( 'style', $width_style . ( $existing_style ? ' ' . $existing_style : '' ) );
 			}
 

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -13,17 +13,11 @@ import {
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
-	__experimentalGetDimensionsClassesAndStyles as getDimensionsClassesAndStyles,
 	__experimentalGetElementClassName,
 	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
 
-/**
- * Internal dependencies
- */
-import { getWidthClasses, isPercentageWidth } from './utils';
-
-export default function save( { attributes, className } ) {
+export default function save( { attributes } ) {
 	const {
 		tagName,
 		type,
@@ -35,8 +29,6 @@ export default function save( { attributes, className } ) {
 		title,
 		url,
 	} = attributes;
-	const { width } = style?.dimensions || {};
-
 	const TagName = tagName || 'a';
 	const isButtonTag = 'button' === TagName;
 	const buttonType = type || 'button';
@@ -44,7 +36,6 @@ export default function save( { attributes, className } ) {
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
-	const dimensionsProps = getDimensionsClassesAndStyles( attributes );
 	const typographyProps = getTypographyClassesAndStyles( attributes );
 	const buttonClasses = clsx(
 		'wp-block-button__link',
@@ -72,23 +63,8 @@ export default function save( { attributes, className } ) {
 	// if it had already been assigned, for the sake of backward-compatibility.
 	// A title will no longer be assigned for new or updated button block links.
 
-	const wrapperClasses = clsx( className, getWidthClasses( width ) );
-
-	// Apply width styles to wrapper
-	let wrapperStyle = {};
-	if ( width ) {
-		wrapperStyle = isPercentageWidth( width )
-			? { '--wp--block-button--width': parseInt( width, 10 ) }
-			: dimensionsProps.style;
-	}
-
 	return (
-		<div
-			{ ...useBlockProps.save( {
-				className: wrapperClasses,
-				style: wrapperStyle,
-			} ) }
-		>
+		<div { ...useBlockProps.save() }>
 			<RichText.Content
 				tagName={ TagName }
 				type={ isButtonTag ? buttonType : null }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -13,9 +13,15 @@ import {
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
+	__experimentalGetDimensionsClassesAndStyles as getDimensionsClassesAndStyles,
 	__experimentalGetElementClassName,
 	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { getWidthClasses, isPercentageWidth } from './utils';
 
 export default function save( { attributes, className } ) {
 	const {
@@ -28,8 +34,8 @@ export default function save( { attributes, className } ) {
 		text,
 		title,
 		url,
-		width,
 	} = attributes;
+	const { width } = style?.dimensions || {};
 
 	const TagName = tagName || 'a';
 	const isButtonTag = 'button' === TagName;
@@ -38,6 +44,7 @@ export default function save( { attributes, className } ) {
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
+	const dimensionsProps = getDimensionsClassesAndStyles( attributes );
 	const typographyProps = getTypographyClassesAndStyles( attributes );
 	const buttonClasses = clsx(
 		'wp-block-button__link',
@@ -65,12 +72,23 @@ export default function save( { attributes, className } ) {
 	// if it had already been assigned, for the sake of backward-compatibility.
 	// A title will no longer be assigned for new or updated button block links.
 
-	const wrapperClasses = clsx( className, {
-		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
-	} );
+	const wrapperClasses = clsx( className, getWidthClasses( width ) );
+
+	// Apply width styles to wrapper
+	let wrapperStyle = {};
+	if ( width ) {
+		wrapperStyle = isPercentageWidth( width )
+			? { '--wp--block-button--width': parseInt( width, 10 ) }
+			: dimensionsProps.style;
+	}
 
 	return (
-		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+		<div
+			{ ...useBlockProps.save( {
+				className: wrapperClasses,
+				style: wrapperStyle,
+			} ) }
+		>
 			<RichText.Content
 				tagName={ TagName }
 				type={ isButtonTag ? buttonType : null }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -55,16 +55,41 @@ $blocks-block__margin: 0.5em;
 		}
 	}
 
+	&[class*="wp-block-button__width"] {
+		width:
+			calc(var(--wp--block-button--width) * 1% -
+			(
+				var(--wp--style--block-gap, #{$blocks-block__margin}) *
+				( 1 - var(--wp--block-button--width) / 100 )
+			));
+	}
+
+	// Legacy width classes for backwards compatibility.
 	&.wp-block-button__width-25 {
-		width: calc(25% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75));
+		width:
+			calc(25% -
+			(
+				var(--wp--style--block-gap, #{$blocks-block__margin}) *
+				0.75
+			));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5));
+		width:
+			calc(50% -
+			(
+				var(--wp--style--block-gap, #{$blocks-block__margin}) *
+				0.5
+			));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25));
+		width:
+			calc(75% -
+			(
+				var(--wp--style--block-gap, #{$blocks-block__margin}) *
+				0.25
+			));
 	}
 
 	&.wp-block-button__width-100 {
@@ -75,6 +100,11 @@ $blocks-block__margin: 0.5em;
 
 // For vertical buttons, gap is not factored into width calculations.
 .wp-block-buttons.is-vertical > .wp-block-button {
+	&[class*="wp-block-button__width"] {
+		width: calc(var(--wp--block-button--width) * 1%);
+	}
+
+	// Legacy width classes for backwards compatibility.
 	&.wp-block-button__width-25 {
 		width: 25%;
 	}
@@ -110,13 +140,25 @@ $blocks-block__margin: 0.5em;
 		padding: 0.667em 1.333em;
 	}
 
-	:where(.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-text-color)),
-	:where(.wp-block-button .wp-block-button__link.is-style-outline:not(.has-text-color)) {
+	:where(
+	.wp-block-button.is-style-outline
+	> .wp-block-button__link:not(.has-text-color)
+),
+	:where(
+	.wp-block-button
+	.wp-block-button__link.is-style-outline:not(.has-text-color)
+) {
 		color: currentColor;
 	}
 
-	:where(.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background)),
-	:where(.wp-block-button .wp-block-button__link.is-style-outline:not(.has-background)) {
+	:where(
+	.wp-block-button.is-style-outline
+	> .wp-block-button__link:not(.has-background)
+),
+	:where(
+	.wp-block-button
+	.wp-block-button__link.is-style-outline:not(.has-background)
+) {
 		background-color: transparent;
 		// background-image is required to overwrite a gradient background
 		background-image: none;

--- a/packages/block-library/src/button/test/utils.js
+++ b/packages/block-library/src/button/test/utils.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { getWidthClasses, isPercentageWidth } from '../utils';
+
+describe( 'isPercentageWidth', () => {
+	it( 'should return true for percentage values', () => {
+		expect( isPercentageWidth( '50%' ) ).toBe( true );
+		expect( isPercentageWidth( '100%' ) ).toBe( true );
+		expect( isPercentageWidth( '33.5%' ) ).toBe( true );
+	} );
+
+	it( 'should return false for non-percentage values', () => {
+		expect( isPercentageWidth( '200px' ) ).toBe( false );
+		expect( isPercentageWidth( '10em' ) ).toBe( false );
+		expect( isPercentageWidth( undefined ) ).toBe( false );
+		expect( isPercentageWidth( null ) ).toBe( false );
+	} );
+
+	it( 'should return false for preset strings', () => {
+		expect( isPercentageWidth( 'var:preset|dimension|custom-width' ) ).toBe(
+			false
+		);
+	} );
+} );
+
+describe( 'getWidthClasses', () => {
+	it( 'should return empty object when no width is provided', () => {
+		expect( getWidthClasses( undefined ) ).toEqual( {} );
+		expect( getWidthClasses( '' ) ).toEqual( {} );
+		expect( getWidthClasses( null ) ).toEqual( {} );
+	} );
+
+	it( 'should return percentage classes for standard percentage widths', () => {
+		expect( getWidthClasses( '25%' ) ).toEqual( {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+			'wp-block-button__width-25': true,
+		} );
+
+		expect( getWidthClasses( '50%' ) ).toEqual( {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+			'wp-block-button__width-50': true,
+		} );
+
+		expect( getWidthClasses( '75%' ) ).toEqual( {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+			'wp-block-button__width-75': true,
+		} );
+
+		expect( getWidthClasses( '100%' ) ).toEqual( {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+			'wp-block-button__width-100': true,
+		} );
+	} );
+
+	it( 'should return generic percentage classes for non-standard percentage widths', () => {
+		expect( getWidthClasses( '33%' ) ).toEqual( {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+		} );
+	} );
+
+	it( 'should return only has-custom-width for non-percentage values', () => {
+		expect( getWidthClasses( '200px' ) ).toEqual( {
+			'has-custom-width': true,
+		} );
+
+		expect( getWidthClasses( '10em' ) ).toEqual( {
+			'has-custom-width': true,
+		} );
+	} );
+
+	it( 'should return only has-custom-width for resolved non-percentage preset values', () => {
+		// When a preset resolves to a non-percentage value (e.g., 200px),
+		// the resolved value is passed to getWidthClasses, not the preset string.
+		expect( getWidthClasses( '300px' ) ).toEqual( {
+			'has-custom-width': true,
+		} );
+	} );
+} );

--- a/packages/block-library/src/button/utils.js
+++ b/packages/block-library/src/button/utils.js
@@ -15,21 +15,24 @@ export function isPercentageWidth( width ) {
  * @return {Object} Object with width-related class names as keys and true as values.
  */
 export function getWidthClasses( width ) {
-	const legacyPercentageWidths = [ '25%', '50%', '75%', '100%' ];
-
 	if ( ! width ) {
 		return {};
 	}
 
 	if ( isPercentageWidth( width ) ) {
-		const numericWidth = parseInt( width, 10 );
+		const legacyWidthClasses = {
+			'25%': 'wp-block-button__width-25',
+			'50%': 'wp-block-button__width-50',
+			'75%': 'wp-block-button__width-75',
+			'100%': 'wp-block-button__width-100',
+		};
 		return {
 			'has-custom-width': true,
 			'wp-block-button__width': true,
 			// Maintain legacy class for backwards compatibility.
-			...( legacyPercentageWidths.includes( width )
-				? { [ `wp-block-button__width-${ numericWidth }` ]: true }
-				: {} ),
+			...( legacyWidthClasses[ width ] && {
+				[ legacyWidthClasses[ width ] ]: true,
+			} ),
 		};
 	}
 

--- a/packages/block-library/src/button/utils.js
+++ b/packages/block-library/src/button/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Returns whether the given width value is a percentage.
+ *
+ * @param {string} width - The width value.
+ * @return {boolean} True if the width is a percentage value.
+ */
+export function isPercentageWidth( width ) {
+	return typeof width === 'string' && width.endsWith( '%' );
+}
+
+/**
+ * Returns the width classes for the button based on the width attribute.
+ *
+ * @param {string} width - The width value (e.g., '25%', '50%', '75%', '100%', or custom value).
+ * @return {Object} Object with width-related class names as keys and true as values.
+ */
+export function getWidthClasses( width ) {
+	const legacyPercentageWidths = [ '25%', '50%', '75%', '100%' ];
+
+	if ( ! width ) {
+		return {};
+	}
+
+	if ( isPercentageWidth( width ) ) {
+		const numericWidth = parseInt( width, 10 );
+		return {
+			'has-custom-width': true,
+			'wp-block-button__width': true,
+			// Maintain legacy class for backwards compatibility.
+			...( legacyPercentageWidths.includes( width )
+				? { [ `wp-block-button__width-${ numericWidth }` ]: true }
+				: {} ),
+		};
+	}
+
+	return {
+		'has-custom-width': true,
+	};
+}

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -906,4 +906,127 @@ describe( 'global styles renderer', () => {
 			} );
 		} );
 	} );
+
+	describe( 'button width declarations', () => {
+		it( 'should convert direct percentage width to calc() formula', () => {
+			const tree: GlobalStylesConfig = {
+				settings: {},
+				styles: {
+					blocks: {
+						'core/button': {
+							dimensions: {
+								width: '25%',
+							},
+						},
+					},
+				},
+			};
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					featureSelectors: {
+						dimensions: {
+							root: '.wp-block-button',
+							width: '.wp-block-button',
+						},
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-button){width: calc(25 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 25 / 100)));}'
+			);
+		} );
+
+		it( 'should convert preset percentage width to calc() formula', () => {
+			const tree: GlobalStylesConfig = {
+				settings: {
+					blocks: {
+						'core/button': {
+							dimensions: {
+								dimensionSizes: {
+									default: [
+										{
+											slug: '50',
+											name: '50%',
+											size: '50%',
+										},
+									],
+								},
+							},
+						},
+					},
+				},
+				styles: {
+					blocks: {
+						'core/button': {
+							dimensions: {
+								width: 'var:preset|dimension|50',
+							},
+						},
+					},
+				},
+			};
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					featureSelectors: {
+						dimensions: {
+							root: '.wp-block-button',
+							width: '.wp-block-button',
+						},
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-button){width: calc(50 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 50 / 100)));}'
+			);
+		} );
+
+		it( 'should not convert non-percentage width', () => {
+			const tree: GlobalStylesConfig = {
+				settings: {},
+				styles: {
+					blocks: {
+						'core/button': {
+							dimensions: {
+								width: '200px',
+							},
+						},
+					},
+				},
+			};
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					featureSelectors: {
+						dimensions: {
+							root: '.wp-block-button',
+							width: '.wp-block-button',
+						},
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-button){width: 200px;}'
+			);
+		} );
+	} );
 } );

--- a/phpunit/blocks/render-block-button-test.php
+++ b/phpunit/blocks/render-block-button-test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Button block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Button block.
+ *
+ * @group blocks
+ */
+class Render_Block_Button_Test extends WP_UnitTestCase {
+
+	/**
+	 * Button content with a link element.
+	 *
+	 * @var string
+	 */
+	private static $button_content = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Click me</a></div>';
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_empty_button_renders_nothing() {
+		$content = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"></a></div>';
+		$result  = gutenberg_render_block_core_button( array(), $content );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_button_without_width_returns_content_unchanged() {
+		$result = gutenberg_render_block_core_button( array(), self::$button_content );
+		$this->assertStringNotContainsString( 'has-custom-width', $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_non_percentage_fixed_width_applies_inline_style() {
+		$attributes = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => '200px',
+				),
+			),
+		);
+
+		$result = gutenberg_render_block_core_button( $attributes, self::$button_content );
+
+		$this->assertStringContainsString( 'has-custom-width', $result );
+		$this->assertStringContainsString( 'width: 200px;', $result );
+		$this->assertStringNotContainsString( 'wp-block-button__width', $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_non_percentage_preset_width_applies_css_var() {
+		$attributes = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => 'var:preset|dimension|custom-width',
+				),
+			),
+		);
+
+		$result = gutenberg_render_block_core_button( $attributes, self::$button_content );
+
+		$this->assertStringContainsString( 'has-custom-width', $result );
+		$this->assertStringContainsString( 'width: var(--wp--preset--dimension--custom-width);', $result );
+		$this->assertStringNotContainsString( 'wp-block-button__width', $result );
+		$this->assertStringNotContainsString( 'var:preset|dimension|custom-width', $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_percentage_width_applies_custom_property_and_classes() {
+		$attributes = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => '50%',
+				),
+			),
+		);
+
+		$result = gutenberg_render_block_core_button( $attributes, self::$button_content );
+
+		$this->assertStringContainsString( 'has-custom-width', $result );
+		$this->assertStringContainsString( 'wp-block-button__width', $result );
+		$this->assertStringContainsString( 'wp-block-button__width-50', $result );
+		$this->assertStringContainsString( '--wp--block-button--width: 50;', $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_percentage_preset_width_applies_custom_property_and_classes() {
+		// Use the default '50' dimension preset which resolves to '50%'.
+		$attributes = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => 'var:preset|dimension|50',
+				),
+			),
+		);
+
+		$result = gutenberg_render_block_core_button( $attributes, self::$button_content );
+
+		$this->assertStringContainsString( 'has-custom-width', $result );
+		$this->assertStringContainsString( 'wp-block-button__width', $result );
+		$this->assertStringContainsString( 'wp-block-button__width-50', $result );
+		$this->assertStringContainsString( '--wp--block-button--width: 50;', $result );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_button
+	 */
+	public function test_custom_percentage_width_adds_generic_class_without_legacy() {
+		$attributes = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => '33%',
+				),
+			),
+		);
+
+		$result = gutenberg_render_block_core_button( $attributes, self::$button_content );
+
+		$this->assertStringContainsString( 'has-custom-width', $result );
+		$this->assertStringContainsString( 'wp-block-button__width', $result );
+		$this->assertStringNotContainsString( 'wp-block-button__width-33', $result );
+		$this->assertStringContainsString( '--wp--block-button--width: 33;', $result );
+	}
+}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5257,7 +5257,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function data_update_button_width_declarations() {
 		return array(
-			'direct percentage value'              => array(
+			'direct percentage value'                   => array(
 				array(
 					'styles' => array(
 						'blocks' => array(
@@ -5271,7 +5271,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => ':root :where(.wp-block-button){width: calc(25 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 25 / 100)));}',
 			),
-			'decimal percentage value'             => array(
+			'decimal percentage value'                  => array(
 				array(
 					'styles' => array(
 						'blocks' => array(
@@ -5285,7 +5285,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => ':root :where(.wp-block-button){width: calc(33.33 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 33.33 / 100)));}',
 			),
-			'non-percentage value is unchanged'    => array(
+			'non-percentage value is unchanged'         => array(
 				array(
 					'styles' => array(
 						'blocks' => array(
@@ -5299,14 +5299,43 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => ':root :where(.wp-block-button){width: 200px;}',
 			),
-			'preset dimension with percentage size' => array(
+			'preset dimension with percentage size (block-level settings)' => array(
+				array(
+					'settings' => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'dimensionSizes' => array(
+										array(
+											'slug' => '50',
+											'name' => '50%',
+											'size' => '50%',
+										),
+									),
+								),
+							),
+						),
+					),
+					'styles'   => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => 'var(--wp--preset--dimension--50)',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: calc(50 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 50 / 100)));}',
+			),
+			'preset dimension with percentage size (top-level settings)' => array(
 				array(
 					'settings' => array(
 						'dimensions' => array(
 							'dimensionSizes' => array(
 								array(
-									'slug' => 'quarter',
-									'name' => 'Quarter',
+									'slug' => '25',
+									'name' => '25%',
 									'size' => '25%',
 								),
 							),
@@ -5316,7 +5345,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'blocks' => array(
 							'core/button' => array(
 								'dimensions' => array(
-									'width' => 'var(--wp--preset--dimension--quarter)',
+									'width' => 'var(--wp--preset--dimension--25)',
 								),
 							),
 						),
@@ -5327,12 +5356,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'preset dimension with non-percentage size' => array(
 				array(
 					'settings' => array(
-						'dimensions' => array(
-							'dimensionSizes' => array(
-								array(
-									'slug' => 'wide',
-									'name' => 'Wide',
-									'size' => '400px',
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'dimensionSizes' => array(
+										array(
+											'slug' => 'wide',
+											'name' => 'Wide',
+											'size' => '400px',
+										),
+									),
 								),
 							),
 						),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5215,6 +5215,143 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that button block width declarations are updated for percentage values.
+	 *
+	 * @dataProvider data_update_button_width_declarations
+	 *
+	 * @param array  $theme_json_args Theme JSON arguments including styles and optional settings.
+	 * @param string $expected_output Expected CSS output.
+	 */
+	public function test_update_button_width_declarations( $theme_json_args, $expected_output ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array_merge(
+				array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA ),
+				$theme_json_args
+			),
+			'default'
+		);
+
+		$button_node = array(
+			'name'       => 'core/button',
+			'path'       => array( 'styles', 'blocks', 'core/button' ),
+			'selector'   => '.wp-block-button .wp-block-button__link',
+			'selectors'  => array(
+				'root'       => '.wp-block-button .wp-block-button__link',
+				'dimensions' => array(
+					'root'  => '.wp-block-button',
+					'width' => '.wp-block-button',
+				),
+			),
+			'duotone'    => null,
+			'variations' => array(),
+			'css'        => '.wp-block-button .wp-block-button__link',
+		);
+		$this->assertSame( $expected_output, $theme_json->get_styles_for_block( $button_node ) );
+	}
+
+	/**
+	 * Data provider for button width declaration tests.
+	 *
+	 * @return array
+	 */
+	public function data_update_button_width_declarations() {
+		return array(
+			'direct percentage value'              => array(
+				array(
+					'styles' => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => '25%',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: calc(25 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 25 / 100)));}',
+			),
+			'decimal percentage value'             => array(
+				array(
+					'styles' => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => '33.33%',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: calc(33.33 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 33.33 / 100)));}',
+			),
+			'non-percentage value is unchanged'    => array(
+				array(
+					'styles' => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => '200px',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: 200px;}',
+			),
+			'preset dimension with percentage size' => array(
+				array(
+					'settings' => array(
+						'dimensions' => array(
+							'dimensionSizes' => array(
+								array(
+									'slug' => 'quarter',
+									'name' => 'Quarter',
+									'size' => '25%',
+								),
+							),
+						),
+					),
+					'styles'   => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => 'var(--wp--preset--dimension--quarter)',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: calc(25 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 25 / 100)));}',
+			),
+			'preset dimension with non-percentage size' => array(
+				array(
+					'settings' => array(
+						'dimensions' => array(
+							'dimensionSizes' => array(
+								array(
+									'slug' => 'wide',
+									'name' => 'Wide',
+									'size' => '400px',
+								),
+							),
+						),
+					),
+					'styles'   => array(
+						'blocks' => array(
+							'core/button' => array(
+								'dimensions' => array(
+									'width' => 'var(--wp--preset--dimension--wide)',
+								),
+							),
+						),
+					),
+				),
+				'expected_output' => ':root :where(.wp-block-button){width: var(--wp--preset--dimension--wide);}',
+			),
+		);
+	}
+
 	public function test_shadow_preset_styles() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -266,28 +266,77 @@ test.describe( 'Buttons', () => {
 		] );
 	} );
 
-	test( 'can resize width', async ( { editor, page } ) => {
-		await editor.insertBlock( { name: 'core/buttons' } );
-		await page.keyboard.type( 'Content' );
-		await editor.openDocumentSettingsSidebar();
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tab', { name: 'Settings' } )
-			.click();
-		await page
-			.getByRole( 'radiogroup', { name: 'Width' } )
-			.getByRole( 'radio', { name: '25%' } )
-			.click();
+	test.describe( 'Width support', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'emptytheme' );
+		} );
 
-		// Check the content.
-		const content = await editor.getEditedPostContent();
-		expect( content ).toBe(
-			`<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"width":25} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-25"><a class="wp-block-button__link wp-element-button">Content</a></div>
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'twentytwentyone' );
+		} );
+
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
+		} );
+
+		test( 'can resize width', async ( { editor, page } ) => {
+			// Mock spacing units to include % for the width control
+			await page.waitForFunction( () => window?.wp?.data );
+			await page.evaluate( () => {
+				const settings = window.wp.data
+					.select( 'core/block-editor' )
+					.getSettings();
+				window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {
+					...settings,
+					spacing: { units: [ 'px', '%', 'em', 'rem', 'vh', 'vw' ] },
+				} );
+			} );
+
+			await editor.insertBlock( { name: 'core/buttons' } );
+			await page.keyboard.type( 'Content' );
+
+			// Select the inner Button block (not the outer Buttons container)
+			const buttonBlock = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} )
+				.filter( { hasText: 'Content' } );
+			await editor.selectBlocks( buttonBlock );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const settingsPanel = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			// Switch from preset slider to custom value input
+			await settingsPanel
+				.getByRole( 'group', { name: 'Width' } )
+				.getByLabel( 'Set custom value' )
+				.click();
+
+			// Change the unit from px to % using the combobox
+			await settingsPanel
+				.getByRole( 'combobox', { name: 'Select unit' } )
+				.first()
+				.selectOption( '%' );
+
+			// Set the width value
+			await settingsPanel
+				.getByRole( 'spinbutton', { name: 'Width', exact: true } )
+				.fill( '25' );
+
+			// Check the content.
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-25" style="--wp--block-button--width:25"><a class="wp-block-button__link wp-element-button">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
-		);
+			);
+		} );
 	} );
 
 	test( 'can apply named colors', async ( { editor, page } ) => {
@@ -295,10 +344,6 @@ test.describe( 'Buttons', () => {
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
 
-		// Switch to the Styles tab.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
-		);
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
@@ -324,10 +369,6 @@ test.describe( 'Buttons', () => {
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
 
-		// Switch to the Styles tab.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
-		);
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
@@ -359,10 +400,6 @@ test.describe( 'Buttons', () => {
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
 
-		// Switch to the Styles tab.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
-		);
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
@@ -388,10 +425,6 @@ test.describe( 'Buttons', () => {
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
 
-		// Switch to the Styles tab.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
-		);
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -332,7 +332,7 @@ test.describe( 'Buttons', () => {
 			expect( content ).toBe(
 				`<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-25" style="--wp--block-button--width:25"><a class="wp-block-button__link wp-element-button">Content</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Content</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 			);

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -893,12 +893,7 @@ test.describe( 'Registered sources', () => {
 				} )
 				.getByRole( 'textbox' )
 				.click();
-			await page
-				.getByRole( 'tabpanel', {
-					name: 'Settings',
-				} )
-				.getByLabel( 'Attributes options' )
-				.click();
+			await page.getByLabel( 'Attributes options' ).click();
 			const urlAttribute = page.getByRole( 'menuitemcheckbox', {
 				name: 'Show url',
 			} );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -234,12 +234,6 @@ test.describe( 'Contrast Checker', () => {
 			name: 'Editor settings',
 		} );
 
-		await editorSettings
-			.getByRole( 'tab', {
-				name: 'Styles',
-			} )
-			.click();
-
 		// Set text color to black
 		const textButton = editorSettings.getByRole( 'button', {
 			name: 'Text',
@@ -279,12 +273,6 @@ test.describe( 'Contrast Checker', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-
-		await editorSettings
-			.getByRole( 'tab', {
-				name: 'Styles',
-			} )
-			.click();
 
 		// Set text color to black
 		const textButton = editorSettings.getByRole( 'button', {

--- a/test/integration/fixtures/blocks/core__button__custom-width.html
+++ b/test/integration/fixtures/blocks/core__button__custom-width.html
@@ -1,5 +1,3 @@
 <!-- wp:button {"style":{"dimensions":{"width":"150px"}}} -->
-<div class="wp-block-button has-custom-width" style="width: 150px">
-	<a class="wp-block-button__link wp-element-button">Custom Width Button</a>
-</div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Custom Width Button</a></div>
 <!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__custom-width.html
+++ b/test/integration/fixtures/blocks/core__button__custom-width.html
@@ -1,0 +1,5 @@
+<!-- wp:button {"style":{"dimensions":{"width":"150px"}}} -->
+<div class="wp-block-button has-custom-width" style="width: 150px">
+	<a class="wp-block-button__link wp-element-button">Custom Width Button</a>
+</div>
+<!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__custom-width.json
+++ b/test/integration/fixtures/blocks/core__button__custom-width.json
@@ -1,0 +1,17 @@
+[
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "Custom Width Button",
+			"style": {
+				"dimensions": {
+					"width": "150px"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__custom-width.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__custom-width.parsed.json
@@ -9,9 +9,9 @@
 			}
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<div class=\"wp-block-button has-custom-width\" style=\"width: 150px\">\n\t<a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a>\n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a></div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-button has-custom-width\" style=\"width: 150px\">\n\t<a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a>\n</div>\n"
+			"\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a></div>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__button__custom-width.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__custom-width.parsed.json
@@ -1,0 +1,17 @@
+[
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"style": {
+				"dimensions": {
+					"width": "150px"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-width\" style=\"width: 150px\">\n\t<a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-width\" style=\"width: 150px\">\n\t<a class=\"wp-block-button__link wp-element-button\">Custom Width Button</a>\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__custom-width.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__custom-width.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:button {"style":{"dimensions":{"width":"150px"}}} -->
+<div class="wp-block-button has-custom-width" style="width:150px"><a class="wp-block-button__link wp-element-button">Custom Width Button</a></div>
+<!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__custom-width.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__custom-width.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:button {"style":{"dimensions":{"width":"150px"}}} -->
-<div class="wp-block-button has-custom-width" style="width:150px"><a class="wp-block-button__link wp-element-button">Custom Width Button</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Custom Width Button</a></div>
 <!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v14.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v14.html
@@ -1,0 +1,23 @@
+<!-- wp:button {"width":25} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-25">
+	<a class="wp-block-button__link wp-element-button">Button 25%</a>
+</div>
+<!-- /wp:button -->
+
+<!-- wp:button {"width":50} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-50">
+	<a class="wp-block-button__link wp-element-button">Button 50%</a>
+</div>
+<!-- /wp:button -->
+
+<!-- wp:button {"width":75} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-75">
+	<a class="wp-block-button__link wp-element-button">Button 75%</a>
+</div>
+<!-- /wp:button -->
+
+<!-- wp:button {"width":100} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100">
+	<a class="wp-block-button__link wp-element-button">Button 100%</a>
+</div>
+<!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v14.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v14.json
@@ -1,0 +1,62 @@
+[
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "Button 25%",
+			"style": {
+				"dimensions": {
+					"width": "25%"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "Button 50%",
+			"style": {
+				"dimensions": {
+					"width": "50%"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "Button 75%",
+			"style": {
+				"dimensions": {
+					"width": "75%"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "Button 100%",
+			"style": {
+				"dimensions": {
+					"width": "100%"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v14.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v14.parsed.json
@@ -1,0 +1,67 @@
+[
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"width": 25
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-width wp-block-button__width-25\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 25%</a>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-width wp-block-button__width-25\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 25%</a>\n</div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"width": 50
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-width wp-block-button__width-50\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 50%</a>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-width wp-block-button__width-50\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 50%</a>\n</div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"width": 75
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-width wp-block-button__width-75\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 75%</a>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-width wp-block-button__width-75\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 75%</a>\n</div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"width": 100
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-width wp-block-button__width-100\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 100%</a>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-width wp-block-button__width-100\">\n\t<a class=\"wp-block-button__link wp-element-button\">Button 100%</a>\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v14.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v14.serialized.html
@@ -1,15 +1,15 @@
 <!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-25" style="--wp--block-button--width:25"><a class="wp-block-button__link wp-element-button">Button 25%</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button 25%</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"style":{"dimensions":{"width":"50%"}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-50" style="--wp--block-button--width:50"><a class="wp-block-button__link wp-element-button">Button 50%</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button 50%</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"style":{"dimensions":{"width":"75%"}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-75" style="--wp--block-button--width:75"><a class="wp-block-button__link wp-element-button">Button 75%</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button 75%</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"style":{"dimensions":{"width":"100%"}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-100" style="--wp--block-button--width:100"><a class="wp-block-button__link wp-element-button">Button 100%</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button 100%</a></div>
 <!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v14.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v14.serialized.html
@@ -1,0 +1,15 @@
+<!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-25" style="--wp--block-button--width:25"><a class="wp-block-button__link wp-element-button">Button 25%</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"dimensions":{"width":"50%"}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-50" style="--wp--block-button--width:50"><a class="wp-block-button__link wp-element-button">Button 50%</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"dimensions":{"width":"75%"}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-75" style="--wp--block-button--width:75"><a class="wp-block-button__link wp-element-button">Button 75%</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"dimensions":{"width":"100%"}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width wp-block-button__width-100" style="--wp--block-button--width:100"><a class="wp-block-button__link wp-element-button">Button 100%</a></div>
+<!-- /wp:button -->


### PR DESCRIPTION
## What?
Migrates the Button block from using an ad-hoc `width` attribute to the `dimensions.width` block support.

## Why?
- Consolidates width handling with the standard block supports system
- Enables global styles support for button width via theme.json
- Allows users to use any width value/unit (not just 25/50/75/100%)
- Allows themes to provide dimension presets via theme.json
- Reduces custom code in the Button block

## How?
- Removed the `width` attribute from block.json
- Added `dimensions.width` support with default controls enabled
- The Button block defines selectors for dimensions in block.json so that global styles and preset CSS vars target the outer button block wrapper rather than the inner link element
- Removed custom WidthPanel component (now uses DimensionsPanel from block supports)
- Added v14 deprecation to migrate numeric width values to `style.dimensions.width` format
- Updated all previous deprecations to include width migration in the chain
- Maintained backward-compatible CSS classes for percentage widths
- When a percentage width is set via Global Styles or theme.json (either as a direct value or a dimension preset), both the PHP renderer and the JS style engine convert it to a `calc()` formula that subtracts a proportional share of the block gap — matching the block-instance-level behavior in `style.scss` — so that buttons tile correctly on a row (e.g. 4 buttons at 25% fit side-by-side without overflowing)
- Depends on #75226

## Testing Instructions
1. Create a new Button block and verify the width control appears in the Dimensions panel
2. Set various width values (25%, 150px, 50vw) and verify they render correctly
3. Open an existing post with buttons that have width set - verify they still render correctly (deprecation migration)
4. In Global Styles > Blocks > Button, set a width value and verify it applies to all buttons
5. Override the global width on a specific button instance using the block inspector
6. Verify the instance-level width overrides the global width
7. Confirm that the default dimension presets work as expected
8. Override dimension presets at the `settings.blocks.core/button.dimensions.dimensionSizes` level and confirm they work
9. In Global Styles > Blocks > Button, set a percentage width (e.g. 25%) and add 4 buttons in a row — verify they tile side-by-side without overflowing (the generated CSS should use a `calc()` formula, not a plain `width: 25%`)
10. Repeat step 9 using a dimension preset that resolves to a percentage value and verify the same tiling behavior

## UX Change
The width control changes from a toggle group with preset buttons (25/50/75/100%) to a dimension control that accepts any value. Default dimension sizes for the Button block have been added in `lib/theme.json` so that the preset 25/50/75/100 values are there.

The core difference now is that, instead of a toggle button group, the dimension control renders the presets as a segmented slider control.

### Backward Compatibility
- All existing buttons with numeric width values migrate automatically
- Width CSS classes (`wp-block-button__width-25`, etc.) are preserved for percentage values
- All 14 deprecation versions include width migration

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/4f1447d7-edcf-4cde-b230-aa293a01e1a6

