### PR TITLE
Footnotes: escape dynamic output to meet coding standards

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -22,7 +22,6 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Bail if the post is password protected.
 	if ( post_password_required( $block->context['postId'] ) ) {
 		return '';
 	}
@@ -51,7 +50,7 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 			'<li id="%1$s">%2$s <a href="#%1$s-link" aria-label="%3$s">↩︎</a></li>',
 			esc_attr( $footnote['id'] ),
 			wp_kses_post( $footnote['content'] ),
-			$aria_label
+			esc_attr( $aria_label )
 		);
 		++$footnote_index;
 	}

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -22,14 +22,15 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Bail if the post is password protected.
 	if ( post_password_required( $block->context['postId'] ) ) {
-		return;
+		return '';
 	}
 
 	$footnotes = get_post_meta( $block->context['postId'], 'footnotes', true );
 
 	if ( ! $footnotes ) {
-		return;
+		return '';
 	}
 
 	$footnotes = json_decode( $footnotes, true );
@@ -48,8 +49,8 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 		$aria_label     = sprintf( __( 'Jump to footnote reference %1$d' ), $footnote_index );
 		$block_content .= sprintf(
 			'<li id="%1$s">%2$s <a href="#%1$s-link" aria-label="%3$s">↩︎</a></li>',
-			$footnote['id'],
-			$footnote['content'],
+			esc_attr( $footnote['id'] ),
+			wp_kses_post( $footnote['content'] ),
 			$aria_label
 		);
 		++$footnote_index;

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -106,6 +106,7 @@ function register_block_core_footnotes_post_meta() {
 		}
 	}
 }
+
 /*
  * Most post types are registered at priority 10, so use priority 20 here in
  * order to catch them.


### PR DESCRIPTION
## What
Escapes dynamic footnote IDs and sanitizes footnote content in the Footnotes block output.

## Why
Aligns server-rendered output with WordPress coding standards and hardens output handling without changing behavior.

## References
Fixes https://core.trac.wordpress.org/ticket/64454
