### PR TITLE
Env: Fixes Parsing special WP.org urls for plugins

### DIFF
--- a/packages/env/lib/config/parse-source-string.js
+++ b/packages/env/lib/config/parse-source-string.js
@@ -69,8 +69,9 @@ function parseSourceString( sourceString, { cacheDirectoryPath } ) {
 
 	if ( zipFields ) {
 		const rawBasename = path.basename( zipFields[ 1 ] );
+		// Strip version suffixes like .1.2.3, .latest-stable, .trunk, .dev, etc.
 		const basename = encodeURIComponent(
-			rawBasename.replace( /\.(\d+\.)*\d+$/, '' )
+			rawBasename.replace( /\.((\d+\.)*\d+|[a-z][\w-]*)$/i, '' )
 		);
 
 		return {

--- a/packages/env/lib/config/test/parse-source-string.js
+++ b/packages/env/lib/config/test/parse-source-string.js
@@ -83,14 +83,42 @@ describe( 'parseSourceString', () => {
 			} );
 		} );
 
+		it( 'should parse WordPress.org latest-stable sources', () => {
+			expect(
+				parseSourceString(
+					'https://downloads.wordpress.org/plugin/two-factor.latest-stable.zip',
+					options
+				)
+			).toEqual( {
+				basename: 'two-factor',
+				path: '/test/cache/two-factor',
+				type: 'zip',
+				url: 'https://downloads.wordpress.org/plugin/two-factor.latest-stable.zip',
+			} );
+		} );
+
 		it( 'should parse other sources', () => {
 			expect(
-				parseSourceString( 'http://test.com/testing.zip', options )
+				parseSourceString( 'http://example.com/testing.zip', options )
 			).toEqual( {
 				basename: 'testing',
 				path: '/test/cache/testing',
 				type: 'zip',
-				url: 'http://test.com/testing.zip',
+				url: 'http://example.com/testing.zip',
+			} );
+		} );
+
+		it( 'should strip version suffix from zip sources', () => {
+			expect(
+				parseSourceString(
+					'https://example.org/example-plugin.1.2.3.zip',
+					options
+				)
+			).toEqual( {
+				basename: 'example-plugin',
+				path: '/test/cache/example-plugin',
+				type: 'zip',
+				url: 'https://example.org/example-plugin.1.2.3.zip',
 			} );
 		} );
 	} );


### PR DESCRIPTION
## What?
Following #74195 I've noted that certain WP.org URL like: 
`https://downloads.wordpress.org/plugin/two-factor.latest-stable.zip`

Are not being properly parsed resulting folder like `two-factor.latest-stable`

This is not a regression: Before this patch these URL were not parsed correctly either.

## Why?
This PR aims to fix this and to add some unit tests to cover this. 

Also I forgot to add some unit tests for #74195, so adding them here.

## How?
Improving the regex, so more suffixes are included like `.latest-stable`, `.trunk`, `.dev`, plus obviously the regular versioning, both for WP.org and any other URL. 

## Testing Instructions
Add in `.wp-env.json` something like this:
```
"plugins": [
        "https://downloads.wordpress.org/plugin/two-factor.latest-stable.zip"
]
```
1. Check if the plugin is correctly loaded
2. Check the format of the directory (should be `two-factor` instead of `two-factor.latest-stable`)

PS: @ObliviousHarmony never use `test.com` for tests 🙀! `example.org` or `example.com`