### PR TITLE
Test: Update URLs in tests to use example.org/com instead of test.com

### DIFF
--- a/packages/block-editor/src/components/link-control/test/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/test/is-url-like.js
@@ -44,12 +44,12 @@ describe( 'isURLLike', () => {
 	// use .each to test multiple cases
 	it.each( [
 		[ true, 'http://example.com' ],
-		[ true, 'https://test.co.uk?query=param' ],
-		[ true, 'ftp://openai.ai?param=value#section' ],
+		[ true, 'https://example.org?query=param' ],
+		[ true, 'ftp://example.org?param=value#section' ],
 		[ true, 'example.com' ],
 		[ true, 'http://example.com?query=param#section' ],
-		[ true, 'https://test.co.uk/some/path' ],
-		[ true, 'ftp://openai.ai/some/path' ],
+		[ true, 'https://example.org/some/path' ],
+		[ true, 'ftp://example.org/some/path' ],
 		[ true, 'example.org/some/path' ],
 		[ true, 'example_test.tld' ],
 		[ true, 'example_test.com' ],

--- a/packages/env/lib/config/test/add-or-replace-port.js
+++ b/packages/env/lib/config/test/add-or-replace-port.js
@@ -14,24 +14,24 @@ describe( 'addOrReplacePort', () => {
 			// Addition
 			{ in: 'test', expect: 'test:101' },
 			{ in: 'test/test?test#test', expect: 'test:101/test?test#test' },
-			{ in: 'http://test.com', expect: 'http://test.com:101' },
+			{ in: 'http://example.org', expect: 'http://example.org:101' },
 			{
-				in: 'http://test.com/test?test#test',
-				expect: 'http://test.com:101/test?test#test',
+				in: 'http://example.org/test?test#test',
+				expect: 'http://example.org:101/test?test#test',
 			},
-			{ in: 'ssh://test.com', expect: 'ssh://test.com:101' },
-			{ in: 'test.com', expect: 'test.com:101' },
+			{ in: 'ssh://example.org', expect: 'ssh://example.org:101' },
+			{ in: 'example.org', expect: 'example.org:101' },
 
 			// Replacement
 			{ in: 'test:99', expect: 'test:101' },
 			{ in: 'test:99/test?test#test', expect: 'test:101/test?test#test' },
-			{ in: 'http://test.com:99', expect: 'http://test.com:101' },
+			{ in: 'http://example.org:99', expect: 'http://example.org:101' },
 			{
-				in: 'http://test.com:99/test?test#test',
-				expect: 'http://test.com:101/test?test#test',
+				in: 'http://example.org:99/test?test#test',
+				expect: 'http://example.org:101/test?test#test',
 			},
-			{ in: 'ssh://test.com:99', expect: 'ssh://test.com:101' },
-			{ in: 'test.com:99', expect: 'test.com:101' },
+			{ in: 'ssh://example.org:99', expect: 'ssh://example.org:101' },
+			{ in: 'example.org:99', expect: 'example.org:101' },
 		];
 
 		for ( const test of testMap ) {

--- a/packages/env/lib/config/test/parse-source-string.js
+++ b/packages/env/lib/config/test/parse-source-string.js
@@ -85,12 +85,12 @@ describe( 'parseSourceString', () => {
 
 		it( 'should parse other sources', () => {
 			expect(
-				parseSourceString( 'http://test.com/testing.zip', options )
+				parseSourceString( 'http://example.com/testing.zip', options )
 			).toEqual( {
 				basename: 'testing',
 				path: '/test/cache/testing',
 				type: 'zip',
-				url: 'http://test.com/testing.zip',
+				url: 'http://example.com/testing.zip',
 			} );
 		} );
 	} );

--- a/packages/env/lib/config/test/validate-config.js
+++ b/packages/env/lib/config/test/validate-config.js
@@ -330,10 +330,10 @@ describe( 'validate-config', () => {
 
 		it( 'passes for valid URLs', () => {
 			expect( () =>
-				checkValidURL( 'test.json', 'test', 'http://test.com' )
+				checkValidURL( 'test.json', 'test', 'http://example.com' )
 			).not.toThrow();
 			expect( () =>
-				checkValidURL( 'test.json', 'test', 'https://test.com' )
+				checkValidURL( 'test.json', 'test', 'https://example.com' )
 			).not.toThrow();
 			expect( () =>
 				checkValidURL( 'test.json', 'test', 'http://test' )
@@ -346,16 +346,13 @@ describe( 'validate-config', () => {
 				)
 			).not.toThrow();
 			expect( () =>
-				checkValidURL( 'test.json', 'test', 'http://test.co.uk' )
-			).not.toThrow();
-			expect( () =>
-				checkValidURL( 'test.json', 'test', 'https://test.co.uk:8888' )
+				checkValidURL( 'test.json', 'test', 'https://example.org:8888' )
 			).not.toThrow();
 			expect( () =>
 				checkValidURL(
 					'test.json',
 					'test',
-					'http://test.co.uk:8888/test?test=test#test'
+					'http://example.org:8888/test?test=test#test'
 				)
 			).not.toThrow();
 		} );

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -17,61 +17,61 @@ describe( 'isValidHref', () => {
 	describe( 'URLs beginning with a protocol', () => {
 		it( 'returns true for valid URLs', () => {
 			expect( isValidHref( 'tel:+123456789' ) ).toBe( true );
-			expect( isValidHref( 'mailto:test@somewhere.com' ) ).toBe( true );
+			expect( isValidHref( 'mailto:test@example.org' ) ).toBe( true );
 			expect( isValidHref( 'file:///c:/WINDOWS/winamp.exe' ) ).toBe(
 				true
 			);
-			expect( isValidHref( 'http://test.com' ) ).toBe( true );
-			expect( isValidHref( 'https://test.com' ) ).toBe( true );
-			expect( isValidHref( 'http://test-with-hyphen.com' ) ).toBe( true );
-			expect( isValidHref( 'http://test.com/' ) ).toBe( true );
-			expect( isValidHref( 'http://test.com#fragment' ) ).toBe( true );
-			expect( isValidHref( 'http://test.com/path#fragment' ) ).toBe(
+			expect( isValidHref( 'http://example.org' ) ).toBe( true );
+			expect( isValidHref( 'https://example.org' ) ).toBe( true );
+			expect( isValidHref( 'http://test-with-hyphen.local' ) ).toBe(
+				true
+			);
+			expect( isValidHref( 'http://example.org/' ) ).toBe( true );
+			expect( isValidHref( 'http://example.org#fragment' ) ).toBe( true );
+			expect( isValidHref( 'http://example.org/path#fragment' ) ).toBe(
 				true
 			);
 			expect(
-				isValidHref( 'http://test.com/with/path/separators' )
+				isValidHref( 'http://example.org/with/path/separators' )
 			).toBe( true );
 			expect(
-				isValidHref( 'http://test.com/with?query=string&params' )
+				isValidHref( 'http://example.org/with?query=string&params' )
 			).toBe( true );
 		} );
 
 		it( 'returns false for invalid urls', () => {
 			expect( isValidHref( 'tel:+12 345 6789' ) ).toBe( false );
-			expect( isValidHref( 'mailto:test @ somewhere.com' ) ).toBe(
-				false
-			);
-			expect( isValidHref( 'mailto: test@somewhere.com' ) ).toBe( false );
+			expect( isValidHref( 'mailto:test @ example.org' ) ).toBe( false );
+			expect( isValidHref( 'mailto: test@example.org' ) ).toBe( false );
 			expect( isValidHref( 'ht#tp://this/is/invalid' ) ).toBe( false );
 			expect( isValidHref( 'ht#tp://th&is/is/invalid' ) ).toBe( false );
-			expect( isValidHref( 'http:/test.com' ) ).toBe( false );
-			expect( isValidHref( 'http://?test.com' ) ).toBe( false );
-			expect( isValidHref( 'http://#test.com' ) ).toBe( false );
-			expect( isValidHref( 'http://test.com?double?params' ) ).toBe(
+			expect( isValidHref( 'http:/example.org' ) ).toBe( false );
+			expect( isValidHref( 'http://?example.org' ) ).toBe( false );
+			expect( isValidHref( 'http://#example.org' ) ).toBe( false );
+			expect( isValidHref( 'http://example.org?double?params' ) ).toBe(
 				false
 			);
-			expect( isValidHref( 'http://test.com#double#anchor' ) ).toBe(
+			expect( isValidHref( 'http://example.org#double#anchor' ) ).toBe(
 				false
 			);
-			expect( isValidHref( 'http://test.com?path/after/params' ) ).toBe(
-				false
-			);
-			expect( isValidHref( 'http://test.com#path/after/fragment' ) ).toBe(
-				false
-			);
+			expect(
+				isValidHref( 'http://example.org?path/after/params' )
+			).toBe( false );
+			expect(
+				isValidHref( 'http://example.org#path/after/fragment' )
+			).toBe( false );
 		} );
 
 		it( 'returns false if the URL has whitespace', () => {
-			expect( isValidHref( 'http:/ /test.com' ) ).toBe( false );
-			expect( isValidHref( 'http://te st.com' ) ).toBe( false );
-			expect( isValidHref( 'http:// test.com' ) ).toBe( false );
-			expect( isValidHref( 'http://test.c om' ) ).toBe( false );
-			expect( isValidHref( 'http://test.com/ee ee/' ) ).toBe( false );
-			expect( isValidHref( 'http://test.com/eeee?qwd qwdw' ) ).toBe(
+			expect( isValidHref( 'http:/ /example.org' ) ).toBe( false );
+			expect( isValidHref( 'http://exam ple.org' ) ).toBe( false );
+			expect( isValidHref( 'http:// example.org' ) ).toBe( false );
+			expect( isValidHref( 'http://example.o rg' ) ).toBe( false );
+			expect( isValidHref( 'http://example.org/ee ee/' ) ).toBe( false );
+			expect( isValidHref( 'http://example.org/eeee?qwd qwdw' ) ).toBe(
 				false
 			);
-			expect( isValidHref( 'http://test.com/eeee#qwd qwdw' ) ).toBe(
+			expect( isValidHref( 'http://example.org/eeee#qwd qwdw' ) ).toBe(
 				false
 			);
 			expect( isValidHref( 'this: is invalid' ) ).toBe( false );

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -144,7 +144,7 @@ describe( 'getProtocol', () => {
 	it( 'returns undefined when the provided value does not contain a URL protocol', () => {
 		expect( getProtocol( '' ) ).toBeUndefined();
 		expect( getProtocol( 'https' ) ).toBeUndefined();
-		expect( getProtocol( 'test.com' ) ).toBeUndefined();
+		expect( getProtocol( 'example.com' ) ).toBeUndefined();
 		expect( getProtocol( ' https:// ' ) ).toBeUndefined();
 	} );
 } );
@@ -206,7 +206,7 @@ describe( 'getAuthority', () => {
 		expect( getAuthority( 'https:///' ) ).toBeUndefined();
 		expect( getAuthority( 'https://#' ) ).toBeUndefined();
 		expect( getAuthority( 'https://?' ) ).toBeUndefined();
-		expect( getAuthority( 'test.com' ) ).toBeUndefined();
+		expect( getAuthority( 'example.com' ) ).toBeUndefined();
 		expect( getAuthority( 'https://#?hello' ) ).toBeUndefined();
 	} );
 } );
@@ -274,7 +274,7 @@ describe( 'getPath', () => {
 		expect( getPath( 'https:///test' ) ).toBeUndefined();
 		expect( getPath( 'https://#' ) ).toBeUndefined();
 		expect( getPath( 'https://?' ) ).toBeUndefined();
-		expect( getPath( 'test.com' ) ).toBeUndefined();
+		expect( getPath( 'example.com' ) ).toBeUndefined();
 		expect( getPath( 'https://#?hello' ) ).toBeUndefined();
 		expect( getPath( 'https' ) ).toBeUndefined();
 	} );
@@ -365,11 +365,11 @@ describe( 'getQueryString', () => {
 				'https://andalouses.example/beach?foo[]=bar&foo[]=baz'
 			)
 		).toBe( 'foo[]=bar&foo[]=baz' );
-		expect( getQueryString( 'https://test.com?foo[]=bar&foo[]=baz' ) ).toBe(
-			'foo[]=bar&foo[]=baz'
-		);
 		expect(
-			getQueryString( 'https://test.com?foo=bar&foo=baz?test' )
+			getQueryString( 'https://example.com?foo[]=bar&foo[]=baz' )
+		).toBe( 'foo[]=bar&foo[]=baz' );
+		expect(
+			getQueryString( 'https://example.com?foo=bar&foo=baz?test' )
 		).toBe( 'foo=bar&foo=baz?test' );
 	} );
 
@@ -564,7 +564,7 @@ describe( 'getFragment', () => {
 		expect( getFragment( 'https://' ) ).toBeUndefined();
 		expect( getFragment( 'https:///test' ) ).toBeUndefined();
 		expect( getFragment( 'https://?' ) ).toBeUndefined();
-		expect( getFragment( 'test.com' ) ).toBeUndefined();
+		expect( getFragment( 'example.com' ) ).toBeUndefined();
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -529,7 +529,7 @@ test.describe( 'Links', () => {
 		// Insert a Link.
 		await editor.clickBlockToolbarButton( 'Link' );
 
-		await page.keyboard.type( 'http://#test.com' );
+		await page.keyboard.type( 'http://#example.com' );
 		await pageUtils.pressKeys( 'Enter' );
 		expect(
 			page.getByText(


### PR DESCRIPTION
## What?
Switching all the `test.com` and other spotted domains coincidences to `example.org` or `example.com` indistinctively. 

## Why?
According to RFC 2606 `example.com`, `example.net` and `example.org` are reserved for testing and documentation purposes. Using other domains is out of convention and we should preferrably avoid it.

## How?
Switching all tests to any of these 3 domains. 

## Testing Instructions
As long as Unit Tests are passing, all should be good. If all tests are passing, a visual inspection of the code to confirm that the substitutions are correct is enough
