### PR TITLE
Block variation transformation: change position and threshold

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -214,8 +214,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 
 	const baseClass = 'block-editor-block-variation-transforms';
 
-	// Show buttons if there are more than 5 variations because the ToggleGroupControl does not wrap
-	const showButtons = variations.length > 5;
+	// Show buttons if there are more than 6 variations because the ToggleGroupControl does not wrap
+	const showButtons = variations.length > 6;
 
 	const ButtonComponent = showButtons
 		? VariationsButtons

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -3,7 +3,7 @@
 
 .block-editor-block-variation-transforms {
 	box-sizing: border-box;
-	padding: 0 $grid-unit-20 $grid-unit-20 52px;
+	padding: 0 $grid-unit-20 $grid-unit-20;
 
 	&:where(fieldset) {
 		// Reset `fieldset` browser defaults, keeping intentional padding.

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -23,7 +23,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// Open the block inspector sidebar and use variations to change level.
 		await editor.openDocumentSettingsSidebar();
 		await page
-			.getByRole( 'button', { name: 'Heading 3', exact: true } )
+			.getByRole( 'radio', { name: 'Transform to Heading 3' } )
 			.click();
 
 		expect( await editor.getBlocks() ).toMatchObject( [


### PR DESCRIPTION
## What?

In #74164, the description text in the block card was moved to the left. Accordingly, let's align the block variation transformation UI to the left as well.

Additionally, when there are five or more variations, this UI changes from a `ToggleGroupControl` to a list of `Button` components to allow wrapping. By aligning the UI to the left, there is more space on the right side. Therefore, if there are up to 6 variations, we can use a ToggleGroupControl.

As a result, we can represent heading variations with a `ToggleGroupControl`.


## Testing Instructions

Insert the three blocks below and check out the block sidebar:

- Heading
- Date
- Group

Run one or both of the following codes in your browser console. You'll notice that when there are seven or more variations, the variation list becomes a button list and wraps.

```javascript
wp.blocks.registerBlockVariation( 'core/heading', {
	name: 'custom-heading-1',
	title: 'Custom Heading 1',
	icon: wp.element.createElement(
		wp.primitives.SVG,
		{ width: 24, height: 24, viewBox: '0 0 24 24' },
		wp.element.createElement( wp.primitives.Circle, {
			cx: 12,
			cy: 12,
			r: 10,
			fill: 'currentColor',
		} )
	),
	scope: [ 'transform' ],
} );
```

```javascript
wp.blocks.registerBlockVariation( 'core/heading', {
	name: 'custom-heading-2',
	title: 'Custom Heading 2',
	icon: wp.element.createElement(
		wp.primitives.SVG,
		{ width: 24, height: 24, viewBox: '0 0 24 24' },
		wp.element.createElement( wp.primitives.Rect, {
			x: 2,
			y: 2,
			width: 20,
			height: 20,
			fill: 'currentColor',
		} )
	),
	scope: [ 'transform' ],
} );
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| |Before|After|
|-|-|-|
| Heading Block | <img width="293" height="247" alt="image" src="https://github.com/user-attachments/assets/70d3e8af-9cbc-45f8-83da-bfaa9aea41cf" /> | <img width="291" height="252" alt="image" src="https://github.com/user-attachments/assets/41bed0bb-6575-4314-b41e-103181c3ffbb" /> |
| Heading Block (has 8 variations) | <img width="278" height="270" alt="image" src="https://github.com/user-attachments/assets/f5bdefbb-69ed-46f4-9297-b6ac1d81fcab" /> | <img width="290" height="282" alt="image" src="https://github.com/user-attachments/assets/ad414417-6090-4930-8469-1f311bc855c2" /> |
| Group block | <img width="296" height="252" alt="image" src="https://github.com/user-attachments/assets/b16036e4-f3ca-4e6c-9984-b3c681a43a14" /> | <img width="290" height="244" alt="image" src="https://github.com/user-attachments/assets/322ea0de-7045-41f7-a21a-f9d53efb6622" /> |
| Date block | <img width="296" height="248" alt="image" src="https://github.com/user-attachments/assets/9ffd5a5e-6773-4f6d-891a-b34aec055b1b" /> | <img width="288" height="241" alt="image" src="https://github.com/user-attachments/assets/352f9436-ef64-4ca7-8916-e2be21ab04bd" /> |

