### PR TITLE
Quote: Fix transformation error

### DIFF
--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -141,15 +141,20 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { citation }, innerBlocks ) =>
-				RichText.isEmpty( citation )
-					? innerBlocks
-					: [
-							...innerBlocks,
-							createBlock( 'core/paragraph', {
-								content: citation,
-							} ),
-					  ],
+			transform: ( { citation }, innerBlocks ) => {
+				if ( RichText.isEmpty( citation ) ) {
+					return innerBlocks.length > 0
+						? innerBlocks
+						: createBlock( 'core/paragraph' );
+				}
+
+				return [
+					...innerBlocks,
+					createBlock( 'core/paragraph', {
+						content: citation,
+					} ),
+				];
+			},
 		},
 		{
 			type: 'block',

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -141,19 +141,40 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { citation }, innerBlocks ) => {
-				if ( RichText.isEmpty( citation ) ) {
-					return innerBlocks.length > 0
-						? innerBlocks
-						: createBlock( 'core/paragraph' );
+			isMatch: ( { citation }, block ) => {
+				const innerBlocks = block.innerBlocks;
+				if ( ! innerBlocks.length ) {
+					return ! RichText.isEmpty( citation );
 				}
 
-				return [
-					...innerBlocks,
-					createBlock( 'core/paragraph', {
-						content: citation,
-					} ),
-				];
+				return innerBlocks.every( ( innerBlock ) => {
+					if ( innerBlock.name === 'core/paragraph' ) {
+						return true;
+					}
+					const converted = switchToBlockType(
+						innerBlock,
+						'core/paragraph'
+					);
+					return converted !== null;
+				} );
+			},
+			transform: ( { citation }, innerBlocks ) => {
+				const paragraphs = innerBlocks.flatMap( ( innerBlock ) => {
+					if ( innerBlock.name === 'core/paragraph' ) {
+						return innerBlock;
+					}
+					return (
+						switchToBlockType( innerBlock, 'core/paragraph' ) || []
+					);
+				} );
+				return RichText.isEmpty( citation )
+					? paragraphs
+					: [
+							...paragraphs,
+							createBlock( 'core/paragraph', {
+								content: citation,
+							} ),
+					  ];
 			},
 		},
 		{


### PR DESCRIPTION
## What?
Closes #74236.

PR fixes the Quote block transformation to Paragraph error when the Quote block has no inner blocks. No transformation will insert an empty paragraph.

## Why?
The transformation assumed the block would always have children.

## Testing Instructions
1. Open a post or page.
2. Add a Quote block.
3. Delete the inner paragraph block.
4. Try converting to a paragraph.
5. The action should work as expected.

### Testing Instructions for Keyboard
Same.
