### PR TITLE
Archives Block: Use new HtmlRenderer component to remove extra div wrapper and remove editor styles

### DIFF
--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -67,6 +67,5 @@
 		"interactivity": {
 			"clientNavigation": true
 		}
-	},
-	"editorStyle": "wp-block-archives-editor"
+	}
 }

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -8,7 +8,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { useDisabled } from '@wordpress/compose';
@@ -44,7 +44,13 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 	if ( status === 'error' ) {
 		return (
 			<div { ...blockProps }>
-				<p>Error: { error }</p>
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
 			</div>
 		);
 	}

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -31,7 +36,13 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 	} );
 
 	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( { ref: disabledRef } );
+	const blockProps = useBlockProps( {
+		ref: disabledRef,
+		className: clsx( 'wp-block-archives', {
+			'wp-block-archives-dropdown': displayAsDropdown,
+			'wp-block-archives-list': ! displayAsDropdown,
+		} ),
+	} );
 
 	if ( status === 'loading' ) {
 		return (

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -36,13 +31,7 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 	} );
 
 	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( {
-		ref: disabledRef,
-		className: clsx( 'wp-block-archives', {
-			'wp-block-archives-dropdown': displayAsDropdown,
-			'wp-block-archives-list': ! displayAsDropdown,
-		} ),
-	} );
+	const blockProps = useBlockProps( { ref: disabledRef } );
 
 	if ( status === 'loading' ) {
 		return (

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -4,23 +4,50 @@
 import {
 	ToggleControl,
 	SelectControl,
-	Disabled,
+	Spinner,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { useServerSideRender } from '@wordpress/server-side-render';
+import { useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import HtmlRenderer from '../utils/html-renderer';
 
-export default function ArchivesEdit( { attributes, setAttributes } ) {
+export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 	const { showLabel, showPostCounts, displayAsDropdown, type } = attributes;
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	const { content, status, error } = useServerSideRender( {
+		attributes,
+		skipBlockSupportAttributes: true,
+		block: name,
+	} );
+
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
+
+	if ( status === 'loading' ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div { ...blockProps }>
+				<p>Error: { error }</p>
+			</div>
+		);
+	}
 
 	return (
 		<>
@@ -121,15 +148,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			<div { ...useBlockProps() }>
-				<Disabled>
-					<ServerSideRender
-						block="core/archives"
-						skipBlockSupportAttributes
-						attributes={ attributes }
-					/>
-				</Disabled>
-			</div>
+			<HtmlRenderer wrapperProps={ blockProps } html={ content } />
 		</>
 	);
 }

--- a/packages/block-library/src/archives/editor.scss
+++ b/packages/block-library/src/archives/editor.scss
@@ -1,7 +1,0 @@
-// The following styles are to prevent duplicate spacing and borders for the archives
-// block in the editor given it uses server side rendering.
-// See https://github.com/WordPress/gutenberg/pull/63400
-.wp-block-archives .wp-block-archives {
-	margin: 0;
-	border: 0;
-}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -1,6 +1,5 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "./utils/media-control.scss" as *;
-@use "./archives/editor.scss" as *;
 @use "./audio/editor.scss" as *;
 @use "./avatar/editor.scss" as *;
 @use "./button/editor.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of Issue-  #74248

<!-- In a few words, what is the PR actually doing? -->
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Remove extra divs and eliminate the extra CSS required to match the frontend and editor UI
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses the HTMLRenderer component and useServerSideRender() hook to eliminate these extra divs and make the HTML on the front end and editor match for Archives Block.
- Remove the extra editor CSS for wrappers.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Edit a Post/Page
2. Add the Archives block
3. Save and Check UI on both frontend and editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8dc371b1-203e-4a5f-b42f-14526f26b93b


