### PR TITLE
Tag Cloud: Make error message prefix text translatable

### DIFF
--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -65,6 +65,5 @@
 				"style": true
 			}
 		}
-	},
-	"editorStyle": "wp-block-tag-cloud-editor"
+	}
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -15,7 +15,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	InspectorControls,
 	useBlockProps,
@@ -254,7 +254,13 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	if ( status === 'error' ) {
 		return (
 			<div { ...blockProps }>
-				<p>Error: { error }</p>
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
 			</div>
 		);
 	}


### PR DESCRIPTION
Follow-up on #74228

## What?

Makes `Error:` prefix text translatable.

## Testing Instructions

The block should work as before.