### PR TITLE
ContentOnlyControls: Polish header style

### DIFF
--- a/packages/block-editor/src/components/content-only-controls/fields-dropdown-menu.js
+++ b/packages/block-editor/src/components/content-only-controls/fields-dropdown-menu.js
@@ -26,6 +26,7 @@ export default function FieldsDropdownMenu( {
 			icon={ moreVertical }
 			label={ __( 'Options' ) }
 			popoverProps={ popoverProps }
+			toggleProps={ { size: 'small' } }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup label={ __( 'Show / Hide' ) }>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/blocks';
 import {
 	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
 	Icon,
 	Navigator,
 } from '@wordpress/components';
@@ -328,11 +329,17 @@ function BlockFields( { clientId } ) {
 	return (
 		<div className="block-editor-content-only-controls__fields-container">
 			<div className="block-editor-content-only-controls__fields-header">
-				<HStack spacing={ 1 } justify="space-between" expanded>
-					<HStack spacing={ 1 } justify="flex-start">
-						<BlockIcon icon={ blockInformation?.icon } />
-						<div>{ blockTitle }</div>
-					</HStack>
+				<HStack spacing={ 1 }>
+					<BlockIcon
+						className="block-editor-content-only-controls__fields-header-icon"
+						icon={ blockInformation?.icon }
+					/>
+					<Truncate
+						className="block-editor-content-only-controls__fields-header-title"
+						numberOfLines={ 1 }
+					>
+						{ blockTitle }
+					</Truncate>
 					<FieldsDropdownMenu
 						fields={ dataFormFields }
 						visibleFields={ form.fields }

--- a/packages/block-editor/src/components/content-only-controls/styles.scss
+++ b/packages/block-editor/src/components/content-only-controls/styles.scss
@@ -42,3 +42,11 @@
 	padding: $grid-unit-10 0;
 	margin-bottom: $grid-unit-05;
 }
+
+.block-editor-content-only-controls__fields-header-icon {
+	flex: 0 0 $icon-size;
+}
+
+.block-editor-content-only-controls__fields-header-title {
+	flex: 1;
+}


### PR DESCRIPTION
## What?

This PR makes the following improvements to the header section of the ContentOnlyControls UI:

- Change the size of dropdown toggle buttons from 36px to 24px
- Truncate the text if it's long to prevent the icon from being squashed

## Testing Instructions

- Enable the ContentOnly experiment in the Gutenberg experiments page
- Insert any of the patterns
- Confirm the block sidebar

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="284" height="279" alt="image" src="https://github.com/user-attachments/assets/8d74811a-7a61-4243-a554-62b4fd32d306" /> | <img width="288" height="246" alt="image" src="https://github.com/user-attachments/assets/2bc6994a-6617-4f4c-a012-73047671dbe4" /> |