### PR TITLE
PHP-only blocks: use `HtmlRenderer` to ensure fontend & editor consistency

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,10 +9,16 @@ import {
 	registerBlockType,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { useDisabled } from '@wordpress/compose';
 import { select } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import HtmlRenderer from './utils/html-renderer';
 
 /**
  * Internal dependencies
@@ -351,7 +357,8 @@ export const registerCoreBlocks = (
 					apiVersion: 3,
 				} ),
 				edit: function Edit( { attributes } ) {
-					const blockProps = useBlockProps();
+					const disabledRef = useDisabled();
+					const blockProps = useBlockProps( { ref: disabledRef } );
 					const { content, status, error } = useServerSideRender( {
 						block: blockName,
 						attributes,
@@ -376,11 +383,9 @@ export const registerCoreBlocks = (
 					}
 
 					return (
-						<div
-							{ ...blockProps }
-							dangerouslySetInnerHTML={ {
-								__html: content || '',
-							} }
+						<HtmlRenderer
+							wrapperProps={ blockProps }
+							html={ content }
 						/>
 					);
 				},

--- a/packages/block-library/src/utils/html-renderer.js
+++ b/packages/block-library/src/utils/html-renderer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import clsx from 'clsx';
 import parse, { attributesToProps, domToReact } from 'html-react-parser';
 
 /**
@@ -26,6 +27,10 @@ const HtmlRenderer = ( { wrapperProps = {}, html = '' } ) => {
 					const mergedProps = {
 						...parsedProps,
 						...wrapperProps,
+						className: clsx(
+							parsedProps.className,
+							wrapperProps.className
+						),
 					};
 					return (
 						<TagName { ...mergedProps }>


### PR DESCRIPTION
## What

Follow-up to #74228, relates to #71792.

Applies the `HtmlRenderer` component to PHP-only auto-registered blocks, replacing `dangerouslySetInnerHTML`.

Following the example of the tag cloud in #74228, this PR also disables the user interaction inside the block editor preview.

## Why

PHP-only blocks currently wrap server-rendered content in an extra `<div>` with `dangerouslySetInnerHTML`, causing HTML inconsistency between the frontend and the editor.

## How

- Updating the auto-register block `Edit` function to use `HtmlRenderer` instead of `dangerouslySetInnerHTML`
- Adding `clsx` to `html-renderer.js` to preserve both customclasses and editor-applied classes
- Adding `useDisabled()` ref to prevent user interaction with links and forms inside the block preview

## Testing Instructions

1. Activate the plugin `Gutenberg Test Server-Side Rendered Block` in wp-env's test environment
2. Insert the block `Auto Register Test Block` in the editor
3. Verify the block renders without an extra wrapper div
4. Verify block supports (like background color) work correctly
5. Verify custom classes from PHP are preserved alongside editor classes
