### PR TITLE
Add toolbar block appender to the navigation block

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -45,6 +45,7 @@ export {
 	ButtonBlockerAppender,
 	default as ButtonBlockAppender,
 } from './button-block-appender';
+export { default as ToolbarBlockAppender } from './toolbar-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPaletteControl } from './color-palette/control';
 export { default as ContrastChecker } from './contrast-checker';

--- a/packages/block-editor/src/components/toolbar-block-appender/README.md
+++ b/packages/block-editor/src/components/toolbar-block-appender/README.md
@@ -1,0 +1,42 @@
+# ToolbarBlockAppender
+
+`ToolbarBlockAppender` provides button with a `+` (plus) icon which when clicked will trigger the default Block `Inserter` UI to allow a Block to be inserted.
+
+## Usage
+
+In a block's `edit` implementation, render a `<ToolbarBlockAppender />` component passing in the `rootClientId`.
+
+```jsx
+function render( { clientId } ) {
+	return (
+		<div>
+			<p>Some rendered content here</p>
+		</div>
+		<ToolbarBlockAppender rootClientId={ clientId } />
+	);
+}
+```
+
+_Note:_
+
+## Props
+
+### `rootClientId`
+
+-   **Type:** `String`
+-   **Required** `true`
+-   **Default:** `undefined`
+
+The `clientId` of the Block from who's root new Blocks should be inserted. This prop is required by the block `Inserter` component. Typically this is the `clientID` of the Block where the prop is being rendered.
+
+### `className`
+
+-   **Type:** `String`
+-   **Default:** `""`
+
+A CSS `class` to be _prepended_ to the default class of `"toolbar-block-appender"`.
+
+## Examples
+
+The [`<InnerBlocks>` component](../inner-blocks/) exposes an enhanced version of `ToolbarBlockAppender` to allow consumers to choose it as an alternative to the standard behaviour of auto-inserting the default Block (typically `core/paragraph`).
+

--- a/packages/block-editor/src/components/toolbar-block-appender/index.js
+++ b/packages/block-editor/src/components/toolbar-block-appender/index.js
@@ -36,6 +36,7 @@ function ToolbarBlockAppender( {
 						className:
 							'wp-block-navigation__toolbar-inserter-button',
 					} }
+					__experimentalIsQuick
 				/>
 			</ToolbarGroup>
 		</__unstableBlockToolbarLastItem>

--- a/packages/block-editor/src/components/toolbar-block-appender/index.js
+++ b/packages/block-editor/src/components/toolbar-block-appender/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import __unstableBlockToolbarLastItem from '../block-toolbar/block-toolbar-last-item';
+import { useBlockEditContext } from '../block-edit/context';
+import Inserter from '../inserter';
+
+function ToolbarBlockAppender( {
+	defaultBlock = { name: 'core/paragraph', attributes: {} },
+} ) {
+	const { clientId } = useBlockEditContext();
+
+	const directInsertBlock = {
+		name: defaultBlock.name,
+		attributes: defaultBlock.attributes,
+	};
+
+	return (
+		<__unstableBlockToolbarLastItem>
+			<ToolbarGroup className="block-editor-toolbar-block-appender">
+				<Inserter
+					rootClientId={ clientId }
+					directInsertBlock={ directInsertBlock }
+					isAppender
+					toggleProps={ {
+						as: ToolbarButton,
+						name: 'add-block',
+						label: __( 'Add block' ),
+						showTooltip: true,
+						className:
+							'wp-block-navigation__toolbar-inserter-button',
+					} }
+				/>
+			</ToolbarGroup>
+		</__unstableBlockToolbarLastItem>
+	);
+}
+export default ToolbarBlockAppender;

--- a/packages/block-editor/src/components/toolbar-block-appender/style.scss
+++ b/packages/block-editor/src/components/toolbar-block-appender/style.scss
@@ -1,0 +1,35 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+/**
+ * Toolbar inserter button
+ * Black square with rounded corners and white plus icon, matching the standard block inserter
+ */
+.block-editor-toolbar-block-appender {
+	align-items: center;
+
+	.wp-block-navigation__toolbar-inserter-button.components-button.has-icon {
+		// Match standard inserter toggle styles
+		background: $gray-900;
+		color: $white;
+		padding: 0;
+		min-width: auto;
+		width: $button-size-small;
+		height: $button-size-small;
+
+		// Hide the default focus ::before pseudo-element
+		&::before {
+			display: none;
+		}
+
+		&:hover {
+			color: $white;
+			background: var(--wp-admin-theme-color);
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
+			outline: none;
+		}
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -53,6 +53,7 @@
 @use "./components/rich-text/style.scss" as *;
 @use "./components/skip-to-selected-block/style.scss" as *;
 @use "./components/tabbed-sidebar/style.scss" as *;
+@use "./components/toolbar-block-appender/style.scss" as *;
 @use "./components/url-input/style.scss" as *;
 @use "./components/url-popover/style.scss" as *;
 @use "./hooks/block-hooks.scss" as *;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -27,6 +27,7 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
 	BlockControls,
+	ToolbarBlockAppender,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
@@ -37,13 +38,9 @@ import {
 	ToggleControl,
 	Spinner,
 	Notice,
-	ToolbarButton,
-	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { page } from '@wordpress/icons';
-import { createBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -82,39 +79,12 @@ import { DEFAULT_BLOCK } from '../constants';
 /**
  * Component that renders the Add page button for the Navigation block.
  *
- * @param {Object} props          Component props.
- * @param {string} props.clientId Block client ID.
- * @return {JSX.Element|null} The Add page button component or null if not applicable.
+ * @return {JSX.Element} The Add page toolbar button component
  */
-function NavigationAddPageButton( { clientId } ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
-	const { getBlockCount } = useSelect( blockEditorStore );
-
-	const onAddPage = useCallback( () => {
-		// Get the current number of blocks to insert at the end
-		const blockCount = getBlockCount( clientId );
-
-		// Create a new navigation link block (default block)
-		const newBlock = createBlock( DEFAULT_BLOCK.name, {
-			kind: DEFAULT_BLOCK.attributes.kind,
-			type: DEFAULT_BLOCK.attributes.type,
-		} );
-
-		// Insert the block at the end of the navigation
-		insertBlock( newBlock, blockCount, clientId );
-	}, [ clientId, insertBlock, getBlockCount ] );
-
+function NavigationAddPageToolbarButton() {
 	return (
 		<BlockControls>
-			<ToolbarGroup>
-				<ToolbarButton
-					name="add-page"
-					icon={ page }
-					onClick={ onAddPage }
-				>
-					{ __( 'Add page' ) }
-				</ToolbarButton>
-			</ToolbarGroup>
+			<ToolbarBlockAppender defaultBlock={ DEFAULT_BLOCK } />
 		</BlockControls>
 	);
 }
@@ -971,9 +941,7 @@ function Navigation( {
 					blockEditingMode={ blockEditingMode }
 				/>
 				{ blockEditingMode === 'default' && stylingInspectorControls }
-				{ blockEditingMode === 'contentOnly' && isEntityAvailable && (
-					<NavigationAddPageButton clientId={ clientId } />
-				) }
+				{ isEntityAvailable && <NavigationAddPageToolbarButton /> }
 				{ blockEditingMode === 'default' && isEntityAvailable && (
 					<InspectorControls group="advanced">
 						{ hasResolvedCanUserUpdateNavigationMenu &&

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -4,7 +4,6 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
-	InnerBlocks,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -22,30 +21,14 @@ export default function NavigationInnerBlocks( {
 	orientation,
 	templateLock,
 } ) {
-	const {
-		isImmediateParentOfSelectedBlock,
-		selectedBlockHasChildren,
-		isSelected,
-		hasSelectedDescendant,
-	} = useSelect(
+	const { isSelected } = useSelect(
 		( select ) => {
-			const {
-				getBlockCount,
-				hasSelectedInnerBlock,
-				getSelectedBlockClientId,
-			} = select( blockEditorStore );
+			const { getSelectedBlockClientId } = select( blockEditorStore );
 			const selectedBlockId = getSelectedBlockClientId();
 
 			return {
-				isImmediateParentOfSelectedBlock: hasSelectedInnerBlock(
-					clientId,
-					false
-				),
-				selectedBlockHasChildren: !! getBlockCount( selectedBlockId ),
-				hasSelectedDescendant: hasSelectedInnerBlock( clientId, true ),
-
 				// This prop is already available but computing it here ensures it's
-				// fresh compared to isImmediateParentOfSelectedBlock.
+				// fresh compared to other selectors.
 				isSelected: selectedBlockId === clientId,
 			};
 		},
@@ -56,13 +39,6 @@ export default function NavigationInnerBlocks( {
 		'postType',
 		'wp_navigation'
 	);
-
-	// When the block is selected itself or has a top level item selected that
-	// doesn't itself have children, show the standard appender. Else show no
-	// appender.
-	const parentOrChildHasSelection =
-		isSelected ||
-		( isImmediateParentOfSelectedBlock && ! selectedBlockHasChildren );
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
@@ -88,21 +64,7 @@ export default function NavigationInnerBlocks( {
 			directInsert: true,
 			orientation,
 			templateLock,
-
-			// As an exception to other blocks which feature nesting, show
-			// the block appender even when a child block is selected.
-			// This should be a temporary fix, to be replaced by improvements to
-			// the sibling inserter.
-			// See https://github.com/WordPress/gutenberg/issues/37572.
-			renderAppender:
-				isSelected ||
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasChildren ) ||
-				hasSelectedDescendant ||
-				// Show the appender while dragging to allow inserting element between item and the appender.
-				parentOrChildHasSelection
-					? InnerBlocks.ButtonBlockAppender
-					: false,
+			renderAppender: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/73647

Alternative to https://github.com/WordPress/gutenberg/pull/73648

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Introduce a toolbar-based [+] inserter for the Navigation block, replacing the in-canvas inserter.

|Before|After|
|-|-|
|<img width="428" height="158" alt="image" src="https://github.com/user-attachments/assets/1588e5a4-2e74-450d-92da-402ef33805cf" />|<img width="328" height="175" alt="Screenshot 2025-12-30 at 15 54 24" src="https://github.com/user-attachments/assets/10e0ca9f-7e43-4651-9974-203c03072469" />|


## Why

The inline inserter inside the Navigation block often leads to:
- Layout shifts as it appears/disappears within the menu
- Ambiguity about which part of the menu it relates to
- Extra complexity in an already nested editing experience

A toolbar-based inserter provides:
- A stable, predictable insertion point
- Clearer association with the Navigation block itself
- A cleaner canvas with fewer shifting elements

## How

- Introduce re-usable `ToolbarBlockAppender` component, similar to [`ButtonBlockAppender`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/button-block-appender/README.md):
   - Implements new block inserter using `[ + ]` icon
   - Reused the standard `Inserter` component with `toggleProps` for consistency
   - Creates a new toolbar group at the end of the block toolbar using `BlockToolbarLastItem`
   - Defaults to inserting a paragraph directly, but can also be used to insert any block via `defaultBlock` prop
- Replace the existing "Add page" control with the new component 
- Styled the button to match the standard block inserter (black square with rounded corners, white plus icon)
- Removed the in-canvas inserter for the Navigation block

## Questions/thoughts

- Should open the dropdown to select a block by default, or always directly insert a block?
    <img width="418" height="424" alt="image" src="https://github.com/user-attachments/assets/e049c52d-dfe6-469a-90d3-065c485634f0" />

- Should check if block allows inner blocks before adding itself to the toolbar?
- Should pull the default inner block from the block where this is used, thus not requiring passing the default block to the component?

## Testing Instructions
- In navigation block, use the block inserter to add new pages.
- Test template editor and focused template part editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5bb26ed0-608b-4345-80d2-65fa5bf75959


https://github.com/user-attachments/assets/539db809-6e71-4e51-bc1a-de0139fe5fb4



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
