### PR TITLE
DataForm: Fix panel field inaccessible when empty with labelPosition none or top

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- Fix panel field width with empty value for top/none label positions.[#74264](https://github.com/WordPress/gutenberg/pull/74264)
 - Fix sticky footer in DataViews grid view. [#73661](https://github.com/WordPress/gutenberg/pull/73661)
 - DataViews: Apply primary style to first column if there is no title field. [#73729](https://github.com/WordPress/gutenberg/pull/73729)
 - DataViews: Combined field alignment in table layout. [#73908](https://github.com/WordPress/gutenberg/pull/73908)

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -79,3 +79,7 @@
 .components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown {
 	z-index: z-index(".components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown");
 }
+
+.dataforms-layouts-panel__summary-button:empty {
+	min-width: $admin-sidebar-width;
+}


### PR DESCRIPTION
Alternative to: https://github.com/WordPress/gutenberg/pull/73764/files
Reduces the scope of https://github.com/WordPress/gutenberg/pull/73764/ as suggested by @oandregal to just prevent the button's width from collapsing for top/none label states.

When a DataForm panel field has labelPosition: none and the field value is empty, the summary button renders with no content, collapsing to zero width. This makes the field inaccessible since there's nothing to click to open the panel. There is no way a use can open the field panel and make the field not empty. This PR sets a min width for the button when it is empty so we can always open the panel to fill its content.

## Testing
1. Open Storybook DataForm panel layout story with `labelPosition: none` http://localhost:50240/?path=/story/dataviews-dataform--layout-panel&args=labelPosition:none
2. Clear the Title field "(Hello World)".
3. Verify the placeholder appears and clicking it opens the panel
