### PR TITLE
Post Editor: Update "Move to trash" label when trash is disabled

### DIFF
--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -23,15 +23,19 @@ import PostTrashCheck from './check';
  */
 export default function PostTrash( { onActionPerformed } ) {
 	const registry = useRegistry();
-	const { isNew, isDeleting, postId, title } = useSelect( ( select ) => {
-		const store = select( editorStore );
-		return {
-			isNew: store.isEditedPostNew(),
-			isDeleting: store.isDeletingPost(),
-			postId: store.getCurrentPostId(),
-			title: store.getCurrentPostAttribute( 'title' ),
-		};
-	}, [] );
+	const { disableTrash, isNew, isDeleting, postId, title } = useSelect(
+		( select ) => {
+			const store = select( editorStore );
+			return {
+				disableTrash: store.getEditorSettings().disableTrash,
+				isNew: store.isEditedPostNew(),
+				isDeleting: store.isDeletingPost(),
+				postId: store.getCurrentPostId(),
+				title: store.getCurrentPostAttribute( 'title' ),
+			};
+		},
+		[]
+	);
 	const { trashPost } = useDispatch( editorStore );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
@@ -49,6 +53,23 @@ export default function PostTrash( { onActionPerformed } ) {
 		// to the post view depending on if the user is on post editor or site editor.
 		onActionPerformed?.( 'move-to-trash', [ item ] );
 	};
+
+	const buttonLabel = disableTrash
+		? __( 'Delete permanently' )
+		: __( 'Move to trash' );
+
+	const confirmMessage = disableTrash
+		? sprintf(
+				/* translators: %s: The item's title. */
+				__( 'Are you sure you want to delete "%s" permanently?' ),
+				title
+		  )
+		: sprintf(
+				/* translators: %s: The item's title. */
+				__( 'Are you sure you want to move "%s" to the trash?' ),
+				title
+		  );
+
 	return (
 		<PostTrashCheck>
 			<Button
@@ -62,20 +83,16 @@ export default function PostTrash( { onActionPerformed } ) {
 					isDeleting ? undefined : () => setShowConfirmDialog( true )
 				}
 			>
-				{ __( 'Move to trash' ) }
+				{ buttonLabel }
 			</Button>
 			<ConfirmDialog
 				isOpen={ showConfirmDialog }
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
-				confirmButtonText={ __( 'Move to trash' ) }
+				confirmButtonText={ buttonLabel }
 				size="small"
 			>
-				{ sprintf(
-					// translators: %s: The item's title.
-					__( 'Are you sure you want to move "%s" to the trash?' ),
-					title
-				) }
+				{ confirmMessage }
 			</ConfirmDialog>
 		</PostTrashCheck>
 	);


### PR DESCRIPTION
## Description
This PR addresses an issue where the "Move to trash" button label and the confirmation modal text remained static even when the trash functionality was disabled (e.g., when `EMPTY_TRASH_DAYS` is set to `0`).

It introduces a check for the `disableTrash` editor setting in the `PostTrash` component. If trash is disabled, the button label and confirmation message now correctly update to "Delete permanently".

## How has this been tested?
1. Define `EMPTY_TRASH_DAYS` as `0` in `wp-config.php` (or filter `block_editor_settings_all` to set `disableTrash` to `true`).
2. Open a post in the Block Editor.
3. Observe the post action button in the "Summary" panel.
4. It should now read **"Delete permanently"** instead of "Move to trash".
5. Click the button and verify the confirmation dialog also reads "Delete permanently".

## Screenshots
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have verified the fix in the browser.

## Impacted Issue
Fixes #74230