### PR TITLE
Disables anchor support for the More block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -521,7 +521,7 @@ Content before this block will be shown in the excerpt on your archives page. ([
 
 -	**Name:** core/more
 -	**Category:** design
--	**Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~
 -	**Attributes:** customText, noTeaser
 
 ## Navigation

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -19,7 +19,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
 		"customClassName": false,
 		"className": false,
 		"html": false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
related #74103 

The More block lacks a block wrapper, so adding an HTML anchor won't assign an ID.
https://github.com/WordPress/gutenberg/blob/e39ec4d5c8e378767a0cee30cff5f633377feae7/packages/block-library/src/more/save.js#L12-L14

Instead, it adds `id="more-' . $_post->ID . '"`.

https://github.com/WordPress/wordpress-develop/blob/7c7e521e36a451a4d73238706a18976b98cd4009/src/wp-includes/post-template.php#L364


Therefore, anchor support is disabled.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a more block. 
3. It is understood that anchors cannot be set.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here --> <img width="281" height="448" alt="before" src="https://github.com/user-attachments/assets/e4738764-607f-48f3-97c9-b89f2a11f3c7" /> | <!-- After screenshot here --> <img width="280" height="306" alt="after" src="https://github.com/user-attachments/assets/a023509a-4478-4c13-a313-14b5519be9fb" /> |
