### PR TITLE
Comment Content: Migrate to text-align block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -188,8 +188,7 @@ Displays the contents of a comment. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/comment-content
 -	**Category:** theme
 -	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight, textAlign), ~~html~~
 
 ## Comment Date
 

--- a/packages/block-library/src/comment-content/block.json
+++ b/packages/block-library/src/comment-content/block.json
@@ -8,11 +8,6 @@
 	"description": "Displays the contents of a comment.",
 	"textdomain": "default",
 	"usesContext": [ "commentId" ],
-	"attributes": {
-		"textAlign": {
-			"type": "string"
-		}
-	},
 	"supports": {
 		"anchor": true,
 		"color": {
@@ -26,6 +21,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/comment-content/deprecated.js
+++ b/packages/block-library/src/comment-content/deprecated.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+	},
+	usesContext: [ 'commentId' ],
+	supports: {
+		anchor: true,
+		color: {
+			gradients: true,
+			link: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+		spacing: {
+			padding: [ 'horizontal', 'vertical' ],
+		},
+		html: false,
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -1,43 +1,23 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	AlignmentControl,
-	BlockControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
- * Renders the `core/comment-content` block on the editor.
- *
- * @param {Object} props                      React props.
- * @param {Object} props.setAttributes        Callback for updating block attributes.
- * @param {Object} props.attributes           Block attributes.
- * @param {string} props.attributes.textAlign The `textAlign` attribute.
- * @param {Object} props.context              Inherited context.
- * @param {string} props.context.commentId    The comment ID.
- *
- * @return {JSX.Element} React element.
+ * Internal dependencies
  */
-export default function Edit( {
-	setAttributes,
-	attributes: { textAlign },
-	context: { commentId },
-} ) {
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
+
+export default function Edit( props ) {
+	const {
+		context: { commentId },
+	} = props;
+	useDeprecatedTextAlign( props );
+	const blockProps = useBlockProps();
 	const [ content ] = useEntityProp(
 		'root',
 		'comment',
@@ -45,21 +25,9 @@ export default function Edit( {
 		commentId
 	);
 
-	const blockControls = (
-		<BlockControls group="block">
-			<AlignmentControl
-				value={ textAlign }
-				onChange={ ( newAlign ) =>
-					setAttributes( { textAlign: newAlign } )
-				}
-			/>
-		</BlockControls>
-	);
-
 	if ( ! commentId || ! content ) {
 		return (
 			<>
-				{ blockControls }
 				<div { ...blockProps }>
 					<p>{ _x( 'Comment Content', 'block title' ) }</p>
 				</div>
@@ -69,7 +37,6 @@ export default function Edit( {
 
 	return (
 		<>
-			{ blockControls }
 			<div { ...blockProps }>
 				<Disabled>
 					<RawHTML key="html">{ content.rendered }</RawHTML>

--- a/packages/block-library/src/comment-content/index.js
+++ b/packages/block-library/src/comment-content/index.js
@@ -9,6 +9,7 @@ import { commentContent as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 	example: {},
 };
 

--- a/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-content {"textAlign":"left"} /-->
+
+<!-- wp:comment-content {"textAlign":"center"} /-->
+
+<!-- wp:comment-content {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.json
@@ -1,0 +1,38 @@
+[
+	{
+		"name": "core/comment-content",
+		"isValid": true,
+		"attributes": {
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-content",
+		"isValid": true,
+		"attributes": {
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-content",
+		"isValid": true,
+		"attributes": {
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/comment-content",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-content",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-content",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__comment-content__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-content {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:comment-content {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:comment-content {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Comment Content` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Comment Content`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Comment Content` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Comment Content` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Comment Content` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Comment Content` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

