### PR TITLE
Calender Block: Use HtmlRenderer to remove extra div from editor

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -7,12 +7,18 @@ import memoize from 'memize';
  * WordPress dependencies
  */
 import { calendar as icon } from '@wordpress/icons';
-import { Disabled, Placeholder, Spinner } from '@wordpress/components';
+import { Placeholder, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import ServerSideRender from '@wordpress/server-side-render';
+import { useServerSideRender } from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { useDisabled } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import HtmlRenderer from '../utils/html-renderer';
 
 /**
  * Returns the year and month of a specified date.
@@ -33,8 +39,7 @@ const getYearMonth = memoize( ( date ) => {
 	};
 } );
 
-export default function CalendarEdit( { attributes } ) {
-	const blockProps = useBlockProps();
+export default function CalendarEdit( { attributes, name } ) {
 	const { date, hasPosts, hasPostsResolved } = useSelect( ( select ) => {
 		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
 
@@ -76,6 +81,40 @@ export default function CalendarEdit( { attributes } ) {
 		};
 	}, [] );
 
+	const { content, status, error } = useServerSideRender( {
+		attributes: {
+			...attributes,
+			...getYearMonth( date ),
+		},
+		skipBlockSupportAttributes: true,
+		block: name,
+	} );
+
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
+
+	if ( status === 'loading' ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div { ...blockProps }>
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
+			</div>
+		);
+	}
+
 	if ( ! hasPosts ) {
 		return (
 			<div { ...blockProps }>
@@ -90,14 +129,5 @@ export default function CalendarEdit( { attributes } ) {
 		);
 	}
 
-	return (
-		<div { ...blockProps }>
-			<Disabled>
-				<ServerSideRender
-					block="core/calendar"
-					attributes={ { ...attributes, ...getYearMonth( date ) } }
-				/>
-			</Disabled>
-		</div>
-	);
+	return <HtmlRenderer wrapperProps={ blockProps } html={ content } />;
 }

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -93,28 +93,6 @@ export default function CalendarEdit( { attributes, name } ) {
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );
 
-	if ( status === 'loading' ) {
-		return (
-			<div { ...blockProps }>
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( status === 'error' ) {
-		return (
-			<div { ...blockProps }>
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
-			</div>
-		);
-	}
-
 	if ( ! hasPosts ) {
 		return (
 			<div { ...blockProps }>
@@ -129,5 +107,27 @@ export default function CalendarEdit( { attributes, name } ) {
 		);
 	}
 
-	return <HtmlRenderer wrapperProps={ blockProps } html={ content } />;
+	return (
+		<>
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
+			{ status === 'error' && (
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
+			) }
+			{ status === 'success' && (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
+		</>
+	);
 }

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -86,7 +86,6 @@ export default function CalendarEdit( { attributes, name } ) {
 			...attributes,
 			...getYearMonth( date ),
 		},
-		skipBlockSupportAttributes: true,
 		block: name,
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/74248

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. Remove extra wrapper div from the block in backend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Uses the HTMLRenderer component and useServerSideRender() hook to eliminate these extra divs and make the HTML on the front end and editor match for Calender Block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post or page.
2. Add core/calendar block.
3. Inspect the block, you will notice no extra div present.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before (Editor)|After (Editor)|
|-|-|
| <img width="1440" height="613" alt="Screenshot 2025-12-30 at 2 38 02 PM" src="https://github.com/user-attachments/assets/953987bf-5786-4c9d-bbdd-cbb418d0fa01" /> | <img width="1440" height="613" alt="Screenshot 2025-12-30 at 2 37 01 PM" src="https://github.com/user-attachments/assets/6c4a7769-0c1f-4e64-8b51-9d5587837494" /> |