### PR TITLE
Breadcrumbs Block: Use HtmlRenderer to remove extra div from editor

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -13,13 +13,15 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect, useState, RawHTML } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
+import { useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import HtmlRenderer from '../utils/html-renderer';
 
 const separatorDefaultValue = '/';
 
@@ -100,19 +102,35 @@ export default function BreadcrumbEdit( {
 		setInvalidationKey( ( c ) => c + 1 );
 	}, [ post ] );
 
-	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const { content } = useServerSideRender( {
+	const { content, status, error } = useServerSideRender( {
 		attributes,
 		skipBlockSupportAttributes: true,
 		block: name,
 		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
 
-	if ( isLoading ) {
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
+
+	if ( isLoading || status === 'loading' ) {
 		return (
 			<div { ...blockProps }>
 				<Spinner />
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div { ...blockProps }>
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
 			</div>
 		);
 	}
@@ -279,13 +297,11 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			<div { ...blockProps }>
-				{ showPlaceholder ? (
-					placeholder
-				) : (
-					<RawHTML inert="true">{ content }</RawHTML>
-				) }
-			</div>
+			{ showPlaceholder ? (
+				<div { ...blockProps }>{ placeholder }</div>
+			) : (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -176,7 +176,7 @@ export default function BreadcrumbEdit( {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
-			<nav { ...blockProps } inert="true">
+			<nav { ...blockProps }>
 				<ol>
 					{ placeholderItems.map( ( text, index ) => (
 						<li key={ index }>

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -111,7 +111,10 @@ export default function BreadcrumbEdit( {
 	} );
 
 	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( { ref: disabledRef } );
+	const blockProps = useBlockProps( {
+		ref: disabledRef,
+		style: { '--separator': `'${ separator }'` },
+	} );
 
 	if ( isLoading || status === 'loading' ) {
 		return (
@@ -173,12 +176,7 @@ export default function BreadcrumbEdit( {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
-			<nav
-				style={ {
-					'--separator': `'${ separator }'`,
-				} }
-				inert="true"
-			>
+			<nav { ...blockProps } inert="true">
 				<ol>
 					{ placeholderItems.map( ( text, index ) => (
 						<li key={ index }>
@@ -298,7 +296,7 @@ export default function BreadcrumbEdit( {
 				/>
 			</InspectorControls>
 			{ showPlaceholder ? (
-				<div { ...blockProps }>{ placeholder }</div>
+				placeholder
 			) : (
 				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
 			) }

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -281,15 +281,21 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			{ status === 'loading' ? <Spinner /> : null }
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
 			{ status === 'error' && (
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
 			) }
 			{ showPlaceholder && placeholder }
 			{ ! showPlaceholder && status === 'success' && (

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -116,24 +116,10 @@ export default function BreadcrumbEdit( {
 		style: { '--separator': `'${ separator }'` },
 	} );
 
-	if ( isLoading || status === 'loading' ) {
+	if ( isLoading ) {
 		return (
 			<div { ...blockProps }>
 				<Spinner />
-			</div>
-		);
-	}
-
-	if ( status === 'error' ) {
-		return (
-			<div { ...blockProps }>
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
 			</div>
 		);
 	}
@@ -295,9 +281,18 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			{ showPlaceholder ? (
-				placeholder
-			) : (
+			{ status === 'loading' ? <Spinner /> : null }
+			{ status === 'error' && (
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
+			) }
+			{ showPlaceholder && placeholder }
+			{ ! showPlaceholder && status === 'success' && (
 				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
 			) }
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/74248

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. Remove extra wrapper div from the block in backend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Uses the HTMLRenderer component and useServerSideRender() hook to eliminate these extra divs and make the HTML on the front end and editor match for Breadcrumbs Block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post or page.
3. Add core/breadcrumbs block.
4. Inspect the block, you will notice no extra div present.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before (Editor)|After (Editor)|
|-|-|
| <img width="1440" height="635" alt="Screenshot 2025-12-30 at 3 32 36 PM" src="https://github.com/user-attachments/assets/b7b8f584-65ae-4f1e-85f4-4f056b9a24b7" /> | <img width="1440" height="635" alt="Screenshot 2025-12-30 at 3 31 38 PM" src="https://github.com/user-attachments/assets/499f5e43-d497-4ff7-9b2e-31b906a90cf6" /> |