### PR TITLE
Breadcrumbs: Remove wrapper div and use HtmlRenderer for dynamic content rendering

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -13,13 +13,15 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect, useState, RawHTML } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
+import { useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import HtmlRenderer from '../utils/html-renderer';
 
 const separatorDefaultValue = '/';
 
@@ -100,7 +102,8 @@ export default function BreadcrumbEdit( {
 		setInvalidationKey( ( c ) => c + 1 );
 	}, [ post ] );
 
-	const blockProps = useBlockProps();
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { content } = useServerSideRender( {
 		attributes,
@@ -279,13 +282,11 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			<div { ...blockProps }>
-				{ showPlaceholder ? (
-					placeholder
-				) : (
-					<RawHTML inert="true">{ content }</RawHTML>
-				) }
-			</div>
+			{ showPlaceholder ? (
+				<div { ...blockProps }>{ placeholder }</div>
+			) : (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of Issue- #74248

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Remove extra divs and eliminate the extra CSS required to match the frontend and editor UI

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses the HTMLRenderer component and useServerSideRender() hook to eliminate these extra divs and make the HTML on the front end and editor match for Breadcrumbs Block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Edit a Post/Page
2. Add the Breadcrumbs block
3. Save and Check UI on both frontend and editor

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/2e47d7b5-d355-451d-80d5-8dbf839461d9
<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
