### PR TITLE
`@wordpress/theme`: update `colorjs.io` to version `0.6.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21304,6 +21304,7 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
 			"integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colorspace": {
@@ -52236,82 +52237,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
-			"integrity": "sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.7",
-				"@babel/helper-member-expression-to-functions": "^7.25.7",
-				"@babel/helper-optimise-call-expression": "^7.25.7",
-				"@babel/helper-replace-supers": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
-			"integrity": "sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.7.tgz",
-			"integrity": "sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/helper-replace-supers": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.7.tgz",
-			"integrity": "sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.25.7",
-				"@babel/helper-optimise-call-expression": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.7.tgz",
-			"integrity": "sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
@@ -52319,310 +52244,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.7.tgz",
-			"integrity": "sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.7.tgz",
-			"integrity": "sha512-EJN2mKxDwfOUCPxMO6MUI58RN3ganiRAG/MS/S3HfB6QFNjroAMelQo/gybyYq97WerCBAZoyrAoW8Tzdq2jWg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.7.tgz",
-			"integrity": "sha512-ZUCjAavsh5CESCmi/xCpX1qcCaAglzs/7tmuvoFnJgA1dM7gQplsguljoTg+Ru8WENpX89cQyAtWoaE0I3X3Pg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-remap-async-to-generator": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.7.tgz",
-			"integrity": "sha512-xHttvIM9fvqW+0a3tZlYcZYSBpSWzGBFIt/sYG3tcdSzBB8ZeVgz2gBP7Df+sM0N1850jrviYSSeUuc+135dmQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.7.tgz",
-			"integrity": "sha512-ZEPJSkVZaeTFG/m2PARwLZQ+OG0vFIhPlKHK/JdIMy8DbRJ/htz6LRrTFtdzxi9EHmcwbNPAKDnadpNSIW+Aow==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-classes": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.7.tgz",
-			"integrity": "sha512-9j9rnl+YCQY0IGoeipXvnk3niWicIB6kCsWRGLwX241qSXpbA4MKxtp/EdvFxsc4zI5vqfLxzOd0twIJ7I99zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-replace-supers": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"globals": "^11.1.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.7.tgz",
-			"integrity": "sha512-QIv+imtM+EtNxg/XBKL3hiWjgdLjMOmZ+XzQwSgmBfKbfxUjBzGgVPklUuE55eq5/uVoh8gg3dqlrwR/jw3ZeA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/template": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.7.tgz",
-			"integrity": "sha512-xKcfLTlJYUczdaM1+epcdh1UGewJqr9zATgrNHcLBcV2QmfvPPEixo/sK/syql9cEmbr7ulu5HMFG5vbbt/sEA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.7.tgz",
-			"integrity": "sha512-n/TaiBGJxYFWvpJDfsxSj9lEEE44BFM1EPGz4KEiTipTgkoFVVcCmzAL3qA7fdQU96dpo4gGf5HBx/KnDvqiHw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.7.tgz",
-			"integrity": "sha512-5MCTNcjCMxQ63Tdu9rxyN6cAWurqfrDZ76qvVPrGYdBxIj+EawuuxTu/+dgJlhK5eRz3v1gLwp6XwS8XaX2NiQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-literals": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.7.tgz",
-			"integrity": "sha512-fwzkLrSu2fESR/cm4t6vqd7ebNIopz2QHGtjoU+dswQo/P6lwAG04Q98lliE3jkz/XqnbGFLnUcE0q0CVUf92w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.7.tgz",
-			"integrity": "sha512-Std3kXwpXfRV0QtQy5JJcRpkqP8/wG4XL7hSKZmGlxPlDqmpXtEPRmhF7ztnlTCtUN3eXRUJp+sBEZjaIBVYaw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.7.tgz",
-			"integrity": "sha512-L9Gcahi0kKFYXvweO6n0wc3ZG1ChpSFdgG+eV1WYZ3/dGbJK7vvk91FgGgak8YwRgrCuihF8tE/Xg07EkL5COg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-simple-access": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.7.tgz",
-			"integrity": "sha512-BtAT9LzCISKG3Dsdw5uso4oV1+v2NlVXIIomKJgQybotJY3OwCwJmkongjHgwGKoZXd0qG5UZ12JUlDQ07W6Ow==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.7.tgz",
-			"integrity": "sha512-pWT6UXCEW3u1t2tcAGtE15ornCBvopHj9Bps9D2DsH15APgNVOTwwczGckX+WkAvBmuoYKRCFa4DK+jM8vh5AA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-replace-supers": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.7.tgz",
-			"integrity": "sha512-FYiTvku63me9+1Nz7TOx4YMtW3tWXzfANZtrzHhUZrz4d47EEtMQhzFoZWESfXuAMMT5mwzD4+y1N8ONAX6lMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.7.tgz",
-			"integrity": "sha512-KY0hh2FluNxMLwOCHbxVOKfdB5sjWG4M183885FmaqWWiGMhRZq4DQRKH6mHdEucbJnyDyYiZNwNG424RymJjA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.7.tgz",
-			"integrity": "sha512-LzA5ESzBy7tqj00Yjey9yWfs3FKy4EmJyKOSWld144OxkTji81WWnUT8nkLUn+imN/zHL8ZQlOu/MTUAhHaX3g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.7",
-				"@babel/helper-create-class-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.7.tgz",
-			"integrity": "sha512-lQEeetGKfFi0wHbt8ClQrUSUMfEeI3MMm74Z73T9/kuz990yYVtfofjf3NuA42Jy3auFOpbjDyCSiIkTs1VIYw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -52662,102 +52283,6 @@
 				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.7.tgz",
-			"integrity": "sha512-uBbxNwimHi5Bv3hUccmOFlUy3ATO6WagTApenHz9KzoIdn0XeACdB12ZJ4cjhuB2WSi80Ez2FWzJnarccriJeA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-spread": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.7.tgz",
-			"integrity": "sha512-Mm6aeymI0PBh44xNIv/qvo8nmbkpZze1KvR8MkEqbIREDxoiWTi18Zr2jryfRMwDfVZF9foKh060fWgni44luw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.7.tgz",
-			"integrity": "sha512-ZFAeNkpGuLnAQ/NCsXJ6xik7Id+tHuS+NT+ue/2+rn/31zcdnupCdmunOizEaP0JsUmTFSTOPoQY7PkK2pttXw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.7.tgz",
-			"integrity": "sha512-SI274k0nUsFFmyQupiO7+wKATAmMFf8iFgq2O+vVFXZ0SV9lNfT1NGzBEhjquFmD8I9sqHLguH+gZVN3vww2AA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.7.tgz",
-			"integrity": "sha512-VKlgy2vBzj8AmEzunocMun2fF06bsSWV+FvVXohtL6FGve/+L217qhHxRTVGHEDO/YR8IANcjzgJsd04J8ge5Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.7",
-				"@babel/helper-create-class-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-				"@babel/plugin-syntax-typescript": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.7.tgz",
-			"integrity": "sha512-8JKfg/hiuA3qXnlLx8qtv5HWRbgyFx2hMMtpDDuU2rTckpKkGu4ycK5yYHwuEa16/quXfoxHBIApEsNyMWnt0g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -52880,15 +52405,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"packages/babel-preset-default/node_modules/semver": {
@@ -55495,7 +55011,7 @@
 			"dependencies": {
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
-				"colorjs.io": "^0.5.2",
+				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
@@ -55517,6 +55033,16 @@
 				"stylelint": {
 					"optional": true
 				}
+			}
+		},
+		"packages/theme/node_modules/colorjs.io": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.0.tgz",
+			"integrity": "sha512-NgaccdK0ajJ9DPfa5OrIFRfTm4XILboOuqKV6tu9UonREcve+RUilZR3cdo7BbG+xIHFbDv4CxTE4M2vsj7nqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
 			}
 		},
 		"packages/token-list": {

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { parse, to, serialize, sRGB } from 'colorjs.io/fn';
+import { parse, to, serialize, sRGB, getAll } from 'colorjs.io/fn';
 
 /**
  * Internal dependencies
@@ -22,26 +22,19 @@ const __dirname = path.dirname( __filename );
 // Path to the color.json file
 const colorJsonPath = path.join( __dirname, '../../tokens/color.json' );
 
-/**
- * Rounds a given hex value (0-255) to 3 decimal places.
- *
- * 3 decimal places is the minimum precision for lossless hex serialization.
- * With 3 decimal places rounding to the nearest 0.001, the maximum rounding
- * error is 0.0005. With 256 possible hex values, 0.0005 × 256 = 0.128,
- * guaranteeing the rounded value stays within 0.5 of the original value.
- *
- * @param n - The hex value to round.
- * @return The rounded hex value.
- */
-const roundHexComponent = ( n: number ) => Math.round( n * 1000 ) / 1000;
+// 3 decimal places is the minimum precision for lossless hex serialization.
+// With 3 decimal places rounding to the nearest 0.001, the maximum rounding
+// error is 0.0005. With 256 possible hex values, 0.0005 × 256 = 0.128,
+// guaranteeing the rounded value stays within 0.5 of the original value.
+const ROUNDING_PRECISION = 3;
 
 const transformColorStringToDTCGValue = ( color: string ) => {
 	const parsed = to( parse( color ), sRGB );
 
 	return {
 		colorSpace: 'srgb',
-		components: parsed.coords.map( roundHexComponent ),
-		...( parsed.alpha < 1 ? { alpha: parsed.alpha } : undefined ),
+		components: getAll( parsed, { precision: ROUNDING_PRECISION } ),
+		...( ( parsed.alpha ?? 1 ) < 1 ? { alpha: parsed.alpha } : undefined ),
 		hex: serialize( parsed, { format: 'hex' } ),
 	};
 };

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -26,14 +26,14 @@ const colorJsonPath = path.join( __dirname, '../../tokens/color.json' );
 // With 3 decimal places rounding to the nearest 0.001, the maximum rounding
 // error is 0.0005. With 256 possible hex values, 0.0005 × 256 = 0.128,
 // guaranteeing the rounded value stays within 0.5 of the original value.
-const ROUNDING_PRECISION = 3;
+const HEX_ROUNDING_PRECISION = 3;
 
 const transformColorStringToDTCGValue = ( color: string ) => {
 	const parsed = to( parse( color ), sRGB );
 
 	return {
 		colorSpace: 'srgb',
-		components: getAll( parsed, { precision: ROUNDING_PRECISION } ),
+		components: getAll( parsed, { precision: HEX_ROUNDING_PRECISION } ),
 		...( ( parsed.alpha ?? 1 ) < 1 ? { alpha: parsed.alpha } : undefined ),
 		hex: serialize( parsed, { format: 'hex' } ),
 	};

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { parse, to, serialize, sRGB, getAll } from 'colorjs.io/fn';
+import { to, serialize, sRGB, getAll } from 'colorjs.io/fn';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ const colorJsonPath = path.join( __dirname, '../../tokens/color.json' );
 const HEX_ROUNDING_PRECISION = 3;
 
 const transformColorStringToDTCGValue = ( color: string ) => {
-	const parsed = to( parse( color ), sRGB );
+	const parsed = to( color, sRGB );
 
 	return {
 		colorSpace: 'srgb',

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -67,7 +67,7 @@
 	"dependencies": {
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
-		"colorjs.io": "^0.5.2",
+		"colorjs.io": "^0.6.0",
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {

--- a/packages/theme/src/color-ramps/index.ts
+++ b/packages/theme/src/color-ramps/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, OKLCH, parse } from 'colorjs.io/fn';
+import { get, OKLCH } from 'colorjs.io/fn';
 
 /**
  * Internal dependencies
@@ -44,7 +44,7 @@ function getBgRampInfo( ramp: InternalRampResult ): {
 		pinLightness: {
 			stepName: STEP_TO_PIN,
 			value: clampAccentScaleReferenceLightness(
-				get( parse( ramp.ramp[ STEP_TO_PIN ] ), [ OKLCH, 'l' ] ),
+				get( ramp.ramp[ STEP_TO_PIN ], [ OKLCH, 'l' ] ),
 				ramp.direction
 			),
 		},

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -22,7 +22,7 @@ import './register-color-spaces';
  * @return String representation
  */
 export function getColorString( color: ColorTypes ): string {
-	return serialize( to( color, sRGB ), { format: 'hex', inGamut: true } );
+	return serialize( color, { format: 'hex', inGamut: true } );
 }
 
 /**

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -5,7 +5,6 @@ import {
 	clone,
 	get,
 	OKLCH,
-	parse,
 	set,
 	type ColorTypes,
 	type PlainColorObject,
@@ -222,7 +221,7 @@ export function buildRamp(
 ): RampResult {
 	let seed: PlainColorObject;
 	try {
-		seed = clampToGamut( parse( seedArg ) );
+		seed = clampToGamut( seedArg );
 	} catch ( error ) {
 		throw new Error(
 			`Invalid seed color "${ seedArg }": ${

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -55,10 +55,10 @@ export function taperChroma(
 	const achromaEpsilon = options.achromaEpsilon ?? 0.005;
 
 	const cSeed = Math.max( 0, get( seed, [ OKLCH, 'c' ] ) );
-	let hSeed = Number( get( seed, [ OKLCH, 'h' ] ) );
+	let hSeed = get( seed, [ OKLCH, 'h' ] );
 
 	const chromaIsTiny = cSeed < achromaEpsilon;
-	const hueIsInvalid = ! Number.isFinite( hSeed );
+	const hueIsInvalid = hSeed === null || ! Number.isFinite( hSeed );
 
 	if ( chromaIsTiny || hueIsInvalid ) {
 		if ( typeof options.hueFallback === 'number' ) {

--- a/packages/theme/src/color-ramps/test/__snapshots__/index.test.ts.snap
+++ b/packages/theme/src/color-ramps/test/__snapshots__/index.test.ts.snap
@@ -14387,9 +14387,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14411,7 +14411,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",
@@ -14422,9 +14422,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14446,7 +14446,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",
@@ -14457,9 +14457,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14481,7 +14481,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",
@@ -14492,9 +14492,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14516,7 +14516,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",
@@ -14527,9 +14527,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14551,7 +14551,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",
@@ -14562,9 +14562,9 @@ exports[`buildRamps background ramp snapshots 1`] = `
   },
   {
     "input": {
-      "seedComputed": "#4d4c4d",
+      "seedComputed": "#4d4d4d",
       "seedOriginal": "#4d4d4d",
-      "seedUnchanged": false,
+      "seedUnchanged": true,
     },
     "output": {
       "direction": "lighter",
@@ -14586,7 +14586,7 @@ exports[`buildRamps background ramp snapshots 1`] = `
         "stroke3": "#a0a0a0",
         "stroke4": "#c6c6c6",
         "surface1": "#484848",
-        "surface2": "#4d4c4d",
+        "surface2": "#4d4d4d",
         "surface3": "#515151",
         "surface4": "#555",
         "surface5": "#595959",

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { parse, to, serialize, sRGB } from 'colorjs.io/fn';
+import { parse, serialize } from 'colorjs.io/fn';
 
 /**
  * Internal dependencies
@@ -26,17 +26,14 @@ describe( 'buildRamps', () => {
 		expect(
 			allBgColors.map( ( bg ) => {
 				const ramp = buildRamp( bg, BG_RAMP_CONFIG );
-				const seedOriginal = serialize( to( parse( bg ), sRGB ), {
+				const seedOriginal = serialize( parse( bg ), {
 					format: 'hex',
 					inGamut: true,
 				} );
-				const seedComputed = serialize(
-					to( parse( ramp.ramp.surface2 ), sRGB ),
-					{
-						format: 'hex',
-						inGamut: true,
-					}
-				);
+				const seedComputed = serialize( parse( ramp.ramp.surface2 ), {
+					format: 'hex',
+					inGamut: true,
+				} );
 
 				return {
 					input: {
@@ -102,15 +99,12 @@ describe( 'buildRamps', () => {
 			allPrimaryColors.map( ( primary ) =>
 				options.map( ( o ) => {
 					const ramp = buildRamp( primary, ACCENT_RAMP_CONFIG, o );
-					const seedOriginal = serialize(
-						to( parse( primary ), sRGB ),
-						{
-							format: 'hex',
-							inGamut: true,
-						}
-					);
+					const seedOriginal = serialize( parse( primary ), {
+						format: 'hex',
+						inGamut: true,
+					} );
 					const seedComputed = serialize(
-						to( parse( ramp.ramp.bgFill1 ), sRGB ),
+						parse( ramp.ramp.bgFill1 ),
 						{
 							format: 'hex',
 							inGamut: true,

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { parse, serialize } from 'colorjs.io/fn';
+import { serialize } from 'colorjs.io/fn';
 
 /**
  * Internal dependencies
@@ -26,11 +26,11 @@ describe( 'buildRamps', () => {
 		expect(
 			allBgColors.map( ( bg ) => {
 				const ramp = buildRamp( bg, BG_RAMP_CONFIG );
-				const seedOriginal = serialize( parse( bg ), {
+				const seedOriginal = serialize( bg, {
 					format: 'hex',
 					inGamut: true,
 				} );
-				const seedComputed = serialize( parse( ramp.ramp.surface2 ), {
+				const seedComputed = serialize( ramp.ramp.surface2, {
 					format: 'hex',
 					inGamut: true,
 				} );
@@ -99,17 +99,14 @@ describe( 'buildRamps', () => {
 			allPrimaryColors.map( ( primary ) =>
 				options.map( ( o ) => {
 					const ramp = buildRamp( primary, ACCENT_RAMP_CONFIG, o );
-					const seedOriginal = serialize( parse( primary ), {
+					const seedOriginal = serialize( primary, {
 						format: 'hex',
 						inGamut: true,
 					} );
-					const seedComputed = serialize(
-						parse( ramp.ramp.bgFill1 ),
-						{
-							format: 'hex',
-							inGamut: true,
-						}
-					);
+					const seedComputed = serialize( ramp.ramp.bgFill1, {
+						format: 'hex',
+						inGamut: true,
+					} );
 
 					return {
 						input: {

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -15,7 +15,7 @@ const lStops = [ 100, 90, 80, 70, 60, 50, 40, 30, 20, 10 ];
 const sStops = [ 100, 80, 60, 40, 20, 0 ];
 const hstops = [ 0, 60, 120, 180, 240, 300 ];
 
-describe.skip( 'buildRamps', () => {
+describe( 'buildRamps', () => {
 	it( 'background ramp snapshots', () => {
 		const allBgColors = lStops.flatMap( ( l ) =>
 			sStops.flatMap( ( s ) =>

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -4,7 +4,6 @@
 import type { CSSProperties } from 'react';
 import {
 	clone,
-	parse,
 	set,
 	to,
 	serialize,
@@ -102,7 +101,7 @@ function customRgbFormat( color: PlainColorObject ): string {
 }
 
 function legacyWpAdminThemeOverridesCSS( accent: string ): Entry[] {
-	const parsedAccent = to( parse( accent ), HSL );
+	const parsedAccent = to( accent, HSL );
 	const parsedL = parsedAccent.coords[ 2 ] ?? 0;
 
 	// Create darker version of accent —

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -103,14 +103,18 @@ function customRgbFormat( color: ColorTypes ) {
 function legacyWpAdminThemeOverridesCSS( accent: string ): Entry[] {
 	const parsedAccent = to( parse( accent ), HSL );
 
-	const coords = parsedAccent.coords;
+	// Fallback to 0 for grayscale colors.
+	const parsedH = parsedAccent.coords[ 0 ] ?? 0;
+	const parsedS = parsedAccent.coords[ 1 ] ?? 0;
+	const parsedL = parsedAccent.coords[ 2 ] ?? 0;
+
 	const darker10 = to(
 		{
 			space: HSL,
 			coords: [
-				coords[ 0 ], // h
-				coords[ 1 ], // s
-				Math.max( 0, Math.min( 100, coords[ 2 ] - 5 ) ), // l (reduced by 5%)
+				parsedH,
+				parsedS,
+				Math.max( 0, Math.min( 100, parsedL - 5 ) ), // L reduced by 5%
 			],
 		},
 		sRGB
@@ -119,9 +123,9 @@ function legacyWpAdminThemeOverridesCSS( accent: string ): Entry[] {
 		{
 			space: HSL,
 			coords: [
-				coords[ 0 ], // h
-				coords[ 1 ], // s
-				Math.max( 0, Math.min( 100, coords[ 2 ] - 10 ) ), // l (reduced by 10%)
+				parsedH,
+				parsedS,
+				Math.max( 0, Math.min( 100, parsedL - 10 ) ), // L reduced by 10%
 			],
 		},
 		sRGB

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -3,13 +3,14 @@
  */
 import type { CSSProperties } from 'react';
 import {
+	clone,
 	parse,
+	set,
 	to,
-	get,
 	serialize,
 	sRGB,
 	HSL,
-	type ColorTypes,
+	type PlainColorObject,
 } from 'colorjs.io/fn';
 import memoize from 'memize';
 
@@ -93,48 +94,33 @@ const legacyWpComponentsOverridesCSS: Entry[] = [
 	],
 ];
 
-function customRgbFormat( color: ColorTypes ) {
+function customRgbFormat( color: PlainColorObject ): string {
 	const rgb = to( color, sRGB );
-	return [ get( rgb, 'srgb.r' ), get( rgb, 'srgb.g' ), get( rgb, 'srgb.b' ) ]
-		.map( ( n ) => Math.round( n * 255 ) )
+	return rgb.coords
+		.map( ( n ) => Math.round( ( n ?? 0 ) * 255 ) )
 		.join( ', ' );
 }
 
 function legacyWpAdminThemeOverridesCSS( accent: string ): Entry[] {
 	const parsedAccent = to( parse( accent ), HSL );
-
-	// Fallback to 0 for grayscale colors.
-	const parsedH = parsedAccent.coords[ 0 ] ?? 0;
-	const parsedS = parsedAccent.coords[ 1 ] ?? 0;
 	const parsedL = parsedAccent.coords[ 2 ] ?? 0;
 
-	const darker10 = to(
-		{
-			space: HSL,
-			coords: [
-				parsedH,
-				parsedS,
-				Math.max( 0, Math.min( 100, parsedL - 5 ) ), // L reduced by 5%
-			],
-		},
-		sRGB
+	// Create darker version of accent —
+	const darker10 = set(
+		clone( parsedAccent ),
+		[ HSL, 'l' ],
+		Math.max( 0, parsedL - 5 ) // L reduced by 5%
 	);
-	const darker20 = to(
-		{
-			space: HSL,
-			coords: [
-				parsedH,
-				parsedS,
-				Math.max( 0, Math.min( 100, parsedL - 10 ) ), // L reduced by 10%
-			],
-		},
-		sRGB
+	const darker20 = set(
+		clone( parsedAccent ),
+		[ HSL, 'l' ],
+		Math.max( 0, parsedL - 10 ) // L reduced by 10%
 	);
 
 	return [
 		[
 			'--wp-admin-theme-color',
-			serialize( to( parsedAccent, sRGB ), { format: 'hex' } ),
+			serialize( parsedAccent, { format: 'hex' } ),
 		],
 		[ '--wp-admin-theme-color--rgb', customRgbFormat( parsedAccent ) ],
 		[


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Stacked on top of https://github.com/WordPress/gutenberg/pull/74281

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Update the `colorjs.io` dependency in the `@wordpress/theme` package to the latest released version `0.6.0`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To benefit from the latest fixes and improvements https://github.com/color-js/color.js/releases/tag/v0.6.0

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Made sure to be using `node@20.19.6` to match the CI environment
- Updated the local `package.json` file for the `@wordpress/theme` package
- Ran `npm install` to update `package-lock.json`
- Followed the release notes and updated the [relevant code where necessary](https://github.com/color-js/color.js/releases/tag/v0.6.0)
  - `null` instead of `NaN` for "none" values
  - plain number instea of `Number` objects
  - implemented suggestion from https://github.com/WordPress/gutenberg/pull/73858#discussion_r2613578185

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Review code changes
- Smoke test storybook ramps
- Run color ramp tests locally