### PR TITLE
Storybook: Show props from component libraries

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -74,6 +74,24 @@ module.exports = {
 	docs: {},
 	typescript: {
 		reactDocgen: 'react-docgen-typescript',
+		// Should match defaults in Storybook except for the propFilter.
+		// https://github.com/storybookjs/storybook/blob/3e34a288c8fabc7d5b5cc43b28ae9d674c48e3ea/code/core/src/core-server/presets/common-preset.ts#L162-L168
+		reactDocgenTypescriptOptions: {
+			shouldExtractLiteralValuesFromEnum: true,
+			shouldRemoveUndefinedFromOptional: true,
+			propFilter: ( prop ) => {
+				if ( ! prop.parent ) {
+					return true;
+				}
+
+				if ( /@base-ui|@ariakit/.test( prop.parent.fileName ) ) {
+					return true;
+				}
+
+				return ! /node_modules/.test( prop.parent.fileName );
+			},
+			savePropValueAsString: true,
+		},
 	},
 	webpackFinal: async ( config ) => {
 		// Find the `babel-loader` rule added by `@storybook/addon-webpack5-compiler-babel`


### PR DESCRIPTION
Split out from #74190
Part of #74178

## What?

Tweak the docgen config in Storybook so prop data coming from our underlying libraries (Ariakit, Base UI) will also show up in the props tables.

## Why?

We're going to start adding more components based on Base UI in `@wordpress/ui`, and we'll want to show props originating from the Base UI library in the Storybook props tables. By default, Storybook will filter out props coming from `node_modules`, so we need to selectively enable the libraries we want to include in the documentation.

## Testing Instructions

Here is an example story to demonstrate what happens:

```diff
diff --git a/packages/ui/src/visually-hidden/stories/test.story.tsx b/packages/ui/src/visually-hidden/stories/test.story.tsx
new file mode 100644
index 0000000000..277eade867
--- /dev/null
+++ b/packages/ui/src/visually-hidden/stories/test.story.tsx
@@ -0,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from '@base-ui/react/checkbox';
+
+export function TestCheckbox( props: Checkbox.Root.Props ) {
+	return (
+		<Checkbox.Root { ...props }>
+			<Checkbox.Indicator />
+		</Checkbox.Root>
+	);
+}
+
+const meta: Meta< typeof TestCheckbox > = {
+	title: 'Design System/Components/TestCheckbox',
+	component: TestCheckbox,
+};
+export default meta;
+
+type Story = StoryObj< typeof TestCheckbox >;
+
+export const Default: Story = {
+	args: {
+		children: <Checkbox.Indicator />,
+	},
+};
```

| Before | After |
|--------|-------|
|<img width="1838" height="1528" alt="Storybook props table, before" src="https://github.com/user-attachments/assets/00da204c-ddbe-4075-b9b3-231dc38437bd" />|<img width="1838" height="1528" alt="Storybook props table, after" src="https://github.com/user-attachments/assets/ca27deb4-598b-447e-8a6a-39cfb00fe171" />|

(Not exactly sure why `render` is included in the Before, to be honest 😅)