### PR TITLE
Feature : New shortcut to copy all blocks.

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -155,7 +155,7 @@ export default function EditorKeyboardShortcuts() {
 
 		// Copy to clipboard.
 		window?.navigator?.clipboard?.writeText( content ).then( () => {
-			createNotice( 'info', __( 'All content copied.' ), {
+			createNotice( 'info', __( 'All blocks copied.' ), {
 				isDismissible: true,
 				type: 'snackbar',
 			} );

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -5,6 +5,10 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -41,7 +45,11 @@ export default function EditorKeyboardShortcuts() {
 		isPostSavingLocked,
 		isListViewOpened,
 		getEditorMode,
+		getCurrentPostId,
+		getCurrentPostType,
 	} = useSelect( editorStore );
+	const { getEditedEntityRecord } = useSelect( coreStore );
+	const { createNotice } = useDispatch( noticesStore );
 
 	useShortcut(
 		'core/editor/toggle-mode',
@@ -116,6 +124,42 @@ export default function EditorKeyboardShortcuts() {
 				: 'edit-post/document';
 			enableComplementaryArea( 'core', sidebarToOpen );
 		}
+	} );
+
+	useShortcut( 'core/editor/copy-all', ( event ) => {
+		event.preventDefault();
+
+		const record = getEditedEntityRecord(
+			'postType',
+			getCurrentPostType(),
+			getCurrentPostId()
+		);
+
+		if ( ! record ) {
+			return;
+		}
+
+		let content = '';
+
+		// If the record has blocks, serialize them.
+		if ( record.blocks ) {
+			content = __unstableSerializeAndClean( record.blocks );
+			// If the record has content, use it.
+		} else if ( record.content ) {
+			content = record.content;
+		}
+
+		if ( ! content ) {
+			return;
+		}
+
+		// Copy to clipboard.
+		window?.navigator?.clipboard?.writeText( content ).then( () => {
+			createNotice( 'info', __( 'All content copied.' ), {
+				isDismissible: true,
+				type: 'snackbar',
+			} );
+		} );
 	} );
 
 	return null;

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -102,7 +102,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/copy-all',
 			category: 'global',
-			description: __( 'Copy all content.' ),
+			description: __( 'Copy all blocks.' ),
 			keyCombination: {
 				modifier: 'secondary',
 				character: 'c',

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -100,6 +100,16 @@ function EditorKeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/editor/copy-all',
+			category: 'global',
+			description: __( 'Copy all content.' ),
+			keyCombination: {
+				modifier: 'secondary',
+				character: 'c',
+			},
+		} );
+
+		registerShortcut( {
 			name: 'core/editor/keyboard-shortcuts',
 			category: 'main',
 			description: __( 'Display these keyboard shortcuts.' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
- Closes : https://github.com/WordPress/gutenberg/issues/73995
- Registers a new shortcut to copy all blocks within a post regardless of the block selection.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Mentioned in : https://github.com/WordPress/gutenberg/issues/73995

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Register a new shortcut to copy all blocks within a post.
- New shortcut : `shift + option + ⌘ + C`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a post and add dummy content. Use combination of normal blocks and some blocks with innerblocks like Gallery.
2. To check for the shortcut, use this shortcut : `^ + option + h`. Search for `Copy all blocks` under `Global` section.
3. Use `shift + option + ⌘ + C`.
4. Create another post and paste.
5. The content should be similar.
