### PR TITLE
Fix: menu_order validation to allow zero and negative values

### DIFF
--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -35,8 +35,7 @@ interface Action< Item > {
 function isItemValid( item: BasePost ): boolean {
 	return (
 		typeof item.menu_order === 'number' &&
-		Number.isInteger( item.menu_order ) &&
-		item.menu_order > 0
+		Number.isInteger( item.menu_order )
 	);
 }
 

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -350,7 +350,7 @@ test.describe( 'Pages', () => {
 
 		// Get the order input and save button
 		let orderInput = page.getByRole( 'spinbutton', { name: 'Order' } );
-		let saveButton = page.getByRole( 'button', { name: 'Save' } );
+		const saveButton = page.getByRole( 'button', { name: 'Save' } );
 
 		// Test that 0 is valid
 		await orderInput.fill( '0' );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -321,4 +321,61 @@ test.describe( 'Pages', () => {
 				.getByText( 'Change template' )
 		).toBeDisabled();
 	} );
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/73820
+	test( 'should allow setting page order to zero and negative values', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Create a published page for testing
+		await requestUtils.createPage( {
+			title: 'Order Test Page',
+			status: 'publish',
+		} );
+
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+
+		// Switch to table layout to access actions
+		await page.getByRole( 'button', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
+		// Open actions menu for the test page
+		const row = page.getByRole( 'row', { name: /Order Test Page/ } );
+		await row.getByRole( 'button', { name: 'Actions' } ).click();
+
+		// Click on Order action
+		await page.getByRole( 'menuitem', { name: 'Order' } ).click();
+
+		// Get the order input and save button
+		const orderInput = page.getByRole( 'spinbutton', { name: 'Order' } );
+		const saveButton = page.getByRole( 'button', { name: 'Save' } );
+
+		// Test that 0 is valid
+		await orderInput.fill( '0' );
+		await expect( saveButton ).toBeEnabled();
+
+		// Test that negative values are valid
+		await orderInput.fill( '-1' );
+		await expect( saveButton ).toBeEnabled();
+
+		await orderInput.fill( '-100' );
+		await expect( saveButton ).toBeEnabled();
+
+		// Test that positive values are still valid
+		await orderInput.fill( '5' );
+		await expect( saveButton ).toBeEnabled();
+
+		// Save with a negative value to verify it persists
+		await orderInput.fill( '-1' );
+		await saveButton.click();
+
+		// Verify success notice
+		await expect(
+			page.locator(
+				'role=button[name="Dismiss this notice"i] >> text="Order updated."'
+			)
+		).toBeVisible();
+	} );
 } );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -342,15 +342,15 @@ test.describe( 'Pages', () => {
 		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 
 		// Open actions menu for the test page
-		const row = page.getByRole( 'row', { name: /Order Test Page/ } );
+		let row = page.getByRole( 'row', { name: /Order Test Page/ } );
 		await row.getByRole( 'button', { name: 'Actions' } ).click();
 
 		// Click on Order action
 		await page.getByRole( 'menuitem', { name: 'Order' } ).click();
 
 		// Get the order input and save button
-		const orderInput = page.getByRole( 'spinbutton', { name: 'Order' } );
-		const saveButton = page.getByRole( 'button', { name: 'Save' } );
+		let orderInput = page.getByRole( 'spinbutton', { name: 'Order' } );
+		let saveButton = page.getByRole( 'button', { name: 'Save' } );
 
 		// Test that 0 is valid
 		await orderInput.fill( '0' );
@@ -368,7 +368,7 @@ test.describe( 'Pages', () => {
 		await expect( saveButton ).toBeEnabled();
 
 		// Save with a negative value to verify it persists
-		await orderInput.fill( '-1' );
+		await orderInput.fill( '-5' );
 		await saveButton.click();
 
 		// Verify success notice
@@ -377,5 +377,20 @@ test.describe( 'Pages', () => {
 				'role=button[name="Dismiss this notice"i] >> text="Order updated."'
 			)
 		).toBeVisible();
+
+		// Reload the page to verify the value persisted
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+		await page.getByRole( 'button', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
+		// Open Order action again for the same page
+		row = page.getByRole( 'row', { name: /Order Test Page/ } );
+		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Order' } ).click();
+
+		// Verify the negative value was persisted
+		orderInput = page.getByRole( 'spinbutton', { name: 'Order' } );
+		await expect( orderInput ).toHaveValue( '-5' );
 	} );
 } );


### PR DESCRIPTION
Fixes #73820

Fixes the `isItemValid` function in the reorder-page action to accept zero and negative values for `menu_order`. Props to @Mamaduka for suggesting the fix.

Since WP 6.9, the Order field in Post Settings incorrectly rejects zero and negative values, disabling the Save button. This is a regression introduced in #72493 when the reorder-page action was refactored.

The validation check `item.menu_order > 0` contradicts:
- The UI text which states "Negative order values are supported"
- WordPress core behavior which has always allowed zero and negative menu_order values
- The BasePost type definition which allows any number

This PR just removed the `item.menu_order > 0` condition from the `isItemValid` function, keeping only the type and integer checks.

## Testing Instructions

1. Open the block editor for a page or custom post type with `page-attributes` support
2. Click the three dots in the sidebar next to the post title
3. Click "Order" in the dropdown menu
4. Enter `0` - verify Save button is enabled
5. Enter `-1` - verify Save button is enabled
6. Click Save - verify the order is saved successfully
7. Reload the page and verify the value persists

Verify the end to end tests pass specically this one: npm run test:e2e test/e2e/specs/site-editor/pages.spec.js
Revert the changes on file packages/fields/src/actions/reorder-page.tsx and verify the tests fail.

