### PR TITLE
Packages: Avoid bumping the major version on prerelease packages

### DIFF
--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -36,12 +36,14 @@ async function findPluginReleaseBranchName( gitWorkingDirectoryPath ) {
  * @param {string[]}                  lines                Changelog content split into lines.
  * @param {('patch'|'minor'|'major')} [minimumVersionBump] Minimum version bump for the package.
  *                                                         Defaults to `patch`.
+ * @param {string}                    [currentVersion]     Current version of the package.
  *
  * @return {string|null} Version bump when applicable, or null otherwise.
  */
 function calculateVersionBumpFromChangelog(
 	lines,
-	minimumVersionBump = 'patch'
+	minimumVersionBump = 'patch',
+	currentVersion = '1.0.0'
 ) {
 	let changesDetected = false;
 	let versionBump = null;
@@ -65,7 +67,12 @@ function calculateVersionBumpFromChangelog(
 
 		// A major version bump required. Stop processing.
 		if ( lineNormalized.startsWith( '### breaking change' ) ) {
-			versionBump = 'major';
+			if ( semver.lt( currentVersion, '1.0.0' ) ) {
+				versionBump = 'minor';
+			} else {
+				versionBump = 'major';
+			}
+
 			break;
 		}
 
@@ -89,6 +96,7 @@ function calculateVersionBumpFromChangelog(
 			versionBump = minimumVersionBump;
 		}
 	}
+
 	return versionBump;
 }
 

--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -65,7 +65,7 @@ function calculateVersionBumpFromChangelog(
 			break;
 		}
 
-		// A major version bump required. Stop processing.
+		// A major version bump required for stable packages. Stop processing.
 		if ( lineNormalized.startsWith( '### breaking change' ) ) {
 			if ( semver.lt( currentVersion, '1.0.0' ) ) {
 				versionBump = 'minor';

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-const { command } = require( 'execa' );
 const path = require( 'path' );
-const glob = require( 'fast-glob' );
 const fs = require( 'fs' );
+const readline = require( 'readline' );
+const { join } = require( 'path' );
+const { command } = require( 'execa' );
+const glob = require( 'fast-glob' );
 const { inc: semverInc } = require( 'semver' );
 const { rimraf } = require( 'rimraf' );
-const readline = require( 'readline' );
 const SimpleGit = require( 'simple-git' );
 
 /**
@@ -24,7 +25,6 @@ const {
 	calculateVersionBumpFromChangelog,
 	findPluginReleaseBranchName,
 } = require( './common' );
-const { join } = require( 'path' );
 const pluginConfig = require( '../config' );
 
 /**
@@ -196,9 +196,11 @@ async function updatePackages( config ) {
 				lines.push( line );
 			}
 
+			const { version } = readJSONFile( packageJSONPath );
 			let versionBump = calculateVersionBumpFromChangelog(
 				lines,
-				minimumVersionBump
+				minimumVersionBump,
+				version
 			);
 			const packageName = `@wordpress/${
 				changelogPath.split( '/' ).reverse()[ 1 ]
@@ -216,7 +218,6 @@ async function updatePackages( config ) {
 				'CHANGELOG.md',
 				'package.json'
 			);
-			const { version } = readJSONFile( packageJSONPath );
 			const nextVersion =
 				versionBump !== null ? semverInc( version, versionBump ) : null;
 

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -196,6 +196,10 @@ async function updatePackages( config ) {
 				lines.push( line );
 			}
 
+			const packageJSONPath = changelogPath.replace(
+				'CHANGELOG.md',
+				'package.json'
+			);
 			const { version } = readJSONFile( packageJSONPath );
 			let versionBump = calculateVersionBumpFromChangelog(
 				lines,
@@ -214,10 +218,6 @@ async function updatePackages( config ) {
 			) {
 				versionBump = minimumVersionBump;
 			}
-			const packageJSONPath = changelogPath.replace(
-				'CHANGELOG.md',
-				'package.json'
-			);
 			const nextVersion =
 				versionBump !== null ? semverInc( version, versionBump ) : null;
 

--- a/bin/plugin/commands/test/common.js
+++ b/bin/plugin/commands/test/common.js
@@ -61,16 +61,31 @@ describe( 'calculateVersionBumpFromChangelog', () => {
 
 	it( 'should return major version bump when breaking changes detected', () => {
 		expect(
-			calculateVersionBumpFromChangelog(
-				[
-					'First line',
-					'## Unreleased',
-					'### Breaking Changes',
-					'  - new item added',
-					'Fifth line',
-				],
-				'major'
-			)
+			calculateVersionBumpFromChangelog( [
+				'First line',
+				'## Unreleased',
+				'### Breaking Changes',
+				'  - new item added',
+				'Fifth line',
+			] )
 		).toBe( 'major' );
+	} );
+
+	describe( 'prerelease versions', () => {
+		it( 'should not bump the major even if breaking changes detected', () => {
+			expect(
+				calculateVersionBumpFromChangelog(
+					[
+						'First line',
+						'## Unreleased',
+						'### Breaking Changes',
+						'  - new item added',
+						'Fifth line',
+					],
+					'patch',
+					'0.1.0'
+				)
+			).toBe( 'minor' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Updates the packages publishing workflow scripts to avoid bumping the major version on prerelease packages, even if it contains breaking changes.

## Why?

A prerelease package (`0.x.y`) becoming a stable package (`>=1.x.y`) is a significant change that should warrant human intervention to decide, as prerelease versions hold significant meaning and should not suddenly shift into 1.0.0+ versioning. 

This is clearly [detailed in the semantic versioning specification](https://semver.org/#spec-item-4):

>Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

While in major version zero, **any version increase is considered a breaking change**. Therefore, it is not necessary to increment the major version while in prerelease, even if the changes include breaking changes. We can still differentiate between minor and patch releases to indicate breaking changes or new APIs vs. bug fixes.

These changes are necessary because currently `@wordpress/ui` is slated to release prematurely as 1.0.0, which is not intended or desirable (see ["next" tags on published versions](https://www.npmjs.com/package/@wordpress/ui?activeTab=versions)).

The expectation would be that we should be able to manually propose a change to assign 1.0.0 in a package's `package.json` when the package is ready to become stable.

An alternative could be to remove the `CHANGELOG.md` file from the package, but these changes are intended to be communicated for the benefit of downstream consumers, even in prerelease form.

## Testing Instructions

Verify included test case passes:

```
npm run test:unit bin/plugin/commands/test/common.js
```