### PR TITLE
Footnotes: prevent inserting footnotes within a footnotes block

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -22,14 +22,13 @@ import { createBlock, store as blocksStore } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-
-const { usesContextKey } = unlock( privateApis );
+import { name as FOOTNOTES_BLOCK_NAME } from './';
 
 export const formatName = 'core/footnote';
 
+const { usesContextKey } = unlock( privateApis );
 const POST_CONTENT_BLOCK_NAME = 'core/post-content';
 const SYNCED_PATTERN_BLOCK_NAME = 'core/block';
-const FOOTNOTES_BLOCK_NAME = 'core/footnotes';
 
 export const format = {
 	title: __( 'Footnote' ),
@@ -86,14 +85,14 @@ export const format = {
 				// Checks if the selected block lives within a pattern.
 				const {
 					getBlockParentsByBlockName: _getBlockParentsByBlockName,
-					getSelectionStart,
+					getSelectedBlockClientId: _getSelectedBlockClientId,
 					getBlockName: _getBlockName,
 				} = select( blockEditorStore );
-				const selectionStart = getSelectionStart();
-				const selectedClientId = selectionStart?.clientId;
+
+				const selectedClientId = _getSelectedBlockClientId();
 
 				if ( ! selectedClientId ) {
-					return true;
+					return false;
 				}
 
 				// Check if the selected block itself is a footnotes block.

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -29,6 +29,7 @@ export const formatName = 'core/footnote';
 
 const POST_CONTENT_BLOCK_NAME = 'core/post-content';
 const SYNCED_PATTERN_BLOCK_NAME = 'core/block';
+const FOOTNOTES_BLOCK_NAME = 'core/footnotes';
 
 export const format = {
 	title: __( 'Footnote' ),
@@ -85,10 +86,25 @@ export const format = {
 				// Checks if the selected block lives within a pattern.
 				const {
 					getBlockParentsByBlockName: _getBlockParentsByBlockName,
-					getSelectedBlockClientId: _getSelectedBlockClientId,
+					getSelectionStart,
+					getBlockName: _getBlockName,
 				} = select( blockEditorStore );
+				const selectionStart = getSelectionStart();
+				const selectedClientId = selectionStart?.clientId;
+
+				if ( ! selectedClientId ) {
+					return true;
+				}
+
+				// Check if the selected block itself is a footnotes block.
+				if (
+					_getBlockName( selectedClientId ) === FOOTNOTES_BLOCK_NAME
+				) {
+					return false;
+				}
+
 				const parentCoreBlocks = _getBlockParentsByBlockName(
-					_getSelectedBlockClientId(),
+					selectedClientId,
 					SYNCED_PATTERN_BLOCK_NAME
 				);
 				return ! parentCoreBlocks || parentCoreBlocks.length === 0;


### PR DESCRIPTION

## What?
Prevents adding footnotes inside footnotes blocks by checking if the selected block is within a footnotes block before enabling the footnote format.

Unless this was intentional and I can't get it to work?



## Why?

To prevent this:

https://github.com/user-attachments/assets/dae034df-129d-45c0-8752-7ac55d285092




## How?
- Added check in `isFootnotesSupported` to detect if the selected block has a footnotes block as a parent
- Disables the footnote format button when editing content inside a footnotes block


## Testing Instructions
1. Create a new post/page
2. Add a paragraph block and insert a footnote (should work)
3. Add a Footnotes block to the post
4. Click inside the Footnotes block to edit a footnote entry
5. Try to insert a footnote inside the footnote text
6. **Expected**: The footnote format button should not appear in the toolbar
7. **Expected**: You should not be able to add a footnote to a footnote
8. Check that you still can't add footnotes inside a synced pattern (no regressions)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="503" height="633" alt="Screenshot 2025-12-31 at 1 36 22 pm" src="https://github.com/user-attachments/assets/9fee74bc-5413-455b-a9bc-16baceed22b6" />|<img width="509" height="714" alt="Screenshot 2025-12-31 at 1 36 46 pm" src="https://github.com/user-attachments/assets/08743cce-7cd3-4c2a-9d41-8e6407d2ac2e" />|




