### PR TITLE
Fix: Gutenberg strips the rel='nofollow' in links when copying content #73872

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -46,13 +46,14 @@ export default function phrasingContentReducer( node, doc ) {
 		// In jsdom-jscore, 'node.target' can be null.
 		// TODO: Explore fixing this by patching jsdom-jscore.
 		if ( node.target && node.target.toLowerCase() === '_blank' ) {
-			const additionalRel = ( node.rel || '' )
+			const existingRels = ( node.rel || '' )
 				.split( /\s+/ )
-				.filter(
-					( part ) =>
-						part && part !== 'noreferrer' && part !== 'noopener'
-				)
-				.join( ' ' );
+				.filter( Boolean );
+			const filteredRels = existingRels.filter(
+				( part ) => part !== 'noreferrer' && part !== 'noopener'
+			);
+			const uniqueAdditionalRel = Array.from( new Set( filteredRels ) );
+			const additionalRel = uniqueAdditionalRel.join( ' ' );
 			node.rel = additionalRel
 				? `noreferrer noopener ${ additionalRel }`
 				: 'noreferrer noopener';

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -46,7 +46,9 @@ export default function phrasingContentReducer( node, doc ) {
 		// In jsdom-jscore, 'node.target' can be null.
 		// TODO: Explore fixing this by patching jsdom-jscore.
 		if ( node.target && node.target.toLowerCase() === '_blank' ) {
-			node.rel = 'noreferrer noopener';
+			if ( ! node.rel || node.rel.trim() === '' ) {
+				node.rel = 'noreferrer noopener';
+			}
 		} else {
 			node.removeAttribute( 'target' );
 			node.removeAttribute( 'rel' );

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -46,9 +46,16 @@ export default function phrasingContentReducer( node, doc ) {
 		// In jsdom-jscore, 'node.target' can be null.
 		// TODO: Explore fixing this by patching jsdom-jscore.
 		if ( node.target && node.target.toLowerCase() === '_blank' ) {
-			if ( ! node.rel || node.rel.trim() === '' ) {
-				node.rel = 'noreferrer noopener';
-			}
+			const additionalRel = ( node.rel || '' )
+				.split( /\s+/ )
+				.filter(
+					( part ) =>
+						part && part !== 'noreferrer' && part !== 'noopener'
+				)
+				.join( ' ' );
+			node.rel = additionalRel
+				? `noreferrer noopener ${ additionalRel }`
+				: 'noreferrer noopener';
 		} else {
 			node.removeAttribute( 'target' );
 			node.removeAttribute( 'rel' );

--- a/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
@@ -61,6 +61,16 @@ describe( 'phrasingContentReducer', () => {
 		).toEqual( output );
 	} );
 
+	it( 'should preserve existing rel attribute when target is _blank', () => {
+		const input =
+			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener nofollow">WordPress</a>';
+		const output =
+			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener nofollow">WordPress</a>';
+		expect(
+			deepFilterHTML( input, [ phrasingContentReducer ], {} )
+		).toEqual( output );
+	} );
+
 	it( 'should only allow target="_blank"', () => {
 		const input =
 			'<a href="https://wordpress.org" target="_self">WordPress</a>';

--- a/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
@@ -63,7 +63,7 @@ describe( 'phrasingContentReducer', () => {
 
 	it( 'should preserve existing rel attribute when target is _blank', () => {
 		const input =
-			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener nofollow">WordPress</a>';
+			'<a href="https://wordpress.org" target="_blank" rel="nofollow noopener">WordPress</a>';
 		const output =
 			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener nofollow">WordPress</a>';
 		expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73872

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR ensure that, whatever is added in rel should be kept as is on pasting when we have `target="_blank"`, it should not strip the rel attributes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Checks if we have `rel` attribute, use that, else fallback to default rel value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open any post/page.
2. Paste the link you copied with rel and target blank as shown in issue #73872.
3. Save post and check on frontend, the rel should have same value which you copied.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f15fdd85-8892-4f2e-884e-719e3387be9d


