### PR TITLE
Tag Cloud, Archives: Fix sidebar flash when changing settings

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -33,28 +33,6 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );
 
-	if ( status === 'loading' ) {
-		return (
-			<div { ...blockProps }>
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( status === 'error' ) {
-		return (
-			<div { ...blockProps }>
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
-			</div>
-		);
-	}
-
 	return (
 		<>
 			<InspectorControls>
@@ -154,7 +132,19 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			{ status === 'loading' && <Spinner /> }
+			{ status === 'error' && (
+				<p>
+					{ sprintf(
+						/* translators: %s: error message returned when rendering the block. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</p>
+			) }
+			{ status === 'success' && (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -243,17 +243,11 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );
 
-	if ( status === 'loading' ) {
-		return (
-			<div { ...blockProps }>
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( status === 'error' ) {
-		return (
-			<div { ...blockProps }>
+	return (
+		<>
+			{ inspectorControls }
+			{ status === 'loading' && <Spinner /> }
+			{ status === 'error' && (
 				<p>
 					{ sprintf(
 						/* translators: %s: error message returned when rendering the block. */
@@ -261,14 +255,10 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 						error
 					) }
 				</p>
-			</div>
-		);
-	}
-
-	return (
-		<>
-			{ inspectorControls }
-			<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
+			{ status === 'success' && (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
Related to #74248

## What? Why? 

We are refactoring the dynamic blocks with `useServerSideRender` hook and `HtmlRenderer` component, but we were not rendering the `InspectorControls` component while loading server-side content. As a result, the sidebar flickers when the settings are changed in the sidebar. To prevent this, I think we need to render the `InspectorControls` consistently.

## How?

https://github.com/WordPress/gutenberg/pull/74291/changes?diff=unified&w=1

## Testing Instructions

- Insert an Archive block or a Tag Cloud block.
- Change the settings.
- Notice that there is no visual change in the sidebar, only the blocks are re-rendered.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/ad4a071e-9d53-4a4d-8eaa-ea7a79c60ee8

### After

https://github.com/user-attachments/assets/17bc5bb8-ac39-4118-b2a9-30c81e985586
