### PR TITLE
Media & Text: Respect image_default_link_type option

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -276,7 +276,6 @@ export function ImageEdit( {
 		if ( ! linkDestination ) {
 			// Use the WordPress option to determine the proper default.
 			// The constants used in Gutenberg do not match WP options so a little more complicated than ideal.
-			// TODO: fix this in a follow up PR, requires updating media-text and ui component.
 			switch (
 				window?.wp?.media?.view?.settings?.defaultProps?.link ||
 				LINK_DESTINATION_NONE

--- a/packages/block-library/src/media-text/constants.js
+++ b/packages/block-library/src/media-text/constants.js
@@ -5,6 +5,7 @@ import { _x } from '@wordpress/i18n';
 
 export const DEFAULT_MEDIA_SIZE_SLUG = 'full';
 export const WIDTH_CONSTRAINT_PERCENTAGE = 15;
+export const LINK_DESTINATION_NONE = 'none';
 export const LINK_DESTINATION_MEDIA = 'media';
 export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const TEMPLATE = [


### PR DESCRIPTION
Fixes #60222
This PR updates the Media & Text block to respect the WordPress `image_default_link_type` option when selecting images.

When the `image_default_link_type` option is set to `file` or `post`, the Image block and Gallery block automatically link images to the media file or attachment page upon selection. However, the Media & Text block was not respecting this setting.

This was noted in the Image block code with a TODO comment: "fix this in a follow up PR, requires updating media-text and ui component.


This PR just fixes the issue following exactly the same logic we use on image and gallery blocks:
1. Check if `linkDestination` is not already set when an image is selected
2. Read the WordPress default link setting from `window.wp.media.view.settings.defaultProps.link`
3. Maps WordPress constants (`file`, `post`) to Gutenberg constants (`media`, `attachment`)
4. Set both `linkDestination` and `href` attributes accordingly


The fix only applies to images, not videos (matching the behavior of other blocks).

## Testing Instructions

1. Add this php code:
```
add_action( 'after_setup_theme', function() {
    update_option( 'image_default_link_type', 'file' );
});
```
4. Create a new post
5. Add a Media & Text block
6. Upload or select an image from the media library
7. Click the link button in the block toolbar
8. Expected: The image should be linked to the media file URL

Also test:
- Setting `image_default_link_type` to `post` should link to the attachment page
- Setting `image_default_link_type` to `none` should not add any link
- Video media should not be affected by this setting
- Existing Media & Text blocks with already-set `linkDestination` should not be affected
- Replacing an image should update the href correctly based on the current `linkDestination`