### PR TITLE
Storybook: Fix Sass warnings

### DIFF
--- a/storybook/global-basic.lazy.scss
+++ b/storybook/global-basic.lazy.scss
@@ -1,4 +1,4 @@
-@import "~@wordpress/base-styles/variables";
+@use "@wordpress/base-styles/variables" as *;
 
 body {
 	font-family: $default-font;

--- a/storybook/global-wordpress.lazy.scss
+++ b/storybook/global-wordpress.lazy.scss
@@ -1,4 +1,4 @@
-@import "~@wordpress/base-styles/colors";
+@use "@wordpress/base-styles/colors" as *;
 
 // These `body` styles have different values defined in common.css,
 // but are overridden to these values within major UI sections that contain wp-components,

--- a/storybook/stories/playground/fullpage/reset.scss
+++ b/storybook/stories/playground/fullpage/reset.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
+
 :root {
 	@include reset;
 }

--- a/storybook/stories/playground/fullpage/style.lazy.scss
+++ b/storybook/stories/playground/fullpage/style.lazy.scss
@@ -1,11 +1,11 @@
-@import "~@wordpress/base-styles/colors";
-@import "~@wordpress/base-styles/variables";
-@import "~@wordpress/base-styles/mixins";
-@import "~@wordpress/base-styles/breakpoints";
-@import "~@wordpress/base-styles/animations";
-@import "~@wordpress/base-styles/z-index";
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/breakpoints" as *;
+@use "@wordpress/base-styles/animations" as *;
+@use "@wordpress/base-styles/z-index" as *;
 
-@import "./reset";
+@use "./reset";
 
 .playground {
 	img {


### PR DESCRIPTION
## What?

Fixes these Sass warnings when loading Storybook:

```
[1] Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
[1] 
[1] More info and automated migrator: https://sass-lang.com/d/import
[1] 
[1] 3 | @import "~@wordpress/base-styles/breakpoints";
[1] 
[1] 
[1] ../../../../storybook/stories/playground/fullpage/style.lazy.scss 4:9  root stylesheet
```

## Testing Instructions

Run Storybook and verify that the Sass warnings are gone.