### PR TITLE
Storybook: Remove outdated story matchers

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -34,8 +34,6 @@ const stories = [
 	'../packages/components/src/**/stories/*.story.@(jsx|tsx)',
 	'../packages/components/src/**/stories/*.mdx',
 	'../packages/icons/src/**/stories/*.story.@(js|tsx|mdx)',
-	'../packages/edit-site/src/**/stories/*.story.@(js|tsx|mdx)',
-	'../packages/global-styles-ui/src/**/stories/*.story.@(js|tsx|mdx)',
 	'../packages/dataviews/src/**/stories/*.story.@(js|tsx|mdx)',
 	'../packages/fields/src/**/stories/*.story.@(js|tsx|mdx)',
 	'../packages/image-cropper/src/**/stories/*.story.@(js|tsx|mdx)',


### PR DESCRIPTION
## What?

Removes outdated story file matchers from the Storybook config.

## Why?

To remove these warnings when loading Storybook:

```
[1] No story files found for the specified pattern: packages/global-styles-ui/src/**/stories/*.story.@(js|tsx|mdx)
[1] No story files found for the specified pattern: packages/edit-site/src/**/stories/*.story.@(js|tsx|mdx)
```

## Testing Instructions

Run Storybook and verify that the warnings are gone.
