### PR TITLE
Query Title: Fix incorrect quotation marks with trailing spaces

### DIFF
--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -48,7 +48,7 @@ function render_block_core_query_title( $attributes, $content, $block ) {
 		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
 			$title = sprintf(
 				/* translators: %s is the search term. */
-				__( 'Search results for: "%s"' ),
+				__( 'Search results for: &#8220;%s&#8221;' ),
 				get_search_query()
 			);
 		}
@@ -66,7 +66,7 @@ function render_block_core_query_title( $attributes, $content, $block ) {
 		if ( $show_prefix ) {
 			$title = sprintf(
 				/* translators: %s is the post type name. */
-				__( 'Post Type: "%s"' ),
+				__( 'Post Type: &#8220;%s&#8221;' ),
 				$post_type_name
 			);
 		} else {


### PR DESCRIPTION
Fixes #71854

Fixes incorrect quotation mark rendering in the Query Title block when the search term has a trailing space.

When a user searches with a trailing space (e.g., "Kitchen Sink QA Page "), the Query Title block displays incorrect quotation marks:

**Before**:
<img width="579" height="126" alt="Screenshot 2025-12-31 at 17 06 34" src="https://github.com/user-attachments/assets/f38a3853-47fa-455e-9965-783181bdb0d9" />

**After**:
<img width="610" height="124" alt="Screenshot 2025-12-31 at 17 06 27" src="https://github.com/user-attachments/assets/8ef4b621-0f39-482e-bc87-d576b60b8e73" />


To fix this we replace straight ASCII quotes (`"`) with HTML entity curly quotes (`&#8220;` for left and `&#8221;` for right) in the translatable strings. 
This follows the existing pattern already used in the `comments-title` block:

```php
// packages/block-library/src/comments-title/index.php:29
$post_title = sprintf( __( '&#8220;%s&#8221;' ), get_the_title() );
```

## Testing Instructions

1. Go to a search page: /?s=Kitchen+Sink+QA+Page+
4. Verify the title shows proper curly quotes: `Search results for: “Kitchen Sink QA Page ”
5. Test without trailing space to ensure normal behavior is preserved

