### PR TITLE
feat(cover-block): add support for insert from url

### DIFF
--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -14,6 +14,7 @@ export default function CoverPlaceholder( {
 	disableMediaButtons = false,
 	children,
 	onSelectMedia,
+	onSelectURL,
 	onError,
 	style,
 	toggleUseFeaturedImage,
@@ -25,6 +26,7 @@ export default function CoverPlaceholder( {
 				title: __( 'Cover' ),
 			} }
 			onSelect={ onSelectMedia }
+			onSelectURL={ onSelectURL }
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -37,6 +37,7 @@ import {
 	isContentPositionCenter,
 	getPositionClassName,
 	mediaPosition,
+	getMediaTypeFromURL,
 } from '../shared';
 import CoverInspectorControls from './inspector-controls';
 import CoverBlockControls from './block-controls';
@@ -344,6 +345,68 @@ function CoverEdit( {
 		} );
 	};
 
+	const onSelectURL = async ( newURL ) => {
+		if ( newURL === url ) {
+			return;
+		}
+
+		// Detect media type from URL (async - may make a HEAD request)
+		const { type: detectedMediaType, error } =
+			await getMediaTypeFromURL( newURL );
+
+		// If we couldn't detect the media type, show an error and don't proceed
+		if ( ! detectedMediaType ) {
+			createErrorNotice(
+				error ||
+					__(
+						'Could not determine if the URL is an image or video.'
+					),
+				{ type: 'snackbar' }
+			);
+			return;
+		}
+
+		const isImage = detectedMediaType === IMAGE_BACKGROUND_TYPE;
+
+		// Only set a new dimRatio if there was no previous media selected
+		// to avoid resetting to 50 if it has been explicitly set to 100.
+		const newDimRatio =
+			originalUrl === undefined && dimRatio === 100 ? 50 : dimRatio;
+
+		// Get average background color for images
+		const averageBackgroundColor = await getMediaColor(
+			isImage ? newURL : undefined
+		);
+
+		let newOverlayColor = overlayColor.color;
+		if ( ! isUserOverlayColor ) {
+			newOverlayColor = averageBackgroundColor;
+			setOverlayColor( newOverlayColor );
+
+			// Make undo revert the next setAttributes and the previous setOverlayColor.
+			__unstableMarkNextChangeAsNotPersistent();
+		}
+
+		const newIsDark = compositeIsDark(
+			newDimRatio,
+			newOverlayColor,
+			averageBackgroundColor
+		);
+
+		setAttributes( {
+			url: newURL,
+			id: undefined,
+			backgroundType: detectedMediaType,
+			focalPoint: undefined,
+			useFeaturedImage: undefined,
+			dimRatio: newDimRatio,
+			isDark: newIsDark,
+			isUserOverlayColor: isUserOverlayColor || false,
+			// Reset parallax for videos
+			...( ! isImage ? { hasParallax: undefined } : {} ),
+		} );
+	};
+
 	// Fetch embed preview for embed videos
 	const { embedPreview, isFetchingEmbed } = useSelect(
 		( select ) => {
@@ -580,6 +643,7 @@ function CoverEdit( {
 					{ resizeListener }
 					<CoverPlaceholder
 						onSelectMedia={ onSelectMedia }
+						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
 					>
@@ -713,6 +777,7 @@ function CoverEdit( {
 				<CoverPlaceholder
 					disableMediaButtons
 					onSelectMedia={ onSelectMedia }
+					onSelectURL={ onSelectURL }
 					onError={ onUploadError }
 					toggleUseFeaturedImage={ toggleUseFeaturedImage }
 				/>

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { getBlobTypeByURL, isBlobURL } from '@wordpress/blob';
+import { __, sprintf } from '@wordpress/i18n';
 
 const POSITION_CLASSNAMES = {
 	'top left': 'is-position-top-left',
@@ -109,4 +110,169 @@ export function getPositionClassName( contentPosition ) {
 	}
 
 	return POSITION_CLASSNAMES[ contentPosition ];
+}
+
+/**
+ * Detects the media type from a URL by first checking the file extension,
+ * then falling back to a HEAD request to check the Content-Type header.
+ *
+ * @param {string} url The URL to analyze.
+ * @return {Promise<{type: string|null, error: string|null}>} Object containing the detected media type ('image' or 'video') or an error message.
+ */
+export async function getMediaTypeFromURL( url ) {
+	if ( ! url ) {
+		return { type: null, error: __( 'No URL provided.' ) };
+	}
+
+	// First, try to detect from file extension (fast path)
+	const extensionType = getMediaTypeFromExtension( url );
+	if ( extensionType ) {
+		return { type: extensionType, error: null };
+	}
+
+	// Fall back to HEAD request to check Content-Type
+	try {
+		const response = await fetch( url, { method: 'HEAD' } );
+
+		if ( ! response.ok ) {
+			return {
+				type: null,
+				error: sprintf(
+					/* translators: %d: HTTP status code */
+					__( 'Unable to access the URL (HTTP %d).' ),
+					response.status
+				),
+			};
+		}
+
+		const contentType = response.headers.get( 'Content-Type' ) || '';
+
+		if ( contentType.startsWith( 'image/' ) ) {
+			return { type: IMAGE_BACKGROUND_TYPE, error: null };
+		}
+
+		if ( contentType.startsWith( 'video/' ) ) {
+			return { type: VIDEO_BACKGROUND_TYPE, error: null };
+		}
+
+		// Content-Type doesn't match image or video
+		return {
+			type: null,
+			error: sprintf(
+				/* translators: %s: Content-Type header value */
+				__(
+					'The URL does not point to a valid image or video file (Content-Type: %s).'
+				),
+				contentType || __( 'unknown' )
+			),
+		};
+	} catch {
+		// If HEAD request fails, try a regular GET request with a range
+		// Some servers don't support HEAD requests
+		try {
+			const response = await fetch( url, {
+				method: 'GET',
+				headers: { Range: 'bytes=0-0' },
+			} );
+
+			if ( ! response.ok && response.status !== 206 ) {
+				return {
+					type: null,
+					error: sprintf(
+						/* translators: %d: HTTP status code */
+						__( 'Unable to access the URL (HTTP %d).' ),
+						response.status
+					),
+				};
+			}
+
+			const contentType = response.headers.get( 'Content-Type' ) || '';
+
+			if ( contentType.startsWith( 'image/' ) ) {
+				return { type: IMAGE_BACKGROUND_TYPE, error: null };
+			}
+
+			if ( contentType.startsWith( 'video/' ) ) {
+				return { type: VIDEO_BACKGROUND_TYPE, error: null };
+			}
+
+			// Content-Type doesn't match image or video
+			return {
+				type: null,
+				error: sprintf(
+					/* translators: %s: Content-Type header value */
+					__(
+						'The URL does not point to a valid image or video file (Content-Type: %s).'
+					),
+					contentType || __( 'unknown' )
+				),
+			};
+		} catch {
+			// Both HEAD and GET requests failed - likely CORS or network error
+			return {
+				type: null,
+				error: __(
+					'Unable to verify the URL. This may be due to CORS restrictions or the resource is not accessible.'
+				),
+			};
+		}
+	}
+}
+
+/**
+ * Detects the media type from a URL based on the file extension.
+ * This is a fast path before making network requests.
+ *
+ * @param {string} url The URL to analyze.
+ * @return {string|null} The media type ('image' or 'video'), or null if unknown.
+ */
+function getMediaTypeFromExtension( url ) {
+	// Extract the pathname from the URL to get the file extension
+	let pathname;
+	try {
+		pathname = new URL( url, window.location.origin ).pathname;
+	} catch {
+		pathname = url;
+	}
+
+	// Remove query string and hash from pathname
+	pathname = pathname.split( '?' )[ 0 ].split( '#' )[ 0 ];
+
+	// Common image extensions
+	const imageExtensions = [
+		'jpg',
+		'jpeg',
+		'png',
+		'gif',
+		'webp',
+		'avif',
+		'svg',
+		'bmp',
+		'ico',
+	];
+	// Common video extensions
+	const videoExtensions = [
+		'mp4',
+		'webm',
+		'ogg',
+		'ogv',
+		'mov',
+		'avi',
+		'wmv',
+		'flv',
+		'm4v',
+	];
+
+	const extension = pathname.split( '.' ).pop()?.toLowerCase();
+
+	if ( extension && imageExtensions.includes( extension ) ) {
+		return IMAGE_BACKGROUND_TYPE;
+	}
+
+	if ( extension && videoExtensions.includes( extension ) ) {
+		return VIDEO_BACKGROUND_TYPE;
+	}
+
+	// Return null to indicate we couldn't determine from extension
+	return null;
 }

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -60,8 +60,9 @@ describe( 'Cover block', () => {
 			await setup();
 
 			expect(
-				within( screen.getByLabelText( 'Block: Cover' ) ).getByText(
-					'To edit this block, you need permission to upload media.'
+				within( screen.getByLabelText( 'Block: Cover' ) ).getByRole(
+					'button',
+					{ name: 'Insert from URL' }
 				)
 			).toBeInTheDocument();
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  https://github.com/WordPress/gutenberg/issues/10853

This PR adds "Insert from URL" support for the Cover block, allowing users to add image or video backgrounds by directly entering a URL instead of only being able to upload media or select from the Media Library.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, the Cover block only allows users to add background media through uploading files or selecting from the Media Library. However, users often want to use images or videos hosted externally (e.g., CDN-hosted assets, stock photo URLs, etc.) without having to download and re-upload them.
Other media-related blocks like Image and Video already support "Insert from URL" functionality. This PR brings feature parity to the Cover block.

## How?
1. Added `onSelectURL` prop to `CoverPlaceholder` component, which is passed to the underlying `MediaPlaceholder` component to enable the URL input UI.
2. Implemented `getMediaTypeFromURL()` async function in `shared.js` that detects whether a URL points to an image or video:
   - **Fast path**: First checks the file extension for common image/video formats
   - **Content-Type detection**: If extension detection fails, makes a HEAD request to check the `Content-Type` header
   - **Fallback**: If HEAD is not supported by the server, falls back to a GET request with `Range: bytes=0-0` header
3. Added proper error handling:
   - If the media type cannot be determined (e.g., CORS restrictions, invalid URL, non-media Content-Type), a snackbar error notification is shown
   - The Cover block is NOT created with a blank background if detection fails
   
   
## Testing Instructions
1. Open a post or page in the editor.
2. Insert a Cover block.
3. Click "Insert from URL" in the placeholder.
4. Enter a valid image URL and press Enter or click Apply.
5. Verify the image is loaded as the Cover background.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![WhatsApp Image 2026-01-01 at 1 13 11 AM](https://github.com/user-attachments/assets/4e300f1b-b006-4b1b-bf61-cee561805aa0) | ![WhatsApp Image 2026-01-01 at 1 12 10 AM](https://github.com/user-attachments/assets/583f1792-c9f3-4770-aaf9-8e86d0b4ace1) |


