### PR TITLE
Real-time collaboration: Add more robust mergeCrdtBlocks() testing

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -282,21 +282,31 @@ export function mergeCrdtBlocks(
 
 					Object.entries( value ).forEach(
 						( [ attributeName, attributeValue ] ) => {
-							if (
-								fastDeepEqual(
-									currentAttributes?.get( attributeName ),
-									attributeValue
-								)
-							) {
-								return;
-							}
-
 							const currentAttribute =
 								currentAttributes.get( attributeName );
 							const isRichText = isRichTextAttribute(
 								block.name,
 								attributeName
 							);
+
+							const attributeHasTypeChange =
+								( isRichText &&
+									! (
+										currentAttribute instanceof Y.Text
+									) ) ||
+								( ! isRichText &&
+									currentAttribute instanceof Y.Text );
+
+							// Skip update if values are equal and type stays the same
+							if (
+								! attributeHasTypeChange &&
+								fastDeepEqual(
+									currentAttribute,
+									attributeValue
+								)
+							) {
+								return;
+							}
 
 							if (
 								isRichText &&

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -194,6 +194,26 @@ export function mergeCrdtBlocks(
 	incomingBlocks: Block[],
 	cursorPosition: number | null
 ): void {
+	// Perform the merge
+	mergeCrdtBlocksInternal( yblocks, incomingBlocks, cursorPosition );
+
+	// Remove duplicate clientIds across all nesting levels (at top level)
+	removeDuplicateClientIds( yblocks );
+}
+
+/**
+ * Internal function to merge blocks without any top-level checks.
+ * Called recursively for innerBlocks.
+ *
+ * @param yblocks        The blocks in the local Y.Doc.
+ * @param incomingBlocks Gutenberg blocks being synced.
+ * @param cursorPosition The position of the cursor after the change occurs.
+ */
+function mergeCrdtBlocksInternal(
+	yblocks: YBlocks,
+	incomingBlocks: Block[],
+	cursorPosition: number | null
+): void {
 	// Ensure we are working with serializable block data.
 	if ( ! serializableBlocksCache.has( incomingBlocks ) ) {
 		serializableBlocksCache.set(
@@ -355,7 +375,7 @@ export function mergeCrdtBlocks(
 						yblock.set( key, yInnerBlocks );
 					}
 
-					mergeCrdtBlocks(
+					mergeCrdtBlocksInternal(
 						yInnerBlocks,
 						value ?? [],
 						cursorPosition
@@ -385,23 +405,36 @@ export function mergeCrdtBlocks(
 
 		yblocks.insert( left, newBlock );
 	}
+}
 
-	// remove duplicate clientids
-	const knownClientIds = new Set< string >();
+/**
+ * Recursively remove duplicate clientIds from blocks and their innerBlocks.
+ *
+ * @param yblocks        The blocks to check.
+ * @param knownClientIds Set of clientIds seen so far.
+ */
+function removeDuplicateClientIds(
+	yblocks: YBlocks,
+	knownClientIds: Set< string > = new Set()
+): void {
 	for ( let j = 0; j < yblocks.length; j++ ) {
 		const yblock: YBlock = yblocks.get( j );
 
 		let clientId = yblock.get( 'clientId' );
 
-		if ( ! clientId ) {
-			continue;
+		if ( clientId ) {
+			if ( knownClientIds.has( clientId ) ) {
+				clientId = uuidv4();
+				yblock.set( 'clientId', clientId );
+			}
+			knownClientIds.add( clientId );
 		}
 
-		if ( knownClientIds.has( clientId ) ) {
-			clientId = uuidv4();
-			yblock.set( 'clientId', clientId );
+		// Recursively check innerBlocks
+		const yInnerBlocks = yblock.get( 'innerBlocks' );
+		if ( yInnerBlocks instanceof Y.Array ) {
+			removeDuplicateClientIds( yInnerBlocks, knownClientIds );
 		}
-		knownClientIds.add( clientId );
 	}
 }
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -311,43 +311,20 @@ function mergeCrdtBlocksInternal(
 								currentAttribute
 							);
 
-							// Skip update if values are equal and type stays the same
-							if (
-								isExpectedType &&
-								fastDeepEqual(
+							const isAttributeChanged =
+								! isExpectedType ||
+								! fastDeepEqual(
 									currentAttribute,
 									attributeValue
-								)
-							) {
-								return;
-							}
-
-							const isRichText = isRichTextAttribute(
-								block.name,
-								attributeName
-							);
-
-							if (
-								isRichText &&
-								'string' === typeof attributeValue &&
-								currentAttributes.has( attributeName ) &&
-								currentAttribute instanceof Y.Text
-							) {
-								// Rich text values are stored as persistent Y.Text instances.
-								// Update the value with a delta in place.
-								mergeRichTextUpdate(
-									currentAttribute,
-									attributeValue,
-									cursorPosition
 								);
-							} else {
-								currentAttributes.set(
+
+							if ( isAttributeChanged ) {
+								updateYBlockAttribute(
+									block.name,
 									attributeName,
-									createNewYAttributeValue(
-										block.name,
-										attributeName,
-										attributeValue
-									)
+									attributeValue,
+									currentAttributes,
+									cursorPosition
 								);
 							}
 						}
@@ -468,6 +445,33 @@ function shouldBlockBeSynced( block: Block ): boolean {
 
 	// Allow all other blocks to be synced.
 	return true;
+}
+
+function updateYBlockAttribute(
+	blockName: string,
+	attributeName: string,
+	attributeValue: unknown,
+	currentAttributes: YBlockAttributes,
+	cursorPosition: number | null
+): void {
+	const isRichText = isRichTextAttribute( blockName, attributeName );
+	const currentAttribute = currentAttributes.get( attributeName );
+
+	if (
+		isRichText &&
+		'string' === typeof attributeValue &&
+		currentAttributes.has( attributeName ) &&
+		currentAttribute instanceof Y.Text
+	) {
+		// Rich text values are stored as persistent Y.Text instances.
+		// Update the value with a delta in place.
+		mergeRichTextUpdate( currentAttribute, attributeValue, cursorPosition );
+	} else {
+		currentAttributes.set(
+			attributeName,
+			createNewYAttributeValue( blockName, attributeName, attributeValue )
+		);
+	}
 }
 
 // Cache rich-text attributes for all block types.

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -304,22 +304,16 @@ function mergeCrdtBlocksInternal(
 						( [ attributeName, attributeValue ] ) => {
 							const currentAttribute =
 								currentAttributes.get( attributeName );
-							const isRichText = isRichTextAttribute(
-								block.name,
-								attributeName
-							);
 
-							const attributeHasTypeChange =
-								( isRichText &&
-									! (
-										currentAttribute instanceof Y.Text
-									) ) ||
-								( ! isRichText &&
-									currentAttribute instanceof Y.Text );
+							const isExpectedType = isExpectedAttributeType(
+								block.name,
+								attributeName,
+								currentAttribute
+							);
 
 							// Skip update if values are equal and type stays the same
 							if (
-								! attributeHasTypeChange &&
+								isExpectedType &&
 								fastDeepEqual(
 									currentAttribute,
 									attributeValue
@@ -327,6 +321,11 @@ function mergeCrdtBlocksInternal(
 							) {
 								return;
 							}
+
+							const isRichText = isRichTextAttribute(
+								block.name,
+								attributeName
+							);
 
 							if (
 								isRichText &&
@@ -472,7 +471,71 @@ function shouldBlockBeSynced( block: Block ): boolean {
 }
 
 // Cache rich-text attributes for all block types.
-let cachedRichTextAttributes: Map< string, Map< string, true > >;
+let cachedBlockAttributeTypes: Map< string, Map< string, string > >;
+
+/**
+ * Get the defined attribute type for a block attribute.
+ *
+ * @param blockName     The name of the block, e.g. 'core/paragraph'.
+ * @param attributeName The name of the attribute, e.g. 'content'.
+ * @return The type of the attribute, e.g. 'rich-text' or 'string'.
+ */
+function getBlockAttributeType(
+	blockName: string,
+	attributeName: string
+): string | undefined {
+	if ( ! cachedBlockAttributeTypes ) {
+		// Parse the attributes for all blocks once.
+		cachedBlockAttributeTypes = new Map< string, Map< string, string > >();
+
+		for ( const blockType of getBlockTypes() as BlockType[] ) {
+			const blockAttributeTypeMap = new Map< string, string >();
+
+			for ( const [ name, definition ] of Object.entries(
+				blockType.attributes ?? {}
+			) ) {
+				if ( definition.type ) {
+					blockAttributeTypeMap.set( name, definition.type );
+				}
+			}
+
+			cachedBlockAttributeTypes.set(
+				blockType.name,
+				blockAttributeTypeMap
+			);
+		}
+	}
+
+	return cachedBlockAttributeTypes.get( blockName )?.get( attributeName );
+}
+
+/**
+ * Check if an attribute value is the expected type.
+ *
+ * @param blockName      The name of the block, e.g. 'core/paragraph'.
+ * @param attributeName  The name of the attribute, e.g. 'content'.
+ * @param attributeValue The current attribute value.
+ * @return True if the attribute type is expected, false otherwise.
+ */
+function isExpectedAttributeType(
+	blockName: string,
+	attributeName: string,
+	attributeValue: unknown
+): boolean {
+	const expectedAttributeType = getBlockAttributeType(
+		blockName,
+		attributeName
+	);
+
+	if ( expectedAttributeType === 'rich-text' ) {
+		return attributeValue instanceof Y.Text;
+	} else if ( expectedAttributeType === 'string' ) {
+		return typeof attributeValue === 'string';
+	}
+
+	// No other types comparisons use special logic.
+	return true;
+}
 
 /**
  * Given a block name and attribute key, return true if the attribute is rich-text typed.
@@ -485,31 +548,7 @@ function isRichTextAttribute(
 	blockName: string,
 	attributeName: string
 ): boolean {
-	if ( ! cachedRichTextAttributes ) {
-		// Parse the attributes for all blocks once.
-		cachedRichTextAttributes = new Map< string, Map< string, true > >();
-
-		for ( const blockType of getBlockTypes() as BlockType[] ) {
-			const richTextAttributeMap = new Map< string, true >();
-
-			for ( const [ name, definition ] of Object.entries(
-				blockType.attributes ?? {}
-			) ) {
-				if ( 'rich-text' === definition.type ) {
-					richTextAttributeMap.set( name, true );
-				}
-			}
-
-			cachedRichTextAttributes.set(
-				blockType.name,
-				richTextAttributeMap
-			);
-		}
-	}
-
-	return (
-		cachedRichTextAttributes.get( blockName )?.has( attributeName ) ?? false
-	);
+	return 'rich-text' === getBlockAttributeType( blockName, attributeName );
 }
 
 let localDoc: Y.Doc;

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -522,5 +522,629 @@ describe( 'crdt-blocks', () => {
 			// The level attribute should still exist
 			expect( attributes.get( 'level' ) ).toBe( 1 );
 		} );
+
+		it( 'handles block type changes from non-rich-text to rich-text', () => {
+			// Start with freeform block (content is non-rich-text)
+			const freeformBlocks: Block[] = [
+				{
+					name: 'core/freeform',
+					attributes: { content: 'Freeform content' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, freeformBlocks, null );
+
+			const block1 = yblocks.get( 0 );
+			const content1 = (
+				block1.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' );
+			expect( block1.get( 'name' ) ).toBe( 'core/freeform' );
+			expect( typeof content1 ).toBe( 'string' );
+			expect( content1 ).toBe( 'Freeform content' );
+
+			// Change to paragraph block (content becomes rich-text)
+			const paragraphBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Freeform content' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, paragraphBlocks, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const block2 = yblocks.get( 0 );
+			const content2 = (
+				block2.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( block2.get( 'name' ) ).toBe( 'core/paragraph' );
+			expect( content2 ).toBeInstanceOf( Y.Text );
+			expect( content2.toString() ).toBe( 'Freeform content' );
+		} );
+
+		it( 'syncs nested blocks with blob attributes', () => {
+			const nestedGallery: Block[] = [
+				{
+					name: 'core/group',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/gallery',
+							attributes: {},
+							innerBlocks: [
+								{
+									name: 'core/image',
+									attributes: {
+										url: 'http://example.com/image.jpg',
+										blob: 'blob:...',
+									},
+									innerBlocks: [],
+								},
+							],
+						},
+					],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, nestedGallery, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const groupBlock = yblocks.get( 0 );
+			expect( groupBlock.get( 'name' ) ).toBe( 'core/group' );
+
+			const innerBlocks = groupBlock.get( 'innerBlocks' ) as YBlocks;
+			expect( innerBlocks.length ).toBe( 1 );
+			expect( innerBlocks.get( 0 ).get( 'name' ) ).toBe( 'core/gallery' );
+		} );
+
+		it( 'handles complex block reordering', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'A' },
+					innerBlocks: [],
+					clientId: 'block-a',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'B' },
+					innerBlocks: [],
+					clientId: 'block-b',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'C' },
+					innerBlocks: [],
+					clientId: 'block-c',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'D' },
+					innerBlocks: [],
+					clientId: 'block-d',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'E' },
+					innerBlocks: [],
+					clientId: 'block-e',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			expect( yblocks.length ).toBe( 5 );
+
+			// Reorder: [A, B, C, D, E] -> [C, A, E, B, D]
+			const reorderedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'C' },
+					innerBlocks: [],
+					clientId: 'block-c',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'A' },
+					innerBlocks: [],
+					clientId: 'block-a',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'E' },
+					innerBlocks: [],
+					clientId: 'block-e',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'B' },
+					innerBlocks: [],
+					clientId: 'block-b',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'D' },
+					innerBlocks: [],
+					clientId: 'block-d',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, reorderedBlocks, null );
+
+			expect( yblocks.length ).toBe( 5 );
+			const contents = [ 'C', 'A', 'E', 'B', 'D' ];
+			contents.forEach( ( expectedContent, i ) => {
+				const block = yblocks.get( i );
+				const content = (
+					block.get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' ) as Y.Text;
+				expect( content.toString() ).toBe( expectedContent );
+			} );
+		} );
+
+		it( 'handles many deletions (10 blocks to 2 blocks)', () => {
+			const manyBlocks: Block[] = Array.from(
+				{ length: 10 },
+				( _, i ) => ( {
+					name: 'core/paragraph',
+					attributes: { content: `Block ${ i }` },
+					innerBlocks: [],
+					clientId: `block-${ i }`,
+				} )
+			);
+
+			mergeCrdtBlocks( yblocks, manyBlocks, null );
+			expect( yblocks.length ).toBe( 10 );
+
+			const fewBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Block 0' },
+					innerBlocks: [],
+					clientId: 'block-0',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Block 9' },
+					innerBlocks: [],
+					clientId: 'block-9',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, fewBlocks, null );
+
+			expect( yblocks.length ).toBe( 2 );
+			const content0 = (
+				yblocks.get( 0 ).get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content0.toString() ).toBe( 'Block 0' );
+			const content1 = (
+				yblocks.get( 1 ).get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content1.toString() ).toBe( 'Block 9' );
+		} );
+
+		it( 'handles many insertions (2 blocks to 10 blocks)', () => {
+			const fewBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Block 0' },
+					innerBlocks: [],
+					clientId: 'block-0',
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Block 9' },
+					innerBlocks: [],
+					clientId: 'block-9',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, fewBlocks, null );
+			expect( yblocks.length ).toBe( 2 );
+
+			const manyBlocks: Block[] = Array.from(
+				{ length: 10 },
+				( _, i ) => ( {
+					name: 'core/paragraph',
+					attributes: { content: `Block ${ i }` },
+					innerBlocks: [],
+					clientId: `block-${ i }`,
+				} )
+			);
+
+			mergeCrdtBlocks( yblocks, manyBlocks, null );
+
+			expect( yblocks.length ).toBe( 10 );
+			manyBlocks.forEach( ( block, i ) => {
+				const yblock = yblocks.get( i );
+				const content = (
+					yblock.get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' ) as Y.Text;
+				expect( content.toString() ).toBe( `Block ${ i }` );
+			} );
+		} );
+
+		it( 'handles changes with all different block content', () => {
+			const blocksA: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'A1' },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'A2' },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'A3' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksA, null );
+			expect( yblocks.length ).toBe( 3 );
+
+			const blocksB: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'B1' },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'B2' },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'B3' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksB, null );
+
+			expect( yblocks.length ).toBe( 3 );
+			[ 'B1', 'B2', 'B3' ].forEach( ( expected, i ) => {
+				const content = (
+					yblocks.get( i ).get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' ) as Y.Text;
+				expect( content.toString() ).toBe( expected );
+			} );
+		} );
+
+		it( 'clears all blocks when syncing empty array', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Content' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+			expect( yblocks.length ).toBe( 1 );
+
+			mergeCrdtBlocks( yblocks, [], null );
+			expect( yblocks.length ).toBe( 0 );
+		} );
+
+		it( 'handles deeply nested blocks', () => {
+			const deeplyNested: Block[] = [
+				{
+					name: 'core/group',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/group',
+							attributes: {},
+							innerBlocks: [
+								{
+									name: 'core/group',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/group',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													attributes: {
+														content: 'Deep content',
+													},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, deeplyNested, null );
+
+			// Navigate to the deepest block
+			let current: YBlocks | YBlock = yblocks;
+			for ( let i = 0; i < 4; i++ ) {
+				expect( ( current as YBlocks ).length ).toBe( 1 );
+				current = ( current as YBlocks ).get( 0 );
+				current = ( current as YBlock ).get( 'innerBlocks' ) as YBlocks;
+			}
+
+			expect( ( current as YBlocks ).length ).toBe( 1 );
+			const deepBlock = ( current as YBlocks ).get( 0 );
+			const content = (
+				deepBlock.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Deep content' );
+
+			// Update innermost block
+			const updatedDeep: Block[] = [
+				{
+					name: 'core/group',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/group',
+							attributes: {},
+							innerBlocks: [
+								{
+									name: 'core/group',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/group',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													attributes: {
+														content: 'Updated deep',
+													},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedDeep, null );
+
+			// Verify update propagated
+			current = yblocks;
+			for ( let i = 0; i < 4; i++ ) {
+				current = ( current as YBlocks ).get( 0 );
+				current = ( current as YBlock ).get( 'innerBlocks' ) as YBlocks;
+			}
+			const updatedBlock = ( current as YBlocks ).get( 0 );
+			const updatedContent = (
+				updatedBlock.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( updatedContent.toString() ).toBe( 'Updated deep' );
+		} );
+
+		it( 'removes duplicate clientIds across different nesting levels', () => {
+			const blocksWithCrossLevelDuplicates: Block[] = [
+				{
+					name: 'core/group',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: 'Nested' },
+							innerBlocks: [],
+							clientId: 'duplicate-id',
+						},
+					],
+					clientId: 'duplicate-id',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksWithCrossLevelDuplicates, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const rootBlock = yblocks.get( 0 );
+			const rootClientId = rootBlock.get( 'clientId' );
+
+			const innerBlocks = rootBlock.get( 'innerBlocks' ) as YBlocks;
+			const nestedBlock = innerBlocks.get( 0 );
+			const nestedClientId = nestedBlock.get( 'clientId' );
+
+			// Cross-level duplicates should be removed
+			expect( rootClientId ).toBe( 'duplicate-id' );
+			expect( nestedClientId ).not.toBe( 'duplicate-id' );
+			expect( nestedClientId ).toBeDefined();
+		} );
+
+		it( 'handles null and undefined attribute values', () => {
+			const blocksWithNullAttrs: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Content',
+						customAttr: null,
+						otherAttr: undefined,
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksWithNullAttrs, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const block = yblocks.get( 0 );
+			const attributes = block.get( 'attributes' ) as YBlockAttributes;
+			expect( attributes.get( 'content' ) ).toBeInstanceOf( Y.Text );
+			expect( attributes.get( 'customAttr' ) ).toBe( null );
+		} );
+
+		it( 'handles rich-text updates with cursor at start', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello World' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'XHello World' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, 0 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'XHello World' );
+		} );
+
+		it( 'handles rich-text updates with cursor at end', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello World' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello World!' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, 11 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Hello World!' );
+		} );
+
+		it( 'handles rich-text updates with cursor beyond text length', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello World' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, 999 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Hello World' );
+		} );
+
+		it( 'deletes extra block properties not in incoming blocks', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Content' },
+					innerBlocks: [],
+					clientId: 'block-1',
+					isValid: true,
+					originalContent: 'Original',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const block1 = yblocks.get( 0 );
+			expect( block1.get( 'isValid' ) ).toBe( true );
+			expect( block1.get( 'originalContent' ) ).toBe( 'Original' );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Content' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const block2 = yblocks.get( 0 );
+			expect( block2.has( 'isValid' ) ).toBe( false );
+			expect( block2.has( 'originalContent' ) ).toBe( false );
+		} );
+
+		it( 'deletes rich-text attributes when removed from block', () => {
+			const blocksWithRichText: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Rich text content',
+						caption: 'Caption text',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksWithRichText, null );
+
+			const block1 = yblocks.get( 0 );
+			const attrs1 = block1.get( 'attributes' ) as YBlockAttributes;
+			expect( attrs1.has( 'content' ) ).toBe( true );
+			expect( attrs1.has( 'caption' ) ).toBe( true );
+
+			const blocksWithoutCaption: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Rich text content',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocksWithoutCaption, null );
+
+			const block2 = yblocks.get( 0 );
+			const attrs2 = block2.get( 'attributes' ) as YBlockAttributes;
+			expect( attrs2.has( 'content' ) ).toBe( true );
+			expect( attrs2.has( 'caption' ) ).toBe( false );
+		} );
 	} );
 } );


### PR DESCRIPTION
As part of the work in [`add/flattened-rtc-blocks`](https://github.com/WordPress/gutenberg/compare/wpvip/rtc-plugin...Automattic:gutenberg:add/flattened-rtc-blocks), we're making significant changes to the `Y.Doc` block data structure. This PR adds more complex and edge-case testing for `mergeCrdtBlocks()`, and also fixes a couple of bugs found during the process.

We will use these tests to reduce the risk that block data structure changes introduce merge errors.

## Fixed bugs

1. The [`handles block type changes from non-rich-text to rich-text` test](https://github.com/Automattic/gutenberg/blob/9a652b00ee7874a5c08e0c291b7a0c4916d400bf/packages/core-data/src/utils/test/crdt-blocks.ts#L526) was failing when an attribute transitioned from a raw string to rich-text (`Y.Text`) content when the string value was the same. The fix is the `attributeHasTypeChange` boolean which ensure both the data type and content must be the same to skip a merge.
2. Client Id deduplication was only running on a single level of blocks, which caused [the `removes duplicate clientIds across different nesting levels` test](https://github.com/Automattic/gutenberg/blob/9a652b00ee7874a5c08e0c291b7a0c4916d400bf/packages/core-data/src/utils/test/crdt-blocks.ts#L940). This meant a client ID could be freely duplicated as long as it was not in the same nesting level within the block structure. The code has been changed to:

    1. Merge blocks, then
    2. Check at the top level that all client IDs are unique.

    This required making an internal `mergeCrdtBlocksInternal()` function that does the normal work of what `mergeCrdtBlocks()` did previously, then run the top level logic after. This ensures the whole block structure of client IDs are deduplicated and avoids recursively making that check.

## Testing Instructions

To run the CRDT test suite:

```
npm run test:unit -- --testPathPattern=crdt-blocks
```
