### PR TITLE
Block Editor: Prevent browser autocomplete in Navigation link search

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -182,6 +182,7 @@ function InserterMenu(
 					value={ filterValue }
 					label={ __( 'Search' ) }
 					placeholder={ __( 'Search' ) }
+					name="block-inserter-search"
 				/>
 				{ !! delayedFilterValue && (
 					<InserterSearchResults

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -182,7 +182,6 @@ function InserterMenu(
 					value={ filterValue }
 					label={ __( 'Search' ) }
 					placeholder={ __( 'Search' ) }
-					name="block-inserter-search"
 				/>
 				{ !! delayedFilterValue && (
 					<InserterSearchResults

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -452,7 +452,7 @@ class URLInput extends Component {
 			value,
 			required: true,
 			type: 'text',
-			name: 'url-input-control',
+			name: inputId,
 			onChange: disabled ? () => {} : this.onChange, // Disable onChange when disabled
 			onFocus: disabled ? () => {} : this.onFocus, // Disable onFocus when disabled
 			placeholder,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -452,6 +452,7 @@ class URLInput extends Component {
 			value,
 			required: true,
 			type: 'text',
+			name: 'url-input-control',
 			onChange: disabled ? () => {} : this.onChange, // Disable onChange when disabled
 			onFocus: disabled ? () => {} : this.onFocus, // Disable onFocus when disabled
 			placeholder,


### PR DESCRIPTION
## What?
Closes #74302

Adds a `name` attribute to the URLInput component to prevent browser autocomplete from obscuring Gutenberg's link suggestions when adding links in the Navigation block.

## Why?
When searching for pages or typing URLs in the Navigation block's link input, browsers display their own autocomplete dropdown with irrelevant search history from other websites. This creates a confusing user experience because:

- Browser autocomplete shows irrelevant URLs/search history unrelated to the user's WordPress site
- It visually obscures Gutenberg's page and link suggestions
- Users may be confused about which dropdown to interact with
- The browser suggestions provide no value in this context (site-specific link search)

Modern browsers often ignore `autocomplete="off"` alone, so an additional solution is needed.

## How?
Added a unique `name: inputId,` attribute to the URLInput component's input props. This prevents browsers from matching the input to any saved autocomplete data, effectively disabling the browser's autocomplete dropdown while maintaining Gutenberg's link search functionality.

This fix applies to all instances where URLInput is used, including:
- Navigation block link search

## Testing Instructions

### Before testing
Make sure you have some URL/search history in your browser that would normally trigger autocomplete.

### Steps to test
1. Add or edit a Navigation block
2. Click the "+" button or click on an existing navigation item to edit it
3. You should see an input field with placeholder "Search or type URL"
4. Start typing in the search field (e.g., page names, URLs, or search terms)
5. Verify that **only** Gutenberg's page/link suggestions appear, with **no** browser autocomplete dropdown
6. Test in other contexts where URLInput is used (e.g., adding links to paragraphs, buttons, etc.)

### Testing Instructions for Keyboard
1. Use Tab to navigate to the link input field
2. Type search terms and verify only Gutenberg's suggestions appear (no browser autocomplete)
3. Use arrow keys to navigate through Gutenberg's suggestions
4. Press Enter to select a suggestion

## Screenshots or screencast

The issue shows browser autocomplete appearing over the block search:
![The issue shows browser autocomplete appearing over the block search](https://private-user-images.githubusercontent.com/13054571/531271971-d54b443c-aeeb-4c80-b012-8ad22f16faf7.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjcyMjQxNzgsIm5iZiI6MTc2NzIyMzg3OCwicGF0aCI6Ii8xMzA1NDU3MS81MzEyNzE5NzEtZDU0YjQ0M2MtYWVlYi00YzgwLWIwMTItOGFkMjJmMTZmYWY3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMzElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjMxVDIzMzExOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTIwMTZhOGQ4MDU2MjIwM2M0NzU5N2UwOTNmODFjNjBhZDkwMmUzZmY4MzNkYTIyZTU4ODBjZTU2YjViOTM5ZTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.hwNT_8eq2QYDiHz0hjMPrmvLhbklE2w6cLVKZ2QArBo)

After this fix, only Gutenberg's block suggestions will appear without browser interference.