### PR TITLE
Update browserslist data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20312,9 +20312,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001731",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-			"integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+			"version": "1.0.30001762",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+			"integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
 			"funding": [
 				{
 					"type": "opencollective",


### PR DESCRIPTION
## What?

Updates our browserslist data, by running `npx update-browserslist-db@latest`.

## Why?

Certain unit tests were starting to [fail](https://github.com/WordPress/gutenberg/actions/runs/20639865354/job/59270047196?pr=74311) due to a console warning being logged.

```
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
npx update-browserslist-db@latest
Why you should do it regularly: https://github.com/browserslist/update-db#readme"
```

## Testing Instructions

`npm run test:unit -- packages/docgen` fails on trunk, but passes on this PR.