### PR TITLE
Fix missing global layout styles on frontend for hybrid themes

### DIFF
--- a/changelog/fix-hybrid-blockgap-frontend
+++ b/changelog/fix-hybrid-blockgap-frontend
@@ -1,0 +1,3 @@
+### Bug Fixes
+
+- Ensure global layout styles from theme.json (including blockGap) are applied on the frontend for hybrid themes.

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -19,7 +19,8 @@ remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 function gutenberg_enqueue_global_styles() {
 	$separate_assets  = wp_should_load_separate_core_block_assets();
 	$is_block_theme   = wp_is_block_theme();
-	$is_classic_theme = ! $is_block_theme;
+	$has_theme_json = wp_theme_has_theme_json();
+	$is_classic_theme = ! $has_theme_json;
 
 	/*
 	 * Global styles should be printed in the head when loading all styles combined.

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -19,7 +19,7 @@ remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 function gutenberg_enqueue_global_styles() {
 	$separate_assets  = wp_should_load_separate_core_block_assets();
 	$is_block_theme   = wp_is_block_theme();
-	$has_theme_json = wp_theme_has_theme_json();
+	$has_theme_json   = wp_theme_has_theme_json();
 	$is_classic_theme = ! $has_theme_json;
 
 	/*


### PR DESCRIPTION
## What?
Closes #74308

Ensures that global layout styles generated from `theme.json` (including
`styles.spacing.blockGap`) are enqueued on the frontend for hybrid themes.

---

## Why?
Hybrid themes (classic themes that include a `theme.json` file) currently show
correct block spacing in the editor, but not on the frontend. This happens
because global styles are only enqueued for block themes, causing layout flow
styles (e.g. `.is-layout-flow > * + *`) to be missing on the frontend.

This results in a visual mismatch between the editor and the rendered site,
which is confusing for users and theme authors.

---

## How?
The logic that determines whether a theme should be treated as “classic” when
enqueuing global styles has been updated.

Instead of classifying themes based solely on `wp_is_block_theme()`, the code
now treats any theme that includes a `theme.json` file as eligible for global
styles. This allows hybrid themes to receive the same global layout styles as
block themes, while preserving existing behavior for true classic themes.

The existing enqueue logic and conditions remain unchanged.

---

## Testing Instructions
1. Create or use a hybrid theme (classic theme with a `theme.json` file).
2. In `theme.json`, enable and define block spacing:
   ```json
   {
     "settings": {
       "spacing": {
         "blockGap": true
       }
     },
     "styles": {
       "spacing": {
         "blockGap": "50px"
       }
     }
   }
3. Create a post with multiple blocks using the default flow layout.
4. Observe block spacing in the editor.
5. View the post on the frontend.
6. Confirm that block spacing on the frontend matches the editor.