### PR TITLE
UI: Exclude package from `jsdoc/require-param` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -425,6 +425,7 @@ module.exports = {
 			files: [
 				'**/@(storybook|stories)/**',
 				'packages/components/src/**/*.tsx',
+				'packages/ui/src/**/*.tsx',
 			],
 			rules: {
 				// Useful to add story descriptions via JSDoc without specifying params,

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -12,8 +12,6 @@ import { type BadgeProps } from './types';
 
 /**
  * Default render function that renders a span element with the given props.
- *
- * @param props The props to apply to the HTML element.
  */
 const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'span' > ) => (
 	<span { ...props } />
@@ -22,7 +20,6 @@ const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'span' > ) => (
 /**
  * Maps intent values to Box backgroundColor and color props.
  * Uses strong emphasis styles (as emphasis prop has been removed).
- * @param intent
  */
 const getIntentStyles = (
 	intent: BadgeProps[ 'intent' ]

--- a/packages/ui/src/box/box.tsx
+++ b/packages/ui/src/box/box.tsx
@@ -11,8 +11,6 @@ import { renderElement } from '../utils/element';
 
 /**
  * Default render function that renders a div element with the given props.
- *
- * @param props The props to apply to the HTML element.
  */
 const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
 	<div { ...props } />
@@ -20,9 +18,6 @@ const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
 
 /**
  * Capitalizes the first character of a string.
- *
- * @param str The string to capitalize.
- * @return The capitalized string.
  */
 const capitalize = ( str: string ): string =>
 	str.charAt( 0 ).toUpperCase() + str.slice( 1 );


### PR DESCRIPTION
## What?

Excludes the `@wordpress/ui` package from the `jsdoc/require-param` rule in eslintrc.

## Why?

In the component packages, types are generally defined in a separate file, and lack of documentation is not really an issue. This lint rule tends to create more hassles in places we just want to add a simple doc comment. It's been turned off in `@wordpress/components`, so we do the same here for `@wordpress/ui`.

## Testing Instructions

See instances in `@wordpress/ui` where `@param` comments exist, and check that they can be removed without an eslint error.