### PR TITLE
Tag Cloud, Archives: Restore missing block wrapper div

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -132,15 +132,21 @@ export default function ArchivesEdit( { attributes, setAttributes, name } ) {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			{ status === 'loading' && <Spinner /> }
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
 			{ status === 'error' && (
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
 			) }
 			{ status === 'success' && (
 				<HtmlRenderer wrapperProps={ blockProps } html={ content } />

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -246,15 +246,21 @@ function TagCloudEdit( { attributes, setAttributes, name } ) {
 	return (
 		<>
 			{ inspectorControls }
-			{ status === 'loading' && <Spinner /> }
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
 			{ status === 'error' && (
-				<p>
-					{ sprintf(
-						/* translators: %s: error message returned when rendering the block. */
-						__( 'Error: %s' ),
-						error
-					) }
-				</p>
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
 			) }
 			{ status === 'success' && (
 				<HtmlRenderer wrapperProps={ blockProps } html={ content } />


### PR DESCRIPTION
Follow-up on #74291

## What?

We forgot to render a wrapper element with blockProps when the block is in error or loading state.

## Testing Instructions

- Insert an Archive block and a Tag Cloud block.
- Modify the server-side PHP code and intentionally cause some serious errors.
- Change any of the settings from the block sidebar.
- The block shows an error message.
- Make sure you can select the block and that the block toolbar is operable.