### PR TITLE
Fix: RangeControl reset produces undefined but UI still displays previous numeric value (controlled state mismatch)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -42,6 +42,7 @@
 -   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
 -   `DatePicker`: Fix missing scheduled events and current date indicators. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
 -   `DatePicker`: Fix handling of `currentDate` when passed values as Date or timestamp. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
+-   `RangeControl`: Fix reset button requiring double-click when value is `0`. ([#74323](https://github.com/WordPress/gutenberg/pull/74323))
 
 ### Internal
 

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -38,6 +38,8 @@ export function useControlledRangeValue(
 	settings: UseControlledRangeValueArgs
 ) {
 	const { min, max, value: valueProp, initial } = settings;
+	const prevValuePropRef = useRef< typeof valueProp >();
+
 	const [ state, setInternalState ] = useControlledState(
 		floatClamp( valueProp, min, max ),
 		{
@@ -46,12 +48,19 @@ export function useControlledRangeValue(
 		}
 	);
 
-	// Clear stale internal state when valueProp is null but state still has a value
+	// Clear stale internal state when valueProp transitions from a number to null/undefined
 	useEffect( () => {
-		if ( valueProp === null && state !== null ) {
+		const isTransitionToNull =
+			typeof prevValuePropRef.current === 'number' &&
+			( valueProp === null || valueProp === undefined );
+
+		if ( isTransitionToNull ) {
 			setInternalState( null );
 		}
-	}, [ valueProp, state, setInternalState ] );
+
+		// Update ref after checking the condition
+		prevValuePropRef.current = valueProp;
+	}, [ valueProp, setInternalState ] );
 
 	const setState = useCallback(
 		( nextValue: number | null ) => {

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,6 +45,13 @@ export function useControlledRangeValue(
 			fallback: null,
 		}
 	);
+
+	// Clear stale internal state when valueProp is null but state still has a value
+	useEffect( () => {
+		if ( valueProp === null && state !== null ) {
+			setInternalState( null );
+		}
+	}, [ valueProp, state, setInternalState ] );
 
 	const setState = useCallback(
 		( nextValue: number | null ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73456

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. PR fixes the issue for clicking twice to reset the range control when input is set to 0.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Updates the hook, `useControlledRangeValue` to compare the value prop and set the internal state with the required value. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Checkout this PR.
2. Use the instruction present in issue description and follow the steps.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->


### Before
https://github.com/user-attachments/assets/5e37afd5-7e9b-4f44-a558-e457e604a8f0

### After
https://github.com/user-attachments/assets/768e6ed3-a26c-48da-95a0-ea35c711f7d8

