### PR TITLE
Breadcrumbs: Render quotes correctly in the editor

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -113,7 +113,7 @@ export default function BreadcrumbEdit( {
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( {
 		ref: disabledRef,
-		style: { '--separator': `'${ separator }'` },
+		style: { '--separator': `"${ separator.replace( /"/g, '\\"' ) }"` },
 	} );
 
 	if ( isLoading ) {


### PR DESCRIPTION
I noticed this while reviewing #74273.

## What? Why? How?

The Breadcrumbs block renders a separator value as is in the editor.  As a result, I noticed that the CSS variable isn't generated correctly when its value ​contains single quotes.

This issue [only existed with the placeholder](https://github.com/WordPress/gutenberg/blob/5ba49047911343f4a2ca63dd3b18f2d7058bb8f7/packages/block-library/src/breadcrumbs/edit.js#L160), but #74273 made it more noticeable by ensuring that the CSS variable is generated consistently client-side.

To solve this issue, I used [the same logic as on the server side](https://github.com/WordPress/gutenberg/blob/575cefa5007e8a22f8ee732d4ebe961d97acc223/packages/block-library/src/breadcrumbs/index.php#L188) to escape double quotes.

## Testing Instructions

- Insert a Breadcrumbs block.
- Enter a separator string containing a single quote.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1278" height="496" alt="breadcrumb" src="https://github.com/user-attachments/assets/2b287079-c707-4e36-8c2b-bb177edabc4a" />

### After

<img width="1287" height="676" alt="image" src="https://github.com/user-attachments/assets/7c859eba-94cf-4434-ab69-c8e37092658b" />

