### PR TITLE
Form Block: Regression fixing, updating variation activation conditions

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -15,7 +15,12 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import {
+	createBlocksFromInnerBlocksTemplate,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -56,8 +61,48 @@ const TEMPLATE = [
 	[ 'core/form-submit-button', {} ],
 ];
 
-const Edit = ( { attributes, setAttributes, clientId } ) => {
+const Edit = ( { attributes, setAttributes, clientId, name } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const previousAnchorRef = useRef( attributes.anchor );
+
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+
+	const { hasInnerBlocks, variations } = useSelect(
+		( select ) => {
+			const { getBlock } = select( blockEditorStore );
+			const { getBlockVariations } = select( blocksStore );
+			const block = getBlock( clientId );
+			return {
+				hasInnerBlocks: !! ( block && block.innerBlocks.length ),
+				variations: getBlockVariations( name, 'transform' ),
+			};
+		},
+		[ clientId, name ]
+	);
+
+	useEffect( () => {
+		const previousAnchor = previousAnchorRef.current;
+		const currentAnchor = attributes.anchor;
+
+		previousAnchorRef.current = currentAnchor;
+
+		if ( previousAnchor === currentAnchor || ! variations ) {
+			return;
+		}
+
+		const activeVariation = variations.find(
+			( variation ) => variation.attributes?.anchor === currentAnchor
+		);
+
+		if ( activeVariation?.innerBlocks ) {
+			replaceInnerBlocks(
+				clientId,
+				createBlocksFromInnerBlocksTemplate(
+					activeVariation.innerBlocks
+				)
+			);
+		}
+	}, [ attributes.anchor, clientId, replaceInnerBlocks, variations ] );
 
 	const resetAllSettings = () => {
 		setAttributes( {
@@ -70,17 +115,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 
 	const { action, method, email, submissionMethod } = attributes;
 	const blockProps = useBlockProps();
-
-	const { hasInnerBlocks } = useSelect(
-		( select ) => {
-			const { getBlock } = select( blockEditorStore );
-			const block = getBlock( clientId );
-			return {
-				hasInnerBlocks: !! ( block && block.innerBlocks.length ),
-			};
-		},
-		[ clientId ]
-	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,

--- a/packages/block-library/src/form/variations.js
+++ b/packages/block-library/src/form/variations.js
@@ -57,7 +57,7 @@ const variations = [
 		],
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
-			! blockAttributes?.type || blockAttributes?.type === 'text',
+			blockAttributes?.anchor === 'comment-form',
 	},
 	{
 		name: 'wp-privacy-form',
@@ -132,7 +132,7 @@ const variations = [
 		],
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
-			! blockAttributes?.type || blockAttributes?.type === 'text',
+			blockAttributes?.anchor === 'gdpr-form',
 	},
 ];
 


### PR DESCRIPTION
## What?
Closes #74327

## Why?
This PR fixes the bug where variations are not switching in the form block

## How?
There are two anchors: `commnt-form` and `gdpr-form`

1. We get the variations via `getBlockVariations` from blocksStore instead of calling getBlockVariations directly
2. Using the `useEffect` we do a similar pattern as in other blocks like Query block with `replaceInnerBlocks`. 

Still this only preserves the current feature, but as I commented in #74327 it's not orthodox, this introduces a new Inspector control variant form that is very poor UX wise, specially when users are used to other variation mechanisms like the ones we can already find in other blocks like columns. After fixing this bug (for now), I will consider implementing a future interation more similar to the columns one, which may require some `feedback-design`

But for now we should be passing this to move forward (or find which caused the regression)

## Testing Instructions
1. Gutenberg -> Experiments -> Enable Blocks add Form
2. Create a new Post
3. Add the form block 
4. Click in the "Transform to variation" in the inspector controls in the right side
5. Click in the "Experimental Privacy Request Form". 
6. 🐞 Nothing happens

## Screencast

### Before
https://github.com/user-attachments/assets/551f0139-562b-4e71-b47f-eee00490bb55
### After
https://github.com/user-attachments/assets/639375ba-c659-439d-926d-a924288dba89
