### PR TITLE
Parent selector: Fix dot divider horizontal spacing

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -141,7 +141,6 @@
 			display: inline-flex;
 			height: 2px;
 			position: absolute;
-			right: 0;
 			top: $grid-unit-20 - $border-width;
 			width: 2px;
 		}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -166,6 +166,11 @@
 			content: "";
 		}
 
+		// Hide the dot divider since the parent selector is visually separated.
+		&::after {
+			display: none;
+		}
+
 		.block-editor-block-parent-selector__button {
 			border: $border-width solid $gray-900;
 			padding-right: 6px;
@@ -186,6 +191,11 @@
 			position: relative;
 			left: auto;
 			margin-left: -$border-width;
+
+			// Show the dot divider since the parent selector is inline.
+			&::after {
+				display: inline-flex;
+			}
 		}
 
 		.block-editor-block-mover__move-button-container,


### PR DESCRIPTION
Fixes #57727
Fixes the horizontal spacing of the dot divider between the parent selector button and the adjacent toolbar button. The dot was not properly centered between the two buttons.


In this PR we just remove `right: 0` from the `.block-editor-block-parent-selector::after` pseudo-element. This property was forcing the dot to be flush against the right edge of the parent selector container. By removing it, the dot is now positioned more naturally and centered between the buttons.

## Testing Instructions

1. Enable the "Top toolbar" preference
2. Select a nested block (e.g., a Paragraph inside a Group block)
3. Observe the dot separator between the parent selector button and the block type button (e.g., "Paragraph")
4. Verify the dot is horizontally centered between the two buttons
5. Also test with "Show button text labels" preference enabled

### Before
<img width="636" height="111" alt="Screenshot 2026-01-02 at 16 56 54" src="https://github.com/user-attachments/assets/f66798a9-7db0-4dd8-a6f6-fdcb43268fcf" />
<img width="274" height="183" alt="Screenshot 2026-01-02 at 16 56 45" src="https://github.com/user-attachments/assets/fbe96495-f36a-4702-b2b9-25a911e9780c" />
<img width="190" height="112" alt="Screenshot 2026-01-02 at 16 56 28" src="https://github.com/user-attachments/assets/72f01e05-367e-4cc4-86b1-669591aba965" />

### After

<img width="545" height="115" alt="Screenshot 2026-01-02 at 16 58 50" src="https://github.com/user-attachments/assets/51da3eb5-e478-4299-9b93-9534bbb1b1a6" />


<img width="216" height="78" alt="Screenshot 2026-01-02 at 16 34 31" src="https://github.com/user-attachments/assets/25659c1c-450d-4422-a24a-df662d993e09" />
<img width="210" height="98" alt="Screenshot 2026-01-02 at 16 34 05" src="https://github.com/user-attachments/assets/69c0ce3f-ced5-43dd-8701-7bce4aafd68a" />
