### PR TITLE
Comments Title Block: Fix double quotes in non-English locales

### DIFF
--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -168,20 +168,23 @@ export default function Edit( {
 		</InspectorControls>
 	);
 
-	const postTitle = isSiteEditor ? __( '“Post Title”' ) : `"${ rawTitle }"`;
+	const postTitle = isSiteEditor ? __( 'Post Title' ) : rawTitle;
 
 	let placeholder;
 	if ( showCommentsCount && commentsCount !== undefined ) {
 		if ( showPostTitle ) {
 			if ( commentsCount === 1 ) {
-				/* translators: %s: Post title. */
-				placeholder = sprintf( __( 'One response to %s' ), postTitle );
+				placeholder = sprintf(
+					/* translators: %s: Post title. */
+					__( 'One response to "%s"' ),
+					postTitle
+				);
 			} else {
 				placeholder = sprintf(
 					/* translators: 1: Number of comments, 2: Post title. */
 					_n(
-						'%1$s response to %2$s',
-						'%1$s responses to %2$s',
+						'%1$s response to "%2$s"',
+						'%1$s responses to "%2$s"',
 						commentsCount
 					),
 					commentsCount,
@@ -200,10 +203,10 @@ export default function Edit( {
 	} else if ( showPostTitle ) {
 		if ( commentsCount === 1 ) {
 			/* translators: %s: Post title. */
-			placeholder = sprintf( __( 'Response to %s' ), postTitle );
+			placeholder = sprintf( __( 'Response to "%s"' ), postTitle );
 		} else {
 			/* translators: %s: Post title. */
-			placeholder = sprintf( __( 'Responses to %s' ), postTitle );
+			placeholder = sprintf( __( 'Responses to "%s"' ), postTitle );
 		}
 	} else if ( commentsCount === 1 ) {
 		placeholder = __( 'Response' );

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -24,10 +24,9 @@ function render_block_core_comments_title( $attributes ) {
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
-	$comments_count      = get_comments_number();
-	/* translators: %s: Post title. */
-	$post_title = sprintf( __( '&#8220;%s&#8221;' ), get_the_title() );
-	$tag_name   = 'h2';
+	$comments_count = get_comments_number();
+	$post_title     = get_the_title();
+	$tag_name       = 'h2';
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 'h' . $attributes['level'];
 	}
@@ -40,13 +39,13 @@ function render_block_core_comments_title( $attributes ) {
 		if ( $show_post_title ) {
 			if ( '1' === $comments_count ) {
 				/* translators: %s: Post title. */
-				$comments_title = sprintf( __( 'One response to %s' ), $post_title );
+				$comments_title = sprintf( __( 'One response to &#8220;%s&#8221;' ), $post_title );
 			} else {
 				$comments_title = sprintf(
 					/* translators: 1: Number of comments, 2: Post title. */
 					_n(
-						'%1$s response to %2$s',
-						'%1$s responses to %2$s',
+						'%1$s response to &#8220;%2$s&#8221;',
+						'%1$s responses to &#8220;%2$s&#8221;',
 						$comments_count
 					),
 					number_format_i18n( $comments_count ),
@@ -65,10 +64,10 @@ function render_block_core_comments_title( $attributes ) {
 	} elseif ( $show_post_title ) {
 		if ( '1' === $comments_count ) {
 			/* translators: %s: Post title. */
-			$comments_title = sprintf( __( 'Response to %s' ), $post_title );
+			$comments_title = sprintf( __( 'Response to &#8220;%s&#8221;' ), $post_title );
 		} else {
 			/* translators: %s: Post title. */
-			$comments_title = sprintf( __( 'Responses to %s' ), $post_title );
+			$comments_title = sprintf( __( 'Responses to &#8220;%s&#8221;' ), $post_title );
 		}
 	} elseif ( '1' === $comments_count ) {
 		$comments_title = __( 'Response' );

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -24,9 +24,9 @@ function render_block_core_comments_title( $attributes ) {
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
-	$comments_count = get_comments_number();
-	$post_title     = get_the_title();
-	$tag_name       = 'h2';
+	$comments_count      = get_comments_number();
+	$post_title          = get_the_title();
+	$tag_name            = 'h2';
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 'h' . $attributes['level'];
 	}


### PR DESCRIPTION
Fixes #43839

Fixes the Comments Title block displaying duplicate quotes when using non-English locales (e.g., Russian shows `«"Test post title"»` instead of just `«Test post title»`).

The block was wrapping the post title with curly quotes (`&#8220;` and `&#8221;`) in PHP code before passing it to translation strings:

```php
// Before: quotes added programmatically, then passed to translation
$post_title = sprintf( __( '&#8220;%s&#8221;' ), get_the_title() );
sprintf( __( 'One response to %s' ), $post_title );
```

When translators create localized versions, they naturally include their language's quotation marks around the placeholder (e.g., Russian uses guillemets `« »`). This resulted in nested quotes: `«"title"»`.

## Fix

Move the quotation marks into each translation string so translators have full control over quote style.

```php
// After: quotes inside translation string (using HTML entities)
$post_title = get_the_title();
sprintf( __( 'One response to &#8220;%s&#8221;' ), $post_title );
```

This follows the established i18n pattern used elsewhere in the codebase:
- `packages/block-library/src/breadcrumbs/index.php:63` - `sprintf( __( 'Search results for: "%s"' ), ... )`
- `packages/block-library/src/pattern/index.php:54` - `sprintf( __( '[block rendering halted for pattern "%s"]' ), $slug )`
- `packages/block-library/src/page-list/edit.js:96` - `sprintf( __( 'Page List: "%s" page has no children.' ), ... )`
- `packages/block-library/src/post-excerpt/edit.js:149` - `__( 'Add "read more" link text' )`

## Testing Instructions

1. Do some smoke testing on the comment title block e.g: with 2025 theme just check comments on posts and verify the result is expected. The issue for Russian language will only be fixed when strings are updated.


