### PR TITLE
MediaEdit: expanded view

### DIFF
--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -102,7 +102,7 @@ _Parameters_
 -   _props.allowedTypes_ `[string[]]`: - Array of allowed media types. Default `['image']`.
 -   _props.multiple_ `[boolean]`: - Whether to allow multiple media selections. Default `false`.
 -   _props.hideLabelFromVision_ `[boolean]`: - Whether the label should be hidden from vision.
--   _props.isCompact_ `[boolean]`: - Whether to render in a compact form. Default `true`.
+-   _props.isExpanded_ `[boolean]`: - Whether to render in an expanded form. Default `false`.
 
 _Returns_
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -102,6 +102,7 @@ _Parameters_
 -   _props.allowedTypes_ `[string[]]`: - Array of allowed media types. Default `['image']`.
 -   _props.multiple_ `[boolean]`: - Whether to allow multiple media selections. Default `false`.
 -   _props.hideLabelFromVision_ `[boolean]`: - Whether the label should be hidden from vision.
+-   _props.isCompact_ `[boolean]`: - Whether to render in a compact form. Default `true`.
 
 _Returns_
 

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -15,7 +20,7 @@ import { store as coreStore, type Attachment } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { archive, audio, video, file } from '@wordpress/icons';
+import { archive, audio, video, file, closeSmall } from '@wordpress/icons';
 import {
 	MediaUpload,
 	privateApis as mediaUtilsPrivateApis,
@@ -115,21 +120,33 @@ const archiveMimeTypes = [
 	'application/x-gzip',
 ];
 
-function MediaPreview( {
-	url,
-	attachment,
+function MediaTitle( { attachment }: { attachment: Attachment< 'view' > } ) {
+	return (
+		<Truncate className="fields__media-edit-filename">
+			{ attachment.title.rendered }
+		</Truncate>
+	);
+}
+
+function MediaEditPlaceholder( {
+	open,
+	label,
 }: {
-	url: string;
-	attachment: Attachment< 'view' > | null;
+	open: () => void;
+	label: string;
 } ) {
-	if ( ! attachment ) {
-		return null;
-	}
-	const attachmentTitle = attachment.title.rendered;
+	return (
+		<MediaPickerButton open={ open } label={ label }>
+			<span className="fields__media-edit-placeholder">{ label }</span>
+		</MediaPickerButton>
+	);
+}
+
+function MediaPreview( { attachment }: { attachment: Attachment< 'view' > } ) {
+	const url = attachment.source_url;
 	const mimeType = attachment.mime_type;
-	let preview: JSX.Element = <Icon icon={ file } />;
 	if ( mimeType.startsWith( 'image/' ) ) {
-		preview = (
+		return (
 			<img
 				className="fields__media-edit-thumbnail"
 				alt={ attachment.alt_text || '' }
@@ -137,18 +154,143 @@ function MediaPreview( {
 			/>
 		);
 	} else if ( mimeType.startsWith( 'audio/' ) ) {
-		preview = <Icon icon={ audio } />;
+		return <Icon icon={ audio } />;
 	} else if ( mimeType.startsWith( 'video/' ) ) {
-		preview = <Icon icon={ video } />;
+		return <Icon icon={ video } />;
 	} else if ( archiveMimeTypes.includes( mimeType ) ) {
-		preview = <Icon icon={ archive } />;
+		return <Icon icon={ archive } />;
 	}
+	return <Icon icon={ file } />;
+}
+
+interface MediaEditAttachmentsProps {
+	attachments: Attachment< 'view' >[] | null;
+	addButtonLabel: string;
+	multiple?: boolean;
+	removeItem: ( itemId: number ) => void;
+	open: () => void;
+}
+
+function ExpandedMediaEditAttachments( {
+	attachments,
+	addButtonLabel,
+	multiple,
+	removeItem,
+	open,
+}: MediaEditAttachmentsProps ) {
+	return (
+		<div
+			className={ clsx( 'fields__media-edit-expanded', {
+				'is-multiple': multiple,
+				'is-single': ! multiple,
+				'is-empty': ! attachments?.length,
+			} ) }
+		>
+			{ attachments?.map( ( attachment ) => {
+				const hasPreviewImage =
+					attachment.mime_type.startsWith( 'image/' );
+				return (
+					<div
+						key={ attachment.id }
+						className={ clsx( 'fields__media-edit-expanded-item', {
+							'has-preview-image': hasPreviewImage,
+						} ) }
+					>
+						<MediaPickerButton
+							open={ open }
+							label={ __( 'Replace' ) }
+							showTooltip
+						>
+							<div className="fields__media-edit-expanded-preview">
+								<VStack
+									spacing={ 0 }
+									alignment="center"
+									justify="center"
+									className="fields__media-edit-expanded-preview-stack"
+								>
+									<MediaPreview attachment={ attachment } />
+									{ ! hasPreviewImage ? (
+										<MediaTitle attachment={ attachment } />
+									) : (
+										<div className="fields__media-edit-expanded-title">
+											<MediaTitle
+												attachment={ attachment }
+											/>
+										</div>
+									) }
+								</VStack>
+							</div>
+						</MediaPickerButton>
+						<div className="fields__media-edit-expanded-overlay">
+							<Button
+								__next40pxDefaultSize
+								className="fields__media-edit-expanded-remove"
+								icon={ closeSmall }
+								label={ __( 'Remove' ) }
+								size="small"
+								onClick={ (
+									event: React.MouseEvent< HTMLButtonElement >
+								) => {
+									event.stopPropagation();
+									removeItem( attachment.id );
+								} }
+							/>
+						</div>
+					</div>
+				);
+			} ) }
+			{ ( multiple || ! attachments?.length ) && (
+				<MediaEditPlaceholder open={ open } label={ addButtonLabel } />
+			) }
+		</div>
+	);
+}
+
+function CompactMediaEditAttachments( {
+	attachments,
+	addButtonLabel,
+	multiple,
+	removeItem,
+	open,
+}: MediaEditAttachmentsProps ) {
 	return (
 		<>
-			{ preview }
-			<Truncate className="fields__media-edit-filename">
-				{ attachmentTitle }
-			</Truncate>
+			{ !! attachments?.length && (
+				<VStack spacing={ 2 }>
+					{ attachments.map( ( attachment ) => (
+						<div
+							key={ attachment.id }
+							className="fields__media-edit-compact"
+						>
+							<MediaPickerButton
+								open={ open }
+								label={ __( 'Replace' ) }
+								showTooltip
+							>
+								<>
+									<MediaPreview attachment={ attachment } />
+									<MediaTitle attachment={ attachment } />
+								</>
+							</MediaPickerButton>
+							<Button
+								__next40pxDefaultSize
+								className="fields__media-edit-remove"
+								text={ __( 'Remove' ) }
+								variant="secondary"
+								onClick={ (
+									event: React.MouseEvent< HTMLButtonElement >
+								) => {
+									event.stopPropagation();
+									removeItem( attachment.id );
+								} }
+							/>
+						</div>
+					) ) }
+				</VStack>
+			) }
+			{ ( multiple || ! attachments?.length ) && (
+				<MediaEditPlaceholder open={ open } label={ addButtonLabel } />
+			) }
 		</>
 	);
 }
@@ -170,6 +312,7 @@ function MediaPreview( {
  * @param {string[]}             [props.allowedTypes]        - Array of allowed media types. Default `['image']`.
  * @param {boolean}              [props.multiple]            - Whether to allow multiple media selections. Default `false`.
  * @param {boolean}              [props.hideLabelFromVision] - Whether the label should be hidden from vision.
+ * @param {boolean}              [props.isCompact]           - Whether to render in a compact form. Default `true`.
  *
  * @return {JSX.Element} The media edit control component.
  *
@@ -198,6 +341,7 @@ export default function MediaEdit< Item >( {
 	hideLabelFromVision,
 	allowedTypes = [ 'image' ],
 	multiple,
+	isCompact = true,
 }: MediaEditProps< Item > ) {
 	const value = field.getValue( { item: data } );
 	const attachments = useSelect(
@@ -223,6 +367,9 @@ export default function MediaEdit< Item >( {
 		const newIds = currentIds.filter( ( id ) => id !== itemId );
 		onChangeControl( newIds.length ? newIds : undefined );
 	};
+	const addButtonLabel =
+		field.placeholder ||
+		( multiple ? __( 'Choose files' ) : __( 'Choose file' ) );
 	return (
 		<fieldset className="fields__media-edit" data-field-id={ field.id }>
 			<ConditionalMediaUpload
@@ -241,9 +388,9 @@ export default function MediaEdit< Item >( {
 				multiple={ multiple }
 				title={ field.label }
 				render={ ( { open }: any ) => {
-					const addButtonLabel = attachments?.length
-						? __( 'Add files' )
-						: field.placeholder || __( 'Choose file' );
+					const AttachmentsComponent = isCompact
+						? CompactMediaEditAttachments
+						: ExpandedMediaEditAttachments;
 					return (
 						<VStack spacing={ 2 }>
 							{ field.label &&
@@ -256,52 +403,13 @@ export default function MediaEdit< Item >( {
 										{ field.label }
 									</BaseControl.VisualLabel>
 								) ) }
-							{ !! attachments?.length && (
-								<VStack spacing={ 2 }>
-									{ attachments.map( ( attachment ) => (
-										<div
-											key={ attachment.id }
-											className="fields__media-edit-row"
-										>
-											<MediaPickerButton
-												open={ open }
-												label={ __( 'Replace' ) }
-												showTooltip
-											>
-												<MediaPreview
-													url={
-														attachment.source_url
-													}
-													attachment={ attachment }
-												/>
-											</MediaPickerButton>
-											<Button
-												__next40pxDefaultSize
-												className="fields__media-edit-remove"
-												text={ __( 'Remove' ) }
-												variant="secondary"
-												onClick={ (
-													event: React.MouseEvent< HTMLButtonElement >
-												) => {
-													event.stopPropagation();
-													removeItem( attachment.id );
-												} }
-											/>
-										</div>
-									) ) }
-								</VStack>
-							) }
-							{ ( multiple || ! attachments?.length ) && (
-								<MediaPickerButton
-									open={ open }
-									label={ addButtonLabel }
-								>
-									<span className="fields__media-edit-placeholder">
-										{ addButtonLabel }
-									</span>
-								</MediaPickerButton>
-							) }
-
+							<AttachmentsComponent
+								attachments={ attachments }
+								addButtonLabel={ addButtonLabel }
+								multiple={ multiple }
+								removeItem={ removeItem }
+								open={ open }
+							/>
 							{ field.description && (
 								<Text variant="muted">
 									{ field.description }

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -312,7 +312,7 @@ function CompactMediaEditAttachments( {
  * @param {string[]}             [props.allowedTypes]        - Array of allowed media types. Default `['image']`.
  * @param {boolean}              [props.multiple]            - Whether to allow multiple media selections. Default `false`.
  * @param {boolean}              [props.hideLabelFromVision] - Whether the label should be hidden from vision.
- * @param {boolean}              [props.isCompact]           - Whether to render in a compact form. Default `true`.
+ * @param {boolean}              [props.isExpanded]          - Whether to render in an expanded form. Default `false`.
  *
  * @return {JSX.Element} The media edit control component.
  *
@@ -341,7 +341,7 @@ export default function MediaEdit< Item >( {
 	hideLabelFromVision,
 	allowedTypes = [ 'image' ],
 	multiple,
-	isCompact = true,
+	isExpanded,
 }: MediaEditProps< Item > ) {
 	const value = field.getValue( { item: data } );
 	const attachments = useSelect(
@@ -388,9 +388,9 @@ export default function MediaEdit< Item >( {
 				multiple={ multiple }
 				title={ field.label }
 				render={ ( { open }: any ) => {
-					const AttachmentsComponent = isCompact
-						? CompactMediaEditAttachments
-						: ExpandedMediaEditAttachments;
+					const AttachmentsComponent = isExpanded
+						? ExpandedMediaEditAttachments
+						: CompactMediaEditAttachments;
 					return (
 						<VStack spacing={ 2 }>
 							{ field.label &&

--- a/packages/fields/src/components/media-edit/style.scss
+++ b/packages/fields/src/components/media-edit/style.scss
@@ -1,6 +1,12 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+@mixin preview-overlay {
+	border-radius: $radius-x-small;
+	backdrop-filter: blur(16px) saturate(180%);
+	background: rgba(255, 255, 255, 0.75);
+}
+
 fieldset.fields__media-edit {
 	// Reset `fieldset` browser defaults.
 	border: 0;
@@ -9,7 +15,10 @@ fieldset.fields__media-edit {
 
 	width: 100%;
 
-	.fields__media-edit-row {
+	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
+	container-type: inline-size;
+
+	.fields__media-edit-compact {
 		display: grid;
 		grid-template-columns: 1fr auto;
 		gap: $grid-unit-10;
@@ -39,8 +48,8 @@ fieldset.fields__media-edit {
 	.fields__media-edit-filename,
 	.fields__media-edit-placeholder {
 		flex: 1;
+		width: 100%;
 		min-width: 0;
-		color: $gray-900;
 	}
 
 	.fields__media-edit-placeholder {
@@ -52,5 +61,129 @@ fieldset.fields__media-edit {
 		aspect-ratio: 1 / 1;
 		flex-shrink: 0;
 		border-radius: $radius-small;
+	}
+
+	.fields__media-edit-expanded {
+		// Always use grid layout
+		display: grid;
+		gap: $grid-unit-10;
+
+		.fields__media-edit-expanded-preview {
+			position: relative;
+			width: 100%;
+			aspect-ratio: 3/2;
+			border-radius: $radius-small;
+			padding: $grid-unit-05;
+			overflow: hidden;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+
+			.fields__media-edit-expanded-preview-stack {
+				width: 100%;
+				height: 100%;
+			}
+		}
+
+		.fields__media-edit-expanded-overlay {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			opacity: 0;
+			pointer-events: none;
+
+			@media not (prefers-reduced-motion) {
+				transition: opacity 50ms ease-out;
+			}
+
+			* {
+				pointer-events: auto;
+			}
+		}
+
+		.fields__media-edit-expanded-remove {
+			position: absolute;
+			top: $grid-unit-10;
+			right: $grid-unit-10;
+			@include preview-overlay;
+		}
+
+		.fields__media-edit-expanded-title {
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			margin: $grid-unit-10;
+			padding: $grid-unit-05;
+			text-align: center;
+			@include preview-overlay;
+		}
+
+		.fields__media-edit-expanded-item {
+			position: relative;
+			min-width: 0;
+
+			&:hover,
+			&:focus-within {
+				.fields__media-edit-expanded-overlay {
+					opacity: 1;
+				}
+			}
+
+			&:not(.has-preview-image) {
+				.fields__media-edit-expanded-preview-stack {
+					padding: $grid-unit-10;
+				}
+			}
+		}
+
+		.fields__media-edit-thumbnail {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			object-position: 50% 50%;
+		}
+
+		.fields__media-edit-filename {
+			text-align: center;
+			flex: none;
+		}
+
+		&.is-single {
+			grid-template-columns: 1fr;
+
+			.fields__media-edit-expanded-preview {
+				aspect-ratio: 2/1;
+			}
+		}
+
+		&.is-multiple:not(.is-empty) {
+			grid-template-columns: repeat(3, 1fr);
+
+			/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
+			@container (max-width: 768px) {
+				grid-template-columns: repeat(2, 1fr);
+			}
+
+			/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
+			@container (max-width: 280px) {
+				grid-template-columns: 1fr;
+			}
+		}
+
+		&:not(.is-empty) {
+			.fields__media-edit-picker-button {
+				padding: 0;
+			}
+
+			.fields__media-edit-placeholder {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				aspect-ratio: 3/2;
+			}
+		}
 	}
 }

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -157,9 +157,9 @@ export interface MediaEditProps< Item >
 	 */
 	multiple?: boolean;
 	/**
-	 * Whether to render in a compact form.
+	 * Whether to render in an expanded form.
 	 *
-	 * @default true
+	 * @default false
 	 */
-	isCompact?: boolean;
+	isExpanded?: boolean;
 }

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -156,4 +156,10 @@ export interface MediaEditProps< Item >
 	 * @default false
 	 */
 	multiple?: boolean;
+	/**
+	 * Whether to render in a compact form.
+	 *
+	 * @default true
+	 */
+	isCompact?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72614

This PR adds the `expanded` view for MediaEdit component, mostly based on the [designs shared ](https://github.com/WordPress/gutenberg/issues/72614#issuecomment-3473852982)in the linked issue.

### Design feedback
1. For now, **if we have no files selected** the placeholder is implemented to be an expanded button (choose files) for any versions of the view (compact | expanded). If we have multiple files and the `expanded` version, the placeholder is part of the grid.
2. The designs show as the default to have 3 grid columns, but it's too narrow for our current place of usage, so it's using `2` columns. The styles exist there for displaying 3 columns based on container queries.
3. For overlay of the title and the remove button I followed a bit the design of the current featured image in post editor (inspector controls). We can change them though to dark if we aim to replace that component eventually. We should be consistent here either way.





## Testing Instructions
1. Ensure the featured image (`featuredImageField`) in site editor's quick edit works as before.
4. Currently there is no way to test the expanded view in trunk, so you can change the `FeaturedImage` field locally to this:
```
Edit: ( props ) => (
    <MediaEdit
        { ...props }
        allowedTypes={ [] }
        multiple
        isExpanded
    />
)
```
5. Test the different combinations by adding/removing the `allowedTypes, multiple and isExpanded` props.



### Expanded view with single file

https://github.com/user-attachments/assets/3e5942d5-0b2b-462f-aea1-ee4d288e2fec




### Expanded view with multiple files

https://github.com/user-attachments/assets/2fdc1656-7812-4aef-8fca-cbc7a7d07186



