### PR TITLE
Block Support: Fix horizontal overflow in Manage allowed blocks modal

### DIFF
--- a/packages/block-editor/src/components/block-allowed-blocks/style.scss
+++ b/packages/block-editor/src/components/block-allowed-blocks/style.scss
@@ -18,10 +18,10 @@
 .block-editor-block-allowed-blocks-modal__actions {
 	background-color: $white;
 	border-top: $border-width solid $gray-300;
-	bottom: -1 * $grid-unit-40;
+	bottom: -1 * $grid-unit-30;
 	left: 0;
-	margin: 0 (-1 * $grid-unit-40) (-1 * $grid-unit-40);
-	padding: $grid-unit-20 $grid-unit-40;
+	margin: 0 (-1 * $grid-unit-30) (-1 * $grid-unit-30);
+	padding: $grid-unit-20 $grid-unit-30;
 	position: sticky;
 	z-index: 1;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

As of #73334, the padding of the modal content has changed from `32px` to `24px`. I adjusted the sticky footer in the modal accordingly.


## Testing Instructions

- Insert a Group block.
- Open the Advanced panel
- Click the Manage allowed blocks button.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
| <img width="535" height="661" alt="image" src="https://github.com/user-attachments/assets/03af43bc-4a42-452e-aae6-b71031d35b4d" /> | <img width="540" height="667" alt="image" src="https://github.com/user-attachments/assets/f5c2691c-bf97-4f2e-be0e-0a008b66109d" /> | 