### PR TITLE
Preview drop down: align preview editing widths with common breakpoints

### DIFF
--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -29,12 +29,17 @@ export default function useResizeCanvas( deviceType ) {
 	const getCanvasWidth = ( device ) => {
 		let deviceWidth;
 
+		/*
+		 * Matches the breakpoints in packages/base-styles/_breakpoints.scss,
+		 * and breakpoints in packages/compose/src/hooks/use-viewport-match/index.js.
+		 * minus 1 to trigger the media query for device preview.
+		 */
 		switch ( device ) {
 			case 'Tablet':
-				deviceWidth = 780;
+				deviceWidth = 782 - 1; // preview for useViewportMatch( 'medium', '<' )
 				break;
 			case 'Mobile':
-				deviceWidth = 360;
+				deviceWidth = 480 - 1; // preview for useViewportMatch( 'mobile', '<' )
 				break;
 			default:
 				return null;

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -21,12 +21,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem } from '@wordpress/interface';
+import { useEffect } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
 
@@ -70,6 +71,15 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	};
 
 	const isMobile = useViewportMatch( 'medium', '<' );
+
+	// Reset device to Desktop when viewport becomes non-mobile
+	useEffect( () => {
+		if ( isMobile && deviceType !== 'Desktop' ) {
+			setDeviceType( 'Desktop' );
+			resetZoomLevel();
+		}
+	}, [ isMobile, deviceType, setDeviceType, resetZoomLevel ] );
+
 	if ( isMobile ) {
 		return null;
 	}

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -21,7 +21,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem } from '@wordpress/interface';
-import { useEffect } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -71,15 +70,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	};
 
 	const isMobile = useViewportMatch( 'medium', '<' );
-
-	// Reset device to Desktop when viewport becomes non-mobile
-	useEffect( () => {
-		if ( isMobile && deviceType !== 'Desktop' ) {
-			setDeviceType( 'Desktop' );
-			resetZoomLevel();
-		}
-	}, [ isMobile, deviceType, setDeviceType, resetZoomLevel ] );
-
 	if ( isMobile ) {
 		return null;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How? Why?!!


Related to: https://github.com/WordPress/gutenberg/issues/72502#issuecomment-3693842196

This PR:

- updates the device preview widths so that they match the default breakpoint values [used everywhere else](https://github.com/WordPress/gutenberg/pull/74025#issuecomment-3677471633)


## Testing Instructions

Open the editor and play with the device previews, e.g., set to "Tablet" or "Mobile"

Check that device-dependent blocks work in the previews, e.g.,

- Columns block stacked = `@media (max-width: #{ ($break-medium - 1) })`
- Media & Text block stacked = `@media (max-width: #{ ($break-small) }) {`
- Navigation - should show mobile menu at `@media (min-width: 600px) {`
- Any others that stand out?

> [!NOTE]
> The fact that the two blocks above have `Stack on mobile` at different breakpoints is another story 😄 

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/16eac47d-f1e1-4c46-9324-3630231801fa


