### PR TITLE
Fix parent popover not closing on click outside

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -42,6 +42,7 @@
 -   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
 -   `DatePicker`: Fix missing scheduled events and current date indicators. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
 -   `DatePicker`: Fix handling of `currentDate` when passed values as Date or timestamp. ([#73887](https://github.com/WordPress/gutenberg/pull/73887))
+-   `Popover`: Fix bug where clicking outside nested popovers only closed the inner one. ([#74340](https://github.com/WordPress/gutenberg/pull/74340))
 
 ### Internal
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -280,8 +280,16 @@ const UnforwardedPopover = (
 						'contains' in referenceElement &&
 						referenceElement.contains( blurTarget ) ) ||
 					floatingElement?.contains( blurTarget );
-				// Only proceed if the blur is actually from this popover
-				if ( ! isBlurFromThisPopover ) {
+				// Ignore blur events that don't originate from this popover when there's no
+				// relatedTarget (next focus target) and focus moves to document.body.
+				// This prevents incorrectly closing the popover when clicking on elements
+				// that don't accept focus (like clicking outside to empty space).
+				const ownerDocument = floatingElement?.ownerDocument;
+				if (
+					! isBlurFromThisPopover &&
+					! ( 'relatedTarget' in event && event.relatedTarget ) &&
+					ownerDocument?.activeElement === ownerDocument?.body
+				) {
 					return;
 				}
 				// Call onFocusOutside if defined or call onClose.

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -578,4 +578,89 @@ describe( 'Popover', () => {
 			}
 		);
 	} );
+
+	describe( 'closing all nested popovers', () => {
+		// Test component that simulates the nested popover scenario:
+		// A parent popover (like ColorGradient dropdown) containing a trigger
+		// that opens a nested popover (like custom color picker dropdown)
+		function NestedPopoverTestComponent( {
+			onParentFocusOutside,
+			onNestedFocusOutside,
+		}: {
+			onParentFocusOutside: jest.Mock;
+			onNestedFocusOutside: jest.Mock;
+		} ) {
+			const [ isNestedOpen, setIsNestedOpen ] = useState( false );
+
+			return (
+				<>
+					<button data-testid="external-button">
+						External Button
+					</button>
+					<Popover
+						data-testid="parent-popover"
+						onFocusOutside={ onParentFocusOutside }
+						focusOnMount={ false }
+					>
+						<button
+							data-testid="parent-button"
+							onClick={ () => setIsNestedOpen( ! isNestedOpen ) }
+						>
+							Open Nested
+						</button>
+						{ isNestedOpen && (
+							<Popover
+								data-testid="nested-popover"
+								onFocusOutside={ onNestedFocusOutside }
+								focusOnMount={ false }
+							>
+								<button data-testid="nested-dummy-button">
+									Nested Dummy Button
+								</button>
+							</Popover>
+						) }
+					</Popover>
+				</>
+			);
+		}
+
+		it( 'should call parent onFocusOutside when focus moves from nested popover to external element', async () => {
+			const user = userEvent.setup();
+			const onParentFocusOutside = jest.fn();
+			const onNestedFocusOutside = jest.fn();
+
+			render(
+				<NestedPopoverTestComponent
+					onParentFocusOutside={ onParentFocusOutside }
+					onNestedFocusOutside={ onNestedFocusOutside }
+				/>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByTestId( 'parent-popover' )
+				).toBeInTheDocument();
+			} );
+
+			await user.click( screen.getByTestId( 'parent-button' ) );
+
+			await waitFor( () => {
+				expect(
+					screen.getByTestId( 'nested-popover' )
+				).toBeInTheDocument();
+			} );
+
+			await user.click( screen.getByTestId( 'nested-dummy-button' ) );
+
+			await user.click( screen.getByTestId( 'external-button' ) );
+
+			await waitFor( () => {
+				expect( onNestedFocusOutside ).toHaveBeenCalled();
+			} );
+
+			await waitFor( () => {
+				expect( onParentFocusOutside ).toHaveBeenCalled();
+			} );
+		} );
+	} );
 } );

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -655,11 +655,11 @@ describe( 'Popover', () => {
 			await user.click( screen.getByTestId( 'external-button' ) );
 
 			await waitFor( () => {
-				expect( onNestedFocusOutside ).toHaveBeenCalled();
+				expect( onNestedFocusOutside ).toHaveBeenCalledTimes( 1 );
 			} );
 
 			await waitFor( () => {
-				expect( onParentFocusOutside ).toHaveBeenCalled();
+				expect( onParentFocusOutside ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #74154; alternative to #74179.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To check that the bug fix from #72376 hasn't regressed:

1. Enable the Dataviews: new media modal experiment.
2. In the editor, add an Image block and populate it with an image.
3. Click the "Replace" button in the block toolbar, then "Open media library" - you should see the modal containing the dataviews picker.
4. Click the filter button and then click outside the resulting dropdown to close it. The modal should stay open.

To check that #74154 is fixed:

1. With a paragraph block selected,  and add a custom color for the text.
2. Click on the background color. Both the color popovers should close.
3. Open the custom color dialog again, and this time click on the paragraph itself in the canvas. Both the popovers should close.
