### PR TITLE
HtmlRenderer: Merge style props

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -111,10 +111,7 @@ export default function BreadcrumbEdit( {
 	} );
 
 	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( {
-		ref: disabledRef,
-		style: { '--separator': `'${ separator }'` },
-	} );
+	const blockProps = useBlockProps( { ref: disabledRef } );
 
 	if ( isLoading ) {
 		return (

--- a/packages/block-library/src/utils/html-renderer.js
+++ b/packages/block-library/src/utils/html-renderer.js
@@ -14,6 +14,7 @@ import { safeHTML } from '@wordpress/dom';
  *
  * @param {Object} props              - The props for the component.
  * @param {Object} props.wrapperProps - The props to merge with the root element.
+ *                                    className and style are merged with the parsed HTML attributes.
  * @param {string} props.html         - The HTML content to render.
  * @return {JSX.Element} The rendered React elements.
  */
@@ -31,6 +32,10 @@ const HtmlRenderer = ( { wrapperProps = {}, html = '' } ) => {
 							parsedProps.className,
 							wrapperProps.className
 						),
+						style: {
+							...( parsedProps.style || {} ),
+							...( wrapperProps.style || {} ),
+						},
 					};
 					return (
 						<TagName { ...mergedProps }>


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/74261#discussion_r2660584759

## What?

The `HTMLRenderer` component is primarily used to render content received from the server side as a React element. This PR combines both props in the `style` prop as well as the `className` prop.

Initially, I considered performing the merge on all props, but depending on the attribute, that might not be appropriate. For example, if we combined the `aria-label` attribute, we'd end up with a strange element being rendered, like this:

```html
<nav class="wp-block-breadcrumbs" aria-label="Block: Breadcrumbs Breadcrumbs"></nav>
```

As a result, this PR solves one problem with the Breadcrumbs block: The CSS variable that is properly escaped on the server side is also used on the client side, so any character will be properly rendered as a separator.

### Before

<img width="1170" height="284" alt="before" src="https://github.com/user-attachments/assets/568f552a-55e1-487b-8aca-40a3581de7e2" />

### After

<img width="1190" height="279" alt="after" src="https://github.com/user-attachments/assets/72182667-cfdc-4937-b89d-cd11c40eb5a6" />

## Testing Instructions

Smoke test blocks that are using the `HTMLRenderer` component:

- Archives
- Breadcrumbs
- Calendar
- Lastest Comments
- RSS
- Tag Cloud 

