### PR TITLE
Build: Fix TypeScript error output in check-build-type-declaration-files script

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -112,7 +112,7 @@ async function checkUnverifiedDeclarationFiles() {
 				chalk.red(
 					`Incorrect published types for ${ reason.file }:\n`
 				),
-				reason.stdout
+				reason.stderr || reason.stdout
 			);
 		}
 	} );


### PR DESCRIPTION
Just a small tweak to surface the real issues when the script fails.