### PR TITLE
E2E Tests: Await frame request before asserting all expected requests

### DIFF
--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -19,6 +19,11 @@ test.describe( 'Preload', () => {
 	} ) => {
 		const requests = [];
 
+		let resolveRequests = null;
+		const requestsPromise = new Promise( ( resolve ) => {
+			resolveRequests = resolve;
+		} );
+
 		function onRequest( request ) {
 			if (
 				request.resourceType() === 'document' &&
@@ -26,6 +31,7 @@ test.describe( 'Preload', () => {
 			) {
 				// Stop recording when the iframe is initialized.
 				page.off( 'request', onRequest );
+				resolveRequests();
 			} else if ( request.resourceType() === 'fetch' ) {
 				const url = request.url();
 				const urlObject = new URL( url );
@@ -42,7 +48,7 @@ test.describe( 'Preload', () => {
 
 		page.on( 'request', onRequest );
 
-		await admin.visitSiteEditor();
+		await Promise.all( [ admin.visitSiteEditor(), requestsPromise ] );
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [


### PR DESCRIPTION
## What?

Attempts to fix intermittent test failures in end-to-end tests ([example](https://github.com/WordPress/gutenberg/actions/runs/20728094992/job/59508722573?pr=74353)):

```
    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 0

      Array [
        "/wp-abilities/v1/categories?per_page=100&context=edit",
        "/wp-abilities/v1/abilities?per_page=100&context=edit",
        "/wp/v2/users/me",
    -   "/wp/v2/settings",
      ]
```

## How?

The hypothesis here was that the tests would attempt to proceed after the site editor page had finished loading and hidden its spinners, not allowing all expected requests to have been issued.

Based on failures here, this appears to be an incorrect hypothesis. As I understand, the spinners are based on requests anyways, so there should likely be symmetry between spinners and expected requests.