### PR TITLE
Env: Simple support for docker compose override

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
-const { v2: dockerCompose } = require( 'docker-compose' );
-const util = require( 'util' );
-const path = require( 'path' );
 const fs = require( 'fs' ).promises;
+const path = require( 'path' );
+const util = require( 'util' );
 const { confirm } = require( '@inquirer/prompts' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 
 /**
  * Promisified dependencies
@@ -236,6 +236,14 @@ module.exports = async function start( {
 		// Set the cache key once everything has been configured.
 		await setCache( CONFIG_CACHE_KEY, configHash, {
 			workDirectoryPath,
+		} );
+	}
+
+	if ( dockerComposeConfigPath.length > 1 ) {
+		spinner.text = 'Starting custom services.';
+		await dockerCompose.upAll( {
+			...dockerComposeConfig,
+			commandOptions: [ '--no-recreate' ],
 		} );
 	}
 

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -4,6 +4,7 @@
  */
 const path = require( 'path' );
 const fs = require( 'fs' ).promises;
+const { existsSync } = require( 'fs' );
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ const postProcessConfig = require( './post-process-config' );
  * @property {string}                               name                    Name of the environment.
  * @property {string}                               configDirectoryPath     Path to the .wp-env.json file.
  * @property {string}                               workDirectoryPath       Path to the work directory located in ~/.wp-env.
- * @property {string}                               dockerComposeConfigPath Path to the docker-compose.yml file.
+ * @property {string[]}                             dockerComposeConfigPath Paths to the docker-compose.yml files.
  * @property {boolean}                              detectedLocalConfig     If true, wp-env detected local config and used it.
  * @property {Object.<string, string>}              lifecycleScripts        Any lifecycle scripts that we might need to execute.
  * @property {Object.<string, WPEnvironmentConfig>} env                     Specific config for different environments.
@@ -56,12 +57,21 @@ module.exports = async function loadConfig( configDirectoryPath ) {
 	// consumption elsewhere in the tool.
 	config = postProcessConfig( config );
 
+	const dockerComposeConfigPath = [
+		path.resolve( cacheDirectoryPath, 'docker-compose.yml' ),
+	];
+
+	const overridePath = path.resolve(
+		configDirectoryPath,
+		'docker-compose.override.yml'
+	);
+	if ( existsSync( overridePath ) ) {
+		dockerComposeConfigPath.push( overridePath );
+	}
+
 	return {
 		name: path.basename( configDirectoryPath ),
-		dockerComposeConfigPath: path.resolve(
-			cacheDirectoryPath,
-			'docker-compose.yml'
-		),
+		dockerComposeConfigPath,
 		configDirectoryPath,
 		workDirectoryPath: cacheDirectoryPath,
 		detectedLocalConfig: await hasLocalConfig( [

--- a/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
@@ -4,7 +4,9 @@ exports[`Config Integration should load local and override configuration files 1
 {
   "configDirectoryPath": "/test/gutenberg",
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": [
+    "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  ],
   "env": {
     "development": {
       "config": {
@@ -83,7 +85,9 @@ exports[`Config Integration should load local configuration file 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": [
+    "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  ],
   "env": {
     "development": {
       "config": {
@@ -162,7 +166,9 @@ exports[`Config Integration should use default configuration 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": [
+    "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  ],
   "env": {
     "development": {
       "config": {
@@ -241,7 +247,9 @@ exports[`Config Integration should use environment variables over local and over
 {
   "configDirectoryPath": "/test/gutenberg",
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": [
+    "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  ],
   "env": {
     "development": {
       "config": {

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 const { readFile } = require( 'fs' ).promises;
+const { existsSync } = require( 'fs' );
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ jest.mock( 'fs', () => ( {
 		mkdir: jest.fn(),
 		writeFile: jest.fn(),
 	},
+	existsSync: jest.fn( () => false ),
 } ) );
 
 // This mocks a small response with a format matching the stable-check API.
@@ -199,5 +201,26 @@ describe( 'Config Integration', () => {
 			'test'
 		);
 		expect( config ).toMatchSnapshot();
+	} );
+
+	it( 'should include docker-compose.override.yml when it exists', async () => {
+		readFile.mockImplementation( async () => {
+			throw { code: 'ENOENT' };
+		} );
+
+		existsSync.mockImplementation(
+			( filePath ) =>
+				filePath === '/test/gutenberg/docker-compose.override.yml'
+		);
+
+		const config = await loadConfig( '/test/gutenberg' );
+
+		expect( config.dockerComposeConfigPath ).toHaveLength( 2 );
+		expect( config.dockerComposeConfigPath[ 0 ] ).toContain(
+			'docker-compose.yml'
+		);
+		expect( config.dockerComposeConfigPath[ 1 ] ).toBe(
+			'/test/gutenberg/docker-compose.override.yml'
+		);
 	} );
 } );

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -83,7 +83,7 @@ module.exports = async function initConfig( {
 		await mkdir( config.workDirectoryPath, { recursive: true } );
 
 		await writeFile(
-			config.dockerComposeConfigPath,
+			config.dockerComposeConfigPath[ 0 ],
 			yaml.dump( dockerComposeConfig )
 		);
 


### PR DESCRIPTION
## What?
Closes #72838 
Alternative to #74128 to simplify with `existsSync` equivalent to Core implementation

## Why?
Adding very simple support to `docker-compose.override.yml` in plugins can be done just be following the similar principles as in Core ([r59283](https://core.trac.wordpress.org/changeset/59283))

## How?
Basically, we can add to `dockerComposeConfigPath` the composer override and execute accordingly. 
Note the reorder of modules in `start.js` because Husky was not happy with the current alphabetical order.

## Testing Instructions
1. Build wp-env in Gutenberg trunk, from the Gutenberg repo root, the path should be: 
`packages/env`

2. Create a new plugin outside the Gutenberg repo, and reference it as a developer dependency. You can use a `package.json` like this (change the path accordingly).

```json
{
  "devDependencies": {
    "@wordpress/env": "file:../gutenberg/packages/env"
  },
  "scripts": {
    "env": "wp-env"
  }
}
```

3. Create a docker-compose.override.yml like:

```yml
services:
  redis:
    image: redis:alpine
    restart: unless-stopped
    ports:
      - "6379:6379"
 ```

4. Run the build commands:

```bash
npm i
npm run env start
```

5. ✅ Check that redis image is running (`docker ps | grep redis`) 

Props to @desrosj for the Core proposal, @nhance and @Raxen001 for the ideas.