### PR TITLE
Clamp signaling server retries to prevent unbounded backoff

### DIFF
--- a/lib/experimental/sync/class-gutenberg-http-signaling-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-signaling-server.php
@@ -171,6 +171,8 @@ class Gutenberg_HTTP_Signaling_Server {
 		list( $fd, $subscriber_to_messages ) = static::get_contents_and_lock_file( $subscriber_to_messages_path );
 		if ( ! $fd ) {
 			$retries = isset( $_COOKIE['signaling_server_retries'] ) ? intval( $_COOKIE['signaling_server_retries'] ) : 0;
+			// Clamp retries to avoid unbounded exponential backoff.
+			$retries = max( 0, min( $retries, 10 ) );
 			$secure  = ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) );
 			setcookie( 'signaling_server_retries', (string) ( $retries + 1 ), time() + DAY_IN_SECONDS, SITECOOKIEPATH, '', $secure );
 			echo 'id: ' . time() . PHP_EOL;


### PR DESCRIPTION
## What?
Closes N/A (hardening / defensive change; no existing issue found).

Clamp the cookie-derived signaling_server_retries value used by the HTTP signaling server to prevent unbounded exponential backoff values being emitted in the SSE retry: field when the messages file cannot be opened.

## Why?
$retries is sourced from $_COOKIE['signaling_server_retries'] and is used in 3000 * pow( 2, $retries ). Because the cookie is client-controlled, a very large value can cause the computed retry interval to become extremely large (and potentially overflow on some platforms). Clamping keeps the behavior predictable.

## How?
After reading $retries from the cookie, clamp it to a reasonable maximum:
	•	max( 0, min( $retries, 10 ) )

This bounds the exponential backoff used to generate the SSE retry: value while preserving the intended progressive backoff behavior.

## Testing Instructions
	1.	Apply this patch.
	2.	Ensure the signaling server feature is enabled so the AJAX endpoint is active.
	3.	Trigger the error path where the server cannot open the required messages file
	4.	Send a request to the signaling server endpoint so it returns the SSE error response.
	5.	Set the signaling_server_retries cookie to a very large integer.
	6.	Verify the response still contains a bounded retry: value and does not grow unbounded.

Testing Instructions for Keyboard

N/A (no UI changes).

Screenshots or screencast

N/A.