### PR TITLE
Media mime type field: Disable sorting for now

### DIFF
--- a/packages/media-fields/src/mime_type/index.ts
+++ b/packages/media-fields/src/mime_type/index.ts
@@ -11,7 +11,9 @@ const mimeTypeField: Partial< Field< Updatable< Attachment > > > = {
 	label: __( 'File type' ),
 	getValue: ( { item } ) => item?.mime_type || '',
 	render: ( { item } ) => item?.mime_type || '-',
-	enableSorting: true,
+	// Disable sorting until REST API support for ordering my `mime_type` is added.
+	// See: https://core.trac.wordpress.org/ticket/64073
+	enableSorting: false,
 	filterBy: false,
 	readOnly: true,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of: #73085

Disable sorting of the mime type field for now.

## Why?

Currently the media endpoint does not support ordering by mime type, so attempting to sort the mime type column in the media modal experiment fails with a 400 error.

Support for sorting is being proposed in core over in https://core.trac.wordpress.org/ticket/64073, however there's more work to be done to address an underlying issue with WP_Query over in https://github.com/WordPress/wordpress-develop/pull/10262. Until that's resolved, let's disable sorting so that users can't get into a broken state with this field.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* For the mime type field, switch `enableSorting` to `false`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Enable the new media modal experiment:

<img width="960" height="66" alt="image" src="https://github.com/user-attachments/assets/7417b78e-9161-465a-bd2a-5252061437f4" />

* Go to add a featured image to a post to open up the media modal.
* Switch to the table view.
* In the view settings (cog icon) click to make the file type field visible.
* Click on the column header.
* With this PR applied, you should not see sorting options.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

The error:

<img width="1440" height="1238" alt="image" src="https://github.com/user-attachments/assets/dd72ae3f-58fe-42b7-833a-13d21d9a1aed" />

|Before|After|
|-|-|
| <img width="1275" height="614" alt="image" src="https://github.com/user-attachments/assets/900255b7-c0cb-403b-b5ad-0a045fcbbfc5" /> | <img width="1277" height="615" alt="image" src="https://github.com/user-attachments/assets/d041cfca-cb4c-4027-b66f-5a255cda9129" /> |