### PR TITLE
E2E tests: restore removal of `settings` path in preload tests

### DIFF
--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -51,9 +51,6 @@ test.describe( 'Preload', () => {
 			'/wp-abilities/v1/abilities?per_page=100&context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
-			// There are two separate settings OPTIONS requests. We should fix
-			// so the one for canUser and getEntityRecord are reused.
-			'/wp/v2/settings',
 		] );
 	} );
 } );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Restores the `settings` preload path expectation removed in 

- https://github.com/WordPress/gutenberg/commit/50942ac4cfb88b633d284a7372431f64c2e82a0b

It was added back in here:

- https://github.com/WordPress/gutenberg/pull/74221/commits/0ed56d218acd97eaff8921b0539061aafc5eb579


See failing trunk test: 

https://github.com/WordPress/gutenberg/actions/runs/20725500202/job/59499916366

<img width="1077" height="735" alt="Screenshot 2026-01-06 at 1 53 55 pm" src="https://github.com/user-attachments/assets/29a75fa3-534e-43c1-97b1-c23d3f90266d" />



## Why?

From what I understand, in some release workflows, fixes on trunk after a release branch is cut don't make it into the release, and then the release branch merge-back can revert those fixes.

So a bot merged `release/22.3` branch back into trunk after the release was published ?

I don't know.

Do the e2e tests pass? 

Good!


