### PR TITLE
Block visibility based on screen size: add rules to hide on viewport size

### DIFF
--- a/backport-changelog/7.0/10629.md
+++ b/backport-changelog/7.0/10629.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10629
 
 * https://github.com/WordPress/gutenberg/pull/73994
+* https://github.com/WordPress/gutenberg/pull/74379

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -44,12 +44,12 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			array(
 				'name' => 'Mobile',
 				'slug' => 'mobile',
-				'size' => '479px',
+				'size' => '480px',
 			),
 			array(
 				'name' => 'Tablet',
 				'slug' => 'tablet',
-				'size' => '959px',
+				'size' => '782px',
 			),
 			array(
 				'name' => 'Desktop',

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -44,7 +44,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			array(
 				'name' => 'Mobile',
 				'slug' => 'mobile',
-				'size' => '599px',
+				'size' => '479px',
 			),
 			array(
 				'name' => 'Tablet',

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -38,7 +38,7 @@ import { useBlockProps } from './use-block-props';
 import { store as blockEditorStore } from '../../store';
 import { useLayout } from './layout';
 import { PrivateBlockContext } from './private-block-context';
-
+import { useBlockVisibility } from '../block-visibility/';
 import { unlock } from '../../lock-unlock';
 
 /**
@@ -555,6 +555,7 @@ BlockListBlock = compose(
 // component, and useBlockProps.
 function BlockListBlockProvider( props ) {
 	const { clientId, rootClientId } = props;
+	const { isBlockCurrentlyHidden } = useBlockVisibility( clientId );
 	const selectedProps = useSelect(
 		( select ) => {
 			const {
@@ -612,9 +613,6 @@ function BlockListBlockProvider( props ) {
 				isPreviewMode,
 				__experimentalBlockBindingsSupportedAttributes,
 			} = getSettings();
-			const { isBlockHidden: _isBlockHidden } = unlock(
-				select( blockEditorStore )
-			);
 			const bindableAttributes =
 				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
 
@@ -635,7 +633,6 @@ function BlockListBlockProvider( props ) {
 					? getBlockDefaultClassName( blockName )
 					: undefined,
 				blockTitle: blockType?.title,
-				isBlockHidden: _isBlockHidden( clientId ),
 				bindableAttributes,
 			};
 
@@ -763,7 +760,6 @@ function BlockListBlockProvider( props ) {
 		className,
 		defaultClassName,
 		originalBlockClientId,
-		isBlockHidden,
 		bindableAttributes,
 	} = selectedProps;
 
@@ -814,12 +810,12 @@ function BlockListBlockProvider( props ) {
 		originalBlockClientId,
 		themeSupportsLayout,
 		canMove,
-		isBlockHidden,
+		isBlockCurrentlyHidden,
 		bindableAttributes,
 	};
 
 	if (
-		isBlockHidden &&
+		isBlockCurrentlyHidden &&
 		! isSelected &&
 		! isMultiSelected &&
 		! hasChildSelected

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -30,6 +30,7 @@ import { useIntersectionObserver } from './use-intersection-observer';
 import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 import { useFirefoxDraggableCompatibility } from './use-firefox-draggable-compatibility';
+import { useBlockVisibility } from '../../block-visibility/';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
@@ -102,7 +103,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isSectionBlock,
 		isWithinSectionBlock,
 		canMove,
-		isBlockHidden,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -137,6 +137,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					'var(--wp-block-synced-color--rgb)',
 		  }
 		: {};
+
+	const { isBlockCurrentlyHidden } = useBlockVisibility( clientId );
 
 	// Ensures it warns only inside the `edit` implementation for the block.
 	if ( blockApiVersion < 2 && clientId === blockEditContext.clientId ) {
@@ -185,7 +187,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'has-editable-outline': hasEditableOutline,
 				'has-negative-margin': hasNegativeMargin,
 				'is-editing-content-only-section': isEditingContentOnlySection,
-				'is-block-hidden': isBlockHidden,
+				'is-block-hidden': isBlockCurrentlyHidden,
 			},
 			className,
 			props.className,

--- a/packages/block-editor/src/components/block-visibility/constants.js
+++ b/packages/block-editor/src/components/block-visibility/constants.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { desktop, tablet, mobile } from '@wordpress/icons';
+
+/**
+ * The choices for the block visibility.
+ * Must match those in packages/editor/src/components/preview-dropdown/index.js.
+ *
+ * @todo create a single source of truth for the viewport types.
+ */
+export const BLOCK_VISIBILITY_VIEWPORTS = {
+	desktop: {
+		label: __( 'Desktop' ),
+		icon: desktop,
+		value: 'desktop',
+	},
+	tablet: {
+		label: __( 'Tablet' ),
+		icon: tablet,
+		value: 'tablet',
+	},
+	mobile: {
+		label: __( 'Mobile' ),
+		icon: mobile,
+		value: 'mobile',
+	},
+};

--- a/packages/block-editor/src/components/block-visibility/index.js
+++ b/packages/block-editor/src/components/block-visibility/index.js
@@ -1,2 +1,3 @@
 export { default as BlockVisibilityMenuItem } from './menu-item';
 export { default as BlockVisibilityToolbar } from './toolbar';
+export { useBlockVisibility } from './use-block-visibility';

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -34,6 +34,43 @@ import { useBlockVisibility } from '../use-block-visibility';
 describe( 'useBlockVisibility', () => {
 	const clientId = 'test-client-id';
 
+	// Helper function to set up block and settings mocks
+	const setupMocks = ( {
+		blockVisibility = true,
+		deviceType = 'Desktop',
+	} = {} ) => {
+		useSelect.mockImplementation( ( callback ) =>
+			callback( () => ( {
+				getBlock: () => ( {
+					attributes: {
+						metadata: {
+							blockVisibility,
+						},
+					},
+				} ),
+				getSettings: () => ( {
+					__experimentalDeviceType: deviceType,
+				} ),
+			} ) )
+		);
+	};
+
+	// Helper function to set up viewport matches
+	const setupViewport = ( { isMobileOrLarger, isMediumOrLarger } ) => {
+		if (
+			isMobileOrLarger !== undefined &&
+			isMediumOrLarger !== undefined
+		) {
+			useViewportMatch
+				.mockReturnValueOnce( isMobileOrLarger )
+				.mockReturnValueOnce( isMediumOrLarger );
+		} else {
+			useViewportMatch.mockReturnValue(
+				isMobileOrLarger ?? isMediumOrLarger ?? true
+			);
+		}
+	};
+
 	beforeEach( () => {
 		// Reset all mocks before each test
 		jest.clearAllMocks();
@@ -47,24 +84,11 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Device type overrides', () => {
 		it( 'should return true when deviceType is Mobile and block is hidden on mobile', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Mobile',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: { mobile: false },
+				deviceType: 'Mobile',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -74,26 +98,15 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when deviceType is Mobile and block is visible on mobile', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: true,
-									tablet: false,
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Mobile',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( false );
+			setupMocks( {
+				blockVisibility: {
+					mobile: true,
+					tablet: false,
+					desktop: false,
+				},
+				deviceType: 'Mobile',
+			} );
+			setupViewport( { isMobileOrLarger: false } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -103,24 +116,11 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return true when deviceType is Tablet and block is hidden on tablet', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									tablet: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Tablet',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( false );
+			setupMocks( {
+				blockVisibility: { tablet: false },
+				deviceType: 'Tablet',
+			} );
+			setupViewport( { isMobileOrLarger: false } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -130,27 +130,14 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should use actual viewport detection when deviceType is Desktop', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			// Mock viewport: >= 782px (desktop)
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
-				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
+			setupMocks( {
+				blockVisibility: { desktop: false },
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -162,27 +149,14 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Viewport detection with Desktop deviceType', () => {
 		it( 'should return true when on mobile viewport and block is hidden on mobile', () => {
-			// Mock viewport: < 480px (mobile)
-			useViewportMatch
-				.mockReturnValueOnce( false ) // isMobileOrLarger (< 480px)
-				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: { mobile: false },
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: false,
+				isMediumOrLarger: false,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -192,29 +166,18 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when on mobile viewport and block is visible on mobile', () => {
-			// Mock viewport: < 480px (mobile)
-			useViewportMatch
-				.mockReturnValueOnce( false ) // isMobileOrLarger (< 480px)
-				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: true,
-									tablet: false,
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: {
+					mobile: true,
+					tablet: false,
+					desktop: false,
+				},
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: false,
+				isMediumOrLarger: false,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -224,27 +187,14 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return true when on tablet viewport and block is hidden on tablet', () => {
-			// Mock viewport: >= 480px and < 782px (tablet)
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
-				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									tablet: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: { tablet: false },
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: false,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -254,29 +204,18 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when on tablet viewport and block is visible on tablet', () => {
-			// Mock viewport: >= 480px and < 782px (tablet)
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
-				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: false,
-									tablet: true,
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: {
+					mobile: false,
+					tablet: true,
+					desktop: false,
+				},
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: false,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -286,27 +225,14 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return true when on desktop viewport and block is hidden on desktop', () => {
-			// Mock viewport: >= 782px (desktop)
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
-				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: { desktop: false },
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -316,29 +242,18 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when on desktop viewport and block is visible on desktop', () => {
-			// Mock viewport: >= 782px (desktop)
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
-				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									mobile: false,
-									tablet: false,
-									desktop: true,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
+			setupMocks( {
+				blockVisibility: {
+					mobile: false,
+					tablet: false,
+					desktop: true,
+				},
+				deviceType: 'Desktop',
+			} );
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -350,22 +265,11 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Block visibility (hidden everywhere)', () => {
 		it( 'should return true when blockVisibility is false', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: false,
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: false,
+				deviceType: 'Desktop',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -375,22 +279,11 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when blockVisibility is true and no viewport restrictions', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: true,
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: true,
+				deviceType: 'Desktop',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -400,20 +293,11 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return false when blockVisibility is undefined', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: undefined,
+				deviceType: 'Desktop',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -423,27 +307,11 @@ describe( 'useBlockVisibility', () => {
 		} );
 
 		it( 'should return true when blockVisibility is false regardless of viewport settings', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: false,
-								blockVisibilityBreakpoints: {
-									mobile: false,
-									tablet: false,
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: false,
+				deviceType: 'Desktop',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -455,22 +323,11 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Edge cases', () => {
 		it( 'should return false when no visibility settings are defined', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: true,
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupMocks( {
+				blockVisibility: true,
+				deviceType: 'Desktop',
+			} );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -490,8 +347,7 @@ describe( 'useBlockVisibility', () => {
 					} ),
 				} ) )
 			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -509,8 +365,7 @@ describe( 'useBlockVisibility', () => {
 					} ),
 				} ) )
 			);
-
-			useViewportMatch.mockReturnValue( true );
+			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
@@ -534,95 +389,16 @@ describe( 'useBlockVisibility', () => {
 					getSettings: () => ( {} ), // No deviceType provided
 				} ) )
 			);
-
-			// Mock desktop viewport
-			useViewportMatch
-				.mockReturnValueOnce( true ) // isMobileOrLarger
-				.mockReturnValueOnce( true ); // isMediumOrLarger
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
+			} );
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( clientId )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
-		} );
-
-		it( 'should not hide blocks when experimental flag is disabled', () => {
-			delete window.__experimentalHideBlocksBasedOnScreenSize;
-
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-
-			useViewportMatch
-				.mockReturnValueOnce( true )
-				.mockReturnValueOnce( true );
-
-			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
-			);
-
-			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
-		} );
-	} );
-
-	describe( 'Memoization', () => {
-		it( 'should maintain referential equality when values do not change', () => {
-			// Create stable references for the mock data
-			const stableBlock = {
-				attributes: {
-					metadata: {
-						blockVisibility: true,
-						blockVisibilityBreakpoints: {
-							mobile: true,
-						},
-					},
-				},
-			};
-			const stableSettings = {
-				__experimentalDeviceType: 'Desktop',
-			};
-
-			// Mock useSelect to return the same object references on each call
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => stableBlock,
-					getSettings: () => stableSettings,
-				} ) )
-			);
-
-			useViewportMatch
-				.mockReturnValueOnce( false )
-				.mockReturnValueOnce( false );
-
-			const { result, rerender } = renderHook( () =>
-				useBlockVisibility( clientId )
-			);
-
-			const firstRender = result.current;
-
-			// Mock same values for rerender
-			useViewportMatch
-				.mockReturnValueOnce( false )
-				.mockReturnValueOnce( false );
-
-			rerender();
-
-			// Should maintain referential equality when data hasn't changed
-			expect( result.current ).toBe( firstRender );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -37,6 +37,12 @@ describe( 'useBlockVisibility', () => {
 	beforeEach( () => {
 		// Reset all mocks before each test
 		jest.clearAllMocks();
+		// Enable experimental flag
+		window.__experimentalHideBlocksBasedOnScreenSize = true;
+	} );
+
+	afterEach( () => {
+		delete window.__experimentalHideBlocksBasedOnScreenSize;
 	} );
 
 	describe( 'Device type overrides', () => {
@@ -539,6 +545,37 @@ describe( 'useBlockVisibility', () => {
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should not hide blocks when experimental flag is disabled', () => {
+			delete window.__experimentalHideBlocksBasedOnScreenSize;
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch
+				.mockReturnValueOnce( true )
+				.mockReturnValueOnce( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 	} );
 

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -1,0 +1,591 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+// Mock WordPress dependencies before importing the hook
+jest.mock( '@wordpress/compose', () => ( {
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '../../../store', () => ( {
+	store: 'block-editor-store',
+} ) );
+
+jest.mock( '../../../store/private-keys', () => ( {
+	deviceTypeKey: '__experimentalDeviceType',
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { useBlockVisibility } from '../use-block-visibility';
+
+describe( 'useBlockVisibility', () => {
+	const clientId = 'test-client-id';
+
+	beforeEach( () => {
+		// Reset all mocks before each test
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Device type overrides', () => {
+		it( 'should return true when deviceType is Mobile and block is hidden on mobile', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Mobile',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should return false when deviceType is Mobile and block is visible on mobile', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: true,
+									tablet: false,
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Mobile',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( false );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return true when deviceType is Tablet and block is hidden on tablet', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									tablet: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Tablet',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( false );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should use actual viewport detection when deviceType is Desktop', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			// Mock viewport: >= 782px (desktop)
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
+				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+	} );
+
+	describe( 'Viewport detection with Desktop deviceType', () => {
+		it( 'should return true when on mobile viewport and block is hidden on mobile', () => {
+			// Mock viewport: < 480px (mobile)
+			useViewportMatch
+				.mockReturnValueOnce( false ) // isMobileOrLarger (< 480px)
+				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should return false when on mobile viewport and block is visible on mobile', () => {
+			// Mock viewport: < 480px (mobile)
+			useViewportMatch
+				.mockReturnValueOnce( false ) // isMobileOrLarger (< 480px)
+				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: true,
+									tablet: false,
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return true when on tablet viewport and block is hidden on tablet', () => {
+			// Mock viewport: >= 480px and < 782px (tablet)
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
+				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									tablet: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should return false when on tablet viewport and block is visible on tablet', () => {
+			// Mock viewport: >= 480px and < 782px (tablet)
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
+				.mockReturnValueOnce( false ); // isMediumOrLarger (< 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: false,
+									tablet: true,
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return true when on desktop viewport and block is hidden on desktop', () => {
+			// Mock viewport: >= 782px (desktop)
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
+				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should return false when on desktop viewport and block is visible on desktop', () => {
+			// Mock viewport: >= 782px (desktop)
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger (>= 480px)
+				.mockReturnValueOnce( true ); // isMediumOrLarger (>= 782px)
+
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									mobile: false,
+									tablet: false,
+									desktop: true,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+	} );
+
+	describe( 'Block visibility (hidden everywhere)', () => {
+		it( 'should return true when blockVisibility is false', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: false,
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'should return false when blockVisibility is true and no viewport restrictions', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: true,
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return false when blockVisibility is undefined', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return true when blockVisibility is false regardless of viewport settings', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: false,
+								blockVisibilityBreakpoints: {
+									mobile: false,
+									tablet: false,
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		it( 'should return false when no visibility settings are defined', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: true,
+							},
+						},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return false when metadata is missing', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {},
+					} ),
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should return false when block is missing', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => null,
+					getSettings: () => ( {
+						__experimentalDeviceType: 'Desktop',
+					} ),
+				} ) )
+			);
+
+			useViewportMatch.mockReturnValue( true );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should default to Desktop deviceType when not provided', () => {
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => ( {
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									desktop: false,
+								},
+							},
+						},
+					} ),
+					getSettings: () => ( {} ), // No deviceType provided
+				} ) )
+			);
+
+			// Mock desktop viewport
+			useViewportMatch
+				.mockReturnValueOnce( true ) // isMobileOrLarger
+				.mockReturnValueOnce( true ); // isMediumOrLarger
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+	} );
+
+	describe( 'Memoization', () => {
+		it( 'should maintain referential equality when values do not change', () => {
+			// Create stable references for the mock data
+			const stableBlock = {
+				attributes: {
+					metadata: {
+						blockVisibility: true,
+						blockVisibilityBreakpoints: {
+							mobile: true,
+						},
+					},
+				},
+			};
+			const stableSettings = {
+				__experimentalDeviceType: 'Desktop',
+			};
+
+			// Mock useSelect to return the same object references on each call
+			useSelect.mockImplementation( ( callback ) =>
+				callback( () => ( {
+					getBlock: () => stableBlock,
+					getSettings: () => stableSettings,
+				} ) )
+			);
+
+			useViewportMatch
+				.mockReturnValueOnce( false )
+				.mockReturnValueOnce( false );
+
+			const { result, rerender } = renderHook( () =>
+				useBlockVisibility( clientId )
+			);
+
+			const firstRender = result.current;
+
+			// Mock same values for rerender
+			useViewportMatch
+				.mockReturnValueOnce( false )
+				.mockReturnValueOnce( false );
+
+			rerender();
+
+			// Should maintain referential equality when data hasn't changed
+			expect( result.current ).toBe( firstRender );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -44,7 +44,7 @@ export function useBlockVisibility( clientId ) {
 	const isLargerThanMobile = useViewportMatch( 'mobile', '>=' ); // >= 480px
 	const isLargerThanTablet = useViewportMatch( 'medium', '>=' ); // >= 782px
 
-	// Determine current viewport based on deviceType
+	// Determine current viewport based on deviceType and/or viewport detection.
 	const currentViewport = useMemo( () => {
 		if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.value ) {
 			return BLOCK_VISIBILITY_VIEWPORTS.mobile.value;
@@ -65,15 +65,18 @@ export function useBlockVisibility( clientId ) {
 		return BLOCK_VISIBILITY_VIEWPORTS.desktop.value;
 	}, [ deviceType, isLargerThanMobile, isLargerThanTablet ] );
 
-	// Determine if block is currently hidden
+	// Determine if block is currently hidden.
 	const isBlockCurrentlyHidden = useMemo( () => {
-		// Hidden everywhere takes precedence
+		// Hidden everywhere takes precedence.
 		if ( blockVisibility === false ) {
 			return true;
 		}
 
-		// Check if hidden on current viewport (false means hidden)
-		if ( blockVisibility?.[ currentViewport ] === false ) {
+		// Check if hidden on current viewport (false means hidden). Only apply when the experimental flag is enabled.
+		if (
+			window.__experimentalHideBlocksBasedOnScreenSize &&
+			blockVisibility?.[ currentViewport ] === false
+		) {
 			return true;
 		}
 

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { deviceTypeKey } from '../../store/private-keys';
+import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+
+/**
+ * Determines if a block should be hidden based on visibility settings.
+ *
+ * Priority:
+ * 1. Device type override (Mobile/Tablet) - uses device type to determine viewport
+ * 2. Actual window size (Desktop mode) - uses viewport detection
+ *
+ * @param {string} clientId Block client ID.
+ * @return {Object} Object with `isBlockCurrentlyHidden` boolean property.
+ */
+export function useBlockVisibility( clientId ) {
+	// Get visibility settings from block attributes and device type from settings
+	const { blockVisibility, deviceType } = useSelect(
+		( select ) => {
+			const block = select( blockEditorStore ).getBlock( clientId );
+			const metadata = block?.attributes?.metadata;
+			const settings = select( blockEditorStore ).getSettings();
+			return {
+				blockVisibility: metadata?.blockVisibility,
+				deviceType:
+					settings?.[ deviceTypeKey ]?.toLowerCase() || 'desktop',
+			};
+		},
+		[ clientId ]
+	);
+
+	// When Desktop is selected, use actual viewport detection
+	// When Mobile/Tablet is selected, override with device type
+	// All hooks must be called unconditionally
+	const isLargerThanMobile = useViewportMatch( 'mobile', '>=' ); // >= 480px
+	const isLargerThanTablet = useViewportMatch( 'medium', '>=' ); // >= 782px
+
+	// Determine current viewport based on deviceType
+	const currentViewport = useMemo( () => {
+		if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.value ) {
+			return BLOCK_VISIBILITY_VIEWPORTS.mobile.value;
+		}
+		if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.tablet.value ) {
+			return BLOCK_VISIBILITY_VIEWPORTS.tablet.value;
+		}
+		if ( ! isLargerThanMobile ) {
+			// Desktop: use actual viewport detection
+			// Mobile: viewport < 480px (matches block-visibility.php: max-width: 479px)
+			return BLOCK_VISIBILITY_VIEWPORTS.mobile.value;
+		}
+		if ( isLargerThanMobile && ! isLargerThanTablet ) {
+			// Tablet: viewport >= 480px and < 782px (matches block-visibility.php: 480px-781px)
+			return BLOCK_VISIBILITY_VIEWPORTS.tablet.value;
+		}
+		// Desktop: viewport >= 782px (matches block-visibility.php: min-width: 782px)
+		return BLOCK_VISIBILITY_VIEWPORTS.desktop.value;
+	}, [ deviceType, isLargerThanMobile, isLargerThanTablet ] );
+
+	// Determine if block is currently hidden
+	const isBlockCurrentlyHidden = useMemo( () => {
+		// Hidden everywhere takes precedence
+		if ( blockVisibility === false ) {
+			return true;
+		}
+
+		// Check if hidden on current viewport (false means hidden)
+		if ( blockVisibility?.[ currentViewport ] === false ) {
+			return true;
+		}
+
+		return false;
+	}, [ blockVisibility, currentViewport ] );
+
+	return useMemo(
+		() => ( { isBlockCurrentlyHidden, currentViewport } ),
+		[ isBlockCurrentlyHidden, currentViewport ]
+	);
+}

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -174,7 +174,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (max-width: 479px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (max-width: 480px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -207,7 +207,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(479px + 1px)) and (max-width: 959px){.wp-block-hidden-tablet{display:none !important;}}',
+			'@media (min-width: calc(480px + 1px)) and (max-width: 782px){.wp-block-hidden-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -240,7 +240,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}',
+			'@media (min-width: calc(782px + 1px)){.wp-block-hidden-desktop{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop visibility rule'
 		);
@@ -278,7 +278,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 479px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (min-width: calc(782px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 480px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain both visibility rules'
 		);

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -174,7 +174,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (max-width: 479px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -207,7 +207,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(599px + 1px)) and (max-width: 959px){.wp-block-hidden-tablet{display:none !important;}}',
+			'@media (min-width: calc(479px + 1px)) and (max-width: 959px){.wp-block-hidden-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -278,7 +278,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 599px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (min-width: calc(959px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 479px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain both visibility rules'
 		);


### PR DESCRIPTION
Part of:

- https://github.com/WordPress/gutenberg/issues/72502

## What?

Adds `useBlockVisibility` hook to determine if blocks should be hidden based on viewport/device settings.

Follow up to 

- https://github.com/WordPress/gutenberg/pull/73994
- https://github.com/WordPress/gutenberg/pull/74025
- https://github.com/WordPress/gutenberg/pull/74339


> [!NOTE]
> This PR just provides the "state" flag of whether a block is hidden or note. The UI based on that will be in https://github.com/WordPress/gutenberg/pull/74249


<!-- In a few words, what is the PR actually doing? -->

## Why?

This harmonizes the editor with the frontend experience.



## How?

- Reads `metadata.blockVisibility` object where `false` = hidden
- Priority: Device type override (Mobile/Tablet) → viewport detection (Desktop)
- Breakpoints: mobile <480px, tablet 480-782px, desktop ≥782px
- Returns `{ isBlockCurrentlyHidden, currentViewport }`

## Testing Instructions

1. Add the test HTML below in a new post.
2. Ensure the device preview is set to Desktop
3. Resize the viewport window and make sure the correct elements hide.
5. Now switch device preview to Mobile or Tablet. The device type should override the viewport width


Some test HTML

```html


<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false}}} -->
<p>🔴 Hidden on MOBILE (≤479px) - You should see this on tablet and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false}}} -->
<p>🟡 Hidden on TABLET (480-959px) - You should see this on mobile and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"desktop":false}}} -->
<p>🟢 Hidden on DESKTOP (≥960px) - You should see this on mobile and tablet only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"desktop":false}}} -->
<p>🟣 Hidden on MOBILE and DESKTOP - You should only see this on tablet (480-959px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"tablet":false}}} -->
<p>🔵 Hidden on MOBILE and TABLET - You should only see this on desktop (≥960px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false,"desktop":false}}} -->
<p>🟠 Hidden on TABLET and DESKTOP - You should only see this on mobile (≤479px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":true,"tablet":true,"desktop":true}}} -->
<p>✅ Visible on ALL breakpoints - You should always see this</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
<p>❌ Completely HIDDEN (boolean false) - You should never see this</p>
<!-- /wp:paragraph -->
```

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/029c7141-65ec-4d07-b540-02e458423288


