### PR TITLE
Build: Build minified and non minified CSS in both npm run dev and npm run build

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -123,10 +123,11 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	// When in production, use the plugin's version as the default asset version;
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
+	$suffix          = SCRIPT_DEBUG ? '' : '.min';
 
 	$style_path      = "build/styles/block-library/$block_name/";
-	$stylesheet_url  = gutenberg_url( $style_path . 'style.css' );
-	$stylesheet_path = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl.css' : 'style.css' );
+	$stylesheet_url  = gutenberg_url( $style_path . 'style' . $suffix . '.css' );
+	$stylesheet_path = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl' . $suffix . '.css' : 'style' . $suffix . '.css' );
 
 	if ( file_exists( $stylesheet_path ) ) {
 
@@ -138,6 +139,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 			$default_version
 		);
 		wp_style_add_data( "wp-block-{$block_name}", 'rtl', 'replace' );
+		wp_style_add_data( "wp-block-{$block_name}", 'suffix', $suffix );
 		// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
 		wp_style_add_data( "wp-block-{$block_name}", 'path', $stylesheet_path );
 	} else {
@@ -152,8 +154,8 @@ function gutenberg_register_core_block_assets( $block_name ) {
 
 		// Get the path to the block's stylesheet.
 		$theme_style_path = is_rtl()
-			? "build/styles/block-library/$block_name/theme-rtl.css"
-			: "build/styles/block-library/$block_name/theme.css";
+			? "build/styles/block-library/$block_name/theme-rtl{$suffix}.css"
+			: "build/styles/block-library/$block_name/theme{$suffix}.css";
 
 		// If the file exists, enqueue it.
 		if ( file_exists( gutenberg_dir_path() . $theme_style_path ) ) {
@@ -165,10 +167,11 @@ function gutenberg_register_core_block_assets( $block_name ) {
 				$default_version
 			);
 			wp_style_add_data( "wp-block-{$block_name}-theme", 'path', gutenberg_dir_path() . $theme_style_path );
+			wp_style_add_data( "wp-block-{$block_name}-theme", 'suffix', $suffix );
 		}
 	}
 
-	$editor_style_path = "build/styles/block-library/$block_name/style-editor.css";
+	$editor_style_path = "build/styles/block-library/$block_name/style-editor{$suffix}.css";
 	if ( file_exists( gutenberg_dir_path() . $editor_style_path ) ) {
 		wp_deregister_style( "wp-block-{$block_name}-editor" );
 		wp_register_style(
@@ -178,6 +181,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 			$default_version
 		);
 		wp_style_add_data( "wp-block-{$block_name}-editor", 'rtl', 'replace' );
+		wp_style_add_data( "wp-block-{$block_name}-editor", 'suffix', $suffix );
 	} else {
 		wp_register_style( "wp-block-{$block_name}-editor", false );
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -132,6 +132,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	// When in production, use the plugin's version as the asset version;
 	// else (for development or test) default to use the current time.
 	$version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
+	$suffix  = SCRIPT_DEBUG ? '' : '.min';
 
 	// wp-components: add dashicons (icon font dependency)
 	$styles->query( 'wp-components', 'registered' )->deps[] = 'dashicons';
@@ -155,33 +156,36 @@ function gutenberg_register_packages_styles( $styles ) {
 	gutenberg_override_style(
 		$styles,
 		'wp-base-styles',
-		gutenberg_url( 'build/styles/base-styles/admin-schemes.css' ),
+		gutenberg_url( 'build/styles/base-styles/admin-schemes' . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'wp-base-styles', 'rtl', 'replace' );
-	$styles->add_data( 'wp-base-styles', 'path', gutenberg_dir_path() . 'build/styles/base-styles/admin-schemes.css' );
+	$styles->add_data( 'wp-base-styles', 'suffix', $suffix );
+	$styles->add_data( 'wp-base-styles', 'path', gutenberg_dir_path() . 'build/styles/base-styles/admin-schemes' . $suffix . '.css' );
 	$styles->query( 'wp-admin', 'registered' )->deps[] = 'wp-base-styles';
 
 	gutenberg_override_style(
 		$styles,
 		'wp-block-editor-content',
-		gutenberg_url( 'build/styles/block-editor/content.css' ),
+		gutenberg_url( 'build/styles/block-editor/content' . $suffix . '.css' ),
 		array( 'wp-components' ),
 		$version
 	);
 	$styles->add_data( 'wp-block-editor-content', 'rtl', 'replace' );
+	$styles->add_data( 'wp-block-editor-content', 'suffix', $suffix );
 
 	$block_library_filename = wp_should_load_separate_core_block_assets() ? 'common' : 'style';
 	gutenberg_override_style(
 		$styles,
 		'wp-block-library',
-		gutenberg_url( 'build/styles/block-library/' . $block_library_filename . '.css' ),
+		gutenberg_url( 'build/styles/block-library/' . $block_library_filename . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'wp-block-library', 'rtl', 'replace' );
-	$styles->add_data( 'wp-block-library', 'path', gutenberg_dir_path() . 'build/styles/block-library/' . $block_library_filename . '.css' );
+	$styles->add_data( 'wp-block-library', 'suffix', $suffix );
+	$styles->add_data( 'wp-block-library', 'path', gutenberg_dir_path() . 'build/styles/block-library/' . $block_library_filename . $suffix . '.css' );
 
 	// Only add CONTENT styles here that should be enqueued in the iframe!
 	$wp_edit_blocks_dependencies = array(
@@ -210,57 +214,63 @@ function gutenberg_register_packages_styles( $styles ) {
 	gutenberg_override_style(
 		$styles,
 		'wp-reset-editor-styles',
-		gutenberg_url( 'build/styles/block-library/reset.css' ),
+		gutenberg_url( 'build/styles/block-library/reset' . $suffix . '.css' ),
 		array( 'common', 'forms' ), // Make sure the reset is loaded after the default WP Admin styles.
 		$version
 	);
 	$styles->add_data( 'wp-reset-editor-styles', 'rtl', 'replace' );
+	$styles->add_data( 'wp-reset-editor-styles', 'suffix', $suffix );
 
 	gutenberg_override_style(
 		$styles,
 		'wp-editor-classic-layout-styles',
-		gutenberg_url( 'build/styles/edit-post/classic.css' ),
+		gutenberg_url( 'build/styles/edit-post/classic' . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'wp-editor-classic-layout-styles', 'rtl', 'replace' );
+	$styles->add_data( 'wp-editor-classic-layout-styles', 'suffix', $suffix );
 
 	gutenberg_override_style(
 		$styles,
 		'wp-block-library-editor',
-		gutenberg_url( 'build/styles/block-library/editor.css' ),
+		gutenberg_url( 'build/styles/block-library/editor' . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'wp-block-library-editor', 'rtl', 'replace' );
+	$styles->add_data( 'wp-block-library-editor', 'suffix', $suffix );
 
 	gutenberg_override_style(
 		$styles,
 		'wp-edit-blocks',
-		gutenberg_url( 'build/styles/block-library/editor.css' ),
+		gutenberg_url( 'build/styles/block-library/editor' . $suffix . '.css' ),
 		$wp_edit_blocks_dependencies,
 		$version
 	);
 	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+	$styles->add_data( 'wp-edit-blocks', 'suffix', $suffix );
 
 	gutenberg_override_style(
 		$styles,
 		'wp-block-library-theme',
-		gutenberg_url( 'build/styles/block-library/theme.css' ),
+		gutenberg_url( 'build/styles/block-library/theme' . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'wp-block-library-theme', 'rtl', 'replace' );
+	$styles->add_data( 'wp-block-library-theme', 'suffix', $suffix );
 
 	gutenberg_override_style(
 		$styles,
 		'classic-theme-styles',
-		gutenberg_url( 'build/styles/block-library/classic.css' ),
+		gutenberg_url( 'build/styles/block-library/classic' . $suffix . '.css' ),
 		array(),
 		$version
 	);
 	$styles->add_data( 'classic-theme-styles', 'rtl', 'replace' );
-	$styles->add_data( 'classic-theme-styles', 'path', gutenberg_dir_path() . 'build/styles/block-library/classic.css' );
+	$styles->add_data( 'classic-theme-styles', 'suffix', $suffix );
+	$styles->add_data( 'classic-theme-styles', 'path', gutenberg_dir_path() . 'build/styles/block-library/classic' . $suffix . '.css' );
 }
 add_action( 'wp_default_styles', 'gutenberg_register_packages_styles', 15 );
 

--- a/packages/wp-build/templates/style-registration.php.template
+++ b/packages/wp-build/templates/style-registration.php.template
@@ -46,6 +46,7 @@ if ( ! function_exists( '{{PREFIX}}_register_package_styles' ) ) {
 		// Load build constants
 		$build_constants = require __DIR__ . '/constants.php';
 		$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
+		$suffix          = SCRIPT_DEBUG ? '' : '.min';
 
 		$styles_dir  = __DIR__ . '/styles';
 		$styles_file = $styles_dir . '/index.php';
@@ -61,13 +62,14 @@ if ( ! function_exists( '{{PREFIX}}_register_package_styles' ) ) {
 			{{PREFIX}}_override_style(
 				$styles,
 				$style_data['handle'],
-				$build_constants['build_url'] . 'styles/' . $style_data['path'] . '.css',
+				$build_constants['build_url'] . 'styles/' . $style_data['path'] . $suffix . '.css',
 				$style_data['dependencies'],
 				$default_version
 			);
 
 			// Enable RTL support (WordPress automatically loads -rtl.css variant)
 			$styles->add_data( $style_data['handle'], 'rtl', 'replace' );
+			$styles->add_data( $style_data['handle'], 'suffix', $suffix );
 		}
 	}
 


### PR DESCRIPTION
## Problem

When SCRIPT_DEBUG is set to false, WordPress Core expects .min.css files (e.g., style.min.css), but Gutenberg's build only produced a single CSS file whose content varied based on NODE_ENV.

## Solution

 - Modified the CSS build to always produce both versions: (just like we do for JS)
   - style.css (non-minified)
   - style.min.css (minified)
 - Updated style registration to load the appropriate file based on SCRIPT_DEBUG
 
## Testing instructions

 - run `npm run dev` or `npm run build` and check the build/styles folder (both files should exist)
 - You can switch your environment SCRIPT_DEBUG to true or false and it should work in both situations. (load the editor)