### PR TITLE
Core Merge: Deduplicate Font Library page and routes

### DIFF
--- a/lib/clear-core-routes.php
+++ b/lib/clear-core-routes.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Clears Core's routes before Gutenberg registers its own.
+ *
+ * This file must be loaded BEFORE build/index.php so that these actions
+ * are added before Gutenberg's routes.php actions. This ensures:
+ * 1. Core's routes.php runs (priority 10, added first)
+ * 2. These clearing functions run (priority 10, added second)
+ * 3. Gutenberg's routes.php runs (priority 10, added third)
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Clears Core's font-library routes before Gutenberg registers its own.
+ */
+function gutenberg_clear_core_font_library_routes() {
+	global $wp_font_library_routes;
+	$wp_font_library_routes = array();
+}
+add_action( 'font-library_init', 'gutenberg_clear_core_font_library_routes' );
+
+/**
+ * Clears Core's font-library-wp-admin routes before Gutenberg registers its own.
+ */
+function gutenberg_clear_core_font_library_wp_admin_routes() {
+	global $wp_font_library_wp_admin_routes;
+	$wp_font_library_wp_admin_routes = array();
+}
+add_action( 'font-library-wp-admin_init', 'gutenberg_clear_core_font_library_wp_admin_routes' );
+
+/**
+ * Clears Core's site-editor-v2 routes before Gutenberg registers its own.
+ */
+function gutenberg_clear_core_site_editor_v2_routes() {
+	global $gutenberg_site_editor_v2_routes;
+	$gutenberg_site_editor_v2_routes = array();
+}
+add_action( 'site-editor-v2_init', 'gutenberg_clear_core_site_editor_v2_routes' );
+
+/**
+ * Clears Core's site-editor-v2 routes before Gutenberg registers its own.
+ */
+function gutenberg_clear_core_site_editor_v2_wp_admin_routes() {
+	global $gutenberg_site_editor_v2_routes;
+	$gutenberg_site_editor_v2_routes = array();
+}
+add_action( 'site-editor-v2-wp-admin_init', 'gutenberg_clear_core_site_editor_v2_wp_admin_routes' );

--- a/lib/experimental/fonts/load.php
+++ b/lib/experimental/fonts/load.php
@@ -5,12 +5,17 @@
  * @package gutenberg
  */
 
-add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item' );
+// Priority 11 to run after Core's menu.php sets up the fonts menu.
+add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item', 11 );
 
 /**
  * Registers the Fonts menu item under Appearance using the font-library page.
+ * Removes Core's fonts menu item first to prevent duplication.
  */
 function gutenberg_register_fonts_menu_item() {
+	// Remove Core's fonts menu item if it exists.
+	remove_submenu_page( 'themes.php', 'font-library.php' );
+
 	add_submenu_page(
 		'themes.php',
 		__( 'Fonts', 'gutenberg' ),

--- a/lib/load.php
+++ b/lib/load.php
@@ -14,6 +14,10 @@ define( 'IS_GUTENBERG_PLUGIN', true );
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/upgrade.php';
 
+// Clear Core's routes before Gutenberg's build/index.php registers its own.
+// This must be loaded before build/index.php to ensure correct action ordering.
+require_once __DIR__ . '/clear-core-routes.php';
+
 // Load auto-generated build registration.
 $build_registration = plugin_dir_path( __DIR__ ) . 'build/index.php';
 if ( file_exists( $build_registration ) ) {


### PR DESCRIPTION
Fixes duplicate "Fonts" menu item and "Duplicate routes found with id: /font-list" error when running Gutenberg alongside WordPress Core.

When both Core and Gutenberg are active, they each register their own fonts menu item and routes for the font-library and site-editor pages. This PR ensures Gutenberg properly overrides Core's implementations by:

  1. Removing Core's fonts menu item before registering Gutenberg's (via remove_submenu_page)
  2. Clearing Core's registered routes before Gutenberg registers its own

The route clearing is done in a dedicated file (lib/clear-core-routes.php) loaded before build/index.php to ensure correct action ordering at priority 10.

##  Testing Instructions

  1. Enable the extensible site editor experiment in Gutenberg
  2. Navigate to Appearance menu - verify only one "Fonts" item appears
  3. Click on Fonts - verify the page loads without duplicate route errors

This may fix one or two of the current failing e2e tests.