### PR TITLE
List Block: Prevent content loss when merging into a fresh empty list item

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1037,16 +1037,10 @@ export const __unstableSplitSelection =
 		}
 
 		if ( ! blocks.length ) {
-			dispatch.replaceBlocks(
-				select.getSelectedBlockClientIds(),
-				[ head, tail ],
-				null,
-				0,
-				{
-					// Don't prune block list settings if the block type didn't change.
-					keepBlockListSettings: head.name === tail.name,
-				}
-			);
+			dispatch.replaceBlocks( select.getSelectedBlockClientIds(), [
+				head,
+				tail,
+			] );
 			return;
 		}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1037,10 +1037,16 @@ export const __unstableSplitSelection =
 		}
 
 		if ( ! blocks.length ) {
-			dispatch.replaceBlocks( select.getSelectedBlockClientIds(), [
-				head,
-				tail,
-			] );
+			dispatch.replaceBlocks(
+				select.getSelectedBlockClientIds(),
+				[ head, tail ],
+				null,
+				0,
+				{
+					// Don't prune block list settings if the block type didn't change.
+					keepBlockListSettings: head.name === tail.name,
+				}
+			);
 			return;
 		}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1870,9 +1870,18 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
  */
 export const blockListSettings = ( state = {}, action ) => {
 	switch ( action.type ) {
-		// Even if the replaced blocks have the same client ID, our logic
-		// should correct the state.
-		case 'REPLACE_BLOCKS':
+		case 'REPLACE_BLOCKS': {
+			if ( !! action.meta?.keepBlockListSettings ) {
+				return state;
+			}
+			// Even if the replaced blocks have the same client ID, our logic
+			// should correct the state.
+			return Object.fromEntries(
+				Object.entries( state ).filter(
+					( [ id ] ) => ! action.clientIds.includes( id )
+				)
+			);
+		}
 		case 'REMOVE_BLOCKS': {
 			return Object.fromEntries(
 				Object.entries( state ).filter(

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1871,14 +1871,23 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 export const blockListSettings = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'REPLACE_BLOCKS': {
-			if ( !! action.meta?.keepBlockListSettings ) {
-				return state;
+			// Collect all clientIds from replacement blocks. If a clientId
+			// is reused, preserve its settings — the block instance (and
+			// its InnerBlocks config) survived the replace. Settings for
+			// clientIds that are truly removed get cleaned up so stale
+			// config from old block types doesn't linger.
+			const replacementIds = new Set();
+			const stack = [ ...action.blocks ];
+			while ( stack.length ) {
+				const block = stack.shift();
+				replacementIds.add( block.clientId );
+				stack.push( ...block.innerBlocks );
 			}
-			// Even if the replaced blocks have the same client ID, our logic
-			// should correct the state.
 			return Object.fromEntries(
 				Object.entries( state ).filter(
-					( [ id ] ) => ! action.clientIds.includes( id )
+					( [ id ] ) =>
+						! action.clientIds.includes( id ) ||
+						replacementIds.has( id )
 				)
 			);
 		}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3291,11 +3291,43 @@ describe( 'state', () => {
 			const state = blockListSettings( original, {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
+				blocks: [],
 			} );
 
 			expect( state ).toEqual( {
 				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
 					allowedBlocks: [ 'core/paragraph' ],
+				},
+			} );
+		} );
+
+		it( 'should preserve the settings of a block when its clientId is reused in replacement', () => {
+			const original = deepFreeze( {
+				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
+					allowedBlocks: [ 'core/paragraph' ],
+				},
+				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+					allowedBlocks: true,
+				},
+			} );
+
+			const state = blockListSettings( original, {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
+				blocks: [
+					{
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+						innerBlocks: [],
+					},
+				],
+			} );
+
+			expect( state ).toEqual( {
+				'9db792c6-a25a-495d-adbd-97d56a4c4189': {
+					allowedBlocks: [ 'core/paragraph' ],
+				},
+				'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+					allowedBlocks: true,
 				},
 			} );
 		} );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1656,6 +1656,68 @@ test.describe( 'List (@firefox)', () => {
 		] );
 	} );
 
+	test( 'should leave the rest of the list intact when merging into an empty list item', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: '1' },
+					innerBlocks: [
+						{
+							name: 'core/list',
+							innerBlocks: [
+								{
+									name: 'core/list-item',
+									attributes: { content: 'a' },
+								},
+								{
+									name: 'core/list-item',
+									attributes: { content: 'b' },
+								},
+							],
+						},
+					],
+				},
+			],
+		} );
+
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: '1' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'a' },
+									},
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should select the list wrapper with select all in empty list item', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Closes #55757.

PR fixes a List block bug where content might be lost when merging into a freshly split list item.

## Why?
> moveBlocksToPosition bails out early, because the block editor thinks it can't insert blocks (list-items) into a new position. This is due to missing blockListSettings for freshly split (__unstableSplitSelection) list item blocks.

See https://github.com/WordPress/gutenberg/issues/55757#issuecomment-3631981699.

## How?
Update `blockListSettings` and, on `REPLACE_BLOCKS`, remove only settings for clientIds that are **not reused** in replacement blocks.

## Testing Instructions
1. Open a post or page.
2. Insert a list block with nested items.
3. Split the top-level list and then merge back.
4. Nested contents shouldn't be lost.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c660e7b9-183b-4424-a15b-6a1479a51bda