### PR TITLE
Global Styles: Add background color control to global styles Background panel

### DIFF
--- a/packages/block-editor/src/components/background-color-control/index.js
+++ b/packages/block-editor/src/components/background-color-control/index.js
@@ -1,0 +1,314 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Flex,
+	FlexItem,
+	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+	__experimentalZStack as ZStack,
+	Dropdown,
+	Button,
+	ColorIndicator,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
+import { reset as resetIcon } from '@wordpress/icons';
+import { getValueFromVariable } from '@wordpress/global-styles-engine';
+
+/**
+ * Internal dependencies
+ */
+import ColorGradientControl from '../colors-gradients/control';
+import { setImmutably } from '../../utils/object';
+import {
+	useColorsPerOrigin,
+	useGradientsPerOrigin,
+} from '../global-styles/hooks';
+import { unlock } from '../../lock-unlock';
+
+const BACKGROUND_POPOVER_PROPS = {
+	placement: 'left-start',
+	offset: 36,
+	shift: true,
+	className: 'block-editor-global-styles-background-panel__popover',
+};
+
+function ColorPanelTab( {
+	isGradient,
+	inheritedValue,
+	userValue,
+	setValue,
+	colorGradientControlSettings,
+} ) {
+	return (
+		<ColorGradientControl
+			{ ...colorGradientControlSettings }
+			showTitle={ false }
+			enableAlpha
+			__experimentalIsRenderedInSidebar
+			colorValue={ isGradient ? undefined : inheritedValue }
+			gradientValue={ isGradient ? inheritedValue : undefined }
+			onColorChange={ isGradient ? undefined : setValue }
+			onGradientChange={ isGradient ? setValue : undefined }
+			clearable={ inheritedValue === userValue }
+			headingLevel={ 3 }
+		/>
+	);
+}
+
+const LabeledColorIndicators = ( { indicators, label } ) => (
+	<Item>
+		<HStack justify="flex-start">
+			<ZStack isLayered={ false } offset={ -8 }>
+				{ indicators.map( ( indicator, index ) => (
+					<Flex key={ index } expanded={ false }>
+						<ColorIndicator colorValue={ indicator } />
+					</Flex>
+				) ) }
+			</ZStack>
+			<FlexItem
+				className="block-editor-panel-color-gradient-settings__color-name"
+				title={ label }
+			>
+				{ label }
+			</FlexItem>
+		</HStack>
+	</Item>
+);
+
+const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Checks if there is a current value in the background color block support
+ * attributes.
+ *
+ * @param {Object} style Style attribute.
+ * @return {boolean}     Whether the block has a background color value set.
+ */
+export function hasBackgroundColorValue( style ) {
+	return (
+		style?.background?.backgroundColor !== undefined ||
+		style?.background?.backgroundGradient !== undefined
+	);
+}
+
+export default function BackgroundColorControl( {
+	value,
+	onChange,
+	inheritedValue = value,
+	settings,
+	label = __( 'Color' ),
+} ) {
+	const colors = useColorsPerOrigin( settings );
+	const gradients = useGradientsPerOrigin( settings );
+	const areCustomSolidsEnabled = settings?.color?.custom;
+	const areCustomGradientsEnabled = settings?.color?.customGradient;
+
+	const decodeValue = ( rawValue ) =>
+		getValueFromVariable( { settings }, '', rawValue );
+
+	const backgroundColor = decodeValue( inheritedValue?.color?.background );
+	const backgroundGradient = decodeValue( inheritedValue?.color?.gradient );
+
+	const userBackgroundColor = decodeValue( value?.color?.background );
+	const userGradient = decodeValue( value?.color?.gradient );
+
+	const setBackgroundColor = ( newColor ) => {
+		const newValue = setImmutably(
+			value,
+			[ 'color', 'background' ],
+			encodeColorValue( newColor )
+		);
+		newValue.color.gradient = undefined;
+		onChange( newValue );
+	};
+
+	const setGradient = ( newGradient ) => {
+		const newValue = setImmutably(
+			value,
+			[ 'color', 'gradient' ],
+			encodeGradientValue( newGradient )
+		);
+		newValue.color.background = undefined;
+		onChange( newValue );
+	};
+
+	const encodeColorValue = ( colorValue ) => {
+		const allColors = colors.flatMap(
+			( { colors: originColors } ) => originColors
+		);
+		const colorObject = allColors.find(
+			( { color } ) => color === colorValue
+		);
+		return colorObject
+			? 'var:preset|color|' + colorObject.slug
+			: colorValue;
+	};
+
+	const encodeGradientValue = ( gradientValue ) => {
+		const allGradients = gradients.flatMap(
+			( { gradients: originGradients } ) => originGradients
+		);
+		const gradientObject = allGradients.find(
+			( { gradient } ) => gradient === gradientValue
+		);
+		return gradientObject
+			? 'var:preset|gradient|' + gradientObject.slug
+			: gradientValue;
+	};
+
+	const hasSolidColors = colors.length > 0 || areCustomSolidsEnabled;
+	const hasGradientColors = gradients.length > 0 || areCustomGradientsEnabled;
+
+	const tabs = [
+		hasSolidColors && {
+			key: 'background',
+			label: __( 'Background' ),
+			inheritedValue: backgroundColor,
+			setValue: setBackgroundColor,
+			userValue: userBackgroundColor,
+		},
+		hasGradientColors && {
+			key: 'gradient',
+			label: __( 'Gradient' ),
+			inheritedValue: backgroundGradient,
+			setValue: setGradient,
+			userValue: userGradient,
+			isGradient: true,
+		},
+	].filter( Boolean );
+
+	const colorGradientControlSettings = {
+		colors,
+		disableCustomColors: ! areCustomSolidsEnabled,
+		gradients,
+		disableCustomGradients: ! areCustomGradientsEnabled,
+	};
+
+	const indicators = [ backgroundGradient ?? backgroundColor ];
+	const currentTab = tabs.find( ( tab ) => tab.userValue !== undefined );
+	const { key: firstTabKey, ...firstTab } = tabs[ 0 ] ?? {};
+
+	const hasValue = userBackgroundColor || userGradient;
+	const colorGradientDropdownButtonRef = useRef( undefined );
+
+	const onReset = () => {
+		onChange(
+			setImmutably( value, [ 'color' ], {
+				...value?.color,
+				background: undefined,
+				gradient: undefined,
+			} )
+		);
+	};
+
+	return (
+		<Item className="block-editor-global-styles-background-panel__color-tools-panel-item">
+			<Dropdown
+				popoverProps={ BACKGROUND_POPOVER_PROPS }
+				className="block-editor-tools-panel-color-gradient-settings__dropdown"
+				renderToggle={ ( { onToggle, isOpen } ) => {
+					const toggleProps = {
+						onClick: onToggle,
+						className: clsx(
+							'block-editor-panel-color-gradient-settings__dropdown',
+							{ 'is-open': isOpen }
+						),
+						'aria-expanded': isOpen,
+						'aria-label': sprintf(
+							/* translators: %s is the type of color property, e.g., "background" */
+							__( 'Color %s styles' ),
+							label
+						),
+						ref: colorGradientDropdownButtonRef,
+					};
+
+					return (
+						<>
+							<Button __next40pxDefaultSize { ...toggleProps }>
+								<LabeledColorIndicators
+									indicators={ indicators }
+									label={ label }
+								/>
+							</Button>
+							{ hasValue && (
+								<Button
+									__next40pxDefaultSize
+									label={ __( 'Reset' ) }
+									className="block-editor-global-styles-background-panel__color-reset"
+									size="small"
+									icon={ resetIcon }
+									onClick={ () => {
+										onReset();
+										if ( isOpen ) {
+											onToggle();
+										}
+										// Return focus to parent button
+										colorGradientDropdownButtonRef.current?.focus();
+									} }
+								/>
+							) }
+						</>
+					);
+				} }
+				renderContent={ () => (
+					<DropdownContentWrapper paddingSize="none">
+						<div className="block-editor-panel-color-gradient-settings__dropdown-content">
+							{ tabs.length === 1 && (
+								<ColorPanelTab
+									key={ firstTabKey }
+									{ ...firstTab }
+									colorGradientControlSettings={
+										colorGradientControlSettings
+									}
+								/>
+							) }
+							{ tabs.length > 1 && (
+								<Tabs defaultTabId={ currentTab?.key }>
+									<Tabs.TabList>
+										{ tabs.map( ( tab ) => (
+											<Tabs.Tab
+												key={ tab.key }
+												tabId={ tab.key }
+											>
+												{ tab.label }
+											</Tabs.Tab>
+										) ) }
+									</Tabs.TabList>
+
+									{ tabs.map( ( tab ) => {
+										const { key: tabKey, ...restTabProps } =
+											tab;
+										return (
+											<Tabs.TabPanel
+												key={ tabKey }
+												tabId={ tabKey }
+												focusable={ false }
+											>
+												<ColorPanelTab
+													key={ tabKey }
+													{ ...restTabProps }
+													colorGradientControlSettings={
+														colorGradientControlSettings
+													}
+												/>
+											</Tabs.TabPanel>
+										);
+									} ) }
+								</Tabs>
+							) }
+						</div>
+					</DropdownContentWrapper>
+				) }
+			/>
+		</Item>
+	);
+}

--- a/packages/block-editor/src/components/background-color-control/style.scss
+++ b/packages/block-editor/src/components/background-color-control/style.scss
@@ -1,0 +1,47 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+.block-editor-global-styles-background-panel__inspector-media-replace-container {
+	.block-editor-global-styles-background-panel__color-tools-panel-item {
+		padding: 0;
+		position: relative;
+
+		button {
+			padding: 0;
+		}
+	}
+}
+
+.block-editor-global-styles-background-panel__color-tools-panel-item {
+	position: relative;
+
+	button {
+		padding: 0;
+	}
+}
+
+.block-editor-global-styles-background-panel__color-reset {
+	position: absolute;
+	right: 0;
+	top: $grid-unit;
+	margin: auto $grid-unit auto;
+	opacity: 0;
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s ease-in-out;
+	}
+
+	&.block-editor-global-styles-background-panel__color-reset {
+		border-radius: $radius-small;
+	}
+
+	.block-editor-panel-color-gradient-settings__dropdown:hover + &,
+	&:focus,
+	&:hover {
+		opacity: 1;
+	}
+
+	@media ( hover: none ) {
+		// Show reset button on devices that do not support hover.
+		opacity: 1;
+	}
+}

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import {
 	ToggleControl,
+	__experimentalItem as Item,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
@@ -29,7 +30,7 @@ import { reset as resetIcon } from '@wordpress/icons';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
-import { useRef, useState, useEffect, useMemo } from '@wordpress/element';
+import { useRef, useState, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { isBlobURL } from '@wordpress/blob';
@@ -134,15 +135,8 @@ function InspectorImagePreviewItem( {
 	toggleProps = {},
 	filename,
 	label,
-	onToggleCallback = noop,
 } ) {
 	const { isOpen, ...restToggleProps } = toggleProps;
-
-	useEffect( () => {
-		if ( typeof isOpen !== 'undefined' ) {
-			onToggleCallback( isOpen );
-		}
-	}, [ isOpen, onToggleCallback ] );
 
 	const renderPreviewContent = () => {
 		return (
@@ -151,19 +145,22 @@ function InspectorImagePreviewItem( {
 				as="span"
 				className="block-editor-global-styles-background-panel__inspector-preview-inner"
 			>
-				{ imgUrl && (
+				<span
+					className="block-editor-global-styles-background-panel__inspector-image-indicator-wrapper"
+					aria-hidden
+				>
 					<span
-						className="block-editor-global-styles-background-panel__inspector-image-indicator-wrapper"
-						aria-hidden
-					>
-						<span
-							className="block-editor-global-styles-background-panel__inspector-image-indicator"
-							style={ {
-								backgroundImage: `url(${ imgUrl })`,
-							} }
-						/>
-					</span>
-				) }
+						className={ clsx(
+							'block-editor-global-styles-background-panel__inspector-image-indicator',
+							{ 'has-image': !! imgUrl }
+						) }
+						style={ {
+							'--wp-admin-background-image-preview-url': imgUrl
+								? `url(${ imgUrl })`
+								: undefined,
+						} }
+					/>
+				</span>
 				<FlexItem as="span" style={ imgUrl ? {} : { flexGrow: 1 } }>
 					<Truncate
 						numberOfLines={ 1 }
@@ -199,7 +196,6 @@ function BackgroundControlsPanel( {
 	filename,
 	url: imgUrl,
 	children,
-	onToggle: onToggleCallback = noop,
 	hasImageValue,
 	onReset,
 	containerRef,
@@ -208,8 +204,7 @@ function BackgroundControlsPanel( {
 		return;
 	}
 
-	const imgLabel =
-		label || getFilename( imgUrl ) || __( 'Add background image' );
+	const imgLabel = label || getFilename( imgUrl ) || __( 'Image' );
 
 	return (
 		<Dropdown
@@ -217,8 +212,12 @@ function BackgroundControlsPanel( {
 			renderToggle={ ( { onToggle, isOpen } ) => {
 				const toggleProps = {
 					onClick: onToggle,
-					className:
+					className: clsx(
 						'block-editor-global-styles-background-panel__dropdown-toggle',
+						{
+							'is-open': isOpen,
+						}
+					),
 					'aria-expanded': isOpen,
 					'aria-label': __(
 						'Background size, position and repeat options.'
@@ -233,7 +232,6 @@ function BackgroundControlsPanel( {
 							label={ imgLabel }
 							toggleProps={ toggleProps }
 							as="button"
-							onToggleCallback={ onToggleCallback }
 						/>
 						{ onReset && (
 							<Button
@@ -385,11 +383,10 @@ function BackgroundImageControls( {
 			} )
 		);
 	const canRemove = ! hasValue && hasBackgroundImageValue( inheritedValue );
-	const imgLabel =
-		title || getFilename( url ) || __( 'Add background image' );
+	const imgLabel = title || getFilename( url ) || __( 'Image' );
 
 	return (
-		<div className="block-editor-global-styles-background-panel__image-tools-panel-item">
+		<Item className="block-editor-global-styles-background-panel__image-tools-panel-item">
 			{ isUploading && <LoadingSpinner /> }
 			<MediaReplaceFlow
 				mediaId={ id }
@@ -435,7 +432,7 @@ function BackgroundImageControls( {
 				onFilesDrop={ onFilesDrop }
 				label={ __( 'Drop to upload' ) }
 			/>
-		</div>
+		</Item>
 	);
 }
 
@@ -714,25 +711,18 @@ export default function BackgroundImagePanel( {
 			settings?.background?.backgroundPosition ||
 			settings?.background?.backgroundRepeat );
 
-	const [ isDropDownOpen, setIsDropDownOpen ] = useState( false );
 	const containerRef = useRef();
 
 	return (
 		<div
 			ref={ containerRef }
-			className={ clsx(
-				'block-editor-global-styles-background-panel__inspector-media-replace-container',
-				{
-					'is-open': isDropDownOpen,
-				}
-			) }
+			className="block-editor-global-styles-background-panel__inspector-media-replace-container"
 		>
 			{ shouldShowBackgroundImageControls ? (
 				<BackgroundControlsPanel
 					label={ title }
 					filename={ title }
 					url={ url }
-					onToggle={ setIsDropDownOpen }
 					hasImageValue={ hasImageValue }
 					onReset={ resetBackground }
 					containerRef={ containerRef }
@@ -743,11 +733,7 @@ export default function BackgroundImagePanel( {
 							style={ value }
 							inheritedValue={ resolvedInheritedValue }
 							displayInPanel
-							onResetImage={ () => {
-								setIsDropDownOpen( false );
-								resetBackground();
-							} }
-							onRemoveImage={ () => setIsDropDownOpen( false ) }
+							onResetImage={ () => resetBackground() }
 							defaultValues={ defaultValues }
 							containerRef={ containerRef }
 						/>
@@ -766,10 +752,8 @@ export default function BackgroundImagePanel( {
 					inheritedValue={ resolvedInheritedValue }
 					defaultValues={ defaultValues }
 					onResetImage={ () => {
-						setIsDropDownOpen( false );
 						resetBackground();
 					} }
-					onRemoveImage={ () => setIsDropDownOpen( false ) }
 					containerRef={ containerRef }
 				/>
 			) }

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -3,19 +3,15 @@
 @use "@wordpress/base-styles/z-index" as *;
 
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
-	border: $border-width solid $gray-300;
 	border-radius: $radius-small;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
 	position: relative;
 
-	&.is-open {
-		background-color: $gray-100;
-	}
-
 	.block-editor-global-styles-background-panel__image-tools-panel-item {
 		flex-grow: 1;
 		border: 0;
+		padding: 0;
 
 		.components-dropdown {
 			display: block;
@@ -64,7 +60,9 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow:
+				inset 0 0 0 var(--wp-admin-border-width-focus)
+				var(--wp-admin-theme-color);
 		}
 	}
 
@@ -89,6 +87,10 @@
 	width: 100%;
 	padding-left: $grid-unit-15;
 	padding-right: $grid-unit-40;
+
+	&.is-open {
+		background-color: $gray-100;
+	}
 }
 
 .block-editor-global-styles-background-panel__reset {
@@ -111,7 +113,7 @@
 		opacity: 1;
 	}
 
-	@media (hover: none) {
+	@media ( hover: none ) {
 		// Show reset button on devices that do not support hover.
 		opacity: 1;
 	}
@@ -124,7 +126,6 @@
 
 	// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
 	text-align: start;
-	text-align-last: center;
 }
 
 .block-editor-global-styles-background-panel__inspector-preview-inner {
@@ -137,11 +138,20 @@
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {
 	background-size: cover;
-	border-radius: $radius-round;
+	border-radius: $radius-small;
+
 	width: 20px;
 	height: 20px;
 	display: block;
 	position: relative;
+	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
+	border: 1px solid transparent;
+	&.has-image {
+		background-image: var(--wp-admin-background-image-preview-url);
+	}
+	&.has-image::after {
+		background: unset;
+	}
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator::after {
@@ -151,10 +161,11 @@
 	left: -1px;
 	bottom: -1px;
 	right: -1px;
-	border-radius: $radius-round;
+	border-radius: $radius-small;
 	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
-	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
-	border: 1px solid transparent;
+	background:
+		#fff
+		linear-gradient(-45deg, #0000 48%, #ddd 0, #ddd 52%, #0000 0);
 	box-sizing: inherit;
 }
 
@@ -176,6 +187,10 @@
 	// Override focal picker to avoid a double border.
 	.components-focal-point-picker::after {
 		content: none;
+	}
+
+	.block-editor-global-styles-background-panel__image-tools-panel-item {
+		padding: 0;
 	}
 }
 

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -4,18 +4,22 @@
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalItemGroup as ItemGroup,
 } from '@wordpress/components';
 import { useCallback, Platform } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import BackgroundImageControl from '../background-image-control';
+import BackgroundColorControl from '../background-color-control';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
-import { __ } from '@wordpress/i18n';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
+	backgroundColor: true,
 };
 
 /**
@@ -77,6 +81,7 @@ function BackgroundToolsPanel( {
 
 	return (
 		<ToolsPanel
+			headingLevel={ 3 }
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
@@ -96,15 +101,28 @@ export default function BackgroundImagePanel( {
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
 	defaultValues = {},
-	headerLabel = __( 'Background image' ),
+	headerLabel = __( 'Options' ),
 } ) {
 	const showBackgroundImageControl = useHasBackgroundPanel( settings );
+	const shouldShowBackgroundColorControls = useHasBackgroundPanel( settings );
+
 	const resetBackground = () =>
 		onChange( setImmutably( value, [ 'background' ], {} ) );
+	const resetBackgroundColor = () => {
+		const newValue = setImmutably(
+			value,
+			[ 'color', 'background' ],
+			undefined
+		);
+		newValue.color.gradient = undefined;
+		onChange( newValue );
+	};
+
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
 			...previousValue,
 			background: {},
+			color: undefined,
 		};
 	}, [] );
 
@@ -116,24 +134,48 @@ export default function BackgroundImagePanel( {
 			panelId={ panelId }
 			headerLabel={ headerLabel }
 		>
-			{ showBackgroundImageControl && (
-				<ToolsPanelItem
-					hasValue={ () => !! value?.background }
-					label={ __( 'Image' ) }
-					onDeselect={ resetBackground }
-					isShownByDefault={ defaultControls.backgroundImage }
-					panelId={ panelId }
-				>
-					<BackgroundImageControl
-						value={ value }
-						onChange={ onChange }
-						settings={ settings }
-						inheritedValue={ inheritedValue }
-						defaultControls={ defaultControls }
-						defaultValues={ defaultValues }
-					/>
-				</ToolsPanelItem>
-			) }
+			<ItemGroup
+				className="block-editor-global-styles-background-panel__inspector-media-replace-container"
+				isSeparated
+				isBordered
+			>
+				{ showBackgroundImageControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! value?.background }
+						label={ __( 'Image' ) }
+						onDeselect={ resetBackground }
+						isShownByDefault={ defaultControls.backgroundImage }
+						panelId={ panelId }
+					>
+						<BackgroundImageControl
+							value={ value }
+							onChange={ onChange }
+							settings={ settings }
+							inheritedValue={ inheritedValue }
+							defaultControls={ defaultControls }
+							defaultValues={ defaultValues }
+						/>
+					</ToolsPanelItem>
+				) }
+				{ shouldShowBackgroundColorControls && (
+					<ToolsPanelItem
+						hasValue={ () => !! value?.color }
+						label={ __( 'Color' ) }
+						onDeselect={ resetBackgroundColor }
+						isShownByDefault={ defaultControls.backgroundColor }
+						panelId={ panelId }
+					>
+						<BackgroundColorControl
+							value={ value }
+							onChange={ onChange }
+							settings={ settings }
+							inheritedValue={ inheritedValue }
+							defaultControls={ defaultControls }
+							defaultValues={ defaultValues }
+						/>
+					</ToolsPanelItem>
+				) }
+			</ItemGroup>
 		</Wrapper>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -16,6 +16,7 @@ import BackgroundImageControl from '../background-image-control';
 import BackgroundColorControl from '../background-color-control';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
+import { useHasBackgroundColorPanel } from './color-panel';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -23,15 +24,26 @@ const DEFAULT_CONTROLS = {
 };
 
 /**
+ * Checks site settings to see if the background image control should be available.
+ *
+ * @param {Object} settings Site settings
+ * @return {boolean}        Whether background image control is enabled.
+ */
+export function useHasBackgroundImageControl( settings ) {
+	return Platform.OS === 'web' && settings?.background?.backgroundImage;
+}
+
+/**
  * Checks site settings to see if the background panel may be used.
- * `settings.background.backgroundSize` exists also,
- * but can only be used if settings?.background?.backgroundImage is `true`.
+ * The panel is available if either background image or background color is enabled.
  *
  * @param {Object} settings Site settings
  * @return {boolean}        Whether site settings has activated background panel.
  */
 export function useHasBackgroundPanel( settings ) {
-	return Platform.OS === 'web' && settings?.background?.backgroundImage;
+	const hasBackgroundImage = useHasBackgroundImageControl( settings );
+	const hasBackgroundColor = useHasBackgroundColorPanel( settings );
+	return hasBackgroundImage || hasBackgroundColor;
 }
 
 /**
@@ -103,8 +115,8 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Options' ),
 } ) {
-	const showBackgroundImageControl = useHasBackgroundPanel( settings );
-	const shouldShowBackgroundColorControls = useHasBackgroundPanel( settings );
+	const showBackgroundImageControl = useHasBackgroundImageControl( settings );
+	const showBackgroundColorControl = useHasBackgroundColorPanel( settings );
 
 	const resetBackground = () =>
 		onChange( setImmutably( value, [ 'background' ], {} ) );
@@ -157,7 +169,7 @@ export default function BackgroundImagePanel( {
 						/>
 					</ToolsPanelItem>
 				) }
-				{ shouldShowBackgroundColorControls && (
+				{ showBackgroundColorControl && (
 					<ToolsPanelItem
 						hasValue={ () => !! value?.color }
 						label={ __( 'Color' ) }

--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -22,4 +22,5 @@ export { default as AdvancedPanel } from './advanced-panel';
 export {
 	default as BackgroundPanel,
 	useHasBackgroundPanel,
+	useHasBackgroundImageControl,
 } from './background-panel';

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/default-custom-properties";
 @use "@wordpress/base-styles/mixins" as *;
 @use "./autocompleters/style.scss" as *;
+@use "./components/background-color-control/style.scss" as *;
 @use "./components/background-image-control/style.scss" as *;
 @use "./components/block-alignment-control/style.scss" as *;
 @use "./components/block-canvas/style.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #63096

<!-- In a few words, what is the PR actually doing? -->

## Why?
Introduces a new `BackgroundColorControl` component that allows users to set solid colors and gradients for backgrounds in the global styles interface.

The control appears in the Background panel alongside the existing background image control and respects theme.json settings for both color and background image features independently.

## How?
- Adds a background-color component for site global styles
- Adds upload icon for background-image control

## Testing Instructions
1. Open the site editor by going Appearance > Editor
2. Go to Styles > Background
3. In the Background there should be two controls now: Image and Color

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6a3bc119-9a24-4e07-a86e-3a820e0e157c
