### PR TITLE
Update: Use 12px as minimum font size for warning on fit text.

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -13,7 +13,7 @@ import {
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 const EMPTY_OBJECT = {};
-const MIN_FONT_SIZE_FOR_WARNING = 6;
+const MIN_FONT_SIZE_FOR_WARNING = 12;
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Very small change, applies feedback from @mcsf to show a readability warning in font sizes smaller than 12px instead of 6px as we had.

# Testing
Add a paragraph, enable fit text block. type "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" which causes an 11px font size and verify the warning appears.