### PR TITLE
Feature : Notes Indicator in Block List and Editor views

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -38,6 +38,7 @@ import { useBlockProps } from './use-block-props';
 import { store as blockEditorStore } from '../../store';
 import { useLayout } from './layout';
 import { PrivateBlockContext } from './private-block-context';
+import BlockNoteIndicator from '../list-view/block-note-indicator';
 
 import { unlock } from '../../lock-unlock';
 
@@ -240,6 +241,7 @@ function BlockListBlock( {
 					</Block>
 				}
 			>
+				<BlockNoteIndicator clientId={ clientId } />
 				{ block }
 			</BlockCrashBoundary>
 		</PrivateBlockContext.Provider>

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -473,3 +473,15 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	cursor: grabbing;
 }
 
+.block-editor-block-note-indicator {
+	position: absolute;
+	right: 40px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+
+	&__count {
+		font-size: 14px;
+		font-weight: 600;
+	}
+}

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -16,6 +16,7 @@ const ListViewBlockContents = forwardRef(
 			onClick,
 			onToggleExpanded,
 			block,
+			notes,
 			isSelected,
 			position,
 			siblingBlockCount,
@@ -57,6 +58,7 @@ const ListViewBlockContents = forwardRef(
 							ref={ ref }
 							className="block-editor-list-view-block-contents"
 							block={ block }
+							notes={ notes }
 							onClick={ onClick }
 							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/block-note-indicator.js
+++ b/packages/block-editor/src/components/list-view/block-note-indicator.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { Icon, comment } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockComments } from './use-block-comments';
+
+/**
+ * Block Note Indicator component
+ *
+ * Shows a visual indicator when a block has associated comment notes.
+ * Displays as a small badge with a comment icon and count.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId The block client ID.
+ *
+ * @return {Element|null} The note indicator or null if no notes exist.
+ */
+export default function BlockNoteIndicator( { clientId } ) {
+	// Get the postId from the editor store
+	const { postId } = useSelect( ( select ) => {
+		const { getCurrentPostId } = select( 'core/editor' ); // eslint-disable-line @wordpress/data-no-store-string-literals
+		return {
+			postId: getCurrentPostId(),
+		};
+	}, [] );
+
+	// Get all comments for the post
+	const { resultComments } = useBlockComments( postId );
+
+	// Find notes associated with this specific block
+	const blockNotes = useMemo( () => {
+		if ( ! resultComments || ! clientId ) {
+			return null;
+		}
+
+		return resultComments.find(
+			( resultComment ) => resultComment.blockClientId === clientId
+		);
+	}, [ resultComments, clientId ] );
+
+	// Don't render if no notes exist for this block
+	if ( ! blockNotes ) {
+		return null;
+	}
+
+	// Count total replies in the thread
+	const noteCount = blockNotes.reply ? blockNotes.reply.length + 1 : 1;
+
+	return (
+		<div className="block-editor-block-note-indicator">
+			<Icon icon={ comment } size={ 16 } />
+			{ noteCount > 1 && (
+				<span className="block-editor-block-note-indicator__count">
+					{ noteCount }
+				</span>
+			) }
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -9,9 +9,10 @@ import clsx from 'clsx';
 import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
+	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 import {
 	Icon,
 	lockSmall as lock,
@@ -22,6 +23,7 @@ import {
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -41,6 +43,7 @@ function ListViewBlockSelectButton(
 	{
 		className,
 		block: { clientId },
+		notes,
 		onClick,
 		onContextMenu,
 		onMouseDown,
@@ -105,6 +108,56 @@ function ListViewBlockSelectButton(
 			onClick( event );
 		}
 	}
+
+	const threadParticipants = useMemo( () => {
+		if ( ! notes ) {
+			return [];
+		}
+
+		const participantsMap = new Map();
+		const allComments = [ notes, ...notes.reply ];
+
+		// Sort by date to show participants in chronological order.
+		allComments.sort( ( a, b ) => new Date( a.date ) - new Date( b.date ) );
+
+		allComments.forEach( ( comment ) => {
+			// Track thread participants (original commenter + repliers).
+			if ( comment.author_name && comment.author_avatar_urls ) {
+				if ( ! participantsMap.has( comment.author ) ) {
+					participantsMap.set( comment.author, {
+						name: comment.author_name,
+						avatar:
+							comment.author_avatar_urls?.[ '48' ] ||
+							comment.author_avatar_urls?.[ '96' ],
+						id: comment.author,
+						date: comment.date,
+					} );
+				}
+			}
+		} );
+
+		return Array.from( participantsMap.values() );
+	}, [ notes ] );
+
+	const maxAvatars = 3;
+	const isOverflow = threadParticipants?.length > maxAvatars;
+	const visibleParticipants = isOverflow
+		? threadParticipants?.slice( 0, maxAvatars - 1 )
+		: threadParticipants;
+	const overflowCount = Math.max(
+		0,
+		threadParticipants?.length - visibleParticipants?.length
+	);
+	const threadHasMoreParticipants = threadParticipants?.length > 100;
+
+	const overflowText =
+		threadHasMoreParticipants && overflowCount > 0
+			? __( '100+' )
+			: sprintf(
+					// translators: %s: Number of participants.
+					__( '+%s' ),
+					overflowCount
+			  );
 
 	return (
 		<a
@@ -181,6 +234,23 @@ function ListViewBlockSelectButton(
 					</span>
 				) }
 			</HStack>
+			{ notes && (
+				<div className="block-editor-list-view-block-comment-avatar-indicator comment-avatar-indicator">
+					<HStack spacing="0.5">
+						{ visibleParticipants.map( ( participant ) => (
+							<img
+								key={ participant.id }
+								src={ participant.avatar }
+								alt={ participant.author_name }
+								className="comment-avatar"
+							/>
+						) ) }
+						{ overflowCount > 0 && (
+							<Text weight={ 500 }>{ overflowText }</Text>
+						) }
+					</HStack>
+				</div>
+			) }
 		</a>
 	);
 }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -57,6 +57,7 @@ import { cleanEmptyObject } from '../../hooks/utils';
 
 function ListViewBlock( {
 	block: { clientId },
+	notes,
 	displacement,
 	isAfterDraggedBlocks,
 	isDragged,
@@ -604,6 +605,7 @@ function ListViewBlock( {
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
 							block={ block }
+							notes={ notes }
 							onClick={ selectEditorBlock }
 							onContextMenu={ onContextMenu }
 							onMouseDown={ onMouseDown }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -17,6 +17,7 @@ import { useListViewContext } from './context';
 import { getDragDisplacementValues, isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
+import { useBlockComments } from './use-block-comments';
 
 /**
  * Given a block, returns the total number of blocks in that subtree. This is used to help determine
@@ -114,6 +115,16 @@ function ListViewBranch( props ) {
 		[ parentId ]
 	);
 
+	// Get the postId, mode, and editorMode from the editor store.
+	const { postId } = useSelect( ( select ) => {
+		const { getCurrentPostId } = select( 'core/editor' ); // eslint-disable-line @wordpress/data-no-store-string-literals
+		return {
+			postId: getCurrentPostId(),
+		};
+	}, [] );
+
+	const { resultComments } = useBlockComments( postId );
+
 	const {
 		blockDropPosition,
 		blockDropTargetIndex,
@@ -190,6 +201,10 @@ function ListViewBranch( props ) {
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBlocks );
 
+				const blockNotes = resultComments.find(
+					( comment ) => comment.blockClientId === clientId
+				);
+
 				// To avoid performance issues, we only render blocks that are in view,
 				// or blocks that are selected or dragged. If a block is selected,
 				// it is only counted if it is the first of the block selection.
@@ -209,6 +224,7 @@ function ListViewBranch( props ) {
 						{ showBlock && (
 							<ListViewBlock
 								block={ block }
+								notes={ blockNotes }
 								selectBlock={ selectBlock }
 								isSelected={ isSelected }
 								isBranchSelected={ isSelectedBranch }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -447,6 +447,10 @@
 			box-shadow: 0 0 0 $radius-small var(--wp-admin-theme-color);
 		}
 	}
+
+	.block-editor-list-view-block-comment-avatar-indicator {
+		padding: 0 $grid-unit-10;
+	}
 }
 
 // First level of indentation is aria-level 2, max indent is 8.

--- a/packages/block-editor/src/components/list-view/use-block-comments.js
+++ b/packages/block-editor/src/components/list-view/use-block-comments.js
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch'; // eslint-disable-line no-restricted-imports
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export function useBlockComments( postId ) {
+	// State to store fetched comment threads
+	const [ threads, setThreads ] = useState( null );
+
+	// Get block data from store
+	const { getBlockAttributes, clientIds } = useSelect( ( select ) => {
+		const { getBlockAttributes: getAttrs, getClientIdsWithDescendants } =
+			select( blockEditorStore );
+
+		return {
+			getBlockAttributes: getAttrs,
+			clientIds: getClientIdsWithDescendants(),
+		};
+	}, [] );
+
+	// Fetch comment threads from WordPress REST API
+	useEffect( () => {
+		// Only fetch if we have a valid postId
+		if ( ! postId || typeof postId !== 'number' ) {
+			return;
+		}
+
+		// Fetch comments using apiFetch
+		apiFetch( {
+			path: `/wp/v2/comments?post=${ postId }&type=note&status=all&per_page=100`,
+		} )
+			.then( ( comments ) => {
+				setThreads( comments );
+			} )
+			.catch( () => {
+				setThreads( [] );
+			} );
+	}, [ postId ] );
+
+	// Process comments to build the tree structure and map to blocks
+	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
+		if ( ! threads || threads.length === 0 ) {
+			return { resultComments: [], unresolvedSortedThreads: [] };
+		}
+
+		// Map clientIds to their comment IDs via metadata.noteId
+		const blocksWithComments = clientIds.reduce( ( results, clientId ) => {
+			const commentId = getBlockAttributes( clientId )?.metadata?.noteId;
+			if ( commentId ) {
+				results[ clientId ] = commentId;
+			}
+			return results;
+		}, {} );
+
+		// Create a map to store references to all comment objects by id
+		const compare = {};
+		const result = [];
+
+		// Create a reverse map for faster lookup (commentId -> clientId)
+		const commentIdToBlockClientId = Object.keys(
+			blocksWithComments
+		).reduce( ( mapping, clientId ) => {
+			mapping[ blocksWithComments[ clientId ] ] = clientId;
+			return mapping;
+		}, {} );
+
+		// Initialize each comment object with an empty `reply` array and map blockClientId
+		threads.forEach( ( item ) => {
+			const itemBlock = commentIdToBlockClientId[ item.id ];
+
+			compare[ item.id ] = {
+				...item,
+				reply: [],
+				blockClientId: item.parent === 0 ? itemBlock : null,
+			};
+		} );
+
+		// Build the tree structure by linking replies to their parents
+		threads.forEach( ( item ) => {
+			if ( item.parent === 0 ) {
+				// If parent is 0, it's a root item
+				result.push( compare[ item.id ] );
+			} else if ( compare[ item.parent ] ) {
+				// Otherwise, add to parent's reply array
+				compare[ item.parent ].reply.push( compare[ item.id ] );
+			}
+		} );
+
+		if ( 0 === result?.length ) {
+			return { resultComments: [], unresolvedSortedThreads: [] };
+		}
+
+		// Reverse replies so newest are at the top
+		const updatedResult = result.map( ( item ) => ( {
+			...item,
+			reply: [ ...item.reply ].reverse(),
+		} ) );
+
+		// Create a map for quick thread lookup
+		const threadIdMap = new Map(
+			updatedResult.map( ( thread ) => [ String( thread.id ), thread ] )
+		);
+
+		// Determine which threads are linked to existing blocks
+		const mappedIds = new Set(
+			Object.values( blocksWithComments ).map( ( id ) => String( id ) )
+		);
+
+		// Get unresolved comments by block order
+		const unresolvedSortedComments = Object.values( blocksWithComments )
+			.map( ( commentId ) => threadIdMap.get( String( commentId ) ) )
+			.filter(
+				( thread ) => thread !== undefined && thread.status === 'hold'
+			);
+
+		// Get resolved comments by block order
+		const resolvedSortedComments = Object.values( blocksWithComments )
+			.map( ( commentId ) => threadIdMap.get( String( commentId ) ) )
+			.filter(
+				( thread ) =>
+					thread !== undefined && thread.status === 'approved'
+			);
+
+		// Append orphaned notes (whose related block was deleted or missing)
+		const orphanedComments = updatedResult.filter(
+			( thread ) => ! mappedIds.has( String( thread.id ) )
+		);
+
+		const allSortedComments = [
+			...unresolvedSortedComments,
+			...resolvedSortedComments,
+			...orphanedComments,
+		];
+
+		return {
+			resultComments: allSortedComments,
+			unresolvedSortedThreads: unresolvedSortedComments,
+		};
+	}, [ threads, clientIds, getBlockAttributes ] );
+
+	return {
+		resultComments,
+		unresolvedSortedThreads,
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes  https://github.com/WordPress/gutenberg/issues/73956
- Related https://github.com/WordPress/gutenberg/issues/73417
- Related https://github.com/WordPress/gutenberg/issues/73414

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Add indicator for faster classification of commented blocks. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds indicator in the block list view on the right hand side
- Adds indicator directly into the editor without the need for side panel to be open

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add notes on multiple blocks.
- Save post and reload.
- New indicator should be visible on the list view and editor iframe.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1470" height="807" alt="Screenshot 2026-01-06 at 5 30 13 PM" src="https://github.com/user-attachments/assets/397017e3-48f7-4bdb-a05a-26326a1c1929" />

