### PR TITLE
Theme: Update semibold font weight to apply workaround at CSS

### DIFF
--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -38,6 +38,28 @@ export default defineConfig( {
 		pluginCSS( {
 			filename: 'css/design-tokens.css',
 			variableName: ( token ) => makeCSSVar( token.id ),
+			// See: https://github.com/terrazzoapp/terrazzo/pull/632
+			// @ts-expect-error - Valid return types excluded from package types.
+			transform( token ) {
+				// This addresses a specific browser issue where Chrome renders
+				// a font-weight of 500 as 600 instead of 400 when the target
+				// weight is not locally available, which is inconsistent with
+				// the spec-defined behavior. This workaround ensures that a 400
+				// weight is used if the 500 weight is not locally available,
+				// while still using the 500 weight if it _is_ available. This
+				// is applied at the plugin layer to ensure the original token
+				// value can be preserved at the intended 500 weight, where the
+				// bug only occurs in specific browser rendering.
+				//
+				// See: https://issues.chromium.org/issues/40552893
+				// See: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight#fallback_weights
+				if (
+					token.id.startsWith( 'wpds-font.weight.' ) &&
+					token.$value === 500
+				) {
+					return '499';
+				}
+			},
 			baseSelector: ':root',
 			modeSelectors: [
 				{

--- a/packages/theme/tokens/typography.json
+++ b/packages/theme/tokens/typography.json
@@ -102,7 +102,7 @@
 				"$description": "Regular font weight for body text"
 			},
 			"medium": {
-				"$value": 499,
+				"$value": 500,
 				"$description": "Medium font weight for emphasis and headings"
 			},
 			"$extensions": {


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/73931#discussion_r2611949330

Updates typography design tokens to specify semibold font weight as the desired `500` in design tokens source of truth, while still maintaining browser-specific workaround at the CSS level.

## Why?

Ensures that design tokens accurately reflect the intended font weight while maintaining expected behavior in the browser.

## How?

Conditionally applies [`transform`](https://terrazzo.app/docs/integrations/css/#transform) in Terrazzo's CSS plugin configuration.

## Testing Instructions

`npm run --workspace @wordpress/theme build` should produce no local changes, indicating that the prebuilt CSS still includes the expected `499` value:

https://github.com/WordPress/gutenberg/blob/e82e2b9b88fd7a00384487ef47f5ffc3fcdfd09e/packages/theme/src/prebuilt/css/design-tokens.css#L155