### PR TITLE
Real-time collaboration: Update long-polling POC to use short-polling and post meta

### DIFF
--- a/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
@@ -336,8 +336,11 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 		$messages = $this->get_new_messages( $room, $client_id, $last_message_id );
 		$this->debug_log( 'Fetched ' . count( $messages ) . ' new messages for room ' . $room . '; last_id=' . $last_message_id );
 
-		return new WP_REST_Response( [
-			'messages' => $messages,
-		], 200 );
+		return new WP_REST_Response(
+			array(
+				'messages' => $messages,
+			),
+			200
+		);
 	}
 }

--- a/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
@@ -1,18 +1,17 @@
 <?php
 /**
- * Gutenberg_HTTP_SSE_Sync_Server class
+ * Gutenberg_HTTP_Polling_Sync_Server class
  *
  * @package Gutenberg
  */
 
 /**
- * Gutenberg class that contains an HTTP-based SSE server used for collaborative
- * editing.
+ * Gutenberg class that contains an HTTP server used for collaborative editing.
  *
  * @access private
  * @internal
  */
-class Gutenberg_HTTP_SSE_Sync_Server {
+class Gutenberg_HTTP_Polling_Sync_Server {
 	/**
 	 * Cache expiration time in seconds
 	 */
@@ -22,11 +21,6 @@ class Gutenberg_HTTP_SSE_Sync_Server {
 	 * Cache key prefix
 	 */
 	const CACHE_PREFIX = 'gutenberg_sse_sync_';
-
-	/**
-	 * Maximum client connection time in seconds
-	 */
-	const MAX_CONNECTION_TIME_IN_S = 60;
 
 	/**
 	 * Register REST API routes.
@@ -165,7 +159,7 @@ class Gutenberg_HTTP_SSE_Sync_Server {
 	}
 
 	/**
-	 * Handle all requests (both SSE connections and message posting).
+	 * Handle all requests (both polling connections and message posting).
 	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return WP_REST_Response|WP_Error Response object or error.
@@ -285,7 +279,7 @@ class Gutenberg_HTTP_SSE_Sync_Server {
 	 */
 	private function debug_log( string $message ): void {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( '[Gutenberg SSE Sync] ' . $message );
+			error_log( '[Gutenberg Sync] ' . $message );
 		}
 	}
 
@@ -334,61 +328,16 @@ class Gutenberg_HTTP_SSE_Sync_Server {
 	 * @param string $room      Room identifier.
 	 * @param int    $client_id Client identifier.
 	 * @param int    $last_message_id Last message ID received.
-	 * @return WP_REST_Response Response with SSE stream.
+	 * @return WP_REST_Response
 	 */
-	private function poll_for_messages( string $room, int $client_id, int $last_message_id = 0 ) {
+	private function poll_for_messages( string $room, int $client_id, int $last_message_id = 0 ): WP_REST_Response {
 		header( 'Cache-Control: no-store' );
-		header( 'Connection: keep-alive' );
-		header( 'Content-Type: text/event-stream' );
-		header( 'X-Accel-Buffering: no' ); // Disable Nginx buffering
 
-		// Disable output buffering and compression.
-		ini_set( 'output_buffering', 'off' );
-		ini_set( 'zlib.output_compression', false );
+		$messages = $this->get_new_messages( $room, $client_id, $last_message_id );
+		$this->debug_log( 'Fetched ' . count( $messages ) . ' new messages for room ' . $room . '; last_id=' . $last_message_id );
 
-		// Check if there are other active clients, if this is the only client,
-		// implement lazy connection. The client will reconnect after a timeout.
-		if ( 0 === count( self::get_new_messages( $room, $client_id, $last_message_id ) ) ) {
-			echo 'data: ' . wp_json_encode( array() ) . "\n\n";
-			flush();
-			exit;
-		}
-
-		$start_time = time();
-
-		// Send initial connection message
-		echo 'data: ' . wp_json_encode( array( 'messages' => array() ) ) . "\n\n";
-		flush();
-
-		// Keep connection alive and send messages
-		while ( true ) {
-			// Check if client is still connected (basic check)
-			if ( connection_aborted() || ( time() - $start_time ) > self::MAX_CONNECTION_TIME_IN_S ) {
-				break;
-			}
-
-			$messages = $this->get_new_messages( $room, $client_id, $last_message_id );
-
-			if ( count( $messages ) > 0 ) {
-				$this->debug_log( 'Fetched ' . count( $messages ) . ' new messages for room ' . $room . '; last_id=' . $last_message_id );
-
-				// Send messages.
-				echo 'data: ' . wp_json_encode( array( 'messages' => $messages ) ) . "\n\n";
-				flush();
-
-				// Update last message ID
-				$last_message    = end( $messages );
-				$last_message_id = $last_message['id'] ?? $last_message_id;
-			} else {
-				// Send heartbeat to keep connection alive. We do not expect a response.
-				echo "heartbeat: ping\n\n";
-				flush();
-			}
-
-			// Sleep briefly before checking again
-			usleep( 100000 ); // 100ms
-		}
-
-		exit;
+		return new WP_REST_Response( [
+			'messages' => $messages,
+		], 200 );
 	}
 }

--- a/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
@@ -13,14 +13,78 @@
  */
 class Gutenberg_HTTP_Polling_Sync_Server {
 	/**
-	 * Cache expiration time in seconds
+	 * Post type for sync storage
 	 */
-	const CACHE_EXPIRATION_IN_S = 300;
+	const POST_TYPE = 'sync_messages';
 
 	/**
-	 * Cache key prefix
+	 * Singleton post ID for storing sync data
+	 *
+	 * @var int|null
 	 */
-	const CACHE_PREFIX = 'gutenberg_sse_sync_';
+	private static $storage_post_id = null;
+
+	/**
+	 * Register the custom post type for sync storage.
+	 */
+	public function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'public'             => false,
+				'publicly_queryable' => false,
+				'show_ui'            => false,
+				'show_in_menu'       => false,
+				'show_in_rest'       => false,
+				'capability_type'    => 'post',
+				'map_meta_cap'       => true,
+				'supports'           => array( 'custom-fields' ),
+				'label'              => 'Gutenberg Sync Storage',
+			)
+		);
+	}
+
+	/**
+	 * Get or create the singleton post for storing sync data.
+	 *
+	 * @return int Post ID.
+	 */
+	private function get_storage_post_id(): int {
+		if ( is_int( self::$storage_post_id ) ) {
+			return self::$storage_post_id;
+		}
+
+		// Try to find existing post
+		$posts = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		if ( ! empty( $posts ) ) {
+			self::$storage_post_id = $posts[0]->ID;
+			return self::$storage_post_id;
+		}
+
+		// Create new post if none exists
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Gutenberg Sync Storage',
+			)
+		);
+
+		if ( ! is_wp_error( $post_id ) ) {
+			self::$storage_post_id = $post_id;
+		}
+
+		return self::$storage_post_id;
+	}
 
 	/**
 	 * Register REST API routes.
@@ -188,29 +252,13 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 	}
 
 	/**
-	 * Get a value from the store.
+	 * Get the meta key for a room's messages.
 	 *
-	 * @param string $cache_key     Cache key.
-	 * @param bool   $force_refresh Whether to force refresh from store.
-	 * @return mixed Cached value.
+	 * @param string $room Room identifier.
+	 * @return string Meta key.
 	 */
-	private function get_value( string $cache_key, bool $force_refresh = true ): mixed {
-		if ( $force_refresh ) {
-			// Delete from object cache to force fresh read from database.
-			wp_cache_delete( '_transient_' . $cache_key, 'options' );
-		}
-
-		return get_transient( $cache_key );
-	}
-
-	/**
-	 * Set a value in the store.
-	 *
-	 * @param string $cache_key Cache key.
-	 * @param mixed  $value     Value to cache.
-	 */
-	private function set_value( string $cache_key, mixed $value ): void {
-		set_transient( $cache_key, $value, self::CACHE_EXPIRATION_IN_S );
+	private function get_room_meta_key( string $room ): string {
+		return 'sync_message_' . $room;
 	}
 
 	/**
@@ -220,56 +268,30 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 	 * @param array  $message Message data.
 	 */
 	private function add_message_to_room( string $room, array $message ): void {
-		$cache_key = $this->get_messages_cache_key( $room );
-		$messages  = $this->get_value( $cache_key );
+		$post_id  = $this->get_storage_post_id();
+		$meta_key = $this->get_room_meta_key( $room );
 
-		if ( ! $messages || ! is_array( $messages ) ) {
-			$messages = array();
+		// Get existing messages.
+		$messages = get_post_meta( $post_id, $meta_key, false );
+
+		// Get the last message to determine next ID.
+		$last_message    = end( $messages );
+		$last_message_id = isset( $last_message['id'] ) ? $last_message['id'] : 0;
+
+		// If this is a full state, confirm that it reflects all of our existing
+		// messages. If so, delete them.
+		if ( $message['is_full_state'] && $message['last_message_id'] >= $last_message_id ) {
+			$this->debug_log( 'Full state received for room ' . $room . ', deleting existing messages' );
+			delete_post_meta( $post_id, $meta_key );
+			$last_message_id = 0;
 		}
 
-		// Add message with incremented ID
-		$last_message  = end( $messages );
-		$message['id'] = isset( $last_message['id'] ) ? $last_message['id'] + 1 : 1;
-		$messages[]    = $message;
+		$message['id'] = $last_message_id + 1;
 
-		$prev_count = count( $messages );
+		// Add the new message (single=false means it's added as a new value)
+		add_post_meta( $post_id, $meta_key, $message, false );
 
-		if ( $message['is_full_state'] && $message['last_message_id'] > 0 ) {
-			$messages = $this->cleanup_old_messages( $messages );
-		}
-
-		$count = count( $messages );
-		if ( $count < $prev_count ) {
-			$this->debug_log( 'Cleaned up ' . ( $prev_count - $count ) . ' old messages in room ' . $room );
-		}
-
-		$this->debug_log( 'Added message ID ' . $message['id'] . ' to room ' . $room . '; count=' . $count );
-		$this->set_value( $cache_key, $messages );
-	}
-
-	/**
-	 * Clean up old messages based on the latest full-state snapshot.
-	 *
-	 * @param array  $messages Current messages array.
-	 * @return array Cleaned messages array.
-	 */
-	private function cleanup_old_messages( array $messages ): array {
-		$previous_last_message_id = 0;
-
-		foreach ( $messages as $message ) {
-			if ( $message['is_full_state'] ?? false ) {
-				if ( $message['last_message_id'] > $previous_last_message_id ) {
-					$previous_last_message_id = $message['last_message_id'];
-				}
-			}
-		}
-
-		return array_filter(
-			$messages,
-			function ( $message ) use ( $previous_last_message_id ) {
-				return $message['id'] > $previous_last_message_id;
-			}
-		);
+		$this->debug_log( 'Added message ID ' . $message['id'] . ' to room ' . $room . '; count=' . $last_message_id );
 	}
 
 	/**
@@ -284,16 +306,6 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 	}
 
 	/**
-	 * Get the cache key for a room's messages
-	 *
-	 * @param string $room Room identifier.
-	 * @return string Cache key.
-	 */
-	private function get_messages_cache_key( string $room ): string {
-		return self::CACHE_PREFIX . "messages_{$room}";
-	}
-
-	/**
 	 * Get new messages from a room since a given message ID.
 	 *
 	 * @param string $room           Room identifier.
@@ -302,14 +314,17 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 	 * @return array Array of messages.
 	 */
 	private function get_new_messages( string $room, int $client_id, int $last_message_id = 0 ): array {
-		$cache_key = $this->get_messages_cache_key( $room );
-		$messages  = $this->get_value( $cache_key );
+		$post_id  = $this->get_storage_post_id();
+		$meta_key = $this->get_room_meta_key( $room );
+
+		// Get all messages for this room (single=false returns array of all values)
+		$messages = get_post_meta( $post_id, $meta_key, false );
 
 		if ( ! $messages || ! is_array( $messages ) ) {
 			return array();
 		}
 
-		// Filter messages newer than last_message_id
+		// Filter messages newer than last_message_id and not from this client
 		$new_messages = array_filter(
 			$messages,
 			function ( $message ) use ( $client_id, $last_message_id ) {

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -24,6 +24,20 @@ function gutenberg_rest_api_init_collaborative_editing() {
 add_action( 'admin_init', 'gutenberg_rest_api_init_collaborative_editing' );
 
 /**
+ * Registers the custom post type for sync storage.
+ */
+function gutenberg_rest_api_register_sync_post_type(): void {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( ! $gutenberg_experiments || ! array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
+		return;
+	}
+
+	$sse_sync_server = new Gutenberg_HTTP_Polling_Sync_Server();
+	$sse_sync_server->register_post_type();
+}
+add_action( 'init', 'gutenberg_rest_api_register_sync_post_type' );
+
+/**
  * Registers REST API routes for collaborative editing.
  */
 function gutenberg_rest_api_register_routes_for_collaborative_editing(): void {

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -32,7 +32,7 @@ function gutenberg_rest_api_register_routes_for_collaborative_editing(): void {
 		return;
 	}
 
-	$sse_sync_server = new Gutenberg_HTTP_SSE_Sync_Server();
+	$sse_sync_server = new Gutenberg_HTTP_Polling_Sync_Server();
 	$sse_sync_server->register_routes();
 
 	// Provide a nonce for the EventSteam connection.

--- a/lib/load.php
+++ b/lib/load.php
@@ -90,9 +90,9 @@ if ( ! class_exists( 'Gutenberg_HTTP_Singling_Server' ) ) {
 	require_once __DIR__ . '/experimental/sync/class-gutenberg-http-signaling-server.php';
 }
 
-// Experimental SSE sync server.
-if ( ! class_exists( 'Gutenberg_HTTP_SSE_Sync_Server' ) ) {
-	require_once __DIR__ . '/experimental/sync/class-gutenberg-http-sse-sync-server.php';
+// Experimental polling sync server.
+if ( ! class_exists( 'Gutenberg_HTTP_Polling_Sync_Server' ) ) {
+	require_once __DIR__ . '/experimental/sync/class-gutenberg-http-polling-sync-server.php';
 }
 
 require_once __DIR__ . '/experimental/editor-settings.php';

--- a/packages/sync/src/providers/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling-provider.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as Y from 'yjs';
+import type * as Y from 'yjs';
 import * as encoding from 'lib0/encoding';
 import * as decoding from 'lib0/decoding';
 import * as syncProtocol from 'y-protocols/sync';
@@ -21,7 +21,6 @@ interface HttpPollingProviderOptions {
 	debug?: boolean;
 	doc: Y.Doc;
 	endpoint: string;
-	fullStateIntervalInMs?: number;
 	pollingIntervalInMs?: number;
 	room: string;
 }
@@ -40,7 +39,6 @@ interface SyncMessagePayload {
 	room: string;
 }
 
-const DEFAULT_FULL_STATE_INTERVAL_IN_MS = 30000;
 const DEFAULT_POLLING_INTERVAL_IN_MS = 200;
 
 /**
@@ -55,7 +53,6 @@ export class HttpPollingProvider extends Observable< string > {
 	private seenMessages = new Set< number >();
 	private synced = false;
 
-	private fullStateTimeout?: NodeJS.Timeout;
 	private pollingTimeout?: NodeJS.Timeout;
 
 	public constructor( options: HttpPollingProviderOptions ) {
@@ -72,15 +69,6 @@ export class HttpPollingProvider extends Observable< string > {
 	 * Connect to the endpoint and initialize sync.
 	 */
 	public connect(): void {
-		// Set up periodic full state sending (every 30 seconds)
-		if ( ! this.fullStateTimeout ) {
-			this.fullStateTimeout = setInterval(
-				this.sendFullState.bind( this ),
-				this.options.fullStateIntervalInMs ??
-					DEFAULT_FULL_STATE_INTERVAL_IN_MS
-			);
-		}
-
 		this.log( 'Initializing polling' );
 		this.pollForMessages();
 
@@ -99,7 +87,6 @@ export class HttpPollingProvider extends Observable< string > {
 		this.emitStatus( 'disconnected' );
 		this.options.doc.off( 'update', this.onDocUpdate );
 
-		clearInterval( this.fullStateTimeout );
 		clearInterval( this.pollingTimeout );
 
 		super.destroy();
@@ -286,16 +273,6 @@ export class HttpPollingProvider extends Observable< string > {
 			.catch( ( error ) => {
 				this.log( 'Error sending message to server', { error } );
 			} );
-	}
-
-	/**
-	 * Send the full document state to the server.
-	 */
-	private sendFullState(): void {
-		const state = Y.encodeStateAsUpdateV2( this.options.doc );
-		const encoder = encoding.createEncoder();
-		syncProtocol.writeUpdate( encoder, state );
-		this.sendEncodedMessage( state, true );
 	}
 
 	/**

--- a/packages/sync/src/providers/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling-provider.ts
@@ -17,7 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import type { ProviderCreator, ProviderCreatorResult } from '../types';
 
-interface HttpSseProviderOptions {
+interface HttpPollingProviderOptions {
 	debug?: boolean;
 	doc: Y.Doc;
 	endpoint: string;
@@ -48,8 +48,8 @@ const DEFAULT_RECONNECT_INTERVAL_IN_MS = 5000;
  * Unlike WebRTC, this provider communicates through a central server
  * which manages rooms and broadcasts updates to all connected clients.
  */
-export class HttpSseProvider extends Observable< string > {
-	private options: HttpSseProviderOptions;
+export class HttpPollingProvider extends Observable< string > {
+	private options: HttpPollingProviderOptions;
 
 	private eventSource: EventSource | null = null;
 	private lastMessageId = 0;
@@ -59,7 +59,7 @@ export class HttpSseProvider extends Observable< string > {
 	private fullStateTimeout?: NodeJS.Timeout;
 	private reconnectTimeout?: NodeJS.Timeout;
 
-	public constructor( options: HttpSseProviderOptions ) {
+	public constructor( options: HttpPollingProviderOptions ) {
 		super();
 
 		this.options = options;
@@ -151,7 +151,7 @@ export class HttpSseProvider extends Observable< string > {
 	private log( message: string, debug: object = {} ): void {
 		if ( this.options.debug ) {
 			// eslint-disable-next-line no-console
-			console.log( `[HttpSseProvider]: ${ message }`, {
+			console.log( `[HttpPollingProvider]: ${ message }`, {
 				room: this.options.room,
 				...debug,
 			} );
@@ -334,18 +334,18 @@ export class HttpSseProvider extends Observable< string > {
 	}
 }
 
-type CreateHttpSseProviderOptions = Omit<
-	HttpSseProviderOptions,
+type CreateHttpPollingProviderOptions = Omit<
+	HttpPollingProviderOptions,
 	'doc' | 'room'
 >;
 
 /**
- * Create a provider creator function for the HttpSseProvider
+ * Create a provider creator function for the HttpPollingProvider
  *
- * @param {CreateHttpSseProviderOptions} options Options for the HttpSseProvider excluding doc and room
+ * @param {CreateHttpPollingProviderOptions} options Options for the HttpPollingProvider excluding doc and room
  */
-export function createHttpSseProvider(
-	options: CreateHttpSseProviderOptions
+export function createHttpPollingProvider(
+	options: CreateHttpPollingProviderOptions
 ): ProviderCreator {
 	return async (
 		objectType: string,
@@ -354,7 +354,7 @@ export function createHttpSseProvider(
 	): Promise< ProviderCreatorResult > => {
 		// Generate room name from objectType and objectId
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
-		const provider = new HttpSseProvider( {
+		const provider = new HttpPollingProvider( {
 			...options,
 			debug: false,
 			doc,

--- a/packages/sync/src/providers/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling-provider.ts
@@ -22,7 +22,7 @@ interface HttpPollingProviderOptions {
 	doc: Y.Doc;
 	endpoint: string;
 	fullStateIntervalInMs?: number;
-	reconnectIntervalInMs?: number;
+	pollingIntervalInMs?: number;
 	room: string;
 }
 
@@ -41,7 +41,7 @@ interface SyncMessagePayload {
 }
 
 const DEFAULT_FULL_STATE_INTERVAL_IN_MS = 30000;
-const DEFAULT_RECONNECT_INTERVAL_IN_MS = 5000;
+const DEFAULT_POLLING_INTERVAL_IN_MS = 200;
 
 /**
  * Yjs provider that uses HTTP SSE for real-time synchronization.
@@ -51,13 +51,12 @@ const DEFAULT_RECONNECT_INTERVAL_IN_MS = 5000;
 export class HttpPollingProvider extends Observable< string > {
 	private options: HttpPollingProviderOptions;
 
-	private eventSource: EventSource | null = null;
 	private lastMessageId = 0;
 	private seenMessages = new Set< number >();
 	private synced = false;
 
 	private fullStateTimeout?: NodeJS.Timeout;
-	private reconnectTimeout?: NodeJS.Timeout;
+	private pollingTimeout?: NodeJS.Timeout;
 
 	public constructor( options: HttpPollingProviderOptions ) {
 		super();
@@ -73,14 +72,6 @@ export class HttpPollingProvider extends Observable< string > {
 	 * Connect to the endpoint and initialize sync.
 	 */
 	public connect(): void {
-		if ( ! this.reconnectTimeout ) {
-			this.reconnectTimeout = setInterval(
-				this.connect.bind( this ),
-				this.options.reconnectIntervalInMs ??
-					DEFAULT_RECONNECT_INTERVAL_IN_MS
-			);
-		}
-
 		// Set up periodic full state sending (every 30 seconds)
 		if ( ! this.fullStateTimeout ) {
 			this.fullStateTimeout = setInterval(
@@ -90,31 +81,13 @@ export class HttpPollingProvider extends Observable< string > {
 			);
 		}
 
-		const readyState = this.eventSource?.readyState;
-		if ( 0 === readyState || 1 === readyState ) {
-			this.log( 'Already connected or connecting to endpoint', {
-				readyState,
-			} );
-			return;
-		}
+		this.log( 'Initializing polling' );
+		this.pollForMessages();
 
-		this.log( 'Connecting to endpoint' );
+		// Send initial sync
+		this.sendSyncStep1();
 
-		// Setup EventSource for receiving messages
-		const url = addQueryArgs( this.options.endpoint, {
-			// @ts-ignore
-			_wpnonce: globalThis.__experimentalCollaborativeEditingNonce ?? '',
-			client_id: this.options.doc.clientID,
-			last_message_id: this.lastMessageId,
-			room: this.options.room,
-		} );
-
-		this.eventSource?.close();
-		this.eventSource = new EventSource( url, { withCredentials: true } );
-
-		this.eventSource.onerror = this.onEventSourceError.bind( this );
-		this.eventSource.onopen = this.onEventSourceOpen.bind( this );
-		this.eventSource.onmessage = this.onEventSourceMessage.bind( this );
+		this.emitStatus( 'connected' );
 	}
 
 	/**
@@ -123,12 +96,11 @@ export class HttpPollingProvider extends Observable< string > {
 	public destroy(): void {
 		this.log( 'Disconnecting' );
 
-		this.eventSource?.close();
 		this.emitStatus( 'disconnected' );
 		this.options.doc.off( 'update', this.onDocUpdate );
 
 		clearInterval( this.fullStateTimeout );
-		clearInterval( this.reconnectTimeout );
+		clearInterval( this.pollingTimeout );
 
 		super.destroy();
 	}
@@ -177,58 +149,60 @@ export class HttpPollingProvider extends Observable< string > {
 		this.sendEncodedMessage( encoding.toUint8Array( encoder ) );
 	};
 
-	/**
-	 * Handle EventSource errors and attempt to reconnect. NOTE: If the connection
-	 * closes for any reason -- even an expected reason like the server closing the
-	 * connection after a time limit is reached -- an error event is emitted. The
-	 * error event is a generic event with no useful information, so it is not
-	 * inspected.
-	 */
-	private onEventSourceError = (): void => {
-		this.log( 'SSE connection error', {
-			readystate: this.eventSource?.readyState,
+	/* END bound arrow functions */
+
+	private pollForMessages(): void {
+		clearTimeout( this.pollingTimeout );
+
+		const url = addQueryArgs( this.options.endpoint, {
+			// @ts-ignore
+			_wpnonce: globalThis.__experimentalCollaborativeEditingNonce ?? '',
+			client_id: this.options.doc.clientID,
+			last_message_id: this.lastMessageId,
+			room: this.options.room,
 		} );
 
-		this.connect();
-	};
+		globalThis
+			.fetch( url, {
+				method: 'GET',
+				credentials: 'include',
+				headers: {
+					'X-WP-Nonce':
+						// @ts-ignore
+						globalThis.__experimentalCollaborativeEditingNonce ??
+						'',
+				},
+			} )
+			.then( async ( response: Response ) => {
+				if ( ! response.ok ) {
+					throw new Error(
+						`HTTP error! status: ${ response.status }`
+					);
+				}
 
-	/**
-	 * Handle EventSource open event and initiate sync.
-	 */
-	private onEventSourceOpen = (): void => {
-		this.log( 'Connection opened' );
-		this.emitStatus( 'connected' );
+				const data = await response.json();
+				if ( Array.isArray( data.messages ) ) {
+					data.messages.forEach( ( message: SyncMessage ) => {
+						this.processMessage( message );
+					} );
+				}
+			} )
+			.catch( ( error ) => {
+				this.log( 'Polling error', { error } );
+			} );
 
-		// Send initial sync
-		this.sendSyncStep1();
-	};
-
-	/**
-	 * Handle incoming EventSource messages.
-	 *
-	 * @param {MessageEvent} event The incoming message event
-	 */
-	private onEventSourceMessage = ( event: MessageEvent ): void => {
-		try {
-			const data = JSON.parse( event.data );
-			if ( Array.isArray( data.messages ) ) {
-				data.messages.forEach( ( message: any ) => {
-					this.processEventSourceMessage( message );
-				} );
-			}
-		} catch ( error ) {
-			this.log( 'Error parsing SSE message', { error } );
-		}
-	};
-
-	/* END bound arrow functions */
+		this.pollingTimeout = setTimeout(
+			this.pollForMessages.bind( this ),
+			this.options.pollingIntervalInMs ?? DEFAULT_POLLING_INTERVAL_IN_MS
+		);
+	}
 
 	/**
 	 * Process incoming messages from the server
 	 *
 	 * @param {SyncMessage} message The incoming sync message
 	 */
-	private processEventSourceMessage( message: SyncMessage ): void {
+	private processMessage( message: SyncMessage ): void {
 		if ( message.from === this.options.doc.clientID ) {
 			this.log( 'Ignoring own message', { messageId: message.id } );
 			return;

--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -6,9 +6,9 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import { createHttpPollingProvider } from './http-polling-provider';
 import { createIndexedDbProvider } from './indexeddb-provider';
 import { createWebRTCProvider } from './webrtc-provider';
-import { createHttpSseProvider } from './http-sse-provider';
 import type { ProviderCreator } from '../types';
 
 let providerCreators: ProviderCreator[] | null = null;
@@ -21,7 +21,7 @@ let providerCreators: ProviderCreator[] | null = null;
  */
 function getDefaultProviderCreators(): ProviderCreator[] {
 	return [
-		createHttpSseProvider( {
+		createHttpPollingProvider( {
 			// @ts-ignore
 			endpoint: window.__experimentalCollaborativeEditingApiUrl,
 		} ),
@@ -70,4 +70,8 @@ export function getProviderCreators(): ProviderCreator[] {
 /**
  * Export provider creators for direct use
  */
-export { createIndexedDbProvider, createWebRTCProvider, createHttpSseProvider };
+export {
+	createIndexedDbProvider,
+	createWebRTCProvider,
+	createHttpPollingProvider,
+};


### PR DESCRIPTION

## What?

Update the [long-polling proof-of-concept](https://github.com/WordPress/gutenberg/pull/74331) to:

1. use short-polling
2. store messages in post meta instead of transients

## Why?

### Long-polling => short-polling

Per [@dmonad's comment on this issue](https://github.com/WordPress/gutenberg/issues/74085#issuecomment-3670177057), a long-polling transport may not be workable on some hosts because it requires:

1. a reasonably long max connection time
   - In practice, we are probably fine with any value >=15s
2. correct handling of `Keep-Alive`
   - In practice, we can implement heartbeat events to sidestep this
3. no output buffering

The requirements apply not just to the server running WordPress, but to every reverse proxy, caching proxy, load balancer, etc., between the server and the client.

We can reasonably work around 1 and 2, but 3 poses a problem. We can issue directives honored by some proxies, but our directives might be ignored or removed en route.

A short-polling approach may prove to the be least common denominator.

### Transients => post meta

Separately, [transients are not an ideal persistence target](https://github.com/WordPress/gutenberg/pull/74331#issuecomment-3710938025) for sync messages.

Post meta is a poor conceptual choice given WordPress's content model, but its durablity and database schema are ideal. We can store messages atomically in post meta values and remove the need to periodically send the full state from each client.

## How?

1. Adapt the long-polling / SSE provider to use short-polling instead.
2. Store sync messages in post meta.

## Testing Instructions

1. Check out this PR.
2. Enable on the collaborative editing experiment (Gutenberg > Experiments).
3. Open a post for editing in two browsers.
