### PR TITLE
List View Panel: Fix circular dependency issue that was breaking some Storybook stories

### DIFF
--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -11,10 +11,7 @@ import { store as blocksStore, hasBlockSupport } from '@wordpress/blocks';
  */
 import InspectorControls from '../components/inspector-controls';
 import { store as blockEditorStore } from '../store';
-import { privateApis } from '../private-apis';
-import { unlock } from '../lock-unlock';
-
-const { PrivateListView } = unlock( privateApis );
+import { PrivateListView } from '../components/list-view';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes a regression introduced in https://github.com/WordPress/gutenberg/pull/74120 that caused some Storybook stories to break (I noticed this in the the Fields and Media Fields stories).

Specifically, in the List View Panel, don't attempt to `unlock` the `PrivateListView` component, but simply use it directly as we're already in the block editor package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we're already in the block editor package, we shouldn't be importing and unlocking the private api, since we're already in this package. This caused a circular dependency that was apparent in Storybook's dev mode (but not its build mode). This is the summary that Claude gave me:

"The PR added the packages/block-editor/src/hooks/list-view.js file which created the circular dependency by importing and unlocking privateApis at the module top-level. The issue became more apparent after the Storybook v9 upgrade (PR #74143) on December 31, 2025, which changed webpack's module resolution behavior in dev mode."

## How?

Import the `PrivateListView` component directly instead of attempting to unlock.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test that everything works correctly:

Insert a social icons block and add a few child blocks. Select the parent social icons block and the list view panel should be available (you could also check the Buttons/Button block):

<img width="1408" height="596" alt="image" src="https://github.com/user-attachments/assets/ba297303-67e7-4f68-922f-0b9e040e7696" />

Next up, run `npm run storybook:dev` locally to boot up Storybook. Then navigate to the Fields stories, e.g. this one, and it should render without error: http://localhost:50240/?path=/story/fields-base-fields--data-views-preview

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="3152" height="1948" alt="image" src="https://github.com/user-attachments/assets/3fcd0347-914d-4ebe-ba95-9a92aff4c485" />

### After

<img width="3150" height="1796" alt="image" src="https://github.com/user-attachments/assets/cce5d36d-22a8-44d0-9e1c-54f37d02cf6f" />
