### PR TITLE
Block: memoize canOverrideBlocks

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -149,6 +149,8 @@ function ReusableBlockControl( {
 	);
 }
 
+const EMPTY_OBJECT = {};
+
 function ReusableBlockEdit( {
 	name,
 	attributes: { ref, content },
@@ -171,7 +173,7 @@ function ReusableBlockEdit( {
 	const {
 		onNavigateToEntityRecord,
 		hasPatternOverridesSource,
-		supportedBlockTypes,
+		supportedBlockTypesRaw,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		// For editing link to the site editor if the theme and user permissions support it.
@@ -180,28 +182,28 @@ function ReusableBlockEdit( {
 			hasPatternOverridesSource: !! getBlockBindingsSource(
 				'core/pattern-overrides'
 			),
-			supportedBlockTypes: Object.keys(
+			supportedBlockTypesRaw:
 				getSettings().__experimentalBlockBindingsSupportedAttributes ||
-					{}
-			),
+				EMPTY_OBJECT,
 		};
 	}, [] );
-
-	const hasOverridableBlocks = ( _blocks ) =>
-		_blocks.some( ( block ) => {
-			if (
-				supportedBlockTypes.includes( block.name ) &&
-				isOverridableBlock( block )
-			) {
-				return true;
-			}
-			return hasOverridableBlocks( block.innerBlocks );
-		} );
-
-	const canOverrideBlocks = useMemo(
-		() => hasPatternOverridesSource && hasOverridableBlocks( blocks ),
-		[ hasPatternOverridesSource, hasOverridableBlocks, blocks ]
+	const supportedBlockTypes = useMemo(
+		() => Object.keys( supportedBlockTypesRaw ),
+		[ supportedBlockTypesRaw ]
 	);
+	const canOverrideBlocks = useMemo( () => {
+		const hasOverridableBlocks = ( _blocks ) =>
+			_blocks.some( ( block ) => {
+				if (
+					supportedBlockTypes.includes( block.name ) &&
+					isOverridableBlock( block )
+				) {
+					return true;
+				}
+				return hasOverridableBlocks( block.innerBlocks );
+			} );
+		return hasPatternOverridesSource && hasOverridableBlocks( blocks );
+	}, [ hasPatternOverridesSource, blocks, supportedBlockTypes ] );
 
 	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
 	const layoutClasses = useLayoutClasses( { layout }, name );

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -187,11 +187,9 @@ function ReusableBlockEdit( {
 				EMPTY_OBJECT,
 		};
 	}, [] );
-	const supportedBlockTypes = useMemo(
-		() => Object.keys( supportedBlockTypesRaw ),
-		[ supportedBlockTypesRaw ]
-	);
+
 	const canOverrideBlocks = useMemo( () => {
+		const supportedBlockTypes = Object.keys( supportedBlockTypesRaw );
 		const hasOverridableBlocks = ( _blocks ) =>
 			_blocks.some( ( block ) => {
 				if (
@@ -203,7 +201,7 @@ function ReusableBlockEdit( {
 				return hasOverridableBlocks( block.innerBlocks );
 			} );
 		return hasPatternOverridesSource && hasOverridableBlocks( blocks );
-	}, [ hasPatternOverridesSource, blocks, supportedBlockTypes ] );
+	}, [ hasPatternOverridesSource, blocks, supportedBlockTypesRaw ] );
 
 	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
 	const layoutClasses = useLayoutClasses( { layout }, name );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/73889

Fixes unnecessary recomputation of `canOverrideBlocks` by memoizing `supportedBlockTypes` and moving `hasOverridableBlocks` inside `useMemo`. Previously, `Object.keys()` created a new array reference on every render, causing the memo to recompute.

Noticed while testing https://github.com/WordPress/gutenberg/pull/73863

## Why?

Getting in before @Mamaduka does 😄 

## How?

- Memoize `supportedBlockTypes` separately to ensure stable reference
- Move `hasOverridableBlocks` function inside `useMemo` to avoid recreating it on every render

## Testing Instructions

First ensure that the test steps in https://github.com/WordPress/gutenberg/pull/73889 still work.

It's pretty crude, but I just logged output from inside `canOverrideBlocks` to see when it was firing.

On this branch it only fires when necessary, not on every interaction.

## Screenshots or screencast <!-- if applicable -->


### Before


https://github.com/user-attachments/assets/7ac9a929-3139-4e24-90f4-7e5c515ca7af



### After


https://github.com/user-attachments/assets/e9c80e3d-6870-473c-96f7-8b5b9b97192d


