### PR TITLE
Media Fields: Add "Date added" and "Date modified" fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54091,6 +54091,7 @@
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
 				"@wordpress/dataviews": "file:../dataviews",
+				"@wordpress/date": "file:../date",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dataviews": "file:../dataviews",
+		"@wordpress/date": "file:../date",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",

--- a/packages/media-fields/src/date_added/index.tsx
+++ b/packages/media-fields/src/date_added/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import type { Field } from '@wordpress/dataviews';
 
 /**
@@ -10,20 +10,15 @@ import type { Field } from '@wordpress/dataviews';
  */
 import type { MediaItem } from '../types';
 
-const getFormattedDate = ( dateToDisplay: string | null ) =>
-	dateI18n(
-		getSettings().formats.datetimeAbbreviated,
-		getDate( dateToDisplay )
-	);
-
 const dateAddedField: Partial< Field< MediaItem > > = {
 	id: 'date',
 	type: 'datetime',
 	label: __( 'Date added' ),
-	getValue: ( { item }: { item: MediaItem } ) =>
-		item?.date ? getFormattedDate( item.date ) : '',
 	filterBy: {
 		operators: [ 'before', 'after' ],
+	},
+	format: {
+		datetime: getSettings().formats.datetimeAbbreviated,
 	},
 	readOnly: true,
 };

--- a/packages/media-fields/src/date_added/index.tsx
+++ b/packages/media-fields/src/date_added/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+
+const getFormattedDate = ( dateToDisplay: string | null ) =>
+	dateI18n(
+		getSettings().formats.datetimeAbbreviated,
+		getDate( dateToDisplay )
+	);
+
+const dateAddedField: Partial< Field< MediaItem > > = {
+	id: 'date',
+	type: 'datetime',
+	label: __( 'Date added' ),
+	getValue: ( { item }: { item: MediaItem } ) =>
+		item?.date ? getFormattedDate( item.date ) : '',
+	filterBy: {
+		operators: [ 'before', 'after' ],
+	},
+	readOnly: true,
+};
+
+export default dateAddedField;

--- a/packages/media-fields/src/date_modified/index.tsx
+++ b/packages/media-fields/src/date_modified/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+
+const getFormattedDate = ( dateToDisplay: string | null ) =>
+	dateI18n(
+		getSettings().formats.datetimeAbbreviated,
+		getDate( dateToDisplay )
+	);
+
+const dateModifiedField: Partial< Field< MediaItem > > = {
+	id: 'modified',
+	type: 'datetime',
+	label: __( 'Date modified' ),
+	getValue: ( { item }: { item: MediaItem } ) =>
+		item?.modified ? getFormattedDate( item.modified ) : '',
+	filterBy: {
+		operators: [ 'before', 'after' ],
+	},
+	readOnly: true,
+};
+
+export default dateModifiedField;

--- a/packages/media-fields/src/date_modified/index.tsx
+++ b/packages/media-fields/src/date_modified/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import type { Field } from '@wordpress/dataviews';
 
 /**
@@ -10,20 +10,15 @@ import type { Field } from '@wordpress/dataviews';
  */
 import type { MediaItem } from '../types';
 
-const getFormattedDate = ( dateToDisplay: string | null ) =>
-	dateI18n(
-		getSettings().formats.datetimeAbbreviated,
-		getDate( dateToDisplay )
-	);
-
 const dateModifiedField: Partial< Field< MediaItem > > = {
 	id: 'modified',
 	type: 'datetime',
 	label: __( 'Date modified' ),
-	getValue: ( { item }: { item: MediaItem } ) =>
-		item?.modified ? getFormattedDate( item.modified ) : '',
 	filterBy: {
 		operators: [ 'before', 'after' ],
+	},
+	format: {
+		datetime: getSettings().formats.datetimeAbbreviated,
 	},
 	readOnly: true,
 };

--- a/packages/media-fields/src/index.ts
+++ b/packages/media-fields/src/index.ts
@@ -1,5 +1,7 @@
 export { default as altTextField } from './alt_text';
 export { default as captionField } from './caption';
+export { default as dateAddedField } from './date_added';
+export { default as dateModifiedField } from './date_modified';
 export { default as descriptionField } from './description';
 export { default as filenameField } from './filename';
 export { default as filesizeField } from './filesize';

--- a/packages/media-fields/src/stories/index.story.tsx
+++ b/packages/media-fields/src/stories/index.story.tsx
@@ -11,6 +11,8 @@ import type { Field, View } from '@wordpress/dataviews';
 import {
 	altTextField,
 	captionField,
+	dateAddedField,
+	dateModifiedField,
 	descriptionField,
 	filenameField,
 	filesizeField,
@@ -232,6 +234,8 @@ const showcaseFields = [
 	filenameField,
 	altTextField,
 	captionField,
+	dateAddedField,
+	dateModifiedField,
 	descriptionField,
 	mimeTypeField,
 	mediaDimensionsField,
@@ -259,6 +263,8 @@ const DataFormsComponent = ( { type }: { type: 'regular' | 'panel' } ) => {
 			'mime_type',
 			'media_dimensions',
 			'filesize',
+			'date',
+			'modified',
 		],
 	};
 

--- a/packages/media-fields/tsconfig.json
+++ b/packages/media-fields/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../core-data" },
 		{ "path": "../data" },
 		{ "path": "../dataviews" },
+		{ "path": "../date" },
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -186,9 +186,12 @@ export function MediaUploadModal( {
 				filters.author = filter.value;
 			}
 			// Handle date filters
-			if ( filter.field === 'date' ) {
-				filters.after = filter.value?.after;
-				filters.before = filter.value?.before;
+			if ( filter.field === 'date' || filter.field === 'modified' ) {
+				if ( filter.operator === 'before' ) {
+					filters.before = filter.value;
+				} else if ( filter.operator === 'after' ) {
+					filters.after = filter.value;
+				}
 			}
 			// Handle mime type filters
 			if ( filter.field === 'mime_type' ) {
@@ -329,7 +332,7 @@ export function MediaUploadModal( {
 				showTitle: false,
 			},
 			[ LAYOUT_PICKER_TABLE ]: {
-				fields: [ 'filename', 'filesize', 'media_dimensions' ],
+				fields: [ 'filename', 'filesize', 'media_dimensions', 'date' ],
 				showTitle: true,
 			},
 		} ),

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -15,6 +15,8 @@ import type { View, Field, ActionButton } from '@wordpress/dataviews';
 import {
 	altTextField,
 	captionField,
+	dateAddedField,
+	dateModifiedField,
 	descriptionField,
 	filenameField,
 	filesizeField,
@@ -240,6 +242,8 @@ export function MediaUploadModal( {
 			altTextField as Field< RestAttachment >,
 			captionField as Field< RestAttachment >,
 			descriptionField as Field< RestAttachment >,
+			dateAddedField as Field< RestAttachment >,
+			dateModifiedField as Field< RestAttachment >,
 			filenameField as Field< RestAttachment >,
 			filesizeField as Field< RestAttachment >,
 			mediaDimensionsField as Field< RestAttachment >,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of: #73085

Add readonly "Date added" and "Date modified" media fields for use in the new media library modal (and in the future, a new media editor).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Media / attachment types need a slightly different display and interaction when it comes to dates that differs to how we handle posts. This is clear in the existing media library where the date is displayed in a read only way as `Uploaded on` or `Date`. For clarity, and to match how these fields tend to be handled in file systems, this PR proposes naming them "Date added" and "Date modified".

They should be read only as the date fields for attachment types are intended to be informational (and used for filtering / sorting), rather than to be used for scheduled publishing.

This PR intends these as a starting point — I imagine in subsequent PRs we might tweak the label naming or the date formatting.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add "Date added" and "Date modified" fields, using the `date` and `modified` ids to match the properties in [the media REST API endpoint](https://developer.wordpress.org/rest-api/reference/media/)
* Update the Media fields stories to include these fields
* Update the default display of the table layout of the media upload modal so that it includes the date added field
* Update the filters in the media upload modal so that the before/after filters work for the date added and date modified fields

## Testing Instructions

* To test in Storybook (and see the readonly state) run `npm run storybook:dev` and then navigate to http://localhost:50240/?path=/story/fields-media-fields--data-forms-preview

For testing in the new media library modal experiment, first activate the experiment:

<img width="952" height="69" alt="image" src="https://github.com/user-attachments/assets/e6515adf-9bdd-494e-9ad2-0cd4dfe5b4bb" />

Then, go to add a featured image to a post. Click to switch to the table layout and you should see the "Date added" field displayed by default. Test that the sorting and filters work as expected.

## Screenshots or screencast <!-- if applicable -->

The read only (form) state:

<img width="1484" height="948" alt="image" src="https://github.com/user-attachments/assets/22be7ef5-81ec-42de-aa62-a377986bb082" />

Within a modal:

<img width="2596" height="1302" alt="image" src="https://github.com/user-attachments/assets/dfb1cdf5-0689-40f8-809b-2a37aa088716" />

Using filters:

https://github.com/user-attachments/assets/313e7811-b330-4326-80e8-7f631b647062


