### PR TITLE
E2E utils: remove ts-expect-error for web-vitals

### DIFF
--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-import type { Page, Browser } from '@playwright/test';
 import { join } from 'path';
-// resolution-mode support in TypeScript 5.3 will resolve this.
-// See https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-beta/
-// @ts-expect-error
+import type { Page, Browser } from '@playwright/test';
 import type { Metric } from 'web-vitals';
 
 type EventType =


### PR DESCRIPTION
Fixing something I notices when working on #74348: the `ts-expect-error` directive when importing `web-vitals` is no longer necessary. At least locally. In CI I noticed that the error still happens. So here I'm doing an isolated experiment to figure this out.
