### PR TITLE
Build: Faster repo building in CI

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -42,7 +42,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build
+              run: npm run build -- --fast
 
             - name: Install Playwright dependencies
               run: |
@@ -133,7 +133,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build
+              run: npm run build -- --fast
 
             - name: Report flaky tests
               uses: ./packages/report-flaky-tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -163,7 +163,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Run build scripts
-              run: npm run build
+              run: npm run build -- --fast
 
             - name: Upload built JavaScript assets
               uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -70,7 +70,7 @@ status "Installing dependencies... 📦"
 npm cache verify
 npm ci
 status "Generating build... 👷‍♀️"
-npm run build
+npm run build -- --fast
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"


### PR DESCRIPTION
This PR adds a --fast flag to skip TypeScript steps in CI builds

The build script (bin/build.mjs) includes three TypeScript-related steps: validating the TS version, running tsc --build, and checking type declaration files. These steps are only needed for type checking in the static checks job—they don't produce any artifacts required for running tests or building the plugin ZIP and they are also the steps that take 90% of the `npm run build` command time

This PR adds a --fast flag that skips these steps, and uses it in the e2e tests, unit test build-assets job, and plugin ZIP build. The static checks workflow continues to run the full build with type checking.

