### PR TITLE
Patterns: Improve memoization in the overrides panel

### DIFF
--- a/packages/patterns/src/components/overrides-panel.js
+++ b/packages/patterns/src/components/overrides-panel.js
@@ -19,29 +19,27 @@ import { unlock } from '../lock-unlock';
 const { BlockQuickNavigation } = unlock( blockEditorPrivateApis );
 
 export default function OverridesPanel() {
-	const { allClientIds, supportedBlockTypes } = useSelect(
+	const { allClientIds, supportedBlockTypesRaw } = useSelect(
 		( select ) => ( {
 			allClientIds:
 				select( blockEditorStore ).getClientIdsWithDescendants(),
-			supportedBlockTypes: Object.keys(
+			supportedBlockTypesRaw:
 				select( blockEditorStore ).getSettings()
-					?.__experimentalBlockBindingsSupportedAttributes || {}
-			),
+					?.__experimentalBlockBindingsSupportedAttributes,
 		} ),
 		[]
 	);
 	const { getBlock } = useSelect( blockEditorStore );
-	const clientIdsWithOverrides = useMemo(
-		() =>
-			allClientIds.filter( ( clientId ) => {
-				const block = getBlock( clientId );
-				return (
-					supportedBlockTypes.includes( block.name ) &&
-					isOverridableBlock( block )
-				);
-			} ),
-		[ allClientIds, getBlock, supportedBlockTypes ]
-	);
+	const clientIdsWithOverrides = useMemo( () => {
+		const supportedBlockTypes = Object.keys( supportedBlockTypesRaw ?? {} );
+		return allClientIds.filter( ( clientId ) => {
+			const block = getBlock( clientId );
+			return (
+				supportedBlockTypes.includes( block.name ) &&
+				isOverridableBlock( block )
+			);
+		} );
+	}, [ allClientIds, getBlock, supportedBlockTypesRaw ] );
 
 	if ( ! clientIdsWithOverrides?.length ) {
 		return null;


### PR DESCRIPTION
## What?
PR applies similar optimizations as #74400, fixing the `useSelect` warning and improving memoization for the `OverridesPanel` component.

## Testing Instructions
Ensure panel is displayed correctly per #59977 instructions.

> 1. Create a new pattern and edit it or edit an existing one (this should work in the post or site editors)
> 2. Add paragraph, heading, image or button blocks to the pattern and name them
> 3. Go to the 'Pattern' tab in the inspector and observe the new 'Content' panel
> 4. Click on one of the blocks in the 'Content' panel to edit it.

Confirm there's no warning in DevTools.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="960" height="375" alt="CleanShot 2026-01-07 at 14 05 18" src="https://github.com/user-attachments/assets/898de1df-4be1-4ccd-9173-90b6f9e05350" />
