### PR TITLE
Don't show overlay settings for navigation blocks that are inside oth…

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -107,6 +107,7 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -107,7 +107,6 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
-		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -29,8 +29,6 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
-
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
@@ -499,17 +497,34 @@ function Navigation( {
 		( select ) => {
 			const { getBlockParentsByBlockName, getBlock } =
 				select( blockEditorStore );
-			const { getCurrentPostType, getCurrentPost } =
-				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
 
-			// Check if we're directly editing a template part with area 'overlay'.
-			const currentPostType = getCurrentPostType();
-			const currentPost = getCurrentPost();
-			if (
-				currentPostType === 'wp_template_part' &&
-				currentPost?.area === 'overlay'
-			) {
-				return true;
+			// Check if we're directly editing a template part by examining the URL.
+			// This avoids needing to import the editor store.
+			// Site editor uses format: ?p=%2Fwp_template_part%2Ftheme%2F%2Fslug
+			if ( typeof window !== 'undefined' && window.location ) {
+				const urlParams = new URLSearchParams( window.location.search );
+				const path = urlParams.get( 'p' );
+
+				// Parse the path to extract post type and ID
+				if ( path && path.includes( 'wp_template_part' ) ) {
+					// Path format: /wp_template_part/theme//slug
+					const pathParts = decodeURIComponent( path ).split( '/' );
+
+					if ( pathParts[ 1 ] === 'wp_template_part' ) {
+						// Reconstruct the template part ID (theme//slug)
+						const templatePartId = pathParts.slice( 2 ).join( '/' );
+
+						const currentTemplatePart = getEditedEntityRecord(
+							'postType',
+							'wp_template_part',
+							templatePartId
+						);
+						if ( currentTemplatePart?.area === 'overlay' ) {
+							return true;
+						}
+					}
+				}
 			}
 
 			// Find all parent template-part blocks.
@@ -521,6 +536,19 @@ function Navigation( {
 			// Check if any parent template part has area 'overlay'.
 			return templatePartParents.some( ( parentClientId ) => {
 				const parentBlock = getBlock( parentClientId );
+				const { slug, theme } = parentBlock?.attributes || {};
+
+				// If we have a slug and theme, get the template part entity to check its area.
+				if ( slug ) {
+					const templatePartEntity = getEditedEntityRecord(
+						'postType',
+						'wp_template_part',
+						`${ theme }//${ slug }`
+					);
+					return templatePartEntity?.area === 'overlay';
+				}
+
+				// Fallback to checking block attributes (for unsaved template parts).
 				return parentBlock?.attributes?.area === 'overlay';
 			} );
 		},

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -28,7 +28,12 @@ import {
 	useBlockEditingMode,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import {
+	EntityProvider,
+	store as coreStore,
+	useEntityId,
+	useEntityRecord,
+} from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
@@ -493,39 +498,14 @@ function Navigation( {
 
 	// Check if this navigation block is inside an overlay template part.
 	// If so, disable the overlay menu to prevent nested overlays.
-	const isWithinOverlayTemplatePart = useSelect( ( select ) => {
-		const { getEditedEntityRecord } = select( coreStore );
-
-		// Check if we're directly editing a template part by examining the URL.
-		// This avoids needing to import the editor store.
-		// Site editor uses format: ?p=%2Fwp_template_part%2Ftheme%2F%2Fslug
-		if ( typeof window !== 'undefined' && window.location ) {
-			const urlParams = new URLSearchParams( window.location.search );
-			const path = urlParams.get( 'p' );
-
-			// Parse the path to extract post type and ID
-			if ( path && path.includes( 'wp_template_part' ) ) {
-				// Path format: /wp_template_part/theme//slug
-				const pathParts = decodeURIComponent( path ).split( '/' );
-
-				if ( pathParts[ 1 ] === 'wp_template_part' ) {
-					// Reconstruct the template part ID (theme//slug)
-					const templatePartId = pathParts.slice( 2 ).join( '/' );
-
-					const currentTemplatePart = getEditedEntityRecord(
-						'postType',
-						'wp_template_part',
-						templatePartId
-					);
-					if ( currentTemplatePart?.area === 'overlay' ) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}, [] );
+	// Use the entity context to get the current template part being edited.
+	const templatePartId = useEntityId( 'postType', 'wp_template_part' );
+	const { record: templatePart } = useEntityRecord(
+		'postType',
+		'wp_template_part',
+		templatePartId
+	);
+	const isWithinOverlayTemplatePart = templatePart?.area === 'overlay';
 
 	// Force overlayMenu to 'never' if within an overlay template part.
 	const effectiveOverlayMenu = isWithinOverlayTemplatePart

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -79,10 +79,13 @@ import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
-import { DEFAULT_BLOCK } from '../constants';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
+import {
+	DEFAULT_BLOCK,
+	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
+} from '../constants';
 
 /**
  * Component that renders the Add page button for the Navigation block.
@@ -505,7 +508,8 @@ function Navigation( {
 		'wp_template_part',
 		templatePartId
 	);
-	const isWithinOverlayTemplatePart = templatePart?.area === 'overlay';
+	const isWithinOverlayTemplatePart =
+		templatePart?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA;
 
 	// Force overlayMenu to 'never' if within an overlay template part
 	// to prevents overlays within overlays.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -507,12 +507,15 @@ function Navigation( {
 	);
 	const isWithinOverlayTemplatePart = templatePart?.area === 'overlay';
 
-	// Force overlayMenu to 'never' if within an overlay template part.
-	const effectiveOverlayMenu = isWithinOverlayTemplatePart
-		? 'never'
-		: overlayMenu;
+	// Force overlayMenu to 'never' if within an overlay template part
+	// to prevents overlays within overlays.
+	useEffect( () => {
+		if ( isWithinOverlayTemplatePart && overlayMenu !== 'never' ) {
+			setAttributes( { overlayMenu: 'never' } );
+		}
+	}, [ isWithinOverlayTemplatePart, overlayMenu, setAttributes ] );
 
-	const isResponsive = 'never' !== effectiveOverlayMenu;
+	const isResponsive = 'never' !== overlayMenu;
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: clsx(
@@ -865,7 +868,7 @@ function Navigation( {
 	);
 
 	const accessibleDescriptionId = `${ clientId }-desc`;
-	const isHiddenByDefault = 'always' === effectiveOverlayMenu;
+	const isHiddenByDefault = 'always' === overlayMenu;
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -29,6 +29,7 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -491,7 +492,47 @@ function Navigation( {
 			),
 		[ clientId ]
 	);
-	const isResponsive = 'never' !== overlayMenu;
+
+	// Check if this navigation block is inside an overlay template part.
+	// If so, disable the overlay menu to prevent nested overlays.
+	const isWithinOverlayTemplatePart = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName, getBlock } =
+				select( blockEditorStore );
+			const { getCurrentPostType, getCurrentPost } =
+				select( editorStore );
+
+			// Check if we're directly editing a template part with area 'overlay'.
+			const currentPostType = getCurrentPostType();
+			const currentPost = getCurrentPost();
+			if (
+				currentPostType === 'wp_template_part' &&
+				currentPost?.area === 'overlay'
+			) {
+				return true;
+			}
+
+			// Find all parent template-part blocks.
+			const templatePartParents = getBlockParentsByBlockName(
+				clientId,
+				'core/template-part'
+			);
+
+			// Check if any parent template part has area 'overlay'.
+			return templatePartParents.some( ( parentClientId ) => {
+				const parentBlock = getBlock( parentClientId );
+				return parentBlock?.attributes?.area === 'overlay';
+			} );
+		},
+		[ clientId ]
+	);
+
+	// Force overlayMenu to 'never' if within an overlay template part.
+	const effectiveOverlayMenu = isWithinOverlayTemplatePart
+		? 'never'
+		: overlayMenu;
+
+	const isResponsive = 'never' !== effectiveOverlayMenu;
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: clsx(
@@ -803,7 +844,7 @@ function Navigation( {
 					</ToolsPanel>
 				) }
 			</InspectorControls>
-			{ isOverlayExperimentEnabled && (
+			{ isOverlayExperimentEnabled && ! isWithinOverlayTemplatePart && (
 				<InspectorControls>
 					<OverlayPanel
 						overlayMenu={ overlayMenu }
@@ -844,7 +885,7 @@ function Navigation( {
 	);
 
 	const accessibleDescriptionId = `${ clientId }-desc`;
-	const isHiddenByDefault = 'always' === overlayMenu;
+	const isHiddenByDefault = 'always' === effectiveOverlayMenu;
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -28,12 +28,7 @@ import {
 	useBlockEditingMode,
 	BlockControls,
 } from '@wordpress/block-editor';
-import {
-	EntityProvider,
-	store as coreStore,
-	useEntityId,
-	useEntityRecord,
-} from '@wordpress/core-data';
+import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
@@ -82,10 +77,7 @@ import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
-import {
-	DEFAULT_BLOCK,
-	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
-} from '../constants';
+import { DEFAULT_BLOCK } from '../constants';
 
 /**
  * Component that renders the Add page button for the Navigation block.
@@ -500,24 +492,15 @@ function Navigation( {
 	);
 
 	// Check if this navigation block is inside an overlay template part.
-	// If so, disable the overlay menu to prevent nested overlays.
-	// Use the entity context to get the current template part being edited.
-	const templatePartId = useEntityId( 'postType', 'wp_template_part' );
-	const { record: templatePart } = useEntityRecord(
-		'postType',
-		'wp_template_part',
-		templatePartId
-	);
-	const isWithinOverlayTemplatePart =
-		templatePart?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA;
+	const isWithinOverlay = useSelect( () => isWithinNavigationOverlay(), [] );
 
 	// Force overlayMenu to 'never' if within an overlay template part
-	// to prevents overlays within overlays.
+	// to prevent overlays within overlays.
 	useEffect( () => {
-		if ( isWithinOverlayTemplatePart && overlayMenu !== 'never' ) {
+		if ( isWithinOverlay && overlayMenu !== 'never' ) {
 			setAttributes( { overlayMenu: 'never' } );
 		}
-	}, [ isWithinOverlayTemplatePart, overlayMenu, setAttributes ] );
+	}, [ isWithinOverlay, overlayMenu, setAttributes ] );
 
 	const isResponsive = 'never' !== overlayMenu;
 	const blockProps = useBlockProps( {
@@ -831,7 +814,7 @@ function Navigation( {
 					</ToolsPanel>
 				) }
 			</InspectorControls>
-			{ isOverlayExperimentEnabled && ! isWithinOverlayTemplatePart && (
+			{ isOverlayExperimentEnabled && ! isWithinOverlay && (
 				<InspectorControls>
 					<OverlayPanel
 						overlayMenu={ overlayMenu }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -493,67 +493,39 @@ function Navigation( {
 
 	// Check if this navigation block is inside an overlay template part.
 	// If so, disable the overlay menu to prevent nested overlays.
-	const isWithinOverlayTemplatePart = useSelect(
-		( select ) => {
-			const { getBlockParentsByBlockName, getBlock } =
-				select( blockEditorStore );
-			const { getEditedEntityRecord } = select( coreStore );
+	const isWithinOverlayTemplatePart = useSelect( ( select ) => {
+		const { getEditedEntityRecord } = select( coreStore );
 
-			// Check if we're directly editing a template part by examining the URL.
-			// This avoids needing to import the editor store.
-			// Site editor uses format: ?p=%2Fwp_template_part%2Ftheme%2F%2Fslug
-			if ( typeof window !== 'undefined' && window.location ) {
-				const urlParams = new URLSearchParams( window.location.search );
-				const path = urlParams.get( 'p' );
+		// Check if we're directly editing a template part by examining the URL.
+		// This avoids needing to import the editor store.
+		// Site editor uses format: ?p=%2Fwp_template_part%2Ftheme%2F%2Fslug
+		if ( typeof window !== 'undefined' && window.location ) {
+			const urlParams = new URLSearchParams( window.location.search );
+			const path = urlParams.get( 'p' );
 
-				// Parse the path to extract post type and ID
-				if ( path && path.includes( 'wp_template_part' ) ) {
-					// Path format: /wp_template_part/theme//slug
-					const pathParts = decodeURIComponent( path ).split( '/' );
+			// Parse the path to extract post type and ID
+			if ( path && path.includes( 'wp_template_part' ) ) {
+				// Path format: /wp_template_part/theme//slug
+				const pathParts = decodeURIComponent( path ).split( '/' );
 
-					if ( pathParts[ 1 ] === 'wp_template_part' ) {
-						// Reconstruct the template part ID (theme//slug)
-						const templatePartId = pathParts.slice( 2 ).join( '/' );
+				if ( pathParts[ 1 ] === 'wp_template_part' ) {
+					// Reconstruct the template part ID (theme//slug)
+					const templatePartId = pathParts.slice( 2 ).join( '/' );
 
-						const currentTemplatePart = getEditedEntityRecord(
-							'postType',
-							'wp_template_part',
-							templatePartId
-						);
-						if ( currentTemplatePart?.area === 'overlay' ) {
-							return true;
-						}
+					const currentTemplatePart = getEditedEntityRecord(
+						'postType',
+						'wp_template_part',
+						templatePartId
+					);
+					if ( currentTemplatePart?.area === 'overlay' ) {
+						return true;
 					}
 				}
 			}
+		}
 
-			// Find all parent template-part blocks.
-			const templatePartParents = getBlockParentsByBlockName(
-				clientId,
-				'core/template-part'
-			);
-
-			// Check if any parent template part has area 'overlay'.
-			return templatePartParents.some( ( parentClientId ) => {
-				const parentBlock = getBlock( parentClientId );
-				const { slug, theme } = parentBlock?.attributes || {};
-
-				// If we have a slug and theme, get the template part entity to check its area.
-				if ( slug ) {
-					const templatePartEntity = getEditedEntityRecord(
-						'postType',
-						'wp_template_part',
-						`${ theme }//${ slug }`
-					);
-					return templatePartEntity?.area === 'overlay';
-				}
-
-				// Fallback to checking block attributes (for unsaved template parts).
-				return parentBlock?.attributes?.area === 'overlay';
-			} );
-		},
-		[ clientId ]
-	);
+		return false;
+	}, [] );
 
 	// Force overlayMenu to 'never' if within an overlay template part.
 	const effectiveOverlayMenu = isWithinOverlayTemplatePart


### PR DESCRIPTION
## What

This PR ensures that navigation blocks within overlay template parts display fully expanded (not collapsed to a menu button), and hides the overlay menu controls.

## Why

  Problem: When editing a navigation block inside an overlay template part:
  - ✅ Frontend: Navigation displayed fully expanded (correct)
  - ❌ Editor: Navigation appeared collapsed to a menu button (incorrect)

The backend (PHP) already had logic to disable overlayMenu for navigation blocks within overlay template parts (commit 64ded17c503), but there was no equivalent logic in the editor (JavaScript).

## How

Looks at the slug of the template part being edited - if it's `overlay` then hide the controls and force the overlay off.


## Testing Instructions
1. Enable the navigation overlay experiment
2. Have at least one overlay template part created
3. Navigate to Appearance → Editor → Template Parts
4. Edit an overlay template part (one with area: overlay)
5. Add or select a navigation block
 6. Verify:
    - Navigation displays fully expanded (not collapsed to menu button)
    - "Overlay Visibility" control is not shown in block settings

### Test 2: Regular Navigation (Not in Overlay)

  1. Edit a template or page
  2. Add a navigation block (not inside an overlay template part)
  3. Verify:
    - "Overlay Visibility" control is shown in block settings
    - Control functions normally
    - Can toggle between responsive modes

## Screenshots

|Before|After|
|-|-|
|<img width="286" height="939" alt="Screenshot 2026-01-07 at 12 20 24" src="https://github.com/user-attachments/assets/c4f51d50-1d41-498e-b915-5beeb50f4773" />|<img width="282" height="937" alt="Screenshot 2026-01-07 at 12 22 28" src="https://github.com/user-attachments/assets/8e1d133e-2f1a-4e07-85cc-4f9dd7df8d64" />|
