### PR TITLE
Field API: add support for `object` type

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/group.tsx
+++ b/packages/dataviews/src/components/dataform-controls/group.tsx
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BaseControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../../types';
+
+function PropertiesToFields< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: DataFormControlProps< Item > ) {
+	const { properties } = field;
+	return (
+		<VStack spacing={ 4 }>
+			{ Object.entries( properties ).map( ( [ propKey, propField ] ) => {
+				if ( ! propField.Edit ) {
+					return null;
+				}
+
+				return (
+					<propField.Edit
+						key={ propKey }
+						data={ data }
+						field={ propField }
+						onChange={ onChange }
+						hideLabelFromVision={ hideLabelFromVision }
+						validity={ validity }
+					/>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+/**
+ * Group field control.
+ *
+ * Groups related fields visually without requiring nested data.
+ * Unlike ObjectControl, this passes data directly to properties
+ * (properties use their own IDs to access root-level data).
+ */
+export default function GroupControl< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: DataFormControlProps< Item > ) {
+	const { properties } = field;
+
+	if (
+		! properties ||
+		typeof properties !== 'object' ||
+		Object.keys( properties ).length === 0
+	) {
+		return null;
+	}
+
+	// KEY DIFFERENCE from ObjectControl:
+	// Pass `data` directly (not field.getValue result).
+	// Properties use their own IDs to access root-level data.
+	return hideLabelFromVision ? (
+		<PropertiesToFields
+			data={ data }
+			field={ field }
+			onChange={ onChange }
+			hideLabelFromVision={ hideLabelFromVision }
+			validity={ validity }
+		/>
+	) : (
+		<fieldset className="dataviews-controls__group">
+			<BaseControl.VisualLabel as="legend">
+				{ field.label }
+			</BaseControl.VisualLabel>
+			<PropertiesToFields
+				data={ data }
+				field={ field }
+				onChange={ onChange }
+				hideLabelFromVision={ hideLabelFromVision }
+				validity={ validity }
+			/>
+		</fieldset>
+	);
+}

--- a/packages/dataviews/src/components/dataform-controls/index.tsx
+++ b/packages/dataviews/src/components/dataform-controls/index.tsx
@@ -23,6 +23,7 @@ import textarea from './textarea';
 import toggleGroup from './toggle-group';
 import array from './array';
 import color from './color';
+import object from './object';
 import password from './password';
 import hasElements from '../../field-types/utils/has-elements';
 
@@ -41,6 +42,7 @@ const FORM_CONTROLS: FormControls = {
 	url,
 	integer,
 	number,
+	object,
 	password,
 	radio,
 	select,

--- a/packages/dataviews/src/components/dataform-controls/index.tsx
+++ b/packages/dataviews/src/components/dataform-controls/index.tsx
@@ -24,6 +24,7 @@ import toggleGroup from './toggle-group';
 import array from './array';
 import color from './color';
 import object from './object';
+import group from './group';
 import password from './password';
 import hasElements from '../../field-types/utils/has-elements';
 
@@ -38,6 +39,7 @@ const FORM_CONTROLS: FormControls = {
 	datetime,
 	date,
 	email,
+	group,
 	telephone,
 	url,
 	integer,

--- a/packages/dataviews/src/components/dataform-controls/object.tsx
+++ b/packages/dataviews/src/components/dataform-controls/object.tsx
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BaseControl,
+	VisuallyHidden,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps, DeepPartial } from '../../types';
+
+function PropertiesToFields< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: DataFormControlProps< Item > ) {
+	const { properties } = field;
+	return (
+		<VStack spacing={ 4 }>
+			{ Object.entries( properties ).map( ( [ propKey, propField ] ) => {
+				if ( ! propField.Edit ) {
+					return null;
+				}
+
+				return (
+					<propField.Edit
+						key={ propKey }
+						data={ data }
+						field={ propField }
+						onChange={ onChange }
+						hideLabelFromVision={ hideLabelFromVision }
+						validity={ validity }
+					/>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+/**
+ * Object field control.
+ *
+ * Auto-generates a form with controls for each property in `properties`.
+ */
+export default function ObjectControl< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: DataFormControlProps< Item > ) {
+	const { properties } = field;
+
+	const currentValue = field.getValue( { item: data } ) ?? {};
+	const handlePropertyChange = useCallback(
+		( updates: DeepPartial< Item > ) => {
+			onChange(
+				field.setValue( {
+					item: data,
+					value: { ...currentValue, ...updates },
+				} )
+			);
+		},
+		[ onChange ]
+	);
+
+	if (
+		! properties ||
+		typeof properties !== 'object' ||
+		Object.keys( properties ).length === 0
+	) {
+		return null;
+	}
+
+	return hideLabelFromVision ? (
+		<PropertiesToFields
+			data={ currentValue }
+			field={ field }
+			onChange={ handlePropertyChange }
+			hideLabelFromVision={ hideLabelFromVision }
+			validity={ validity }
+		/>
+	) : (
+		<fieldset className="dataviews-controls__object">
+			<BaseControl.VisualLabel as="legend">
+				{ field.label }
+			</BaseControl.VisualLabel>
+			<PropertiesToFields
+				data={ currentValue }
+				field={ field }
+				onChange={ handlePropertyChange }
+				hideLabelFromVision={ hideLabelFromVision }
+				validity={ validity }
+			/>
+		</fieldset>
+	);
+}

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -63,19 +63,35 @@ function ModalContent< Item >( {
 		[ field ]
 	);
 
-	const fieldsAsFieldType: Field< Item >[] = fields.map( ( f ) => ( {
-		...f,
-		Edit: f.Edit === null ? undefined : f.Edit,
-		isValid: {
-			required: f.isValid.required?.constraint,
-			elements: f.isValid.elements?.constraint,
-			min: f.isValid.min?.constraint,
-			max: f.isValid.max?.constraint,
-			pattern: f.isValid.pattern?.constraint,
-			minLength: f.isValid.minLength?.constraint,
-			maxLength: f.isValid.maxLength?.constraint,
-		},
-	} ) );
+	function denormalizeFields< T >(
+		normalizedFields: NormalizedField< T >[]
+	): Field< T >[] {
+		return normalizedFields.map( ( f ) => ( {
+			...f,
+			properties: f.properties
+				? Object.fromEntries(
+						Object.entries( f.properties ).map(
+							( [ key, property ] ) => [
+								key,
+								denormalizeFields( [ property ] )[ 0 ],
+							]
+						)
+				  )
+				: {},
+			Edit: f.Edit === null ? undefined : f.Edit,
+			isValid: {
+				required: f.isValid.required?.constraint,
+				elements: f.isValid.elements?.constraint,
+				min: f.isValid.min?.constraint,
+				max: f.isValid.max?.constraint,
+				pattern: f.isValid.pattern?.constraint,
+				minLength: f.isValid.minLength?.constraint,
+				maxLength: f.isValid.maxLength?.constraint,
+			},
+		} ) ) as Field< T >[];
+	}
+
+	const fieldsAsFieldType: Field< Item >[] = denormalizeFields( fields );
 	const { validity } = useFormValidity( modalData, fieldsAsFieldType, form );
 
 	const onApply = () => {

--- a/packages/dataviews/src/field-types/group.tsx
+++ b/packages/dataviews/src/field-types/group.tsx
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from '../types';
+import type { FieldType } from '../types/private';
+import render from './utils/render-default';
+
+/**
+ * Format group value for display by joining property display values.
+ */
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	const { properties } = field;
+
+	if ( ! properties || Object.keys( properties ).length === 0 ) {
+		return '';
+	}
+
+	return Object.values( properties )
+		.map( ( propField ) =>
+			propField.getValueFormatted( { item, field: propField } )
+		)
+		.filter( Boolean )
+		.join( ', ' );
+}
+
+export default {
+	type: 'group',
+	render,
+	Edit: 'group',
+	sort: () => 0,
+	enableSorting: false,
+	enableGlobalSearch: false,
+	defaultOperators: [],
+	validOperators: [],
+	format: {},
+	getValueFormatted,
+	validate: {},
+} satisfies FieldType< any >;

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -27,6 +27,7 @@ import { default as telephone } from './telephone';
 import { default as color } from './color';
 import { default as url } from './url';
 import { default as object } from './object';
+import { default as group } from './group';
 import { default as noType } from './no-type';
 import getIsValid from './utils/get-is-valid';
 import getFormat from './utils/get-format';
@@ -53,6 +54,7 @@ function getFieldTypeByName< Item >( type?: FieldTypeName ): FieldType< Item > {
 		color,
 		url,
 		object,
+		group,
 	].find( ( fieldType ) => fieldType?.type === type );
 
 	if ( !! found ) {

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -26,6 +26,7 @@ import { default as password } from './password';
 import { default as telephone } from './telephone';
 import { default as color } from './color';
 import { default as url } from './url';
+import { default as object } from './object';
 import { default as noType } from './no-type';
 import getIsValid from './utils/get-is-valid';
 import getFormat from './utils/get-format';
@@ -51,6 +52,7 @@ function getFieldTypeByName< Item >( type?: FieldTypeName ): FieldType< Item > {
 		telephone,
 		color,
 		url,
+		object,
 	].find( ( fieldType ) => fieldType?.type === type );
 
 	if ( !! found ) {
@@ -114,6 +116,16 @@ export default function normalizeFields< Item >(
 			format: getFormat( field, fieldType ),
 			getValueFormatted:
 				field.getValueFormatted ?? fieldType.getValueFormatted,
+			properties: field.properties
+				? Object.fromEntries(
+						Object.entries( field.properties ).map(
+							( [ key, property ] ) => [
+								key,
+								normalizeFields( [ property ] )[ 0 ],
+							]
+						)
+				  )
+				: {},
 		};
 	} );
 }

--- a/packages/dataviews/src/field-types/object.tsx
+++ b/packages/dataviews/src/field-types/object.tsx
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from '../types';
+import type { FieldType } from '../types/private';
+import render from './utils/render-default';
+
+/**
+ * Format object value for display.
+ */
+function getValueFormatted< Item >( {
+	item,
+	field,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+} ): string {
+	const value = field.getValue( { item } );
+
+	if ( value === undefined || value === null ) {
+		return '';
+	}
+
+	if ( typeof value !== 'object' ) {
+		return String( value );
+	}
+
+	return Object.values( value ).filter( Boolean ).join( ', ' );
+}
+
+/**
+ * Validate that value is an object.
+ */
+function isValidCustom< Item >( item: Item, field: NormalizedField< Item > ) {
+	const value = field.getValue( { item } );
+
+	if ( [ undefined, '', null ].includes( value ) ) {
+		return null;
+	}
+
+	if ( typeof value !== 'object' ) {
+		return __( 'Value must be an object.' );
+	}
+
+	return null;
+}
+
+export default {
+	type: 'object',
+	render,
+	Edit: 'object',
+	sort: () => 0,
+	enableSorting: false,
+	enableGlobalSearch: false,
+	defaultOperators: [],
+	validOperators: [],
+	format: {},
+	getValueFormatted,
+	validate: {
+		custom: isValidCustom,
+	},
+} satisfies FieldType< any >;

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -40,6 +40,7 @@ const meta = {
 				'date',
 				'datetime',
 				'email',
+				'group',
 				'integer',
 				'number',
 				'object',
@@ -135,6 +136,10 @@ type DataType = {
 		city: string;
 		country: string;
 	};
+	// Flat data for group example (not nested)
+	imageId: string;
+	imageUrl: string;
+	imageCaption: string;
 };
 
 const data: DataType[] = [
@@ -186,6 +191,9 @@ const data: DataType[] = [
 			city: 'San Francisco',
 			country: 'USA',
 		},
+		imageId: '42',
+		imageUrl: 'https://wordpress.org/image.png',
+		imageCaption: 'A sample image',
 	},
 ];
 
@@ -610,6 +618,17 @@ const fields: Field< DataType >[] = [
 			country: { id: 'country', type: 'text', label: 'Country' },
 		},
 	},
+	{
+		id: 'imageGroup',
+		type: 'group',
+		label: 'Image',
+		description: 'Group field with flat data (not nested).',
+		properties: {
+			imageId: { id: 'imageId', type: 'text', label: 'Image ID' },
+			imageUrl: { id: 'imageUrl', type: 'url', label: 'URL' },
+			imageCaption: { id: 'imageCaption', type: 'text', label: 'Caption' },
+		},
+	},
 ];
 
 type PanelTypes = 'regular' | 'panel';
@@ -621,6 +640,7 @@ type ControlTypes =
 	| 'date'
 	| 'datetime'
 	| 'email'
+	| 'group'
 	| 'integer'
 	| 'number'
 	| 'object'
@@ -1328,6 +1348,31 @@ export const ObjectComponent = ( {
 	);
 };
 ObjectComponent.storyName = 'object';
+
+export const GroupComponent = ( {
+	type,
+	Edit,
+	asyncElements,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+	asyncElements: boolean;
+} ) => {
+	const groupFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'group' ),
+		[]
+	);
+
+	return (
+		<FieldTypeStory
+			fields={ groupFields }
+			type={ type }
+			Edit={ Edit }
+			asyncElements={ asyncElements }
+		/>
+	);
+};
+GroupComponent.storyName = 'group';
 
 export const NoTypeComponent = ( {
 	type,

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -42,6 +42,7 @@ const meta = {
 				'email',
 				'integer',
 				'number',
+				'object',
 				'password',
 				'radio',
 				'select',
@@ -124,6 +125,16 @@ type DataType = {
 	ratingWithIcon?: string;
 	percentageWithSuffix?: string;
 	priceWithBoth?: string;
+	link: {
+		url: string;
+		rel: string;
+		target: string;
+	};
+	address: {
+		street: string;
+		city: string;
+		country: string;
+	};
 };
 
 const data: DataType[] = [
@@ -165,6 +176,16 @@ const data: DataType[] = [
 		ratingWithIcon: '4.5',
 		percentageWithSuffix: '85',
 		priceWithBoth: '199.99',
+		link: {
+			url: 'https://wordpress.org',
+			rel: 'noopener',
+			target: '_blank',
+		},
+		address: {
+			street: '123 Main St',
+			city: 'San Francisco',
+			country: 'USA',
+		},
 	},
 ];
 
@@ -522,6 +543,73 @@ const fields: Field< DataType >[] = [
 			suffix: USDSuffix,
 		},
 	},
+	{
+		id: 'link',
+		type: 'object',
+		label: 'Link',
+		description: 'Object field with URL, rel, and target properties.',
+		properties: {
+			url: { id: 'url', type: 'url', label: 'URL' },
+			rel: {
+				id: 'rel',
+				type: 'text',
+				label: 'Rel attribute',
+				elements: [
+					// https://html.spec.whatwg.org/multipage/links.html#linkTypes
+					{ label: 'None', value: '' },
+					{ label: 'alternate', value: 'alternate' },
+					{ label: 'author', value: 'author' },
+					{ label: 'bookmark', value: 'bookmark' },
+					{ label: 'external', value: 'external' },
+					{ label: 'help', value: 'help' },
+					{ label: 'license', value: 'license' },
+					{ label: 'next', value: 'next' },
+					{ label: 'nofollow', value: 'nofollow' },
+					{ label: 'noopener', value: 'noopener' },
+					{ label: 'noreferrer', value: 'noreferrer' },
+					{ label: 'opener', value: 'opener' },
+					{ label: 'prev', value: 'prev' },
+					{ label: 'privacy-policy', value: 'privacy-policy' },
+					{ label: 'search', value: 'search' },
+					{ label: 'tag', value: 'tag' },
+					{ label: 'terms-of-service', value: 'terms-of-service' },
+				],
+			},
+			target: {
+				id: 'target',
+				type: 'text',
+				label: 'Target',
+				elements: [
+					// https://html.spec.whatwg.org/multipage/document-sequences.html#navigable-target-names
+					{ label: 'Blank', value: '_blank' },
+					{ label: 'Self', value: '_self' },
+					{ label: 'Parent', value: '_parent' },
+					{ label: 'Top', value: '_top' },
+				],
+			},
+		},
+		render: ( { item } ) => {
+			const {
+				link: { url, rel, target },
+			} = item;
+			return (
+				<a href={ url } rel={ rel } target={ target }>
+					{ url }
+				</a>
+			);
+		},
+	},
+	{
+		id: 'address',
+		type: 'object',
+		label: 'Address',
+		description: 'Object field with street, city, and country properties.',
+		properties: {
+			street: { id: 'street', type: 'text', label: 'Street' },
+			city: { id: 'city', type: 'text', label: 'City' },
+			country: { id: 'country', type: 'text', label: 'Country' },
+		},
+	},
 ];
 
 type PanelTypes = 'regular' | 'panel';
@@ -535,6 +623,7 @@ type ControlTypes =
 	| 'email'
 	| 'integer'
 	| 'number'
+	| 'object'
 	| 'password'
 	| 'radio'
 	| 'select'
@@ -1214,6 +1303,31 @@ export const PasswordComponent = ( {
 	);
 };
 PasswordComponent.storyName = 'password';
+
+export const ObjectComponent = ( {
+	type,
+	Edit,
+	asyncElements,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+	asyncElements: boolean;
+} ) => {
+	const objectFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'object' ),
+		[]
+	);
+
+	return (
+		<FieldTypeStory
+			fields={ objectFields }
+			type={ type }
+			Edit={ Edit }
+			asyncElements={ asyncElements }
+		/>
+	);
+};
+ObjectComponent.storyName = 'object';
 
 export const NoTypeComponent = ( {
 	type,

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -74,7 +74,8 @@ export type FieldTypeName =
 	| 'telephone'
 	| 'color'
 	| 'url'
-	| 'array';
+	| 'array'
+	| 'object';
 
 export type Rules< Item > = {
 	required?: boolean;
@@ -170,6 +171,12 @@ export type Field< Item > = {
 	 * Type of the fields.
 	 */
 	type?: FieldTypeName;
+
+	/**
+	 * Properties definition for object field type.
+	 * Each key in the object represents a nested property with its own field configuration.
+	 */
+	properties?: Record< string, Field< Item > >;
 
 	/**
 	 * The unique identifier of the field.
@@ -342,8 +349,9 @@ export type FormatInteger = {
 
 export type NormalizedField< Item > = Omit<
 	Field< Item >,
-	'Edit' | 'isValid'
+	'Edit' | 'isValid' | 'properties'
 > & {
+	properties: Record< string, NormalizedField< Item > >;
 	label: string;
 	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -75,7 +75,8 @@ export type FieldTypeName =
 	| 'color'
 	| 'url'
 	| 'array'
-	| 'object';
+	| 'object'
+	| 'group';
 
 export type Rules< Item > = {
 	required?: boolean;


### PR DESCRIPTION
## What?

This PR adds support for the `object` field type in the Field API.

Example of an `object` field type:

```tsx
{
  id: 'address',
  type: 'object',
  label: 'Address',
  properties: {
    street: { id: 'street', type: 'text', label: 'Street' },
    city: { id: 'city', type: 'text', label: 'City' },
    country: { id: 'country', type: 'text', label: 'Country' },
  },
}
```

## Why?

The work for content-only has surfaced this as a priority, see https://github.com/WordPress/gutenberg/pull/73374#issuecomment-3564198037

## How?

- Create a `object` field type.
- Create a `object` dataform control.

## Testing Instructions

- Open the local storybook (`npm install && npm run storybook:dev`).
- Visit to "DataViews > Field Types > Object".

There are two objects in the story, `link` and `address` fields:

```tsx
{
		id: 'link',
		type: 'object',
		label: 'Link',
		description: 'Object field with URL, rel, and target properties.',
		properties: {
			url: { id: 'url', type: 'url', label: 'URL' },
			rel: {
				id: 'rel',
				type: 'text',
				label: 'Rel attribute',
				elements: [
					// https://html.spec.whatwg.org/multipage/links.html#linkTypes
				],
			},
			target: {
				id: 'target',
				type: 'text',
				label: 'Target',
				elements: [
					// https://html.spec.whatwg.org/multipage/document-sequences.html#navigable-target-names
				],
			},
		},
		render: ( { item } ) => {
			const {
				link: { url, rel, target },
			} = item;
			return (
				<a href={ url } rel={ rel } target={ target }>
					{ url }
				</a>
			);
		},
	},
        {
		id: 'address',
		type: 'object',
		label: 'Address',
		description: 'Object field with street, city, and country properties.',
		properties: {
			street: { id: 'street', type: 'text', label: 'Street' },
			city: { id: 'city', type: 'text', label: 'City' },
			country: { id: 'country', type: 'text', label: 'Country' },
		},
	},
```


https://github.com/user-attachments/assets/968cce7a-50d2-43c6-bd51-38e60a02c83d



## TODO

- Validate the approach with some content-only attributes.
- Validation story: update to reflect `object` types.
