### PR TITLE
Docs: Remove "Customizing supported attributes filter" section from Block Bindings docs

### DIFF
--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -425,26 +425,6 @@ function wpmovies_format_visualization_date( $value, $name ) {
 add_filter( 'block_bindings_source_value', 'wpmovies_format_visualization_date', 10, 2 );
 ```
 
-#### Customizing supported attributes filter
-
-_**Note:** Since WordPress 6.9._
-
-The `block_bindings_supported_attributes_{$block_type}` filter allows developers to customize which of a block's attributes can be connected to a Block Bindings source. This filter enables the Block Bindings UI in the editor for the specified attributes.
-
-This filter provides a way to extend or restrict which attributes of a specific block type can be bound to dynamic sources. The attributes registered through this filter will appear as options in the block binding interface.
-
-<div class="callout callout-warning">This filter has no impact on pattern overrides as they are handled independently.</div>
-
-Example:
-
-```php
-// Allow binding the 'caption' attribute for image blocks
-add_filter( 'block_bindings_supported_attributes_core/image', function( $supported_attributes ) {
-    $supported_attributes[] = 'caption';
-    return $supported_attributes;
-} );
-```
-
 #### Server registration Core examples
 
 There are a few examples in Core that can be used as reference.


### PR DESCRIPTION
## What?

Remove a now-redundant section from Block Bindings docs.

## Why?

This was added by https://github.com/WordPress/gutenberg/pull/73763, but it is already covered by the "Extending supported attributes" section further above. (The latter was part of https://github.com/WordPress/gutenberg/pull/73889 which was merged just briefly before https://github.com/WordPress/gutenberg/pull/73763.)

First documented here: https://github.com/WordPress/gutenberg/pull/73763/files#r2668524820.

## How?
By removing a now-redundant section.

## Review notes.

Verify that the information from this section is already covered by the "Extending supported attributes" section. If something is missing, feel free to leave a comment or push a commit.
