### PR TITLE
wp-build: Fix script module IDs to use configured packageNamespace

### DIFF
--- a/packages/wp-build/src/build.mjs
+++ b/packages/wp-build/src/build.mjs
@@ -456,8 +456,8 @@ async function bundlePackage( packageName, options = {} ) {
 
 			const scriptModuleId =
 				exportName === '.'
-					? `@wordpress/${ packageName }`
-					: `@wordpress/${ packageName }/${ fileName }`;
+					? `@${ packageNamespace }/${ packageName }`
+					: `@${ packageNamespace }/${ packageName }/${ fileName }`;
 
 			builtModules.push( {
 				id: scriptModuleId,


### PR DESCRIPTION
## What?

Fixes the `bundlePackage` function in `@wordpress/wp-build` to use the configured `packageNamespace` when generating script module IDs, instead of hardcoding `@wordpress/`.

## Why?

When using `@wordpress/wp-build` with a custom `packageNamespace` configuration (e.g., `wc-analytics`), the generated script module IDs were incorrectly using `@wordpress/*` instead of the configured namespace (`@wc-analytics/*`).

This caused runtime errors when the page configuration referenced modules with the correct namespace, but the import map only contained entries with the hardcoded `@wordpress/` prefix:

```
TypeError: Failed to resolve module specifier '@wc-analytics/init'
```

**Example configuration:**
```json
{
  "wpPlugin": {
    "packageNamespace": "wc-analytics",
    "pages": [
      {
        "id": "wc-analytics",
        "init": ["@wc-analytics/init"]
      }
    ]
  }
}
```

**Before:** Module registered as `@wordpress/init`
**After:** Module registered as `@wc-analytics/init`

## How?

Changed the `scriptModuleId` construction in `bundlePackage()` to use the `packageNamespace` parameter (which was already available in scope but not being used):

```diff
- ? `@wordpress/${ packageName }`
- : `@wordpress/${ packageName }/${ fileName }`;
+ ? `@${ packageNamespace }/${ packageName }`
+ : `@${ packageNamespace }/${ packageName }/${ fileName }`;
```

## Testing

1. Create a project using `@wordpress/wp-build` with a custom `packageNamespace` in `package.json`
2. Run the build process
3. Verify that generated module IDs in `build/modules/index.php` use the configured namespace instead of `@wordpress/`