### PR TITLE
UI: add `Button`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -467,13 +467,13 @@ module.exports = {
 			extends: [ 'plugin:ssr-friendly/recommended' ],
 		},
 		{
-			files: [ 'packages/components/src/**' ],
+			files: [ 'packages/components/src/**', 'packages/ui/src/**' ],
 			rules: {
 				'no-restricted-imports': [
 					'error',
 					// The `ariakit` and `framer-motion` APIs are meant to be consumed via
-					// the `@wordpress/components` package, hence why importing those
-					// dependencies should be allowed in the components package.
+					// the `@wordpress/components` and @wordpress/ui` packages, hence why
+					// importing those imports should be allowed only in those packages.
 					{
 						paths: restrictedImports.filter(
 							( { name } ) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -55694,7 +55694,9 @@
 			"version": "0.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@ariakit/react": "^0.4.15",
 				"@base-ui/react": "^1.0.0",
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,3 +13,4 @@
 -   Add `Field` primitives ([#74190](https://github.com/WordPress/gutenberg/pull/74190)).
 -   Add `Fieldset` primitives ([#74296](https://github.com/WordPress/gutenberg/pull/74296)).
 -   Add `Icon` component ([#74311](https://github.com/WordPress/gutenberg/pull/74311)).
+-   Add `Button` component ([#74415](https://github.com/WordPress/gutenberg/pull/74415)).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,9 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@ariakit/react": "^0.4.15",
 		"@base-ui/react": "^1.0.0",
+		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,11 +1,4 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { Box } from '../box';
 import { type BoxProps } from '../box/types';
 import { type BadgeProps } from './types';

--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-
-/**
- * WordPress dependencies
- */
 import { Fragment } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { Badge } from '../index';
 
 const meta: Meta< typeof Badge > = {

--- a/packages/ui/src/badge/types.ts
+++ b/packages/ui/src/badge/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { type ComponentProps } from '../utils/types';
 
 export interface BadgeProps extends ComponentProps< 'span' > {

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
 import { Button as AriakitButton } from '@ariakit/react';
-import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';
-
-/**
- * WordPress dependencies
- */
+import { forwardRef, useEffect } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
-
-/**
- * Internal dependencies
- */
 import { type ButtonProps } from './types';
 import styles from './style.module.css';
 import resetStyles from '../utils/css/resets.module.css';

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { forwardRef, useEffect } from 'react';
 import { Button as AriakitButton } from '@ariakit/react';
+import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 
 /**

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import { Button as AriakitButton } from '@ariakit/react';
 import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -18,10 +18,6 @@ import styles from './style.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import focusStyles from '../utils/css/focus.module.css';
 
-/**
- * A versatile button component with multiple variants, tones, and sizes.
- * Built on design tokens for consistent theming and accessibility.
- */
 export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 	function Button(
 		{

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { forwardRef, useEffect } from 'react';
+import { Button as AriakitButton } from '@ariakit/react';
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { type ButtonProps } from './types';
+import styles from './style.module.css';
+import resetStyles from '../utils/css/resets.module.css';
+import focusStyles from '../utils/css/focus.module.css';
+
+/**
+ * A versatile button component with multiple variants, tones, and sizes.
+ * Built on design tokens for consistent theming and accessibility.
+ */
+export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
+	function Button(
+		{
+			tone = 'brand',
+			variant = 'solid',
+			size = 'default',
+			className,
+			accessibleWhenDisabled = true,
+			disabled,
+			loading,
+			loadingAnnouncement,
+			children,
+			...props
+		},
+		ref
+	) {
+		const mergedClassName = clsx(
+			resetStyles[ 'box-sizing' ],
+			focusStyles[ 'outset-ring--focus-except-active' ],
+			variant !== 'unstyled' && styles.button,
+			styles[ `is-${ tone }` ],
+			styles[ `is-${ variant }` ],
+			styles[ `is-${ size }` ],
+			loading && styles[ 'is-loading' ],
+			className
+		);
+
+		// Announce loading state to assistive technology
+		useEffect( () => {
+			if ( loading && loadingAnnouncement ) {
+				speak( loadingAnnouncement );
+			}
+		}, [ loading, loadingAnnouncement ] );
+
+		return (
+			<AriakitButton
+				ref={ ref }
+				className={ mergedClassName }
+				accessibleWhenDisabled={ accessibleWhenDisabled }
+				disabled={ disabled ?? loading }
+				{ ...props }
+			>
+				{ children }
+			</AriakitButton>
+		);
+	}
+);

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import { Button as AriakitButton } from '@ariakit/react';
 import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,7 +1,8 @@
 import { Button as AriakitButton } from '@ariakit/react';
 import clsx from 'clsx';
-import { forwardRef, useEffect } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
+import { forwardRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { type ButtonProps } from './types';
 import styles from './style.module.css';
 import resetStyles from '../utils/css/resets.module.css';
@@ -17,7 +18,7 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			accessibleWhenDisabled = true,
 			disabled,
 			loading,
-			loadingAnnouncement,
+			loadingAnnouncement = __( 'Loading' ),
 			children,
 			...props
 		},

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forwardRef } from 'react';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { type IconProps } from '../icon/types';
 import { Icon } from '../icon';
 

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { type IconProps } from '../icon/types';
+import { Icon } from '../icon';
+
+interface ButtonIconProps extends IconProps {
+	/**
+	 * The icon to display, from the `@wordpress/icons` package.
+	 */
+	icon: IconProps[ 'icon' ];
+}
+
+export const ButtonIcon = forwardRef< SVGSVGElement, ButtonIconProps >(
+	function ButtonIcon( { icon, ...props }, ref ) {
+		return (
+			<Icon
+				ref={ ref }
+				icon={ icon }
+				viewBox="4 4 16 16"
+				size={ 16 }
+				{ ...props }
+			/>
+		);
+	}
+);

--- a/packages/ui/src/button/index.stories.tsx
+++ b/packages/ui/src/button/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 /**
  * External dependencies
  */
@@ -213,3 +214,5 @@ export const Pressed: Story = {
 		);
 	},
 };
+
+/* eslint-enable no-restricted-syntax */

--- a/packages/ui/src/button/index.stories.tsx
+++ b/packages/ui/src/button/index.stories.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { Fragment, useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Fragment, useState } from '@wordpress/element';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 /**
  * WordPress dependencies

--- a/packages/ui/src/button/index.stories.tsx
+++ b/packages/ui/src/button/index.stories.tsx
@@ -1,0 +1,215 @@
+/**
+ * External dependencies
+ */
+import { Fragment, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * WordPress dependencies
+ */
+import { cog } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from './index';
+
+const meta: Meta< typeof Button > = {
+	title: 'Design System/Button',
+	component: Button,
+};
+export default meta;
+
+type Story = StoryObj< typeof Button >;
+
+export const Default: Story = {
+	args: {
+		children: 'Button',
+		loadingAnnouncement: 'Loading',
+	},
+	argTypes: {
+		'aria-pressed': {
+			control: { type: 'boolean' },
+		},
+	},
+};
+
+export const Outline: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		variant: 'outline',
+	},
+};
+
+export const Minimal: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		variant: 'minimal',
+	},
+};
+
+export const Compact: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		size: 'compact',
+	},
+};
+
+export const Small: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		size: 'small',
+	},
+};
+
+export const Neutral: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		tone: 'neutral',
+	},
+};
+
+export const NeutralOutline: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		tone: 'neutral',
+		variant: 'outline',
+	},
+};
+
+export const Unstyled: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		variant: 'unstyled',
+	},
+};
+
+export const AllTonesAndVariants: Story = {
+	...Default,
+	render: ( args ) => (
+		<div
+			style={ {
+				display: 'grid',
+				gridTemplateColumns: 'max-content repeat(2, min-content)',
+				color: 'var(--wpds-color-fg-content-neutral)',
+			} }
+		>
+			<div></div>
+			<div style={ { textAlign: 'center' } }>Resting</div>
+			<div style={ { textAlign: 'center' } }>Disabled</div>
+			{ ( [ 'brand', 'neutral' ] as const ).map( ( tone ) => (
+				<Fragment key={ tone }>
+					{ (
+						[ 'solid', 'outline', 'minimal', 'unstyled' ] as const
+					 ).map( ( variant ) => (
+						<Fragment key={ variant }>
+							<div
+								style={ {
+									paddingInlineEnd: '1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								{ variant }, { tone }
+							</div>
+							<div
+								style={ {
+									padding: '0.5rem 1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Button
+									{ ...args }
+									tone={ tone }
+									variant={ variant }
+								/>
+							</div>
+							<div
+								style={ {
+									padding: '0.5rem 1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Button
+									{ ...args }
+									tone={ tone }
+									variant={ variant }
+									disabled
+								/>
+							</div>
+						</Fragment>
+					) ) }
+				</Fragment>
+			) ) }
+		</div>
+	),
+};
+
+export const LinkStyledAsButton: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		// Link content passed through `children`
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		render: <a href="https://example.com" />,
+		children: 'Link',
+	},
+};
+
+export const WithIcon: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		children: (
+			<>
+				<Button.Icon icon={ cog } />
+				Button
+			</>
+		),
+	},
+};
+
+export const Loading: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		loading: true,
+		loadingAnnouncement: 'Saving data',
+	},
+};
+
+/**
+ * The pressed state is only available for buttons with `tone="neutral"` and
+ * `variant="minimal"`. This represents a toggle button that is currently in an
+ * active/pressed state.
+ */
+export const Pressed: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		tone: 'neutral',
+		variant: 'minimal',
+	},
+	render: ( args ) => {
+		const [ isPressed, setIsPressed ] = useState( false );
+
+		return (
+			<Button
+				{ ...args }
+				aria-pressed={ isPressed }
+				onClick={ () => setIsPressed( ! isPressed ) }
+			>
+				Button
+			</Button>
+		);
+	},
+};

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { Button as ButtonButton } from './button';
+import { ButtonIcon } from './icon';
+
+export const Button = Object.assign( ButtonButton, {
+	Icon: ButtonIcon,
+} ) as typeof ButtonButton & {
+	Icon: typeof ButtonIcon;
+};

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -4,7 +4,15 @@
 import { Button as ButtonButton } from './button';
 import { ButtonIcon } from './icon';
 
+/**
+ * A versatile button component with multiple variants, tones, and sizes.
+ * Built on design tokens for consistent theming and accessibility.
+ */
 export const Button = Object.assign( ButtonButton, {
+	/**
+	 * An icon component specifically designed to work well when rendered inside
+	 * a `Button` component.
+	 */
 	Icon: ButtonIcon,
 } ) as typeof ButtonButton & {
 	Icon: typeof ButtonIcon;

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { Button as ButtonButton } from './button';
 import { ButtonIcon } from './icon';
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -6,6 +6,11 @@ import { Button } from '../index';
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
 	component: Button,
+	argTypes: {
+		'aria-pressed': {
+			control: { type: 'boolean' },
+		},
+	},
 };
 export default meta;
 
@@ -15,11 +20,6 @@ export const Default: Story = {
 	args: {
 		children: 'Button',
 		loadingAnnouncement: 'Loading',
-	},
-	argTypes: {
-		'aria-pressed': {
-			control: { type: 'boolean' },
-		},
 	},
 };
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -19,7 +19,6 @@ type Story = StoryObj< typeof Button >;
 export const Default: Story = {
 	args: {
 		children: 'Button',
-		loadingAnnouncement: 'Loading',
 	},
 };
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -194,7 +194,7 @@ export const Pressed: Story = {
 		variant: 'minimal',
 	},
 	render: ( args ) => {
-		const [ isPressed, setIsPressed ] = useState( false );
+		const [ isPressed, setIsPressed ] = useState( true );
 
 		return (
 			<Button

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,18 +1,7 @@
 /* eslint-disable no-restricted-syntax */
-/**
- * External dependencies
- */
 import { Fragment, useState } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-
-/**
- * WordPress dependencies
- */
 import { cog } from '@wordpress/icons';
-
-/**
- * Internal dependencies
- */
 import { Button } from '../index';
 
 const meta: Meta< typeof Button > = {

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import { Fragment, useState } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { cog } from '@wordpress/icons';
@@ -133,6 +132,11 @@ export const AllTonesAndVariants: Story = {
 									{ ...args }
 									tone={ tone }
 									variant={ variant }
+									// Disabling because this lint rule was meant for the
+									// `@wordpress/components` Button, but is being applied here.
+									// TODO: rework the lint rule so that it checks the package
+									// where the Button comes from.
+									// eslint-disable-next-line no-restricted-syntax
 									disabled
 								/>
 							</div>
@@ -203,5 +207,3 @@ export const Pressed: Story = {
 		);
 	},
 };
-
-/* eslint-enable no-restricted-syntax */

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -13,10 +13,10 @@ import { cog } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Button } from './index';
+import { Button } from '../index';
 
 const meta: Meta< typeof Button > = {
-	title: 'Design System/Button',
+	title: 'Design System/Components/Button',
 	component: Button,
 };
 export default meta;

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -1,0 +1,326 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+	.button,
+	.is-unstyled {
+		appearance: none;
+		padding: 0;
+	}
+
+	.button {
+		/* Internal variables */
+		--wp-ui-button-font-weight: 499;
+
+		--wp-ui-button-background-color: var(
+			--wpds-color-bg-interactive-brand-strong
+		);
+		--wp-ui-button-background-color-active: var(
+			--wpds-color-bg-interactive-brand-strong-active
+		);
+		--wp-ui-button-background-color-disabled: var(
+			--wpds-color-bg-interactive-brand-strong-disabled
+		);
+		--wp-ui-button-foreground-color: var(
+			--wpds-color-fg-interactive-brand-strong
+		);
+		--wp-ui-button-foreground-color-active: var(
+			--wpds-color-fg-interactive-brand-strong-active
+		);
+		--wp-ui-button-foreground-color-disabled: var(
+			--wpds-color-fg-interactive-brand-strong-disabled
+		);
+		--wp-ui-button-padding-inline: calc(
+			3 * var( --wpds-dimension-base )
+		); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-height: 40px;
+		--wp-ui-button-aspect-ratio: auto; /* Useful for overrides such as icon buttons */
+		--wp-ui-button-font-size: var( --wpds-font-size-md );
+
+		/* by default, borders have the same color as the background */
+		--wp-ui-button-border-color: var( --wp-ui-button-background-color );
+		--wp-ui-button-border-color-active: var(
+			--wp-ui-button-background-color-active
+		);
+		--wp-ui-button-border-color-disabled: var(
+			--wp-ui-button-background-color-disabled
+		);
+
+		/* Styles */
+		position: relative;
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		gap: calc(
+			2 * var( --wpds-dimension-base )
+		); /* TODO: Consider new interactive/control gap tokens */
+		aspect-ratio: var( --wp-ui-button-aspect-ratio );
+		height: var( --wp-ui-button-height );
+		padding-inline: var( --wp-ui-button-padding-inline );
+		border-style: solid;
+		border-width: 1px;
+		border-color: var( --wp-ui-button-border-color );
+		border-radius: var( --wpds-border-radius-surface-sm );
+		background-color: var( --wp-ui-button-background-color );
+		background-clip: padding-box;
+		font-family: var( --wpds-font-family-body );
+		font-size: var( --wp-ui-button-font-size );
+		font-weight: var( --wp-ui-button-font-weight );
+		line-height: var( --wpds-font-line-height-sm );
+		text-decoration: none;
+		color: var( --wp-ui-button-foreground-color );
+
+		@media not ( prefers-reduced-motion ) {
+			transition: color 0.1s ease-out;
+
+			* {
+				transition: opacity 0.1s ease-out;
+			}
+		}
+
+		/* Use pointer cursor for buttons that are links */
+		&[href] {
+			cursor: pointer;
+		}
+
+		/* Make sure that links rendered as children of `Button` use button styles */
+		*[href] {
+			color: inherit;
+			text-decoration: inherit;
+		}
+
+		/* States */
+		&:not( [aria-disabled="true"] ):is( :hover, :active, :focus ) {
+			/* hover/active/focus states apply when the button is not disabled. A non
+			disabled, loading button will have hover/active/focus styles */
+			--wp-ui-button-background-color: var(
+				--wp-ui-button-background-color-active
+			);
+			--wp-ui-button-foreground-color: var(
+				--wp-ui-button-foreground-color-active
+			);
+			--wp-ui-button-border-color: var(
+				--wp-ui-button-border-color-active
+			);
+		}
+
+		&[aria-disabled="true"]:not( .is-loading ) {
+			/* A loading button, even when disabled, won't "look" disabled */
+			--wp-ui-button-background-color: var(
+				--wp-ui-button-background-color-disabled
+			);
+			--wp-ui-button-foreground-color: var(
+				--wp-ui-button-foreground-color-disabled
+			);
+			--wp-ui-button-border-color: var(
+				--wp-ui-button-border-color-disabled
+			);
+
+			@media ( forced-colors: active ) {
+				border-color: GrayText;
+				color: GrayText;
+			}
+		}
+
+		/* Loading spinner — not animated and hidden unless in loading state */
+		&::before {
+			content: "";
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate( -50%, -50% );
+
+			display: block;
+			box-sizing: border-box;
+			height: var( --wp-ui-button-font-size );
+			aspect-ratio: 1;
+
+			border: var( --wpds-border-width-interactive-focus ) solid;
+			border-color: var( --wp-ui-button-foreground-color )
+				var( --wp-ui-button-foreground-color ) transparent transparent;
+			border-radius: 50%;
+
+			pointer-events: none;
+			opacity: 0;
+
+			@media not ( prefers-reduced-motion ) {
+				transition: opacity 0.1s ease-out;
+			}
+		}
+	}
+
+	.is-small {
+		--wp-ui-button-padding-inline: calc(
+			2 * var( --wpds-dimension-base )
+		); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-height: 24px;
+	}
+
+	/* Variants (`tone` + `variant`) overrides compared to default styles */
+
+	/* All outline buttons have a border */
+	.is-brand {
+		/* no need to redefine variables for .is-brand.is-solid as it's the default variant */
+
+		/* Outline and minimal buttons use the same foreground color */
+		&.is-outline,
+		&.is-minimal {
+			--wp-ui-button-foreground-color: var(
+				--wpds-color-fg-interactive-brand
+			);
+			--wp-ui-button-foreground-color-active: var(
+				--wpds-color-fg-interactive-brand-active
+			);
+			--wp-ui-button-foreground-color-disabled: var(
+				--wpds-color-fg-interactive-brand-disabled
+			);
+		}
+
+		&.is-outline {
+			--wp-ui-button-background-color: var(
+				--wpds-color-bg-interactive-brand
+			);
+			--wp-ui-button-background-color-active: var(
+				--wpds-color-bg-interactive-brand-active
+			);
+			--wp-ui-button-background-color-disabled: var(
+				--wpds-color-bg-interactive-brand-disabled
+			);
+			--wp-ui-button-border-color: var(
+				--wpds-color-stroke-interactive-brand
+			);
+			--wp-ui-button-border-color-active: var(
+				--wpds-color-stroke-interactive-brand-active
+			);
+		}
+
+		&.is-minimal {
+			--wp-ui-button-background-color: var(
+				--wpds-color-bg-interactive-brand-weak
+			);
+			--wp-ui-button-background-color-active: var(
+				--wpds-color-bg-interactive-brand-weak-active
+			);
+			--wp-ui-button-background-color-disabled: var(
+				--wpds-color-bg-interactive-brand-weak-disabled
+			);
+		}
+	}
+
+	.is-neutral {
+		&.is-solid {
+			--wp-ui-button-background-color: var(
+				--wpds-color-bg-interactive-neutral-strong
+			);
+			--wp-ui-button-background-color-active: var(
+				--wpds-color-bg-interactive-neutral-strong-active
+			);
+			--wp-ui-button-background-color-disabled: var(
+				--wpds-color-bg-interactive-neutral-strong-disabled
+			);
+			--wp-ui-button-foreground-color: var(
+				--wpds-color-fg-interactive-neutral-strong
+			);
+			--wp-ui-button-foreground-color-active: var(
+				--wpds-color-fg-interactive-neutral-strong-active
+			);
+			--wp-ui-button-foreground-color-disabled: var(
+				--wpds-color-fg-interactive-neutral-strong-disabled
+			);
+		}
+
+		/* Outline and minimal buttons use the same foreground color */
+		&.is-outline,
+		&.is-minimal {
+			--wp-ui-button-foreground-color: var(
+				--wpds-color-fg-interactive-neutral
+			);
+			--wp-ui-button-foreground-color-active: var(
+				--wpds-color-fg-interactive-neutral-active
+			);
+			--wp-ui-button-foreground-color-disabled: var(
+				--wpds-color-fg-interactive-neutral-disabled
+			);
+		}
+
+		&.is-outline {
+			--wp-ui-button-background-color: var(
+				--wpds-color-bg-interactive-neutral
+			);
+			--wp-ui-button-background-color-active: var(
+				--wpds-color-bg-interactive-neutral-active
+			);
+			--wp-ui-button-background-color-disabled: var(
+				--wpds-color-bg-interactive-neutral-disabled
+			);
+			--wp-ui-button-border-color: var(
+				--wpds-color-stroke-interactive-neutral
+			);
+			--wp-ui-button-border-color-active: var(
+				--wpds-color-stroke-interactive-neutral-active
+			);
+		}
+
+		&.is-minimal {
+			--wp-ui-button-background-color: var(
+				--wpds-color-bg-interactive-neutral-weak
+			);
+			--wp-ui-button-background-color-active: var(
+				--wpds-color-bg-interactive-neutral-weak-active
+			);
+			--wp-ui-button-background-color-disabled: var(
+				--wpds-color-bg-interactive-neutral-weak-disabled
+			);
+		}
+	}
+
+	.is-unstyled {
+		border: none;
+		background: none;
+	}
+
+	.is-compact {
+		--wp-ui-button-height: 32px;
+	}
+
+	.is-loading {
+		color: transparent;
+
+		* {
+			opacity: 0;
+		}
+
+		&::before {
+			transition-delay: 0.05s;
+			opacity: 1;
+
+			@media not ( prefers-reduced-motion ) {
+				animation: loading-animation 1s linear infinite;
+			}
+		}
+	}
+
+	[aria-pressed="true"].is-minimal.is-neutral {
+		--wp-ui-button-background-color: var(
+			--wpds-color-bg-interactive-neutral-strong
+		);
+		--wp-ui-button-background-color-active: var(
+			--wpds-color-bg-interactive-neutral-strong
+		);
+		--wp-ui-button-foreground-color: var(
+			--wpds-color-fg-interactive-neutral-strong
+		);
+		--wp-ui-button-foreground-color-active: var(
+			--wpds-color-fg-interactive-neutral-strong
+		);
+	}
+}
+
+@keyframes loading-animation {
+	0% {
+		transform: translate( -50%, -50% ) rotate( 0deg );
+	}
+
+	100% {
+		transform: translate( -50%, -50% ) rotate( 360deg );
+	}
+}

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -11,63 +11,43 @@
 		/* Internal variables */
 		--wp-ui-button-font-weight: 499;
 
-		--wp-ui-button-background-color: var(
-			--wpds-color-bg-interactive-brand-strong
-		);
-		--wp-ui-button-background-color-active: var(
-			--wpds-color-bg-interactive-brand-strong-active
-		);
-		--wp-ui-button-background-color-disabled: var(
-			--wpds-color-bg-interactive-brand-strong-disabled
-		);
-		--wp-ui-button-foreground-color: var(
-			--wpds-color-fg-interactive-brand-strong
-		);
-		--wp-ui-button-foreground-color-active: var(
-			--wpds-color-fg-interactive-brand-strong-active
-		);
-		--wp-ui-button-foreground-color-disabled: var(
-			--wpds-color-fg-interactive-brand-strong-disabled
-		);
-		--wp-ui-button-padding-inline: calc(
-			3 * var( --wpds-dimension-base )
-		); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-background-color: var(--wpds-color-bg-interactive-brand-strong);
+		--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-brand-strong-active);
+		--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-brand-strong-disabled);
+		--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-brand-strong);
+		--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-brand-strong-active);
+		--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-brand-strong-disabled);
+		--wp-ui-button-padding-inline: calc(3 * var(--wpds-dimension-base)); /* TODO: Create new interactive padding tokens */
 		--wp-ui-button-height: 40px;
 		--wp-ui-button-aspect-ratio: auto; /* Useful for overrides such as icon buttons */
-		--wp-ui-button-font-size: var( --wpds-font-size-md );
+		--wp-ui-button-font-size: var(--wpds-font-size-md);
 
 		/* by default, borders have the same color as the background */
-		--wp-ui-button-border-color: var( --wp-ui-button-background-color );
-		--wp-ui-button-border-color-active: var(
-			--wp-ui-button-background-color-active
-		);
-		--wp-ui-button-border-color-disabled: var(
-			--wp-ui-button-background-color-disabled
-		);
+		--wp-ui-button-border-color: var(--wp-ui-button-background-color);
+		--wp-ui-button-border-color-active: var(--wp-ui-button-background-color-active);
+		--wp-ui-button-border-color-disabled: var(--wp-ui-button-background-color-disabled);
 
 		/* Styles */
 		position: relative;
 		display: inline-flex;
 		justify-content: center;
 		align-items: center;
-		gap: calc(
-			2 * var( --wpds-dimension-base )
-		); /* TODO: Consider new interactive/control gap tokens */
-		aspect-ratio: var( --wp-ui-button-aspect-ratio );
-		height: var( --wp-ui-button-height );
-		padding-inline: var( --wp-ui-button-padding-inline );
+		gap: calc(2 * var(--wpds-dimension-base)); /* TODO: Consider new interactive/control gap tokens */
+		aspect-ratio: var(--wp-ui-button-aspect-ratio);
+		height: var(--wp-ui-button-height);
+		padding-inline: var(--wp-ui-button-padding-inline);
 		border-style: solid;
 		border-width: 1px;
-		border-color: var( --wp-ui-button-border-color );
-		border-radius: var( --wpds-border-radius-surface-sm );
-		background-color: var( --wp-ui-button-background-color );
+		border-color: var(--wp-ui-button-border-color);
+		border-radius: var(--wpds-border-radius-surface-sm);
+		background-color: var(--wp-ui-button-background-color);
 		background-clip: padding-box;
-		font-family: var( --wpds-font-family-body );
-		font-size: var( --wp-ui-button-font-size );
-		font-weight: var( --wp-ui-button-font-weight );
-		line-height: var( --wpds-font-line-height-sm );
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wp-ui-button-font-size);
+		font-weight: var(--wp-ui-button-font-weight);
+		line-height: var(--wpds-font-line-height-sm);
 		text-decoration: none;
-		color: var( --wp-ui-button-foreground-color );
+		color: var(--wp-ui-button-foreground-color);
 
 		@media not ( prefers-reduced-motion ) {
 			transition: color 0.1s ease-out;
@@ -89,31 +69,19 @@
 		}
 
 		/* States */
-		&:not( [aria-disabled="true"] ):is( :hover, :active, :focus ) {
+		&:not([aria-disabled="true"]):is(:hover, :active, :focus) {
 			/* hover/active/focus states apply when the button is not disabled. A non
 			disabled, loading button will have hover/active/focus styles */
-			--wp-ui-button-background-color: var(
-				--wp-ui-button-background-color-active
-			);
-			--wp-ui-button-foreground-color: var(
-				--wp-ui-button-foreground-color-active
-			);
-			--wp-ui-button-border-color: var(
-				--wp-ui-button-border-color-active
-			);
+			--wp-ui-button-background-color: var(--wp-ui-button-background-color-active);
+			--wp-ui-button-foreground-color: var(--wp-ui-button-foreground-color-active);
+			--wp-ui-button-border-color: var(--wp-ui-button-border-color-active);
 		}
 
-		&[aria-disabled="true"]:not( .is-loading ) {
+		&[aria-disabled="true"]:not(.is-loading) {
 			/* A loading button, even when disabled, won't "look" disabled */
-			--wp-ui-button-background-color: var(
-				--wp-ui-button-background-color-disabled
-			);
-			--wp-ui-button-foreground-color: var(
-				--wp-ui-button-foreground-color-disabled
-			);
-			--wp-ui-button-border-color: var(
-				--wp-ui-button-border-color-disabled
-			);
+			--wp-ui-button-background-color: var(--wp-ui-button-background-color-disabled);
+			--wp-ui-button-foreground-color: var(--wp-ui-button-foreground-color-disabled);
+			--wp-ui-button-border-color: var(--wp-ui-button-border-color-disabled);
 
 			@media ( forced-colors: active ) {
 				border-color: GrayText;
@@ -126,17 +94,19 @@
 			content: "";
 			position: absolute;
 			top: 50%;
-			left: 50%;
-			transform: translate( -50%, -50% );
+			inset-inline-start: 50%;
+			transform: translate(-50%, -50%);
 
 			display: block;
 			box-sizing: border-box;
-			height: var( --wp-ui-button-font-size );
+			height: var(--wp-ui-button-font-size);
 			aspect-ratio: 1;
 
-			border: var( --wpds-border-width-interactive-focus ) solid;
-			border-color: var( --wp-ui-button-foreground-color )
-				var( --wp-ui-button-foreground-color ) transparent transparent;
+			border: var(--wpds-border-width-interactive-focus) solid;
+			border-block-start-color: var(--wp-ui-button-foreground-color);
+			border-inline-end-color: var(--wp-ui-button-foreground-color);
+			border-block-end-color: transparent;
+			border-inline-start-color: transparent;
 			border-radius: 50%;
 
 			pointer-events: none;
@@ -149,9 +119,7 @@
 	}
 
 	.is-small {
-		--wp-ui-button-padding-inline: calc(
-			2 * var( --wpds-dimension-base )
-		); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-padding-inline: calc(2 * var(--wpds-dimension-base)); /* TODO: Create new interactive padding tokens */
 		--wp-ui-button-height: 24px;
 	}
 
@@ -164,112 +132,56 @@
 		/* Outline and minimal buttons use the same foreground color */
 		&.is-outline,
 		&.is-minimal {
-			--wp-ui-button-foreground-color: var(
-				--wpds-color-fg-interactive-brand
-			);
-			--wp-ui-button-foreground-color-active: var(
-				--wpds-color-fg-interactive-brand-active
-			);
-			--wp-ui-button-foreground-color-disabled: var(
-				--wpds-color-fg-interactive-brand-disabled
-			);
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-brand);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-brand-active);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-brand-disabled);
 		}
 
 		&.is-outline {
-			--wp-ui-button-background-color: var(
-				--wpds-color-bg-interactive-brand
-			);
-			--wp-ui-button-background-color-active: var(
-				--wpds-color-bg-interactive-brand-active
-			);
-			--wp-ui-button-background-color-disabled: var(
-				--wpds-color-bg-interactive-brand-disabled
-			);
-			--wp-ui-button-border-color: var(
-				--wpds-color-stroke-interactive-brand
-			);
-			--wp-ui-button-border-color-active: var(
-				--wpds-color-stroke-interactive-brand-active
-			);
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-brand);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-brand-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-brand-disabled);
+			--wp-ui-button-border-color: var(--wpds-color-stroke-interactive-brand);
+			--wp-ui-button-border-color-active: var(--wpds-color-stroke-interactive-brand-active);
 		}
 
 		&.is-minimal {
-			--wp-ui-button-background-color: var(
-				--wpds-color-bg-interactive-brand-weak
-			);
-			--wp-ui-button-background-color-active: var(
-				--wpds-color-bg-interactive-brand-weak-active
-			);
-			--wp-ui-button-background-color-disabled: var(
-				--wpds-color-bg-interactive-brand-weak-disabled
-			);
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-brand-weak);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-brand-weak-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-brand-weak-disabled);
 		}
 	}
 
 	.is-neutral {
 		&.is-solid {
-			--wp-ui-button-background-color: var(
-				--wpds-color-bg-interactive-neutral-strong
-			);
-			--wp-ui-button-background-color-active: var(
-				--wpds-color-bg-interactive-neutral-strong-active
-			);
-			--wp-ui-button-background-color-disabled: var(
-				--wpds-color-bg-interactive-neutral-strong-disabled
-			);
-			--wp-ui-button-foreground-color: var(
-				--wpds-color-fg-interactive-neutral-strong
-			);
-			--wp-ui-button-foreground-color-active: var(
-				--wpds-color-fg-interactive-neutral-strong-active
-			);
-			--wp-ui-button-foreground-color-disabled: var(
-				--wpds-color-fg-interactive-neutral-strong-disabled
-			);
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-strong);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-strong-disabled);
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong-active);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
 		}
 
 		/* Outline and minimal buttons use the same foreground color */
 		&.is-outline,
 		&.is-minimal {
-			--wp-ui-button-foreground-color: var(
-				--wpds-color-fg-interactive-neutral
-			);
-			--wp-ui-button-foreground-color-active: var(
-				--wpds-color-fg-interactive-neutral-active
-			);
-			--wp-ui-button-foreground-color-disabled: var(
-				--wpds-color-fg-interactive-neutral-disabled
-			);
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-active);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-disabled);
 		}
 
 		&.is-outline {
-			--wp-ui-button-background-color: var(
-				--wpds-color-bg-interactive-neutral
-			);
-			--wp-ui-button-background-color-active: var(
-				--wpds-color-bg-interactive-neutral-active
-			);
-			--wp-ui-button-background-color-disabled: var(
-				--wpds-color-bg-interactive-neutral-disabled
-			);
-			--wp-ui-button-border-color: var(
-				--wpds-color-stroke-interactive-neutral
-			);
-			--wp-ui-button-border-color-active: var(
-				--wpds-color-stroke-interactive-neutral-active
-			);
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-disabled);
+			--wp-ui-button-border-color: var(--wpds-color-stroke-interactive-neutral);
+			--wp-ui-button-border-color-active: var(--wpds-color-stroke-interactive-neutral-active);
 		}
 
 		&.is-minimal {
-			--wp-ui-button-background-color: var(
-				--wpds-color-bg-interactive-neutral-weak
-			);
-			--wp-ui-button-background-color-active: var(
-				--wpds-color-bg-interactive-neutral-weak-active
-			);
-			--wp-ui-button-background-color-disabled: var(
-				--wpds-color-bg-interactive-neutral-weak-disabled
-			);
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-weak);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-weak-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-weak-disabled);
 		}
 	}
 
@@ -300,27 +212,19 @@
 	}
 
 	[aria-pressed="true"].is-minimal.is-neutral {
-		--wp-ui-button-background-color: var(
-			--wpds-color-bg-interactive-neutral-strong
-		);
-		--wp-ui-button-background-color-active: var(
-			--wpds-color-bg-interactive-neutral-strong
-		);
-		--wp-ui-button-foreground-color: var(
-			--wpds-color-fg-interactive-neutral-strong
-		);
-		--wp-ui-button-foreground-color-active: var(
-			--wpds-color-fg-interactive-neutral-strong
-		);
+		--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-strong);
+		--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong);
+		--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
+		--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong);
 	}
 }
 
 @keyframes loading-animation {
 	0% {
-		transform: translate( -50%, -50% ) rotate( 0deg );
+		transform: translate(-50%, -50%) rotate(0deg);
 	}
 
 	100% {
-		transform: translate( -50%, -50% ) rotate( 360deg );
+		transform: translate(-50%, -50%) rotate(360deg);
 	}
 }

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -47,11 +47,7 @@ describe( 'Button', () => {
 	} );
 
 	it( 'is disabled when loading', () => {
-		render(
-			<Button loading loadingAnnouncement="Loading">
-				Click me
-			</Button>
-		);
+		render( <Button loading>Click me</Button> );
 
 		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
@@ -67,7 +63,7 @@ describe( 'Button', () => {
 			// where the Button comes from.
 			// TODO: Additional improvement in the original lint rule: only error if disabled=true?
 			// eslint-disable-next-line no-restricted-syntax
-			<Button loading loadingAnnouncement="Loading" disabled={ false }>
+			<Button loading disabled={ false }>
 				Click me
 			</Button>
 		);

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../index';
+
+describe( 'Button', () => {
+	it( 'renders a button element by default', () => {
+		const { getByRole } = render( <Button>Click me</Button> );
+
+		expect(
+			getByRole( 'button', { name: 'Click me' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'forwards ref', () => {
+		const ref = createRef< HTMLButtonElement >();
+
+		render( <Button ref={ ref }>Click me</Button> );
+
+		expect( ref.current ).toBeInstanceOf( HTMLButtonElement );
+	} );
+
+	it( 'is accessible when disabled by default', async () => {
+		const user = userEvent.setup();
+
+		const onClickMock = jest.fn();
+		const { getByRole } = render(
+			<Button disabled onClick={ onClickMock }>
+				Click me
+			</Button>
+		);
+		const button = getByRole( 'button', { name: 'Click me' } );
+
+		expect( button ).toBeEnabled();
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.keyboard( '{Tab}' );
+		expect( button ).toHaveFocus();
+
+		await user.keyboard( '{Enter}' );
+		expect( onClickMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'is disabled when loading', () => {
+		const { getByRole } = render(
+			<Button loading loadingAnnouncement="Loading">
+				Click me
+			</Button>
+		);
+
+		const button = getByRole( 'button', { name: 'Click me' } );
+
+		expect( button ).toBeEnabled();
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'can be enabled explicitly when loading', () => {
+		const { getByRole } = render(
+			<Button loading loadingAnnouncement="Loading" disabled={ false }>
+				Click me
+			</Button>
+		);
+
+		const button = getByRole( 'button', { name: 'Click me' } );
+
+		expect( button ).toBeEnabled();
+		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'supports custom render prop while retaining the default accessible when disabled behavior', () => {
+		const { getByRole } = render(
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			<Button render={ <a href="/" /> } disabled>
+				Click me
+			</Button>
+		);
+		const button = getByRole( 'link', { name: 'Click me' } );
+
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'merges custom className with built-in classes', () => {
+		const customClass = 'my-button';
+		const { getByRole } = render(
+			<Button render={ <button /> } className={ customClass }>
+				Click me
+			</Button>
+		);
+		const button = getByRole( 'button', { name: 'Click me' } );
+
+		// Should have both built-in classes and custom class
+		expect( button ).toHaveClass( 'button' );
+		expect( button ).toHaveClass( customClass );
+	} );
+} );

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -96,10 +96,9 @@ describe( 'Button', () => {
 				Click me
 			</Button>
 		);
-		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
-		// Should have both built-in classes and custom class
-		expect( button ).toHaveClass( 'button' );
-		expect( button ).toHaveClass( customClass );
+		expect(
+			screen.getByRole( 'button', { name: 'Click me' } )
+		).toHaveClass( customClass );
 	} );
 } );

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -25,6 +25,10 @@ describe( 'Button', () => {
 
 		const onClickMock = jest.fn();
 		render(
+			// Disabling because this lint rule was meant for the
+			// `@wordpress/components` Button, but is being applied here.
+			// TODO: rework the lint rule so that it checks the package
+			// where the Button comes from.
 			// eslint-disable-next-line no-restricted-syntax
 			<Button disabled onClick={ onClickMock }>
 				Click me
@@ -57,7 +61,11 @@ describe( 'Button', () => {
 
 	it( 'can be enabled explicitly when loading', () => {
 		render(
-			// Additional improvement in the original lint rule: only error if disabled=true?
+			// Disabling because this lint rule was meant for the
+			// `@wordpress/components` Button, but is being applied here.
+			// TODO: rework the lint rule so that it checks the package
+			// where the Button comes from.
+			// TODO: Additional improvement in the original lint rule: only error if disabled=true?
 			// eslint-disable-next-line no-restricted-syntax
 			<Button loading loadingAnnouncement="Loading" disabled={ false }>
 				Click me

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -9,7 +9,7 @@ describe( 'Button', () => {
 
 		expect(
 			screen.getByRole( 'button', { name: 'Click me' } )
-		).toBeInTheDocument();
+		).toBeVisible();
 	} );
 
 	it( 'forwards ref', () => {

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -32,6 +32,7 @@ describe( 'Button', () => {
 
 		const onClickMock = jest.fn();
 		const { getByRole } = render(
+			// eslint-disable-next-line no-restricted-syntax
 			<Button disabled onClick={ onClickMock }>
 				Click me
 			</Button>
@@ -63,6 +64,8 @@ describe( 'Button', () => {
 
 	it( 'can be enabled explicitly when loading', () => {
 		const { getByRole } = render(
+			// Additional improvement in the original lint rule: only error if disabled=true?
+			// eslint-disable-next-line no-restricted-syntax
 			<Button loading loadingAnnouncement="Loading" disabled={ false }>
 				Click me
 			</Button>
@@ -76,7 +79,7 @@ describe( 'Button', () => {
 
 	it( 'supports custom render prop while retaining the default accessible when disabled behavior', () => {
 		const { getByRole } = render(
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			// eslint-disable-next-line jsx-a11y/anchor-has-content, no-restricted-syntax
 			<Button render={ <a href="/" /> } disabled>
 				Click me
 			</Button>

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -12,10 +12,10 @@ import { Button } from '../index';
 
 describe( 'Button', () => {
 	it( 'renders a button element by default', () => {
-		const { getByRole } = render( <Button>Click me</Button> );
+		render( <Button>Click me</Button> );
 
 		expect(
-			getByRole( 'button', { name: 'Click me' } )
+			screen.getByRole( 'button', { name: 'Click me' } )
 		).toBeInTheDocument();
 	} );
 
@@ -31,13 +31,13 @@ describe( 'Button', () => {
 		const user = userEvent.setup();
 
 		const onClickMock = jest.fn();
-		const { getByRole } = render(
+		render(
 			// eslint-disable-next-line no-restricted-syntax
 			<Button disabled onClick={ onClickMock }>
 				Click me
 			</Button>
 		);
-		const button = getByRole( 'button', { name: 'Click me' } );
+		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
 		expect( button ).toBeEnabled();
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
@@ -50,20 +50,20 @@ describe( 'Button', () => {
 	} );
 
 	it( 'is disabled when loading', () => {
-		const { getByRole } = render(
+		render(
 			<Button loading loadingAnnouncement="Loading">
 				Click me
 			</Button>
 		);
 
-		const button = getByRole( 'button', { name: 'Click me' } );
+		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
 		expect( button ).toBeEnabled();
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'can be enabled explicitly when loading', () => {
-		const { getByRole } = render(
+		render(
 			// Additional improvement in the original lint rule: only error if disabled=true?
 			// eslint-disable-next-line no-restricted-syntax
 			<Button loading loadingAnnouncement="Loading" disabled={ false }>
@@ -71,32 +71,32 @@ describe( 'Button', () => {
 			</Button>
 		);
 
-		const button = getByRole( 'button', { name: 'Click me' } );
+		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
 		expect( button ).toBeEnabled();
 		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'supports custom render prop while retaining the default accessible when disabled behavior', () => {
-		const { getByRole } = render(
+		render(
 			// eslint-disable-next-line jsx-a11y/anchor-has-content, no-restricted-syntax
 			<Button render={ <a href="/" /> } disabled>
 				Click me
 			</Button>
 		);
-		const button = getByRole( 'link', { name: 'Click me' } );
+		const button = screen.getByRole( 'link', { name: 'Click me' } );
 
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'merges custom className with built-in classes', () => {
 		const customClass = 'my-button';
-		const { getByRole } = render(
+		render(
 			<Button render={ <button /> } className={ customClass }>
 				Click me
 			</Button>
 		);
-		const button = getByRole( 'button', { name: 'Click me' } );
+		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
 		// Should have both built-in classes and custom class
 		expect( button ).toHaveClass( 'button' );

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { createRef } from 'react';
 import { render } from '@testing-library/react';
+import { createRef } from '@wordpress/element';
 import userEvent from '@testing-library/user-event';
 
 /**

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { createRef } from '@wordpress/element';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-/**
- * Internal dependencies
- */
 import { Button } from '../index';
 
 describe( 'Button', () => {

--- a/packages/ui/src/button/test/icon.test.tsx
+++ b/packages/ui/src/button/test/icon.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createRef } from 'react';
+import { createRef } from '@wordpress/element';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/ui/src/button/test/icon.test.tsx
+++ b/packages/ui/src/button/test/icon.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ButtonIcon } from '../icon';
+
+describe( 'Button.Icon', () => {
+	it( 'forwards ref', () => {
+		const ref = createRef< SVGSVGElement >();
+
+		render( <ButtonIcon ref={ ref } icon={ <svg /> } /> );
+
+		expect( ref.current ).toBeInstanceOf( SVGSVGElement );
+	} );
+} );

--- a/packages/ui/src/button/test/icon.test.tsx
+++ b/packages/ui/src/button/test/icon.test.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { createRef } from '@wordpress/element';
 import { render } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
 import { ButtonIcon } from '../icon';
 
 describe( 'Button.Icon', () => {

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -2,7 +2,7 @@ import { type ReactNode, type HTMLAttributes } from 'react';
 import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
 import { type ComponentProps } from '../utils/types';
 
-interface ButtonBaseProps
+export interface ButtonProps
 	extends Omit< ComponentProps< 'button' >, 'disabled' | 'aria-pressed' > {
 	/**
 	 * The variant of the button. Variants describe the visual style treatment
@@ -52,33 +52,16 @@ interface ButtonBaseProps
 	 * The content of the button.
 	 */
 	children?: ReactNode;
-}
 
-interface ButtonNotLoadingProps {
 	/**
 	 * Whether the button is in a loading state, such as when an action is being
 	 * performed.
+	 * @default false
 	 */
-	loading?: never;
+	loading?: boolean;
 
 	/**
 	 * The text used for assistive technology to indicate the loading state.
 	 */
-	loadingAnnouncement?: never;
+	loadingAnnouncement?: string;
 }
-
-interface ButtonLoadingProps {
-	/**
-	 * Whether the button is in a loading state, such as when an action is being
-	 * performed.
-	 */
-	loading: boolean;
-
-	/**
-	 * The text used for assistive technology to indicate the loading state.
-	 */
-	loadingAnnouncement: string;
-}
-
-export type ButtonProps = ButtonBaseProps &
-	( ButtonLoadingProps | ButtonNotLoadingProps );

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { type ReactNode, type HTMLAttributes } from 'react';
+import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
+
+/**
+ * Internal dependencies
+ */
+import { type ComponentProps } from '../utils/types';
+
+interface ButtonBaseProps
+	extends Omit< ComponentProps< 'button' >, 'disabled' | 'aria-pressed' > {
+	/**
+	 * The variant of the button. Variants describe the visual style treatment
+	 * of the button.
+	 *
+	 * @default "solid"
+	 */
+	variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
+
+	/**
+	 * The tone of the button. Tone describes a semantic color intent.
+	 *
+	 * @default "brand"
+	 */
+	tone?: 'brand' | 'neutral';
+
+	/**
+	 * The size of the button.
+	 *
+	 * - `'default'`: For normal text-label buttons, unless it is a toggle button.
+	 * - `'compact'`: For toggle buttons, icon buttons, and buttons when used in context of either.
+	 * - `'small'`: For icon buttons associated with more advanced or auxiliary features.
+	 *
+	 * @default "default"
+	 */
+	size?: 'default' | 'compact' | 'small';
+
+	/**
+	 * Whether the button is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Whether the element should be focusable even when it is disabled.
+	 *
+	 * @default true
+	 */
+	accessibleWhenDisabled?: AriakitButtonProps[ 'accessibleWhenDisabled' ];
+
+	/**
+	 * Indicates the current "pressed" state of toggle buttons. This should only
+	 * be used with neutral minimal buttons.
+	 */
+	'aria-pressed'?: HTMLAttributes< HTMLButtonElement >[ 'aria-pressed' ];
+
+	/**
+	 * The content of the button.
+	 */
+	children?: ReactNode;
+}
+
+interface ButtonNotLoadingProps {
+	/**
+	 * Whether the button is in a loading state, such as when an action is being
+	 * performed.
+	 */
+	loading?: never;
+
+	/**
+	 * The text used for assistive technology to indicate the loading state.
+	 */
+	loadingAnnouncement?: never;
+}
+
+interface ButtonLoadingProps {
+	/**
+	 * Whether the button is in a loading state, such as when an action is being
+	 * performed.
+	 */
+	loading: boolean;
+
+	/**
+	 * The text used for assistive technology to indicate the loading state.
+	 */
+	loadingAnnouncement: string;
+}
+
+export type ButtonProps = ButtonBaseProps &
+	( ButtonLoadingProps | ButtonNotLoadingProps );

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { type ReactNode, type HTMLAttributes } from 'react';
-// eslint-disable-next-line no-restricted-imports
 import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
 
 /**

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { type ReactNode, type HTMLAttributes } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
 
 /**

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { type ReactNode, type HTMLAttributes } from 'react';
 import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
-
-/**
- * Internal dependencies
- */
 import { type ComponentProps } from '../utils/types';
 
 interface ButtonBaseProps

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export * from './badge';
 export * from './box';
+export * from './button';
 export * from './form/primitives';
 export * from './icon';
 export * from './stack';

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -1,0 +1,33 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-utilities {
+	.outset-ring--focus,
+	.outset-ring--focus-except-active,
+	.outset-ring--focus-visible,
+	.outset-ring--focus-within,
+	.outset-ring--focus-within-except-active,
+	.outset-ring--focus-within-visible {
+		@media not ( prefers-reduced-motion ) {
+			transition: outline 0.1s ease-out;
+		}
+
+		/* Outline width must be kept at 0 even with a transparent color,
+		or else the outline will be visible in forced-colors mode. */
+		outline-width: 0;
+		outline-style: solid;
+		outline-color: transparent;
+		outline-offset: 1px;
+	}
+
+	.outset-ring--focus:focus,
+	.outset-ring--focus-except-active:focus:not( :active ),
+	.outset-ring--focus-visible:focus-visible,
+	.outset-ring--focus-within:focus-within,
+	.outset-ring--focus-within-except-active:focus-within:not(
+			:has( :active )
+		),
+	.outset-ring--focus-within-visible:focus-within:has( :focus-visible ) {
+		outline-width: var( --wpds-border-width-focus );
+		outline-color: var( --wpds-color-stroke-focus-brand );
+	}
+}

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -20,14 +20,12 @@
 	}
 
 	.outset-ring--focus:focus,
-	.outset-ring--focus-except-active:focus:not( :active ),
+	.outset-ring--focus-except-active:focus:not(:active),
 	.outset-ring--focus-visible:focus-visible,
 	.outset-ring--focus-within:focus-within,
-	.outset-ring--focus-within-except-active:focus-within:not(
-			:has( :active )
-		),
-	.outset-ring--focus-within-visible:focus-within:has( :focus-visible ) {
-		outline-width: var( --wpds-border-width-focus );
-		outline-color: var( --wpds-color-stroke-focus-brand );
+	.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
+	.outset-ring--focus-within-visible:focus-within:has(:focus-visible) {
+		outline-width: var(--wpds-border-width-interactive-focus);
+		outline-color: var(--wpds-color-stroke-focus-brand);
 	}
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -5,6 +5,7 @@
 		"types": [ "node", "jest" ]
 	},
 	"references": [
+		{ "path": "../a11y" },
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Requires #74311
Part of https://github.com/WordPress/gutenberg/issues/71196

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Add new `Button` component to `@wordpress/ui`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a replacement for the `Icon` component in `@wordpress/components`, with these changes:

- better themability thanks to `@wordpress/theme` variables (design tokens)
- cleaner API which allows consumers to easily pick a tone / variant / size (incluing an unstyled variant)
- less reliance on custom React props in favour of existing HTML attributes (eg `aria-pressed`)
- accessible when disabled by default
- removed internal tooltip dependency (smaller bundle when importing Button)
- loading state


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See code

**Note**: _ignore changes from the first commit to see the actual code changes that I applied to adapt the component's code to the WP UI package._

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- See code changes
- Test in Storybook

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

![Screenshot 2026-01-07 at 18 25 57](https://github.com/user-attachments/assets/87d19459-6180-4753-b7b5-b03a46484dbd)

## Follow-ups

- [x] https://github.com/WordPress/gutenberg/pull/74416
- [x] https://github.com/WordPress/gutenberg/pull/74463
  - [x] later undone https://github.com/WordPress/gutenberg/pull/74540
- [x] https://github.com/WordPress/gutenberg/pull/74470
- [x] https://github.com/WordPress/gutenberg/pull/74557 
- [x] https://github.com/WordPress/gutenberg/pull/74611
- [x] https://github.com/WordPress/gutenberg/pull/75143
- [x] https://github.com/WordPress/gutenberg/issues/75134
- [x] https://github.com/WordPress/gutenberg/pull/75133