### PR TITLE
`@wordpress/ui` `Button`: refactor to base ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55649,7 +55649,6 @@
 			"version": "0.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
 				"@base-ui/react": "^1.0.0",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/element": "file:../element",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,4 +13,4 @@
 -   Add `Field` primitives ([#74190](https://github.com/WordPress/gutenberg/pull/74190)).
 -   Add `Fieldset` primitives ([#74296](https://github.com/WordPress/gutenberg/pull/74296)).
 -   Add `Icon` component ([#74311](https://github.com/WordPress/gutenberg/pull/74311)).
--   Add `Button` component ([#74415](https://github.com/WordPress/gutenberg/pull/74415)).
+-   Add `Button` component ([#74415](https://github.com/WordPress/gutenberg/pull/74415), [#74416](https://github.com/WordPress/gutenberg/pull/74416) ).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,6 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@ariakit/react": "^0.4.15",
 		"@base-ui/react": "^1.0.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/element": "file:../element",

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,4 +1,4 @@
-import { Button as AriakitButton } from '@ariakit/react';
+import { Button as _Button } from '@base-ui/react/button';
 import clsx from 'clsx';
 import { speak } from '@wordpress/a11y';
 import { forwardRef, useEffect } from '@wordpress/element';
@@ -15,7 +15,7 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			variant = 'solid',
 			size = 'default',
 			className,
-			accessibleWhenDisabled = true,
+			focusableWhenDisabled = true,
 			disabled,
 			loading,
 			loadingAnnouncement = __( 'Loading' ),
@@ -43,15 +43,15 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 		}, [ loading, loadingAnnouncement ] );
 
 		return (
-			<AriakitButton
+			<_Button
 				ref={ ref }
 				className={ mergedClassName }
-				accessibleWhenDisabled={ accessibleWhenDisabled }
+				focusableWhenDisabled={ focusableWhenDisabled }
 				disabled={ disabled ?? loading }
 				{ ...props }
 			>
 				{ children }
-			</AriakitButton>
+			</_Button>
 		);
 	}
 );

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -157,18 +157,6 @@ export const AllTonesAndVariants: Story = {
 	),
 };
 
-export const LinkStyledAsButton: Story = {
-	...Default,
-	args: {
-		...Default.args,
-		// Link content passed through `children`
-		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		render: <a href="https://example.com" />,
-		nativeButton: false,
-		children: 'Link',
-	},
-};
-
 export const WithIcon: Story = {
 	...Default,
 	args: {

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -164,6 +164,7 @@ export const LinkStyledAsButton: Story = {
 		// Link content passed through `children`
 		// eslint-disable-next-line jsx-a11y/anchor-has-content
 		render: <a href="https://example.com" />,
+		nativeButton: false,
 		children: 'Link',
 	},
 };

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -74,14 +74,18 @@ describe( 'Button', () => {
 		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
-	it( 'supports custom render prop while retaining the default accessible when disabled behavior', () => {
+	it( 'supports custom render prop while retaining the default focusable when disabled behavior', () => {
 		render(
+			// Disabling because this lint rule was meant for the
+			// `@wordpress/components` Button, but is being applied here.
+			// TODO: rework the lint rule so that it checks the package
+			// where the Button comes from.
 			// eslint-disable-next-line jsx-a11y/anchor-has-content, no-restricted-syntax
-			<Button render={ <a href="/" /> } disabled>
+			<Button render={ <a href="/" /> } nativeButton={ false } disabled>
 				Click me
 			</Button>
 		);
-		const button = screen.getByRole( 'link', { name: 'Click me' } );
+		const button = screen.getByRole( 'button', { name: 'Click me' } );
 
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
@@ -93,7 +97,6 @@ describe( 'Button', () => {
 				Click me
 			</Button>
 		);
-
 		expect(
 			screen.getByRole( 'button', { name: 'Click me' } )
 		).toHaveClass( customClass );

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -1,9 +1,8 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
-import { type ButtonProps as AriakitButtonProps } from '@ariakit/react';
-import { type ComponentProps } from '../utils/types';
+import type { ButtonProps as _ButtonProps } from '@base-ui/react/button';
 
 export interface ButtonProps
-	extends Omit< ComponentProps< 'button' >, 'disabled' | 'aria-pressed' > {
+	extends Omit< _ButtonProps, 'disabled' | 'aria-pressed' > {
 	/**
 	 * The variant of the button. Variants describe the visual style treatment
 	 * of the button.
@@ -43,7 +42,7 @@ export interface ButtonProps
 	 *
 	 * @default true
 	 */
-	accessibleWhenDisabled?: AriakitButtonProps[ 'accessibleWhenDisabled' ];
+	focusableWhenDisabled?: _ButtonProps[ 'focusableWhenDisabled' ];
 
 	/**
 	 * Indicates the current "pressed" state of toggle buttons. This should only

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -1,5 +1,8 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
-import type { ButtonProps as _ButtonProps } from '@base-ui/react/button';
+import type { Button as _Button } from '@base-ui/react/button';
+import type { ComponentProps } from '../utils/types';
+
+type _ButtonProps = ComponentProps< typeof _Button >;
 
 export interface ButtonProps
 	extends Omit< _ButtonProps, 'disabled' | 'aria-pressed' > {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Stacked on top of #74415

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Refactor the `Button` component in the `@wordpress/ui` package from ariakit to base ui

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To use the same underlying component library already used in the package

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swapped imports
- Adapted APIs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Unit tests pass
- Test the component in Storybook
