### PR TITLE
Fix focus loss when collapsing DataForm Card view

### DIFF
--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -13,6 +13,7 @@ import {
 	useEffect,
 	useMemo,
 	useState,
+	useRef,
 } from '@wordpress/element';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -32,78 +33,83 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import { getSummaryFields } from '../get-summary-fields';
 
-const NonCollapsibleCardHeader = ( {
+const NonCollapsibleCardHeader = ({
 	children,
 	...props
 }: {
 	children: React.ReactNode;
-} ) => (
-	<OriginalCardHeader isBorderless { ...props }>
+}) => (
+	<OriginalCardHeader isBorderless {...props}>
 		<div
-			style={ {
-				height: '40px', // This is to match the chevron's __next40pxDefaultSize
+			style={{
+				height: '40px',
 				width: '100%',
 				display: 'flex',
 				justifyContent: 'space-between',
 				alignItems: 'center',
-			} }
+			}}
 		>
-			{ children }
+			{children}
 		</div>
 	</OriginalCardHeader>
 );
 
-export function useCardHeader( layout: NormalizedCardLayout ) {
+export function useCardHeader(layout: NormalizedCardLayout) {
 	const { isOpened, isCollapsible } = layout;
-	const [ isOpen, setIsOpen ] = useState( isOpened );
+	const [isOpen, setIsOpen] = useState(isOpened);
+	const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
 
 	// Sync internal state when the isOpened prop changes.
-	// This is unlikely to happen in production, but it helps with storybook controls.
-	useEffect( () => {
-		setIsOpen( isOpened );
-	}, [ isOpened ] );
+	useEffect(() => {
+		setIsOpen(isOpened);
+	}, [isOpened]);
 
-	const toggle = useCallback( () => {
-		setIsOpen( ( prev ) => ! prev );
-	}, [] );
+	const toggle = useCallback(() => {
+		setIsOpen((prev) => !prev);
+
+		requestAnimationFrame(() => {
+			toggleButtonRef.current?.focus();
+		});
+	}, []);
 
 	const CollapsibleCardHeader = useCallback(
-		( {
+		({
 			children,
 			...props
 		}: {
 			children: React.ReactNode;
-			[ key: string ]: any;
-		} ) => (
+			[key: string]: any;
+		}) => (
 			<OriginalCardHeader
-				{ ...props }
-				onClick={ toggle }
-				style={ {
+				{...props}
+				onClick={toggle}
+				style={{
 					cursor: 'pointer',
 					...props.style,
-				} }
+				}}
 				isBorderless
 			>
 				<div
-					style={ {
+					style={{
 						width: '100%',
 						display: 'flex',
 						justifyContent: 'space-between',
 						alignItems: 'center',
-					} }
+					}}
 				>
-					{ children }
+					{children}
 				</div>
 				<Button
+					ref={toggleButtonRef}
 					__next40pxDefaultSize
 					variant="tertiary"
-					icon={ isOpen ? chevronUp : chevronDown }
-					aria-expanded={ isOpen }
-					aria-label={ isOpen ? 'Collapse' : 'Expand' }
+					icon={isOpen ? chevronUp : chevronDown}
+					aria-expanded={isOpen}
+					aria-label={isOpen ? 'Collapse' : 'Expand'}
 				/>
 			</OriginalCardHeader>
 		),
-		[ toggle, isOpen ]
+		[toggle, isOpen]
 	);
 
 	const effectiveIsOpen = isCollapsible ? isOpen : true;
@@ -114,81 +120,74 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 	return { isOpen: effectiveIsOpen, CardHeader: CardHeaderComponent };
 }
 
-function isSummaryFieldVisible< Item >(
-	summaryField: NormalizedField< Item >,
-	summaryConfig: NormalizedCardLayout[ 'summary' ],
+function isSummaryFieldVisible<Item>(
+	summaryField: NormalizedField<Item>,
+	summaryConfig: NormalizedCardLayout['summary'],
 	isOpen: boolean
 ) {
-	// If no summary config, dont't show any fields
 	if (
-		! summaryConfig ||
-		( Array.isArray( summaryConfig ) && summaryConfig.length === 0 )
+		!summaryConfig ||
+		(Array.isArray(summaryConfig) && summaryConfig.length === 0)
 	) {
 		return false;
 	}
 
-	// Convert to array for consistent handling
-	const summaryConfigArray = Array.isArray( summaryConfig )
+	const summaryConfigArray = Array.isArray(summaryConfig)
 		? summaryConfig
-		: [ summaryConfig ];
+		: [summaryConfig];
 
-	// Find the config for this specific field
-	const fieldConfig = summaryConfigArray.find( ( config ) => {
-		if ( typeof config === 'string' ) {
+	const fieldConfig = summaryConfigArray.find((config) => {
+		if (typeof config === 'string') {
 			return config === summaryField.id;
 		}
-		if ( typeof config === 'object' && 'id' in config ) {
+		if (typeof config === 'object' && 'id' in config) {
 			return config.id === summaryField.id;
 		}
 		return false;
-	} );
+	});
 
-	// If field is not in summary config, don't show it
-	if ( ! fieldConfig ) {
+	if (!fieldConfig) {
 		return false;
 	}
 
-	// If it's a string, always show it
-	if ( typeof fieldConfig === 'string' ) {
+	if (typeof fieldConfig === 'string') {
 		return true;
 	}
 
-	// If it has visibility rules, respect them
-	if ( typeof fieldConfig === 'object' && 'visibility' in fieldConfig ) {
+	if (typeof fieldConfig === 'object' && 'visibility' in fieldConfig) {
 		return (
 			fieldConfig.visibility === 'always' ||
-			( fieldConfig.visibility === 'when-collapsed' && ! isOpen )
+			(fieldConfig.visibility === 'when-collapsed' && !isOpen)
 		);
 	}
 
-	// Default to always show
 	return true;
 }
 
-export default function FormCardField< Item >( {
+export default function FormCardField<Item>({
 	data,
 	field,
 	onChange,
 	hideLabelFromVision,
 	validity,
-}: FieldLayoutProps< Item > ) {
-	const { fields } = useContext( DataFormContext );
+}: FieldLayoutProps<Item>) {
+	const { fields } = useContext(DataFormContext);
 	const layout = field.layout as NormalizedCardLayout;
 
 	const form: NormalizedForm = useMemo(
-		() => ( {
+		() => ({
 			layout: DEFAULT_LAYOUT as NormalizedLayout,
 			fields: field.children ?? [],
-		} ),
-		[ field ]
+		}),
+		[field]
 	);
 
-	const { isOpen, CardHeader } = useCardHeader( layout );
+	const { isOpen, CardHeader } = useCardHeader(layout);
 
-	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
+	const summaryFields = getSummaryFields<Item>(layout.summary, fields);
 
-	const visibleSummaryFields = summaryFields.filter( ( summaryField ) =>
-		isSummaryFieldVisible( summaryField, layout.summary, isOpen )
+	const visibleSummaryFields = summaryFields.filter((summaryField) =>
+		isSummaryFieldVisible(summaryField, layout.summary, isOpen)
 	);
 
 	const sizeCard = {
@@ -198,124 +197,119 @@ export default function FormCardField< Item >( {
 		inlineEnd: 'medium' as const,
 	};
 
-	if ( !! field.children ) {
-		const withHeader = !! field.label && layout.withHeader;
+	if (!!field.children) {
+		const withHeader = !!field.label && layout.withHeader;
 
 		const sizeCardBody = {
-			blockStart: withHeader
-				? ( 'none' as const )
-				: ( 'medium' as const ),
+			blockStart: withHeader ? ('none' as const) : ('medium' as const),
 			blockEnd: 'medium' as const,
 			inlineStart: 'medium' as const,
 			inlineEnd: 'medium' as const,
 		};
 
+
 		return (
-			<Card className="dataforms-layouts-card__field" size={ sizeCard }>
-				{ withHeader && (
+			<Card className="dataforms-layouts-card__field" size={sizeCard}>
+				{withHeader && (
 					<CardHeader className="dataforms-layouts-card__field-header">
 						<span className="dataforms-layouts-card__field-header-label">
-							{ field.label }
+							{field.label}
 						</span>
-						{ visibleSummaryFields.length > 0 &&
+						{visibleSummaryFields.length > 0 &&
 							layout.withHeader && (
 								<div className="dataforms-layouts-card__field-summary">
-									{ visibleSummaryFields.map(
-										( summaryField ) => (
+									{visibleSummaryFields.map(
+										(summaryField) => (
 											<summaryField.render
-												key={ summaryField.id }
-												item={ data }
-												field={ summaryField }
+												key={summaryField.id}
+												item={data}
+												field={summaryField}
 											/>
 										)
-									) }
+									)}
 								</div>
-							) }
+							)}
 					</CardHeader>
-				) }
-				{ ( isOpen || ! withHeader ) && (
-					// If it doesn't have a header, keep it open.
-					// Otherwise, the card will not be visible.
+				)}
+				{(isOpen || !withHeader) && (
 					<CardBody
-						size={ sizeCardBody }
+						size={sizeCardBody}
 						className="dataforms-layouts-card__field-control"
 					>
-						{ field.description && (
+						{field.description && (
 							<div className="dataforms-layouts-card__field-description">
-								{ field.description }
+								{field.description}
 							</div>
-						) }
+						)}
 						<DataFormLayout
-							data={ data }
-							form={ form }
-							onChange={ onChange }
-							validity={ validity?.children }
+							data={data}
+							form={form}
+							onChange={onChange}
+							validity={validity?.children}
 						/>
 					</CardBody>
-				) }
+				)}
 			</Card>
 		);
 	}
 
 	const fieldDefinition = fields.find(
-		( fieldDef ) => fieldDef.id === field.id
+		(fieldDef) => fieldDef.id === field.id
 	);
 
-	if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
+	if (!fieldDefinition || !fieldDefinition.Edit) {
 		return null;
 	}
 
-	const RegularLayout = getFormFieldLayout( 'regular' )?.component;
-	if ( ! RegularLayout ) {
+	const RegularLayout = getFormFieldLayout('regular')?.component;
+	if (!RegularLayout) {
 		return null;
 	}
-	const withHeader = !! fieldDefinition.label && layout.withHeader;
+
+	const withHeader = !!fieldDefinition.label && layout.withHeader;
 
 	const sizeCardBody = {
-		blockStart: withHeader ? ( 'none' as const ) : ( 'medium' as const ),
+		blockStart: withHeader ? ('none' as const) : ('medium' as const),
 		blockEnd: 'medium' as const,
 		inlineStart: 'medium' as const,
 		inlineEnd: 'medium' as const,
 	};
 
+
 	return (
-		<Card className="dataforms-layouts-card__field" size={ sizeCard }>
-			{ withHeader && (
+		<Card className="dataforms-layouts-card__field" size={sizeCard}>
+			{withHeader && (
 				<CardHeader className="dataforms-layouts-card__field-header">
 					<span className="dataforms-layouts-card__field-header-label">
-						{ fieldDefinition.label }
+						{fieldDefinition.label}
 					</span>
-					{ visibleSummaryFields.length > 0 && layout.withHeader && (
+					{visibleSummaryFields.length > 0 && layout.withHeader && (
 						<div className="dataforms-layouts-card__field-summary">
-							{ visibleSummaryFields.map( ( summaryField ) => (
+							{visibleSummaryFields.map((summaryField) => (
 								<summaryField.render
-									key={ summaryField.id }
-									item={ data }
-									field={ summaryField }
+									key={summaryField.id}
+									item={data}
+									field={summaryField}
 								/>
-							) ) }
+							))}
 						</div>
-					) }
+					)}
 				</CardHeader>
-			) }
-			{ ( isOpen || ! withHeader ) && (
-				// If it doesn't have a header, keep it open.
-				// Otherwise, the card will not be visible.
+			)}
+			{(isOpen || !withHeader) && (
 				<CardBody
-					size={ sizeCardBody }
+					size={sizeCardBody}
 					className="dataforms-layouts-card__field-control"
 				>
 					<RegularLayout
-						data={ data }
-						field={ field }
-						onChange={ onChange }
-						hideLabelFromVision={
-							hideLabelFromVision || withHeader
-						}
-						validity={ validity }
+						data={data}
+						field={field}
+						onChange={onChange}
+						hideLabelFromVision={hideLabelFromVision || withHeader}
+						validity={validity}
 					/>
 				</CardBody>
-			) }
+			)}
 		</Card>
 	);
 }


### PR DESCRIPTION
@mirka  Please Check 
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #73242

Preserves keyboard focus when collapsing or expanding a DataForm Card so focus remains on the toggle button.

## Why?
When a DataForm Card is collapsed or expanded, the component re-renders and the collapse/expand toggle button loses focus.
This breaks keyboard navigation and creates an accessibility issue for keyboard and assistive technology users.

## How?
- Added a `useRef` to persist a reference to the collapse/expand toggle button.
- Restored focus to the toggle button after updating the card’s open state.
- No visual, behavioral, or layout changes beyond focus management.

## Testing Instructions
1. Run `npm run storybook`
2. Open the **DataForm → Card layout** story
3. Ensure the card is configured as collapsible

### Keyboard Testing
1. Use `Tab` to focus the card’s collapse/expand toggle button
2. Press `Enter` or `Space` to collapse the card
3. Verify focus remains on the toggle button
4. Press `Enter` or `Space` again to expand the card
5. Verify focus is still preserved
 
## Screen Recording 

https://github.com/user-attachments/assets/be7c9a07-5c20-4f54-ac45-423e878ae7c5


