### PR TITLE
Block Parser: Update error-handling for stack of unclosed blocks.

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -110,22 +110,42 @@ class WP_Block_Parser {
 				 * we have options
 				 * - treat it all as freeform text
 				 * - assume an implicit closer (easiest when not nesting)
+				 *
+				 * Treat this as a stack of implicit closers.
 				 */
+				$implicitly_closed = null;
+				$last_freeform     = null;
+				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition --
+				while ( null !== ( $stack_top = array_pop( $this->stack ) ) ) {
+					if ( isset( $last_freeform ) ) {
+						$html = substr( $this->document, $stack_top->prev_offset, $last_freeform[1] - $stack_top->prev_offset );
+					} else {
+						$html = substr( $this->document, $stack_top->prev_offset );
+					}
 
-				// for the easy case we'll assume an implicit closer.
-				if ( 1 === $stack_depth ) {
-					$this->add_block_from_stack();
-					return false;
+					$stack_top->block->innerHTML     .= $html;
+					$stack_top->block->innerContent[] = $html;
+
+					// Trap potential leading freeform content for the final output.
+					$last_freeform = array( $stack_top->leading_html_start ?? 0, $stack_top->token_start );
+
+					if ( isset( $implicitly_closed ) ) {
+						$stack_top->block->innerContent[] = null;
+						$stack_top->block->innerBlocks[]  = $implicitly_closed;
+					}
+
+					$implicitly_closed = $stack_top->block;
 				}
 
-				/*
-				 * for the nested case where it's more difficult we'll
-				 * have to assume that multiple closers are missing
-				 * and so we'll collapse the whole stack piecewise
-				 */
-				while ( 0 < count( $this->stack ) ) {
-					$this->add_block_from_stack();
+				if ( isset( $last_freeform ) && $last_freeform[1] > $last_freeform[0] ) {
+					$html           = substr( $this->document, $last_freeform[0], $last_freeform[1] - $last_freeform[0] );
+					$this->output[] = (array) $this->freeform( $html );
 				}
+
+				if ( isset( $implicitly_closed ) ) {
+					$this->output[] = $implicitly_closed;
+				}
+
 				return false;
 
 			case 'void-block':

--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -97,55 +97,32 @@ class WP_Block_Parser {
 
 		switch ( $token_type ) {
 			case 'no-more-tokens':
-				// if not in a block then flush output.
+				/*
+				 * Most documents will end with all blocks properly closed.
+				 * In these cases, all that’s necessary is to flush the output.
+				 * There is probably a terminating newline.
+				 */
 				if ( 0 === $stack_depth ) {
 					$this->add_freeform();
 					return false;
 				}
 
 				/*
-				 * Otherwise we have a problem
-				 * This is an error
+				 * However, if blocks remain open it means there were missing
+				 * closing block delimiters. The post may have been truncated,
+				 * for example, but some amount of corruption produced a malformed
+				 * document.
 				 *
-				 * we have options
-				 * - treat it all as freeform text
-				 * - assume an implicit closer (easiest when not nesting)
+				 * The spec parser considers this a parse error and returns a long
+				 * freeform block containing the full span of text from the input
+				 * document from the start of the un-closed block.
 				 *
-				 * Treat this as a stack of implicit closers.
+				 * This parser, however, is making a different pragmatic choice: it
+				 * will implicitly close any remaining open blocks, as if the closers
+				 * were provided. This ensures recovery of as much of the provided
+				 * block structure as is possible.
 				 */
-				$implicitly_closed = null;
-				$last_freeform     = null;
-				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition --
-				while ( null !== ( $stack_top = array_pop( $this->stack ) ) ) {
-					if ( isset( $last_freeform ) ) {
-						$html = substr( $this->document, $stack_top->prev_offset, $last_freeform[1] - $stack_top->prev_offset );
-					} else {
-						$html = substr( $this->document, $stack_top->prev_offset );
-					}
-
-					$stack_top->block->innerHTML     .= $html;
-					$stack_top->block->innerContent[] = $html;
-
-					// Trap potential leading freeform content for the final output.
-					$last_freeform = array( $stack_top->leading_html_start ?? 0, $stack_top->token_start );
-
-					if ( isset( $implicitly_closed ) ) {
-						$stack_top->block->innerContent[] = null;
-						$stack_top->block->innerBlocks[]  = $implicitly_closed;
-					}
-
-					$implicitly_closed = $stack_top->block;
-				}
-
-				if ( isset( $last_freeform ) && $last_freeform[1] > $last_freeform[0] ) {
-					$html           = substr( $this->document, $last_freeform[0], $last_freeform[1] - $last_freeform[0] );
-					$this->output[] = (array) $this->freeform( $html );
-				}
-
-				if ( isset( $implicitly_closed ) ) {
-					$this->output[] = $implicitly_closed;
-				}
-
+				$this->implicitly_close_and_add_open_blocks();
 				return false;
 
 			case 'void-block':
@@ -373,6 +350,47 @@ class WP_Block_Parser {
 
 		$parent->block->innerContent[] = null;
 		$parent->prev_offset           = $last_offset ? $last_offset : $token_start + $token_length;
+	}
+
+	/**
+	 * Closes all open blocks and adds remaining blocks and freeform content to the output list.
+	 *
+	 * @internal
+	 * @since 6.9.1
+	 */
+	public function implicitly_close_and_add_open_blocks() {
+		$implicitly_closed = null;
+		$last_freeform     = null;
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition --
+		while ( null !== ( $stack_top = array_pop( $this->stack ) ) ) {
+			if ( isset( $last_freeform ) ) {
+				$html = substr( $this->document, $stack_top->prev_offset, $last_freeform[1] - $stack_top->prev_offset );
+			} else {
+				$html = substr( $this->document, $stack_top->prev_offset );
+			}
+
+			$stack_top->block->innerHTML     .= $html;
+			$stack_top->block->innerContent[] = $html;
+
+			// Trap potential leading freeform content for the final output.
+			$last_freeform = array( $stack_top->leading_html_start ?? 0, $stack_top->token_start );
+
+			if ( isset( $implicitly_closed ) ) {
+				$stack_top->block->innerContent[] = null;
+				$stack_top->block->innerBlocks[]  = $implicitly_closed;
+			}
+
+			$implicitly_closed = $stack_top->block;
+		}
+
+		if ( isset( $last_freeform ) && $last_freeform[1] > $last_freeform[0] ) {
+			$html           = substr( $this->document, $last_freeform[0], $last_freeform[1] - $last_freeform[0] );
+			$this->output[] = (array) $this->freeform( $html );
+		}
+
+		if ( isset( $implicitly_closed ) ) {
+			$this->output[] = $implicitly_closed;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Status

 - [ ] Move new code into new method, `$this->implicitly_close_open_blocks()`.
 - [ ] Port to JS parser, as it is also susceptible to the memory issue.

## Summary

There has been a known memory explosion for posts with deep stacks of unclosed blocks. These posts experience exponential memory use and can require gigabytes of memory to parse completely.

This was due to a mismatch in the spec and default PHP parsers which led to catastrophic string duplciation on account of how the default parser closed out these blocks.

In this patch, the behavior is updated to implicitly close all open blocks when the end of the document is reached. This remains divergent from the spec parser, which treats a failure to find the closing delimiters as one giant freeform block, but the behavior should be better in general for truncated posts, given that it leaves intact as many elements of the block structure as are viable.

## Impact

The motivating post for `WP_Block_Processor` and this change is a 3 MB post which currently takes 18 GB of memory to parse on my laptop, taking 2.5 s to produce 10,930 blocks.

After this change, the basic `parse_blocks()` call _now_ takes a mere 30 ms and 57 MB to produce 11,258 blocks.

I’m not sure how many blocks are truly there. `WP_Block_Processor` counts 14,266 opening and void block delimiters. Regardless, the post is corrupted and it’s hard to claim there’s one correct count or parse.

For another test post, which is around 1.8 MB large, goes from 205 ms and 2 GB down to 12 ms and 46 MB.