### PR TITLE
List View: Fix focus shift to the selected nested block

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -19,7 +19,6 @@ import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import {
 	useCallback,
-	useEffect,
 	useMemo,
 	useRef,
 	useReducer,
@@ -118,7 +117,8 @@ function ListViewComponent(
 		useListViewClientIds( { blocks, rootClientId } );
 	const blockIndexes = useListViewBlockIndexes( clientIdsTree );
 
-	const { getBlock } = useSelect( blockEditorStore );
+	const { getBlock, getSelectedBlockClientIds } =
+		useSelect( blockEditorStore );
 	const { visibleBlockCount } = useSelect(
 		( select ) => {
 			const { getGlobalBlockCount, getClientIdsOfDescendants } =
@@ -172,21 +172,25 @@ function ListViewComponent(
 		selectBlock: selectEditorBlock,
 	} );
 
+	const focusSelectedBlock = useCallback(
+		( node ) => {
+			const [ firstSelectedClientId ] = getSelectedBlockClientIds();
+			// If a blocks are already selected when the list view is initially
+			// mounted, shift focus to the first selected block.
+			if ( firstSelectedClientId && node ) {
+				focusListItem( firstSelectedClientId, node );
+			}
+		},
+		[ getSelectedBlockClientIds ]
+	);
+
 	const treeGridRef = useMergeRefs( [
 		clipBoardRef,
+		focusSelectedBlock,
 		elementRef,
 		dropZoneRef,
 		ref,
 	] );
-
-	useEffect( () => {
-		// If a blocks are already selected when the list view is initially
-		// mounted, shift focus to the first selected block.
-		if ( selectedClientIds?.length ) {
-			focusListItem( selectedClientIds[ 0 ], elementRef?.current );
-		}
-		// Only focus on the selected item when the list view is mounted.
-	}, [] );
 
 	const expand = useCallback(
 		( clientId ) => {


### PR DESCRIPTION
## What?

PR fixes a bug where focus wasn't shifted to the selected child block when opening the List View. The focus block on the mount handler was called before the list branch expanded, so it failed to focus anything.

I've borrowed the deferred focus helper from Notes; while not perfect, it works in most cases.

## Testing Instructions
1. Open a post or page.
2. Add any block with children.
3. Selected a child block.
4. Open the List View.
5. Confirm that focus is shifted to the selected child block and not the first block in the list.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/2d1dfd05-a549-4d18-867a-54ef8ee8becb

**After**

https://github.com/user-attachments/assets/6c428d85-aaeb-4d0b-9910-11bdfe568217
