### PR TITLE
Media Fields: Add an attached_to field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54567,6 +54567,7 @@
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
+				"@wordpress/compose": "file:../compose",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
 				"@wordpress/dataviews": "file:../dataviews",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -51,6 +51,7 @@
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dataviews": "file:../dataviews",

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -1,0 +1,185 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { Button, ComboboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState, createInterpolateElement } from '@wordpress/element';
+import { debounce } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import type { DataFormControlProps } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+import { getRenderedContent } from '../utils/get-rendered-content';
+
+export type SearchResult = {
+	/**
+	 * Post or term id.
+	 */
+	id: number;
+	/**
+	 * Link url.
+	 */
+	url: string;
+	/**
+	 * Title of the link.
+	 */
+	title: string;
+	/**
+	 * The taxonomy or post type slug or type URL.
+	 */
+	type: string;
+	/**
+	 * Link kind of post-type or taxonomy
+	 */
+	kind?: string;
+};
+
+export default function MediaAttachedToEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< MediaItem > ) {
+	const defaultPost =
+		!! data.post && !! data?._embedded?.[ 'wp:attached-to' ]?.[ 0 ]
+			? [
+					{
+						label: getRenderedContent(
+							data._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.title
+						),
+						value: data.post.toString(),
+					},
+			  ]
+			: [];
+	const [ options, setOptions ] =
+		useState< { label: string; value: string }[] >( defaultPost );
+	const [ searchResults, setSearchResults ] = useState< SearchResult[] >(
+		[]
+	);
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ value, setValue ] = useState< string | null >(
+		data?.post?.toString() ?? null
+	);
+
+	const postTypes = useSelect(
+		( select ) => select( coreStore ).getPostTypes(),
+		[]
+	);
+	const handleDetach = () => {
+		onChange( {
+			post: 0,
+			_embedded: { ...data?._embedded, 'wp:attached-to': undefined },
+		} );
+		setOptions( [] );
+	};
+
+	const onValueChange = async ( filterValue: string ) => {
+		setIsLoading( true );
+		const results = await fetchLinkSuggestions(
+			filterValue,
+			/*
+			 * @TODO `fetchLinkSuggestions()` should accept `perPage` as an option argument.
+			 * `isInitialSuggestions` limits the result to 3, otherwise it's hardcoded to 20.
+			 */
+			{ type: 'post', isInitialSuggestions: true },
+			{}
+		);
+		setSearchResults( results );
+		const mappedSuggestions = results.map( ( result ) => {
+			return {
+				label: result.title,
+				value: result.id.toString(),
+			};
+		} );
+		setOptions( mappedSuggestions );
+		setIsLoading( false );
+	};
+
+	/**
+	 * Handle selection.
+	 *
+	 * @param {Object} selectedPostId The selected post id.
+	 */
+	const handleSelectOption = (
+		selectedPostId: string | null | undefined
+	) => {
+		if ( ! selectedPostId ) {
+			handleDetach();
+			return;
+		}
+		setValue( selectedPostId );
+		if ( selectedPostId ) {
+			const selectedPost = searchResults.find(
+				( result ) => result.id === Number( selectedPostId )
+			);
+			if ( selectedPost && postTypes ) {
+				const postType = postTypes.find(
+					( _postType: { slug: string } ) =>
+						_postType.slug === selectedPost?.type
+				);
+				if ( ! postType ) {
+					throw new Error( 'Post type not found' );
+				}
+
+				const attachedTo = {
+					type: postType.slug,
+					id: Number( selectedPostId ),
+					title: {
+						raw: selectedPost.title,
+						rendered: selectedPost.title,
+					},
+				};
+
+				onChange( {
+					post: Number( selectedPostId ),
+					_embedded: {
+						...data?._embedded,
+						'wp:attached-to': [ attachedTo ],
+					},
+				} );
+			}
+		}
+	};
+
+	const help = !! data.post
+		? createInterpolateElement(
+				__(
+					'Search for a post or page to attach this media to or <button>detach current</button>.'
+				),
+				{
+					button: (
+						<Button
+							__next40pxDefaultSize
+							onClick={ handleDetach }
+							variant="link"
+							accessibleWhenDisabled
+						/>
+					),
+				}
+		  )
+		: __( 'Search for a post or page to attach this media to.' );
+
+	return (
+		<ComboboxControl
+			className="dataviews-media-field__attached-to"
+			__next40pxDefaultSize
+			isLoading={ isLoading }
+			label={ __( 'Attached to' ) }
+			help={ help }
+			value={ value }
+			options={ options }
+			onFilterValueChange={ debounce(
+				( filterValue: unknown ) =>
+					onValueChange( filterValue as string ),
+				300
+			) }
+			onChange={ handleSelectOption }
+			hideLabelFromVision
+		/>
+	);
+}

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -117,17 +117,17 @@ export default function MediaAttachedToEdit( {
 			const selectedPost = searchResults.find(
 				( result ) => result.id === Number( selectedPostId )
 			);
+			// Although unlikely, it's technically possible for selectedPost to not be found.
+			// E.g. if the user selects an option just as new search results are loaded.
+			// TODO: Add error handling for when selectedPost is not found.
 			if ( selectedPost && postTypes ) {
 				const postType = postTypes.find(
 					( _postType: { slug: string } ) =>
 						_postType.slug === selectedPost?.type
 				);
-				if ( ! postType ) {
-					throw new Error( 'Post type not found' );
-				}
 
 				const attachedTo = {
-					type: postType.slug,
+					...( postType && { type: postType.slug } ),
 					id: Number( selectedPostId ),
 					title: {
 						raw: selectedPost.title,

--- a/packages/media-fields/src/attached_to/index.tsx
+++ b/packages/media-fields/src/attached_to/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+import MediaAttachedToView from './view';
+import MediaAttachedToEdit from './edit';
+
+const attachedToField: Partial< Field< MediaItem > > = {
+	id: 'attached_to',
+	type: 'text',
+	label: __( 'Attached to' ),
+	Edit: MediaAttachedToEdit,
+	render: MediaAttachedToView,
+	enableSorting: false,
+	filterBy: false,
+};
+
+export default attachedToField;

--- a/packages/media-fields/src/attached_to/view.tsx
+++ b/packages/media-fields/src/attached_to/view.tsx
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+import { getRenderedContent } from '../utils/get-rendered-content';
+
+export default function MediaAttachedToView( {
+	item,
+}: DataViewRenderFieldProps< MediaItem > ) {
+	// Store the displayed title in state, as the embedded post may be loaded
+	// asynchronously. This ensures that the title remains stable after it
+	// is updated by the user, and while it is re-fetched from the server.
+	const [ attachedPostTitle, setAttachedPostTitle ] = useState<
+		string | null
+	>( null );
+
+	const parentId = item.post;
+	const embeddedPostId = item._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.id;
+	const embeddedPostTitle =
+		item._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.title;
+
+	useEffect( () => {
+		if ( !! parentId && parentId === embeddedPostId ) {
+			setAttachedPostTitle(
+				getRenderedContent( embeddedPostTitle ) ||
+					embeddedPostId?.toString() ||
+					''
+			);
+		}
+
+		if ( ! parentId ) {
+			setAttachedPostTitle( __( '(Unattached)' ) );
+		}
+	}, [ parentId, embeddedPostId, embeddedPostTitle ] );
+
+	return <>{ attachedPostTitle }</>;
+}

--- a/packages/media-fields/src/index.ts
+++ b/packages/media-fields/src/index.ts
@@ -1,4 +1,5 @@
 export { default as altTextField } from './alt_text';
+export { default as attachedToField } from './attached_to';
 export { default as captionField } from './caption';
 export { default as dateAddedField } from './date_added';
 export { default as dateModifiedField } from './date_modified';

--- a/packages/media-fields/src/stories/index.story.tsx
+++ b/packages/media-fields/src/stories/index.story.tsx
@@ -10,6 +10,7 @@ import type { Field, View } from '@wordpress/dataviews';
  */
 import {
 	altTextField,
+	attachedToField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -150,7 +151,7 @@ const sampleMediaItemZip: MediaItem = {
 	},
 	mime_type: 'application/zip',
 	media_type: 'file',
-	post: 1,
+	post: 123,
 	source_url:
 		'http://localhost:8888/wp-content/uploads/2025/11/gutenberg-v22-0-0.zip',
 	media_details: {
@@ -175,6 +176,28 @@ const sampleMediaItemZip: MediaItem = {
 		sizes: {},
 	},
 	missing_image_sizes: [],
+	_embedded: {
+		'wp:attached-to': [
+			{
+				id: 123,
+				date: '2025-12-19T00:21:52',
+				slug: '',
+				type: 'post',
+				link: 'http://localhost:8888/?p=123',
+				title: {
+					raw: 'A post title',
+					rendered: 'A post title',
+				},
+				excerpt: {
+					raw: '',
+					rendered: '',
+					protected: false,
+				},
+				author: 1,
+				featured_media: 0,
+			},
+		],
+	},
 };
 
 // Sample data for a broken image (demonstrates error fallback)
@@ -233,6 +256,7 @@ const showcaseFields = [
 	mediaThumbnailField,
 	filenameField,
 	altTextField,
+	attachedToField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -265,6 +289,7 @@ const DataFormsComponent = ( { type }: { type: 'regular' | 'panel' } ) => {
 			'filesize',
 			'date',
 			'modified',
+			'attached_to',
 		],
 	};
 

--- a/packages/media-fields/tsconfig.json
+++ b/packages/media-fields/tsconfig.json
@@ -6,6 +6,7 @@
 	},
 	"references": [
 		{ "path": "../components" },
+		{ "path": "../compose" },
 		{ "path": "../core-data" },
 		{ "path": "../data" },
 		{ "path": "../dataviews" },

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -14,6 +14,7 @@ import { DataViewsPicker } from '@wordpress/dataviews';
 import type { View, Field, ActionButton } from '@wordpress/dataviews';
 import {
 	altTextField,
+	attachedToField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -213,6 +214,7 @@ export function MediaUploadModal( {
 			order: view.sort?.direction,
 			orderby: view.sort?.field,
 			search: view.search,
+			_embed: 'wp:attached-to',
 			...filters,
 		};
 	}, [ view, allowedTypes ] );
@@ -251,6 +253,7 @@ export function MediaUploadModal( {
 			filesizeField as Field< RestAttachment >,
 			mediaDimensionsField as Field< RestAttachment >,
 			mimeTypeField as Field< RestAttachment >,
+			attachedToField as Field< RestAttachment >,
 		],
 		[]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Closes: https://github.com/WordPress/gutenberg/issues/72612 (this is the last of the dedicated media fields we _need_ to include in this package, though we might want to continue to add to them as feedback comes in for the media modal and media editors).

Add an "Attached to" media field, that corresponds to the attached to/uploaded to behaviour in the existing media library.

Part of:

* https://github.com/WordPress/gutenberg/issues/72734
* https://github.com/WordPress/gutenberg/issues/72735
* https://github.com/WordPress/gutenberg/issues/73085

This is a fairly basic MVP version of how the attached to behaviour could work and is based on work by @ramonjd that we collaborated on in proof of concepts (kudos Ramon!). It currently uses a Combobox for selecting posts, but further down the track we might use a generalised post picker for this sort of control (i.e. what's proposed in #71128). The goal with this PR is to provide a decent enough "floor" for work to progress in follow-ups.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Being able to attach an image to a post or page is an important part of media handling in WordPress, so the "attached to" relationship should be available wherever we're displaying (or editing) media items.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an `attached_to` field that uses `Combobox` and `fetchLinkSuggestions` for its edit state
* In the experimental media modal, add the `attached_to` field (not shown by default) and ensure the `wp:attached-to` data is embedded in requests for media items
* Display the embedded post title if available
* Add these to the media fields Storybook stories. Note you _can_ kind of test out the DataForm experience for this field, but without actually being able to select posts since Storybook isn't in an WP instance. I'm proposing we land the Edit control in this PR, but we won't really be able to test it properly until the media editor PRs I'm chipping away at are ready for review
* Also, note that this PR doesn't yet support filtering or sorting by this field — again, this is an MVP so that stuff can be looked at in follow-ups

## Testing Instructions

* In the existing media library, ensure you've got at least one media item that is attached to a post or page (you can go to the media library and click the Attach button to do so)
* Then, make sure you've enabled the media modal experiment:

<img width="1904" height="138" alt="image" src="https://github.com/user-attachments/assets/8e7fab1e-4757-453f-9f33-654eb772c9d7" />

* Go to a post or page and click to add a featured image
* Switch to the table view
* Click the cog icon and click to show the "attached to" field
* Having done that, you should see an "attached to" field with the name of the post that the image is currently attached to (if the post has a title, it'll fallback to a post id otherwise)
* Check that the Storybook stories are working okay (run `npm run storybook:dev`) and for the Data Forms Preview, use the panel layout to see how the field will look when it's used in the media editor (roughly)

## Screenshots or screencast <!-- if applicable -->

### In the media modal (after enabling the attached to field from the settings dropdown — it's hidden by default)

<img width="3110" height="1432" alt="image" src="https://github.com/user-attachments/assets/42f94e3c-1fb0-4d6c-97ef-bee14ec49437" />

### In Storybook

<img width="1982" height="738" alt="image" src="https://github.com/user-attachments/assets/e6688c63-4e14-4ad7-a6b7-30bc6b16bd8c" />

<img width="1934" height="956" alt="image" src="https://github.com/user-attachments/assets/f5afaf63-72fb-4d24-b681-b072c07b7b79" />

### Quick video of revealing the field

https://github.com/user-attachments/assets/ab45902f-1dfb-45f5-af28-99e9d3276cd0