### PR TITLE
Block fields: Add object type support for media and link controls

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -93,42 +93,42 @@ function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 				config: { ...fieldDef.args, defaultValues },
 				hideLabelFromVision: fieldDef.id === 'content',
 				// getValue and setValue handle the mapping to block attributes
-				getValue: ( { item } ) => {
-					// When a field is an object, flatten all the properties to the root
-					// of the block attributes.
-					if ( fieldDef.type === 'object' && fieldDef.properties ) {
-						const mappedValue = {};
+				// getValue: ( { item } ) => {
+				// 	// When a field is an object, flatten all the properties to the root
+				// 	// of the block attributes.
+				// 	if ( fieldDef.type === 'object' && fieldDef.properties ) {
+				// 		const mappedValue = {};
 
-						// Convert to field keys.
-						Object.keys( fieldDef.properties ).forEach( ( key ) => {
-							const attributeKey =
-								fieldDef.properties[ key ].id ?? key;
-							if ( item[ attributeKey ] ) {
-								mappedValue[ key ] = item[ attributeKey ];
-							}
-						} );
-						return mappedValue;
-					}
-					return item[ fieldDef.id ];
-				},
-				setValue: ( { value } ) => {
-					// When a field is an object, flatten all the properties to the root
-					// of the block attributes.
-					if ( fieldDef.type === 'object' && fieldDef.properties ) {
-						const mappedValue = {};
+				// 		// Convert to field keys.
+				// 		Object.keys( fieldDef.properties ).forEach( ( key ) => {
+				// 			const attributeKey =
+				// 				fieldDef.properties[ key ].id ?? key;
+				// 			if ( item[ attributeKey ] ) {
+				// 				mappedValue[ key ] = item[ attributeKey ];
+				// 			}
+				// 		} );
+				// 		return mappedValue;
+				// 	}
+				// 	return item[ fieldDef.id ];
+				// },
+				// setValue: ( { value } ) => {
+				// 	// When a field is an object, flatten all the properties to the root
+				// 	// of the block attributes.
+				// 	if ( fieldDef.type === 'object' && fieldDef.properties ) {
+				// 		const mappedValue = {};
 
-						// Convert to attribute keys.
-						Object.keys( fieldDef.properties ).forEach( ( key ) => {
-							if ( value[ key ] ) {
-								const attributeKey =
-									fieldDef.properties[ key ].id ?? key;
-								mappedValue[ attributeKey ] = value[ key ];
-							}
-						} );
-						return mappedValue;
-					}
-					return { [ fieldDef.id ]: value };
-				},
+				// 		// Convert to attribute keys.
+				// 		Object.keys( fieldDef.properties ).forEach( ( key ) => {
+				// 			if ( value[ key ] ) {
+				// 				const attributeKey =
+				// 					fieldDef.properties[ key ].id ?? key;
+				// 				mappedValue[ attributeKey ] = value[ key ];
+				// 			}
+				// 		} );
+				// 		return mappedValue;
+				// 	}
+				// 	return { [ fieldDef.id ]: value };
+				// },
 			};
 
 			// Only add custom Edit component if one exists for this type

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -55,120 +55,6 @@ function createConfiguredControl( config ) {
 	};
 }
 
-/**
- * Normalize a media value to a canonical structure.
- * Only includes properties that are present in the field's mapping (if provided).
- *
- * @param {Object} value    - The mapped value from the block attributes (with canonical keys)
- * @param {Object} fieldDef - Optional field definition containing the mapping
- * @return {Object} Normalized media value with canonical properties
- */
-function normalizeMediaValue( value, fieldDef ) {
-	const defaults = {
-		id: null,
-		url: '',
-		caption: '',
-		alt: '',
-		type: 'image',
-		poster: '',
-		featuredImage: false,
-		link: '',
-	};
-
-	const result = {};
-
-	// If there's a mapping, only include properties that are in it
-	if ( fieldDef?.mapping ) {
-		Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-			result[ key ] = value?.[ key ] ?? defaults[ key ] ?? '';
-		} );
-		return result;
-	}
-
-	// Without mapping, include all default properties
-	Object.keys( defaults ).forEach( ( key ) => {
-		result[ key ] = value?.[ key ] ?? defaults[ key ];
-	} );
-	return result;
-}
-
-/**
- * Denormalize a media value from canonical structure back to mapped keys.
- * Only includes properties that are present in the field's mapping.
- *
- * @param {Object} value    - The normalized media value
- * @param {Object} fieldDef - The field definition containing the mapping
- * @return {Object} Value with only mapped properties
- */
-function denormalizeMediaValue( value, fieldDef ) {
-	if ( ! fieldDef.mapping ) {
-		return value;
-	}
-
-	const result = {};
-	Object.entries( fieldDef.mapping ).forEach( ( [ key ] ) => {
-		if ( key in value ) {
-			result[ key ] = value[ key ];
-		}
-	} );
-	return result;
-}
-
-/**
- * Normalize a link value to a canonical structure.
- * Only includes properties that are present in the field's mapping (if provided).
- *
- * @param {Object} value    - The mapped value from the block attributes (with canonical keys)
- * @param {Object} fieldDef - Optional field definition containing the mapping
- * @return {Object} Normalized link value with canonical properties
- */
-function normalizeLinkValue( value, fieldDef ) {
-	const defaults = {
-		url: '',
-		rel: '',
-		linkTarget: '',
-		destination: '',
-	};
-
-	const result = {};
-
-	// If there's a mapping, only include properties that are in it
-	if ( fieldDef?.mapping ) {
-		Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-			result[ key ] = value?.[ key ] ?? defaults[ key ] ?? '';
-		} );
-		return result;
-	}
-
-	// Without mapping, include all default properties
-	Object.keys( defaults ).forEach( ( key ) => {
-		result[ key ] = value?.[ key ] ?? defaults[ key ];
-	} );
-	return result;
-}
-
-/**
- * Denormalize a link value from canonical structure back to mapped keys.
- * Only includes properties that are present in the field's mapping.
- *
- * @param {Object} value    - The normalized link value
- * @param {Object} fieldDef - The field definition containing the mapping
- * @return {Object} Value with only mapped properties
- */
-function denormalizeLinkValue( value, fieldDef ) {
-	if ( ! fieldDef.mapping ) {
-		return value;
-	}
-
-	const result = {};
-	Object.entries( fieldDef.mapping ).forEach( ( [ key ] ) => {
-		if ( key in value ) {
-			result[ key ] = value[ key ];
-		}
-	} );
-	return result;
-}
-
 function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -189,8 +75,6 @@ function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 		}
 
 		return blockTypeFields.map( ( fieldDef ) => {
-			const ControlComponent = CONTROLS[ fieldDef.type ];
-
 			const defaultValues = {};
 			if ( fieldDef.mapping && blockType?.attributes ) {
 				Object.entries( fieldDef.mapping ).forEach(
@@ -210,71 +94,48 @@ function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 				hideLabelFromVision: fieldDef.id === 'content',
 				// getValue and setValue handle the mapping to block attributes
 				getValue: ( { item } ) => {
-					if ( fieldDef.mapping ) {
-						// Extract mapped properties from the block attributes
+					// When a field is an object, flatten all the properties to the root
+					// of the block attributes.
+					if ( fieldDef.type === 'object' && fieldDef.properties ) {
 						const mappedValue = {};
-						Object.entries( fieldDef.mapping ).forEach(
-							( [ key, attrKey ] ) => {
-								mappedValue[ key ] = item[ attrKey ];
+
+						// Convert to field keys.
+						Object.keys( fieldDef.properties ).forEach( ( key ) => {
+							const attributeKey =
+								fieldDef.properties[ key ].id ?? key;
+							if ( item[ attributeKey ] ) {
+								mappedValue[ key ] = item[ attributeKey ];
 							}
-						);
-
-						// Normalize to canonical structure based on field type
-						if ( fieldDef.type === 'media' ) {
-							return normalizeMediaValue( mappedValue, fieldDef );
-						}
-						if ( fieldDef.type === 'link' ) {
-							return normalizeLinkValue( mappedValue, fieldDef );
-						}
-
-						// For other types, return as-is
+						} );
 						return mappedValue;
 					}
-					// For simple id-based fields, use the id as the attribute key
 					return item[ fieldDef.id ];
 				},
-				setValue: ( { item, value } ) => {
-					if ( fieldDef.mapping ) {
-						// Denormalize from canonical structure back to mapped keys
-						let denormalizedValue = value;
-						if ( fieldDef.type === 'media' ) {
-							denormalizedValue = denormalizeMediaValue(
-								value,
-								fieldDef
-							);
-						} else if ( fieldDef.type === 'link' ) {
-							denormalizedValue = denormalizeLinkValue(
-								value,
-								fieldDef
-							);
-						}
+				setValue: ( { value } ) => {
+					// When a field is an object, flatten all the properties to the root
+					// of the block attributes.
+					if ( fieldDef.type === 'object' && fieldDef.properties ) {
+						const mappedValue = {};
 
-						// Build an object with all mapped attributes
-						const updates = {};
-						Object.entries( fieldDef.mapping ).forEach(
-							( [ key, attrKey ] ) => {
-								// If key is explicitly in value, use it (even if undefined to allow clearing)
-								// Otherwise, preserve the old value
-								if ( key in denormalizedValue ) {
-									updates[ attrKey ] =
-										denormalizedValue[ key ];
-								} else {
-									updates[ attrKey ] = item[ attrKey ];
-								}
+						// Convert to attribute keys.
+						Object.keys( fieldDef.properties ).forEach( ( key ) => {
+							if ( value[ key ] ) {
+								const attributeKey =
+									fieldDef.properties[ key ].id ?? key;
+								mappedValue[ attributeKey ] = value[ key ];
 							}
-						);
-						return updates;
+						} );
+						return mappedValue;
 					}
-					// For simple id-based fields, use the id as the attribute key
 					return { [ fieldDef.id ]: value };
 				},
 			};
 
 			// Only add custom Edit component if one exists for this type
-			if ( ControlComponent ) {
+			if ( fieldDef.Edit ) {
 				// Use EditConfig pattern: Edit is an object with control type and config props
 				field.Edit = createConfiguredControl( {
-					control: fieldDef.type,
+					control: fieldDef.Edit,
 					clientId,
 					fieldDef,
 				} );

--- a/packages/block-editor/src/hooks/block-fields/link/index.js
+++ b/packages/block-editor/src/hooks/block-fields/link/index.js
@@ -73,16 +73,10 @@ export default function Link( { data, field, onChange, config = {} } ) {
 		isControl: true,
 	} );
 	const { fieldDef } = config;
-	const updateAttributes = ( newValue ) => {
-		const mappedChanges = field.setValue( { item: data, value: newValue } );
-		onChange( mappedChanges );
-	};
-
 	const value = field.getValue( { item: data } );
 	const url = value?.url;
 	const rel = value?.rel || '';
 	const target = value?.linkTarget;
-
 	const opensInNewTab = target === NEW_TAB_TARGET;
 	const nofollow = rel === NOFOLLOW_REL;
 
@@ -146,51 +140,44 @@ export default function Link( { data, field, onChange, config = {} } ) {
 							} );
 
 							// Build update object dynamically based on what's in the mapping
-							const updateValue = { ...value };
+							const newValue = {};
 
-							if ( fieldDef?.mapping ) {
-								Object.keys( fieldDef.mapping ).forEach(
+							if ( fieldDef?.properties ) {
+								Object.keys( fieldDef.properties ).forEach(
 									( key ) => {
-										if ( key === 'href' || key === 'url' ) {
-											updateValue[ key ] =
-												updatedAttrs.url;
-										} else if ( key === 'rel' ) {
-											updateValue[ key ] =
-												updatedAttrs.rel;
-										} else if (
-											key === 'target' ||
-											key === 'linkTarget'
-										) {
-											updateValue[ key ] =
-												updatedAttrs.linkTarget;
+										if ( updatedAttrs[ key ] ) {
+											newValue[ key ] =
+												updatedAttrs[ key ];
 										}
 									}
 								);
 							}
 
-							updateAttributes( updateValue );
+							onChange(
+								field.setValue( {
+									item: data,
+									value: newValue,
+								} )
+							);
 						} }
 						onRemove={ () => {
 							// Remove all link-related properties based on what's in the mapping
 							const removeValue = {};
 
-							if ( fieldDef?.mapping ) {
-								Object.keys( fieldDef.mapping ).forEach(
+							if ( fieldDef?.properties ) {
+								Object.keys( fieldDef.properties ).forEach(
 									( key ) => {
-										if (
-											key === 'href' ||
-											key === 'url' ||
-											key === 'rel' ||
-											key === 'target' ||
-											key === 'linkTarget'
-										) {
-											removeValue[ key ] = undefined;
-										}
+										removeValue[ key ] = undefined;
 									}
 								);
 							}
 
-							updateAttributes( removeValue );
+							onChange(
+								field.setValue( {
+									item: data,
+									value: removeValue,
+								} )
+							);
 						} }
 					/>
 				</Popover>

--- a/packages/block-editor/src/hooks/block-fields/link/index.js
+++ b/packages/block-editor/src/hooks/block-fields/link/index.js
@@ -139,7 +139,6 @@ export default function Link( { data, field, onChange, config = {} } ) {
 								...newValues,
 							} );
 
-							// Build update object dynamically based on what's in the mapping
 							const newValue = {};
 
 							if ( fieldDef?.properties ) {
@@ -161,7 +160,6 @@ export default function Link( { data, field, onChange, config = {} } ) {
 							);
 						} }
 						onRemove={ () => {
-							// Remove all link-related properties based on what's in the mapping
 							const removeValue = {};
 
 							if ( fieldDef?.properties ) {

--- a/packages/block-editor/src/hooks/block-fields/link/index.js
+++ b/packages/block-editor/src/hooks/block-fields/link/index.js
@@ -17,6 +17,7 @@ import { prependHTTP } from '@wordpress/url';
  */
 import LinkControl from '../../../components/link-control';
 import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement';
+import { getValue, setValue } from '../utils';
 
 export const NEW_TAB_REL = 'noreferrer noopener';
 export const NEW_TAB_TARGET = '_blank';
@@ -67,13 +68,13 @@ export function getUpdatedLinkAttributes( {
 	};
 }
 
-export default function Link( { data, field, onChange, config = {} } ) {
+export default function Link( { data, onChange, config = {} } ) {
 	const [ isLinkControlOpen, setIsLinkControlOpen ] = useState( false );
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
 	} );
 	const { fieldDef } = config;
-	const value = field.getValue( { item: data } );
+	const value = getValue( data, fieldDef );
 	const url = value?.url;
 	const rel = value?.rel || '';
 	const target = value?.linkTarget;
@@ -152,12 +153,7 @@ export default function Link( { data, field, onChange, config = {} } ) {
 								);
 							}
 
-							onChange(
-								field.setValue( {
-									item: data,
-									value: newValue,
-								} )
-							);
+							onChange( setValue( newValue, fieldDef ) );
 						} }
 						onRemove={ () => {
 							const removeValue = {};
@@ -170,12 +166,7 @@ export default function Link( { data, field, onChange, config = {} } ) {
 								);
 							}
 
-							onChange(
-								field.setValue( {
-									item: data,
-									value: removeValue,
-								} )
-							);
+							onChange( setValue( removeValue, fieldDef ) );
 						} }
 					/>
 				</Popover>

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -87,13 +87,6 @@ export default function Media( { data, field, onChange, config = {} } ) {
 	const value = field.getValue( { item: data } );
 	const { allowedTypes = [], multiple = false } = field.config || {};
 	const { fieldDef } = config;
-	const updateAttributes = ( newFieldValue ) => {
-		const mappedChanges = field.setValue( {
-			item: data,
-			value: newFieldValue,
-		} );
-		onChange( mappedChanges );
-	};
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =
@@ -150,17 +143,12 @@ export default function Media( { data, field, onChange, config = {} } ) {
 					// Build reset value dynamically based on mapping
 					const resetValue = {};
 
-					if ( fieldDef?.mapping ) {
-						Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-							if (
-								key === 'id' ||
-								key === 'src' ||
-								key === 'url'
-							) {
-								resetValue[ key ] = undefined;
-							} else if ( key === 'caption' || key === 'alt' ) {
+					if ( fieldDef?.properties ) {
+						Object.keys( fieldDef.properties ).forEach( ( key ) => {
+							if ( key === 'caption' || key === 'alt' ) {
 								resetValue[ key ] = '';
 							}
+							resetValue[ key ] = undefined;
 						} );
 					}
 
@@ -170,71 +158,35 @@ export default function Media( { data, field, onChange, config = {} } ) {
 					}
 
 					// Merge with existing value to preserve other field properties
-					updateAttributes( { ...value, ...resetValue } );
+					onChange(
+						field.setValue( {
+							item: data,
+							value: resetValue,
+						} )
+					);
 				} }
 				{ ...( hasFeaturedImageSupport && {
 					useFeaturedImage: !! value?.featuredImage,
 					onToggleFeaturedImage: () => {
-						updateAttributes( {
-							...value,
+						// TODO - this should unset id, src, etc.
+						onChange( {
 							featuredImage: ! value?.featuredImage,
 						} );
 					},
 				} ) }
 				onSelect={ ( selectedMedia ) => {
 					if ( selectedMedia.id && selectedMedia.url ) {
-						// Determine mediaType from MIME type, not from object type
-						let mediaType = 'image'; // default
-						if ( selectedMedia.mime_type ) {
-							if (
-								selectedMedia.mime_type.startsWith( 'video/' )
-							) {
-								mediaType = 'video';
-							} else if (
-								selectedMedia.mime_type.startsWith( 'audio/' )
-							) {
-								mediaType = 'audio';
-							}
-						}
-
-						// Build new value dynamically based on what's in the mapping
+						// // Build new value dynamically based on what's in the mapping
 						const newValue = {};
 
-						// Iterate over mapping keys and set values for supported properties
-						if ( fieldDef?.mapping ) {
-							Object.keys( fieldDef.mapping ).forEach(
+						// Iterate over mapping keys and set values for supported properties.
+						// The properties used by the field should closely match those returned
+						// by the media API to ensure no mapping is required.
+						if ( fieldDef?.properties ) {
+							Object.keys( fieldDef.properties ).forEach(
 								( key ) => {
-									if ( key === 'id' ) {
-										newValue[ key ] = selectedMedia.id;
-									} else if (
-										key === 'src' ||
-										key === 'url'
-									) {
-										newValue[ key ] = selectedMedia.url;
-									} else if ( key === 'type' ) {
-										newValue[ key ] = mediaType;
-									} else if (
-										key === 'link' &&
-										selectedMedia.link
-									) {
-										newValue[ key ] = selectedMedia.link;
-									} else if (
-										key === 'caption' &&
-										! value?.caption &&
-										selectedMedia.caption
-									) {
-										newValue[ key ] = selectedMedia.caption;
-									} else if (
-										key === 'alt' &&
-										! value?.alt &&
-										selectedMedia.alt
-									) {
-										newValue[ key ] = selectedMedia.alt;
-									} else if (
-										key === 'poster' &&
-										selectedMedia.poster
-									) {
-										newValue[ key ] = selectedMedia.poster;
+									if ( selectedMedia[ key ] ) {
+										newValue[ key ] = selectedMedia[ key ];
 									}
 								}
 							);
@@ -246,8 +198,12 @@ export default function Media( { data, field, onChange, config = {} } ) {
 						}
 
 						// Merge with existing value to preserve other field properties
-						const finalValue = { ...value, ...newValue };
-						updateAttributes( finalValue );
+						onChange(
+							field.setValue( {
+								item: data,
+								value: newValue,
+							} )
+						);
 					}
 				} }
 				renderToggle={ ( buttonProps ) => (

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -90,7 +90,7 @@ export default function Media( { data, field, onChange, config = {} } ) {
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =
-		fieldDef?.mapping && 'featuredImage' in fieldDef.mapping;
+		fieldDef?.properties && 'featuredImage' in fieldDef.properties;
 
 	const id = value?.id;
 	const url = value?.url;
@@ -140,7 +140,6 @@ export default function Media( { data, field, onChange, config = {} } ) {
 				multiple={ multiple }
 				popoverProps={ popoverProps }
 				onReset={ () => {
-					// Build reset value dynamically based on mapping
 					const resetValue = {};
 
 					if ( fieldDef?.properties ) {
@@ -152,7 +151,7 @@ export default function Media( { data, field, onChange, config = {} } ) {
 						} );
 					}
 
-					// Turn off featured image when resetting (only if it's in the mapping)
+					// Turn off featured image when resetting (only if it's in the properties)
 					if ( hasFeaturedImageSupport ) {
 						resetValue.featuredImage = false;
 					}
@@ -176,12 +175,11 @@ export default function Media( { data, field, onChange, config = {} } ) {
 				} ) }
 				onSelect={ ( selectedMedia ) => {
 					if ( selectedMedia.id && selectedMedia.url ) {
-						// // Build new value dynamically based on what's in the mapping
 						const newValue = {};
 
-						// Iterate over mapping keys and set values for supported properties.
+						// Iterate over properties keys and pick only values for supported properties.
 						// The properties used by the field should closely match those returned
-						// by the media API to ensure no mapping is required.
+						// by the media API to ensure no mapping of keys is required.
 						if ( fieldDef?.properties ) {
 							Object.keys( fieldDef.properties ).forEach(
 								( key ) => {

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -85,8 +85,8 @@ export default function Media( { data, field, onChange, config = {} } ) {
 		isControl: true,
 	} );
 	const value = field.getValue( { item: data } );
-	const { allowedTypes = [], multiple = false } = field.config || {};
 	const { fieldDef } = config;
+	const { allowedTypes = [], multiple = false } = fieldDef.args || {};
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -23,6 +23,7 @@ import MediaUploadCheck from '../../../components/media-upload/check';
 import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement';
 import { getMediaSelectKey } from '../../../store/private-keys';
 import { store as blockEditorStore } from '../../../store';
+import { getValue, setValue } from '../utils';
 
 function MediaThumbnail( { data, field, attachment } ) {
 	const config = field.config || {};
@@ -50,7 +51,7 @@ function MediaThumbnail( { data, field, attachment } ) {
 	}
 
 	if ( allowedTypes.length === 1 ) {
-		const value = field.getValue( { item: data } );
+		const value = getValue( data, config.fieldDef );
 		const url = value?.url;
 
 		if ( url ) {
@@ -84,13 +85,14 @@ export default function Media( { data, field, onChange, config = {} } ) {
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
 	} );
-	const value = field.getValue( { item: data } );
 	const { fieldDef } = config;
 	const { allowedTypes = [], multiple = false } = fieldDef.args || {};
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =
 		fieldDef?.properties && 'featuredImage' in fieldDef.properties;
+
+	const value = getValue( data, fieldDef );
 
 	const id = value?.id;
 	const url = value?.url;
@@ -157,20 +159,20 @@ export default function Media( { data, field, onChange, config = {} } ) {
 					}
 
 					// Merge with existing value to preserve other field properties
-					onChange(
-						field.setValue( {
-							item: data,
-							value: resetValue,
-						} )
-					);
+					onChange( setValue( resetValue, fieldDef ) );
 				} }
 				{ ...( hasFeaturedImageSupport && {
-					useFeaturedImage: !! value?.featuredImage,
+					useFeaturedImage: !! data?.featuredImage,
 					onToggleFeaturedImage: () => {
 						// TODO - this should unset id, src, etc.
-						onChange( {
-							featuredImage: ! value?.featuredImage,
-						} );
+						onChange(
+							setValue(
+								{
+									featuredImage: ! data?.featuredImage,
+								},
+								fieldDef
+							)
+						);
 					},
 				} ) }
 				onSelect={ ( selectedMedia ) => {
@@ -196,12 +198,7 @@ export default function Media( { data, field, onChange, config = {} } ) {
 						}
 
 						// Merge with existing value to preserve other field properties
-						onChange(
-							field.setValue( {
-								item: data,
-								value: newValue,
-							} )
-						);
+						onChange( setValue( newValue, fieldDef ) );
 					}
 				} }
 				renderToggle={ ( buttonProps ) => (

--- a/packages/block-editor/src/hooks/block-fields/utils.js
+++ b/packages/block-editor/src/hooks/block-fields/utils.js
@@ -1,0 +1,37 @@
+export function getValue( data, fieldDef ) {
+	if ( ! fieldDef.properties ) {
+		return data;
+	}
+
+	// When a field is an object, flatten all the properties to the root
+	// of the block attributes.
+	const mappedValue = {};
+
+	// Convert to field keys.
+	Object.keys( fieldDef.properties ).forEach( ( key ) => {
+		const attributeKey = fieldDef.properties[ key ].id ?? key;
+		if ( data[ attributeKey ] ) {
+			mappedValue[ key ] = data[ attributeKey ];
+		}
+	} );
+	return mappedValue;
+}
+
+export function setValue( value, fieldDef ) {
+	if ( ! fieldDef.properties ) {
+		return value;
+	}
+
+	// When a field is an object, flatten all the properties to the root
+	// of the block attributes.
+	const mappedValue = {};
+
+	// Convert to attribute keys.
+	Object.keys( fieldDef.properties ).forEach( ( key ) => {
+		if ( value[ key ] ) {
+			const attributeKey = fieldDef.properties[ key ].id ?? key;
+			mappedValue[ attributeKey ] = value[ key ];
+		}
+	} );
+	return mappedValue;
+}

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -41,7 +41,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'audio',
 			label: __( 'Audio' ),
-			type: 'media',
+			Edit: 'media',
+			type: 'object',
 			mapping: {
 				id: 'id',
 				url: 'src',
@@ -54,7 +55,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -42,7 +42,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'audio',
 			label: __( 'Audio' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				id: {
 					id: 'id',

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -43,9 +43,17 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Audio' ),
 			Edit: 'media',
 			type: 'object',
-			mapping: {
-				id: 'id',
-				url: 'src',
+			properties: {
+				id: {
+					id: 'id',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				url: {
+					id: 'src',
+					type: 'url',
+					label: __( 'Url' ),
+				},
 			},
 			args: {
 				allowedTypes: [ 'audio' ],

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -63,10 +63,22 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			Edit: 'link',
 			type: 'object',
-			mapping: {
-				url: 'url',
-				rel: 'rel',
-				linkTarget: 'linkTarget',
+			properties: {
+				url: {
+					id: 'url',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
+				linkTarget: {
+					id: 'linkTarget',
+					type: 'text',
+					label: __( 'Target' ),
+				},
 			},
 		},
 	];

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -55,12 +55,14 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'text',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
+			Edit: 'link',
+			type: 'object',
 			mapping: {
 				url: 'url',
 				rel: 'rel',

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -62,7 +62,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				url: {
 					id: 'url',

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -48,7 +48,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Code' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -67,12 +67,32 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Background' ),
 			Edit: 'media',
 			type: 'object',
-			mapping: {
-				type: 'backgroundType',
-				id: 'id',
-				url: 'url',
-				alt: 'alt',
-				featuredImage: 'useFeaturedImage',
+			properties: {
+				media_type: {
+					id: 'backgroundType',
+					type: 'string',
+					label: __( 'Type' ),
+				},
+				id: {
+					id: 'id',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				url: {
+					id: 'url',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				alt: {
+					id: 'alt',
+					type: 'text',
+					label: __( 'Alt text' ),
+				},
+				featuredImage: {
+					id: 'useFeaturedImage',
+					type: 'boolean',
+					label: __( 'Use featured image' ),
+				},
 			},
 			args: {
 				// TODO - How to support custom gradient?

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -65,7 +65,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'background',
 			label: __( 'Background' ),
-			type: 'media',
+			Edit: 'media',
+			type: 'object',
 			mapping: {
 				type: 'backgroundType',
 				id: 'id',

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -66,7 +66,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'background',
 			label: __( 'Background' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				media_type: {
 					id: 'backgroundType',

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -70,7 +70,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'summary',
 			label: __( 'Summary' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -42,7 +42,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'file',
 			label: __( 'File' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				id: {
 					id: 'id',

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -43,9 +43,17 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'File' ),
 			Edit: 'media',
 			type: 'object',
-			mapping: {
-				id: 'id',
-				url: 'href',
+			properties: {
+				id: {
+					id: 'id',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				url: {
+					id: 'href',
+					type: 'url',
+					label: __( 'Url' ),
+				},
 			},
 			args: {
 				allowedTypes: [],

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -41,7 +41,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'file',
 			label: __( 'File' ),
-			type: 'media',
+			Edit: 'media',
+			type: 'object',
 			mapping: {
 				id: 'id',
 				url: 'href',
@@ -54,12 +55,14 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'fileName',
 			label: __( 'Filename' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'downloadButtonText',
 			label: __( 'Button Text' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -82,7 +82,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -71,12 +71,29 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'image',
 			label: __( 'Image' ),
-			type: 'media',
-			mapping: {
-				id: 'id',
-				url: 'url',
-				caption: 'caption',
-				alt: 'alt',
+			Edit: 'media',
+			type: 'object',
+			properties: {
+				id: {
+					id: 'id',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				url: {
+					id: 'url',
+					type: 'url',
+					label: __( 'URL' ),
+				},
+				caption: {
+					id: 'caption',
+					type: 'text',
+					label: __( 'Caption' ),
+				},
+				alt: {
+					id: 'alt',
+					type: 'text',
+					label: __( 'Alt Text' ),
+				},
 			},
 			args: {
 				allowedTypes: [ 'image' ],
@@ -86,18 +103,36 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
-			mapping: {
-				url: 'href',
-				rel: 'rel',
-				linkTarget: 'linkTarget',
-				destination: 'linkDestination',
+			Edit: 'link',
+			type: 'object',
+			properties: {
+				url: {
+					id: 'href',
+					type: 'url',
+					label: __( 'URL' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
+				linkTarget: {
+					id: 'linkTarget',
+					type: 'text',
+					label: __( 'Target' ),
+				},
+				destination: {
+					id: 'linkDestination',
+					type: 'text',
+					label: __( 'Destination' ),
+				},
 			},
 		},
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'text',
 		},
 		{
 			id: 'alt',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -72,7 +72,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'image',
 			label: __( 'Image' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				id: {
 					id: 'id',
@@ -104,7 +104,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				url: {
 					id: 'href',

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -41,7 +41,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -60,7 +60,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'media',
 			label: __( 'Media' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				id: {
 					id: 'mediaId',
@@ -92,7 +92,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				url: {
 					id: 'href',

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -61,11 +61,27 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Media' ),
 			Edit: 'media',
 			type: 'object',
-			mapping: {
-				id: 'mediaId',
-				type: 'mediaType',
-				url: 'mediaUrl',
-				link: 'mediaLink',
+			properties: {
+				id: {
+					id: 'mediaId',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				media_type: {
+					id: 'mediaType',
+					type: 'string',
+					label: __( 'Type' ),
+				},
+				url: {
+					id: 'mediaUrl',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				link: {
+					id: 'mediaLink',
+					type: 'url',
+					label: __( 'Link' ),
+				},
 			},
 			args: {
 				allowedTypes: [ 'image', 'video' ],
@@ -77,10 +93,22 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			Edit: 'link',
 			type: 'object',
-			mapping: {
-				url: 'href',
-				rel: 'rel',
-				linkTarget: 'linkTarget',
+			properties: {
+				url: {
+					id: 'href',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
+				linkTarget: {
+					id: 'linkTarget',
+					type: 'text',
+					label: __( 'Target' ),
+				},
 			},
 		},
 	];

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -59,7 +59,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'media',
 			label: __( 'Media' ),
-			type: 'media',
+			Edit: 'media',
+			type: 'object',
 			mapping: {
 				id: 'mediaId',
 				type: 'mediaType',
@@ -74,7 +75,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
+			Edit: 'link',
+			type: 'object',
 			mapping: {
 				url: 'href',
 				rel: 'rel',

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -45,7 +45,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'customText',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -98,12 +98,14 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
+			Edit: 'link',
+			type: 'object',
 			mapping: {
 				href: 'url',
 				rel: 'rel',

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -106,9 +106,17 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			Edit: 'link',
 			type: 'object',
-			mapping: {
-				href: 'url',
-				rel: 'rel',
+			properties: {
+				href: {
+					id: 'url',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
 				// TODO - opens in new tab? id?
 			},
 		},

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -105,7 +105,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				href: {
 					id: 'url',

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -64,7 +64,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				href: {
 					id: 'url',

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -65,9 +65,17 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			Edit: 'link',
 			type: 'object',
-			mapping: {
-				href: 'url',
-				rel: 'rel',
+			properties: {
+				href: {
+					id: 'url',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
 				// TODO - opens in new tab? id?
 			},
 		},

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -57,12 +57,14 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
+			Edit: 'link',
+			type: 'object',
 			mapping: {
 				href: 'url',
 				rel: 'rel',

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -65,7 +65,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -48,7 +48,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -45,12 +45,14 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'value',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'citation',
 			label: __( 'Citation' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -35,18 +35,21 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 			shownByDefault: true,
 		},
 		{
 			id: 'buttonText',
 			label: __( 'Button text' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 		{
 			id: 'placeholder',
 			label: __( 'Placeholder' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -31,7 +31,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'link',
 			label: __( 'Link' ),
-			type: 'link',
+			Edit: 'link',
+			type: 'object',
 			mapping: {
 				href: 'url',
 				rel: 'rel',
@@ -40,7 +41,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'label',
 			label: __( 'Label' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -32,7 +32,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			Edit: 'link',
-			type: 'object',
+			type: 'group',
 			properties: {
 				href: {
 					id: 'url',

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -33,9 +33,17 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			Edit: 'link',
 			type: 'object',
-			mapping: {
-				href: 'url',
-				rel: 'rel',
+			properties: {
+				href: {
+					id: 'url',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				rel: {
+					id: 'rel',
+					type: 'text',
+					label: __( 'Rel' ),
+				},
 			},
 		},
 		{

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -50,7 +50,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'content',
 			label: __( 'Content' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -42,7 +42,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'video',
 			label: __( 'Video' ),
-			type: 'media',
+			Edit: 'media',
+			type: 'object',
 			mapping: {
 				id: 'id',
 				url: 'src',
@@ -57,7 +58,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		{
 			id: 'caption',
 			label: __( 'Caption' ),
-			type: 'richtext',
+			Edit: 'richtext',
+			type: 'string',
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -44,11 +44,27 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Video' ),
 			Edit: 'media',
 			type: 'object',
-			mapping: {
-				id: 'id',
-				url: 'src',
-				caption: 'caption',
-				poster: 'poster',
+			properties: {
+				id: {
+					id: 'id',
+					type: 'number',
+					label: __( 'Id' ),
+				},
+				url: {
+					id: 'src',
+					type: 'url',
+					label: __( 'Url' ),
+				},
+				caption: {
+					id: 'caption',
+					type: 'text',
+					label: __( 'Caption' ),
+				},
+				poster: {
+					id: 'poster',
+					type: 'url',
+					label: __( 'Poster' ),
+				},
 			},
 			args: {
 				allowedTypes: [ 'video' ],

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -43,7 +43,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'video',
 			label: __( 'Video' ),
 			Edit: 'media',
-			type: 'object',
+			type: 'group',
 			properties: {
 				id: {
 					id: 'id',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on #74409

Takes some steps towards aligning the block fields implementation with dataforms/fields APIs.

#74409 proposes adding an <s>'object'</s> 'group' type that has sub properties, which would be useful for media and link fields. This PR adopts it.

## How?
The PR generally switches away from using a custom `type` for the field types instead adding an `Edit` property to implement the custom controls for fields.

The `mapping` property becomes `properties`.

In general I've tried to remove as much special code as possible from the implementation to make it closer to a native DataForm, but some mapping from field properties to attributes still seems to be required. I'm not sure if this is due to something wrong in the implementation of block fields.

## Testing Instructions
Prerequisite: Enable the two 'contentOnly' gutenberg experiments

1. Add blocks like paragraph, image, media text
2. Open the block inspector
3. In the content tab interact with the block fields
4. It should generally work like it does in trunk, possibly with some caveats.

