### PR TITLE
DataForm validation story: add support for the details layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improve stories and tests. [#74192](https://github.com/WordPress/gutenberg/pull/74192)
 - Update DataForm stories. [#74196](https://github.com/WordPress/gutenberg/pull/74196)
 - Fix missing dependencies. [#74310](https://github.com/WordPress/gutenberg/pull/74310)
+- Add details layout to DataForm validation story. [#74445](https://github.com/WordPress/gutenberg/pull/74445)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -100,7 +100,7 @@ export const Validation = {
 		layout: {
 			control: { type: 'select' },
 			description: 'Choose the form layout type.',
-			options: [ 'regular', 'panel', 'card' ],
+			options: [ 'regular', 'panel', 'card', 'details' ],
 		},
 		required: {
 			control: { type: 'boolean' },

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -86,7 +86,7 @@ const ValidationComponent = ( {
 	custom: 'sync' | 'async' | 'none';
 	pattern: boolean;
 	minMax: boolean;
-	layout: 'regular' | 'panel' | 'card';
+	layout: 'regular' | 'panel' | 'card' | 'details';
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -904,6 +904,13 @@ const ValidationComponent = ( {
 		if ( layout === 'panel' ) {
 			return {
 				layout: { type: 'panel' as const },
+				fields: groupedFields,
+			};
+		}
+
+		if ( layout === 'details' ) {
+			return {
+				layout: { type: 'details' as const },
 				fields: groupedFields,
 			};
 		}


### PR DESCRIPTION
## What?

This PR adds support for the details layout in [the validation story](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataform--validation&args=layout:card).

## Why?

So we can assess how it works with validation.

## Testing Instructions

Run the local storybook (`npm run storybook:dev`) and verify you can switch to the details layout.