### PR TITLE
iAPI: Preserve boolean HTML attributes during client side navigation

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve boolean HTML attributes during client-side navigation. ([#XXX](https://github.com/WordPress/gutenberg/pull/XXX))
+
 ## 6.36.0 (2025-11-26)
 
 ### Bug Fixes

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Preserve boolean HTML attributes during client-side navigation. ([#XXX](https://github.com/WordPress/gutenberg/pull/XXX))
+-   Preserve boolean HTML attributes during client-side navigation. ([#74446](https://github.com/WordPress/gutenberg/pull/74446))
 
 ## 6.36.0 (2025-11-26)
 

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -218,6 +218,56 @@ describe( 'toVdom', () => {
 
 			console.warn = originalWarn;
 		} );
+
+		it( 'should convert boolean attribute "open" to true', () => {
+			const element = createElementFromHTML( '<details open></details>' );
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'details', { open: true }, [] )
+			);
+		} );
+
+		it( 'should convert boolean attribute "disabled" to true', () => {
+			const element = createElementFromHTML(
+				'<button disabled></button>'
+			);
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'button', { disabled: true }, [] )
+			);
+		} );
+
+		it( 'should convert boolean attribute "checked" to true', () => {
+			const element = createElementFromHTML(
+				'<input type="checkbox" checked />'
+			);
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'input', { type: 'checkbox', checked: true }, [] )
+			);
+		} );
+
+		it( 'should keep camelCase boolean attributes as empty strings', () => {
+			// readonly maps to readOnly property, so typeof element['readonly']
+			// is undefined, not boolean. This falls through to Preact's setAttribute.
+			const element = createElementFromHTML( '<input readonly />' );
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'input', { readonly: '' }, [] )
+			);
+		} );
+
+		it( 'should preserve non-boolean empty string attributes', () => {
+			const element = createElementFromHTML( '<input value="" />' );
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'input', { value: '' }, [] )
+			);
+		} );
+
+		it( 'should preserve non-empty attribute values unchanged', () => {
+			const element = createElementFromHTML(
+				'<input type="text" value="hello" />'
+			);
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'input', { type: 'text', value: 'hello' }, [] )
+			);
+		} );
 	} );
 
 	describe( 'Directive processing', () => {

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -160,7 +160,19 @@ export function toVdom( root: Node ): ComponentChild {
 			} else if ( attributeName === 'ref' ) {
 				continue;
 			}
-			props[ attributeName ] = attributeValue;
+			// For boolean attributes with empty string values, use the actual
+			// boolean property value. This prevents Preact from coercing "" to
+			// false. Camelcase mismatches (readonly→readOnly) return undefined
+			// for typeof, falling through to setAttribute which handles them
+			// correctly: https://github.com/preactjs/preact/blob/bf7a195ac4b1706468e876e41b27428e3d8a08f3/src/diff/props.js#L114
+			if (
+				attributeValue === '' &&
+				typeof elementNode[ attributeName ] === 'boolean'
+			) {
+				props[ attributeName ] = elementNode[ attributeName ];
+			} else {
+				props[ attributeName ] = attributeValue;
+			}
 		}
 
 		if ( ignore && ! island ) {

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -160,16 +160,16 @@ export function toVdom( root: Node ): ComponentChild {
 			} else if ( attributeName === 'ref' ) {
 				continue;
 			}
-			// For boolean attributes with empty string values, use the actual
-			// boolean property value. This prevents Preact from coercing "" to
-			// false. Camelcase mismatches (readonly→readOnly) return undefined
-			// for typeof, falling through to setAttribute which handles them
+			// For boolean attributes with empty string values, use `true`.
+			// This prevents Preact from coercing "" to false. Camelcase
+			// mismatches (readonly→readOnly) are `undefined`, not `true`,
+			// falling through to Preact's setAttribute path, which handles them
 			// correctly: https://github.com/preactjs/preact/blob/bf7a195ac4b1706468e876e41b27428e3d8a08f3/src/diff/props.js#L114
 			if (
 				attributeValue === '' &&
-				typeof elementNode[ attributeName ] === 'boolean'
+				elementNode[ attributeName ] === true
 			) {
-				props[ attributeName ] = elementNode[ attributeName ];
+				props[ attributeName ] = true;
 			} else {
 				props[ attributeName ] = attributeValue;
 			}


### PR DESCRIPTION
## What?

Closes #74148

This PR preserves boolean HTML attributes (like `open`, `checked`, `disabled`) during client-side navigation in the Interactivity API.

## Why?

Boolean attributes were being lost during iAPI router navigation. For example, a Details block configured to "Open by default" would collapse after pagination.

1. HTML boolean attributes like `<details open>` return `""` (empty string) via `getAttribute('open')`
2. `toVdom` was passing `props.open = ""` to Preact
3. Preact checks `'open' in detailsElement` → `true`, so it sets the DOM property directly: `detailsElement.open = ""`
4. Empty string coerces to `false` → Details closes unexpectedly

This is an alternative to #74217 that uses dynamic type checking instead of maintaining a hardcoded list of boolean attributes.

## How?

Instead of maintaining a hardcoded list of boolean attributes, this PR uses the browser's native type information to detect boolean properties dynamically:

```typescript
if (
    attributeValue === '' &&
    typeof elementNode[ attributeName ] === 'boolean'
) {
    props[ attributeName ] = elementNode[ attributeName ];
} else {
    props[ attributeName ] = attributeValue;
}
```

How this works:
- For boolean attributes where property name matches (`open`, `checked`, `disabled`): `typeof element['open']` returns `"boolean"`, so we use the actual boolean value
- For camelCase mismatches (`readonly` → `readOnly`): `typeof element['readonly']` returns `"undefined"`, falling through to the string path where [Preact uses `setAttribute()`](https://github.com/preactjs/preact/blob/bf7a195ac4b1706468e876e41b27428e3d8a08f3/src/diff/props.js#L114) which handles them correctly
- For non-boolean attributes: `typeof` never returns `"boolean"`, so no change in behavior

## Testing Instructions

1. Create a new page
2. Add a Query Loop block with "Enhanced Pagination" enabled
3. Inside the Query Loop, add a Details block and set it to "Open by default"
4. Save and view the page on the frontend
5. Click pagination to navigate to another page
6. **Expected:** The Details block should remain open after navigation
7. **Before this fix:** The Details block would collapse

### Testing Instructions for Keyboard

1. Follow the same steps above using keyboard navigation
2. Use Tab to reach the pagination links
3. Press Enter to navigate
4. The Details block should remain in its open state


