### PR TITLE
Blocks: cache url root when registering assets

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -114,6 +114,12 @@ function gutenberg_deregister_core_block_and_assets( $block_name ) {
  * @return void
  */
 function gutenberg_register_core_block_assets( $block_name ) {
+	// Running `gutenberg_url` inside of a loop can be expensive in systems with
+	// many callbacks attached to the `plugins_url` hook.
+	// Since all of the paths have the same root, we can instead retrieve the
+	// corresponding URL root once, and manually concatenate the URL below.
+	static $gutenberg_url_root = gutenberg_url( '/' );
+
 	if ( ! wp_should_load_separate_core_block_assets() ) {
 		return;
 	}
@@ -126,7 +132,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	$suffix          = SCRIPT_DEBUG ? '' : '.min';
 
 	$style_path      = "build/styles/block-library/$block_name/";
-	$stylesheet_url  = gutenberg_url( $style_path . 'style' . $suffix . '.css' );
+	$stylesheet_url  = $gutenberg_url_root . $style_path . 'style' . $suffix . '.css';
 	$stylesheet_path = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl' . $suffix . '.css' : 'style' . $suffix . '.css' );
 
 	if ( file_exists( $stylesheet_path ) ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -168,7 +168,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 			wp_deregister_style( "wp-block-{$block_name}-theme" );
 			wp_register_style(
 				"wp-block-{$block_name}-theme",
-				gutenberg_url( $theme_style_path ),
+				$gutenberg_url_root . $theme_style_path,
 				array(),
 				$default_version
 			);
@@ -182,7 +182,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		wp_deregister_style( "wp-block-{$block_name}-editor" );
 		wp_register_style(
 			"wp-block-{$block_name}-editor",
-			gutenberg_url( $editor_style_path ),
+			$gutenberg_url_root . $editor_style_path,
 			array(),
 			$default_version
 		);


### PR DESCRIPTION
## What?
This PR reduces the amount of calls to `gutenberg_url()` that happen inside of `gutenberg_register_core_block_assets()`.

## Why?
In systems with many callbacks attached to the `plugins_url` hook, running `gutenberg_register_core_block_assets()` (and consequently `gutenberg_url()`) in a loop can lead to a measurable delay on `init`.

Since all of the URLs share the same root, this repeated work is unnecessary, and we can improve things by ensuring we only run `gutenberg_url()` once.

## How?
This PR switches adds a root URL cache to `gutenberg_register_core_block_assets()`, and changes the method to concatenate URLs manually, based on that cache.

## Testing Instructions
- Ensure the PHP tests continue to work properly
- Smoke-test the plugin and ensure nothing breaks on the editor or the frontend
