### PR TITLE
Dev: Fix file change logs not displaying in watch mode

### DIFF
--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -203,15 +203,15 @@ async function dev() {
 		// Wait for wp-build to complete its initial build, then signal ready.
 		// Using .then() ensures cleanup handlers are registered before awaiting,
 		// so early termination still triggers cleanup.
-		const onStdoutData = ( data ) => {
+		let isReady = false;
+		buildWatch.stdout.on( 'data', ( data ) => {
 			const output = data.toString();
 			process.stdout.write( output );
-			if ( output.includes( 'Watching for changes' ) ) {
-				buildWatch.stdout.off( 'data', onStdoutData );
+			if ( ! isReady && output.includes( 'Watching for changes' ) ) {
+				isReady = true;
 				readyMarkerFile.create();
 			}
-		};
-		buildWatch.stdout.on( 'data', onStdoutData );
+		} );
 
 		// Keep the process running
 		await new Promise( () => {} );


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/74290#discussion_r2672388185

Fixes file change logs not displaying during watch mode in `npm run dev`.

## Why?

After the race condition fix in #74290, the stdout listener for `wp-build` was being removed once "Watching for changes" was detected. This caused subsequent rebuild logs (showing which files changed) to be suppressed, degrading the developer experience.

## How?

Instead of removing the stdout listener after detecting the initial build completion marker, we now:

1. Keep the listener active to continue piping all stdout to the console
2. Use an `isReady` flag to ensure the ready marker file is only created once
3. Continue checking for the marker text but don't remove the listener

This ensures both:
- The ready marker file is created at the right time (preserving the race condition fix)
- All subsequent file change logs continue to be displayed during watch mode

## Testing Instructions

1. Run `npm run dev`
2. Wait for the initial build to complete ("Watching for changes..." appears)
3. Modify a file in one of the packages (e.g., edit a file in `packages/components/src/`)
4. Verify that the console shows the rebuild output indicating which files were rebuilt

## Testing Instructions for Keyboard

N/A - This is a developer tooling change with no UI impact.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="541" height="134" alt="Screenshot 2026-01-08 at 7 32 12 PM" src="https://github.com/user-attachments/assets/6a985bf9-b50a-4b3d-a00c-f1ffe68b817a" /> | <img width="541" height="145" alt="Screenshot 2026-01-08 at 7 30 58 PM" src="https://github.com/user-attachments/assets/ddf0de8c-97d3-433e-9b02-49a20359d597" /> | 
