### PR TITLE
Inserter: only show blocks that can be inserted on the page

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2281,13 +2281,21 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 						)
 				);
 			} else {
+				const { getClosestAllowedInsertionPoint } = unlock(
+					select( STORE_NAME )
+				);
 				blockTypeInserterItems = blockTypeInserterItems
-					.filter( ( blockType ) =>
-						isBlockVisibleInTheInserter(
-							state,
-							blockType,
-							rootClientId
-						)
+					.filter(
+						( blockType ) =>
+							isBlockVisibleInTheInserter(
+								state,
+								blockType,
+								rootClientId
+							) &&
+							getClosestAllowedInsertionPoint(
+								blockType.name,
+								rootClientId
+							) !== null
 					)
 					.map( ( blockType ) => ( {
 						...blockType,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Makes sure that blocks shown in the inserter can actually be inserted on the page.

History:
* [Inserter: show all blocks (alternative)](https://github.com/WordPress/gutenberg/pull/62169#top)
* [Inserter: Update how we compute the actual insertion point for blocks](https://github.com/WordPress/gutenberg/pull/65490#top) (I suspect this actually broke thing because the `canInsertBlockTypeUnmemoized` was removed.)

Solution: check the `getClosestAllowedInsertionPoint` output that was added in the that last PR.

<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try the following example:

```
addFilter(
    'blockEditor.__unstableCanInsertBlockType',
    'removeVerseFromInserter',
    ( canInsert, blockType ) => {
        return blockType.name === 'core/verse' ? false : canInsert;
    }
);
```

The verse block should no longer be visible in the inserter.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
