### PR TITLE
Bump minimum required PHP version to 7.4.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -184,15 +184,11 @@ jobs:
             fail-fast: true
             matrix:
                 event: ['${{ github.event_name }}']
-                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+                php: ['7.4', '8.0', '8.1', '8.2', '8.3']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
                     # On PRs: Only test PHP 8.3, single-site, latest WP
-                    - event: 'pull_request'
-                      php: '7.2'
-                    - event: 'pull_request'
-                      php: '7.3'
                     - event: 'pull_request'
                       php: '7.4'
                     - event: 'pull_request'
@@ -206,8 +202,6 @@ jobs:
                     - event: 'pull_request'
                       wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
-                    - php: '7.3'
-                      wordpress: 'previous major version'
                     - php: '8.0'
                       wordpress: 'previous major version'
                     - php: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2.24",
+		"php": ">=7.4",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"scripts": {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.7
- * Requires PHP: 7.2
+ * Requires PHP: 7.4
  * Version: 22.3.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,8 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<!-- Check for cross-version support for PHP 7.2 and higher. -->
-	<config name="testVersion" value="7.2-"/>
+	<!-- Check for cross-version support for PHP 7.4 and higher. -->
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
## What?

Closes #74456

This bumps the minimum supported version of PHP to 7.4 and removes some 7.2 and 7.3 jobs and exclusions that are no longer needed.

See #60714 and #52982 for previous bumps.