### PR TITLE
CI: Run the PHP unit tests with the oldest and latest versions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -188,9 +188,7 @@ jobs:
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
-                    # On PRs: Only test PHP 8.3, single-site, latest WP
-                    - event: 'pull_request'
-                      php: '7.4'
+                    # On PRs: Only test PHP 7.4 and 8.3, single-site, latest WP
                     - event: 'pull_request'
                       php: '8.0'
                     - event: 'pull_request'


### PR DESCRIPTION
## What?
This is a follow-up to #72506.

Updates the list of PHP versions used for unit tests in pull requests. It should now run on the latest and oldest PHP versions, which should help us catch issues like https://github.com/WordPress/gutenberg/pull/74451#issuecomment-3724469640 earlier.


## Testing Instructions
Confirm CI checks are green.