### PR TITLE
Navigation Submenu: Show (Invalid) indicator when parent page is deleted

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -23,13 +23,11 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 	useInnerBlocksProps,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 
 /**
@@ -42,6 +40,7 @@ import {
 	useEntityBinding,
 	MissingEntityHelpText,
 	useHandleLinkChange,
+	useIsInvalidLink,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -99,62 +98,6 @@ const useIsDraggingWithin = ( elementRef ) => {
 	}, [ elementRef ] );
 
 	return isDraggingWithin;
-};
-
-const useIsInvalidLink = ( kind, type, id, enabled ) => {
-	const isPostType =
-		kind === 'post-type' || type === 'post' || type === 'page';
-	const hasId = Number.isInteger( id );
-	const blockEditingMode = useBlockEditingMode();
-
-	const { postStatus, isDeleted } = useSelect(
-		( select ) => {
-			if ( ! isPostType ) {
-				return { postStatus: null, isDeleted: false };
-			}
-
-			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
-			// When the block is rendered in a template or other disabled contexts we can skip this check in order
-			// to avoid all these additional requests that don't really add any value in that mode.
-			if ( blockEditingMode === 'disabled' || ! enabled ) {
-				return { postStatus: null, isDeleted: false };
-			}
-
-			const { getEntityRecord, hasFinishedResolution } =
-				select( coreStore );
-			const entityRecord = getEntityRecord( 'postType', type, id );
-			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
-				'postType',
-				type,
-				id,
-			] );
-
-			// If resolution has finished and entityRecord is undefined, the entity was deleted.
-			const deleted = hasResolved && entityRecord === undefined;
-
-			return {
-				postStatus: entityRecord?.status,
-				isDeleted: deleted,
-			};
-		},
-		[ isPostType, blockEditingMode, enabled, type, id ]
-	);
-
-	// Check Navigation Link validity if:
-	// 1. Link is 'post-type'.
-	// 2. It has an id.
-	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
-	// If those conditions are met, check if
-	// 1. The post status is trash (trashed).
-	// 2. The entity doesn't exist (deleted).
-	// If either of those is true, invalidate.
-	const isInvalid =
-		isPostType &&
-		hasId &&
-		( isDeleted || ( postStatus && 'trash' === postStatus ) );
-	const isDraft = 'draft' === postStatus;
-
-	return [ isInvalid, isDraft ];
 };
 
 function getMissingText( type ) {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -41,6 +41,7 @@ import {
 	useHandleLinkChange,
 	useIsInvalidLink,
 	InvalidDraftDisplay,
+	useEnableLinkStatusValidation,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -167,7 +168,6 @@ export default function NavigationLinkEdit( {
 		isTopLevelLink,
 		isParentOfSelectedBlock,
 		hasChildren,
-		validateLinkStatus,
 		parentBlockClientId,
 		isSubmenu,
 	} = useSelect(
@@ -178,12 +178,10 @@ export default function NavigationLinkEdit( {
 				getBlockRootClientId,
 				hasSelectedInnerBlock,
 				getBlockParentsByBlockName,
-				getSelectedBlockClientId,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 			const parentBlockName = getBlockName( rootClientId );
 			const isTopLevel = parentBlockName === 'core/navigation';
-			const selectedBlockClientId = getSelectedBlockClientId();
 			const rootNavigationClientId = isTopLevel
 				? rootClientId
 				: getBlockParentsByBlockName(
@@ -197,11 +195,6 @@ export default function NavigationLinkEdit( {
 					? rootClientId
 					: rootNavigationClientId;
 
-			// Enable when the root Navigation block is selected or any of its inner blocks.
-			const enableLinkStatusValidation =
-				selectedBlockClientId === rootNavigationClientId ||
-				hasSelectedInnerBlock( rootNavigationClientId, true );
-
 			return {
 				isAtMaxNesting:
 					getBlockParentsByBlockName( clientId, NESTING_BLOCK_NAMES )
@@ -212,13 +205,14 @@ export default function NavigationLinkEdit( {
 					true
 				),
 				hasChildren: !! getBlockCount( clientId ),
-				validateLinkStatus: enableLinkStatusValidation,
 				parentBlockClientId: parentBlockId,
 				isSubmenu: parentBlockName === 'core/navigation-submenu',
 			};
 		},
 		[ clientId, maxNestingLevel ]
 	);
+
+	const validateLinkStatus = useEnableLinkStatusValidation( clientId );
 	const { getBlocks } = useSelect( blockEditorStore );
 
 	// URL binding logic

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -26,7 +26,6 @@ import {
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 
@@ -41,6 +40,7 @@ import {
 	MissingEntityHelpText,
 	useHandleLinkChange,
 	useIsInvalidLink,
+	InvalidDraftDisplay,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -436,10 +436,6 @@ export default function NavigationLinkEdit( {
 	} );
 
 	const missingText = getMissingText( type );
-	/* translators: Whether the navigation link is Invalid or a Draft. */
-	const placeholderText = `(${
-		isInvalid ? __( 'Invalid' ) : __( 'Draft' )
-	})`;
 
 	return (
 		<>
@@ -521,31 +517,12 @@ export default function NavigationLinkEdit( {
 								</>
 							) }
 							{ ( isInvalid || isDraft ) && (
-								<div
-									className={ clsx(
-										'wp-block-navigation-link__placeholder-text',
-										'wp-block-navigation-link__label',
-										{
-											'is-invalid': isInvalid,
-											'is-draft': isDraft,
-										}
-									) }
-								>
-									<span>
-										{
-											// Some attributes are stored in an escaped form. It's a legacy issue.
-											// Ideally they would be stored in a raw, unescaped form.
-											// Unescape is used here to "recover" the escaped characters
-											// so they display without encoding.
-											// See `updateAttributes` for more details.
-											`${ decodeEntities( label ) } ${
-												isInvalid || isDraft
-													? placeholderText
-													: ''
-											}`.trim()
-										}
-									</span>
-								</div>
+								<InvalidDraftDisplay
+									label={ label }
+									isInvalid={ isInvalid }
+									isDraft={ isDraft }
+									className="wp-block-navigation-link__label"
+								/>
 							) }
 						</>
 					) }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -195,8 +195,14 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	);
 	$style_attribute = $font_sizes['inline_styles'];
 
+	// Render inner blocks first to check if any menu items will actually display.
+	$inner_blocks_html = '';
+	foreach ( $block->inner_blocks as $inner_block ) {
+		$inner_blocks_html .= $inner_block->render();
+	}
+	$has_submenu = ! empty( trim( $inner_blocks_html ) );
+
 	$css_classes = trim( implode( ' ', $classes ) );
-	$has_submenu = count( $block->inner_blocks ) > 0;
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
@@ -269,11 +275,6 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-		$inner_blocks_html = '';
-		foreach ( $block->inner_blocks as $inner_block ) {
-			$inner_blocks_html .= $inner_block->render();
-		}
-
 		$html .= sprintf(
 			'<ul class="wp-block-navigation__submenu-container">%s</ul>',
 			$inner_blocks_html

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -179,7 +179,7 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
 			return '';
 		}
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -5,6 +5,13 @@
  * @package WordPress
  */
 
+// Path differs between source and build: './shared/helpers.php' in source, './navigation-link/shared/helpers.php' in build.
+if ( file_exists( __DIR__ . '/shared/helpers.php' ) ) {
+	require_once __DIR__ . '/shared/helpers.php';
+} else {
+	require_once __DIR__ . '/navigation-link/shared/helpers.php';
+}
+
 /**
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
@@ -170,31 +177,9 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
-	$navigation_link_has_id = isset( $attributes['id'] ) && is_numeric( $attributes['id'] );
-	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
-	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
-
-	// Don't render the block's subtree if it is a draft or if the ID does not exist.
-	if ( $is_post_type && $navigation_link_has_id ) {
-		$post = get_post( $attributes['id'] );
-		/**
-		 * Filter allowed post_status for navigation link block to render.
-		 *
-		 * @since 6.8.0
-		 *
-		 * @param array $post_status
-		 * @param array $attributes
-		 * @param WP_Block $block
-		 */
-		$allowed_post_status = (array) apply_filters(
-			'render_block_core_navigation_link_allowed_post_status',
-			array( 'publish' ),
-			$attributes,
-			$block
-		);
-		if ( ! $post || ! in_array( $post->post_status, $allowed_post_status, true ) ) {
-			return '';
-		}
+	// Check if this navigation item should render based on post status.
+	if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+		return '';
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -178,8 +178,10 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
  */
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
-	if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
-		return '';
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+			return '';
+		}
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-link/shared/helpers.php
+++ b/packages/block-library/src/navigation-link/shared/helpers.php
@@ -8,7 +8,7 @@
 /**
  * Checks if a navigation item should render based on post status.
  *
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @param array    $attributes The block attributes.
  * @param WP_Block $block      The parsed block.

--- a/packages/block-library/src/navigation-link/shared/helpers.php
+++ b/packages/block-library/src/navigation-link/shared/helpers.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Shared helper functions for Navigation Link and Navigation Submenu blocks.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Checks if a navigation item should render based on post status.
+ *
+ * @since 6.9.0
+ *
+ * @param array    $attributes The block attributes.
+ * @param WP_Block $block      The parsed block.
+ * @return bool True if the item should render, false otherwise.
+ */
+function block_core_navigation_item_should_render( $attributes, $block ) {
+	$navigation_link_has_id = isset( $attributes['id'] ) && is_numeric( $attributes['id'] );
+	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
+	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
+
+	// Don't render the block's subtree if it is a draft or if the ID does not exist.
+	if ( $is_post_type && $navigation_link_has_id ) {
+		$post = get_post( $attributes['id'] );
+		/**
+		 * Filter allowed post_status for navigation link block to render.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array    $post_status Array of allowed post statuses.
+		 * @param array    $attributes  Block attributes.
+		 * @param WP_Block $block       The parsed block.
+		 */
+		$allowed_post_status = (array) apply_filters(
+			'render_block_core_navigation_link_allowed_post_status',
+			array( 'publish' ),
+			$attributes,
+			$block
+		);
+		if ( ! $post || ! in_array( $post->post_status, $allowed_post_status, true ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/packages/block-library/src/navigation-link/shared/helpers.php
+++ b/packages/block-library/src/navigation-link/shared/helpers.php
@@ -14,7 +14,7 @@
  * @param WP_Block $block      The parsed block.
  * @return bool True if the item should render, false otherwise.
  */
-function block_core_navigation_item_should_render( $attributes, $block ) {
+function block_core_shared_navigation_item_should_render( $attributes, $block ) {
 	$navigation_link_has_id = isset( $attributes['id'] ) && is_numeric( $attributes['id'] );
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -14,3 +14,4 @@ export {
 export { LinkUI } from '../link-ui';
 export { useHandleLinkChange } from './use-handle-link-change';
 export { useIsInvalidLink } from './use-is-invalid-link';
+export { InvalidDraftDisplay } from './invalid-draft-display';

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -15,3 +15,4 @@ export { LinkUI } from '../link-ui';
 export { useHandleLinkChange } from './use-handle-link-change';
 export { useIsInvalidLink } from './use-is-invalid-link';
 export { InvalidDraftDisplay } from './invalid-draft-display';
+export { useEnableLinkStatusValidation } from './use-enable-link-status-validation';

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -13,3 +13,4 @@ export {
 } from './use-entity-binding';
 export { LinkUI } from '../link-ui';
 export { useHandleLinkChange } from './use-handle-link-change';
+export { useIsInvalidLink } from './use-is-invalid-link';

--- a/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
+++ b/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
@@ -44,7 +44,14 @@ export function InvalidDraftDisplay( {
 			) }
 		>
 			<span>
-				{ `${ decodeEntities( label ) } (${ statusText })`.trim() }
+				{
+					// Some attributes are stored in an escaped form. It's a legacy issue.
+					// Ideally they would be stored in a raw, unescaped form.
+					// Unescape is used here to "recover" the escaped characters
+					// so they display without encoding.
+					// See `updateAttributes` for more details.
+					`${ decodeEntities( label ) } (${ statusText })`.trim()
+				}
 			</span>
 		</div>
 	);

--- a/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
+++ b/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Displays a label with an "(Invalid)" or "(Draft)" indicator for navigation links.
+ *
+ * @param {Object}  props           Component props.
+ * @param {string}  props.label     The label text to display.
+ * @param {boolean} props.isInvalid Whether the link is invalid (deleted or trashed).
+ * @param {boolean} props.isDraft   Whether the link is a draft.
+ * @param {string}  props.className Optional additional CSS class for the label element.
+ *
+ * @return {Element} The invalid/draft display component.
+ */
+export function InvalidDraftDisplay( {
+	label,
+	isInvalid,
+	isDraft,
+	className = 'wp-block-navigation-link__label',
+} ) {
+	const statusText = isInvalid
+		? /* translators: Indicating that the navigation link is Invalid. */
+		  __( 'Invalid' )
+		: /* translators: Indicating that the navigation link is a Draft. */
+		  __( 'Draft' );
+
+	return (
+		<div
+			className={ clsx(
+				'wp-block-navigation-link__placeholder-text',
+				className,
+				{
+					'is-invalid': isInvalid,
+					'is-draft': isDraft,
+				}
+			) }
+		>
+			<span>
+				{ `${ decodeEntities( label ) } (${ statusText })`.trim() }
+			</span>
+		</div>
+	);
+}

--- a/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
+++ b/packages/block-library/src/navigation-link/shared/invalid-draft-display.js
@@ -26,6 +26,11 @@ export function InvalidDraftDisplay( {
 	isDraft,
 	className = 'wp-block-navigation-link__label',
 } ) {
+	// Only render if the link is invalid or a draft.
+	if ( ! isInvalid && ! isDraft ) {
+		return null;
+	}
+
 	const statusText = isInvalid
 		? /* translators: Indicating that the navigation link is Invalid. */
 		  __( 'Invalid' )

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -23,6 +23,8 @@ jest.mock( '@wordpress/data', () => ( {
 		} );
 		return newState;
 	} ),
+	createSelector: jest.fn( ( fn ) => fn ),
+	createRegistrySelector: jest.fn( ( fn ) => fn ),
 } ) );
 
 describe( 'useEnableLinkStatusValidation', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -16,6 +16,13 @@ import { useEnableLinkStatusValidation } from '../use-enable-link-status-validat
 // Mock the @wordpress/data module
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
+	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+		const newState = {};
+		Object.keys( reducers ).forEach( ( key ) => {
+			newState[ key ] = reducers[ key ]( state[ key ], action );
+		} );
+		return newState;
+	} ),
 } ) );
 
 describe( 'useEnableLinkStatusValidation', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useEnableLinkStatusValidation } from '../use-enable-link-status-validation';
+
+// Mock the @wordpress/data module
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+describe( 'useEnableLinkStatusValidation', () => {
+	const mockClientId = 'test-client-id';
+	const mockRootNavigationId = 'root-navigation-id';
+	const mockSelectedBlockId = 'selected-block-id';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return true when root navigation block is selected', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSelectedBlockClientId: () => mockRootNavigationId,
+				hasSelectedInnerBlock: () => false,
+				getBlockParentsByBlockName: () => [ mockRootNavigationId ],
+			} ) );
+		} );
+
+		const { result } = renderHook( () =>
+			useEnableLinkStatusValidation( mockClientId )
+		);
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'should return true when an inner block of root navigation is selected', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSelectedBlockClientId: () => mockSelectedBlockId,
+				hasSelectedInnerBlock: ( clientId, deep ) =>
+					clientId === mockRootNavigationId && deep === true,
+				getBlockParentsByBlockName: () => [ mockRootNavigationId ],
+			} ) );
+		} );
+
+		const { result } = renderHook( () =>
+			useEnableLinkStatusValidation( mockClientId )
+		);
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'should return false when neither root navigation nor its inner blocks are selected', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSelectedBlockClientId: () => 'other-block-id',
+				hasSelectedInnerBlock: () => false,
+				getBlockParentsByBlockName: () => [ mockRootNavigationId ],
+			} ) );
+		} );
+
+		const { result } = renderHook( () =>
+			useEnableLinkStatusValidation( mockClientId )
+		);
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'should handle case when root navigation id is not found', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSelectedBlockClientId: () => mockSelectedBlockId,
+				hasSelectedInnerBlock: () => false,
+				getBlockParentsByBlockName: () => [],
+			} ) );
+		} );
+
+		const { result } = renderHook( () =>
+			useEnableLinkStatusValidation( mockClientId )
+		);
+
+		// When rootNavigationId is undefined (empty array),
+		// both conditions will be false
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'should update when clientId changes', () => {
+		const newClientId = 'new-client-id';
+		const newRootNavigationId = 'new-root-navigation-id';
+
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSelectedBlockClientId: () => newRootNavigationId,
+				hasSelectedInnerBlock: () => false,
+				getBlockParentsByBlockName: ( clientId ) => {
+					return clientId === newClientId
+						? [ newRootNavigationId ]
+						: [ mockRootNavigationId ];
+				},
+			} ) );
+		} );
+
+		const { result, rerender } = renderHook(
+			( { clientId } ) => useEnableLinkStatusValidation( clientId ),
+			{
+				initialProps: { clientId: mockClientId },
+			}
+		);
+
+		// Initially false (different IDs)
+		expect( result.current ).toBe( false );
+
+		// Rerender with new clientId
+		rerender( { clientId: newClientId } );
+
+		// Should now be true (matching IDs)
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -4,28 +4,17 @@
 import { renderHook } from '@testing-library/react';
 
 /**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import { useEnableLinkStatusValidation } from '../use-enable-link-status-validation';
 
-// Mock the @wordpress/data module
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
-		const newState = {};
-		Object.keys( reducers ).forEach( ( key ) => {
-			newState[ key ] = reducers[ key ]( state[ key ], action );
-		} );
-		return newState;
-	} ),
-	createSelector: jest.fn( ( fn ) => fn ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-} ) );
+// Mock useSelect directly at the implementation level to avoid loading complex dependencies
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	const mock = jest.fn();
+	return mock;
+} );
+
+const { useSelect } = require( '@wordpress/data' );
 
 describe( 'useEnableLinkStatusValidation', () => {
 	const mockClientId = 'test-client-id';

--- a/packages/block-library/src/navigation-link/shared/use-enable-link-status-validation.js
+++ b/packages/block-library/src/navigation-link/shared/use-enable-link-status-validation.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Hook to determine if link status validation should be enabled.
+ *
+ * Link status validation is enabled when the root Navigation block is selected
+ * or any of its inner blocks are selected. This ensures validation only runs
+ * when the user is actively working within the navigation structure.
+ *
+ * @param {string} clientId The client ID of the current block.
+ * @return {boolean} Whether link status validation should be enabled.
+ */
+export function useEnableLinkStatusValidation( clientId ) {
+	return useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				hasSelectedInnerBlock,
+				getBlockParentsByBlockName,
+			} = select( blockEditorStore );
+
+			const selectedBlockId = getSelectedBlockClientId();
+			const rootNavigationId = getBlockParentsByBlockName(
+				clientId,
+				'core/navigation'
+			)[ 0 ];
+
+			// Enable when the root Navigation block is selected or any of its inner blocks.
+			return (
+				selectedBlockId === rootNavigationId ||
+				hasSelectedInnerBlock( rootNavigationId, true )
+			);
+		},
+		[ clientId ]
+	);
+}

--- a/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
+++ b/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useBlockEditingMode } from '@wordpress/block-editor';
+
+/**
+ * A React hook to determine if a navigation link or submenu's parent link is invalid.
+ *
+ * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
+ * @param {string}  type    The type of post (post, page, etc).
+ * @param {number}  id      The post or term id.
+ * @param {boolean} enabled Whether to enable the validation check.
+ *
+ * @return {Array} Array containing [isInvalid, isDraft] booleans.
+ */
+export const useIsInvalidLink = ( kind, type, id, enabled ) => {
+	const isPostType =
+		kind === 'post-type' || type === 'post' || type === 'page';
+	const hasId = Number.isInteger( id );
+	const blockEditingMode = useBlockEditingMode();
+
+	const { postStatus, isDeleted } = useSelect(
+		( select ) => {
+			if ( ! isPostType ) {
+				return { postStatus: null, isDeleted: false };
+			}
+
+			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
+			// When the block is rendered in a template or other disabled contexts we can skip this check in order
+			// to avoid all these additional requests that don't really add any value in that mode.
+			if ( blockEditingMode === 'disabled' || ! enabled ) {
+				return { postStatus: null, isDeleted: false };
+			}
+
+			const { getEntityRecord, hasFinishedResolution } =
+				select( coreStore );
+			const entityRecord = getEntityRecord( 'postType', type, id );
+			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				type,
+				id,
+			] );
+
+			// If resolution has finished and entityRecord is undefined, the entity was deleted.
+			const deleted = hasResolved && entityRecord === undefined;
+
+			return {
+				postStatus: entityRecord?.status,
+				isDeleted: deleted,
+			};
+		},
+		[ isPostType, blockEditingMode, enabled, type, id ]
+	);
+
+	// Check Navigation Link validity if:
+	// 1. Link is 'post-type'.
+	// 2. It has an id.
+	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
+	// If those conditions are met, check if
+	// 1. The post status is trash (trashed).
+	// 2. The entity doesn't exist (deleted).
+	// If either of those is true, invalidate.
+	const isInvalid =
+		isPostType &&
+		hasId &&
+		( isDeleted || ( postStatus && 'trash' === postStatus ) );
+	const isDraft = 'draft' === postStatus;
+
+	return [ isInvalid, isDraft ];
+};

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -39,6 +39,7 @@ import {
 	useEntityBinding,
 	useIsInvalidLink,
 	InvalidDraftDisplay,
+	useEnableLinkStatusValidation,
 } from '../navigation-link/shared';
 import {
 	getColors,
@@ -167,7 +168,6 @@ export default function NavigationSubmenuEdit( {
 		hasChildren,
 		selectedBlockHasChildren,
 		onlyDescendantIsEmptyLink,
-		validateLinkStatus,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -196,16 +196,6 @@ export default function NavigationSubmenuEdit( {
 					! singleBlock?.attributes?.label;
 			}
 
-			const rootNavigationId = getBlockParentsByBlockName(
-				clientId,
-				'core/navigation'
-			)[ 0 ];
-
-			// Enable when the root Navigation block is selected or any of its inner blocks.
-			const enableLinkStatusValidation =
-				selectedBlockId === rootNavigationId ||
-				hasSelectedInnerBlock( rootNavigationId, true );
-
 			return {
 				parentCount: getBlockParentsByBlockName(
 					clientId,
@@ -222,11 +212,12 @@ export default function NavigationSubmenuEdit( {
 				hasChildren: !! getBlockCount( clientId ),
 				selectedBlockHasChildren: !! selectedBlockChildren?.length,
 				onlyDescendantIsEmptyLink: _onlyDescendantIsEmptyLink,
-				validateLinkStatus: enableLinkStatusValidation,
 			};
 		},
 		[ clientId ]
 	);
+
+	const validateLinkStatus = useEnableLinkStatusValidation( clientId );
 
 	const prevHasChildren = usePrevious( hasChildren );
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -27,6 +27,8 @@ import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -102,6 +104,72 @@ const useIsDraggingWithin = ( elementRef ) => {
 };
 
 /**
+ * A React hook to determine if the submenu's parent link is invalid.
+ *
+ * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
+ * @param {string}  type    The type of post (post, page, etc).
+ * @param {number}  id      The post or term id.
+ * @param {boolean} enabled Whether to enable the validation check.
+ *
+ * @return {Array} Array containing [isInvalid, isDraft] booleans.
+ */
+const useIsInvalidLink = ( kind, type, id, enabled ) => {
+	const isPostType =
+		kind === 'post-type' || type === 'post' || type === 'page';
+	const hasId = Number.isInteger( id );
+	const blockEditingMode = useBlockEditingMode();
+
+	const { postStatus, isDeleted } = useSelect(
+		( select ) => {
+			if ( ! isPostType ) {
+				return { postStatus: null, isDeleted: false };
+			}
+
+			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
+			// When the block is rendered in a template or other disabled contexts we can skip this check in order
+			// to avoid all these additional requests that don't really add any value in that mode.
+			if ( blockEditingMode === 'disabled' || ! enabled ) {
+				return { postStatus: null, isDeleted: false };
+			}
+
+			const { getEntityRecord, hasFinishedResolution } =
+				select( coreStore );
+			const entityRecord = getEntityRecord( 'postType', type, id );
+			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				type,
+				id,
+			] );
+
+			// If resolution has finished and entityRecord is undefined, the entity was deleted.
+			const deleted = hasResolved && entityRecord === undefined;
+
+			return {
+				postStatus: entityRecord?.status,
+				isDeleted: deleted,
+			};
+		},
+		[ isPostType, blockEditingMode, enabled, type, id ]
+	);
+
+	// Check Navigation Link validity if:
+	// 1. Link is 'post-type'.
+	// 2. It has an id.
+	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
+	// If those conditions are met, check if
+	// 1. The post status is trash (trashed).
+	// 2. The entity doesn't exist (deleted).
+	// If either of those is true, invalidate.
+	const isInvalid =
+		isPostType &&
+		hasId &&
+		( isDeleted || ( postStatus && 'trash' === postStatus ) );
+	const isDraft = 'draft' === postStatus;
+
+	return [ isInvalid, isDraft ];
+};
+
+/**
  * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
  */
 
@@ -128,7 +196,7 @@ export default function NavigationSubmenuEdit( {
 	context,
 	clientId,
 } ) {
-	const { label, url, description } = attributes;
+	const { label, url, description, kind, type, id } = attributes;
 
 	const {
 		showSubmenuIcon,
@@ -165,6 +233,7 @@ export default function NavigationSubmenuEdit( {
 		hasChildren,
 		selectedBlockHasChildren,
 		onlyDescendantIsEmptyLink,
+		validateLinkStatus,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -193,6 +262,16 @@ export default function NavigationSubmenuEdit( {
 					! singleBlock?.attributes?.label;
 			}
 
+			const rootNavigationId = getBlockParentsByBlockName(
+				clientId,
+				'core/navigation'
+			)[ 0 ];
+
+			// Enable when the root Navigation block is selected or any of its inner blocks.
+			const enableLinkStatusValidation =
+				selectedBlockId === rootNavigationId ||
+				hasSelectedInnerBlock( rootNavigationId, true );
+
 			return {
 				parentCount: getBlockParentsByBlockName(
 					clientId,
@@ -209,12 +288,21 @@ export default function NavigationSubmenuEdit( {
 				hasChildren: !! getBlockCount( clientId ),
 				selectedBlockHasChildren: !! selectedBlockChildren?.length,
 				onlyDescendantIsEmptyLink: _onlyDescendantIsEmptyLink,
+				validateLinkStatus: enableLinkStatusValidation,
 			};
 		},
 		[ clientId ]
 	);
 
 	const prevHasChildren = usePrevious( hasChildren );
+
+	// Check if the submenu's parent link is invalid or draft
+	const [ isInvalid, isDraft ] = useIsInvalidLink(
+		kind,
+		type,
+		id,
+		validateLinkStatus
+	);
 
 	// Show the LinkControl on mount if the URL is empty
 	// ( When adding a new menu item)
@@ -392,29 +480,55 @@ export default function NavigationSubmenuEdit( {
 			</InspectorControls>
 			<div { ...blockProps }>
 				<ParentElement className="wp-block-navigation-item__content">
-					<RichText
-						ref={ ref }
-						identifier="label"
-						className="wp-block-navigation-item__label"
-						value={ label }
-						onChange={ ( labelValue ) =>
-							setAttributes( { label: labelValue } )
-						}
-						onMerge={ mergeBlocks }
-						onReplace={ onReplace }
-						aria-label={ __( 'Navigation link text' ) }
-						placeholder={ itemLabelPlaceholder }
-						withoutInteractiveFormatting
-						onClick={ () => {
-							if ( ! openSubmenusOnClick && ! url ) {
-								setIsLinkOpen( true );
-							}
-						} }
-					/>
-					{ description && (
-						<span className="wp-block-navigation-item__description">
-							{ description }
-						</span>
+					{ ! isInvalid && ! isDraft && (
+						<>
+							<RichText
+								ref={ ref }
+								identifier="label"
+								className="wp-block-navigation-item__label"
+								value={ label }
+								onChange={ ( labelValue ) =>
+									setAttributes( { label: labelValue } )
+								}
+								onMerge={ mergeBlocks }
+								onReplace={ onReplace }
+								aria-label={ __( 'Navigation link text' ) }
+								placeholder={ itemLabelPlaceholder }
+								withoutInteractiveFormatting
+								onClick={ () => {
+									if ( ! openSubmenusOnClick && ! url ) {
+										setIsLinkOpen( true );
+									}
+								} }
+							/>
+							{ description && (
+								<span className="wp-block-navigation-item__description">
+									{ description }
+								</span>
+							) }
+						</>
+					) }
+					{ ( isInvalid || isDraft ) && (
+						<div
+							className={ clsx(
+								'wp-block-navigation-link__placeholder-text',
+								'wp-block-navigation-item__label',
+								{
+									'is-invalid': isInvalid,
+									'is-draft': isDraft,
+								}
+							) }
+						>
+							<span>
+								{ `${ decodeEntities( label ) } ${
+									isInvalid
+										? /* translators: Indicating that the navigation link is Invalid. */
+										  `(${ __( 'Invalid' ) })`
+										: /* translators: Indicating that the navigation link is a Draft. */
+										  `(${ __( 'Draft' ) })`
+								}`.trim() }
+							</span>
+						</div>
 					) }
 					{ ! openSubmenusOnClick && isLinkOpen && (
 						<LinkUI

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -27,7 +27,6 @@ import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -39,6 +38,7 @@ import {
 	updateAttributes,
 	useEntityBinding,
 	useIsInvalidLink,
+	InvalidDraftDisplay,
 } from '../navigation-link/shared';
 import {
 	getColors,
@@ -443,26 +443,12 @@ export default function NavigationSubmenuEdit( {
 						</>
 					) }
 					{ ( isInvalid || isDraft ) && (
-						<div
-							className={ clsx(
-								'wp-block-navigation-link__placeholder-text',
-								'wp-block-navigation-item__label',
-								{
-									'is-invalid': isInvalid,
-									'is-draft': isDraft,
-								}
-							) }
-						>
-							<span>
-								{ `${ decodeEntities( label ) } ${
-									isInvalid
-										? /* translators: Indicating that the navigation link is Invalid. */
-										  `(${ __( 'Invalid' ) })`
-										: /* translators: Indicating that the navigation link is a Draft. */
-										  `(${ __( 'Draft' ) })`
-								}`.trim() }
-							</span>
-						</div>
+						<InvalidDraftDisplay
+							label={ label }
+							isInvalid={ isInvalid }
+							isDraft={ isDraft }
+							className="wp-block-navigation-item__label"
+						/>
 					) }
 					{ ! openSubmenusOnClick && isLinkOpen && (
 						<LinkUI

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -28,7 +28,6 @@ import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -39,6 +38,7 @@ import {
 	LinkUI,
 	updateAttributes,
 	useEntityBinding,
+	useIsInvalidLink,
 } from '../navigation-link/shared';
 import {
 	getColors,
@@ -101,72 +101,6 @@ const useIsDraggingWithin = ( elementRef ) => {
 	}, [] );
 
 	return isDraggingWithin;
-};
-
-/**
- * A React hook to determine if the submenu's parent link is invalid.
- *
- * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
- * @param {string}  type    The type of post (post, page, etc).
- * @param {number}  id      The post or term id.
- * @param {boolean} enabled Whether to enable the validation check.
- *
- * @return {Array} Array containing [isInvalid, isDraft] booleans.
- */
-const useIsInvalidLink = ( kind, type, id, enabled ) => {
-	const isPostType =
-		kind === 'post-type' || type === 'post' || type === 'page';
-	const hasId = Number.isInteger( id );
-	const blockEditingMode = useBlockEditingMode();
-
-	const { postStatus, isDeleted } = useSelect(
-		( select ) => {
-			if ( ! isPostType ) {
-				return { postStatus: null, isDeleted: false };
-			}
-
-			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
-			// When the block is rendered in a template or other disabled contexts we can skip this check in order
-			// to avoid all these additional requests that don't really add any value in that mode.
-			if ( blockEditingMode === 'disabled' || ! enabled ) {
-				return { postStatus: null, isDeleted: false };
-			}
-
-			const { getEntityRecord, hasFinishedResolution } =
-				select( coreStore );
-			const entityRecord = getEntityRecord( 'postType', type, id );
-			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
-				'postType',
-				type,
-				id,
-			] );
-
-			// If resolution has finished and entityRecord is undefined, the entity was deleted.
-			const deleted = hasResolved && entityRecord === undefined;
-
-			return {
-				postStatus: entityRecord?.status,
-				isDeleted: deleted,
-			};
-		},
-		[ isPostType, blockEditingMode, enabled, type, id ]
-	);
-
-	// Check Navigation Link validity if:
-	// 1. Link is 'post-type'.
-	// 2. It has an id.
-	// 3. It's neither null, nor undefined, as valid items might be either of those while loading.
-	// If those conditions are met, check if
-	// 1. The post status is trash (trashed).
-	// 2. The entity doesn't exist (deleted).
-	// If either of those is true, invalidate.
-	const isInvalid =
-		isPostType &&
-		hasId &&
-		( isDeleted || ( postStatus && 'trash' === postStatus ) );
-	const isDraft = 'draft' === postStatus;
-
-	return [ isInvalid, isDraft ];
 };
 
 /**

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -69,9 +69,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
-	// Don't render the block's subtree if it is a draft.
-	if ( $is_post_type && $navigation_link_has_id && 'publish' !== get_post_status( $attributes['id'] ) ) {
-		return '';
+	// Don't render the block's subtree if the post doesn't exist or is not published.
+	if ( $is_post_type && $navigation_link_has_id ) {
+		$post_status = get_post_status( $attributes['id'] );
+		// If post doesn't exist (deleted) or is not published, don't render.
+		if ( ! $post_status || 'publish' !== $post_status ) {
+			return '';
+		}
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -229,7 +229,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		if ( $has_submenu ) {
 			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_submenu_render_submenu_icon() . '</span>';
 		}
-
 	}
 
 	if ( $has_submenu ) {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -5,6 +5,13 @@
  * @package WordPress
  */
 
+// Path differs between source and build: '../navigation-link/shared/helpers.php' in source, './navigation-link/shared/helpers.php' in build.
+if ( file_exists( __DIR__ . '/../navigation-link/shared/helpers.php' ) ) {
+	require_once __DIR__ . '/../navigation-link/shared/helpers.php';
+} else {
+	require_once __DIR__ . '/navigation-link/shared/helpers.php';
+}
+
 /**
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
@@ -65,17 +72,9 @@ function block_core_navigation_submenu_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
-	$navigation_link_has_id = isset( $attributes['id'] ) && is_numeric( $attributes['id'] );
-	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
-	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
-
-	// Don't render the block's subtree if the post doesn't exist or is not published.
-	if ( $is_post_type && $navigation_link_has_id ) {
-		$post_status = get_post_status( $attributes['id'] );
-		// If post doesn't exist (deleted) or is not published, don't render.
-		if ( ! $post_status || 'publish' !== $post_status ) {
-			return '';
-		}
+	// Check if this navigation item should render based on post status.
+	if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+		return '';
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -87,9 +87,15 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
 	$style_attribute = $font_sizes['inline_styles'];
 
-	$has_submenu = count( $block->inner_blocks ) > 0;
-	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
+	// Render inner blocks first to check if any menu items will actually display.
+	$inner_blocks_html = '';
+	foreach ( $block->inner_blocks as $inner_block ) {
+		$inner_blocks_html .= $inner_block->render();
+	}
+	$has_submenu = ! empty( trim( $inner_blocks_html ) );
+
+	$kind      = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
+	$is_active = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
@@ -195,7 +201,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= '</a>';
 		// End anchor tag content.
 
-		if ( $show_submenu_indicators ) {
+		if ( $show_submenu_indicators && $has_submenu ) {
 			// The submenu icon is rendered in a button here
 			// so that there's a clickable element to open the submenu.
 			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . block_core_navigation_submenu_render_submenu_icon() . '</button>';
@@ -220,7 +226,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		$html .= '</button>';
 
-		$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_submenu_render_submenu_icon() . '</span>';
+		if ( $has_submenu ) {
+			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_submenu_render_submenu_icon() . '</span>';
+		}
 
 	}
 
@@ -251,11 +259,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$style_attribute = '';
 		if ( array_key_exists( 'style', $colors_supports ) ) {
 			$style_attribute = $colors_supports['style'];
-		}
-
-		$inner_blocks_html = '';
-		foreach ( $block->inner_blocks as $inner_block ) {
-			$inner_blocks_html .= $inner_block->render();
 		}
 
 		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -73,8 +73,10 @@ function block_core_navigation_submenu_render_submenu_icon() {
  */
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
-	if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
-		return '';
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+			return '';
+		}
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -74,7 +74,7 @@ function block_core_navigation_submenu_render_submenu_icon() {
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_navigation_item_should_render( $attributes, $block ) ) {
+		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
 			return '';
 		}
 	}


### PR DESCRIPTION
## What?

Adds validation logic to the Navigation Submenu block to display an "(Invalid)" or "(Draft)" indicator when the parent page is deleted or in draft status.

## Why?

Fixes #44760

Currently, when a page referenced by a navigation submenu is deleted, the submenu appears normal in the editor but mysteriously disappears on the frontend. This creates confusion for editors who don't understand why their navigation isn't working.

This PR implements the same validation pattern used by the Navigation Link block, ensuring UI consistency across both block types.

## How?

### Editor Changes (`edit.js`)
- Added `useIsInvalidLink` hook (identical to navigation-link's implementation) to validate parent link status
- Hook checks if the referenced post/page exists and its publication status
- Conditionally renders:
  - Normal editable label when valid
  - Styled placeholder with "(Invalid)" or "(Draft)" indicator when invalid
- Performance optimized: only runs validation when navigation block is active
- Also adds a new component called `InvalidDraftDisplay` to share the draft display code.

### Frontend Changes (`index.php`)
- Updated server-side rendering to properly detect deleted posts
- `get_post_status()` returns `false` for non-existent posts
- Returns empty string for deleted/invalid posts, preventing broken navigation items

## Testing Instructions

### Manual Testing

1. Create a new page (e.g., "Test Page")
2. Add a Navigation block to a page/template
3. Add a Navigation Submenu block that links to "Test Page"
4. Add some child navigation links inside the submenu
5. **Save and verify** the submenu appears correctly in the editor
6. Go to the Pages list and **delete "Test Page"** (move to trash)
7. Return to the editor and **refresh the page**

**Expected Results:**
- ✅ The submenu label now displays "Test Page (Invalid)" in the editor
- ✅ The submenu and its children do not appear on the frontend

**Before this PR:**
- ❌ The submenu appeared normal in the editor with no indication of issues
- ❌ The submenu disappeared on the frontend without explanation

### Additional Test Cases

**Draft Status:**
1. Create a navigation submenu linking to a page
2. Change that page's status to "Draft"
3. The submenu should show "(Draft)" indicator

**Restore Functionality:**
1. After deleting a page, restore it from trash
2. The submenu should return to normal (no indicator)

## Screenshots
<img width="1554" height="648" alt="Screenshot 2026-01-08 at 17 33 08" src="https://github.com/user-attachments/assets/dc815ea0-cf94-4396-8bbb-a4f455a5b353" />

## Related PR

This issue was previously attempted in #69138 but wasn't completed. This implementation uses the new shared directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)