### PR TITLE
`@wordpress/ui` `Button`: add `destructive` tone

### DIFF
--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -62,12 +62,15 @@ export const Neutral: Story = {
 	},
 };
 
-export const NeutralOutline: Story = {
+/**
+ * Destructive buttons should be used for high-stakes, irreversible actions.
+ */
+export const Destructive: Story = {
 	...Default,
 	args: {
 		...Default.args,
-		tone: 'neutral',
-		variant: 'outline',
+		children: 'Permanently delete',
+		tone: 'destructive',
 	},
 };
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -92,57 +92,64 @@ export const AllTonesAndVariants: Story = {
 			<div></div>
 			<div style={ { textAlign: 'center' } }>Resting</div>
 			<div style={ { textAlign: 'center' } }>Disabled</div>
-			{ ( [ 'brand', 'neutral' ] as const ).map( ( tone ) => (
-				<Fragment key={ tone }>
-					{ (
-						[ 'solid', 'outline', 'minimal', 'unstyled' ] as const
-					 ).map( ( variant ) => (
-						<Fragment key={ variant }>
-							<div
-								style={ {
-									paddingInlineEnd: '1rem',
-									display: 'flex',
-									alignItems: 'center',
-								} }
-							>
-								{ variant }, { tone }
-							</div>
-							<div
-								style={ {
-									padding: '0.5rem 1rem',
-									display: 'flex',
-									alignItems: 'center',
-								} }
-							>
-								<Button
-									{ ...args }
-									tone={ tone }
-									variant={ variant }
-								/>
-							</div>
-							<div
-								style={ {
-									padding: '0.5rem 1rem',
-									display: 'flex',
-									alignItems: 'center',
-								} }
-							>
-								<Button
-									{ ...args }
-									tone={ tone }
-									variant={ variant }
-									// Disabling because this lint rule was meant for the
-									// `@wordpress/components` Button, but is being applied here.
-									// TODO: rework the lint rule so that it checks the package
-									// where the Button comes from.
-									// eslint-disable-next-line no-restricted-syntax
-									disabled
-								/>
-							</div>
-						</Fragment>
-					) ) }
-				</Fragment>
-			) ) }
+			{ ( [ 'brand', 'neutral', 'destructive' ] as const ).map(
+				( tone ) => (
+					<Fragment key={ tone }>
+						{ (
+							[
+								'solid',
+								'outline',
+								'minimal',
+								'unstyled',
+							] as const
+						 ).map( ( variant ) => (
+							<Fragment key={ variant }>
+								<div
+									style={ {
+										paddingInlineEnd: '1rem',
+										display: 'flex',
+										alignItems: 'center',
+									} }
+								>
+									{ variant }, { tone }
+								</div>
+								<div
+									style={ {
+										padding: '0.5rem 1rem',
+										display: 'flex',
+										alignItems: 'center',
+									} }
+								>
+									<Button
+										{ ...args }
+										tone={ tone }
+										variant={ variant }
+									/>
+								</div>
+								<div
+									style={ {
+										padding: '0.5rem 1rem',
+										display: 'flex',
+										alignItems: 'center',
+									} }
+								>
+									<Button
+										{ ...args }
+										tone={ tone }
+										variant={ variant }
+										// Disabling because this lint rule was meant for the
+										// `@wordpress/components` Button, but is being applied here.
+										// TODO: rework the lint rule so that it checks the package
+										// where the Button comes from.
+										// eslint-disable-next-line no-restricted-syntax
+										disabled
+									/>
+								</div>
+							</Fragment>
+						) ) }
+					</Fragment>
+				)
+			) }
 		</div>
 	),
 };

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -185,6 +185,39 @@
 		}
 	}
 
+	.is-destructive {
+		&.is-solid {
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-strong-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-strong-disabled);
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error-strong);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-strong-active);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-error-strong-disabled);
+		}
+
+		/* Outline and minimal buttons use the same foreground color */
+		&.is-outline,
+		&.is-minimal {
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-active);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-error-disabled);
+		}
+
+		&.is-outline {
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-disabled);
+			--wp-ui-button-border-color: var(--wpds-color-stroke-interactive-error);
+			--wp-ui-button-border-color-active: var(--wpds-color-stroke-interactive-error-active);
+		}
+
+		&.is-minimal {
+			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-weak);
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-weak-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-weak-disabled);
+		}
+	}
+
 	.is-unstyled {
 		border: none;
 		background: none;

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -17,7 +17,7 @@ export interface ButtonProps
 	 *
 	 * @default "brand"
 	 */
-	tone?: 'brand' | 'neutral';
+	tone?: 'brand' | 'neutral' | 'destructive';
 
 	/**
 	 * The size of the button.

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -13,8 +13,11 @@ export interface ButtonProps
 	variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
 
 	/**
-	 * The tone of the button. Tone describes a semantic color intent.
+	 * The tone of the button:
 	 *
+	 * - `'brand': for the most prominent actions, using the brand colors.
+	 * - `'neutral'` for less prominent actions.
+	 * - `'destructive'`: for high-stakes, irreversible actions.
 	 * @default "brand"
 	 */
 	tone?: 'brand' | 'neutral' | 'destructive';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Add `destructive` tone variant to the `Button` component in `@wordpress/ui`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `destructive` tone variant will be used to denote irreversible actions

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add a new `destructive` option for the `tone` prop
- Add style that consume the [recently added tokens](https://github.com/WordPress/gutenberg/pull/73793)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Visit Storybook

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/d16674d8-ee5a-4950-b8bf-61ace7d067f4

