### PR TITLE
Disable Search Suggestions when Custom URL is Selected

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -104,6 +104,7 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  * @property {boolean=}                   withCreateSuggestion       Whether to allow creation of link value from suggestion.
  * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
  * @property {boolean=}                   noURLSuggestion            Whether to add a fallback suggestion which treats the search query as a URL.
+ * @property {boolean=}                   noEntitySearch             Whether to disable entity-based search (posts, pages, terms). When true, only URL-like suggestions will be shown.
  * @property {boolean=}                   hasTextControl             Whether to add a text field to the UI to update the value.title.
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
  * @property {Function}                   renderControlBottom        Optional controls to be rendered at the bottom of the component.
@@ -138,6 +139,7 @@ function LinkControl( {
 	inputValue: propInputValue = '',
 	suggestionsQuery = {},
 	noURLSuggestion = false,
+	noEntitySearch = false,
 	createSuggestionButtonText,
 	hasRichPreviews = false,
 	hasTextControl = false,
@@ -467,6 +469,7 @@ function LinkControl( {
 							showSuggestions={ showSuggestions }
 							suggestionsQuery={ suggestionsQuery }
 							withURLSuggestion={ ! noURLSuggestion }
+							noEntitySearch={ noEntitySearch }
 							createSuggestionButtonText={
 								createSuggestionButtonText
 							}

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -45,6 +45,7 @@ const LinkControlSearchInput = forwardRef(
 			hideLabelFromVision = false,
 			suffix,
 			isEntity = false,
+			noEntitySearch = false,
 		},
 		ref
 	) => {
@@ -52,7 +53,8 @@ const LinkControlSearchInput = forwardRef(
 			suggestionsQuery,
 			allowDirectEntry,
 			withCreateSuggestion,
-			withURLSuggestion
+			withURLSuggestion,
+			noEntitySearch
 		);
 
 		const searchHandler = showSuggestions

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -106,8 +106,7 @@ const handleEntitySearch = async (
 export default function useSearchHandler(
 	suggestionsQuery,
 	allowDirectEntry,
-	withCreateSuggestion,
-	noEntitySearch = false
+	withCreateSuggestion
 ) {
 	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
 		( select ) => {
@@ -126,6 +125,10 @@ export default function useSearchHandler(
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry
 		: handleNoop;
+
+	// Extract noEntitySearch from suggestionsQuery if provided.
+	// This allows disabling entity search without changing the function signature.
+	const noEntitySearch = suggestionsQuery?.noEntitySearch ?? false;
 
 	return useCallback(
 		( val, { isInitialSuggestions } ) => {

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -106,7 +106,8 @@ const handleEntitySearch = async (
 export default function useSearchHandler(
 	suggestionsQuery,
 	allowDirectEntry,
-	withCreateSuggestion
+	withCreateSuggestion,
+	noEntitySearch = false
 ) {
 	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
 		( select ) => {
@@ -128,7 +129,17 @@ export default function useSearchHandler(
 
 	return useCallback(
 		( val, { isInitialSuggestions } ) => {
-			return isURLLike( val )
+			const isUrlLike = isURLLike( val );
+
+			// When noEntitySearch is true, only show suggestions for URL-like input.
+			// For non-URL input, return empty results instead of searching entities.
+			if ( noEntitySearch ) {
+				return isUrlLike
+					? directEntryHandler( val, { isInitialSuggestions } )
+					: Promise.resolve( [] );
+			}
+
+			return isUrlLike
 				? directEntryHandler( val, { isInitialSuggestions } )
 				: handleEntitySearch(
 						val,
@@ -142,6 +153,7 @@ export default function useSearchHandler(
 		[
 			directEntryHandler,
 			fetchSearchSuggestions,
+			noEntitySearch,
 			pageOnFront,
 			pageForPosts,
 			suggestionsQuery,

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -143,6 +143,10 @@ function UnforwardedLinkUI( props, ref ) {
 
 	const blockEditingMode = useBlockEditingMode();
 
+	// Custom Link variation is identified by having no type.
+	// When true, disable entity search but keep URL suggestions.
+	const hasType = !! type;
+
 	return (
 		<Popover
 			ref={ ref }
@@ -173,8 +177,9 @@ function UnforwardedLinkUI( props, ref ) {
 						value={ link }
 						showInitialSuggestions
 						withCreateSuggestion={ false }
-						noDirectEntry={ !! type }
-						noURLSuggestion={ !! type }
+						noDirectEntry={ hasType }
+						noURLSuggestion={ hasType }
+						noEntitySearch={ ! hasType }
 						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -32,29 +32,33 @@ import { useEntityBinding } from '../shared/use-entity-binding';
  * Given the Link block's type attribute, return the query params to give to
  * /wp/v2/search.
  *
- * @param {string} type Link block's type attribute.
- * @param {string} kind Link block's entity of kind (post-type|taxonomy)
- * @return {{ type?: string, subtype?: string }} Search query params.
+ * @param {string}  type           Link block's type attribute.
+ * @param {string}  kind           Link block's entity of kind (post-type|taxonomy)
+ * @param {boolean} noEntitySearch Whether to disable entity search.
+ * @return {{ type?: string, subtype?: string, noEntitySearch?: boolean }} Search query params.
  */
-export function getSuggestionsQuery( type, kind ) {
+export function getSuggestionsQuery( type, kind, noEntitySearch = false ) {
+	const baseQuery = noEntitySearch ? { noEntitySearch: true } : {};
+
 	switch ( type ) {
 		case 'post':
 		case 'page':
-			return { type: 'post', subtype: type };
+			return { ...baseQuery, type: 'post', subtype: type };
 		case 'category':
-			return { type: 'term', subtype: 'category' };
+			return { ...baseQuery, type: 'term', subtype: 'category' };
 		case 'tag':
-			return { type: 'term', subtype: 'post_tag' };
+			return { ...baseQuery, type: 'term', subtype: 'post_tag' };
 		case 'post_format':
-			return { type: 'post-format' };
+			return { ...baseQuery, type: 'post-format' };
 		default:
 			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type };
+				return { ...baseQuery, type: 'term', subtype: type };
 			}
 			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type };
+				return { ...baseQuery, type: 'post', subtype: type };
 			}
 			return {
+				...baseQuery,
 				// for custom link which has no type
 				// always show pages as initial suggestions
 				initialSuggestionsSearchOptions: {
@@ -145,7 +149,7 @@ function UnforwardedLinkUI( props, ref ) {
 
 	// Custom Link variation is identified by having no type.
 	// When true, disable entity search but keep URL suggestions.
-	const hasType = !! type;
+	const isCustomLinkVariation = ! type;
 
 	return (
 		<Popover
@@ -175,12 +179,15 @@ function UnforwardedLinkUI( props, ref ) {
 						hasTextControl
 						hasRichPreviews
 						value={ link }
-						showInitialSuggestions
+						showInitialSuggestions={ ! isCustomLinkVariation }
 						withCreateSuggestion={ false }
-						noDirectEntry={ hasType }
-						noURLSuggestion={ hasType }
-						noEntitySearch={ ! hasType }
-						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
+						noDirectEntry={ !! type }
+						noURLSuggestion={ !! type }
+						suggestionsQuery={ getSuggestionsQuery(
+							type,
+							kind,
+							isCustomLinkVariation
+						) }
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }


### PR DESCRIPTION
## What?
Ref https://github.com/WordPress/gutenberg/issues/73293

## Why?
When using custom URL's in link control component it still displays the post and pages.

## How?
Add an extra prop to determine the custom functionality.

## Testing Instructions
1. Add a new paragraph text.
2. Convert it to a link and enter a custom url.

