### PR TITLE
Add the necessary types to reference the preferences redux store by name

### DIFF
--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- TypeScript types added for accessing the `core/preferences` store by name
+
 ## 4.36.0 (2025-11-26)
 
 ## 4.35.0 (2025-11-12)

--- a/packages/preferences/src/store/index.ts
+++ b/packages/preferences/src/store/index.ts
@@ -28,3 +28,19 @@ export const store = createReduxStore<
 } );
 
 register( store );
+
+type SubsequentArgsOfFunc< F > = F extends ( arg: any, ...args: infer R ) => any
+	? R
+	: never;
+type CurriedSelectors = {
+	[ key in keyof typeof selectors ]: (
+		...args: SubsequentArgsOfFunc< ( typeof selectors )[ key ] >
+	) => ReturnType< ( typeof selectors )[ key ] >;
+};
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_NAME ): typeof actions;
+	function select( key: typeof STORE_NAME ): CurriedSelectors;
+
+	function useDispatch( key: typeof STORE_NAME ): typeof actions;
+	function useSelect( key: typeof STORE_NAME ): CurriedSelectors;
+}


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74475

This PR adds the necessary types to access the redux store in the preferences package by name.

## Why?
It's a nice convenience feature.

## How?
See above

## Testing Instructions
I don't actually know how to test compile-time-only stuff in this repo. DefinitelyTyped has a whole system set up for testing compile-time-only types, but I didn't see anything about that here.