### PR TITLE
Cover: Add automatic sticky header height detection

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -50,6 +50,7 @@ import {
 } from './color-utils';
 import { DEFAULT_MEDIA_SIZE_SLUG } from '../constants';
 import { getIframeSrc, getBackgroundVideoSrc } from '../embed-video-utils';
+import { observeStickyHeaderHeight } from '../sticky-header-utils';
 
 function getInnerBlocksTemplate( attributes ) {
 	return [
@@ -175,6 +176,12 @@ function CoverEdit( {
 		} )();
 		// Update the block only when the featured image changes.
 	}, [ mediaUrl ] );
+
+	// Observe sticky header height and update CSS custom property
+	useEffect( () => {
+		const cleanup = observeStickyHeaderHeight();
+		return cleanup;
+	}, [] );
 
 	// instead of destructuring the attributes
 	// we define the url and background type

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -16,119 +16,9 @@
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */
 function render_block_core_cover( $attributes, $content ) {
-	// Handle embed video background.
-	if (
-		isset( $attributes['backgroundType'] ) &&
-		'embed-video' === $attributes['backgroundType'] &&
-		isset( $attributes['url'] ) &&
-		! empty( $attributes['url'] ) &&
-		is_string( $attributes['url'] )
-	) {
-		$url = $attributes['url'];
-
-		// Use WordPress's native oEmbed processing (includes caching).
-		$oembed_html = wp_oembed_get( $url );
-
-		if ( $oembed_html ) {
-			// Extract iframe src from the oEmbed HTML.
-			preg_match( '/src=["\']([^"\']+)["\']/', $oembed_html, $src_matches );
-			if ( ! empty( $src_matches[1] ) ) {
-				$iframe_src = $src_matches[1];
-
-				// Detect provider from iframe src URL.
-				$lower_src = strtolower( $iframe_src );
-				$provider  = null;
-
-				if ( strpos( $lower_src, 'youtube.com' ) !== false || strpos( $lower_src, 'youtu.be' ) !== false ) {
-					$provider = 'youtube';
-				} elseif ( strpos( $lower_src, 'vimeo.com' ) !== false ) {
-					$provider = 'vimeo';
-				} elseif ( strpos( $lower_src, 'videopress.com' ) !== false ) {
-					$provider = 'videopress';
-				} elseif ( strpos( $lower_src, 'wordpress.tv' ) !== false ) {
-					$provider = 'wordpress-tv';
-				}
-
-				// Modify iframe src to add background video parameters based on provider.
-				$parsed_url = wp_parse_url( $iframe_src );
-				if ( $parsed_url && isset( $parsed_url['host'] ) ) {
-					// Parse existing query parameters.
-					$query_params = array();
-					if ( isset( $parsed_url['query'] ) ) {
-						parse_str( $parsed_url['query'], $query_params );
-					}
-
-					// Add background video parameters based on provider.
-					if ( 'youtube' === $provider ) {
-						$query_params['autoplay']       = '1';
-						$query_params['mute']           = '1';
-						$query_params['loop']           = '1';
-						$query_params['controls']       = '0';
-						$query_params['modestbranding'] = '1';
-						$query_params['playsinline']    = '1';
-					} elseif ( 'vimeo' === $provider ) {
-						$query_params['autoplay']    = '1';
-						$query_params['muted']       = '1';
-						$query_params['loop']        = '1';
-						$query_params['background']  = '1';
-						$query_params['controls']    = '0';
-						$query_params['transparent'] = '0';
-					} elseif ( 'videopress' === $provider || 'wordpress-tv' === $provider ) {
-						$query_params['autoplay'] = '1';
-						$query_params['loop']     = '1';
-						$query_params['muted']    = '1';
-					}
-
-					// Rebuild the URL with new parameters.
-					$iframe_src = $parsed_url['scheme'] . '://' . $parsed_url['host'];
-					if ( isset( $parsed_url['path'] ) ) {
-						$iframe_src .= $parsed_url['path'];
-					}
-					if ( ! empty( $query_params ) ) {
-						$iframe_src .= '?' . http_build_query( $query_params );
-					}
-				}
-
-				// Build the iframe HTML that will replace the figure.
-				$iframe_html = sprintf(
-					'<div class="wp-block-cover__video-background wp-block-cover__embed-background"><iframe src="%s" title="Background video" frameborder="0" allow="autoplay; fullscreen"></iframe></div>',
-					esc_url( $iframe_src )
-				);
-
-				// Use the HTML API to find and replace the figure.wp-block-embed element.
-				$processor = new WP_HTML_Tag_Processor( $content );
-
-				if ( $processor->next_tag(
-					array(
-						'tag_name'   => 'FIGURE',
-						'class_name' => 'wp-block-embed',
-					)
-				) ) {
-					// Use regex with PREG_OFFSET_CAPTURE to find the position of the figure element.
-					// This follows the same pattern used for featured image insertion below.
-					$figure_pattern = '/<figure\s+[^>]*\bwp-block-embed\b[^>]*>.*?<\/figure>/is';
-					if ( 1 === preg_match( $figure_pattern, $content, $matches, PREG_OFFSET_CAPTURE ) ) {
-						$figure_start  = $matches[0][1];
-						$figure_length = strlen( $matches[0][0] );
-						$figure_end    = $figure_start + $figure_length;
-
-						// Replace the figure element with the iframe HTML.
-						$content = substr( $content, 0, $figure_start ) . $iframe_html . substr( $content, $figure_end );
-					}
-				}
-			}
-		}
-
-		return $content;
-	}
-
 	if ( 'image' !== $attributes['backgroundType'] || false === $attributes['useFeaturedImage'] ) {
 		return $content;
 	}
-
-	$object_position = isset( $attributes['focalPoint'] )
-		? round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%'
-		: null;
 
 	if ( ! ( $attributes['hasParallax'] || $attributes['isRepeated'] ) ) {
 		$attr = array(
@@ -136,51 +26,20 @@ function render_block_core_cover( $attributes, $content ) {
 			'data-object-fit' => 'cover',
 		);
 
-		if ( $object_position ) {
+		if ( isset( $attributes['focalPoint'] ) ) {
+			$object_position              = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
 			$attr['data-object-position'] = $object_position;
-			$attr['style']                = 'object-position:' . $object_position . ';';
+			$attr['style']                = 'object-position:' . $object_position;
 		}
 
-		$image = get_the_post_thumbnail( null, $attributes['sizeSlug'] ?? 'post-thumbnail', $attr );
+		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );
 	} else {
-		if ( in_the_loop() ) {
-			update_post_thumbnail_cache();
-		}
-		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? null );
-		if ( ! $current_featured_image ) {
-			return $content;
-		}
-
-		$current_thumbnail_id = get_post_thumbnail_id();
-
-		$processor = new WP_HTML_Tag_Processor( '<div></div>' );
-		$processor->next_tag();
-
-		$current_alt = trim( strip_tags( get_post_meta( $current_thumbnail_id, '_wp_attachment_image_alt', true ) ) );
-		if ( $current_alt ) {
-			$processor->set_attribute( 'role', 'img' );
-			$processor->set_attribute( 'aria-label', $current_alt );
-		}
-
-		$processor->add_class( 'wp-block-cover__image-background' );
-		$processor->add_class( 'wp-image-' . $current_thumbnail_id );
-		if ( $attributes['hasParallax'] ) {
-			$processor->add_class( 'has-parallax' );
-		}
-		if ( $attributes['isRepeated'] ) {
-			$processor->add_class( 'is-repeated' );
-		}
-
-		$styles  = 'background-position:' . ( $object_position ?? '50% 50%' ) . ';';
-		$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
-		$processor->set_attribute( 'style', $styles );
-
-		$image = $processor->get_updated_html();
+		$image = '';
 	}
 
 	/*
 	 * Inserts the featured image between the (1st) cover 'background' `span` and 'inner_container' `div`,
-	 * and removes eventual whitespace characters between the two (typically introduced at template level)
+	 * and removes eventual withespace before the inner closing tag.
 	 */
 	$inner_container_start = '/<div\b[^>]+wp-block-cover__inner-container[\s|"][^>]*>/U';
 	if ( 1 === preg_match( $inner_container_start, $content, $matches, PREG_OFFSET_CAPTURE ) ) {
@@ -188,7 +47,7 @@ function render_block_core_cover( $attributes, $content ) {
 		$content = substr( $content, 0, $offset ) . $image . substr( $content, $offset );
 	}
 
-	return $content;
+	return trim( $content );
 }
 
 /**
@@ -203,5 +62,129 @@ function register_block_core_cover() {
 			'render_callback' => 'render_block_core_cover',
 		)
 	);
+
+	// Add inline script for sticky header detection on frontend only
+	if ( ! is_admin() ) {
+		// Register an empty script handle to attach inline script to
+		wp_register_script(
+			'wp-block-cover-view',
+			'',
+			array(),
+			'1.0.0',
+			array( 'in_footer' => true )
+		);
+
+		// Add inline script with sticky header detection logic
+		$inline_script = <<<'JAVASCRIPT'
+(function() {
+	'use strict';
+	
+	/**
+	 * Gets the total height of sticky Group blocks containing header template parts.
+	 * 
+	 * Improved detection logic:
+	 * 1. Find all elements with position: sticky
+	 * 2. Filter for .wp-block-group elements
+	 * 3. Check if the Group contains a header template part (any of):
+	 *    - .wp-block-template-part[data-area="header"]
+	 *    - <header> element with .wp-block-template-part class
+	 *    - Any .wp-block-template-part inside a sticky group (likely header)
+	 */
+	function getStickyHeaderHeight() {
+		// Find all elements with position: sticky
+		var allElements = document.querySelectorAll('*');
+		var stickyElements = Array.from(allElements).filter(function(el) {
+			var computed = window.getComputedStyle(el);
+			return el.style.position === 'sticky' || 
+			       el.classList.contains('is-position-sticky') ||
+			       computed.position === 'sticky';
+		});
+
+		// Filter for Group blocks only
+		var stickyGroups = stickyElements.filter(function(el) {
+			return el.classList.contains('wp-block-group');
+		});
+
+		// Check each Group for header template parts with improved detection
+		var stickyHeaders = stickyGroups.filter(function(group) {
+			// Check for explicit header area attribute
+			var hasExplicitHeader = group.querySelector('.wp-block-template-part[data-area="header"]');
+			if (hasExplicitHeader) {
+				return true;
+			}
+
+			// Check for header element (semantic HTML)
+			var hasHeaderElement = group.querySelector('header.wp-block-template-part');
+			if (hasHeaderElement) {
+				return true;
+			}
+
+			// Check for any template part in a sticky group (likely a header if sticky)
+			var hasAnyTemplatePart = group.querySelector('.wp-block-template-part');
+			if (hasAnyTemplatePart) {
+				return true;
+			}
+
+			return false;
+		});
+
+		if (stickyHeaders.length === 0) {
+			return 0;
+		}
+
+		// Calculate total height of all sticky headers
+		var totalHeight = 0;
+		stickyHeaders.forEach(function(header) {
+			var rect = header.getBoundingClientRect();
+			var style = window.getComputedStyle(header);
+			var marginTop = parseFloat(style.marginTop) || 0;
+			var marginBottom = parseFloat(style.marginBottom) || 0;
+			totalHeight += rect.height + marginTop + marginBottom;
+		});
+
+		return totalHeight;
+	}
+
+	/**
+	 * Updates the CSS custom property with the current sticky header height.
+	 */
+	function updateStickyHeaderHeight() {
+		var height = getStickyHeaderHeight();
+		document.documentElement.style.setProperty('--wp-sticky-header-height', height + 'px');
+	}
+
+	/**
+	 * Initialize on DOMContentLoaded
+	 */
+	function init() {
+		updateStickyHeaderHeight();
+
+		// Set up ResizeObserver to detect when elements are added/removed or resized
+		if (typeof ResizeObserver !== 'undefined') {
+			var resizeObserver = new ResizeObserver(updateStickyHeaderHeight);
+			resizeObserver.observe(document.body);
+		}
+
+		// Also listen for window resize events
+		window.addEventListener('resize', updateStickyHeaderHeight);
+	}
+
+	// Run on DOMContentLoaded
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+})();
+JAVASCRIPT;
+
+		wp_add_inline_script(
+			'wp-block-cover-view',
+			$inline_script
+		);
+
+		// Enqueue the script (this will output the inline script)
+		wp_enqueue_script( 'wp-block-cover-view' );
+	}
 }
 add_action( 'init', 'register_block_core_cover' );

--- a/packages/block-library/src/cover/sticky-header-utils.js
+++ b/packages/block-library/src/cover/sticky-header-utils.js
@@ -1,0 +1,124 @@
+/**
+ * Utility functions for detecting and calculating sticky header heights.
+ */
+
+/**
+ * Gets the total height of sticky Group blocks containing header template parts.
+ *
+ * Detection logic:
+ * 1. Find all elements with position: sticky (inline style or .is-position-sticky class)
+ * 2. Filter for .wp-block-group elements
+ * 3. Check if the Group contains a header template part (any of):
+ *    - .wp-block-template-part[data-area="header"]
+ *    - .wp-block-template-part that is a <header> element
+ *    - .wp-block-template-part with data-area="null" (inside sticky group at top)
+ * 4. Calculate total height including margins
+ *
+ * @return {number} Total height in pixels of all sticky headers
+ */
+export function getStickyHeaderHeight() {
+	// Find all elements with position: sticky
+	const allElements = document.querySelectorAll( '*' );
+	const stickyElements = Array.from( allElements ).filter( ( el ) => {
+		const computed = window.getComputedStyle( el );
+		return (
+			el.style.position === 'sticky' ||
+			el.classList.contains( 'is-position-sticky' ) ||
+			computed.position === 'sticky'
+		);
+	} );
+
+	// Filter for Group blocks only
+	const stickyGroups = stickyElements.filter( ( el ) =>
+		el.classList.contains( 'wp-block-group' )
+	);
+
+	// Check each Group for header template parts with improved detection
+	const stickyHeaders = stickyGroups.filter( ( group ) => {
+		// Check for explicit header area attribute
+		const hasExplicitHeader = group.querySelector(
+			'.wp-block-template-part[data-area="header"]'
+		);
+		if ( hasExplicitHeader ) {
+			return true;
+		}
+
+		// Check for header element (semantic HTML)
+		const hasHeaderElement = group.querySelector(
+			'header.wp-block-template-part'
+		);
+		if ( hasHeaderElement ) {
+			return true;
+		}
+
+		// Check for any template part in a sticky group (likely a header if sticky)
+		const hasAnyTemplatePart = group.querySelector(
+			'.wp-block-template-part'
+		);
+		if ( hasAnyTemplatePart ) {
+			return true;
+		}
+
+		return false;
+	} );
+
+	if ( stickyHeaders.length === 0 ) {
+		return 0;
+	}
+
+	// Calculate total height of all sticky headers
+	let totalHeight = 0;
+	stickyHeaders.forEach( ( header ) => {
+		const rect = header.getBoundingClientRect();
+		const style = window.getComputedStyle( header );
+		const marginTop = parseFloat( style.marginTop ) || 0;
+		const marginBottom = parseFloat( style.marginBottom ) || 0;
+		totalHeight += rect.height + marginTop + marginBottom;
+	} );
+
+	return totalHeight;
+}
+
+/**
+ * Updates the CSS custom property with the current sticky header height.
+ */
+export function updateStickyHeaderHeight() {
+	const height = getStickyHeaderHeight();
+	document.documentElement.style.setProperty(
+		'--wp-sticky-header-height',
+		`${ height }px`
+	);
+}
+
+/**
+ * Observes changes to sticky header height and updates the CSS custom property.
+ *
+ * Sets up:
+ * - ResizeObserver on document.body to detect layout changes
+ * - Window resize listener for viewport changes
+ *
+ * @return {Function} Cleanup function to disconnect observers and remove listeners
+ */
+export function observeStickyHeaderHeight() {
+	// Initial calculation
+	updateStickyHeaderHeight();
+
+	// Set up ResizeObserver to detect when elements are added/removed or resized
+	// eslint-disable-next-line no-undef
+	const resizeObserver = new ResizeObserver( () => {
+		updateStickyHeaderHeight();
+	} );
+	resizeObserver.observe( document.body );
+
+	// Also listen for window resize events
+	const handleResize = () => {
+		updateStickyHeaderHeight();
+	};
+	window.addEventListener( 'resize', handleResize );
+
+	// Return cleanup function
+	return () => {
+		resizeObserver.disconnect();
+		window.removeEventListener( 'resize', handleResize );
+	};
+}

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -377,3 +377,11 @@ body:not(.editor-styles-wrapper) .wp-block-cover:not(
 		}
 	}
 }
+
+// Adjust min-height for Cover blocks when there's a sticky header.
+// This prevents content from being hidden behind sticky headers.
+// The attribute selector targets inline styles set to 100vh.
+.wp-block-cover[style*="min-height:100vh"],
+.wp-block-cover[style*="min-height: 100vh"] {
+	min-height: calc(100vh - var(--wp-sticky-header-height, 0px)) !important;
+}


### PR DESCRIPTION
## What?
Implements automatic detection and adjustment for Cover blocks set to 100vh height when sticky headers are present on the page.

## Why?
Closes #51015 

When a Cover block is set to 100vh and there's a sticky header on the page, content at the bottom of the Cover block gets hidden behind the sticky header. This creates a poor user experience where important content is inaccessible.

## How?
The solution automatically detects sticky Group blocks containing header template parts and subtracts their height from Cover blocks set to 100vh.

### Detection Logic
The implementation searches for:
1. Group blocks with `position: sticky` (via inline style or `.is-position-sticky` class)
2. That contain a header template part:
   - Elements with `data-area="header"` attribute (explicit headers)
   - Semantic `<header>` elements with template part class
   - Any template part inside a sticky group (for broader compatibility)

### Implementation Details
- **JavaScript detection** (`sticky-header-utils.js`): Calculates total sticky header height including margins
- **CSS custom property**: Sets `--wp-sticky-header-height` on document root
- **CSS rule** (`style.scss`): Applies `calc(100vh - var(--wp-sticky-header-height))` to Cover blocks with inline `min-height: 100vh`
- **Dynamic updates**: Uses ResizeObserver and window resize listeners to update when header size changes
- **Editor integration** (`edit/index.js`): useEffect hook ensures detection runs in the editor
- **Frontend script** (`index.php`): Inline script runs on DOMContentLoaded for frontend

### Technical Approach
- Uses CSS custom properties for clean separation between detection and styling
- Falls back gracefully when no sticky header is detected (0px)
- `!important` flag ensures inline styles are overridden
- Works in both Site Editor and Post Editor
- Fully responsive and updates automatically

## Testing Instructions

### Setup
1. Create a Group block and set it to `position: sticky` (Styles → Position → Sticky)
2. Add a Header template part inside the Group (or any content for testing)
3. Below the sticky group, add a Cover block
4. Set the Cover block's min-height to `100vh` (Dimensions → Min height → 100 → vh)

### Expected Behavior
- The Cover block should automatically adjust its height to account for the sticky header
- Content at the bottom of the Cover block should be fully visible (not hidden behind the header)
- When you resize the browser window, the Cover block should adjust accordingly
- Works on both frontend and in the editor

### Test Scenarios
- [ ] Cover block (100vh) with sticky header above it
- [ ] Cover block (100vh) without any sticky header (should remain 100vh)
- [ ] Sticky Group without header template part (should not affect Cover)
- [ ] Multiple Cover blocks on same page
- [ ] Header height changes responsively
- [ ] Works in Site Editor
- [ ] Works in Post Editor  
- [ ] Works on frontend