### PR TITLE
Block Fields: Decouple the experiment from contentOnly/pattern editing experiments

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -34,7 +34,7 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
 	}
-	if ( array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -33,10 +33,9 @@ function gutenberg_enable_experiments() {
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
-		// Only enable inspector fields if both parent and sub-experiment are enabled
-		if ( array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
-			wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
-		}
+	}
+	if ( array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -187,7 +187,7 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-content-only-pattern-insertion',
-		__( 'contentOnly: Make patterns contentOnly by default upon insertion', 'gutenberg' ),
+		__( 'Pattern Editing: Make patterns contentOnly by default upon insertion', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -199,14 +199,13 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-content-only-inspector-fields',
-		__( 'contentOnly: Enable editable inspector fields', 'gutenberg' ),
+		__( 'Block fields: Show dataform driven inspector fields on blocks that support them', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label'    => __( 'Enables editable inspector fields (media, links, alt text, etc.) in the content-only pattern editing interface. Requires "contentOnly: Make patterns contentOnly by default upon insertion" to be enabled.', 'gutenberg' ),
-			'id'       => 'gutenberg-content-only-inspector-fields',
-			'requires' => 'gutenberg-content-only-pattern-insertion',
+			'label' => __( 'Enables editable block inspector fields that are generated using a dataform.', 'gutenberg' ),
+			'id'    => 'gutenberg-content-only-inspector-fields',
 		)
 	);
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -15,7 +15,6 @@ const ContentTab = ( { contentClientIds } ) => {
 	}
 
 	const shouldShowBlockFields =
-		window?.__experimentalContentOnlyPatternInsertion &&
 		window?.__experimentalContentOnlyInspectorFields;
 
 	return (

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -348,7 +348,6 @@ const withBlockFields = createHigherOrderComponent(
 		} = useContext( PrivateBlockContext );
 
 		const shouldShowBlockFields =
-			window?.__experimentalContentOnlyPatternInsertion &&
 			window?.__experimentalContentOnlyInspectorFields;
 		const blockTypeFields = blockType?.[ fieldsKey ];
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -713,7 +713,6 @@ export default function Image( {
 		);
 
 	const hasDataFormBlockFields =
-		window?.__experimentalContentOnlyPatternInsertion &&
 		window?.__experimentalContentOnlyInspectorFields;
 
 	const controls = (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Previously there was a requirement that the 'contentOnly' experiment had to be enabled for the related 'Inspector Fields' experiment to be enabled. The two features were quite dependent on one another.

After #73863 that's no longer the case. Individual blocks now also have the fields when outside of a pattern so the two experiments can be decoupled.

## How?
Decouples the experiment completely. Also does some renaming:
- The reference to 'content only' is now removed for the experiment, and it's instead called 'Block fields'.
- The other contentOnly experiment is now called 'Pattern Editing'

Keeps the variable names unchanged so that users won't have to re-enable the experiments.

## Testing Instructions
1. Enable the Block Fields experiment and disable the Pattern Editing experiment
2. Individual blocks that support them (Paragraph, Image etc) should have block fields displayed in a content tab
3. Try different combinations of the two experiments and check that everything works as expected.

## Screenshots or screencast <!-- if applicable -->
<img width="276" height="474" alt="Screenshot 2026-01-09 at 10 05 10 am" src="https://github.com/user-attachments/assets/52e4266f-1b54-484f-9457-d1ffdca42e50" />

