### PR TITLE
Components: Apply aria button attributes conditionally

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -167,15 +167,21 @@ export function UnforwardedButton(
 	const trulyDisabled = disabled && ! accessibleWhenDisabled;
 	const Tag = href !== undefined && ! disabled ? 'a' : 'button';
 	const buttonProps: ComponentPropsWithoutRef< 'button' > =
-		Tag === 'button'
-			? {
-					type: 'button',
-					disabled: trulyDisabled,
+	Tag === 'button'
+		? {
+				type: 'button',
+				disabled: trulyDisabled,
+				...( ariaChecked !== undefined && {
 					'aria-checked': ariaChecked,
+				} ),
+				...( ariaPressed !== undefined && {
 					'aria-pressed': ariaPressed,
+				} ),
+				...( ariaSelected !== undefined && {
 					'aria-selected': ariaSelected,
-			  }
-			: {};
+				} ),
+		  }
+		: {};
 	const anchorProps: ComponentPropsWithoutRef< 'a' > =
 		Tag === 'a' ? { href, target } : {};
 


### PR DESCRIPTION
## What problem does this PR solve?
Button-related aria attributes may be passed as undefined values, which can
result in unnecessary or invalid accessibility attributes.

## How does this PR fix it?
This PR ensures aria button attributes are only applied when explicitly defined,
keeping accessibility semantics clean and correct.

## How to test
- View the Button component in Storybook
- Verify no visual or behavioral changes
