### PR TITLE
Block visibility based on screen size: don't subscribe to state in the hook

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -103,6 +103,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isSectionBlock,
 		isWithinSectionBlock,
 		canMove,
+		blockVisibility,
+		deviceType,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -138,7 +140,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		  }
 		: {};
 
-	const { isBlockCurrentlyHidden } = useBlockVisibility( clientId );
+	// Use block visibility hook with data from context to avoid extra subscription.
+	const { isBlockCurrentlyHidden } = useBlockVisibility( {
+		blockVisibility,
+		deviceType,
+	} );
 
 	// Ensures it warns only inside the `edit` implementation for the block.
 	if ( blockApiVersion < 2 && clientId === blockEditContext.clientId ) {

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -7,23 +7,10 @@ import { renderHook } from '@testing-library/react';
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 
 // Mock WordPress dependencies before importing the hook
 jest.mock( '@wordpress/compose', () => ( {
 	useViewportMatch: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-} ) );
-
-jest.mock( '../../../store', () => ( {
-	store: 'block-editor-store',
-} ) );
-
-jest.mock( '../../../store/private-keys', () => ( {
-	deviceTypeKey: '__experimentalDeviceType',
 } ) );
 
 /**
@@ -32,29 +19,6 @@ jest.mock( '../../../store/private-keys', () => ( {
 import { useBlockVisibility } from '../use-block-visibility';
 
 describe( 'useBlockVisibility', () => {
-	const clientId = 'test-client-id';
-
-	// Helper function to set up block and settings mocks
-	const setupMocks = ( {
-		blockVisibility = true,
-		deviceType = 'Desktop',
-	} = {} ) => {
-		useSelect.mockImplementation( ( callback ) =>
-			callback( () => ( {
-				getBlock: () => ( {
-					attributes: {
-						metadata: {
-							blockVisibility,
-						},
-					},
-				} ),
-				getSettings: () => ( {
-					__experimentalDeviceType: deviceType,
-				} ),
-			} ) )
-		);
-	};
-
 	// Helper function to set up viewport matches
 	const setupViewport = ( { isMobileOrLarger, isMediumOrLarger } ) => {
 		if (
@@ -84,63 +48,59 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Device type overrides', () => {
 		it( 'should return true when deviceType is Mobile and block is hidden on mobile', () => {
-			setupMocks( {
-				blockVisibility: { mobile: false },
-				deviceType: 'Mobile',
-			} );
 			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { mobile: false },
+					deviceType: 'mobile',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should return false when deviceType is Mobile and block is visible on mobile', () => {
-			setupMocks( {
-				blockVisibility: {
-					mobile: true,
-					tablet: false,
-					desktop: false,
-				},
-				deviceType: 'Mobile',
-			} );
 			setupViewport( { isMobileOrLarger: false } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: {
+						mobile: true,
+						tablet: false,
+						desktop: false,
+					},
+					deviceType: 'mobile',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 
 		it( 'should return true when deviceType is Tablet and block is hidden on tablet', () => {
-			setupMocks( {
-				blockVisibility: { tablet: false },
-				deviceType: 'Tablet',
-			} );
 			setupViewport( { isMobileOrLarger: false } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { tablet: false },
+					deviceType: 'tablet',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should use actual viewport detection when deviceType is Desktop', () => {
-			setupMocks( {
-				blockVisibility: { desktop: false },
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: true,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { desktop: false },
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
@@ -149,114 +109,108 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Viewport detection with Desktop deviceType', () => {
 		it( 'should return true when on mobile viewport and block is hidden on mobile', () => {
-			setupMocks( {
-				blockVisibility: { mobile: false },
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: false,
 				isMediumOrLarger: false,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { mobile: false },
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should return false when on mobile viewport and block is visible on mobile', () => {
-			setupMocks( {
-				blockVisibility: {
-					mobile: true,
-					tablet: false,
-					desktop: false,
-				},
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: false,
 				isMediumOrLarger: false,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: {
+						mobile: true,
+						tablet: false,
+						desktop: false,
+					},
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 
 		it( 'should return true when on tablet viewport and block is hidden on tablet', () => {
-			setupMocks( {
-				blockVisibility: { tablet: false },
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: false,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { tablet: false },
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should return false when on tablet viewport and block is visible on tablet', () => {
-			setupMocks( {
-				blockVisibility: {
-					mobile: false,
-					tablet: true,
-					desktop: false,
-				},
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: false,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: {
+						mobile: false,
+						tablet: true,
+						desktop: false,
+					},
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 
 		it( 'should return true when on desktop viewport and block is hidden on desktop', () => {
-			setupMocks( {
-				blockVisibility: { desktop: false },
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: true,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { desktop: false },
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should return false when on desktop viewport and block is visible on desktop', () => {
-			setupMocks( {
-				blockVisibility: {
-					mobile: false,
-					tablet: false,
-					desktop: true,
-				},
-				deviceType: 'Desktop',
-			} );
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: true,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: {
+						mobile: false,
+						tablet: false,
+						desktop: true,
+					},
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
@@ -265,140 +219,142 @@ describe( 'useBlockVisibility', () => {
 
 	describe( 'Block visibility (hidden everywhere)', () => {
 		it( 'should return true when blockVisibility is false', () => {
-			setupMocks( {
-				blockVisibility: false,
-				deviceType: 'Desktop',
-			} );
 			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: false,
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 
 		it( 'should return false when blockVisibility is true and no viewport restrictions', () => {
-			setupMocks( {
-				blockVisibility: true,
-				deviceType: 'Desktop',
-			} );
 			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: true,
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 
 		it( 'should return false when blockVisibility is undefined', () => {
-			setupMocks( {
-				blockVisibility: undefined,
-				deviceType: 'Desktop',
-			} );
 			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: undefined,
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
 		} );
 
 		it( 'should return true when blockVisibility is false regardless of viewport settings', () => {
-			setupMocks( {
-				blockVisibility: false,
-				deviceType: 'Desktop',
-			} );
 			setupViewport( { isMobileOrLarger: true } );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: false,
+					deviceType: 'desktop',
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 	} );
 
-	describe( 'Edge cases', () => {
-		it( 'should return false when no visibility settings are defined', () => {
-			setupMocks( {
-				blockVisibility: true,
-				deviceType: 'Desktop',
+	describe( 'Default values', () => {
+		it( 'should return false when no options are provided', () => {
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
 			} );
-			setupViewport( { isMobileOrLarger: true } );
 
-			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
-			);
+			const { result } = renderHook( () => useBlockVisibility( {} ) );
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+			expect( result.current.currentViewport ).toBe( 'desktop' );
 		} );
 
-		it( 'should return false when metadata is missing', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {},
-					} ),
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-			setupViewport( { isMobileOrLarger: true } );
-
-			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
-			);
-
-			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
-		} );
-
-		it( 'should return false when block is missing', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => null,
-					getSettings: () => ( {
-						__experimentalDeviceType: 'Desktop',
-					} ),
-				} ) )
-			);
-			setupViewport( { isMobileOrLarger: true } );
-
-			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
-			);
-
-			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
-		} );
-
-		it( 'should default to Desktop deviceType when not provided', () => {
-			useSelect.mockImplementation( ( callback ) =>
-				callback( () => ( {
-					getBlock: () => ( {
-						attributes: {
-							metadata: {
-								blockVisibility: {
-									desktop: false,
-								},
-							},
-						},
-					} ),
-					getSettings: () => ( {} ), // No deviceType provided
-				} ) )
-			);
+		it( 'should default to desktop deviceType when not provided', () => {
 			setupViewport( {
 				isMobileOrLarger: true,
 				isMediumOrLarger: true,
 			} );
 
 			const { result } = renderHook( () =>
-				useBlockVisibility( clientId )
+				useBlockVisibility( {
+					blockVisibility: { desktop: false },
+				} )
 			);
 
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+			expect( result.current.currentViewport ).toBe( 'desktop' );
+		} );
+
+		it( 'should default to undefined blockVisibility when not provided', () => {
+			setupViewport( {
+				isMobileOrLarger: true,
+				isMediumOrLarger: true,
+			} );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					deviceType: 'desktop',
+				} )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		it( 'should return false when blockVisibility is an empty object', () => {
+			setupViewport( { isMobileOrLarger: true } );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					blockVisibility: {},
+					deviceType: 'desktop',
+				} )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should handle null blockVisibility', () => {
+			setupViewport( { isMobileOrLarger: true } );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					blockVisibility: null,
+					deviceType: 'desktop',
+				} )
+			);
+
+			expect( result.current.isBlockCurrentlyHidden ).toBe( false );
+		} );
+
+		it( 'should handle case-insensitive deviceType', () => {
+			setupViewport( { isMobileOrLarger: true } );
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					blockVisibility: { mobile: false },
+					deviceType: 'MOBILE',
+				} )
+			);
+
+			// Should still work but viewport detection uses lowercase
+			expect( result.current.currentViewport ).toBe( 'desktop' );
 		} );
 	} );
 } );


### PR DESCRIPTION

Follow up to https://github.com/WordPress/gutenberg/pull/74379#pullrequestreview-3642166979



Updated `useBlockVisibility` to accept block visibility and device type from context, with the intention to reduce unnecessary store subscriptions.

Kudos to @talldan for picking up on it.

Here's the result of my local performance tests (note, they might not be reliable as I was listening to YouTube, working in an IDE with 10 AI agents running, and also mining Bitcoin at the same time)

```
┌──────────────────────┬────────────────────────────┐
│ (index)              │ value                      │
├──────────────────────┼────────────────────────────┤
│ serverResponse       │ '201.9 ms +4.56% -3.71%'   │
│ firstPaint           │ '400.85 ms +4.48% -1.38%'  │
│ domContentLoaded     │ '266.8 ms +0.52% -0.79%'   │
│ loaded               │ '267 ms +0.52% -0.82%'     │
│ firstContentfulPaint │ '400.85 ms +4.48% -1.38%'  │
│ firstBlock           │ '1045.15 ms +1.57% -1.43%' │
│ type                 │ '6.92 ms +3.18% -1.01%'    │
│ typeWithoutInspector │ '6.46 ms +3.41% -1.24%'    │
│ typeWithTopToolbar   │ '8.39 ms +5.36% -3.69%'    │
│ typeContainer        │ '6.64 ms +5.87% -6.33%'    │
│ focus                │ '24.99 ms +6.56% -3.64%'   │
│ inserterOpen         │ '11.54 ms +5.46% -13.86%'  │
│ inserterSearch       │ '3.69 ms +5.15% -10.57%'   │
│ inserterHover        │ '1.59 ms +15.09% -5.66%'   │
│ loadPatterns         │ '323.89 ms +3.69% -4.12%'  │
│ listViewOpen         │ '40.29 ms +4.1% -1.71%'    │
│ wpTotal              │ '194.46 ms +4.88% -3.87%'  │
│ wpMemoryUsage        │ '12.66 MB +0% -0%'         │
│ wpDbQueries          │ '57 +0% -0%'               │
└──────────────────────┴────────────────────────────┘
```

If this doesn't work, I'll roll back #74379

## Why?

Trying to fix a performance regression. See https://github.com/WordPress/gutenberg/pull/74379#pullrequestreview-3642166979 and graph at https://www.codevitals.run/project/gutenberg/inserterHover

## How?

- Refactored `useBlockVisibility` to accept options directly (no `clientId` or store access)
- Updated `block.js` and `use-block-props/index.js` to pass data from existing `useSelect` calls
- Added default values: `blockVisibility = undefined`, `deviceType = 'desktop'`
- Updated all tests to match new API

## Testing Instructions

Smoke test block visibility (test steps over at https://github.com/WordPress/gutenberg/pull/74379)

