### PR TITLE
dom-ready: Replace @ts-expect-error with MockDocument in tests

### DIFF
--- a/packages/dom-ready/src/test/index.test.ts
+++ b/packages/dom-ready/src/test/index.test.ts
@@ -3,6 +3,13 @@
  */
 import domReady from '../';
 
+/**
+ * In JSDOM, unlike browsers, readyState can be overwritten to simulate different document states.
+ */
+interface MockDocument extends Document {
+	readyState: DocumentReadyState;
+}
+
 describe( 'domReady', () => {
 	beforeAll( () => {
 		Object.defineProperty( document, 'readyState', {
@@ -14,8 +21,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is complete', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			// @ts-expect-error document.readyState is read-only
-			document.readyState = 'complete';
+			( document as MockDocument ).readyState = 'complete';
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -24,8 +30,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is interactive', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			// @ts-expect-error document.readyState is read-only
-			document.readyState = 'interactive';
+			( document as MockDocument ).readyState = 'interactive';
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -34,8 +39,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is still loading', () => {
 		it( 'should add the callback as an event listener to the DOMContentLoaded event.', () => {
 			const addEventListener = jest.fn( () => {} );
-			// @ts-expect-error document.readyState is read-only
-			document.readyState = 'loading';
+			( document as MockDocument ).readyState = 'loading';
 			Object.defineProperty( document, 'addEventListener', {
 				value: addEventListener,
 			} );


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/67671#discussion_r2674001465

Addresses review feedback on the `dom-ready` TypeScript conversion by improving how `@ts-expect-error` comments are handled in tests.

## Why?

In the original PR, `@ts-expect-error` comments were used to suppress TypeScript errors when assigning to the read-only `document.readyState` property during tests. The review feedback suggested being clearer about why we're okay to override it, or using a better approach altogether.

## How?

Instead of using `@ts-expect-error` comments, this PR introduces a `MockDocument` interface that extends `Document` with a writable `readyState` property:

```typescript
interface MockDocument extends Document {
	readyState: DocumentReadyState;
}
```

This allows type-safe assignment using `( document as MockDocument ).readyState = 'complete'` without needing error suppression comments. This approach is cleaner and makes the test intent explicit.

## Testing Instructions

1. Run the `dom-ready` package tests: `npm run test:unit -- packages/dom-ready`
2. Verify all tests pass
3. Run TypeScript type checking: `npm run build:package-types -- packages/dom-ready`

### Testing Instructions for Keyboard

N/A - No UI changes.

## Screenshots or screencast

N/A - Code-only changes.
