### PR TITLE
Media Fields: Add readonly author field to media fields package and use in the media modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54576,7 +54576,8 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/primitives": "file:../primitives",
-				"@wordpress/url": "file:../url"
+				"@wordpress/url": "file:../url",
+				"clsx": "2.1.1"
 			},
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.6.3",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -60,7 +60,8 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/primitives": "file:../primitives",
-		"@wordpress/url": "file:../url"
+		"@wordpress/url": "file:../url",
+		"clsx": "2.1.1"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.6.3",

--- a/packages/media-fields/src/author/index.tsx
+++ b/packages/media-fields/src/author/index.tsx
@@ -9,15 +9,15 @@ import { store as coreDataStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import type { BasePostWithEmbeddedAuthor } from '../../types';
-import AuthorView from './author-view';
+import type { MediaItem } from '../types';
+import AuthorView from './view';
 
 interface Author {
 	id: number;
 	name: string;
 }
 
-const authorField: Field< BasePostWithEmbeddedAuthor > = {
+const authorField: Partial< Field< MediaItem > > = {
 	label: __( 'Author' ),
 	id: 'author',
 	type: 'integer',
@@ -35,7 +35,6 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 			label: name,
 		} ) );
 	},
-	setValue: ( { value } ) => ( { author: Number( value ) } ),
 	render: AuthorView,
 	sort: ( a, b, direction ) => {
 		const nameA = a._embedded?.author?.[ 0 ]?.name || '';
@@ -48,9 +47,7 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 	filterBy: {
 		operators: [ 'isAny', 'isNone' ],
 	},
+	readOnly: true,
 };
 
-/**
- * Author field for BasePost.
- */
 export default authorField;

--- a/packages/media-fields/src/author/style.scss
+++ b/packages/media-fields/src/author/style.scss
@@ -1,0 +1,47 @@
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-author-field__avatar {
+	flex-shrink: 0;
+	overflow: hidden;
+	width: $grid-unit-30;
+	height: $grid-unit-30;
+	align-items: center;
+	justify-content: left;
+	display: flex;
+
+	img {
+		width: $grid-unit-20;
+		height: $grid-unit-20;
+		object-fit: cover;
+		opacity: 0;
+		border-radius: 100%;
+
+		@media not (prefers-reduced-motion) {
+			transition: opacity 0.1s linear;
+		}
+	}
+
+	&.is-loaded {
+		img {
+			opacity: 1;
+		}
+	}
+}
+
+.media-author-field__icon {
+	display: flex;
+	flex-shrink: 0;
+	width: $grid-unit-30;
+	height: $grid-unit-30;
+
+	svg {
+		margin-left: -$grid-unit-05;
+		fill: currentColor;
+	}
+}
+
+.media-author-field__name {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}

--- a/packages/media-fields/src/author/style.scss
+++ b/packages/media-fields/src/author/style.scss
@@ -14,11 +14,22 @@
 		width: $grid-unit-20;
 		height: $grid-unit-20;
 		object-fit: cover;
-		opacity: 0;
+		opacity: 1;
 		border-radius: 100%;
+	}
 
-		@media not (prefers-reduced-motion) {
-			transition: opacity 0.1s linear;
+	&.is-loading,
+	&.is-loaded {
+		img {
+			@media not (prefers-reduced-motion) {
+				transition: opacity 0.1s linear;
+			}
+		}
+	}
+
+	&.is-loading {
+		img {
+			opacity: 0;
 		}
 	}
 

--- a/packages/media-fields/src/author/view.tsx
+++ b/packages/media-fields/src/author/view.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+
+export default function AuthorView( {
+	item,
+}: DataViewRenderFieldProps< MediaItem > ) {
+	const author = item?._embedded?.author?.[ 0 ];
+	const text = author?.name;
+	const imageUrl = author?.avatar_urls?.[ 48 ];
+	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+
+	return (
+		<HStack alignment="left" spacing={ 0 }>
+			{ !! imageUrl && (
+				<div
+					className={ clsx( 'media-author-field__avatar', {
+						'is-loaded': isImageLoaded,
+					} ) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt={ __( 'Author avatar' ) }
+						src={ imageUrl }
+					/>
+				</div>
+			) }
+			{ ! imageUrl && (
+				<div className="media-author-field__icon">
+					<Icon icon={ authorIcon } />
+				</div>
+			) }
+			<span className="media-author-field__name">{ text }</span>
+		</HStack>
+	);
+}

--- a/packages/media-fields/src/author/view.tsx
+++ b/packages/media-fields/src/author/view.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
@@ -23,18 +23,38 @@ export default function AuthorView( {
 	const author = item?._embedded?.author?.[ 0 ];
 	const text = author?.name;
 	const imageUrl = author?.avatar_urls?.[ 48 ];
-	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+	const [ loadingState, setLoadingState ] = useState<
+		'instant' | 'loading' | 'loaded'
+	>( 'loading' );
+
+	useEffect( () => {
+		setLoadingState( 'loading' );
+	}, [ imageUrl ] );
+
+	const imgRef = useCallback( ( img: HTMLImageElement | null ) => {
+		if ( img?.complete ) {
+			setLoadingState( 'instant' );
+		}
+	}, [] );
+
+	const handleLoad = () => {
+		if ( loadingState === 'loading' ) {
+			setLoadingState( 'loaded' );
+		}
+	};
 
 	return (
 		<HStack alignment="left" spacing={ 0 }>
 			{ !! imageUrl && (
 				<div
 					className={ clsx( 'media-author-field__avatar', {
-						'is-loaded': isImageLoaded,
+						'is-loading': loadingState === 'loading',
+						'is-loaded': loadingState === 'loaded',
 					} ) }
 				>
 					<img
-						onLoad={ () => setIsImageLoaded( true ) }
+						ref={ imgRef }
+						onLoad={ handleLoad }
 						alt={ __( 'Author avatar' ) }
 						src={ imageUrl }
 					/>

--- a/packages/media-fields/src/author/view.tsx
+++ b/packages/media-fields/src/author/view.tsx
@@ -23,6 +23,11 @@ export default function AuthorView( {
 	const author = item?._embedded?.author?.[ 0 ];
 	const text = author?.name;
 	const imageUrl = author?.avatar_urls?.[ 48 ];
+
+	/*
+	 * Use three states to avoid fade-in animation for cached images:
+	 * 'instant' = image already cached, 'loading' = waiting, 'loaded' = just finished.
+	 */
 	const [ loadingState, setLoadingState ] = useState<
 		'instant' | 'loading' | 'loaded'
 	>( 'loading' );

--- a/packages/media-fields/src/index.ts
+++ b/packages/media-fields/src/index.ts
@@ -1,5 +1,6 @@
 export { default as altTextField } from './alt_text';
 export { default as attachedToField } from './attached_to';
+export { default as authorField } from './author';
 export { default as captionField } from './caption';
 export { default as dateAddedField } from './date_added';
 export { default as dateModifiedField } from './date_modified';

--- a/packages/media-fields/src/stories/index.story.tsx
+++ b/packages/media-fields/src/stories/index.story.tsx
@@ -11,6 +11,7 @@ import type { Field, View } from '@wordpress/dataviews';
 import {
 	altTextField,
 	attachedToField,
+	authorField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -109,6 +110,19 @@ const sampleMediaItem: MediaItem = {
 		},
 	},
 	missing_image_sizes: [],
+	_embedded: {
+		author: [
+			{
+				id: 1,
+				name: 'John Doe',
+				avatar_urls: {
+					'24': 'https://gravatar.com/avatar/?s=24&d=mm&r=g',
+					'48': 'https://gravatar.com/avatar/?s=48&d=mm&r=g',
+					'96': 'https://gravatar.com/avatar/?s=96&d=mm&r=g',
+				},
+			},
+		],
+	},
 };
 
 // Sample data for a non-image file (ZIP)
@@ -197,6 +211,17 @@ const sampleMediaItemZip: MediaItem = {
 				featured_media: 0,
 			},
 		],
+		author: [
+			{
+				id: 1,
+				name: 'Jane Smith',
+				avatar_urls: {
+					'24': 'https://gravatar.com/avatar/?s=24&d=mm&r=g',
+					'48': 'https://gravatar.com/avatar/?s=48&d=mm&r=g',
+					'96': 'https://gravatar.com/avatar/?s=96&d=mm&r=g',
+				},
+			},
+		],
 	},
 };
 
@@ -249,6 +274,19 @@ const sampleMediaItemBrokenImage: MediaItem = {
 		sizes: {},
 	},
 	missing_image_sizes: [],
+	_embedded: {
+		author: [
+			{
+				id: 1,
+				name: 'Admin User',
+				avatar_urls: {
+					'24': 'https://gravatar.com/avatar/?s=24&d=mm&r=g',
+					'48': 'https://gravatar.com/avatar/?s=48&d=mm&r=g',
+					'96': 'https://gravatar.com/avatar/?s=96&d=mm&r=g',
+				},
+			},
+		],
+	},
 };
 
 // Create a showcase of all media fields.
@@ -257,6 +295,7 @@ const showcaseFields = [
 	filenameField,
 	altTextField,
 	attachedToField,
+	authorField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -287,6 +326,7 @@ const DataFormsComponent = ( { type }: { type: 'regular' | 'panel' } ) => {
 			'mime_type',
 			'media_dimensions',
 			'filesize',
+			'author',
 			'date',
 			'modified',
 			'attached_to',

--- a/packages/media-fields/src/style.scss
+++ b/packages/media-fields/src/style.scss
@@ -1,1 +1,2 @@
+@use "./author/style.scss" as *;
 @use "./media_thumbnail/style.scss" as *;

--- a/packages/media-fields/src/types.ts
+++ b/packages/media-fields/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import type { Attachment, Updatable, Post } from '@wordpress/core-data';
+import type { Attachment, Updatable, Post, User } from '@wordpress/core-data';
 
 export type MediaKind = 'image' | 'video' | 'audio' | 'application';
 
@@ -18,6 +18,7 @@ export interface MediaItem extends Attachment< 'edit' > {
 	_embedded?: {
 		// TODO: Include wp:attached-to properly, and backport PHP changes from wordpress-develop to support this.
 		'wp:attached-to'?: Post[] | Partial< Post >[];
+		author?: User[] | Partial< User >[];
 	};
 }
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -15,6 +15,7 @@ import type { View, Field, ActionButton } from '@wordpress/dataviews';
 import {
 	altTextField,
 	attachedToField,
+	authorField,
 	captionField,
 	dateAddedField,
 	dateModifiedField,
@@ -184,7 +185,11 @@ export function MediaUploadModal( {
 			}
 			// Handle author filters
 			if ( filter.field === 'author' ) {
-				filters.author = filter.value;
+				if ( filter.operator === 'isAny' ) {
+					filters.author = filter.value;
+				} else if ( filter.operator === 'isNone' ) {
+					filters.author_exclude = filter.value;
+				}
 			}
 			// Handle date filters
 			if ( filter.field === 'date' || filter.field === 'modified' ) {
@@ -214,7 +219,7 @@ export function MediaUploadModal( {
 			order: view.sort?.direction,
 			orderby: view.sort?.field,
 			search: view.search,
-			_embed: 'wp:attached-to',
+			_embed: 'author,wp:attached-to',
 			...filters,
 		};
 	}, [ view, allowedTypes ] );
@@ -249,6 +254,7 @@ export function MediaUploadModal( {
 			descriptionField as Field< RestAttachment >,
 			dateAddedField as Field< RestAttachment >,
 			dateModifiedField as Field< RestAttachment >,
+			authorField as Field< RestAttachment >,
 			filenameField as Field< RestAttachment >,
 			filesizeField as Field< RestAttachment >,
 			mediaDimensionsField as Field< RestAttachment >,
@@ -335,7 +341,13 @@ export function MediaUploadModal( {
 				showTitle: false,
 			},
 			[ LAYOUT_PICKER_TABLE ]: {
-				fields: [ 'filename', 'filesize', 'media_dimensions', 'date' ],
+				fields: [
+					'filename',
+					'filesize',
+					'media_dimensions',
+					'author',
+					'date',
+				],
 				showTitle: true,
 			},
 		} ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes https://github.com/WordPress/gutenberg/issues/72612

Part of:

* https://github.com/WordPress/gutenberg/issues/72734
* https://github.com/WordPress/gutenberg/issues/72735
* https://github.com/WordPress/gutenberg/issues/73085

Add a readonly author field to the media fields package that's very similar to the author field in the `fields` package, but is readonly.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's a subtle difference in how the author field for media should work compared to posts/pages. For media (and in the existing media library) it's effectively a read only field as it flags "uploaded by" rather than the author of a published article. For this reason, and because the needs for displaying media fields is in flux, this PR proposes a dedicated media field for `author`. It borrows much of the same code, but it allows more flexibility for this to actually be a separate field for media.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Make essentially a duplicate of the existing author field, but simplifying the logic slightly as it only needs to work in a readonly mode (and for sorting / filtering)
* Include the CSS for the field _with_ the field. This borrows the styling from the `edit-site` package. However the styling needs to be bundled with the field as the modal will exist in multiple places. I've also tweaked things slightly so that it feels a bit more stable across pagination
* Use in the media modal experiment

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the media modal experiment:

<img width="967" height="74" alt="image" src="https://github.com/user-attachments/assets/72cbb060-9c72-439a-a346-86de82fa8d7e" />

* Go to add a featured image to a post or page.
* Switch to the Table layout and you should see the Author column.
* You should be able to sort and filter by Author.
* To see the DataForm representation of this field (readonly field) you'll need to test it in Storybook (`npm run storybook:dev`), but it'll be used in future PRs that explore a DataForm-based media editor

## Screenshots or screencast <!-- if applicable -->

### Storybook

| DataViews | DataForm |
| --- | --- |
| <img width="2330" height="926" alt="image" src="https://github.com/user-attachments/assets/4ca17009-f906-4ee0-b521-541b803d0acf" /> | <img width="836" height="666" alt="image" src="https://github.com/user-attachments/assets/4561f08c-17bc-419f-a87b-2d769449254a" /> |

### Media modal

<img width="1501" height="773" alt="image" src="https://github.com/user-attachments/assets/c7823548-a935-4949-b53a-1354c80c0bfb" />