### PR TITLE
DependencyExtractionWebpackPlugin: add ui as bundled package

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -10,6 +10,7 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/upload-media',
 	'@wordpress/fields',
 	'@wordpress/views',
+	'@wordpress/ui',
 ];
 
 /**


### PR DESCRIPTION
Adds `@wordpress/ui` as an externalized package so that builds using the semi-legacy `DependencyExtractionWebpackPlugin` don't compile its imports to a non-existent `wp-ui` reference.

Pointed out by @anomiex in https://github.com/Automattic/jetpack/pull/46397#issuecomment-3724907953 when trying to use the new packages in Jetpack.
