### PR TITLE
Block Fields: show all form fields by default

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -180,7 +180,7 @@ function denormalizeLinkValue( value, fieldDef ) {
  * @param {boolean}  props.isCollapsed   Whether the DataForm is rendered as 'collapsed' with only the first field
  *                                       displayed by default. When collapsed a dropdown is displayed to allow
  *                                       displaying additional fields. The block's title is displayed as the title.
- *                                       The collapsed mode is often used when multiple BlockForm's are shown together.
+ *                                       The collapsed mode is often used when multiple BlockForms are shown together.
  */
 function BlockFields( {
 	clientId,

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -10,6 +10,7 @@ import {
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { DataForm } from '@wordpress/dataviews';
 import { useContext, useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -169,7 +170,13 @@ function denormalizeLinkValue( value, fieldDef ) {
 	return result;
 }
 
-function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
+function BlockFields( {
+	clientId,
+	blockType,
+	attributes,
+	setAttributes,
+	isCollapsed = false,
+} ) {
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
 		context: 'list-view',
@@ -178,9 +185,19 @@ function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 
 	const blockTypeFields = blockType?.[ fieldsKey ];
 
-	const [ form, setForm ] = useState( () => {
-		return blockType?.[ formKey ];
-	} );
+	const computedForm = useMemo( () => {
+		if ( ! isCollapsed ) {
+			return blockType?.[ formKey ];
+		}
+
+		// For a collapsed form only show the first field by default.
+		return {
+			...blockType?.[ formKey ],
+			fields: [ blockType?.[ formKey ]?.fields?.[ 0 ] ],
+		};
+	}, [ blockType, isCollapsed ] );
+
+	const [ form, setForm ] = useState( computedForm );
 
 	// Build DataForm fields with proper structure
 	const dataFormFields = useMemo( () => {
@@ -310,16 +327,24 @@ function BlockFields( { clientId, blockType, attributes, setAttributes } ) {
 		<div className="block-editor-block-fields__container">
 			<div className="block-editor-block-fields__header">
 				<HStack spacing={ 1 }>
-					<BlockIcon
-						className="block-editor-block-fields__header-icon"
-						icon={ blockInformation?.icon }
-					/>
-					<Truncate
-						className="block-editor-block-fields__header-title"
-						numberOfLines={ 1 }
-					>
-						{ blockTitle }
-					</Truncate>
+					{ isCollapsed && (
+						<>
+							<BlockIcon
+								className="block-editor-block-fields__header-icon"
+								icon={ blockInformation?.icon }
+							/>
+							<h2 className="block-editor-block-fields__header-title">
+								<Truncate numberOfLines={ 1 }>
+									{ blockTitle }
+								</Truncate>
+							</h2>
+						</>
+					) }
+					{ ! isCollapsed && (
+						<h2 className="block-editor-block-fields__header-title">
+							{ __( 'Content' ) }
+						</h2>
+					) }
 					<FieldsDropdownMenu
 						fields={ dataFormFields }
 						visibleFields={ form.fields }
@@ -371,6 +396,7 @@ const withBlockFields = createHigherOrderComponent(
 								<BlockFields
 									{ ...props }
 									blockType={ blockType }
+									isCollapsed
 								/>
 							</PrivateInspectorControlsFill>
 						)

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -338,6 +338,11 @@ function BlockFields( {
 									{ blockTitle }
 								</Truncate>
 							</h2>
+							<FieldsDropdownMenu
+								fields={ dataFormFields }
+								visibleFields={ form.fields }
+								onToggleField={ handleToggleField }
+							/>
 						</>
 					) }
 					{ ! isCollapsed && (
@@ -345,11 +350,6 @@ function BlockFields( {
 							{ __( 'Content' ) }
 						</h2>
 					) }
-					<FieldsDropdownMenu
-						fields={ dataFormFields }
-						visibleFields={ form.fields }
-						onToggleField={ handleToggleField }
-					/>
 				</HStack>
 			</div>
 			<DataForm

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -170,6 +170,18 @@ function denormalizeLinkValue( value, fieldDef ) {
 	return result;
 }
 
+/**
+ * Component that renders a DataForm for a single block's attributes
+ * @param {Object}   props
+ * @param {string}   props.clientId      The clientId of the block.
+ * @param {Object}   props.blockType     The blockType definition.
+ * @param {Object}   props.attributes    The block's attribute values.
+ * @param {Function} props.setAttributes Action to set the block's attributes.
+ * @param {boolean}  props.isCollapsed   Whether the DataForm is rendered as 'collapsed' with only the first field
+ *                                       displayed by default. When collapsed a dropdown is displayed to allow
+ *                                       displaying additional fields. The block's title is displayed as the title.
+ *                                       The collapsed mode is often used when multiple BlockForm's are shown together.
+ */
 function BlockFields( {
 	clientId,
 	blockType,

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -30,4 +30,5 @@
 
 .block-editor-block-fields__header-title {
 	flex: 1;
+	margin: 0 !important;
 }

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -30,5 +30,6 @@
 
 .block-editor-block-fields__header-title {
 	flex: 1;
+	// Override the default margin on a h2 element.
 	margin: 0 !important;
 }

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -58,7 +58,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'audio' ],
+		fields: [ 'audio', 'caption' ],
 	};
 }
 

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -69,7 +69,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'text' ],
+		fields: [ 'text', 'link' ],
 	};
 }
 

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -63,7 +63,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'file' ],
+		fields: [ 'file', 'fileName', 'downloadButtonText' ],
 	};
 }
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -106,7 +106,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'image' ],
+		fields: [ 'image', 'link', 'caption', 'alt' ],
 	};
 }
 

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -83,7 +83,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'media' ],
+		fields: [ 'media', 'link' ],
 	};
 }
 

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -112,7 +112,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'label' ],
+		fields: [ 'label', 'link' ],
 	};
 }
 

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -71,7 +71,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'label' ],
+		fields: [ 'label', 'link' ],
 	};
 }
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -54,7 +54,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'value' ],
+		fields: [ 'value', 'citation' ],
 	};
 }
 

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -50,7 +50,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'label' ],
+		fields: [ 'label', 'buttonText', 'placeholder' ],
 	};
 }
 

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -44,7 +44,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'link' ],
+		fields: [ 'link', 'label' ],
 	};
 }
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -61,7 +61,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 		},
 	];
 	settings[ formKey ] = {
-		fields: [ 'video' ],
+		fields: [ 'video', 'caption' ],
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Shows all block fields by default by specifying all fields in the form. This is optimizing for single block selection, where there's plenty of space to show all the fields. In this situation the panel heading is also changed to display the title of the tab / attribute group (in this case 'Content' as that's all that block fields currently supports).:
<img width="180" alt="Screenshot 2026-01-09 at 4 20 25 pm" src="https://github.com/user-attachments/assets/16794871-5321-48d0-8c36-2a9511e4afe8" />

The behavior is still very similar to before when a pattern is inserted and selected. In this situation only the first field for each block in the pattern is displayed, and the block title is shown instead of 'Content':
<img width="180" alt="Screenshot 2026-01-09 at 4 21 49 pm" src="https://github.com/user-attachments/assets/36ca084a-1c1c-4995-bd33-0b7c3f7371d0" />

## How?
Adds an `isCollapsed` prop to blockFields which dictates the behavior.
## Testing Instructions
### Single blocks
1. Enable the Block Fields gutenberg experiment
2. Insert and select a block that has multiple fields like Image
3. Observe that all fields are shown in the Content tab, and that the panel heading says 'Content'.

### Pattern editing
1. Enable the Pattern Editing and Block Fields gutenberg experiments
2. Insert a pattern
3. Observe that for only the first field for each block is shown by default. Each block has its block title as the panel heading. 
