### PR TITLE
Block Editor: Close the inserter on small screens after adding a block

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -131,7 +131,7 @@ function InserterMenu(
 				}
 			} );
 		},
-		[ onInsertBlocks, onSelect, shouldFocusBlock ]
+		[ onInsertBlocks, onInserterClose, onSelect, ref, shouldFocusBlock ]
 	);
 
 	const onInsertPattern = useCallback(
@@ -141,7 +141,7 @@ function InserterMenu(
 			onSelect();
 			onInserterClose();
 		},
-		[ onInsertBlocks, onSelect ]
+		[ onInsertBlocks, onInserterClose, onSelect, onToggleInsertionPoint ]
 	);
 
 	const onHover = useCallback(

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -76,7 +76,7 @@ function InserterMenu(
 		useState( null );
 	const isLargeViewport = useViewportMatch( 'large' );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const onInserterClose = isMobileViewport ? onClose : NOOP;
+	const maybeCloseInserter = isMobileViewport ? onClose : NOOP;
 
 	function getInitialTab() {
 		if ( __experimentalInitialTab ) {
@@ -116,7 +116,7 @@ function InserterMenu(
 				_rootClientId
 			);
 			onSelect( blocks );
-			onInserterClose();
+			maybeCloseInserter();
 
 			// Check for focus loss due to filtering blocks by selected block type
 			window.requestAnimationFrame( () => {
@@ -131,7 +131,7 @@ function InserterMenu(
 				}
 			} );
 		},
-		[ onInsertBlocks, onInserterClose, onSelect, ref, shouldFocusBlock ]
+		[ onInsertBlocks, maybeCloseInserter, onSelect, ref, shouldFocusBlock ]
 	);
 
 	const onInsertPattern = useCallback(
@@ -139,9 +139,9 @@ function InserterMenu(
 			onToggleInsertionPoint( false );
 			onInsertBlocks( blocks, { patternName }, ...args );
 			onSelect();
-			onInserterClose();
+			maybeCloseInserter();
 		},
-		[ onInsertBlocks, onInserterClose, onSelect, onToggleInsertionPoint ]
+		[ onInsertBlocks, maybeCloseInserter, onSelect, onToggleInsertionPoint ]
 	);
 
 	const onHover = useCallback(

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -75,6 +75,8 @@ function InserterMenu(
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
 	const isLargeViewport = useViewportMatch( 'large' );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const onInserterClose = isMobileViewport ? onClose : NOOP;
 
 	function getInitialTab() {
 		if ( __experimentalInitialTab ) {
@@ -114,6 +116,7 @@ function InserterMenu(
 				_rootClientId
 			);
 			onSelect( blocks );
+			onInserterClose();
 
 			// Check for focus loss due to filtering blocks by selected block type
 			window.requestAnimationFrame( () => {
@@ -136,6 +139,7 @@ function InserterMenu(
 			onToggleInsertionPoint( false );
 			onInsertBlocks( blocks, { patternName }, ...args );
 			onSelect();
+			onInserterClose();
 		},
 		[ onInsertBlocks, onSelect ]
 	);


### PR DESCRIPTION
## What?
Closes #68790.
Alternative to #68791.

Update the Inserter menu logic to close it when a block is added on a small screen, so it doesn't obscure the canvas.

## Testing Instructions
1. Open a post or page.
2. Resize your browser window to a small screen.
3. Open the inserter and add a block.
4. Confirm that the inserter closes.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/2af65bc1-d0f2-4b8c-8866-b2ad3df7e9ed

