### PR TITLE
Fix: Remove newline between more and noteaser tags in More block

### DIFF
--- a/packages/block-library/src/more/save.js
+++ b/packages/block-library/src/more/save.js
@@ -10,7 +10,7 @@ export default function save( { attributes: { customText, noTeaser } } ) {
 
 	return (
 		<RawHTML>
-			{ [ moreTag, noTeaserTag ].filter( Boolean ).join( '\n' ) }
+			{ [ moreTag, noTeaserTag ].filter( Boolean ).join( '' ) }
 		</RawHTML>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #74439 (Partial Fix)

This PR removes the newline character between the and tags in the More block. While this ensures the data is saved in a format compatible with the WordPress parser, further investigation may be needed for how block themes render this directive on the frontend.
<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, the block saves the tags on separate lines. While investigating the report that "Hide excerpt" isn't functioning in certain themes, I found that the newline prevents the WordPress PHP parser from correctly identifying the noteaser directive. Joining them into a single string ensures better compatibility with the core rendering engine.

## How?
Modified packages/block-library/src/more/save.js to change .join( '\n' ) to .join( '' ). This ensures that when the noTeaser attribute is true, the resulting HTML is `` instead of having a line break between them.

## Testing Instructions
1. Open a new post and insert a More block.

2. In the Block settings sidebar, toggle "Hide the excerpt on the full content page" to ON.

3. Open the Code Editor view (Ctrl+Shift+Alt+M).

4. Verify that the tags and are on the same line without a space or newline.

### Testing Instructions for Keyboard
Keyboard testing is not applicable as this PR only affects the saved HTML output string and does not modify any interactive UI components or focus states.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|N/A - Formatting Fix|<img width="1914" height="1053" alt="Screenshot 2026-01-09 150848" src="https://github.com/user-attachments/assets/da58a128-bead-45fc-826c-71fca74b24d5" />| 




