### PR TITLE
Navigation: Disable overlay colors for custom overlays

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -130,6 +130,7 @@ function ColorTools( {
 	setOverlayBackgroundColor,
 	clientId,
 	navRef,
+	overlay,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -178,44 +179,52 @@ function ColorTools( {
 	if ( ! colorGradientSettings.hasColorsOrGradients ) {
 		return null;
 	}
+	const baseColorSettings = [
+		{
+			colorValue: textColor.color,
+			label: __( 'Text' ),
+			onColorChange: setTextColor,
+			resetAllFilter: () => setTextColor(),
+			clearable: true,
+			enableAlpha: true,
+		},
+		{
+			colorValue: backgroundColor.color,
+			label: __( 'Background' ),
+			onColorChange: setBackgroundColor,
+			resetAllFilter: () => setBackgroundColor(),
+			clearable: true,
+			enableAlpha: true,
+		},
+	];
+
+	// Only include overlay color controls when no custom overlay is selected
+	const overlayColorSettings = ! overlay
+		? [
+				{
+					colorValue: overlayTextColor.color,
+					label: __( 'Submenu & overlay text' ),
+					onColorChange: setOverlayTextColor,
+					resetAllFilter: () => setOverlayTextColor(),
+					clearable: true,
+					enableAlpha: true,
+				},
+				{
+					colorValue: overlayBackgroundColor.color,
+					label: __( 'Submenu & overlay background' ),
+					onColorChange: setOverlayBackgroundColor,
+					resetAllFilter: () => setOverlayBackgroundColor(),
+					clearable: true,
+					enableAlpha: true,
+				},
+		  ]
+		: [];
+
 	return (
 		<>
 			<ColorGradientSettingsDropdown
 				__experimentalIsRenderedInSidebar
-				settings={ [
-					{
-						colorValue: textColor.color,
-						label: __( 'Text' ),
-						onColorChange: setTextColor,
-						resetAllFilter: () => setTextColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: backgroundColor.color,
-						label: __( 'Background' ),
-						onColorChange: setBackgroundColor,
-						resetAllFilter: () => setBackgroundColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: overlayTextColor.color,
-						label: __( 'Submenu & overlay text' ),
-						onColorChange: setOverlayTextColor,
-						resetAllFilter: () => setOverlayTextColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: overlayBackgroundColor.color,
-						label: __( 'Submenu & overlay background' ),
-						onColorChange: setOverlayBackgroundColor,
-						resetAllFilter: () => setOverlayBackgroundColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-				] }
+				settings={ [ ...baseColorSettings, ...overlayColorSettings ] }
 				panelId={ clientId }
 				{ ...colorGradientSettings }
 				gradients={ [] }
@@ -819,6 +828,7 @@ function Navigation( {
 					setOverlayBackgroundColor={ setOverlayBackgroundColor }
 					clientId={ clientId }
 					navRef={ navRef }
+					overlay={ overlay }
 				/>
 			</InspectorControls>
 		</>

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -37,25 +37,30 @@ export default function ResponsiveWrapper( {
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
 		{
+			// Only add overlay color classes if no custom overlay is selected
 			'has-text-color':
-				!! overlayTextColor.color || !! overlayTextColor?.class,
+				! overlay &&
+				( !! overlayTextColor.color || !! overlayTextColor?.class ),
 			[ getColorClassName( 'color', overlayTextColor?.slug ) ]:
-				!! overlayTextColor?.slug,
+				! overlay && !! overlayTextColor?.slug,
 			'has-background':
-				!! overlayBackgroundColor.color ||
-				overlayBackgroundColor?.class,
+				! overlay &&
+				( !! overlayBackgroundColor.color ||
+					overlayBackgroundColor?.class ),
 			[ getColorClassName(
 				'background-color',
 				overlayBackgroundColor?.slug
-			) ]: !! overlayBackgroundColor?.slug,
+			) ]: ! overlay && !! overlayBackgroundColor?.slug,
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
 		}
 	);
 
 	const styles = {
-		color: ! overlayTextColor?.slug && overlayTextColor?.color,
+		// Only apply overlay color styles if no custom overlay is selected
+		color: ! overlay && ! overlayTextColor?.slug && overlayTextColor?.color,
 		backgroundColor:
+			! overlay &&
 			! overlayBackgroundColor?.slug &&
 			overlayBackgroundColor?.color &&
 			overlayBackgroundColor.color,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -651,13 +651,11 @@ class WP_Navigation_Block_Renderer {
 
 		// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
 		// Skip adding default overlay color classes if a custom overlay is used.
-		$should_skip_overlay_colors = $has_custom_overlay;
-
 		$responsive_container_classes = array(
 			'wp-block-navigation__responsive-container',
 			$is_hidden_by_default ? 'hidden-by-default' : '',
 			$has_custom_overlay ? 'disable-default-overlay' : '',
-			$should_skip_overlay_colors ? '' : implode( ' ', $colors['overlay_css_classes'] ),
+			$has_custom_overlay ? '' : implode( ' ', $colors['overlay_css_classes'] ),
 		);
 		$open_button_classes          = array(
 			'wp-block-navigation__responsive-container-open',
@@ -709,7 +707,7 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Only apply overlay inline styles if no custom overlay is selected.
-		$overlay_inline_styles = $should_skip_overlay_colors ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
+		$overlay_inline_styles = $has_custom_overlay ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -651,7 +651,7 @@ class WP_Navigation_Block_Renderer {
 
 		// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
 		// Skip adding default overlay color classes if a custom overlay is used.
-		$should_skip_overlay_colors = $has_custom_overlay || ! empty( $attributes['overlay'] );
+		$should_skip_overlay_colors = $has_custom_overlay;
 
 		$responsive_container_classes = array(
 			'wp-block-navigation__responsive-container',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -650,11 +650,14 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
+		// Skip adding default overlay color classes if a custom overlay is used.
+		$should_skip_overlay_colors = $has_custom_overlay || ! empty( $attributes['overlay'] );
+
 		$responsive_container_classes = array(
 			'wp-block-navigation__responsive-container',
 			$is_hidden_by_default ? 'hidden-by-default' : '',
 			$has_custom_overlay ? 'disable-default-overlay' : '',
-			implode( ' ', $colors['overlay_css_classes'] ),
+			$should_skip_overlay_colors ? '' : implode( ' ', $colors['overlay_css_classes'] ),
 		);
 		$open_button_classes          = array(
 			'wp-block-navigation__responsive-container-open',
@@ -705,7 +708,8 @@ class WP_Navigation_Block_Renderer {
 			';
 		}
 
-		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
+		// Only apply overlay inline styles if no custom overlay is selected.
+		$overlay_inline_styles = $should_skip_overlay_colors ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(


### PR DESCRIPTION
##  What?

Fixes an issue where default overlay colors were being applied even when users had customized the Navigation block overlay.

 ## Why?
When users have a custom overlay, the default overlay color classes and inline styles shouldn't be applied as this creates two places where overlay colors can be set.

  This is particularly problematic because:
  1. Custom overlay blocks should have full control over their styling
  2. Default color classes can override or conflict with user customizations
  3. The has-{color}-background-color classes and inline styles are unnecessary when a custom overlay is present

 ## How?
  The fix introduces a $should_skip_overlay_colors check that prevents default overlay color classes and inline styles from being added when:
  - A custom overlay has been defined ($has_custom_overlay), OR
  - The overlay attribute is set

  The changes are made in two locations:
  1. Line 660: Skip adding overlay_css_classes to $responsive_container_classes when custom overlay is used
  2. Line 712: Skip adding overlay_inline_styles when custom overlay is used

 ## Testing Instructions
  1. Create or open a post/page
  2. Insert a Navigation block
  3. In the block settings, add a custom overlay by inserting blocks into the overlay area (this requires the Navigation block overlay experiment to be enabled)
  4. Set custom background colors on the overlay blocks
  5. Verify that only your custom colors are applied, not the default theme colors
  6. Inspect the overlay container element and confirm it does NOT have default color classes like has-*-background-color when custom overlay blocks are present
  7. Test with the overlay attribute set directly via code editor to ensure inline styles are also skipped
