### PR TITLE
Hide Display section from Nav Inspector Controls if empty

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -254,7 +254,6 @@ function Navigation( {
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
-	hasSubmenuIndicatorSetting = true,
 	customPlaceholder: CustomPlaceholder = null,
 	__unstableLayoutClassNames: layoutClassNames,
 } ) {
@@ -655,7 +654,7 @@ function Navigation( {
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
-				{ hasSubmenuIndicatorSetting && (
+				{ ( ! isOverlayExperimentEnabled || hasSubmenus ) && (
 					<ToolsPanel
 						label={ __( 'Display' ) }
 						resetAll={ () => {


### PR DESCRIPTION
## What?

Hides the Display inspector section when it would be empty (overlay experiment enabled + no submenus) and removes unused `hasSubmenuIndicatorSetting` prop. Part of the Overlay Experiment: https://github.com/WordPress/gutenberg/issues/73084

## Why?
When the customizable navigation overlays experiment is enabled and a navigation block has no submenus, the Display section appears empty. This creates a poor UX.

The `hasSubmenuIndicatorSetting` prop has been unused since the Navigation Editor experiment was removed in #47055 (Jan 2023). It was originally added in #25329 to allow the Navigation Editor to hide controls, but nothing sets it to `false` anymore.

## How?

Added condition to hide the Display section when overlay experiment is enabled AND there are no submenus. Removed the unused `hasSubmenuIndicatorSetting` prop.

## Testing Instructions

1. Enable the "Customizable navigation overlays" experiment
2. Add a navigation block with no submenus
3. Select the block - the Display section should not appear
4. Add a Navigation Submenu block
5. The Display section should now appear with submenu controls
6. Disable the overlay experiment
7. The Display section should appear with overlay visibility controls

### Testing Instructions for Keyboard

