### PR TITLE
Docs: clarify default block editor settings comment

### DIFF
--- a/packages/block-editor/src/store/constants.js
+++ b/packages/block-editor/src/store/constants.js
@@ -1,1 +1,3 @@
+// Default block editor settings
+
 export const STORE_NAME = 'core/block-editor';


### PR DESCRIPTION
Improved inline documentation for better clarity and maintainability.
