### PR TITLE
Add design-tokens.css to stylelintignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -2,4 +2,5 @@ build
 build-style
 node_modules
 packages/stylelint-config/test
+packages/theme/src/prebuilt
 packages/theme/src/stylelint-plugins/test/fixtures


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Excludes `packages/theme/src/prebuilt` from stylelint checks.

## Why?

While the `lint:css` command [only checks](https://github.com/WordPress/gutenberg/blob/8e372fba3788913a9e515b0e7bfe70b13ae886fe/package.json#L161) `.scss` and `.module.css` files, an IDE will run linters based on the config it can see. The `packages/theme/src/prebuilt/css/design-tokens.css` is not linted by the `lint:css` command due to a non-matching extension, but it is linted in the IDE. This is annoying because we refer to this file a lot to inspect the actual values of the tokens. Every time I do that, the whole file is painted with red squiggly lines.

I think we can ignore a slightly wider path than just the `design-tokens.css` file alone, so I opted for `packages/theme/src/prebuilt`.

## Testing Instructions

Open the `packages/theme/src/prebuilt/css/design-tokens.css` file in your IDE with style linting set up.