### PR TITLE
List View: Add recursive expand and collapse options to block context menu

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -74,6 +74,9 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	children,
 	__experimentalSelectBlock,
+	expand,
+	collapse,
+	expandedState,
 	...props
 } ) {
 	// Get the client id of the current block for this menu, if one is set.
@@ -126,7 +129,7 @@ export function BlockSettingsDropdown( {
 		[ firstBlockClientId ]
 	);
 
-	const { getBlockOrder, getSelectedBlockClientIds } =
+	const { getBlockOrder, getSelectedBlockClientIds, getBlocks } =
 		useSelect( blockEditorStore );
 
 	const shortcuts = useSelect( ( select ) => {
@@ -186,6 +189,74 @@ export function BlockSettingsDropdown( {
 	const shouldShowBlockParentMenuItem =
 		! parentBlockIsSelected && !! firstParentClientId;
 
+	// Only show expand/collapse options if we're in List View context
+	// (expand, collapse, and expandedState are only passed from List View)
+	const showExpandCollapseOptions = expand && collapse && expandedState;
+
+	// Helper functions for expand/collapse - defined inline to avoid import issues
+	function hasInnerBlocksHelper( clientId ) {
+		try {
+			const innerBlocks = getBlocks( clientId );
+			return innerBlocks && innerBlocks.length > 0;
+		} catch ( error ) {
+			return false;
+		}
+	}
+
+	function getAllDescendantIdsHelper( clientId ) {
+		try {
+			const innerBlocks = getBlocks( clientId );
+			const descendants = [];
+
+			if ( ! innerBlocks ) {
+				return descendants;
+			}
+
+			innerBlocks.forEach( ( innerBlock ) => {
+				if ( innerBlock && innerBlock.clientId ) {
+					descendants.push( innerBlock.clientId );
+					descendants.push(
+						...getAllDescendantIdsHelper( innerBlock.clientId )
+					);
+				}
+			} );
+
+			return descendants;
+		} catch ( error ) {
+			return [];
+		}
+	}
+
+	function handleExpandRecursively() {
+		if ( ! expand ) {
+			return;
+		}
+
+		// Expand all selected blocks and their descendants
+		const allIdsToExpand = [];
+		clientIds.forEach( ( clientId ) => {
+			allIdsToExpand.push( clientId );
+			allIdsToExpand.push( ...getAllDescendantIdsHelper( clientId ) );
+		} );
+
+		expand( allIdsToExpand );
+	}
+
+	function handleCollapseChildren() {
+		if ( ! collapse ) {
+			return;
+		}
+
+		// Collapse all selected blocks and their descendants
+		clientIds.forEach( ( clientId ) => {
+			collapse( clientId );
+			const descendantIds = getAllDescendantIdsHelper( clientId );
+			descendantIds.forEach( ( childId ) => {
+				collapse( childId );
+			} );
+		} );
+	}
+
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -226,134 +297,241 @@ export function BlockSettingsDropdown( {
 						noIcons
 						{ ...props }
 					>
-						{ ( { onClose } ) => (
-							<>
-								<MenuGroup>
-									<__unstableBlockSettingsMenuFirstItem.Slot
-										fillProps={ { onClose } }
-									/>
-									{ shouldShowBlockParentMenuItem && (
-										<BlockParentSelectorMenuItem
-											parentClientId={
-												firstParentClientId
-											}
-											parentBlockType={ parentBlockType }
+						{ ( { onClose } ) => {
+							// Calculate these values only when the menu is opened
+							// to avoid performance issues during render
+							let blockHasChildren = false;
+							let canExpandRecursively = false;
+							let canCollapseChildren = false;
+
+							if ( showExpandCollapseOptions ) {
+								// Check all selected blocks
+								let anyBlockHasChildren = false;
+								let anyBlockIsCollapsed = false;
+								let anyBlockIsExpanded = false;
+
+								clientIds.forEach( ( clientId ) => {
+									const hasChildren =
+										hasInnerBlocksHelper( clientId );
+
+									if ( hasChildren ) {
+										anyBlockHasChildren = true;
+
+										const isInState =
+											clientId in expandedState;
+										const isExplicitlyCollapsed =
+											expandedState[ clientId ] === false;
+										const isCollapsed =
+											! isInState ||
+											isExplicitlyCollapsed;
+
+										if ( isCollapsed ) {
+											anyBlockIsCollapsed = true;
+
+											// Also check if this block has collapsed descendants
+											const descendants =
+												getAllDescendantIdsHelper(
+													clientId
+												);
+											descendants.forEach(
+												( descendantId ) => {
+													const descendantHasChildren =
+														hasInnerBlocksHelper(
+															descendantId
+														);
+													if (
+														descendantHasChildren
+													) {
+														const descIsInState =
+															descendantId in
+															expandedState;
+														const descIsCollapsed =
+															! descIsInState ||
+															expandedState[
+																descendantId
+															] === false;
+														if ( descIsCollapsed ) {
+															anyBlockIsCollapsed = true;
+														}
+													}
+												}
+											);
+										} else {
+											anyBlockIsExpanded = true;
+										}
+									}
+								} );
+
+								blockHasChildren = anyBlockHasChildren;
+								canExpandRecursively = anyBlockIsCollapsed;
+								canCollapseChildren = anyBlockIsExpanded;
+							}
+
+							return (
+								<>
+									<MenuGroup>
+										<__unstableBlockSettingsMenuFirstItem.Slot
+											fillProps={ { onClose } }
 										/>
-									) }
-									{ count === 1 && (
-										<BlockHTMLConvertButton
-											clientId={ firstBlockClientId }
-										/>
-									) }
-									{ ! isContentOnly && (
-										<CopyMenuItem
-											clientIds={ clientIds }
-											onCopy={ onCopy }
-											shortcut={ shortcuts.copy }
-										/>
-									) }
-									{ ! isContentOnly && (
-										<CopyMenuItem
-											clientIds={ clientIds }
-											label={ __( 'Cut' ) }
-											eventType="cut"
-											shortcut={ shortcuts.cut }
-											__experimentalUpdateSelection={
-												! __experimentalSelectBlock
-											}
-										/>
-									) }
-									{ canDuplicate && (
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onDuplicate,
-												updateSelectionAfterDuplicate
-											) }
-											shortcut={ shortcuts.duplicate }
-										>
-											{ __( 'Duplicate' ) }
-										</MenuItem>
-									) }
-									{ canInsertBlock && ! isZoomOut && (
-										<>
+										{ shouldShowBlockParentMenuItem && (
+											<BlockParentSelectorMenuItem
+												parentClientId={
+													firstParentClientId
+												}
+												parentBlockType={
+													parentBlockType
+												}
+											/>
+										) }
+										{ count === 1 && (
+											<BlockHTMLConvertButton
+												clientId={ firstBlockClientId }
+											/>
+										) }
+										{ ! isContentOnly && (
+											<CopyMenuItem
+												clientIds={ clientIds }
+												onCopy={ onCopy }
+												shortcut={ shortcuts.copy }
+											/>
+										) }
+										{ ! isContentOnly && (
+											<CopyMenuItem
+												clientIds={ clientIds }
+												label={ __( 'Cut' ) }
+												eventType="cut"
+												shortcut={ shortcuts.cut }
+												__experimentalUpdateSelection={
+													! __experimentalSelectBlock
+												}
+											/>
+										) }
+										{ canDuplicate && (
 											<MenuItem
 												onClick={ pipe(
 													onClose,
-													onInsertBefore
+													onDuplicate,
+													updateSelectionAfterDuplicate
 												) }
-												shortcut={
-													shortcuts.insertBefore
-												}
+												shortcut={ shortcuts.duplicate }
 											>
-												{ __( 'Add before' ) }
+												{ __( 'Duplicate' ) }
 											</MenuItem>
-											<MenuItem
-												onClick={ pipe(
+										) }
+										{ canInsertBlock && ! isZoomOut && (
+											<>
+												<MenuItem
+													onClick={ pipe(
+														onClose,
+														onInsertBefore
+													) }
+													shortcut={
+														shortcuts.insertBefore
+													}
+												>
+													{ __( 'Add before' ) }
+												</MenuItem>
+												<MenuItem
+													onClick={ pipe(
+														onClose,
+														onInsertAfter
+													) }
+													shortcut={
+														shortcuts.insertAfter
+													}
+												>
+													{ __( 'Add after' ) }
+												</MenuItem>
+											</>
+										) }
+										{ count === 1 && (
+											<CommentIconSlotFill.Slot
+												fillProps={ {
+													clientId:
+														firstBlockClientId,
 													onClose,
-													onInsertAfter
+												} }
+											/>
+										) }
+									</MenuGroup>
+									{ showExpandCollapseOptions &&
+										blockHasChildren &&
+										( canExpandRecursively ||
+											canCollapseChildren ) && (
+											<MenuGroup>
+												{ canExpandRecursively && (
+													<MenuItem
+														onClick={ pipe(
+															onClose,
+															handleExpandRecursively
+														) }
+													>
+														{ __(
+															'Expand all blocks'
+														) }
+													</MenuItem>
 												) }
-												shortcut={
-													shortcuts.insertAfter
-												}
-											>
-												{ __( 'Add after' ) }
+												{ canCollapseChildren && (
+													<MenuItem
+														onClick={ pipe(
+															onClose,
+															handleCollapseChildren
+														) }
+													>
+														{ __(
+															'Collapse nested blocks'
+														) }
+													</MenuItem>
+												) }
+											</MenuGroup>
+										) }
+									{ canCopyStyles && ! isContentOnly && (
+										<MenuGroup>
+											<CopyMenuItem
+												clientIds={ clientIds }
+												onCopy={ onCopy }
+												label={ __( 'Copy styles' ) }
+												eventType="copyStyles"
+											/>
+											<MenuItem onClick={ onPasteStyles }>
+												{ __( 'Paste styles' ) }
 											</MenuItem>
-										</>
+										</MenuGroup>
 									) }
-									{ count === 1 && (
-										<CommentIconSlotFill.Slot
+									{ ! isContentOnly && (
+										<BlockSettingsMenuControls.Slot
 											fillProps={ {
-												clientId: firstBlockClientId,
 												onClose,
+												count,
+												firstBlockClientId,
 											} }
+											clientIds={ clientIds }
 										/>
 									) }
-								</MenuGroup>
-								{ canCopyStyles && ! isContentOnly && (
-									<MenuGroup>
-										<CopyMenuItem
-											clientIds={ clientIds }
-											onCopy={ onCopy }
-											label={ __( 'Copy styles' ) }
-											eventType="copyStyles"
-										/>
-										<MenuItem onClick={ onPasteStyles }>
-											{ __( 'Paste styles' ) }
-										</MenuItem>
-									</MenuGroup>
-								) }
-								{ ! isContentOnly && (
-									<BlockSettingsMenuControls.Slot
-										fillProps={ {
-											onClose,
-											count,
-											firstBlockClientId,
-										} }
-										clientIds={ clientIds }
-									/>
-								) }
-								{ typeof children === 'function'
-									? children( { onClose } )
-									: Children.map( ( child ) =>
-											cloneElement( child, { onClose } )
-									  ) }
-								{ canRemove && (
-									<MenuGroup>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onRemove,
-												updateSelectionAfterRemove
-											) }
-											shortcut={ shortcuts.remove }
-										>
-											{ __( 'Delete' ) }
-										</MenuItem>
-									</MenuGroup>
-								) }
-							</>
-						) }
+									{ typeof children === 'function'
+										? children( { onClose } )
+										: Children.map( ( child ) =>
+												cloneElement( child, {
+													onClose,
+												} )
+										  ) }
+									{ canRemove && (
+										<MenuGroup>
+											<MenuItem
+												onClick={ pipe(
+													onClose,
+													onRemove,
+													updateSelectionAfterRemove
+												) }
+												shortcut={ shortcuts.remove }
+											>
+												{ __( 'Delete' ) }
+											</MenuItem>
+										</MenuGroup>
+									) }
+								</>
+							);
+						} }
 					</DropdownMenu>
 				);
 			} }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -690,6 +690,7 @@ function ListViewBlock( {
 							} }
 							disableOpenOnArrowDown
 							expand={ expand }
+							collapse={ collapse }
 							expandedState={ expandedState }
 							setInsertedBlock={ setInsertedBlock }
 							__experimentalSelectBlock={


### PR DESCRIPTION
## What?
Adds two new context menu options to the List View block settings dropdown that allow users to recursively expand or collapse blocks.

## Why?
Fixes #53004

When working with deeply nested block structures in List View, users currently need to manually expand or collapse each level individually. This becomes tedious when working with complex layouts.

## How?
- Adds "Expand all blocks" menu option that expands the selected block(s) and all nested descendants recursively
- Adds "Collapse nested blocks" menu option that collapses the selected block(s) and all nested descendants recursively
- Options are shown dynamically based on the current expand/collapse state:
  - "Expand all blocks" shows when any selected block or its descendants are collapsed
  - "Collapse nested blocks" shows when any selected block is expanded
- Works with both single and multiple block selections

## Testing Instructions
1. Create a post with deeply nested blocks (e.g., Group > Group > Columns > Column > Paragraph)
2. Open the List View
3. Right-click on a parent block with nested children
4. Verify you see "Expand all blocks" option in the context menu
5. Click "Expand all blocks" and verify all nested levels expand
6. Right-click the same block again
7. Verify you now see "Collapse nested blocks" option
8. Click "Collapse nested blocks" and verify all nested levels collapse
9. Test with multiple blocks selected (select 2+ parent blocks and verify the options work correctly)

## Screencast
https://github.com/user-attachments/assets/a4de8c0a-65ed-4679-8096-defec70e3fdf