### PR TITLE
dom-ready: Refactor tests to use defineProperty

### DIFF
--- a/packages/dom-ready/src/test/index.test.ts
+++ b/packages/dom-ready/src/test/index.test.ts
@@ -3,25 +3,14 @@
  */
 import domReady from '../';
 
-/**
- * In JSDOM, unlike browsers, readyState can be overwritten to simulate different document states.
- */
-interface MockDocument extends Document {
-	readyState: DocumentReadyState;
-}
-
 describe( 'domReady', () => {
-	beforeAll( () => {
-		Object.defineProperty( document, 'readyState', {
-			value: 'loading',
-			writable: true,
-		} );
-	} );
-
 	describe( 'when document readystate is complete', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			( document as MockDocument ).readyState = 'complete';
+			Object.defineProperty( document, 'readyState', {
+				get: () => 'complete',
+				configurable: true,
+			} );
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -30,7 +19,10 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is interactive', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			( document as MockDocument ).readyState = 'interactive';
+			Object.defineProperty( document, 'readyState', {
+				get: () => 'interactive',
+				configurable: true,
+			} );
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -39,7 +31,10 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is still loading', () => {
 		it( 'should add the callback as an event listener to the DOMContentLoaded event.', () => {
 			const addEventListener = jest.fn( () => {} );
-			( document as MockDocument ).readyState = 'loading';
+			Object.defineProperty( document, 'readyState', {
+				get: () => 'loading',
+				configurable: true,
+			} );
 			Object.defineProperty( document, 'addEventListener', {
 				value: addEventListener,
 			} );


### PR DESCRIPTION
Follow-up to #74482
https://github.com/WordPress/gutenberg/commit/4ade20c9d7d8fbf92234422094b7af90d8cca3cf

## Why?
I was researching a bit, and after reading through this SO topic 
https://stackoverflow.com/questions/37059010/workarounds-for-jsdom-document-readystate-being-readonly
It seems there is a better way to achieve this. You can ignore the interface all around and simply use:

```js
Object.defineProperty( document, 'readyState', {
	get: () => 'complete',
	configurable: true,
} );
```

Tests are passing and no TS errors

<img width="658" height="255" alt="image" src="https://github.com/user-attachments/assets/5a1bffed-54d8-4b42-9f71-ac9d2e60c340" />


