### PR TITLE
Navigation Overlay: Fix area and icon name

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/index.js
+++ b/packages/block-library/src/navigation-overlay-close/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import icon from './icon';
+import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../navigation/constants';
 
 const { name } = metadata;
 
@@ -50,7 +51,9 @@ function isWithinOverlay() {
 			postId
 		);
 
-		return templatePartEntity?.area === 'overlay';
+		return (
+			templatePartEntity?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA
+		);
 	}
 
 	return false;

--- a/packages/block-library/src/template-part/edit/utils/get-template-part-icon.js
+++ b/packages/block-library/src/template-part/edit/utils/get-template-part-icon.js
@@ -12,7 +12,7 @@ import {
 /**
  * Helper function to retrieve the corresponding icon by area name or icon name.
  *
- * @param {string} areaOrIconName The area name (e.g., 'header', 'overlay') or icon name (e.g., 'menu').
+ * @param {string} areaOrIconName The area name (e.g., 'header', 'navigation-overlay') or icon name (e.g., 'menu').
  *
  * @return {Object} The corresponding icon.
  */

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -52,11 +52,11 @@ function CategoriesGroup( {
 				}
 			/>
 			{ Object.entries( templatePartAreas ).map(
-				( [ area, { label, templateParts } ] ) => (
+				( [ area, { label, templateParts, icon } ] ) => (
 					<CategoryItem
 						key={ area }
 						count={ templateParts?.length }
-						icon={ getTemplatePartIcon( area ) }
+						icon={ getTemplatePartIcon( icon ) }
 						label={ label }
 						id={ area }
 						type={ TEMPLATE_PART_POST_TYPE }

--- a/packages/editor/src/utils/get-template-part-icon.js
+++ b/packages/editor/src/utils/get-template-part-icon.js
@@ -24,7 +24,7 @@ export function getTemplatePartIcon( areaOrIconName ) {
 		return footerIcon;
 	} else if ( 'sidebar' === areaOrIconName ) {
 		return sidebarIcon;
-	} else if ( 'navigation-overlay' === areaOrIconName ) {
+	} else if ( 'overlay' === areaOrIconName ) {
 		// TODO: Replace with a proper overlay icon when available.
 		// Using tableColumnAfter as a placeholder.
 		return overlayIcon;

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -100,7 +100,7 @@ const getTemplatePartIcon = ( areaOrIconName: string ) => {
 		return footerIcon;
 	} else if ( 'sidebar' === areaOrIconName ) {
 		return sidebarIcon;
-	} else if ( 'navigation-overlay' === areaOrIconName ) {
+	} else if ( 'overlay' === areaOrIconName ) {
 		// TODO: Replace with a proper overlay icon when available.
 		// Using tableColumnAfter as a placeholder.
 		return overlayIcon;


### PR DESCRIPTION
## What?

This PR fixes two regressions introduced in #74444:

- Unable to insert `Navigation Overlay Close` block
- The navigation overlay template icon is not displayed correctly

## Why?

#74444 changed the name of the overlay template area from `ovelay` to `navigation-overlay`, but 'overlay' remained hard-coded in the `isWithinOverlay()` function, which determines whether a close button can be inserted.

Furthermore, although the name of the overlay area has changed, the icon slug remains `overlay`. The `getTemplatePartIcon()` function basically recieves the icon name, so we should check `overlay`, not `navigation-overlay`.

## How?

I kept the icon name `overlay` and adjusted it so that everything works properly. We could also change the icon name from `overlay` to `navigation-overlay` to match the area name, but I don't have a strong opinion on this.

## Testing Instructions

- Enable the "Customizable Navigation Overlays" experiment setting.
- Select the Navigation Overlay area and create a new template part.
- Open the template part.
- Confirm that the Navigation Overlay Close button can be inserted.

## Screenshots or screencast <!-- if applicable -->

The icon should now be displayed correctly in the following two places:

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Add Template Part
|Before|After|
|-|-|
| <img width="524" height="591" alt="image" src="https://github.com/user-attachments/assets/eccd993a-2492-45ee-97c9-731a4b5ccbae" /> | <img width="529" height="602" alt="image" src="https://github.com/user-attachments/assets/cc4465a4-cac8-40ef-94ad-9e9121df6b25" /> |

### Block Card

|Before|After|
|-|-|
| <img width="290" height="198" alt="image" src="https://github.com/user-attachments/assets/3edc6554-6298-4980-b528-906e491a93b6" /> | <img width="295" height="200" alt="image" src="https://github.com/user-attachments/assets/d7cfd965-d306-444e-8aaa-8182bb6bdd0b" /> |