### PR TITLE
Block visibility support: use CSS range syntax for media queries

### DIFF
--- a/backport-changelog/7.0/10629.md
+++ b/backport-changelog/7.0/10629.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/10629
 
 * https://github.com/WordPress/gutenberg/pull/73994
 * https://github.com/WordPress/gutenberg/pull/74379
+* https://github.com/WordPress/gutenberg/pull/74526

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -37,8 +37,8 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		 * as the feature is developed.
 		 *
 		 * Breakpoints as array items are defined sequentially. The first item's size is the max value.
-		 * Each subsequent item's min is calc(previous size + 1px), and its size is the max.
-		 * The last item's min is previous size plus 1px, and it has no max.
+		 * Each subsequent item starts after the previous size (using > operator), and its size is the max.
+		 * The last item starts after the previous size (using > operator), and it has no max.
 		 */
 		$breakpoints = array(
 			array(
@@ -59,31 +59,25 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		);
 
 		/*
-		 * Build media queries from breakpoint definitions.
+		 * Build media queries from breakpoint definitions using CSS range syntax.
 		 * Could be absorbed into the style engine,
 		 * as well as classname building, and declaration of the display property, if required.
 		 */
 		$breakpoint_queries = array();
 		$previous_size      = null;
 		foreach ( $breakpoints as $index => $breakpoint ) {
-			$slug        = $breakpoint['slug'];
-			$size        = $breakpoint['size'];
-			$query_parts = array();
+			$slug = $breakpoint['slug'];
+			$size = $breakpoint['size'];
 
-			// First item: max = size.
+			// First item: width <= size.
 			if ( 0 === $index ) {
-				$query_parts[] = '(max-width: ' . $size . ')';
+				$breakpoint_queries[ $slug ] = '@media (width <= ' . $size . ')';
 			} elseif ( count( $breakpoints ) - 1 === $index ) {
-				// Last item: min = calc(previous size + 1px), no max.
-				$query_parts[] = '(min-width: calc(' . $previous_size . ' + 1px))';
+				// Last item: width > previous size.
+				$breakpoint_queries[ $slug ] = '@media (width > ' . $previous_size . ')';
 			} else {
-				// Middle items: min = calc(previous size + 1px), max = size.
-				$query_parts[] = '(min-width: calc(' . $previous_size . ' + 1px))';
-				$query_parts[] = '(max-width: ' . $size . ')';
-			}
-
-			if ( ! empty( $query_parts ) ) {
-				$breakpoint_queries[ $slug ] = '@media ' . implode( ' and ', $query_parts );
+				// Middle items: previous size < width <= size.
+				$breakpoint_queries[ $slug ] = '@media (' . $previous_size . ' < width <= ' . $size . ')';
 			}
 
 			$previous_size = $size;

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -129,21 +129,19 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			);
 		}
 
-		if ( ! empty( $css_rules ) ) {
-			gutenberg_style_engine_get_stylesheet_from_css_rules(
-				$css_rules,
-				array(
-					'context'  => 'block-supports',
-					'prettify' => false,
-				)
-			);
+		gutenberg_style_engine_get_stylesheet_from_css_rules(
+			$css_rules,
+			array(
+				'context'  => 'block-supports',
+				'prettify' => false,
+			)
+		);
 
-			if ( ! empty( $block_content ) ) {
-				$processor = new WP_HTML_Tag_Processor( $block_content );
-				if ( $processor->next_tag() ) {
-					$processor->add_class( implode( ' ', $class_names ) );
-					$block_content = $processor->get_updated_html();
-				}
+		if ( ! empty( $block_content ) ) {
+			$processor = new WP_HTML_Tag_Processor( $block_content );
+			if ( $processor->next_tag() ) {
+				$processor->add_class( implode( ' ', $class_names ) );
+				$block_content = $processor->get_updated_html();
 			}
 		}
 	}

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -59,7 +59,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		);
 
 		/*
-		 * Build media queries from breakpoint definitions using CSS range syntax.
+		 * Build media queries from breakpoint definitions using the CSS range syntax.
 		 * Could be absorbed into the style engine,
 		 * as well as classname building, and declaration of the display property, if required.
 		 */
@@ -71,13 +71,13 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 			// First item: width <= size.
 			if ( 0 === $index ) {
-				$breakpoint_queries[ $slug ] = '@media (width <= ' . $size . ')';
+				$breakpoint_queries[ $slug ] = "@media (width <= $size)";
 			} elseif ( count( $breakpoints ) - 1 === $index ) {
 				// Last item: width > previous size.
-				$breakpoint_queries[ $slug ] = '@media (width > ' . $previous_size . ')';
+				$breakpoint_queries[ $slug ] = "@media (width > $previous_size)";
 			} else {
 				// Middle items: previous size < width <= size.
-				$breakpoint_queries[ $slug ] = '@media (' . $previous_size . ' < width <= ' . $size . ')';
+				$breakpoint_queries[ $slug ] = "@media ($previous_size < width <= $size)";
 			}
 
 			$previous_size = $size;

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -174,7 +174,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (max-width: 480px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -207,7 +207,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(480px + 1px)) and (max-width: 782px){.wp-block-hidden-tablet{display:none !important;}}',
+			'@media (480px < width <= 782px){.wp-block-hidden-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -240,7 +240,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(782px + 1px)){.wp-block-hidden-desktop{display:none !important;}}',
+			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop visibility rule'
 		);
@@ -278,7 +278,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (min-width: calc(782px + 1px)){.wp-block-hidden-desktop{display:none !important;}}@media (max-width: 480px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain both visibility rules'
 		);

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -280,7 +280,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
-			'CSS should contain both visibility rules'
+			'CSS should contain desktop and mobile visibility rules'
 		);
 	}
 


### PR DESCRIPTION
## What?

Follow up to: https://github.com/WordPress/gutenberg/pull/73994

- Refactor media query generation in `block-visibility.php` to use 'width <=', 'width >=', and range syntax for breakpoints.
- Update corresponding tests in `block-visibility-test.php`.

See: https://github.com/WordPress/wordpress-develop/pull/10629#pullrequestreview-3638038059

Props to @westonruter for the nudge

## Why?

I'll quote from https://github.com/WordPress/performance/issues/1696

> The max-width numbers are coming from od_get_breakpoint_max_widths() with the min-width numbers being one greater than the previous max-width.
>
> However, could there be an issue where windows are sized sub-pixel dimensions, so that a window is for example 601.5px wide? In this case, neither of these rules would apply and it would be better to use the new CSS range syntax ([Can I use?](https://caniuse.com/css-media-range-syntax)). See [writeup](https://cssence.com/2024/superior-range-syntax/).

## How?

Use range syntax instead of adding `1px` to the next breakpoint.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries/Using#targeting_media_features

## Testing


Unit tests:


`npm run test:unit:php:base -- --filter=WP_Block_Supports_Block_Visibility_Test`

To test manually, enable the experiment:

<img width="998" height="90" alt="Screenshot 2025-12-15 at 10 53 52 am" src="https://github.com/user-attachments/assets/ec7052f1-3758-4f2c-8ad1-93ddd50fd0c5" />

Then copy and paste this into your post editor, publish and view the frontend. 

```html


<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false}}} -->
<p>🔴 Hidden on MOBILE (≤599px) - You should see this on tablet and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false}}} -->
<p>🟡 Hidden on TABLET (600-959px) - You should see this on mobile and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"desktop":false}}} -->
<p>🟢 Hidden on DESKTOP (≥960px) - You should see this on mobile and tablet only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"desktop":false}}} -->
<p>🟣 Hidden on MOBILE and DESKTOP - You should only see this on tablet (600-959px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":false,"tablet":false}}} -->
<p>🔵 Hidden on MOBILE and TABLET - You should only see this on desktop (≥960px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"tablet":false,"desktop":false}}} -->
<p>🟠 Hidden on TABLET and DESKTOP - You should only see this on mobile (≤599px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"mobile":true,"tablet":true,"desktop":true}}} -->
<p>✅ Visible on ALL breakpoints - You should always see this</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
<p>❌ Completely HIDDEN (boolean false) - You should never see this</p>
<!-- /wp:paragraph -->
```

https://github.com/user-attachments/assets/45f86b73-f8f8-4763-a1eb-2303fda96105

Make sure to test with the experiment off as well. The last item should never show with the experiment on and off.