### PR TITLE
Paragraph block: Stop using named export from block.json

### DIFF
--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -6,7 +6,9 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { name } from './block.json';
+import metadata from './block.json';
+
+const { name } = metadata;
 
 const transforms = {
 	from: [


### PR DESCRIPTION
## What?

This PR suppresses Webpack warnings logged when Storybook starts.

<img width="786" height="321" alt="naed-export-error" src="https://github.com/user-attachments/assets/3f7e72e1-b034-46b2-8683-577a89ecce01" />

## Why? How?
Named imports from JSON files are not recommended, so change to default imports.

## Testing Instructions

- Run `storybook:dev`
- Verify that no errors appear in the browser console.