### PR TITLE
Fix blockGap styles not working in block style variations

### DIFF
--- a/backport-changelog/7.0/10767.md
+++ b/backport-changelog/7.0/10767.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10767
+
+* https://github.com/WordPress/gutenberg/pull/74529

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -781,6 +781,8 @@ If you set `supports.interactivity` to `true`, it is equivalent to setting both 
 
 This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.
 
+Note that for layout to work correctly, the block it applies to should have a classname as its selector. That classname will be concatenated with a layout type string to form the layout selector.
+
 ### layout.default
 
 -   Type: `Object`

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -155,8 +155,13 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	);
 
 	$config = array(
-		'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-		'styles'  => array(
+		'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+		'settings' => array(
+			'spacing' => array(
+				'blockGap' => true,
+			),
+		),
+		'styles'   => array(
 			'elements' => $elements_data,
 			'blocks'   => $blocks_data,
 		),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -311,7 +311,6 @@ class WP_Theme_JSON_Gutenberg {
 		'height'                            => array( 'dimensions', 'height' ),
 		'width'                             => array( 'dimensions', 'width' ),
 		'writing-mode'                      => array( 'typography', 'writingMode' ),
-		'gap'                               => array( 'spacing', 'blockGap' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2951,7 +2951,7 @@ class WP_Theme_JSON_Gutenberg {
 					$style_variation_declarations[ $combined_selectors ] = $new_declarations;
 				}
 				// Compute declarations for remaining styles not covered by feature level selectors.
-				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json, null, null );
+				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
 				$block_name                    = $block_metadata['name'] ?? ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? static::get_block_name_from_metadata_path( $block_metadata ) : null );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1713,7 +1713,7 @@ class WP_Theme_JSON_Gutenberg {
 		$selector                 = $block_metadata['selector'] ?? '';
 		$has_block_gap_support    = isset( $this->theme_json['settings']['spacing']['blockGap'] );
 		$has_fallback_gap_support = ! $has_block_gap_support; // This setting isn't useful yet: it exists as a placeholder for a future explicit fallback gap styles support.
-		$node                     = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
+		$node                     = $options['node'] ?? _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$layout_definitions       = gutenberg_get_layout_definitions();
 		$layout_selector_pattern  = '/^[a-zA-Z0-9\-\.\,\ *+>:\(\)]*$/'; // Allow alphanumeric classnames, spaces, wildcard, sibling, child combinator and pseudo class selectors.
 
@@ -2917,8 +2917,9 @@ class WP_Theme_JSON_Gutenberg {
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
 		// If there are style variations, generate the declarations for them, including any feature selectors the block may have.
-		$style_variation_declarations = array();
-		$style_variation_custom_css   = array();
+		$style_variation_declarations        = array();
+		$style_variation_custom_css          = array();
+		$style_variation_layout_metadata     = array();
 		if ( ! empty( $block_metadata['variations'] ) ) {
 			foreach ( $block_metadata['variations'] as $style_variation ) {
 				$style_variation_node           = _wp_array_get( $this->theme_json, $style_variation['path'], array() );
@@ -2962,6 +2963,18 @@ class WP_Theme_JSON_Gutenberg {
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
 					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
+				}
+
+				// Store variation metadata and node for layout styles generation.
+				// Only store if the variation has blockGap defined.
+				if ( isset( $style_variation_node['spacing']['blockGap'] ) ) {
+					// Append block selector to the variation selector for proper targeting.
+					$variation_metadata_with_selector = $style_variation;
+					$variation_metadata_with_selector['selector'] = $style_variation['selector'] . $block_metadata['css'];
+					$style_variation_layout_metadata[ $style_variation['selector'] ] = array(
+						'metadata' => $variation_metadata_with_selector,
+						'node'     => $style_variation_node,
+					);
 				}
 			}
 		}
@@ -3142,6 +3155,10 @@ class WP_Theme_JSON_Gutenberg {
 		// 6. Generate and append the style variation rulesets.
 		foreach ( $style_variation_declarations as $style_variation_selector => $individual_style_variation_declarations ) {
 			$block_rules .= static::to_ruleset( ":root :where($style_variation_selector)", $individual_style_variation_declarations );
+			if ( isset( $style_variation_layout_metadata[ $style_variation_selector ] ) ) {
+				$variation_data = $style_variation_layout_metadata[ $style_variation_selector ];
+				$block_rules .= $this->get_layout_styles( $variation_data['metadata'], array( 'node' => $variation_data['node'] ) );
+			}
 			if ( isset( $style_variation_custom_css[ $style_variation_selector ] ) ) {
 				$block_rules .= $style_variation_custom_css[ $style_variation_selector ];
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2967,8 +2967,8 @@ class WP_Theme_JSON_Gutenberg {
 				// Only store if the variation has blockGap defined.
 				if ( isset( $style_variation_node['spacing']['blockGap'] ) ) {
 					// Append block selector to the variation selector for proper targeting.
-					$variation_metadata_with_selector = $style_variation;
-					$variation_metadata_with_selector['selector'] = $style_variation['selector'] . $block_metadata['css'];
+					$variation_metadata_with_selector                                = $style_variation;
+					$variation_metadata_with_selector['selector']                    = $style_variation['selector'] . $block_metadata['css'];
 					$style_variation_layout_metadata[ $style_variation['selector'] ] = array(
 						'metadata' => $variation_metadata_with_selector,
 						'node'     => $style_variation_node,
@@ -3155,7 +3155,7 @@ class WP_Theme_JSON_Gutenberg {
 			$block_rules .= static::to_ruleset( ":root :where($style_variation_selector)", $individual_style_variation_declarations );
 			if ( isset( $style_variation_layout_metadata[ $style_variation_selector ] ) ) {
 				$variation_data = $style_variation_layout_metadata[ $style_variation_selector ];
-				$block_rules .= $this->get_layout_styles( $variation_data['metadata'], array( 'node' => $variation_data['node'] ) );
+				$block_rules   .= $this->get_layout_styles( $variation_data['metadata'], array( 'node' => $variation_data['node'] ) );
 			}
 			if ( isset( $style_variation_custom_css[ $style_variation_selector ] ) ) {
 				$block_rules .= $style_variation_custom_css[ $style_variation_selector ];

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -358,7 +358,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 5.9.0
 	 */
 	const PROTECTED_PROPERTIES = array(
-		'spacing.blockGap' => array( 'spacing', 'blockGap' ),
+		'gap' => array( 'spacing', 'blockGap' ),
 	);
 
 	/**
@@ -2402,7 +2402,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param boolean $use_root_padding Whether to add custom properties at root level.
 	 * @return array  Returns the modified $declarations.
 	 */
-	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null ) {
+	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null, $include_protected_properties = false ) {
 		if ( empty( $styles ) ) {
 			return array();
 		}
@@ -2410,6 +2410,16 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $properties ) {
 			$properties = static::PROPERTIES_METADATA;
 		}
+
+		// Include protected properties if requested.
+		if ( $include_protected_properties ) {
+			foreach ( static::PROTECTED_PROPERTIES as $key => $value_path ) {
+				if ( ! isset( $properties[ $key ] ) ) {
+					$properties[ $key ] = $value_path;
+				}
+			}
+		}
+
 		$declarations             = array();
 		$root_variable_duplicates = array();
 		$root_style_length        = strlen( '--wp--style--root--' );
@@ -2972,7 +2982,7 @@ class WP_Theme_JSON_Gutenberg {
 					$style_variation_declarations[ $combined_selectors ] = $new_declarations;
 				}
 				// Compute declarations for remaining styles not covered by feature level selectors.
-				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
+				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json, null, null, true );
 
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
 				$block_name                    = $block_metadata['name'] ?? ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? static::get_block_name_from_metadata_path( $block_metadata ) : null );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -242,6 +242,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.3.0 Added `writing-mode` property.
 	 * @since 6.6.0 Added `background-[image|position|repeat|size]` properties.
 	 * @since 7.0.0 Added `dimensions.width` and `dimensions.height`.
+	 * @since 7.0.0 Added `gap` property.
 	 *
 	 * @var array
 	 */
@@ -310,6 +311,7 @@ class WP_Theme_JSON_Gutenberg {
 		'height'                            => array( 'dimensions', 'height' ),
 		'width'                             => array( 'dimensions', 'width' ),
 		'writing-mode'                      => array( 'typography', 'writingMode' ),
+		'gap'                               => array( 'spacing', 'blockGap' ),
 	);
 
 	/**
@@ -346,20 +348,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 	);
 
-	/**
-	 * Protected style properties.
-	 *
-	 * These style properties are only rendered if a setting enables it
-	 * via a value other than `null`.
-	 *
-	 * Each element maps the style property to the corresponding theme.json
-	 * setting key.
-	 *
-	 * @since 5.9.0
-	 */
-	const PROTECTED_PROPERTIES = array(
-		'gap' => array( 'spacing', 'blockGap' ),
-	);
+
 
 	/**
 	 * The top-level keys a theme.json can have.
@@ -2402,22 +2391,13 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param boolean $use_root_padding Whether to add custom properties at root level.
 	 * @return array  Returns the modified $declarations.
 	 */
-	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null, $include_protected_properties = false ) {
+	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null ) {
 		if ( empty( $styles ) ) {
 			return array();
 		}
 
 		if ( null === $properties ) {
 			$properties = static::PROPERTIES_METADATA;
-		}
-
-		// Include protected properties if requested.
-		if ( $include_protected_properties ) {
-			foreach ( static::PROTECTED_PROPERTIES as $key => $value_path ) {
-				if ( ! isset( $properties[ $key ] ) ) {
-					$properties[ $key ] = $value_path;
-				}
-			}
 		}
 
 		$declarations             = array();
@@ -2473,16 +2453,6 @@ class WP_Theme_JSON_Gutenberg {
 			// Skip if empty and not "0" or value represents array of longhand values.
 			$has_missing_value = empty( $value ) && ! is_numeric( $value );
 			if ( $has_missing_value || is_array( $value ) ) {
-				continue;
-			}
-
-			// Look up protected properties, keyed by value path.
-			// Skip protected properties that are explicitly set to `null`.
-			$path_string = implode( '.', $value_path );
-			if (
-				isset( static::PROTECTED_PROPERTIES[ $path_string ] ) &&
-				_wp_array_get( $settings, static::PROTECTED_PROPERTIES[ $path_string ], null ) === null
-			) {
 				continue;
 			}
 
@@ -2982,7 +2952,7 @@ class WP_Theme_JSON_Gutenberg {
 					$style_variation_declarations[ $combined_selectors ] = $new_declarations;
 				}
 				// Compute declarations for remaining styles not covered by feature level selectors.
-				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json, null, null, true );
+				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json, null, null );
 
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
 				$block_name                    = $block_metadata['name'] ?? ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? static::get_block_name_from_metadata_path( $block_metadata ) : null );
@@ -3245,7 +3215,7 @@ class WP_Theme_JSON_Gutenberg {
 			$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 		}
 
-		// Block gap styles will be output unless explicitly set to `null`. See static::PROTECTED_PROPERTIES.
+		// Block gap styles will be output unless explicitly set to `null`.
 		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
 			$css            .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2399,7 +2399,6 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $properties ) {
 			$properties = static::PROPERTIES_METADATA;
 		}
-
 		$declarations             = array();
 		$root_variable_duplicates = array();
 		$root_style_length        = strlen( '--wp--style--root--' );
@@ -2917,9 +2916,9 @@ class WP_Theme_JSON_Gutenberg {
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
 		// If there are style variations, generate the declarations for them, including any feature selectors the block may have.
-		$style_variation_declarations        = array();
-		$style_variation_custom_css          = array();
-		$style_variation_layout_metadata     = array();
+		$style_variation_declarations    = array();
+		$style_variation_custom_css      = array();
+		$style_variation_layout_metadata = array();
 		if ( ! empty( $block_metadata['variations'] ) ) {
 			foreach ( $block_metadata['variations'] as $style_variation ) {
 				$style_variation_node           = _wp_array_get( $this->theme_json, $style_variation['path'], array() );

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -243,6 +243,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		},
 		useEngine: true,
 	},
+	gap: {
+		value: [ 'spacing', 'blockGap' ],
+		support: [ 'spacing', 'blockGap' ],
+	},
 	textAlign: {
 		value: [ 'typography', 'textAlign' ],
 		support: [ 'typography', 'textAlign' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -243,10 +243,6 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		},
 		useEngine: true,
 	},
-	gap: {
-		value: [ 'spacing', 'blockGap' ],
-		support: [ 'spacing', 'blockGap' ],
-	},
 	textAlign: {
 		value: [ 'typography', 'textAlign' ],
 		support: [ 'typography', 'textAlign' ],

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -4,6 +4,8 @@
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
+	getBlockSupport,
+	getBlockTypes,
 	store as blocksStore,
 	// @ts-expect-error - @wordpress/blocks module doesn't have TypeScript declarations
 } from '@wordpress/blocks';
@@ -1469,7 +1471,7 @@ export const getBlockSelectors = (
 		// Keep backwards compatibility for support.color.__experimentalDuotone.
 		if ( ! duotoneSelector ) {
 			const rootSelector = getBlockSelector( blockType );
-			const duotoneSupport = select( blocksStore ).getBlockSupport(
+			const duotoneSupport = getBlockSupport(
 				blockType,
 				'color.__experimentalDuotone',
 				false
@@ -1649,10 +1651,7 @@ export function generateGlobalStyles(
 	} = options;
 
 	// Use provided block types or fall back to getBlockTypes()
-	const blocks =
-		blockTypes.length > 0
-			? blockTypes
-			: select( blocksStore ).getBlockTypes();
+	const blocks = blockTypes.length > 0 ? blockTypes : getBlockTypes();
 
 	const blockGap = getSetting( config, 'spacing.blockGap' );
 	const hasBlockGapSupport = hasBlockGapSupportOption ?? blockGap !== null;

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -833,6 +833,10 @@ export const getNodesWithStyles = (
 			const blockStyles = pickStyleKeys( node );
 			const typedNode = node as BlockNode;
 
+			// Store variation data for later processing, but don't add to nodes yet.
+			// Variations should be processed AFTER the main block styles to match PHP order.
+			const variationNodesToAdd: typeof nodes = [];
+
 			if ( typedNode?.variations ) {
 				const variations: Record< string, any > = {};
 				Object.entries( typedNode.variations ).forEach(
@@ -860,7 +864,7 @@ export const getNodesWithStyles = (
 							typedVariation?.elements ?? {}
 						).forEach( ( [ element, elementStyles ] ) => {
 							if ( elementStyles && ELEMENTS[ element ] ) {
-								nodes.push( {
+								variationNodesToAdd.push( {
 									styles: elementStyles,
 									selector: scopeSelector(
 										variationSelector,
@@ -919,7 +923,7 @@ export const getNodesWithStyles = (
 									return;
 								}
 
-								nodes.push( {
+								variationNodesToAdd.push( {
 									selector: variationBlockSelector,
 									duotoneSelector: variationDuotoneSelector,
 									featureSelectors: variationFeatureSelectors,
@@ -945,7 +949,7 @@ export const getNodesWithStyles = (
 											variationBlockElementStyles &&
 											ELEMENTS[ variationBlockElement ]
 										) {
-											nodes.push( {
+											variationNodesToAdd.push( {
 												styles: variationBlockElementStyles,
 												selector: scopeSelector(
 													variationBlockSelector,
@@ -1009,6 +1013,10 @@ export const getNodesWithStyles = (
 					}
 				}
 			);
+
+			// Add variation nodes AFTER the main block and its elements
+			// to match PHP processing order.
+			nodes.push( ...variationNodesToAdd );
 		}
 	);
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -4,8 +4,6 @@
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
-	getBlockSupport,
-	getBlockTypes,
 	store as blocksStore,
 	// @ts-expect-error - @wordpress/blocks module doesn't have TypeScript declarations
 } from '@wordpress/blocks';
@@ -1308,6 +1306,22 @@ export const transformToStyles = (
 										`:root :where(${ styleVariationSelector })`
 									);
 								}
+								// Generate layout styles for the variation if it supports layout and has blockGap defined.
+								if (
+									hasLayoutSupport &&
+									styleVariations?.spacing?.blockGap
+								) {
+									// Append block selector to variation selector so layout classes are properly constructed.
+									const variationSelectorWithBlock =
+										styleVariationSelector + selector;
+									ruleset += getLayoutStyles( {
+										style: styleVariations,
+										selector: variationSelectorWithBlock,
+										hasBlockGapSupport: true,
+										hasFallbackGapSupport,
+										fallbackGapValue,
+									} );
+								}
 							}
 						}
 					);
@@ -1455,7 +1469,7 @@ export const getBlockSelectors = (
 		// Keep backwards compatibility for support.color.__experimentalDuotone.
 		if ( ! duotoneSelector ) {
 			const rootSelector = getBlockSelector( blockType );
-			const duotoneSupport = getBlockSupport(
+			const duotoneSupport = select( blocksStore ).getBlockSupport(
 				blockType,
 				'color.__experimentalDuotone',
 				false
@@ -1635,7 +1649,10 @@ export function generateGlobalStyles(
 	} = options;
 
 	// Use provided block types or fall back to getBlockTypes()
-	const blocks = blockTypes.length > 0 ? blockTypes : getBlockTypes();
+	const blocks =
+		blockTypes.length > 0
+			? blockTypes
+			: select( blocksStore ).getBlockTypes();
 
 	const blockGap = getSetting( config, 'spacing.blockGap' );
 	const hasBlockGapSupport = hasBlockGapSupportOption ?? blockGap !== null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #72318.

<details>
<summary>previous description</summary>

Essentially, block gap styles get left out of block style variation stylesheets because block gap isn't included in `PROPERTIES_METADATA` that gets iterated through when generating the stylesheet. Instead, block gap exists by itself in a `PROTECTED_PROPERTIES` array.

(I'm not sure what the history behind `PROTECTED_PROPERTIES` is; gap is unique in its dependency on layout styles, that are output separately from other block supports, but `PROTECTED_PROPERTIES` doesn't seem to be doing much at present.)

This PR fixes the issue by adding an optional `$include_protected_properties` flag to `compute_style_properties` which, if set, includes those properties in with the regular properties to be computed.

It also adds the block gap setting to the block style variations config, without which block gap styles aren't output (this might be related to the reason block gap is a protected property)

For styles to be generated in the editor as well as on the front end, I also had to add gap to `__EXPERIMENTAL_STYLE_PROPERTY`. If we think it makes sense to keep the PHP `PROTECTED_PROPERTIES` around, it might be worth reflecting this construction on the JS side too.

I'm not too certain about this solution, so feedback and ideas very welcome!

</details>

I've iterated a bit and finally arrived at a solution that seems satisfactory 😅 

It ended up not being necessary to add gap to `PROPERTIES_METADATA` but I'm removing `PROTECTED_PROPERTIES` all the same because it's not needed anymore.

What this PR now does is generate layout styles for block style variations and section styles that have a blockGap defined. In order for this to work correctly, I had to fiddle a bit with the selectors, because the order they're output in (for valid reasons, namely the Paragraph block has an element selector instead of a classname) is `.block-selector.variation-selector`, but for layout style generation we need block selector to come last, so we can append the layout type classname extension to it. So I added another block selector to the end: `.block-selector.variation-selector.block-selector`, which after the layouts are processed becomes something like `.block-selector.variation-selector.block-selector-is-layout-flex`. This shouldn't cause any problems in the scenario that the classnames were originally ordered for, because Paragraph blocks don't support layout.

I also had to switch the output order of theme style variations and section styles in the editor code, because it was different from the front end and resulted in higher-level theme styles overriding section styles. The editor order now matches the front end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. in your block theme folder, under styles > blocks, add a file with something like:

```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Gaplesss",
	"slug": "gapless",
	"blockTypes": ["core/group"],
	"styles": {
		"spacing": {
			"blockGap": "1px"
		}
	}
}
```

2. if your theme has any section styles, you can also try adding the following in one of the section style files, under styles > blocks:

```
"core/group": {
				"spacing": {
					"blockGap": "3px"
				}
			}
```

3. If your theme has theme style variations, try adding the following to an inactive variation:

```
"core/group": {
				"spacing": {
					"blockGap": "5px"
				}
			}
```
and then activate it.

Then, add some Group blocks using these section styles and variations to a post, nest a few of them, make use of all the different layout types (gap should apply to flex and grid as `gap` on the container, and to flow/constrained layouts as `margin-block-start` on the children)  and check that they render correctly in the editor. Save, and check the front end. 

(Be mindful that for the section styles, the above style snippet will apply only to a group _within_ the section, not to the section wrapper)

In the screenshot, the Paragraph margin is determined by a section style, which overrides a theme style variation:


<img width="1496" height="700" alt="Screenshot 2026-01-15 at 6 11 07 pm" src="https://github.com/user-attachments/assets/5047f25d-e401-404f-ac5d-4e0be660d0d0" />

