### PR TITLE
Fully resolve some intra-package import paths

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/block-editor/src/components/block-bindings/source-fields-list.js
+++ b/packages/block-editor/src/components/block-bindings/source-fields-list.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -54,6 +54,7 @@
 -   `AnglePickerControl`: Migrate styles from Emotion to a CSS module ([#73786](https://github.com/WordPress/gutenberg/pull/73786)).
 -   `Menu`: Clean up popover wrappers ([#74207](https://github.com/WordPress/gutenberg/pull/74207)).
 -   `Button`, `DateCalendar`, `DateRangeCalendar`, `CheckboxControl`, `Panel`, `Placeholder`: Remove outdated vendor prefix properties in CSS ([#74213](https://github.com/WordPress/gutenberg/pull/74213)).
+-    Updated `fast-deep-equal` imports for compatibility with strict Node.js resolution ([#74530](https://github.com/WordPress/gutenberg/pull/74530)).
 
 ## 30.9.0 (2025-11-26)
 

--- a/packages/components/src/context/context-system-provider.js
+++ b/packages/components/src/context/context-system-provider.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deepmerge from 'deepmerge';
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 import { isPlainObject } from 'is-plain-object';
 
 /**

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/components/src/higher-order/with-fallback-styles/index.tsx
+++ b/packages/components/src/higher-order/with-fallback-styles/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import Mousetrap from 'mousetrap';
-import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
+import 'mousetrap/plugins/global-bind/mousetrap-global-bind.js';
 
 /**
  * WordPress dependencies

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 import { v4 as uuid } from 'uuid';
 
 /**

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/core-data/src/utils/conservative-map-item.js
+++ b/packages/core-data/src/utils/conservative-map-item.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * Given the current and next item entity record, returns the minimally "modified"

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/use-sidebar-block-editor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update DataForm stories. [#74196](https://github.com/WordPress/gutenberg/pull/74196)
 - Fix missing dependencies. [#74310](https://github.com/WordPress/gutenberg/pull/74310)
 - Add details layout to DataForm validation story. [#74445](https://github.com/WordPress/gutenberg/pull/74445)
+- Updated `fast-deep-equal` imports for compatibility with strict Node.js resolution ([#74530](https://github.com/WordPress/gutenberg/pull/74530))
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deepMerge from 'deepmerge';
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -4,7 +4,7 @@
 import type { Moment } from 'moment';
 import momentLib from 'moment';
 import 'moment-timezone/moment-timezone';
-import 'moment-timezone/moment-timezone-utils';
+import 'moment-timezone/moment-timezone-utils.js';
 
 /**
  * WordPress dependencies

--- a/packages/global-styles-engine/src/core/equal.ts
+++ b/packages/global-styles-engine/src/core/equal.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import fastDeepEqual from 'fast-deep-equal/es6';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * Internal dependencies

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -233,16 +233,12 @@ function momentTimezoneAliasPlugin() {
 
 			// Cached paths - resolved lazily on first use
 			let preBuiltBundlePath;
-			let momentTimezoneUtilsPath;
 			const resolvePaths = () => {
 				if ( preBuiltBundlePath ) {
 					return;
 				}
 				preBuiltBundlePath = require.resolve(
-					'moment-timezone/builds/moment-timezone-with-data-1970-2030'
-				);
-				momentTimezoneUtilsPath = require.resolve(
-					'moment-timezone/moment-timezone-utils.js'
+					'moment-timezone/builds/moment-timezone-with-data-1970-2030.js'
 				);
 			};
 
@@ -252,17 +248,6 @@ function momentTimezoneAliasPlugin() {
 				() => {
 					resolvePaths();
 					return { path: preBuiltBundlePath };
-				}
-			);
-
-			// For utils, we need to load it but ensure it works with the pre-built bundle.
-			// The utils file tries to require('./') which would load index.js.
-			// We need to make sure it gets the pre-built bundle instead.
-			build.onResolve(
-				{ filter: /^moment-timezone\/moment-timezone-utils$/ },
-				() => {
-					resolvePaths();
-					return { path: momentTimezoneUtilsPath };
 				}
 			);
 


### PR DESCRIPTION
This PR resolves some import package paths to full file names, so that they are compliant with strict Node.js resolution. Which doesn't do any expansion of directory names to `index.js` or auto-appending the `.js` extension.

This is required for seamless adoption in Jetpack. The affected packages (`fast-deep-equal`, `mousetrap`, `moment-timezone`) don't have `exports` field that would define the "deep" exports, and we are doing imports from "deep" paths for them.

I'm not very happy with this PR, as there are some open problems. Maybe the resolution should be a part of the transpilation process. And we should have some linting in place, too, so that we don't introduce similar problems again. But I'm not sure right now how to approach this.
