### PR TITLE
Disables visibility support for the More and  Page Break block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -520,7 +520,7 @@ Content before this block will be shown in the excerpt on your archives page. ([
 
 -	**Name:** core/more
 -	**Category:** design
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~multiple~~, ~~visibility~~
 -	**Attributes:** customText, noTeaser
 
 ## Navigation
@@ -571,7 +571,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Name:** core/nextpage
 -	**Category:** design
 -	**Parent:** core/post-content
--	**Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~
+-	**Supports:** anchor, interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 
 ## Page List
 

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -23,6 +23,7 @@
 		"className": false,
 		"html": false,
 		"multiple": false,
+		"visibility": false,
 		"interactivity": {
 			"clientNavigation": true
 		}

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -13,6 +13,7 @@
 		"customClassName": false,
 		"className": false,
 		"html": false,
+		"visibility": false,
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74439

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Page Break and More blocks don't support visibility, so we're disabling support for them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Go to post or page
2. Place the More and Page Break block
3. You can confirm that the Hide button does not appear even when clicking on the toolbar options.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="581" height="459" alt="before-more" src="https://github.com/user-attachments/assets/11165c91-57be-478e-b69e-89b0524e81d7" /> | <img width="578" height="428" alt="after-more" src="https://github.com/user-attachments/assets/291adbed-178c-4715-9d5d-b851b6529e8e" /> |
| <img width="576" height="467" alt="before-page" src="https://github.com/user-attachments/assets/8c4d1215-a356-4f8b-b48f-b26c02b533c7" /> | <img width="573" height="427" alt="after-page" src="https://github.com/user-attachments/assets/493fcd86-ad9e-4780-919e-8431d402def0" /> |
