### PR TITLE
Block Fields: Remove normalization code and tidy up

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -106,22 +106,10 @@ function BlockFields( {
 		return blockTypeFields.map( ( fieldDef ) => {
 			const ControlComponent = CONTROLS[ fieldDef.type ];
 
-			const defaultValues = {};
-			if ( fieldDef.mapping && blockType?.attributes ) {
-				Object.entries( fieldDef.mapping ).forEach(
-					( [ key, attrKey ] ) => {
-						defaultValues[ key ] =
-							blockType.attributes[ attrKey ]?.defaultValue ??
-							undefined;
-					}
-				);
-			}
-
 			const field = {
 				id: fieldDef.id,
 				label: fieldDef.label,
 				type: fieldDef.type, // Use the field's type; DataForm will use built-in or custom Edit
-				config: { ...fieldDef.args, defaultValues },
 				hideLabelFromVision: fieldDef.id === 'content',
 			};
 
@@ -159,7 +147,7 @@ function BlockFields( {
 
 			return field;
 		} );
-	}, [ blockTypeFields, blockType?.attributes, clientId ] );
+	}, [ blockTypeFields, clientId ] );
 
 	const handleToggleField = ( fieldId ) => {
 		setForm( ( prev ) => {

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -107,7 +107,6 @@ function BlockFields( {
 				id: fieldDef.id,
 				label: fieldDef.label,
 				type: fieldDef.type, // Use the field's type; DataForm will use built-in or custom Edit
-				hideLabelFromVision: fieldDef.id === 'content',
 			};
 
 			if ( fieldDef.mapping ) {

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -150,6 +150,12 @@ function BlockFields( {
 		} );
 	}, [ blockTypeFields, clientId ] );
 
+	if ( ! blockTypeFields?.length ) {
+		// TODO - we might still want to show a placeholder for blocks with no fields.
+		// for example, a way to select the block.
+		return null;
+	}
+
 	const handleToggleField = ( fieldId ) => {
 		setForm( ( prev ) => {
 			if ( prev.fields?.includes( fieldId ) ) {
@@ -165,12 +171,6 @@ function BlockFields( {
 			};
 		} );
 	};
-
-	if ( ! blockTypeFields?.length ) {
-		// TODO - we might still want to show a placeholder for blocks with no fields.
-		// for example, a way to select the block.
-		return null;
-	}
 
 	return (
 		<div className="block-editor-block-fields__container">

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -57,120 +57,6 @@ function createConfiguredControl( config ) {
 }
 
 /**
- * Normalize a media value to a canonical structure.
- * Only includes properties that are present in the field's mapping (if provided).
- *
- * @param {Object} value    - The mapped value from the block attributes (with canonical keys)
- * @param {Object} fieldDef - Optional field definition containing the mapping
- * @return {Object} Normalized media value with canonical properties
- */
-function normalizeMediaValue( value, fieldDef ) {
-	const defaults = {
-		id: null,
-		url: '',
-		caption: '',
-		alt: '',
-		type: 'image',
-		poster: '',
-		featuredImage: false,
-		link: '',
-	};
-
-	const result = {};
-
-	// If there's a mapping, only include properties that are in it
-	if ( fieldDef?.mapping ) {
-		Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-			result[ key ] = value?.[ key ] ?? defaults[ key ] ?? '';
-		} );
-		return result;
-	}
-
-	// Without mapping, include all default properties
-	Object.keys( defaults ).forEach( ( key ) => {
-		result[ key ] = value?.[ key ] ?? defaults[ key ];
-	} );
-	return result;
-}
-
-/**
- * Denormalize a media value from canonical structure back to mapped keys.
- * Only includes properties that are present in the field's mapping.
- *
- * @param {Object} value    - The normalized media value
- * @param {Object} fieldDef - The field definition containing the mapping
- * @return {Object} Value with only mapped properties
- */
-function denormalizeMediaValue( value, fieldDef ) {
-	if ( ! fieldDef.mapping ) {
-		return value;
-	}
-
-	const result = {};
-	Object.entries( fieldDef.mapping ).forEach( ( [ key ] ) => {
-		if ( key in value ) {
-			result[ key ] = value[ key ];
-		}
-	} );
-	return result;
-}
-
-/**
- * Normalize a link value to a canonical structure.
- * Only includes properties that are present in the field's mapping (if provided).
- *
- * @param {Object} value    - The mapped value from the block attributes (with canonical keys)
- * @param {Object} fieldDef - Optional field definition containing the mapping
- * @return {Object} Normalized link value with canonical properties
- */
-function normalizeLinkValue( value, fieldDef ) {
-	const defaults = {
-		url: '',
-		rel: '',
-		linkTarget: '',
-		destination: '',
-	};
-
-	const result = {};
-
-	// If there's a mapping, only include properties that are in it
-	if ( fieldDef?.mapping ) {
-		Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-			result[ key ] = value?.[ key ] ?? defaults[ key ] ?? '';
-		} );
-		return result;
-	}
-
-	// Without mapping, include all default properties
-	Object.keys( defaults ).forEach( ( key ) => {
-		result[ key ] = value?.[ key ] ?? defaults[ key ];
-	} );
-	return result;
-}
-
-/**
- * Denormalize a link value from canonical structure back to mapped keys.
- * Only includes properties that are present in the field's mapping.
- *
- * @param {Object} value    - The normalized link value
- * @param {Object} fieldDef - The field definition containing the mapping
- * @return {Object} Value with only mapped properties
- */
-function denormalizeLinkValue( value, fieldDef ) {
-	if ( ! fieldDef.mapping ) {
-		return value;
-	}
-
-	const result = {};
-	Object.entries( fieldDef.mapping ).forEach( ( [ key ] ) => {
-		if ( key in value ) {
-			result[ key ] = value[ key ];
-		}
-	} );
-	return result;
-}
-
-/**
  * Component that renders a DataForm for a single block's attributes
  * @param {Object}   props
  * @param {string}   props.clientId      The clientId of the block.
@@ -237,67 +123,29 @@ function BlockFields( {
 				type: fieldDef.type, // Use the field's type; DataForm will use built-in or custom Edit
 				config: { ...fieldDef.args, defaultValues },
 				hideLabelFromVision: fieldDef.id === 'content',
-				// getValue and setValue handle the mapping to block attributes
-				getValue: ( { item } ) => {
-					if ( fieldDef.mapping ) {
-						// Extract mapped properties from the block attributes
-						const mappedValue = {};
-						Object.entries( fieldDef.mapping ).forEach(
-							( [ key, attrKey ] ) => {
-								mappedValue[ key ] = item[ attrKey ];
-							}
-						);
-
-						// Normalize to canonical structure based on field type
-						if ( fieldDef.type === 'media' ) {
-							return normalizeMediaValue( mappedValue, fieldDef );
-						}
-						if ( fieldDef.type === 'link' ) {
-							return normalizeLinkValue( mappedValue, fieldDef );
-						}
-
-						// For other types, return as-is
-						return mappedValue;
-					}
-					// For simple id-based fields, use the id as the attribute key
-					return item[ fieldDef.id ];
-				},
-				setValue: ( { item, value } ) => {
-					if ( fieldDef.mapping ) {
-						// Denormalize from canonical structure back to mapped keys
-						let denormalizedValue = value;
-						if ( fieldDef.type === 'media' ) {
-							denormalizedValue = denormalizeMediaValue(
-								value,
-								fieldDef
-							);
-						} else if ( fieldDef.type === 'link' ) {
-							denormalizedValue = denormalizeLinkValue(
-								value,
-								fieldDef
-							);
-						}
-
-						// Build an object with all mapped attributes
-						const updates = {};
-						Object.entries( fieldDef.mapping ).forEach(
-							( [ key, attrKey ] ) => {
-								// If key is explicitly in value, use it (even if undefined to allow clearing)
-								// Otherwise, preserve the old value
-								if ( key in denormalizedValue ) {
-									updates[ attrKey ] =
-										denormalizedValue[ key ];
-								} else {
-									updates[ attrKey ] = item[ attrKey ];
-								}
-							}
-						);
-						return updates;
-					}
-					// For simple id-based fields, use the id as the attribute key
-					return { [ fieldDef.id ]: value };
-				},
 			};
+
+			if ( fieldDef.mapping ) {
+				field.getValue = ( { item } ) => {
+					// Extract mapped properties from the block attributes
+					const mappedValue = {};
+					Object.entries( fieldDef.mapping ).forEach(
+						( [ key, attrKey ] ) => {
+							mappedValue[ key ] = item[ attrKey ];
+						}
+					);
+					return mappedValue;
+				};
+				field.setValue = ( { value } ) => {
+					const attributeUpdates = {};
+					Object.entries( fieldDef.mapping ).forEach(
+						( [ key, attrKey ] ) => {
+							attributeUpdates[ attrKey ] = value[ key ];
+						}
+					);
+					return attributeUpdates;
+				};
+			}
 
 			// Only add custom Edit component if one exists for this type
 			if ( ControlComponent ) {

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -39,20 +39,19 @@ const CONTROLS = {
  * Creates a configured control component that wraps a custom control
  * and passes configuration as props.
  *
- * @param {Object} config         - The control configuration
- * @param {string} config.control - The control type (key in CONTROLS map)
+ * @param {Component} ControlComponent The React component for the control.
+ * @param {string}    type             The type of control.
+ * @param {Object}    config           The control configuration passed as a prop.
+ *
  * @return {Function} A wrapped control component
  */
-function createConfiguredControl( config ) {
-	const { control, ...controlConfig } = config;
-	const ControlComponent = CONTROLS[ control ];
-
+function createConfiguredControl( ControlComponent, type, config ) {
 	if ( ! ControlComponent ) {
-		throw new Error( `Control type "${ control }" not found` );
+		throw new Error( `Control type "${ type }" not found` );
 	}
 
 	return function ConfiguredControl( props ) {
-		return <ControlComponent { ...props } config={ controlConfig } />;
+		return <ControlComponent { ...props } config={ config } />;
 	};
 }
 
@@ -104,8 +103,6 @@ function BlockFields( {
 		}
 
 		return blockTypeFields.map( ( fieldDef ) => {
-			const ControlComponent = CONTROLS[ fieldDef.type ];
-
 			const field = {
 				id: fieldDef.id,
 				label: fieldDef.label,
@@ -136,13 +133,17 @@ function BlockFields( {
 			}
 
 			// Only add custom Edit component if one exists for this type
+			const ControlComponent = CONTROLS[ fieldDef.type ];
 			if ( ControlComponent ) {
 				// Use EditConfig pattern: Edit is an object with control type and config props
-				field.Edit = createConfiguredControl( {
-					control: fieldDef.type,
-					clientId,
-					fieldDef,
-				} );
+				field.Edit = createConfiguredControl(
+					ControlComponent,
+					fieldDef.type,
+					{
+						clientId,
+						fieldDef,
+					}
+				);
 			}
 
 			return field;

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -109,6 +109,12 @@ function BlockFields( {
 				type: fieldDef.type, // Use the field's type; DataForm will use built-in or custom Edit
 			};
 
+			// If the field defines a `mapping`, then custom `getValue` and `setValue`
+			// implementations are provided.
+			// These functions map from the inconsistent attribute keys found on blocks
+			// to consistent keys that the field can use internally (and back again).
+			// When `mapping` isn't provided, we can use the field API's default
+			// implementation of these functions.
 			if ( fieldDef.mapping ) {
 				field.getValue = ( { item } ) => {
 					// Extract mapped properties from the block attributes

--- a/packages/block-editor/src/hooks/block-fields/link/index.js
+++ b/packages/block-editor/src/hooks/block-fields/link/index.js
@@ -73,11 +73,6 @@ export default function Link( { data, field, onChange, config = {} } ) {
 		isControl: true,
 	} );
 	const { fieldDef } = config;
-	const updateAttributes = ( newValue ) => {
-		const mappedChanges = field.setValue( { item: data, value: newValue } );
-		onChange( mappedChanges );
-	};
-
 	const value = field.getValue( { item: data } );
 	const url = value?.url;
 	const rel = value?.rel || '';
@@ -145,30 +140,12 @@ export default function Link( { data, field, onChange, config = {} } ) {
 								...newValues,
 							} );
 
-							// Build update object dynamically based on what's in the mapping
-							const updateValue = { ...value };
-
-							if ( fieldDef?.mapping ) {
-								Object.keys( fieldDef.mapping ).forEach(
-									( key ) => {
-										if ( key === 'href' || key === 'url' ) {
-											updateValue[ key ] =
-												updatedAttrs.url;
-										} else if ( key === 'rel' ) {
-											updateValue[ key ] =
-												updatedAttrs.rel;
-										} else if (
-											key === 'target' ||
-											key === 'linkTarget'
-										) {
-											updateValue[ key ] =
-												updatedAttrs.linkTarget;
-										}
-									}
-								);
-							}
-
-							updateAttributes( updateValue );
+							onChange(
+								field.setValue( {
+									item: data,
+									value: updatedAttrs,
+								} )
+							);
 						} }
 						onRemove={ () => {
 							// Remove all link-related properties based on what's in the mapping
@@ -177,20 +154,17 @@ export default function Link( { data, field, onChange, config = {} } ) {
 							if ( fieldDef?.mapping ) {
 								Object.keys( fieldDef.mapping ).forEach(
 									( key ) => {
-										if (
-											key === 'href' ||
-											key === 'url' ||
-											key === 'rel' ||
-											key === 'target' ||
-											key === 'linkTarget'
-										) {
-											removeValue[ key ] = undefined;
-										}
+										removeValue[ key ] = undefined;
 									}
 								);
 							}
 
-							updateAttributes( removeValue );
+							onChange(
+								field.setValue( {
+									item: data,
+									value: removeValue,
+								} )
+							);
 						} }
 					/>
 				</Popover>

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -24,9 +24,9 @@ import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement
 import { getMediaSelectKey } from '../../../store/private-keys';
 import { store as blockEditorStore } from '../../../store';
 
-function MediaThumbnail( { data, field, attachment } ) {
-	const config = field.config || {};
-	const { allowedTypes = [], multiple = false } = config;
+function MediaThumbnail( { data, field, attachment, config } ) {
+	const { fieldDef } = config;
+	const { allowedTypes = [], multiple = false } = fieldDef.args || {};
 
 	if ( multiple ) {
 		return 'todo multiple';
@@ -53,7 +53,7 @@ function MediaThumbnail( { data, field, attachment } ) {
 		const value = field.getValue( { item: data } );
 		const url = value?.url;
 
-		if ( url ) {
+		if ( allowedTypes[ 0 ] === 'image' && url ) {
 			return (
 				<div className="block-editor-content-only-controls__media-thumbnail">
 					<img alt="" width={ 24 } height={ 24 } src={ url } />
@@ -208,6 +208,7 @@ export default function Media( { data, field, onChange, config = {} } ) {
 										attachment={ attachment }
 										field={ field }
 										data={ data }
+										config={ config }
 									/>
 									<span className="block-editor-content-only-controls__media-title">
 										{

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -85,8 +85,8 @@ export default function Media( { data, field, onChange, config = {} } ) {
 		isControl: true,
 	} );
 	const value = field.getValue( { item: data } );
-	const { allowedTypes = [], multiple = false } = field.config || {};
 	const { fieldDef } = config;
+	const { allowedTypes = [], multiple = false } = fieldDef.args || {};
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -87,13 +87,6 @@ export default function Media( { data, field, onChange, config = {} } ) {
 	const value = field.getValue( { item: data } );
 	const { allowedTypes = [], multiple = false } = field.config || {};
 	const { fieldDef } = config;
-	const updateAttributes = ( newFieldValue ) => {
-		const mappedChanges = field.setValue( {
-			item: data,
-			value: newFieldValue,
-		} );
-		onChange( mappedChanges );
-	};
 
 	// Check if featured image is supported by checking if it's in the mapping
 	const hasFeaturedImageSupport =
@@ -152,51 +145,32 @@ export default function Media( { data, field, onChange, config = {} } ) {
 
 					if ( fieldDef?.mapping ) {
 						Object.keys( fieldDef.mapping ).forEach( ( key ) => {
-							if (
-								key === 'id' ||
-								key === 'src' ||
-								key === 'url'
-							) {
-								resetValue[ key ] = undefined;
-							} else if ( key === 'caption' || key === 'alt' ) {
-								resetValue[ key ] = '';
-							}
+							resetValue[ key ] = undefined;
 						} );
 					}
 
-					// Turn off featured image when resetting (only if it's in the mapping)
-					if ( hasFeaturedImageSupport ) {
-						resetValue.featuredImage = false;
-					}
-
-					// Merge with existing value to preserve other field properties
-					updateAttributes( { ...value, ...resetValue } );
+					onChange(
+						field.setValue( {
+							item: data,
+							value: resetValue,
+						} )
+					);
 				} }
 				{ ...( hasFeaturedImageSupport && {
 					useFeaturedImage: !! value?.featuredImage,
 					onToggleFeaturedImage: () => {
-						updateAttributes( {
-							...value,
-							featuredImage: ! value?.featuredImage,
-						} );
+						onChange(
+							field.setValue( {
+								item: data,
+								value: {
+									featuredImage: ! value?.featuredImage,
+								},
+							} )
+						);
 					},
 				} ) }
 				onSelect={ ( selectedMedia ) => {
 					if ( selectedMedia.id && selectedMedia.url ) {
-						// Determine mediaType from MIME type, not from object type
-						let mediaType = 'image'; // default
-						if ( selectedMedia.mime_type ) {
-							if (
-								selectedMedia.mime_type.startsWith( 'video/' )
-							) {
-								mediaType = 'video';
-							} else if (
-								selectedMedia.mime_type.startsWith( 'audio/' )
-							) {
-								mediaType = 'audio';
-							}
-						}
-
 						// Build new value dynamically based on what's in the mapping
 						const newValue = {};
 
@@ -204,38 +178,13 @@ export default function Media( { data, field, onChange, config = {} } ) {
 						if ( fieldDef?.mapping ) {
 							Object.keys( fieldDef.mapping ).forEach(
 								( key ) => {
-									if ( key === 'id' ) {
-										newValue[ key ] = selectedMedia.id;
-									} else if (
-										key === 'src' ||
-										key === 'url'
-									) {
-										newValue[ key ] = selectedMedia.url;
-									} else if ( key === 'type' ) {
-										newValue[ key ] = mediaType;
-									} else if (
-										key === 'link' &&
-										selectedMedia.link
-									) {
-										newValue[ key ] = selectedMedia.link;
-									} else if (
-										key === 'caption' &&
-										! value?.caption &&
-										selectedMedia.caption
-									) {
-										newValue[ key ] = selectedMedia.caption;
-									} else if (
-										key === 'alt' &&
-										! value?.alt &&
-										selectedMedia.alt
-									) {
-										newValue[ key ] = selectedMedia.alt;
-									} else if (
-										key === 'poster' &&
-										selectedMedia.poster
-									) {
-										newValue[ key ] = selectedMedia.poster;
+									// Handle weird camel-casing.
+									if ( key === 'mediaType' ) {
+										newValue[ key ] =
+											selectedMedia.media_type;
+										return;
 									}
+									newValue[ key ] = selectedMedia[ key ];
 								}
 							);
 						}
@@ -245,9 +194,12 @@ export default function Media( { data, field, onChange, config = {} } ) {
 							newValue.featuredImage = false;
 						}
 
-						// Merge with existing value to preserve other field properties
-						const finalValue = { ...value, ...newValue };
-						updateAttributes( finalValue );
+						onChange(
+							field.setValue( {
+								item: data,
+								value: newValue,
+							} )
+						);
 					}
 				} }
 				renderToggle={ ( buttonProps ) => (

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -172,22 +172,10 @@ export default function Media( { data, field, onChange, config = {} } ) {
 				onSelect={ ( selectedMedia ) => {
 					if ( selectedMedia.id && selectedMedia.url ) {
 						// Build new value dynamically based on what's in the mapping
-						const newValue = {};
-
-						// Iterate over mapping keys and set values for supported properties
-						if ( fieldDef?.mapping ) {
-							Object.keys( fieldDef.mapping ).forEach(
-								( key ) => {
-									// Handle weird camel-casing.
-									if ( key === 'mediaType' ) {
-										newValue[ key ] =
-											selectedMedia.media_type;
-										return;
-									}
-									newValue[ key ] = selectedMedia[ key ];
-								}
-							);
-						}
+						const newValue = {
+							...selectedMedia,
+							mediaType: selectedMedia.media_type,
+						};
 
 						// Turn off featured image when manually selecting media
 						if ( hasFeaturedImageSupport ) {

--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -33,10 +33,6 @@ export default function RichTextControl( {
 	const attrValue = field.getValue( { item: data } );
 	const fieldConfig = field.config || {};
 	const { clientId } = config;
-	const updateAttributes = ( html ) => {
-		const mappedChanges = field.setValue( { item: data, value: html } );
-		onChange( mappedChanges );
-	};
 	const [ selection, setSelection ] = useState( {
 		start: undefined,
 		end: undefined,
@@ -107,7 +103,7 @@ export default function RichTextControl( {
 	} = useRichText( {
 		value: attrValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
-			updateAttributes( html );
+			onChange( field.setValue( { item: data, value: html } ) );
 			Object.values( changeHandlers ).forEach( ( changeHandler ) => {
 				changeHandler( __unstableFormats, __unstableText );
 			} );

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -67,7 +67,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Background' ),
 			type: 'media',
 			mapping: {
-				type: 'backgroundType',
+				mediaType: 'backgroundType',
 				id: 'id',
 				url: 'url',
 				alt: 'alt',

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -62,7 +62,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			type: 'media',
 			mapping: {
 				id: 'mediaId',
-				type: 'mediaType',
+				mediaType: 'mediaType',
 				url: 'mediaUrl',
 				link: 'mediaLink',
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a fairly substantial code quality PR for Block Fields, based on some discoveries made while working on a more experimental PR -  #74435.

Also fixes a couple of small issues, so I've labelled it a bug fix.

Let me know if you'd like to break it up and I can try, but some of the changes are based on some of the other changes, so I found it easier to roll it into one PR.

## Why?
The goal of this PR is to move a few steps closer to the regular DataForm API and remove any special code.

## How?
Removals:
- `normalizeMediaValue`, `denormalizeMediaValue`, `normalizeLinkValue`, `denormalizeLinkValue` - I found these function are largely doubling up work that was already being done (in `field.setValue` and `field.getValue`), so they're removed.
- `hideLabelFromVision` - As discovered in #74486, this property doesn't do anything, so it's now removed.
- `field.config` - I found that this property also doesn't do anything, the config is passed through via `createConfiguredControl`.
- `config.defaultValues` - I've removed all handling of `defaultValues`. I've realized that it's much easier to unset attribute values using `undefined` instead, the block itself will then pass its default. 💡 

Small changes:
- `field.getValue` / `field.setValue` - these functions can be simplified by only setting them on the `field` object when `mapping` exists. When `mapping` doesn't exist we can use the default implementation that the fields api provides.
- `createConfiguredControl` - I've changed the function signature slightly, I found it makes it a little easier to read.
- Remove as much use of `mapping` within the controls as possible. `mapping` is a special thing that was invented for Block Fields. The only place it's needed currently is for resetting links or media, since we need to know which properties to set back to `undefined`.
- Prefer calling `onChange( field.setValue( // ... ) )` inline. This matches the style used by fields in the dataforms package, so the idea is to make it a closer implementation.

Fixes:
- `allowedTypes` and `multiple` were not being handled correctly by `media` fields (it always defaulted to image).
- Cover block `backgroundType` was not being correctly set.

## Testing Instructions
1. Enable the Block Fields experiment
2. Add various blocks and try using the controls in the content tab of the Inspector. It should generally work. Maybe even a little better than trunk 😄 
