### PR TITLE
Block Visibility: Fix block position shift when toggling

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -109,7 +109,8 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		border: none !important;
 		padding: 0 !important;
 		opacity: 0;
-		margin: 0 !important;
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
 	}
 
 	&.is-layout-flex:not(.is-vertical) > .is-block-hidden {
@@ -117,6 +118,8 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		height: auto;
 		align-self: stretch;
 		white-space: nowrap !important;
+		margin-left: 0 !important;
+		margin-right: 0 !important;
 	}
 
 	// Re-enable it on components inside.


### PR DESCRIPTION
## What?

I noticed that when a block is hidden, a margin of 0 is applied and the block's position shifts:

![524e602f53fbc98a3c81fae0d5099bfd](https://github.com/user-attachments/assets/65cd680b-ec7c-43cf-85b9-8d92df85c925)


This PR overrides the margin in the necessary direction with zero to prevent the block from shifting position as much as possible. It may not be possible to account for every scenario, but it should work well in many.

## Testing Instructions

- Insert a Paragraph block at the root level:
  - The toolbar will not move out of position when toggling the block's visibility.
  - Hides the block after applying top and bottom margins to it. Top and bottom margins should be overwritten with zeros.
- Insert a paragraph block inside a Row layout:
  - Hide the block after applying left and right margins to it. Left and right margins should be overridden with zeros.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f337cc31-d12a-4209-8383-0bf7d66a345b