### PR TITLE
Allow all e2e tests to be run with core only

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"phpmyadminPort": 9000
 }

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -3,14 +3,13 @@
 	"testsEnvironment": false,
 	"port": 8889,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"config": {
 		"WP_DEBUG": false,
 		"SCRIPT_DEBUG": false
 	},
 	"mappings": {
-		"wp-content/plugins/gutenberg": ".",
 		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 		"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 		"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",

--- a/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
@@ -9,14 +9,18 @@ import type { RequestUtils } from './index';
  * @param this
  * @param experiments Array of experimental flags to enable. Pass in an empty array to disable all experiments.
  *                    Use 'active_templates' for the template activation feature.
+ * @return Returns true if experiments were set successfully, false if Gutenberg plugin is not active.
  */
 async function setGutenbergExperiments(
 	this: RequestUtils,
 	experiments: string[]
-) {
+): Promise< boolean > {
 	const response = await this.request.get(
 		'/wp-admin/admin.php?page=gutenberg-experiments'
 	);
+	if ( response.status() !== 200 ) {
+		return false;
+	}
 	const html = await response.text();
 	const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
 
@@ -56,6 +60,8 @@ async function setGutenbergExperiments(
 		form: formData,
 		failOnStatusCode: true,
 	} );
+
+	return true;
 }
 
 export { setGutenbergExperiments };

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -133,6 +133,7 @@ const test = base.extend<
 	{
 		requestUtils: RequestUtils;
 		lighthousePort: number;
+		isGutenbergPluginActive: boolean;
 	}
 >( {
 	admin: async ( { page, pageUtils, editor }, use ) => {
@@ -197,6 +198,19 @@ const test = base.extend<
 	metrics: async ( { page }, use ) => {
 		await use( new Metrics( { page } ) );
 	},
+	isGutenbergPluginActive: [
+		async ( { requestUtils }, use ) => {
+			const plugins = await requestUtils.rest( {
+				path: '/wp/v2/plugins',
+			} );
+			const gutenberg = plugins.find(
+				( p: { plugin: string; status: string } ) =>
+					p.plugin === 'gutenberg/gutenberg'
+			);
+			await use( gutenberg?.status === 'active' );
+		},
+		{ scope: 'worker' },
+	],
 } );
 
 export { test, expect };

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,7 +8,20 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
+		requestUtils,
 	} ) => {
+		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
+		const gutenberg = plugins.find(
+			( p ) => p.plugin === 'gutenberg/gutenberg'
+		);
+		const isGutenbergPluginActive = gutenberg?.status === 'active';
+
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test requires Gutenberg plugin to be active'
+		);
+
 		await admin.visitAdminPage( 'post-new.php', 'gutenberg-demo' );
 		await editor.setPreferences( 'core/edit-site', {
 			welcomeGuide: false,

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,14 +8,8 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
-		requestUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
-		const gutenberg = plugins.find(
-			( p ) => p.plugin === 'gutenberg/gutenberg'
-		);
-		const isGutenbergPluginActive = gutenberg?.status === 'active';
-
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
 			! isGutenbergPluginActive,

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -106,7 +106,13 @@ test.describe( 'Server-side rendered block', () => {
 } );
 
 test.describe( 'PHP-only auto-register blocks', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test suite requires Gutenberg plugin to be active'
+		);
+
 		await requestUtils.activatePlugin(
 			'gutenberg-test-server-side-rendered-block'
 		);

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Should iframe', () => {
 	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 
@@ -33,7 +34,12 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		// The editor should remain iframed because Gutenberg is active.
-		await expect( iframe ).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			// Gutenberg keeps the editor iframed even with v1 blocks.
+			await expect( iframe ).toBeVisible();
+		} else {
+			// Core exits iframe mode when a v1 block is added.
+			await expect( iframe ).toBeHidden();
+		}
 	} );
 } );

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -97,15 +97,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		await this.requestUtils.activatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.activatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		await this.requestUtils.deactivatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.deactivatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 }

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -97,15 +97,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		// await this.requestUtils.activatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.activatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		// await this.requestUtils.deactivatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.deactivatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 }

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -20,7 +20,10 @@ test.describe( 'Global styles sidebar', () => {
 		} );
 	} );
 
-	test( 'should filter blocks list results', async ( { page } ) => {
+	test( 'should filter blocks list results', async ( {
+		page,
+		isGutenbergPluginActive,
+	} ) => {
 		// Navigate to Styles -> Blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -43,5 +46,12 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Accordion Item' } )
 		).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Table of Contents',
+				} )
+			).toBeVisible();
+		}
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

.wp-env.json change is just for testing.

Previously: #73440

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It would be nice if all e2e test can run on core without the plugin active. This requires a few tests to be skipped or adjusted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
