### PR TITLE
Storybook: Remove "background" tools from toolbar

### DIFF
--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -105,6 +105,9 @@ export const parameters = {
 	controls: {
 		sort: 'requiredFirst',
 	},
+	backgrounds: {
+		disable: true,
+	},
 	docs: {
 		controls: {
 			sort: 'requiredFirst',


### PR DESCRIPTION
## What?

Removes the grid and background color toolbar items from Storybook.

## Why?

These aren't useful for our usage. For the background color in particular, it's only useful in combination with theming, and the background color will be provided as part of the theme switcher (#74318).

We have a good number of toolbar items available, so it's better not to have it cluttered with unused items.

## Testing Instructions

Launch Storybook and see that the items are removed.

## Screenshots or screencast <!-- if applicable -->

Removed toolbar items:

https://github.com/user-attachments/assets/52d22bea-4a50-4db7-9736-bb434eb5883e

