### PR TITLE
`@wordpress/ui` `Button`: undo `destructive` tone variant

### DIFF
--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -62,15 +62,12 @@ export const Neutral: Story = {
 	},
 };
 
-/**
- * Destructive buttons should be used for high-stakes, irreversible actions.
- */
-export const Destructive: Story = {
+export const NeutralOutline: Story = {
 	...Default,
 	args: {
 		...Default.args,
-		children: 'Permanently delete',
-		tone: 'destructive',
+		tone: 'neutral',
+		variant: 'outline',
 	},
 };
 
@@ -95,64 +92,57 @@ export const AllTonesAndVariants: Story = {
 			<div></div>
 			<div style={ { textAlign: 'center' } }>Resting</div>
 			<div style={ { textAlign: 'center' } }>Disabled</div>
-			{ ( [ 'brand', 'neutral', 'destructive' ] as const ).map(
-				( tone ) => (
-					<Fragment key={ tone }>
-						{ (
-							[
-								'solid',
-								'outline',
-								'minimal',
-								'unstyled',
-							] as const
-						 ).map( ( variant ) => (
-							<Fragment key={ variant }>
-								<div
-									style={ {
-										paddingInlineEnd: '1rem',
-										display: 'flex',
-										alignItems: 'center',
-									} }
-								>
-									{ variant }, { tone }
-								</div>
-								<div
-									style={ {
-										padding: '0.5rem 1rem',
-										display: 'flex',
-										alignItems: 'center',
-									} }
-								>
-									<Button
-										{ ...args }
-										tone={ tone }
-										variant={ variant }
-									/>
-								</div>
-								<div
-									style={ {
-										padding: '0.5rem 1rem',
-										display: 'flex',
-										alignItems: 'center',
-									} }
-								>
-									<Button
-										{ ...args }
-										tone={ tone }
-										variant={ variant }
-										// Disabling because this lint rule was meant for the
-										// `@wordpress/components` Button, but is being applied here.
-										// TODO: rework the lint rule so that it checks the package
-										// where the Button comes from.
-										// eslint-disable-next-line no-restricted-syntax
-										disabled
-									/>
-								</div>
-							</Fragment>
-						) ) }
-					</Fragment>
-				)
-			) }
+			{ ( [ 'brand', 'neutral' ] as const ).map( ( tone ) => (
+				<Fragment key={ tone }>
+					{ (
+						[ 'solid', 'outline', 'minimal', 'unstyled' ] as const
+					 ).map( ( variant ) => (
+						<Fragment key={ variant }>
+							<div
+								style={ {
+									paddingInlineEnd: '1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								{ variant }, { tone }
+							</div>
+							<div
+								style={ {
+									padding: '0.5rem 1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Button
+									{ ...args }
+									tone={ tone }
+									variant={ variant }
+								/>
+							</div>
+							<div
+								style={ {
+									padding: '0.5rem 1rem',
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Button
+									{ ...args }
+									tone={ tone }
+									variant={ variant }
+									// Disabling because this lint rule was meant for the
+									// `@wordpress/components` Button, but is being applied here.
+									// TODO: rework the lint rule so that it checks the package
+									// where the Button comes from.
+									// eslint-disable-next-line no-restricted-syntax
+									disabled
+								/>
+							</div>
+						</Fragment>
+					) ) }
+				</Fragment>
+			) ) }
 		</div>
 	),
 };

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -185,39 +185,6 @@
 		}
 	}
 
-	.is-destructive {
-		&.is-solid {
-			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);
-			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-strong-active);
-			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-strong-disabled);
-			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error-strong);
-			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-strong-active);
-			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-error-strong-disabled);
-		}
-
-		/* Outline and minimal buttons use the same foreground color */
-		&.is-outline,
-		&.is-minimal {
-			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error);
-			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-active);
-			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-error-disabled);
-		}
-
-		&.is-outline {
-			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error);
-			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-active);
-			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-disabled);
-			--wp-ui-button-border-color: var(--wpds-color-stroke-interactive-error);
-			--wp-ui-button-border-color-active: var(--wpds-color-stroke-interactive-error-active);
-		}
-
-		&.is-minimal {
-			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-weak);
-			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-weak-active);
-			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-error-weak-disabled);
-		}
-	}
-
 	.is-unstyled {
 		border: none;
 		background: none;

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -13,14 +13,11 @@ export interface ButtonProps
 	variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
 
 	/**
-	 * The tone of the button:
+	 * The tone of the button. Tone describes a semantic color intent.
 	 *
-	 * - `'brand': for the most prominent actions, using the brand colors.
-	 * - `'neutral'` for less prominent actions.
-	 * - `'destructive'`: for high-stakes, irreversible actions.
 	 * @default "brand"
 	 */
-	tone?: 'brand' | 'neutral' | 'destructive';
+	tone?: 'brand' | 'neutral';
 
 	/**
 	 * The size of the button.

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -13,7 +13,10 @@ export interface ButtonProps
 	variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
 
 	/**
-	 * The tone of the button. Tone describes a semantic color intent.
+	 * The tone of the button, describing a semantic color intent:
+	 *
+	 * - `'brand': for the most prominent actions, using the brand colors.
+	 * - `'neutral'` for less prominent actions.
 	 *
 	 * @default "brand"
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Remove recently added `destructive` tone variant for the `Button` component in the `@wordpress/ui` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

TL;DR: the destructive variant shouldn't be wildely available via the `Button` component, and should be reserved only for specific buttons rendered inside the `Dialog` component (coming soon).

See https://github.com/WordPress/gutenberg/pull/74463#issuecomment-3732898516 for more context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Undid changes from #74463

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Smoke test Storybook, make sure everything behaves as normal and that the `destructive` tone is completely removed.
