### PR TITLE
Fix documentation title for @wordpress/build package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2100,7 +2100,7 @@
 		"parent": "packages"
 	},
 	{
-		"title": "@wordpress/wp-build",
+		"title": "@wordpress/build",
 		"slug": "packages-wp-build",
 		"markdown_source": "../packages/wp-build/README.md",
 		"parent": "packages"

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -40,10 +40,20 @@ function getPackageManifest( packageFolderNames ) {
 	return packageFolderNames.reduce( ( manifest, folderName ) => {
 		const path = `${ baseRepoUrl }/packages/${ folderName }/README.md`;
 		const tocPath = `${ baseRepoUrl }/packages/${ folderName }/docs/toc.json`;
+		const packageJson = require(
+			join(
+				__dirname,
+				'..',
+				'..',
+				'packages',
+				folderName,
+				'package.json'
+			)
+		);
 
 		// First add any README files to the TOC
 		manifest.push( {
-			title: `@wordpress/${ folderName }`,
+			title: packageJson.name,
 			slug: `packages-${ folderName }`,
 			markdown_source: path,
 			parent: 'packages',


### PR DESCRIPTION
Related #72032 

## What?

Fixes the documentation title for the `@wordpress/build` package on developer.wordpress.org. The package was incorrectly showing as `@wordpress/wp-build` instead of `@wordpress/build`.

## Why?

The `@wordpress/build` package folder is named `wp-build` (rather than `build`) to avoid gitignore issues with build directories. The manifest generation script was using the folder name directly to construct the package title, resulting in incorrect documentation titles.

## How?

Modified `docs/tool/manifest.js` to read the actual package name from each package's `package.json` file instead of constructing it from the folder name. This ensures the correct npm package name is used for the documentation title while keeping the slug and file paths based on the filesystem folder name.