### PR TITLE
Navigation: When a navigation block has a custom overlay, the submenu colors should not apply to the overlay

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -130,6 +130,7 @@ function ColorTools( {
 	setOverlayBackgroundColor,
 	clientId,
 	navRef,
+	hasCustomOverlay,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -201,7 +202,9 @@ function ColorTools( {
 					},
 					{
 						colorValue: overlayTextColor.color,
-						label: __( 'Submenu & overlay text' ),
+						label: hasCustomOverlay
+							? __( 'Submenu text' )
+							: __( 'Submenu & overlay text' ),
 						onColorChange: setOverlayTextColor,
 						resetAllFilter: () => setOverlayTextColor(),
 						clearable: true,
@@ -209,7 +212,9 @@ function ColorTools( {
 					},
 					{
 						colorValue: overlayBackgroundColor.color,
-						label: __( 'Submenu & overlay background' ),
+						label: hasCustomOverlay
+							? __( 'Submenu background' )
+							: __( 'Submenu & overlay background' ),
 						onColorChange: setOverlayBackgroundColor,
 						resetAllFilter: () => setOverlayBackgroundColor(),
 						clearable: true,
@@ -818,6 +823,7 @@ function Navigation( {
 					setOverlayBackgroundColor={ setOverlayBackgroundColor }
 					clientId={ clientId }
 					navRef={ navRef }
+					hasCustomOverlay={ !! overlay }
 				/>
 			</InspectorControls>
 		</>

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -51,6 +51,10 @@ export default function ResponsiveWrapper( {
 				'background-color',
 				overlayBackgroundColor?.slug
 			) ]: !! overlayBackgroundColor?.slug,
+		},
+		{
+			'is-menu-open': isOpen,
+			'hidden-by-default': isHiddenByDefault,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -39,32 +39,24 @@ export default function ResponsiveWrapper( {
 
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
-		{
+		! hasCustomOverlay && {
 			'has-text-color':
-				! hasCustomOverlay &&
-				( !! overlayTextColor.color || !! overlayTextColor?.class ),
+				!! overlayTextColor.color || !! overlayTextColor?.class,
 			[ getColorClassName( 'color', overlayTextColor?.slug ) ]:
-				! hasCustomOverlay && !! overlayTextColor?.slug,
+				!! overlayTextColor?.slug,
 			'has-background':
-				! hasCustomOverlay &&
-				( !! overlayBackgroundColor.color ||
-					overlayBackgroundColor?.class ),
+				!! overlayBackgroundColor.color ||
+				overlayBackgroundColor?.class,
 			[ getColorClassName(
 				'background-color',
 				overlayBackgroundColor?.slug
-			) ]: ! hasCustomOverlay && !! overlayBackgroundColor?.slug,
-			'is-menu-open': isOpen,
-			'hidden-by-default': isHiddenByDefault,
+			) ]: !! overlayBackgroundColor?.slug,
 		}
 	);
 
-	const styles = {
-		color:
-			! hasCustomOverlay &&
-			! overlayTextColor?.slug &&
-			overlayTextColor?.color,
+	const styles = ! hasCustomOverlay && {
+		color: ! overlayTextColor?.slug && overlayTextColor?.color,
 		backgroundColor:
-			! hasCustomOverlay &&
 			! overlayBackgroundColor?.slug &&
 			overlayBackgroundColor?.color &&
 			overlayBackgroundColor.color,

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -54,13 +54,15 @@ export default function ResponsiveWrapper( {
 		}
 	);
 
-	const styles = ! hasCustomOverlay && {
-		color: ! overlayTextColor?.slug && overlayTextColor?.color,
-		backgroundColor:
-			! overlayBackgroundColor?.slug &&
-			overlayBackgroundColor?.color &&
-			overlayBackgroundColor.color,
-	};
+	const styles = ! hasCustomOverlay
+		? {
+				color: ! overlayTextColor?.slug && overlayTextColor?.color,
+				backgroundColor:
+					! overlayBackgroundColor?.slug &&
+					overlayBackgroundColor?.color &&
+					overlayBackgroundColor.color,
+		  }
+		: {};
 
 	const openButtonClasses = clsx(
 		'wp-block-navigation__responsive-container-open',

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -34,28 +34,37 @@ export default function ResponsiveWrapper( {
 		return children;
 	}
 
+	// Only apply overlay colors if there's no custom overlay template part.
+	const hasCustomOverlay = !! overlay;
+
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
 		{
 			'has-text-color':
-				!! overlayTextColor.color || !! overlayTextColor?.class,
+				! hasCustomOverlay &&
+				( !! overlayTextColor.color || !! overlayTextColor?.class ),
 			[ getColorClassName( 'color', overlayTextColor?.slug ) ]:
-				!! overlayTextColor?.slug,
+				! hasCustomOverlay && !! overlayTextColor?.slug,
 			'has-background':
-				!! overlayBackgroundColor.color ||
-				overlayBackgroundColor?.class,
+				! hasCustomOverlay &&
+				( !! overlayBackgroundColor.color ||
+					overlayBackgroundColor?.class ),
 			[ getColorClassName(
 				'background-color',
 				overlayBackgroundColor?.slug
-			) ]: !! overlayBackgroundColor?.slug,
+			) ]: ! hasCustomOverlay && !! overlayBackgroundColor?.slug,
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
 		}
 	);
 
 	const styles = {
-		color: ! overlayTextColor?.slug && overlayTextColor?.color,
+		color:
+			! hasCustomOverlay &&
+			! overlayTextColor?.slug &&
+			overlayTextColor?.color,
 		backgroundColor:
+			! hasCustomOverlay &&
 			! overlayBackgroundColor?.slug &&
 			overlayBackgroundColor?.color &&
 			overlayBackgroundColor.color,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -654,7 +654,9 @@ class WP_Navigation_Block_Renderer {
 			'wp-block-navigation__responsive-container',
 			$is_hidden_by_default ? 'hidden-by-default' : '',
 			$has_custom_overlay ? 'disable-default-overlay' : '',
-			implode( ' ', $colors['overlay_css_classes'] ),
+			// Don't apply overlay color classes if using a custom overlay template part.
+			// The custom overlay is responsible for its own styling.
+			$has_custom_overlay ? '' : implode( ' ', $colors['overlay_css_classes'] ),
 		);
 		$open_button_classes          = array(
 			'wp-block-navigation__responsive-container-open',
@@ -705,7 +707,9 @@ class WP_Navigation_Block_Renderer {
 			';
 		}
 
-		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
+		// Don't apply overlay inline styles if using a custom overlay template part.
+		// The custom overlay is responsible for its own styling.
+		$overlay_inline_styles = $has_custom_overlay ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -610,7 +610,7 @@ class WP_Navigation_Block_Renderer {
 	 * @return array Returns the responsive container classes.
 	 */
 	private static function get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors ) {
-		$responsive_container_classes = array('wp-block-navigation__responsive-container');
+		$responsive_container_classes = array( 'wp-block-navigation__responsive-container' );
 
 		if ( $is_hidden_by_default ) {
 			$responsive_container_classes[] = 'hidden-by-default';
@@ -693,13 +693,13 @@ class WP_Navigation_Block_Renderer {
 
 		$responsive_container_classes = static::get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors );
 
-		$open_button_classes          = array(
+		$open_button_classes = array(
 			'wp-block-navigation__responsive-container-open',
 			$is_hidden_by_default ? 'always-shown' : '',
 		);
 
 		$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
-		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 7.5h16v1.5H4z"></path><path d="M4 15h16v1.5H4z"></path></svg>';
+		$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 7.5h16v1.5H4z"></path><path d="M4 15h16v1.5H4z"></path></svg>';
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5z"></path><path d="M5 12.8h14v-1.5H5v1.5z"></path><path d="M5 19h14v-1.5H5V19z"></path></svg>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -699,7 +699,7 @@ class WP_Navigation_Block_Renderer {
 		);
 
 		$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
-		$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 7.5h16v1.5H4z"></path><path d="M4 15h16v1.5H4z"></path></svg>';
+		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 7.5h16v1.5H4z"></path><path d="M4 15h16v1.5H4z"></path></svg>';
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5z"></path><path d="M5 12.8h14v-1.5H5v1.5z"></path><path d="M5 19h14v-1.5H5V19z"></path></svg>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -600,6 +600,34 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Get responsive container classes for the navigation block.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param bool  $is_hidden_by_default Whether the responsive menu is hidden by default.
+	 * @param bool  $has_custom_overlay Whether a custom overlay is used.
+	 * @param array $colors The colors array.
+	 */
+	private static function get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors ) {
+		$responsive_container_classes = array('wp-block-navigation__responsive-container');
+
+		if ( $is_hidden_by_default ) {
+			$responsive_container_classes[] = 'hidden-by-default';
+		}
+
+		if ( $has_custom_overlay ) {
+			// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
+			$responsive_container_classes[] = 'disable-default-overlay';
+		} else {
+			// Don't apply overlay color classes if using a custom overlay template part.
+			// The custom overlay is responsible for its own styling.
+			$responsive_container_classes[] = implode( ' ', $colors['overlay_css_classes'] );
+		}
+
+		return $responsive_container_classes;
+	}
+
+	/**
 	 * Get the responsive container markup
 	 *
 	 * @since 6.5.0
@@ -649,15 +677,8 @@ class WP_Navigation_Block_Renderer {
 			$has_custom_overlay = ! empty( $overlay_blocks_html );
 		}
 
-		// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
-		$responsive_container_classes = array(
-			'wp-block-navigation__responsive-container',
-			$is_hidden_by_default ? 'hidden-by-default' : '',
-			$has_custom_overlay ? 'disable-default-overlay' : '',
-			// Don't apply overlay color classes if using a custom overlay template part.
-			// The custom overlay is responsible for its own styling.
-			$has_custom_overlay ? '' : implode( ' ', $colors['overlay_css_classes'] ),
-		);
+		$responsive_container_classes = get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors );
+
 		$open_button_classes          = array(
 			'wp-block-navigation__responsive-container-open',
 			$is_hidden_by_default ? 'always-shown' : '',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -607,6 +607,7 @@ class WP_Navigation_Block_Renderer {
 	 * @param bool  $is_hidden_by_default Whether the responsive menu is hidden by default.
 	 * @param bool  $has_custom_overlay Whether a custom overlay is used.
 	 * @param array $colors The colors array.
+	 * @return array Returns the responsive container classes.
 	 */
 	private static function get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors ) {
 		$responsive_container_classes = array('wp-block-navigation__responsive-container');
@@ -625,6 +626,19 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		return $responsive_container_classes;
+	}
+
+	/**
+	 * Get overlay inline styles for the navigation block.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $colors The colors array.
+	 * @return string Returns the overlay inline styles.
+	 */
+	private static function get_overlay_inline_styles( $has_custom_overlay, $colors ) {
+		$overlay_inline_styles = $has_custom_overlay ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
+		return ( ! empty( $overlay_inline_styles ) ) ? "style=\"$overlay_inline_styles\"" : '';
 	}
 
 	/**
@@ -677,7 +691,7 @@ class WP_Navigation_Block_Renderer {
 			$has_custom_overlay = ! empty( $overlay_blocks_html );
 		}
 
-		$responsive_container_classes = get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors );
+		$responsive_container_classes = static::get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors );
 
 		$open_button_classes          = array(
 			'wp-block-navigation__responsive-container-open',
@@ -730,7 +744,7 @@ class WP_Navigation_Block_Renderer {
 
 		// Don't apply overlay inline styles if using a custom overlay template part.
 		// The custom overlay is responsible for its own styling.
-		$overlay_inline_styles = $has_custom_overlay ? '' : esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
+		$overlay_inline_styles = static::get_overlay_inline_styles( $has_custom_overlay, $colors );
 
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(
@@ -769,7 +783,7 @@ class WP_Navigation_Block_Renderer {
 			$toggle_aria_label_close,
 			esc_attr( trim( implode( ' ', $responsive_container_classes ) ) ),
 			esc_attr( trim( implode( ' ', $open_button_classes ) ) ),
-			( ! empty( $overlay_inline_styles ) ) ? "style=\"$overlay_inline_styles\"" : '',
+			$overlay_inline_styles,
 			$toggle_button_content,
 			$toggle_close_button_content,
 			$open_button_directives,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
If a navigation block has a custom overlay, the submenu/overlay colors should only apply to submenus.

Part of https://github.com/WordPress/gutenberg/issues/74097

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The enables us to separate the overlay and submenu color settings for custom overlays while still maintaining backwards compatibility for blocks using the default overlay.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Skip adding custom class and inline styles for blocks that have custom overlays

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Enable the custom overlays experiment
2. Set text and overlay colors for a navigation block
3. Check that these settings work in the editor and frontend
4. Set a custom overlay for a navigation block
5. Confirm that the submenu color buttons no longer mentions overlays
6. Confirm that the colors still apply to the submenu but not to the overlays


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="297" height="270" alt="Screenshot 2026-01-12 at 12 52 51" src="https://github.com/user-attachments/assets/7257c48b-bf7e-4d2a-bfd8-dea3f2d232f4" />|<img width="282" height="267" alt="Screenshot 2026-01-12 at 12 52 42" src="https://github.com/user-attachments/assets/527b0cd0-e270-4514-a3df-ad565c6184d1" />|
