### PR TITLE
Editor: Make distraction-free mode appearance settings configurable

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -15,12 +15,13 @@ import { unlock } from '../../lock-unlock';
 
 export function useInBetweenInserter() {
 	const openRef = useContext( InsertionPointOpenRef );
-	const isInBetweenInserterDisabled = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree ||
-			unlock( select( blockEditorStore ) ).isZoomOut(),
-		[]
-	);
+	const isInBetweenInserterDisabled = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return (
+			( settings.showBlockHelpers ?? true ) === false ||
+			unlock( select( blockEditorStore ) ).isZoomOut()
+		);
+	}, [] );
 	const {
 		getBlockListSettings,
 		getBlockIndex,

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -31,13 +31,12 @@ function useDebouncedShowGestures( {
 		useSelect( blockEditorStore );
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 	const timeoutRef = useRef();
-	const isDistractionFree = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree,
-		[]
-	);
+	const showBlockHelpers = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings.showBlockHelpers ?? true;
+	}, [] );
 	const handleOnChange = ( nextIsFocused ) => {
-		if ( nextIsFocused && isDistractionFree ) {
+		if ( nextIsFocused && ! showBlockHelpers ) {
 			return;
 		}
 		const selectedBlockClientId = getSelectedBlockClientId();

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -43,7 +43,7 @@ function InbetweenInsertionPointPopover( {
 		nextClientId,
 		rootClientId,
 		isInserterShown,
-		isDistractionFree,
+		showBlockHelpers,
 		isZoomOutMode,
 	} = useSelect( ( select ) => {
 		const {
@@ -83,7 +83,7 @@ function InbetweenInsertionPointPopover( {
 				getBlockListSettings( insertionPoint.rootClientId )
 					?.orientation || 'vertical',
 			rootClientId: insertionPoint.rootClientId,
-			isDistractionFree: settings.isDistractionFree,
+			showBlockHelpers: settings.showBlockHelpers ?? true,
 			isInserterShown: insertionPoint?.__unstableWithInserter,
 			isZoomOutMode: isZoomOut(),
 		};
@@ -160,7 +160,7 @@ function InbetweenInsertionPointPopover( {
 		},
 	};
 
-	if ( isDistractionFree ) {
+	if ( ! showBlockHelpers ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -22,14 +22,13 @@ import ButtonBlockAppender from '../button-block-appender';
 import { unlock } from '../../lock-unlock';
 
 export function GridVisualizer( { clientId, contentRef, parentLayout } ) {
-	const isDistractionFree = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree,
-		[]
-	);
+	const showBlockHelpers = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings.showBlockHelpers ?? true;
+	}, [] );
 	const gridElement = useBlockElement( clientId );
 
-	if ( isDistractionFree || ! gridElement ) {
+	if ( ! showBlockHelpers || ! gridElement ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -18,7 +18,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {number}        maxWidth                               Max width to constraint resizing
  * @property {boolean|Array} allowedBlockTypes                      Allowed block types
  * @property {boolean}       hasFixedToolbar                        Whether or not the editor toolbar is fixed
- * @property {boolean}       distractionFree                        Whether or not the editor UI is distraction free
+ * @property {boolean}       showBlockHelpers                       Whether or not to show block editing helpers (insertion points, in-between inserter, etc.)
  * @property {boolean}       focusMode                              Whether the focus mode is enabled or not
  * @property {Array}         styles                                 Editor Styles
  * @property {boolean}       keepCaretInsideBlock                   Whether caret should move between blocks in edit mode

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -84,9 +84,12 @@ const DESIGN_POST_TYPES = [
 
 function useEditorStyles( settings ) {
 	const { hasThemeStyleSupport } = useSelect( ( select ) => {
+		const { getEditorUIPreference } = unlock( select( editorStore ) );
 		return {
-			hasThemeStyleSupport:
-				select( editPostStore ).isFeatureActive( 'themeStyles' ),
+			hasThemeStyleSupport: getEditorUIPreference(
+				'themeStyles',
+				'core/edit-post'
+			),
 		};
 	}, [] );
 

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -13,7 +13,8 @@ import { unlock } from '../../lock-unlock';
 import MetaBoxesSection from './meta-boxes-section';
 
 const { PreferenceToggleControl } = unlock( preferencesPrivateApis );
-const { PreferencesModal } = unlock( editorPrivateApis );
+const { PreferencesModal, DistractionFreeConfigControl } =
+	unlock( editorPrivateApis );
 
 export default function EditPostPreferencesModal() {
 	const extraSections = {
@@ -22,6 +23,13 @@ export default function EditPostPreferencesModal() {
 			<PreferenceToggleControl
 				scope="core/edit-post"
 				featureName="themeStyles"
+				help={ __( 'Make the editor look like your theme.' ) }
+				label={ __( 'Use theme styles' ) }
+			/>
+		),
+		distractionFreeAppearance: (
+			<DistractionFreeConfigControl
+				configKey="themeStyles"
 				help={ __( 'Make the editor look like your theme.' ) }
 				label={ __( 'Use theme styles' ) }
 			/>

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -64,6 +64,8 @@ export function initializeEditor(
 		editorMode: 'visual',
 		editorTool: 'edit',
 		fixedToolbar: false,
+		focusMode: false,
+		autoHideHeader: false,
 		hiddenBlockTypes: [],
 		inactivePanels: [],
 		openPanels: [ 'post-status' ],
@@ -72,6 +74,17 @@ export function initializeEditor(
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
+		showSimpleTopbar: true,
+		showBlockHelpers: true,
+		distractionFreeConfig: {
+			fixedToolbar: true,
+			focusMode: false,
+			showBlockBreadcrumbs: false,
+			autoHideHeader: true,
+			themeStyles: true,
+			showSimpleTopbar: false,
+			showBlockHelpers: false,
+		},
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -67,12 +67,23 @@ export function initializeEditor( id, settings ) {
 		editorTool: 'edit',
 		fixedToolbar: false,
 		focusMode: false,
+		autoHideHeader: false,
 		inactivePanels: [],
 		keepCaretInsideBlock: false,
 		openPanels: [ 'post-status' ],
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		showSimpleTopbar: true,
+		showBlockHelpers: true,
+		distractionFreeConfig: {
+			fixedToolbar: true,
+			focusMode: false,
+			showBlockBreadcrumbs: false,
+			autoHideHeader: true,
+			showSimpleTopbar: false,
+			showBlockHelpers: false,
+		},
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -14,7 +14,6 @@ import { ToolbarButton, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -28,7 +27,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
 	const {
-		isDistractionFree,
+		showSimpleTopbar,
 		isInserterOpened,
 		isListViewOpen,
 		listViewShortcut,
@@ -36,13 +35,13 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		listViewToggleRef,
 		showIconLabels,
 	} = useSelect( ( select ) => {
-		const { get } = select( preferencesStore );
 		const {
 			isListViewOpened,
 			getEditorMode,
 			getInserterSidebarToggleRef,
 			getListViewToggleRef,
 		} = unlock( select( editorStore ) );
+		const { getEditorUIPreference } = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
 		return {
@@ -53,8 +52,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			),
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			listViewToggleRef: getListViewToggleRef(),
-			showIconLabels: get( 'core', 'showIconLabels' ),
-			isDistractionFree: get( 'core', 'distractionFree' ),
+			showIconLabels: getEditorUIPreference( 'showIconLabels' ),
+			showSimpleTopbar: getEditorUIPreference( 'showSimpleTopbar' ),
 			isVisualMode: getEditorMode() === 'visual',
 		};
 	}, [] );
@@ -109,7 +108,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
-				{ ! isDistractionFree && (
+				{ showSimpleTopbar && (
 					<ToolbarButton
 						ref={ inserterSidebarToggleRef }
 						className="editor-document-tools__inserter-toggle"
@@ -138,7 +137,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 							variant={ showIconLabels ? 'tertiary' : undefined }
 							size="compact"
 						/>
-						{ ! isDistractionFree && (
+						{ showSimpleTopbar && (
 							<ToolbarButton
 								className="editor-document-tools__document-overview-toggle"
 								icon={ listView }

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -61,15 +61,15 @@ export default function EditorInterface( {
 		isDistractionFree,
 		isPreviewMode,
 		showBlockBreadcrumbs,
+		autoHideHeader,
 		postTypeLabel,
 		stylesPath,
 		showStylebook,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
-		const { getStylesPath, getShowStylebook } = unlock(
-			select( editorStore )
-		);
+		const { getStylesPath, getShowStylebook, getEditorUIPreference } =
+			unlock( select( editorStore ) );
 		const editorSettings = getEditorSettings();
 
 		let _mode = select( editorStore ).getEditorMode();
@@ -86,7 +86,8 @@ export default function EditorInterface( {
 			isListViewOpened: select( editorStore ).isListViewOpened(),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isPreviewMode: editorSettings.isPreviewMode,
-			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
+			showBlockBreadcrumbs: getEditorUIPreference( 'showBlockBreadcrumbs' ),
+			autoHideHeader: getEditorUIPreference( 'autoHideHeader' ),
 			postTypeLabel: getPostTypeLabel(),
 			stylesPath: getStylesPath(),
 			showStylebook: getShowStylebook(),
@@ -116,6 +117,7 @@ export default function EditorInterface( {
 	return (
 		<InterfaceSkeleton
 			isDistractionFree={ isDistractionFree }
+			autoHideHeader={ autoHideHeader }
 			className={ clsx( 'editor-editor-interface', className, {
 				'is-entity-save-view-open': !! entitiesSavedStatesCallback,
 				'is-distraction-free': isDistractionFree && ! isPreviewMode,
@@ -186,7 +188,6 @@ export default function EditorInterface( {
 			}
 			footer={
 				! isPreviewMode &&
-				! isDistractionFree &&
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				mode === 'visual' && (

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -28,17 +28,12 @@ import { store as editorStore } from '../../store';
 
 export default function MoreMenu() {
 	const { openModal } = useDispatch( interfaceStore );
-	const { set: setPreference } = useDispatch( preferencesStore );
 	const { toggleDistractionFree } = useDispatch( editorStore );
 	const showIconLabels = useSelect(
 		( select ) =>
 			select( preferencesStore ).get( 'core', 'showIconLabels' ),
 		[]
 	);
-
-	const turnOffDistractionFree = () => {
-		setPreference( 'core', 'distractionFree', false );
-	};
 
 	return (
 		<>
@@ -61,21 +56,6 @@ export default function MoreMenu() {
 						<MenuGroup label={ _x( 'View', 'noun' ) }>
 							<PreferenceToggleMenuItem
 								scope="core"
-								name="fixedToolbar"
-								onToggle={ turnOffDistractionFree }
-								label={ __( 'Top toolbar' ) }
-								info={ __(
-									'Access all block and document tools in a single place'
-								) }
-								messageActivated={ __(
-									'Top toolbar activated.'
-								) }
-								messageDeactivated={ __(
-									'Top toolbar deactivated.'
-								) }
-							/>
-							<PreferenceToggleMenuItem
-								scope="core"
 								name="distractionFree"
 								label={ __( 'Distraction free' ) }
 								info={ __( 'Write with calmness' ) }
@@ -93,18 +73,6 @@ export default function MoreMenu() {
 								) }
 								shortcut={ displayShortcut.primaryShift(
 									'\\'
-								) }
-							/>
-							<PreferenceToggleMenuItem
-								scope="core"
-								name="focusMode"
-								label={ __( 'Spotlight mode' ) }
-								info={ __( 'Focus on one block at a time' ) }
-								messageActivated={ __(
-									'Spotlight mode activated.'
-								) }
-								messageDeactivated={ __(
-									'Spotlight mode deactivated.'
 								) }
 							/>
 							<ViewMoreMenuGroup.Slot fillProps={ { onClose } } />

--- a/packages/editor/src/components/preferences-modal/distraction-free-config-control.js
+++ b/packages/editor/src/components/preferences-modal/distraction-free-config-control.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * A component for toggling values within the distractionFreeConfig object.
+ *
+ * @param {Object} props           Component props.
+ * @param {string} props.configKey The key within distractionFreeConfig to toggle.
+ * @param {string} props.label     The label for the toggle control.
+ * @param {string} props.help      Help text for the toggle control.
+ */
+export default function DistractionFreeConfigControl( {
+	configKey,
+	label,
+	help,
+} ) {
+	const isChecked = useSelect(
+		( select ) => {
+			const config =
+				select( preferencesStore ).get(
+					'core',
+					'distractionFreeConfig'
+				) || {};
+			return !! config[ configKey ];
+		},
+		[ configKey ]
+	);
+
+	const { set } = useDispatch( preferencesStore );
+
+	const onChange = () => {
+		const config =
+			window.wp.data
+				.select( preferencesStore )
+				.get( 'core', 'distractionFreeConfig' ) || {};
+		set( 'core', 'distractionFreeConfig', {
+			...config,
+			[ configKey ]: ! config[ configKey ],
+		} );
+	};
+
+	return (
+		<div className="preference-base-option">
+			<ToggleControl
+				label={ label }
+				help={ help }
+				checked={ isChecked }
+				onChange={ onChange }
+			/>
+		</div>
+	);
+}

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -18,13 +18,13 @@ import { store as interfaceStore } from '@wordpress/interface';
 import EnablePanelOption from './enable-panel';
 import EnablePluginDocumentSettingPanelOption from './enable-plugin-document-setting-panel';
 import EnablePublishSidebarOption from './enable-publish-sidebar';
+import DistractionFreeConfigControl from './distraction-free-config-control';
 import BlockVisibility from '../block-visibility';
 import PostTaxonomies from '../post-taxonomies';
 import PostFeaturedImageCheck from '../post-featured-image/check';
 import PostExcerptCheck from '../post-excerpt/check';
 import PageAttributesCheck from '../page-attributes/check';
 import PostTypeSupportCheck from '../post-type-support-check';
-import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const {
@@ -53,25 +53,68 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 	);
 }
 
+function AppearanceToggles( { Toggle, isLargeViewport } ) {
+	return (
+		<>
+			<Toggle
+				featureKey="fixedToolbar"
+				help={ __( 'Access all block and document tools in a single place.' ) }
+				label={ __( 'Top toolbar' ) }
+			/>
+			<Toggle
+				featureKey="focusMode"
+				help={ __( 'Highlights the current block and fades other content.' ) }
+				label={ __( 'Spotlight mode' ) }
+			/>
+			{ isLargeViewport && (
+				<Toggle
+					featureKey="showBlockBreadcrumbs"
+					help={ __( 'Display the block hierarchy trail at the bottom of the editor.' ) }
+					label={ __( 'Block breadcrumbs' ) }
+				/>
+			) }
+			<Toggle
+				featureKey="autoHideHeader"
+				help={ __( 'Hide the toolbar and show it on hover.' ) }
+				label={ __( 'Auto-hide header' ) }
+			/>
+			<Toggle
+				featureKey="showSimpleTopbar"
+				help={ __( 'Show the inserter, list view, and zoom out toggles.' ) }
+				label={ __( 'Simplified topbar' ) }
+			/>
+			<Toggle
+				featureKey="showBlockHelpers"
+				help={ __( 'Show insertion points and block helpers.' ) }
+				label={ __( 'Block helpers' ) }
+			/>
+		</>
+	);
+}
+
+function NormalModeToggle( { featureKey, help, label } ) {
+	return (
+		<PreferenceToggleControl
+			scope="core"
+			featureName={ featureKey }
+			help={ help }
+			label={ label }
+		/>
+	);
+}
+
+function DistractionFreeModeToggle( { featureKey, help, label } ) {
+	return (
+		<DistractionFreeConfigControl
+			configKey={ featureKey }
+			help={ help }
+			label={ label }
+		/>
+	);
+}
+
 function PreferencesModalContents( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const showBlockBreadcrumbsOption = useSelect(
-		( select ) => {
-			const { getEditorSettings } = select( editorStore );
-			const { get } = select( preferencesStore );
-			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
-			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
-			return (
-				! isDistractionFreeEnabled &&
-				isLargeViewport &&
-				isRichEditingEnabled
-			);
-		},
-		[ isLargeViewport ]
-	);
-	const { setIsListViewOpened, setIsInserterOpened } =
-		useDispatch( editorStore );
-	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const sections = useMemo(
 		() =>
@@ -92,16 +135,6 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									) }
 									label={ __( 'Always open List View' ) }
 								/>
-								{ showBlockBreadcrumbsOption && (
-									<PreferenceToggleControl
-										scope="core"
-										featureName="showBlockBreadcrumbs"
-										help={ __(
-											'Display the block hierarchy trail at the bottom of the editor.'
-										) }
-										label={ __( 'Show block breadcrumbs' ) }
-									/>
-								) }
 								<PreferenceToggleControl
 									scope="core"
 									featureName="allowRightClickOverrides"
@@ -185,54 +218,32 @@ function PreferencesModalContents( { extraSections = {} } ) {
 					name: 'appearance',
 					tabLabel: __( 'Appearance' ),
 					content: (
-						<PreferencesModalSection
-							title={ __( 'Appearance' ) }
-							description={ __(
-								'Customize the editor interface to suit your needs.'
-							) }
-						>
-							<PreferenceToggleControl
-								scope="core"
-								featureName="fixedToolbar"
-								onToggle={ () =>
-									setPreference(
-										'core',
-										'distractionFree',
-										false
-									)
-								}
-								help={ __(
-									'Access all block and document tools in a single place.'
+						<>
+							<PreferencesModalSection
+								title={ __( 'Normal mode' ) }
+								description={ __(
+									'Settings when distraction-free mode is off.'
 								) }
-								label={ __( 'Top toolbar' ) }
-							/>
-							<PreferenceToggleControl
-								scope="core"
-								featureName="distractionFree"
-								onToggle={ () => {
-									setPreference(
-										'core',
-										'fixedToolbar',
-										true
-									);
-									setIsInserterOpened( false );
-									setIsListViewOpened( false );
-								} }
-								help={ __(
-									'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
+							>
+								<AppearanceToggles
+									Toggle={ NormalModeToggle }
+									isLargeViewport={ isLargeViewport }
+								/>
+								{ extraSections?.appearance }
+							</PreferencesModalSection>
+							<PreferencesModalSection
+								title={ __( 'Distraction-free mode' ) }
+								description={ __(
+									'Settings when distraction-free mode is on.'
 								) }
-								label={ __( 'Distraction free' ) }
-							/>
-							<PreferenceToggleControl
-								scope="core"
-								featureName="focusMode"
-								help={ __(
-									'Highlights the current block and fades other content.'
-								) }
-								label={ __( 'Spotlight mode' ) }
-							/>
-							{ extraSections?.appearance }
-						</PreferencesModalSection>
+							>
+								<AppearanceToggles
+									Toggle={ DistractionFreeModeToggle }
+									isLargeViewport={ isLargeViewport }
+								/>
+								{ extraSections?.distractionFreeAppearance }
+							</PreferencesModalSection>
+						</>
 					),
 				},
 				{
@@ -330,14 +341,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 					),
 				},
 			].filter( Boolean ),
-		[
-			showBlockBreadcrumbsOption,
-			extraSections,
-			setIsInserterOpened,
-			setIsListViewOpened,
-			setPreference,
-			isLargeViewport,
-		]
+		[ extraSections, isLargeViewport ]
 	);
 
 	return <PreferencesModalTabs sections={ sections } />;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -141,7 +141,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
-			const { getDeviceType } = unlock( select( editorStore ) );
+			const { getDeviceType } = select( editorStore );
+			const { getEditorUIPreference } = unlock( select( editorStore ) );
 			const { getBlocksByName, getBlockAttributes } =
 				select( blockEditorStore );
 			const siteSettings = canUser( 'read', {
@@ -175,11 +176,11 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					postType,
 					postId
 				)?._links?.hasOwnProperty( 'wp:action-unfiltered-html' ),
-				focusMode: get( 'core', 'focusMode' ),
+				focusMode: getEditorUIPreference( 'focusMode' ),
 				hasFixedToolbar:
-					get( 'core', 'fixedToolbar' ) || ! isLargeViewport,
+					getEditorUIPreference( 'fixedToolbar' ) || ! isLargeViewport,
 				hiddenBlockTypes: get( 'core', 'hiddenBlockTypes' ),
-				isDistractionFree: get( 'core', 'distractionFree' ),
+				showBlockHelpers: getEditorUIPreference( 'showBlockHelpers' ),
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				hasUploadPermissions:
 					canUser( 'create', {

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -7,7 +7,6 @@ import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { square as zoomOutIcon } from '@wordpress/icons';
-import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	useShortcut,
 	store as keyboardShortcutsStore,
@@ -18,20 +17,18 @@ import { isAppleOS } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
 
 const ZoomOutToggle = ( { disabled } ) => {
-	const { isZoomOut, showIconLabels, isDistractionFree } = useSelect(
-		( select ) => ( {
-			isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
-			showIconLabels: select( preferencesStore ).get(
-				'core',
-				'showIconLabels'
-			),
-			isDistractionFree: select( preferencesStore ).get(
-				'core',
-				'distractionFree'
-			),
-		} )
+	const { isZoomOut, showIconLabels, showSimpleTopbar } = useSelect(
+		( select ) => {
+			const { getEditorUIPreference } = unlock( select( editorStore ) );
+			return {
+				isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
+				showIconLabels: getEditorUIPreference( 'showIconLabels' ),
+				showSimpleTopbar: getEditorUIPreference( 'showSimpleTopbar' ),
+			};
+		}
 	);
 
 	const { resetZoomLevel, setZoomLevel } = unlock(
@@ -68,7 +65,7 @@ const ZoomOutToggle = ( { disabled } ) => {
 			}
 		},
 		{
-			isDisabled: isDistractionFree,
+			isDisabled: ! showSimpleTopbar,
 		}
 	);
 

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -18,6 +18,7 @@ import Editor from './components/editor';
 import PluginPostExcerpt from './components/post-excerpt/plugin';
 import PostCardPanel from './components/post-card-panel';
 import PreferencesModal from './components/preferences-modal';
+import DistractionFreeConfigControl from './components/preferences-modal/distraction-free-config-control';
 import { usePostActions } from './components/post-actions/actions';
 import usePostFields from './components/post-fields';
 import ToolsMoreMenuGroup from './components/more-menu/tools-more-menu-group';
@@ -47,6 +48,7 @@ lock( privateApis, {
 	PluginPostExcerpt,
 	PostCardPanel,
 	PreferencesModal,
+	DistractionFreeConfigControl,
 	usePostActions,
 	usePostFields,
 	ToolsMoreMenuGroup,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -913,16 +913,10 @@ export const toggleDistractionFree =
 		const isDistractionFree = registry
 			.select( preferencesStore )
 			.get( 'core', 'distractionFree' );
-		if ( isDistractionFree ) {
-			registry
-				.dispatch( preferencesStore )
-				.set( 'core', 'fixedToolbar', false );
-		}
+
+		// When entering distraction-free mode, close panels and reset zoom.
 		if ( ! isDistractionFree ) {
 			registry.batch( () => {
-				registry
-					.dispatch( preferencesStore )
-					.set( 'core', 'fixedToolbar', true );
 				dispatch.setIsInserterOpened( false );
 				dispatch.setIsListViewOpened( false );
 				unlock(
@@ -930,6 +924,7 @@ export const toggleDistractionFree =
 				).resetZoomLevel();
 			} );
 		}
+
 		registry.batch( () => {
 			registry
 				.dispatch( preferencesStore )
@@ -949,21 +944,12 @@ export const toggleDistractionFree =
 								{
 									label: __( 'Undo' ),
 									onClick: () => {
-										registry.batch( () => {
-											registry
-												.dispatch( preferencesStore )
-												.set(
-													'core',
-													'fixedToolbar',
-													isDistractionFree
-												);
-											registry
-												.dispatch( preferencesStore )
-												.toggle(
-													'core',
-													'distractionFree'
-												);
-										} );
+										registry
+											.dispatch( preferencesStore )
+											.toggle(
+												'core',
+												'distractionFree'
+											);
 									},
 								},
 							],

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -300,3 +300,35 @@ export function getShowStylebook( state ) {
 export function getCanvasMinHeight( state ) {
 	return state.canvasMinHeight;
 }
+
+/**
+ * Returns the effective value of an editor UI preference based on the current mode.
+ * When distraction-free mode is enabled, returns the distraction-free config value.
+ * Otherwise, returns the normal mode preference value.
+ *
+ * This selector should only be used for preferences that have both a normal mode
+ * and distraction-free mode variant: fixedToolbar, focusMode, showBlockBreadcrumbs,
+ * autoHideHeader, themeStyles.
+ *
+ * @param {Object} state          Global application state.
+ * @param {string} preferenceName The name of the preference to get.
+ * @param {string} scope          Optional scope for the preference. Defaults to 'core'.
+ *
+ * @return {*} The effective preference value.
+ */
+export const getEditorUIPreference = createRegistrySelector(
+	( select ) =>
+		( state, preferenceName, scope = 'core' ) => {
+			const { get } = select( preferencesStore );
+			const isDistractionFree = get( 'core', 'distractionFree' );
+
+			if ( isDistractionFree ) {
+				const config = get( 'core', 'distractionFreeConfig' ) || {};
+				if ( preferenceName in config ) {
+					return config[ preferenceName ];
+				}
+			}
+
+			return get( scope, preferenceName );
+		}
+);

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -70,6 +70,7 @@ const headerVariants = {
 function InterfaceSkeleton(
 	{
 		isDistractionFree,
+		autoHideHeader,
 		footer,
 		header,
 		editorNotices,
@@ -82,6 +83,9 @@ function InterfaceSkeleton(
 	},
 	ref
 ) {
+	// Determine if header should auto-hide. If autoHideHeader is not explicitly set,
+	// fall back to isDistractionFree for backward compatibility.
+	const shouldAutoHideHeader = autoHideHeader ?? isDistractionFree;
 	const [ secondarySidebarResizeListener, secondarySidebarSize ] =
 		useResizeObserver();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -127,22 +131,22 @@ function InterfaceSkeleton(
 							className="interface-interface-skeleton__header"
 							aria-label={ mergedLabels.header }
 							initial={
-								isDistractionFree && ! isMobileViewport
+								shouldAutoHideHeader && ! isMobileViewport
 									? 'distractionFreeHidden'
 									: 'hidden'
 							}
 							whileHover={
-								isDistractionFree && ! isMobileViewport
+								shouldAutoHideHeader && ! isMobileViewport
 									? 'distractionFreeHover'
 									: 'visible'
 							}
 							animate={
-								isDistractionFree && ! isMobileViewport
+								shouldAutoHideHeader && ! isMobileViewport
 									? 'distractionFreeDisabled'
 									: 'visible'
 							}
 							exit={
-								isDistractionFree && ! isMobileViewport
+								shouldAutoHideHeader && ! isMobileViewport
 									? 'distractionFreeHidden'
 									: 'hidden'
 							}
@@ -153,7 +157,7 @@ function InterfaceSkeleton(
 						</NavigableRegion>
 					) }
 				</AnimatePresence>
-				{ isDistractionFree && (
+				{ shouldAutoHideHeader && (
 					<div className="interface-interface-skeleton__header">
 						{ editorNotices }
 					</div>


### PR DESCRIPTION
## What?


This is an experiment to make "distraction-free" more of a configurable experience. Distraction Free doesn't mean the same thing per user, this PR allows the user to tweak what happens when you go into distraction free. All the other configs are now "sub configs" of normal or distraction free modes.

## Why?

Currently, enabling distraction-free mode applies a fixed set of UI changes all at once. Users have no way to customize which elements are hidden or shown in each mode. This PR introduces a `distractionFreeConfig` object that allows per-setting customization, giving users control over their editing experience in both normal and distraction-free modes.

## How?

The implementation introduces a dual-mode preference system:

**New preferences:**
- `showSimpleTopbar` - Controls the inserter, list view, and zoom out toggles
- `showBlockHelpers` - Controls insertion points, in-between inserter, grid visualizer, and block highlight effects

**Architecture changes:**
- Added `distractionFreeConfig` object in edit-post and edit-site initialization that mirrors normal mode settings
- Created `getEditorUIPreference` selector that returns the appropriate value based on whether distraction-free mode is active
- Block editor components receive `showBlockHelpers` through settings instead of checking `isDistractionFree` directly

**Preferences modal:**
- Split into two sections: "Normal mode" and "Distraction-free mode"
- Both sections share the same `AppearanceToggles` component, just with different toggle implementations
- `DistractionFreeConfigControl` component manages values within the config object
- edit-post exposes its `themeStyles` preference through the shared component system

## Testing Instructions

1. Open the post editor
2. Go to Preferences (three-dot menu → Preferences)
3. In the Appearance section, you should see "Normal mode" and "Distraction-free mode" sections
4. Toggle "Distraction free" mode on
5. Verify that changing settings in "Distraction-free mode" section affects the UI while in that mode
6. Toggle "Distraction free" mode off
7. Verify that the "Normal mode" settings are now applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)