### PR TITLE
DataViews: Add card form layout validation

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
+
 ### Bug Fixes
 
 - Fix primary action visibility in table layout when the action doesn't support bulk operations, and fix compact action menu not visible on mobile when there is only one action. [#74836](https://github.com/WordPress/gutenberg/pull/74836)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -62,7 +62,6 @@
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
 - DataViews: Simplify list layout field color styles. [#73884](https://github.com/WordPress/gutenberg/pull/73884)
 - DataViews: Add panel form layout validation. [#73700](https://github.com/WordPress/gutenberg/pull/73700)
-- DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
 - Converted package to a compliant dual CJS/ESM module ([#73822](https://github.com/WordPress/gutenberg/pull/73822) and [#74348](https://github.com/WordPress/gutenberg/pull/74348))
 - Add density preference support to List view with compact, balanced (default), and comfortable options. ([#71050](https://github.com/WordPress/gutenberg/pull/71050))
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -58,6 +58,7 @@
 - DataViews: Update padding to 24px for consistency. [#73334](https://github.com/WordPress/gutenberg/pull/73334)
 - DataViews: Simplify list layout field color styles. [#73884](https://github.com/WordPress/gutenberg/pull/73884)
 - DataViews: Add panel form layout validation. [#73700](https://github.com/WordPress/gutenberg/pull/73700)
+- DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
 - Converted package to a compliant dual CJS/ESM module ([#73822](https://github.com/WordPress/gutenberg/pull/73822) and [#74348](https://github.com/WordPress/gutenberg/pull/74348))
 - Add density preference support to List view with compact, balanced (default), and comfortable options. ([#71050](https://github.com/WordPress/gutenberg/pull/71050))
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -151,6 +151,7 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 		isOpen: effectiveIsOpen,
 		CardHeader: CardHeaderComponent,
 		touched,
+		setTouched,
 	};
 }
 
@@ -224,7 +225,16 @@ export default function FormCardField< Item >( {
 		[ field ]
 	);
 
-	const { isOpen, CardHeader, touched } = useCardHeader( layout );
+	const { isOpen, CardHeader, touched, setTouched } = useCardHeader( layout );
+
+	// Mark the card as touched when any field changes value.
+	const handleChange: typeof onChange = useCallback(
+		( value ) => {
+			setTouched( true );
+			onChange( value );
+		},
+		[ onChange, setTouched ]
+	);
 
 	// When the card is expanded after being touched (collapsed with errors),
 	// trigger reportValidity to show field-level errors.
@@ -325,7 +335,7 @@ export default function FormCardField< Item >( {
 						<DataFormLayout
 							data={ data }
 							form={ form }
-							onChange={ onChange }
+							onChange={ handleChange }
 							validity={ validity?.children }
 						/>
 					</CardBody>
@@ -387,7 +397,7 @@ export default function FormCardField< Item >( {
 						<RegularLayout
 							data={ data }
 							field={ field }
-							onChange={ onChange }
+							onChange={ handleChange }
 							hideLabelFromVision={
 								hideLabelFromVision || withHeader
 							}

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -13,6 +13,7 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { chevronDown, chevronUp } from '@wordpress/icons';
@@ -213,6 +214,7 @@ export default function FormCardField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedCardLayout;
+	const cardBodyRef = useRef< HTMLDivElement >( null );
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -223,6 +225,22 @@ export default function FormCardField< Item >( {
 	);
 
 	const { isOpen, CardHeader, touched } = useCardHeader( layout );
+
+	// When the card is expanded after being touched (collapsed with errors),
+	// trigger reportValidity to show field-level errors.
+	// This matches the pattern from the "Showing Errors At Arbitrary Times" story.
+	useEffect( () => {
+		if ( isOpen && touched && cardBodyRef.current ) {
+			// Trigger reportValidity on each input within the card to fire the
+			// 'invalid' event, which makes validated controls show errors.
+			const inputs = cardBodyRef.current.querySelectorAll(
+				'input, textarea, select, fieldset'
+			);
+			inputs.forEach( ( input ) => {
+				( input as HTMLInputElement ).reportValidity();
+			} );
+		}
+	}, [ isOpen, touched ] );
 
 	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
 
@@ -298,6 +316,7 @@ export default function FormCardField< Item >( {
 					<CardBody
 						size={ sizeCardBody }
 						className="dataforms-layouts-card__field-control"
+						ref={ cardBodyRef }
 					>
 						{ field.description && (
 							<div className="dataforms-layouts-card__field-description">
@@ -365,15 +384,17 @@ export default function FormCardField< Item >( {
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
 				>
-					<RegularLayout
-						data={ data }
-						field={ field }
-						onChange={ onChange }
-						hideLabelFromVision={
-							hideLabelFromVision || withHeader
-						}
-						validity={ validity }
-					/>
+					<div ref={ cardBodyRef }>
+						<RegularLayout
+							data={ data }
+							field={ field }
+							onChange={ onChange }
+							hideLabelFromVision={
+								hideLabelFromVision || withHeader
+							}
+							validity={ validity }
+						/>
+					</div>
 				</CardBody>
 			) }
 		</Card>

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -390,18 +390,18 @@ export default function FormCardField< Item >( {
 				<CardBody
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
+					ref={ cardBodyRef }
+					onBlur={ handleBlur }
 				>
-					<div ref={ cardBodyRef } onBlur={ handleBlur }>
-						<RegularLayout
-							data={ data }
-							field={ field }
-							onChange={ onChange }
-							hideLabelFromVision={
-								hideLabelFromVision || withHeader
-							}
-							validity={ validity }
-						/>
-					</div>
+					<RegularLayout
+						data={ data }
+						field={ field }
+						onChange={ onChange }
+						hideLabelFromVision={
+							hideLabelFromVision || withHeader
+						}
+						validity={ validity }
+					/>
 				</CardBody>
 			) }
 		</Card>

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -6,8 +6,8 @@ import {
 	Card,
 	CardBody,
 	CardHeader as OriginalCardHeader,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import {
 	useCallback,
 	useContext,
@@ -21,7 +21,6 @@ import { sprintf, _n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { unlock } from '../../../lock-unlock';
 import { getFormFieldLayout } from '..';
 import DataFormContext from '../../dataform-context';
 import type {
@@ -35,8 +34,6 @@ import type {
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import { getSummaryFields } from '../get-summary-fields';
-
-const { Badge } = unlock( componentsPrivateApis );
 
 function countInvalidFields( validity: FieldValidity | undefined ): number {
 	if ( ! validity ) {
@@ -274,7 +271,7 @@ export default function FormCardField< Item >( {
 							{ field.label }
 						</span>
 						{ showValidationBadge && (
-							<Badge intent="error">
+							<Badge intent="high">
 								{ sprintf(
 									/* translators: %s: Number of fields that need attention */
 									_n(
@@ -356,7 +353,7 @@ export default function FormCardField< Item >( {
 						{ fieldDefinition.label }
 					</span>
 					{ showValidationBadge && (
-						<Badge intent="error">
+						<Badge intent="high">
 							{ sprintf(
 								/* translators: %s: Number of fields that need attention */
 								_n(

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -95,14 +95,12 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 	}, [ isOpened ] );
 
 	const toggle = useCallback( () => {
-		setIsOpen( ( prev ) => {
-			// Mark as touched when collapsing (going from open to closed)
-			if ( prev ) {
-				setTouched( true );
-			}
-			return ! prev;
-		} );
-	}, [] );
+		// Mark as touched when collapsing (going from open to closed)
+		if ( isOpen ) {
+			setTouched( true );
+		}
+		setIsOpen( ( prev ) => ! prev );
+	}, [ isOpen ] );
 
 	const CollapsibleCardHeader = useCallback(
 		( {

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -16,6 +16,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { chevronDown, chevronUp } from '@wordpress/icons';
+import { sprintf, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -274,11 +275,15 @@ export default function FormCardField< Item >( {
 						</span>
 						{ showValidationBadge && (
 							<Badge intent="error">
-								{ invalidCount }{ ' ' }
-								{ invalidCount === 1
-									? 'field needs'
-									: 'fields need' }{ ' ' }
-								attention
+								{ sprintf(
+									/* translators: %s: Number of fields that need attention */
+									_n(
+										'%s field needs attention',
+										'%s fields need attention',
+										invalidCount
+									),
+									invalidCount.toString()
+								) }
 							</Badge>
 						) }
 						{ visibleSummaryFields.length > 0 &&
@@ -352,11 +357,15 @@ export default function FormCardField< Item >( {
 					</span>
 					{ showValidationBadge && (
 						<Badge intent="error">
-							{ invalidCount }{ ' ' }
-							{ invalidCount === 1
-								? 'field needs'
-								: 'fields need' }{ ' ' }
-							attention
+							{ sprintf(
+								/* translators: %s: Number of fields that need attention */
+								_n(
+									'%s field needs attention',
+									'%s fields need attention',
+									invalidCount
+								),
+								invalidCount.toString()
+							) }
 						</Badge>
 					) }
 					{ visibleSummaryFields.length > 0 && layout.withHeader && (

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -235,6 +235,20 @@ export default function FormCardField< Item >( {
 	const showValidationBadge =
 		touched && invalidCount > 0 && layout.isCollapsible;
 
+	const validationBadge = showValidationBadge ? (
+		<Badge intent="high">
+			{ sprintf(
+				/* translators: %d: Number of fields that need attention */
+				_n(
+					'%d field needs attention',
+					'%d fields need attention',
+					invalidCount
+				),
+				invalidCount
+			) }
+		</Badge>
+	) : null;
+
 	const sizeCard = {
 		blockStart: 'medium' as const,
 		blockEnd: 'medium' as const,
@@ -261,19 +275,7 @@ export default function FormCardField< Item >( {
 						<span className="dataforms-layouts-card__field-header-label">
 							{ field.label }
 						</span>
-						{ showValidationBadge && (
-							<Badge intent="high">
-								{ sprintf(
-									/* translators: %s: Number of fields that need attention */
-									_n(
-										'%s field needs attention',
-										'%s fields need attention',
-										invalidCount
-									),
-									invalidCount.toString()
-								) }
-							</Badge>
-						) }
+						{ validationBadge }
 						{ visibleSummaryFields.length > 0 &&
 							layout.withHeader && (
 								<div className="dataforms-layouts-card__field-summary">
@@ -342,19 +344,7 @@ export default function FormCardField< Item >( {
 					<span className="dataforms-layouts-card__field-header-label">
 						{ fieldDefinition.label }
 					</span>
-					{ showValidationBadge && (
-						<Badge intent="high">
-							{ sprintf(
-								/* translators: %s: Number of fields that need attention */
-								_n(
-									'%s field needs attention',
-									'%s fields need attention',
-									invalidCount
-								),
-								invalidCount.toString()
-							) }
-						</Badge>
-					) }
+					{ validationBadge }
 					{ visibleSummaryFields.length > 0 && layout.withHeader && (
 						<div className="dataforms-layouts-card__field-summary">
 							{ visibleSummaryFields.map( ( summaryField ) => (

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -225,7 +225,7 @@ export default function FormCardField< Item >( {
 		[ field ]
 	);
 
-	const { isOpen, CardHeader, touched, setTouched } = useCardHeader( layout );
+	const { isOpen, CardHeader, touched } = useCardHeader( layout );
 
 	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -228,7 +228,6 @@ export default function FormCardField< Item >( {
 
 	// When the card is expanded after being touched (collapsed with errors),
 	// trigger reportValidity to show field-level errors.
-	// This matches the pattern from the "Showing Errors At Arbitrary Times" story.
 	useEffect( () => {
 		if ( isOpen && touched && cardBodyRef.current ) {
 			// Trigger reportValidity on each input within the card to fire the

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -235,14 +235,8 @@ export default function FormCardField< Item >( {
 
 	// Count invalid fields for validation badge
 	const invalidCount = countInvalidFields( validity );
-	const showValidationBadge = touched && invalidCount > 0;
-
-	// For non-collapsible cards, mark as touched when user interacts with fields
-	const handleBlurCapture = useCallback( () => {
-		if ( ! layout.isCollapsible ) {
-			setTouched( true );
-		}
-	}, [ layout.isCollapsible, setTouched ] );
+	const showValidationBadge =
+		touched && invalidCount > 0 && layout.isCollapsible;
 
 	const sizeCard = {
 		blockStart: 'medium' as const,
@@ -305,7 +299,6 @@ export default function FormCardField< Item >( {
 					<CardBody
 						size={ sizeCardBody }
 						className="dataforms-layouts-card__field-control"
-						onBlurCapture={ handleBlurCapture }
 					>
 						{ field.description && (
 							<div className="dataforms-layouts-card__field-description">
@@ -384,7 +377,6 @@ export default function FormCardField< Item >( {
 				<CardBody
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
-					onBlurCapture={ handleBlurCapture }
 				>
 					<RegularLayout
 						data={ data }

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -150,7 +150,6 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 		isOpen: effectiveIsOpen,
 		CardHeader: CardHeaderComponent,
 		touched,
-		setTouched,
 	};
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -227,14 +227,11 @@ export default function FormCardField< Item >( {
 
 	const { isOpen, CardHeader, touched, setTouched } = useCardHeader( layout );
 
-	// Mark the card as touched when any field changes value.
-	const handleChange: typeof onChange = useCallback(
-		( value ) => {
-			setTouched( true );
-			onChange( value );
-		},
-		[ onChange, setTouched ]
-	);
+	// Mark the card as touched when any field inside it is blurred.
+	// This aligns with how validated controls show errors on blur.
+	const handleBlur = useCallback( () => {
+		setTouched( true );
+	}, [ setTouched ] );
 
 	// When the card is expanded after being touched (collapsed with errors),
 	// trigger reportValidity to show field-level errors.
@@ -326,6 +323,7 @@ export default function FormCardField< Item >( {
 						size={ sizeCardBody }
 						className="dataforms-layouts-card__field-control"
 						ref={ cardBodyRef }
+						onBlur={ handleBlur }
 					>
 						{ field.description && (
 							<div className="dataforms-layouts-card__field-description">
@@ -335,7 +333,7 @@ export default function FormCardField< Item >( {
 						<DataFormLayout
 							data={ data }
 							form={ form }
-							onChange={ handleChange }
+							onChange={ onChange }
 							validity={ validity?.children }
 						/>
 					</CardBody>
@@ -393,11 +391,11 @@ export default function FormCardField< Item >( {
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
 				>
-					<div ref={ cardBodyRef }>
+					<div ref={ cardBodyRef } onBlur={ handleBlur }>
 						<RegularLayout
 							data={ data }
 							field={ field }
-							onChange={ handleChange }
+							onChange={ onChange }
 							hideLabelFromVision={
 								hideLabelFromVision || withHeader
 							}

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -6,6 +6,7 @@ import {
 	Card,
 	CardBody,
 	CardHeader as OriginalCardHeader,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
 	useCallback,
@@ -19,10 +20,12 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../../lock-unlock';
 import { getFormFieldLayout } from '..';
 import DataFormContext from '../../dataform-context';
 import type {
 	FieldLayoutProps,
+	FieldValidity,
 	NormalizedCardLayout,
 	NormalizedField,
 	NormalizedForm,
@@ -31,6 +34,35 @@ import type {
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import { getSummaryFields } from '../get-summary-fields';
+
+const { Badge } = unlock( componentsPrivateApis );
+
+function countInvalidFields( validity: FieldValidity | undefined ): number {
+	if ( ! validity ) {
+		return 0;
+	}
+
+	let count = 0;
+	const validityRules = Object.keys( validity ).filter(
+		( key ) => key !== 'children'
+	);
+
+	for ( const key of validityRules ) {
+		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
+		if ( rule?.type === 'invalid' ) {
+			count++;
+		}
+	}
+
+	// Count children recursively
+	if ( validity.children ) {
+		for ( const childValidity of Object.values( validity.children ) ) {
+			count += countInvalidFields( childValidity );
+		}
+	}
+
+	return count;
+}
 
 const NonCollapsibleCardHeader = ( {
 	children,
@@ -56,6 +88,7 @@ const NonCollapsibleCardHeader = ( {
 export function useCardHeader( layout: NormalizedCardLayout ) {
 	const { isOpened, isCollapsible } = layout;
 	const [ isOpen, setIsOpen ] = useState( isOpened );
+	const [ touched, setTouched ] = useState( false );
 
 	// Sync internal state when the isOpened prop changes.
 	// This is unlikely to happen in production, but it helps with storybook controls.
@@ -64,7 +97,13 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 	}, [ isOpened ] );
 
 	const toggle = useCallback( () => {
-		setIsOpen( ( prev ) => ! prev );
+		setIsOpen( ( prev ) => {
+			// Mark as touched when collapsing (going from open to closed)
+			if ( prev ) {
+				setTouched( true );
+			}
+			return ! prev;
+		} );
 	}, [] );
 
 	const CollapsibleCardHeader = useCallback(
@@ -111,7 +150,12 @@ export function useCardHeader( layout: NormalizedCardLayout ) {
 		? CollapsibleCardHeader
 		: NonCollapsibleCardHeader;
 
-	return { isOpen: effectiveIsOpen, CardHeader: CardHeaderComponent };
+	return {
+		isOpen: effectiveIsOpen,
+		CardHeader: CardHeaderComponent,
+		touched,
+		setTouched,
+	};
 }
 
 function isSummaryFieldVisible< Item >(
@@ -183,13 +227,24 @@ export default function FormCardField< Item >( {
 		[ field ]
 	);
 
-	const { isOpen, CardHeader } = useCardHeader( layout );
+	const { isOpen, CardHeader, touched, setTouched } = useCardHeader( layout );
 
 	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
 
 	const visibleSummaryFields = summaryFields.filter( ( summaryField ) =>
 		isSummaryFieldVisible( summaryField, layout.summary, isOpen )
 	);
+
+	// Count invalid fields for validation badge
+	const invalidCount = countInvalidFields( validity );
+	const showValidationBadge = touched && invalidCount > 0;
+
+	// For non-collapsible cards, mark as touched when user interacts with fields
+	const handleBlurCapture = useCallback( () => {
+		if ( ! layout.isCollapsible ) {
+			setTouched( true );
+		}
+	}, [ layout.isCollapsible, setTouched ] );
 
 	const sizeCard = {
 		blockStart: 'medium' as const,
@@ -217,6 +272,15 @@ export default function FormCardField< Item >( {
 						<span className="dataforms-layouts-card__field-header-label">
 							{ field.label }
 						</span>
+						{ showValidationBadge && (
+							<Badge intent="error">
+								{ invalidCount }{ ' ' }
+								{ invalidCount === 1
+									? 'field needs'
+									: 'fields need' }{ ' ' }
+								attention
+							</Badge>
+						) }
 						{ visibleSummaryFields.length > 0 &&
 							layout.withHeader && (
 								<div className="dataforms-layouts-card__field-summary">
@@ -239,6 +303,7 @@ export default function FormCardField< Item >( {
 					<CardBody
 						size={ sizeCardBody }
 						className="dataforms-layouts-card__field-control"
+						onBlurCapture={ handleBlurCapture }
 					>
 						{ field.description && (
 							<div className="dataforms-layouts-card__field-description">
@@ -285,6 +350,15 @@ export default function FormCardField< Item >( {
 					<span className="dataforms-layouts-card__field-header-label">
 						{ fieldDefinition.label }
 					</span>
+					{ showValidationBadge && (
+						<Badge intent="error">
+							{ invalidCount }{ ' ' }
+							{ invalidCount === 1
+								? 'field needs'
+								: 'fields need' }{ ' ' }
+							attention
+						</Badge>
+					) }
 					{ visibleSummaryFields.length > 0 && layout.withHeader && (
 						<div className="dataforms-layouts-card__field-summary">
 							{ visibleSummaryFields.map( ( summaryField ) => (
@@ -304,6 +378,7 @@ export default function FormCardField< Item >( {
 				<CardBody
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
+					onBlurCapture={ handleBlurCapture }
 				>
 					<RegularLayout
 						data={ data }

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -100,7 +100,13 @@ export const Validation = {
 		layout: {
 			control: { type: 'select' },
 			description: 'Choose the form layout type.',
-			options: [ 'regular', 'panel', 'card', 'details' ],
+			options: [
+				'regular',
+				'panel',
+				'card-collapsible',
+				'card-not-collapsible',
+				'details',
+			],
 		},
 		required: {
 			control: { type: 'boolean' },

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -973,6 +973,43 @@ const ValidationComponent = ( {
 			},
 		];
 
+		// Card layout with a non-collapsible example
+		const cardFields = [
+			{
+				id: 'textFields',
+				label: 'Text Fields (Non-collapsible)',
+				layout: { type: 'card' as const, isCollapsible: false },
+				children: [ 'password', 'text', 'textarea', 'customEdit' ],
+			},
+			{
+				id: 'numberFields',
+				label: 'Number Fields',
+				children: [ 'integer', 'number' ],
+			},
+			{
+				id: 'contactFields',
+				label: 'Contact Fields',
+				children: [ 'email', 'telephone', 'url' ],
+			},
+			{
+				id: 'selectFields',
+				label: 'Selection Fields',
+				children: [ 'select', 'textWithRadio' ],
+			},
+			{
+				id: 'booleanFields',
+				label: 'Boolean Fields',
+				children: [ 'boolean', 'toggle', 'toggleGroup' ],
+			},
+			{ id: 'color' },
+			{ id: 'array' },
+			{
+				id: 'dateFields',
+				label: 'Date Fields',
+				children: [ 'date', 'dateRange', 'datetime' ],
+			},
+		];
+
 		if ( layout === 'panel' ) {
 			return {
 				layout: { type: 'panel' as const },
@@ -989,7 +1026,7 @@ const ValidationComponent = ( {
 
 		return {
 			layout: { type: 'card' as const },
-			fields: groupedFields,
+			fields: cardFields,
 		};
 	}, [ layout ] );
 

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -993,8 +993,8 @@ const ValidationComponent = ( {
 		}
 
 		if ( layout === 'card-collapsible' ) {
-		return {
-			layout: { type: 'card' as const },
+			return {
+				layout: { type: 'card' as const },
 				fields: groupedFields,
 			};
 		}

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -86,7 +86,12 @@ const ValidationComponent = ( {
 	custom: 'sync' | 'async' | 'none';
 	pattern: boolean;
 	minMax: boolean;
-	layout: 'regular' | 'panel' | 'card' | 'details';
+	layout:
+		| 'regular'
+		| 'panel'
+		| 'card-collapsible'
+		| 'card-not-collapsible'
+		| 'details';
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -973,43 +978,6 @@ const ValidationComponent = ( {
 			},
 		];
 
-		// Card layout with a non-collapsible example
-		const cardFields = [
-			{
-				id: 'textFields',
-				label: 'Text Fields (Non-collapsible)',
-				layout: { type: 'card' as const, isCollapsible: false },
-				children: [ 'password', 'text', 'textarea', 'customEdit' ],
-			},
-			{
-				id: 'numberFields',
-				label: 'Number Fields',
-				children: [ 'integer', 'number' ],
-			},
-			{
-				id: 'contactFields',
-				label: 'Contact Fields',
-				children: [ 'email', 'telephone', 'url' ],
-			},
-			{
-				id: 'selectFields',
-				label: 'Selection Fields',
-				children: [ 'select', 'textWithRadio' ],
-			},
-			{
-				id: 'booleanFields',
-				label: 'Boolean Fields',
-				children: [ 'boolean', 'toggle', 'toggleGroup' ],
-			},
-			{ id: 'color' },
-			{ id: 'array' },
-			{
-				id: 'dateFields',
-				label: 'Date Fields',
-				children: [ 'date', 'dateRange', 'datetime' ],
-			},
-		];
-
 		if ( layout === 'panel' ) {
 			return {
 				layout: { type: 'panel' as const },
@@ -1024,9 +992,17 @@ const ValidationComponent = ( {
 			};
 		}
 
+		if ( layout === 'card-collapsible' ) {
 		return {
 			layout: { type: 'card' as const },
-			fields: cardFields,
+				fields: groupedFields,
+			};
+		}
+
+		// card-not-collapsible
+		return {
+			layout: { type: 'card' as const, isCollapsible: false },
+			fields: groupedFields,
 		};
 	}, [ layout ] );
 


### PR DESCRIPTION
## Summary

Part of: https://github.com/WordPress/gutenberg/issues/72321

Adds validation support to the card form layout, similar to #73700 (panel layout validation).

- Displays a badge in the card header showing "X field(s) need attention" when there are invalid fields
- For collapsible cards: badge appears after collapsing the card
- For non-collapsible cards: badge appears after blurring from any field inside
- Includes a non-collapsible card example in the Validation story

## Screenshot
<img width="568" height="113" alt="Screenshot 2026-01-12 at 14 39 48" src="https://github.com/user-attachments/assets/111da659-5964-4a09-9129-01558ef36a1a" />
<img width="573" height="798" alt="Screenshot 2026-01-12 at 14 39 33" src="https://github.com/user-attachments/assets/fd3d1d45-b61b-42bb-82d9-4ad3cf3d679f" />


## Test plan

1. Go to Storybook > DataViews > DataForm > Validation
2. Select `layout: "card"`
3. For collapsible cards: expand, clear a required field, collapse - badge should appear
4. For non-collapsible cards ("Text Fields"): clear a required field and blur - badge should appear
5. Verify singular/plural: "1 field needs attention" vs "2 fields need attention"