### PR TITLE
Menu: Remove animation on submenus

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -39,6 +39,7 @@
 -   Converted package to a compliant dual CJS/ESM module ([#73822](https://github.com/WordPress/gutenberg/pull/73822) and [#74348](https://github.com/WordPress/gutenberg/pull/74348)).
 -   `ToggleGroupControl`: Update visual design ([#74036](https://github.com/WordPress/gutenberg/pull/74036)).
 -   `Notice`: Add `disabled` prop to action buttons. Also allow `onClick` to work alongside `url` ([#74094](https://github.com/WordPress/gutenberg/pull/74094)).
+-   `Menu`: Remove animation on submenus ([#74548](https://github.com/WordPress/gutenberg/pull/74548)).
 
 ### Bug Fixes
 

--- a/packages/components/src/menu/popover.tsx
+++ b/packages/components/src/menu/popover.tsx
@@ -84,6 +84,7 @@ export const Popover = forwardRef<
 			shift={ shift ?? ( menuContext.store.parent ? -4 : 0 ) }
 			hideOnHoverOutside={ false }
 			data-side={ appliedPlacementSide }
+			data-submenu={ !! menuContext.store.parent || undefined }
 			wrapperProps={ wrapperProps }
 			hideOnEscape={ hideOnEscape }
 			unmountOnHide

--- a/packages/components/src/menu/styles.ts
+++ b/packages/components/src/menu/styles.ts
@@ -72,32 +72,42 @@ export const Menu = styled( Ariakit.Menu )< Pick< ContextProps, 'variant' > >`
 			${ DROPDOWN_MOTION_CSS.FADE_EASING };
 		will-change: transform, opacity;
 
-		/* Regardless of the side, fade in and out. */
-		opacity: 0;
-		&[data-enter] {
-			opacity: 1;
-		}
+		&:not( [data-submenu] ) {
+			/* Regardless of the side, fade in and out. */
+			opacity: 0;
+			&[data-enter] {
+				opacity: 1;
+			}
 
-		/* Slide in the direction the menu is opening. */
-		&[data-side='bottom'] {
-			transform: translateY( -${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE } );
-		}
-		&[data-side='top'] {
-			transform: translateY( ${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE } );
-		}
-		&[data-side='left'] {
-			transform: translateX( ${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE } );
-		}
-		&[data-side='right'] {
-			transform: translateX( -${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE } );
-		}
-		&[data-enter][data-side='bottom'],
-		&[data-enter][data-side='top'] {
-			transform: translateY( 0 );
-		}
-		&[data-enter][data-side='left'],
-		&[data-enter][data-side='right'] {
-			transform: translateX( 0 );
+			/* Slide in the direction the menu is opening. */
+			&[data-side='bottom'] {
+				transform: translateY(
+					-${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE }
+				);
+			}
+			&[data-side='top'] {
+				transform: translateY(
+					${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE }
+				);
+			}
+			&[data-side='left'] {
+				transform: translateX(
+					${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE }
+				);
+			}
+			&[data-side='right'] {
+				transform: translateX(
+					-${ DROPDOWN_MOTION_CSS.SLIDE_DISTANCE }
+				);
+			}
+			&[data-enter][data-side='bottom'],
+			&[data-enter][data-side='top'] {
+				transform: translateY( 0 );
+			}
+			&[data-enter][data-side='left'],
+			&[data-enter][data-side='right'] {
+				transform: translateX( 0 );
+			}
 		}
 	}
 `;


### PR DESCRIPTION
## What?

Closes #74442

Removes animation from submenus in `Menu`.

## Why?

For a snappier feel.

## How?

Add a data attribute on menus that are submenus. Disable animations on these.

## Testing Instructions

See the "With Submenu" story for `Menu` in Storybook.

## Screenshots or screencast <!-- if applicable -->

## Before

https://github.com/user-attachments/assets/9bc233ec-dd26-4316-aefe-5d57b1b0ece5


## After


https://github.com/user-attachments/assets/94d716f3-f496-46e7-a283-9490025339bf

