### PR TITLE
Rename `--fast` build flag and use in Storybook build

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -42,7 +42,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build -- --fast
+              run: npm run build -- --runtime-only
 
             - name: Install Playwright dependencies
               run: |
@@ -133,7 +133,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build -- --fast
+              run: npm run build -- --runtime-only
 
             - name: Report flaky tests
               uses: ./packages/report-flaky-tests

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -42,7 +42,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build -- --runtime-only
+              run: npm run build -- --skip-types
 
             - name: Install Playwright dependencies
               run: |
@@ -133,7 +133,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build -- --runtime-only
+              run: npm run build -- --skip-types
 
             - name: Report flaky tests
               uses: ./packages/report-flaky-tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -163,7 +163,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Run build scripts
-              run: npm run build -- --fast
+              run: npm run build -- --runtime-only
 
             - name: Upload built JavaScript assets
               uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -163,7 +163,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Run build scripts
-              run: npm run build -- --runtime-only
+              run: npm run build -- --skip-types
 
             - name: Upload built JavaScript assets
               uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -70,7 +70,7 @@ status "Installing dependencies... 📦"
 npm cache verify
 npm ci
 status "Generating build... 👷‍♀️"
-npm run build -- --fast
+npm run build -- --runtime-only
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -70,7 +70,7 @@ status "Installing dependencies... 📦"
 npm cache verify
 npm ci
 status "Generating build... 👷‍♀️"
-npm run build -- --runtime-only
+npm run build -- --skip-types
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"

--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -78,7 +78,7 @@ function exec( command, args = [], options = {} ) {
  * Main build orchestration function.
  */
 async function build() {
-	const runtimeOnly = process.argv.includes( '--runtime-only' );
+	const skipTypes = process.argv.includes( '--skip-types' );
 
 	console.log( '🔨 Starting build process...\n' );
 
@@ -97,7 +97,7 @@ async function build() {
 			{ silent: true }
 		);
 
-		if ( ! runtimeOnly ) {
+		if ( ! skipTypes ) {
 			// Step 3: Validate TypeScript version
 			console.log( '\n🔍 Validating TypeScript version...' );
 			await exec( 'node', [
@@ -128,7 +128,7 @@ async function build() {
 		console.log( '\n📦 Building packages (production mode)...' );
 		const buildArgs = process.argv
 			.slice( 2 )
-			.filter( ( arg ) => arg !== '--runtime-only' );
+			.filter( ( arg ) => arg !== '--skip-types' );
 		await exec( 'wp-build', buildArgs, {
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );

--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -78,7 +78,7 @@ function exec( command, args = [], options = {} ) {
  * Main build orchestration function.
  */
 async function build() {
-	const fast = process.argv.includes( '--fast' );
+	const runtimeOnly = process.argv.includes( '--runtime-only' );
 
 	console.log( '🔨 Starting build process...\n' );
 
@@ -97,7 +97,7 @@ async function build() {
 			{ silent: true }
 		);
 
-		if ( ! fast ) {
+		if ( ! runtimeOnly ) {
 			// Step 3: Validate TypeScript version
 			console.log( '\n🔍 Validating TypeScript version...' );
 			await exec( 'node', [
@@ -128,7 +128,7 @@ async function build() {
 		console.log( '\n📦 Building packages (production mode)...' );
 		const buildArgs = process.argv
 			.slice( 2 )
-			.filter( ( arg ) => arg !== '--fast' );
+			.filter( ( arg ) => arg !== '--runtime-only' );
 		await exec( 'wp-build', buildArgs, {
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
 		"prepare": "husky install",
 		"prepublishOnly": "npm run build",
 		"start": "npm run dev",
-		"prestorybook:build": "npm run build",
+		"prestorybook:build": "npm run build -- --runtime-only",
 		"storybook:build": "storybook build -c ./storybook -o ./storybook/build",
 		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c ./storybook -p 50240\"",
 		"storybook:e2e:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c test/storybook-playwright/storybook -p 50241\"",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
 		"prepare": "husky install",
 		"prepublishOnly": "npm run build",
 		"start": "npm run dev",
-		"prestorybook:build": "npm run build -- --runtime-only",
+		"prestorybook:build": "npm run build -- --skip-types",
 		"storybook:build": "storybook build -c ./storybook -o ./storybook/build",
 		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c ./storybook -p 50240\"",
 		"storybook:e2e:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c test/storybook-playwright/storybook -p 50241\"",

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1949,6 +1949,7 @@ async function main() {
 				default: 'plugin_dir_url( __FILE__ )',
 			},
 		},
+		strict: false,
 	} );
 
 	const baseUrlExpression = values[ 'base-url' ];


### PR DESCRIPTION
## What?

Follow-up to #74406

- Renames `--fast` build flag to ~`--runtime-only`~ `--skip-types`, to clarify what it's doing
- Updates `storybook:build` NPM to use this flag

I also considered making this a default with `storybook:dev`, as the TypeScript builds are a big contributor to the startup time for Storybook, but this requires a few more changes to the `dev` command. I suppose there's value in having TypeScript error feedback for development workflows. Maybe it should be optionally supported?

Based on discussion in https://github.com/WordPress/gutenberg/pull/72487#discussion_r2444838657 , I wonder if the availability of this "TypeScript skipping" logic changes anything about whether we even need the pre-build steps?

## Why?

- Everyone wants fast builds, and there's value in clarifying why this is not the default.
- Faster Storybook builds improves CI time

## Testing Instructions

Affected CI builds should continue to pass and not run TypeScript steps (see details logs).

`npm run storybook:build` should still build without errors and produce a working Storybook site.