### PR TITLE
Fix default Close text not showing in Navigation Overlay Close block

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/save.js
+++ b/packages/block-library/src/navigation-overlay-close/save.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 const saveBlockProps = useBlockProps.save;
 
 export default function NavigationOverlayCloseSave( { attributes } ) {
 	const { displayMode, text } = attributes;
+
+	const label = text || __( 'Close', 'gutenberg' );
+
 	const showIcon = displayMode === 'icon' || displayMode === 'both';
 	const showText = displayMode === 'text' || displayMode === 'both';
 
@@ -18,7 +22,7 @@ export default function NavigationOverlayCloseSave( { attributes } ) {
 		<button
 			{ ...blockProps }
 			type="button"
-			aria-label={ ! showText ? 'Close' : undefined }
+			aria-label={ ! showText ? label : undefined }
 		>
 			{ showIcon && (
 				<svg
@@ -35,7 +39,7 @@ export default function NavigationOverlayCloseSave( { attributes } ) {
 			{ showText && (
 				<RichText.Content
 					tagName="span"
-					value={ text }
+					value={ label }
 					className="wp-block-navigation-overlay-close__text"
 				/>
 			) }


### PR DESCRIPTION
## What?
Closes #74537

This PR fixes the Navigation Overlay Close block so that the default “Close” label is shown on the frontend when no custom text is provided.

## Why?
Currently, when the Navigation Overlay Close block is set to display text (or both icon and text) and the user does not enter a custom label, nothing is rendered on the frontend. This results in an invisible button label, which is confusing for users and inconsistent with expected default behavior.

This change ensures that a sensible default (“Close”) is always displayed.

## How?
The save component now falls back to a translated default label using `__( 'Close', 'gutenberg' )` when the `text` attribute is empty. This value is then used both for rendering the text and for the aria-label when appropriate.

## Testing Instructions
1. Go to the Site Editor.
2. Create or edit a Navigation Overlay template part.
3. Add the **Navigation Overlay Close** block.
4. Set the display mode to **Text** or **Both**.
5. Do not enter any custom text.
6. Save and view the frontend.
7. Verify that the **“Close”** text is now visible.

### Testing Instructions for Keyboard
1. Open the Navigation Overlay on the frontend.
2. Use the `Tab` key to focus the Close button.
3. Verify that the visible “Close” label is present and the button can be activated using `Enter` or `Space`.

## Screenshots or screencast
Not applicable (text-only change).

