### PR TITLE
@wordpress/ui: use semantic dimension tokens

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -53,6 +53,19 @@ module.exports = {
 		{
 			files: [ '**/*.module.css' ],
 			rules: {
+				'function-no-unknown': [
+					true,
+					{
+						ignoreFunctions: [
+							// CSS stepped value math functions in Baseline 2024.
+							// This rule exception can likely be removed when
+							// updating to a more recent version of Stylelint.
+							'round',
+							'rem',
+							'mod',
+						],
+					},
+				],
 				'declaration-property-max-values': {
 					// Prevents left/right values with shorthand property names (unclear for RTL)
 					margin: 3,

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `Button`: Add minimum content width (`6ch` + padding) to prevent overly narrow buttons with short labels ([#75133](https://github.com/WordPress/gutenberg/pull/75133)).
 
+### Internal
+
+-   `Button`, `InputLayout`, `Tabs`: use semantic dimension tokens ([#74557](https://github.com/WordPress/gutenberg/pull/74557)).
+
 ## 0.6.0 (2026-01-29)
 
 ### New Features

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -17,7 +17,7 @@
 		--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-brand-strong);
 		--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-brand-strong-active);
 		--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
-		--wp-ui-button-padding-inline: calc(3 * var(--wpds-dimension-base)); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-padding-inline: var(--wpds-dimension-padding-md);
 		--wp-ui-button-height: 40px;
 		--wp-ui-button-aspect-ratio: auto; /* Useful for overrides such as icon buttons */
 		--wp-ui-button-font-size: var(--wpds-font-size-md);
@@ -33,7 +33,7 @@
 		display: inline-flex;
 		justify-content: center;
 		align-items: center;
-		gap: calc(2 * var(--wpds-dimension-base)); /* TODO: Consider new interactive/control gap tokens */
+		gap: var(--wpds-dimension-gap-sm);
 		aspect-ratio: var(--wp-ui-button-aspect-ratio);
 		min-width: var(--wp-ui-button-min-width);
 		height: var(--wp-ui-button-height);
@@ -121,7 +121,7 @@
 	}
 
 	.is-small {
-		--wp-ui-button-padding-inline: calc(2 * var(--wpds-dimension-base)); /* TODO: Create new interactive padding tokens */
+		--wp-ui-button-padding-inline: var(--wpds-dimension-padding-sm);
 		--wp-ui-button-height: 24px;
 	}
 

--- a/packages/ui/src/form/primitives/input-layout/style.module.css
+++ b/packages/ui/src/form/primitives/input-layout/style.module.css
@@ -2,8 +2,7 @@
 
 @layer wp-ui-components {
 	.input-layout {
-		/* TODO: Use padding tokens */
-		--wp-ui-input-layout-padding-inline: calc(var(--wpds-dimension-base) * 3);
+		--wp-ui-input-layout-padding-inline: var(--wpds-dimension-padding-md);
 
 		display: flex;
 		height: 40px;
@@ -22,14 +21,12 @@
 		}
 
 		&.is-size-compact {
-			/* TODO: Use padding tokens */
-			--wp-ui-input-layout-padding-inline: calc(var(--wpds-dimension-base) * 2);
+			--wp-ui-input-layout-padding-inline: var(--wpds-dimension-padding-sm);
 			height: 32px;
 		}
 
 		&.is-size-small {
-			/* TODO: Use padding tokens */
-			--wp-ui-input-layout-padding-inline: calc(var(--wpds-dimension-base) * 2);
+			--wp-ui-input-layout-padding-inline: var(--wpds-dimension-padding-sm);
 			height: 24px;
 		}
 
@@ -66,10 +63,10 @@
 		&.is-padding-minimal {
 			--wp-ui-input-layout-prefix-padding-start:
 				calc(var(--wp-ui-input-layout-padding-inline) -
-				var(--wpds-dimension-base));
+				var(--wpds-dimension-padding-xs));
 			--wp-ui-input-layout-suffix-padding-end:
 				calc(var(--wp-ui-input-layout-padding-inline) -
-				var(--wpds-dimension-base));
+				var(--wpds-dimension-padding-xs));
 		}
 
 		&.is-prefix {

--- a/packages/ui/src/tabs/style.module.css
+++ b/packages/ui/src/tabs/style.module.css
@@ -185,10 +185,11 @@
 
 			&::after {
 				/*
-				 * Add enough inset to prevent the focus ring (which is 1.5px thick)
-				 * from being visually clipped by the tablist.
+				 * Prevent clipping the focus ring at the tablist edge.
+				 * Use rounding, as the focus ring width may have sub-pixel values
+				 * depending on the screen pixel ratio.
 				 */
-				inset-inline: 2px;
+				inset-inline: round(up, var(--wpds-border-width-focus), 1px);
 			}
 		}
 

--- a/packages/ui/src/tabs/style.module.css
+++ b/packages/ui/src/tabs/style.module.css
@@ -170,13 +170,13 @@
 		}
 
 		[data-orientation="horizontal"] & {
-			padding-inline: calc(4 * var(--wpds-dimension-base)); /* TODO: Use or create new control/interactive padding token */
-			height: calc(12 * var(--wpds-dimension-base)); /* TODO: Can we eliminate or hard-code? */
+			padding-inline: var(--wpds-dimension-padding-lg);
+			height: 48px;
 			scroll-margin: 24px;
 
 			&::after {
 				content: "";
-				inset: calc(3 * var(--wpds-dimension-base)); /* TODO: Use or create new control/interactive padding token */
+				inset: var(--wpds-dimension-padding-md);
 			}
 		}
 
@@ -193,10 +193,8 @@
 		}
 
 		[data-orientation="vertical"] & {
-			padding:
-				calc(2 * var(--wpds-dimension-base))
-				calc(3 * var(--wpds-dimension-base)); /* TODO: Use or create new control/interactive padding token */
-			min-height: calc(10 * var(--wpds-dimension-base)); /* TODO: Can we eliminate or hard-code? */
+			padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+			min-height: 40px;
 		}
 
 		[data-orientation="vertical"][data-select-on-move="false"] &::after {
@@ -222,7 +220,7 @@
 
 	.tab-chevron {
 		flex-shrink: 0;
-		margin-inline-end: calc(var(--wpds-dimension-base) * -1); /* TODO: Use or create new control/interactive padding token */
+		margin-inline-end: calc(var(--wpds-dimension-gap-xs) * -1);
 
 		[data-orientation="horizontal"] & {
 			display: none;

--- a/packages/ui/src/tabs/style.module.css
+++ b/packages/ui/src/tabs/style.module.css
@@ -171,7 +171,7 @@
 
 		[data-orientation="horizontal"] & {
 			padding-inline: var(--wpds-dimension-padding-lg);
-			height: 48px;
+			height: 48px; /* TODO: use semantic size/height tokens when available */
 			scroll-margin: 24px;
 
 			&::after {
@@ -194,7 +194,7 @@
 
 		[data-orientation="vertical"] & {
 			padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
-			min-height: 40px;
+			min-height: 40px;  /* TODO: use semantic size/height tokens when available */
 		}
 
 		[data-orientation="vertical"][data-select-on-move="false"] &::after {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow up to https://github.com/WordPress/gutenberg/pull/74415#discussion_r2670026143
Follow up to https://github.com/WordPress/gutenberg/pull/74652
Follow up to https://github.com/WordPress/gutenberg/pull/74313
Follow up to https://github.com/WordPress/gutenberg/pull/75054

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With https://github.com/WordPress/gutenberg/pull/75054 merged, this PR refactor styles in the `@wordpress/ui` so that semantic dimension tokens are used instead of explicit multiples of the `--wpds-dimension-base` token

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swapped CSS variables with the correct one when applicable, otherwise used a hardcoded value

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure all affected components (`Button`, `InputLayou`, `Tabs`) look the same as on trunk
