### PR TITLE
Make custom navigation overlay full width

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -637,6 +637,10 @@ button.wp-block-navigation-item__content {
 			width: 100%;
 		}
 
+		.wp-block-navigation__responsive-close {
+			max-width: none;
+		}
+
 		// When menu is open with custom overlay, hide default navigation and show overlay.
 		&.is-menu-open {
 			.wp-block-navigation__responsive-container-content {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/73081
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Custom overlay template parts were limited by the default max width, and on large screens would not span the full width of the window.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove max-width for close wrapper when using a custom overlay.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a custom overlay to a navigation template part
- Give your group background a color
- Make your window greater than 1500px
- Go to the overlay on the frontend
- It should stretch to be the full width of the window

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1540" height="423" alt="overlay does not stretch full width and shows white background on sides" src="https://github.com/user-attachments/assets/271e728f-9145-4b30-9f83-25024b621f92" />|<img width="1543" height="451" alt="pink overlay background stretches full width" src="https://github.com/user-attachments/assets/b30ad4b0-993b-45bf-bd4b-64edd4c8c4ef" />
|

