### PR TITLE
Real-time collaboration: Move collaborative editing from experiments to default Gutenberg plugin experience

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -10,9 +10,6 @@
  */
 function gutenberg_enable_experiments() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableSync = true', 'before' );
-	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );
 	}

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -9,11 +9,6 @@
  * Registers post meta for persisting CRDT documents.
  */
 function gutenberg_rest_api_crdt_post_meta() {
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if ( ! $gutenberg_experiments || ! array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
-		return;
-	}
-
 	// This string must match WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE in @wordpress/sync.
 	$persisted_crdt_post_meta_key = '_crdt_document';
 

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -126,18 +126,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-sync-collaboration',
-		__( 'Collaboration: add real time editing', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enables live collaboration and offline persistence between peers.', 'gutenberg' ),
-			'id'    => 'gutenberg-sync-collaboration',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-color-randomizer',
 		__( 'Color randomizer', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -411,8 +411,8 @@ export const editEntityRecord =
 				return acc;
 			}, {} ),
 		};
-		if ( window.__experimentalEnableSync && entityConfig.syncConfig ) {
-			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			if ( entityConfig.syncConfig ) {
 				const objectType = `${ kind }/${ name }`;
 				const objectId = recordId;
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -283,12 +283,10 @@ export const prePersistPostType = (
 			const objectType = `postType/${ name }`;
 			const objectId = persistedRecord.id;
 			const meta = getSyncManager()?.createMeta( objectType, objectId );
-			if ( meta && Object.keys( meta ).length ) {
-				newEdits.meta = {
-					...edits.meta,
-					...meta,
-				};
-			}
+			newEdits.meta = {
+				...edits.meta,
+				...meta,
+			};
 		}
 	}
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -285,10 +285,12 @@ export const prePersistPostType = (
 			const objectType = `postType/${ name }`;
 			const objectId = persistedRecord.id;
 			const meta = getSyncManager()?.createMeta( objectType, objectId );
-			newEdits.meta = {
-				...edits.meta,
-				...meta,
-			};
+			if ( meta && Object.keys( meta ).length ) {
+				newEdits.meta = {
+					...edits.meta,
+					...meta,
+				};
+			}
 		}
 	}
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -16,8 +16,6 @@ import { __ } from '@wordpress/i18n';
 import { getSyncManager } from './sync';
 import {
 	applyPostChangesToCRDTDoc,
-	defaultApplyChangesToCRDTDoc,
-	defaultGetChangesFromCRDTDoc,
 	getPostChangesFromCRDTDoc,
 } from './utils/crdt';
 
@@ -429,16 +427,6 @@ async function loadSiteEntity() {
 		baseURL: '/wp/v2/settings',
 		meta: {},
 	};
-
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		/**
-		 * @type {import('@wordpress/sync').SyncConfig}
-		 */
-		entity.syncConfig = {
-			applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
-			getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
-		};
-	}
 
 	const site = await apiFetch( {
 		path: entity.baseURL,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -280,8 +280,8 @@ export const prePersistPostType = (
 	}
 
 	// Add meta for persisted CRDT document.
-	if ( persistedRecord && window.__experimentalEnableSync ) {
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( persistedRecord ) {
 			const objectType = `postType/${ name }`;
 			const objectId = persistedRecord.id;
 			const meta = getSyncManager()?.createMeta( objectType, objectId );
@@ -344,48 +344,46 @@ async function loadPostTypeEntities() {
 					: DEFAULT_ENTITY_KEY,
 		};
 
-		if ( window.__experimentalEnableSync ) {
-			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			/**
+			 * @type {import('@wordpress/sync').SyncConfig}
+			 */
+			entity.syncConfig = {
 				/**
-				 * @type {import('@wordpress/sync').SyncConfig}
+				 * Apply changes from the local editor to the local CRDT document so
+				 * that those changes can be synced to other peers (via the provider).
+				 *
+				 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
+				 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+				 * @return {void}
 				 */
-				entity.syncConfig = {
-					/**
-					 * Apply changes from the local editor to the local CRDT document so
-					 * that those changes can be synced to other peers (via the provider).
-					 *
-					 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
-					 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
-					 * @return {void}
-					 */
-					applyChangesToCRDTDoc: ( crdtDoc, changes ) =>
-						applyPostChangesToCRDTDoc( crdtDoc, changes, postType ),
+				applyChangesToCRDTDoc: ( crdtDoc, changes ) =>
+					applyPostChangesToCRDTDoc( crdtDoc, changes, postType ),
 
-					/**
-					 * Extract changes from a CRDT document that can be used to update the
-					 * local editor state.
-					 *
-					 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
-					 * @param {import('@wordpress/sync').ObjectData} editedRecord
-					 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
-					 */
-					getChangesFromCRDTDoc: ( crdtDoc, editedRecord ) =>
-						getPostChangesFromCRDTDoc(
-							crdtDoc,
-							editedRecord,
-							postType
-						),
+				/**
+				 * Extract changes from a CRDT document that can be used to update the
+				 * local editor state.
+				 *
+				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
+				 * @param {import('@wordpress/sync').ObjectData} editedRecord
+				 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
+				 */
+				getChangesFromCRDTDoc: ( crdtDoc, editedRecord ) =>
+					getPostChangesFromCRDTDoc(
+						crdtDoc,
+						editedRecord,
+						postType
+					),
 
-					/**
-					 * Sync features supported by the entity.
-					 *
-					 * @type {Record< string, boolean >}
-					 */
-					supports: {
-						crdtPersistence: true,
-					},
-				};
-			}
+				/**
+				 * Sync features supported by the entity.
+				 *
+				 * @type {Record< string, boolean >}
+				 */
+				supports: {
+					crdtPersistence: true,
+				},
+			};
 		}
 
 		return entity;
@@ -430,16 +428,14 @@ async function loadSiteEntity() {
 		meta: {},
 	};
 
-	if ( window.__experimentalEnableSync ) {
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-			/**
-			 * @type {import('@wordpress/sync').SyncConfig}
-			 */
-			entity.syncConfig = {
-				applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
-				getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
-			};
-		}
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		/**
+		 * @type {import('@wordpress/sync').SyncConfig}
+		 */
+		entity.syncConfig = {
+			applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
+			getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
+		};
 	}
 
 	const site = await apiFetch( {

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -36,7 +36,11 @@ type EntityRecordKey = string | number;
  */
 export function getUndoManager( state: State ) {
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		return getSyncManager()?.undoManager ?? state.undoManager;
+		const syncManager = getSyncManager();
+		// Only use the sync undo manager if sync is enabled (providers registered).
+		if ( syncManager?.isSyncEnabled() ) {
+			return syncManager.undoManager;
+		}
 	}
 
 	return state.undoManager;

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -36,11 +36,8 @@ type EntityRecordKey = string | number;
  */
 export function getUndoManager( state: State ) {
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		const syncManager = getSyncManager();
-		// Only use the sync undo manager if sync is enabled (providers registered).
-		if ( syncManager?.isSyncEnabled() ) {
-			return syncManager.undoManager;
-		}
+		// undoManager is undefined until the first sync-enabled entity is loaded.
+		return getSyncManager()?.undoManager ?? state.undoManager;
 	}
 
 	return state.undoManager;

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -35,10 +35,8 @@ type EntityRecordKey = string | number;
  * @return The undo manager.
  */
 export function getUndoManager( state: State ) {
-	if ( window.__experimentalEnableSync ) {
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-			return getSyncManager()?.undoManager ?? state.undoManager;
-		}
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		return getSyncManager()?.undoManager ?? state.undoManager;
 	}
 
 	return state.undoManager;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -155,13 +155,12 @@ export const getEntityRecord =
 			}
 
 			// Entity supports syncing.
-			if (
-				window.__experimentalEnableSync &&
-				entityConfig.syncConfig &&
-				isNumericID( key ) &&
-				! query
-			) {
-				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+				if (
+					entityConfig.syncConfig &&
+					isNumericID( key ) &&
+					! query
+				) {
 					const objectType = `${ kind }/${ name }`;
 					const objectId = key;
 

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -4,6 +4,9 @@
 import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../sync', () => ( {
+	getSyncManager: jest.fn(),
+} ) );
 
 /**
  * Internal dependencies
@@ -53,14 +56,15 @@ describe( 'prePersistPostType', () => {
 		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
 			status: 'draft',
 			title: '',
+			meta: {},
 		} );
 
 		record = {
 			status: 'publish',
 		};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual(
-			{}
-		);
+		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
+			meta: {},
+		} );
 
 		record = {
 			status: 'auto-draft',
@@ -69,15 +73,16 @@ describe( 'prePersistPostType', () => {
 		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
 			status: 'draft',
 			title: '',
+			meta: {},
 		} );
 
 		record = {
 			status: 'publish',
 			title: 'My Title',
 		};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual(
-			{}
-		);
+		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
+			meta: {},
+		} );
 	} );
 
 	it( 'does not set the status to draft and empty the title when saving templates', () => {
@@ -86,9 +91,9 @@ describe( 'prePersistPostType', () => {
 			title: 'Auto Draft',
 		};
 		const edits = {};
-		expect( prePersistPostType( record, edits, 'post', true ) ).toEqual(
-			{}
-		);
+		expect( prePersistPostType( record, edits, 'post', true ) ).toEqual( {
+			meta: {},
+		} );
 	} );
 } );
 

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -4,9 +4,6 @@
 import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
-} ) );
 
 /**
  * Internal dependencies

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -59,10 +59,6 @@ describe( 'getEntityRecord', () => {
 		getSyncManager.mockImplementation( () => syncManager );
 	} );
 
-	afterEach( () => {
-		delete window.__experimentalEnableSync;
-	} );
-
 	it( 'yields with requested post type', async () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPE_RESPONSE );
@@ -132,7 +128,7 @@ describe( 'getEntityRecord', () => {
 		);
 	} );
 
-	it( 'loads entity with sync manager when __experimentalEnableSync is true', async () => {
+	it( 'loads entity with sync manager when IS_GUTENBERG_PLUGIN is true', async () => {
 		const POST_RECORD = { id: 1, title: 'Test Post' };
 		const POST_RESPONSE = {
 			json: () => Promise.resolve( POST_RECORD ),
@@ -146,8 +142,6 @@ describe( 'getEntityRecord', () => {
 				syncConfig: {},
 			},
 		];
-
-		window.__experimentalEnableSync = true;
 
 		const resolveSelectWithSync = {
 			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
@@ -201,8 +195,6 @@ describe( 'getEntityRecord', () => {
 			},
 		];
 
-		window.__experimentalEnableSync = true;
-
 		const resolveSelectWithSync = {
 			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
 			getEditedEntityRecord: jest.fn(),
@@ -250,8 +242,6 @@ describe( 'getEntityRecord', () => {
 			},
 		];
 
-		window.__experimentalEnableSync = true;
-
 		const resolveSelectWithSync = {
 			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
 		};
@@ -260,40 +250,6 @@ describe( 'getEntityRecord', () => {
 
 		// Call with a query parameter
 		await getEntityRecord( 'postType', 'post', 1, { foo: 'bar' } )( {
-			dispatch,
-			registry,
-			resolveSelect: resolveSelectWithSync,
-		} );
-
-		expect( syncManager.load ).not.toHaveBeenCalled();
-	} );
-
-	it( 'does not load entity when __experimentalEnableSync is undefined', async () => {
-		const POST_RECORD = { id: 1, title: 'Test Post' };
-		const POST_RESPONSE = {
-			json: () => Promise.resolve( POST_RECORD ),
-		};
-		const ENTITIES_WITH_SYNC = [
-			{
-				name: 'post',
-				kind: 'postType',
-				baseURL: '/wp/v2/posts',
-				baseURLParams: { context: 'edit' },
-				syncConfig: {},
-			},
-		];
-
-		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-		};
-
-		triggerFetch.mockImplementation( () => POST_RESPONSE );
-
-		await getEntityRecord(
-			'postType',
-			'post',
-			1
-		)( {
 			dispatch,
 			registry,
 			resolveSelect: resolveSelectWithSync,

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -1,9 +1,3 @@
-declare global {
-	interface Window {
-		__experimentalEnableSync?: boolean;
-	}
-}
-
 export interface AnyFunction {
 	( ...args: any[] ): any;
 }

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -1,4 +1,4 @@
-# Status of the sync experiment in Gutenberg
+# Real-time collaboration in Gutenberg
 
 The sync package provides an implementation of real-time collaboration in Gutenberg.
 
@@ -9,13 +9,9 @@ Relevant docs and discussions:
 -   https://github.com/WordPress/gutenberg/discussions/65012
 -   https://docs.yjs.dev/
 
-## Enable the experiment
+## Availability
 
-The real-time collaboration experiment must be enabled on the "Gutenberg > Experiments" page.
-
-When it is enabled, the following global variables are defined::
-
--   `window.__experimentalEnableSync` (`boolean`): Used by the `core-data` package to determine whether entity syncing is available.
+Real-time collaboration is automatically enabled when using the Gutenberg plugin. The `core-data` package checks for `IS_GUTENBERG_PLUGIN` to determine whether entity syncing is available.
 
 ## The data flow
 

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -335,7 +335,10 @@ export function createSyncManager(): SyncManager {
 	return {
 		createMeta: createEntityMeta,
 		load: loadEntity,
-		undoManager,
+		// Use getter to ensure we always return the current value of `undoManager`.
+		get undoManager(): SyncUndoManager | undefined {
+			return undoManager;
+		},
 		unload: unloadEntity,
 		update: updateCRDTDoc,
 	};

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -21,6 +21,7 @@ import type {
 	RecordHandlers,
 	SyncConfig,
 	SyncManager,
+	SyncUndoManager,
 } from './types';
 import { createUndoManager } from './undo-manager';
 import { createYjsDoc } from './utils';
@@ -41,7 +42,37 @@ interface EntityState {
  */
 export function createSyncManager(): SyncManager {
 	const entityStates: Map< EntityID, EntityState > = new Map();
-	let undoManager: ReturnType< typeof createUndoManager > | undefined;
+
+	/**
+	 * A "sync-aware" undo manager for all synced entities. It is lazily created
+	 * when the first entity is loaded.
+	 *
+	 * IMPORTANT: In Gutenberg, the undo manager is effectively global and manages
+	 * undo/redo state for all entities. If the default WPUndoManager is used,
+	 * changes to entities are recorded in the `editEntityRecord` action:
+	 *
+	 * https://github.com/WordPress/gutenberg/blob/b63451e26e3c91b6bb291a2f9994722e3850417e/packages/core-data/src/actions.js#L428-L442
+	 *
+	 * In contrast, the `SyncUndoManager` only manages undo/redo for entities that
+	 * **are being synced by this sync manager**. The `addRecord` method is still
+	 * called in the code linked above, but it is a no-op. Yjs automatically tracks
+	 * changes to entities via the associated CRDT doc:
+	 *
+	 * https://github.com/WordPress/gutenberg/blob/b63451e26e3c91b6bb291a2f9994722e3850417e/packages/sync/src/undo-manager.ts#L42-L48
+	 *
+	 * This means that if at least one entity is being synced, then undo/redo
+	 * operations will be **restricted to synced entities only.**
+	 *
+	 * We could improve the `SyncUndoManager` to also track non-synced entities by
+	 * delegating to a secondary `WPUndoManager`, but this would add complexity
+	 * since we would need to maintain two separate undo/redo stacks and ensure
+	 * that they retain ordering and integrity.
+	 *
+	 * However, we also anticipate that most entities being edited in Gutenberg
+	 * will be synced entities (e.g. posts, pages, templates, template parts,
+	 * etc.), so this limitation may be temporary.
+	 */
+	let undoManager: SyncUndoManager | undefined;
 
 	/**
 	 * Load an entity for syncing and manage its lifecycle.
@@ -304,10 +335,7 @@ export function createSyncManager(): SyncManager {
 	return {
 		createMeta: createEntityMeta,
 		load: loadEntity,
-		// undoManager is undefined until the first entity is loaded.
-		get undoManager() {
-			return undoManager;
-		},
+		undoManager,
 		unload: unloadEntity,
 		update: updateCRDTDoc,
 	};

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -18,7 +18,6 @@ import type {
 	ObjectID,
 	ObjectData,
 	ObjectType,
-	ProviderCreator,
 	RecordHandlers,
 	SyncConfig,
 	SyncManager,
@@ -60,7 +59,9 @@ export function createSyncManager(): SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	): Promise< void > {
-		if ( ! isSyncEnabled() ) {
+		const providerCreators = getProviderCreators();
+
+		if ( 0 === providerCreators.length ) {
 			return; // No provider creators, so syncing is effectively disabled.
 		}
 
@@ -72,8 +73,6 @@ export function createSyncManager(): SyncManager {
 
 		const ydoc = createYjsDoc( { objectType } );
 		const recordMap = ydoc.getMap( RECORD_KEY );
-
-		const providerCreators: ProviderCreator[] = getProviderCreators();
 
 		// Clean up providers and in-memory state when the entity is unloaded.
 		const unload = (): void => {
@@ -300,15 +299,6 @@ export function createSyncManager(): SyncManager {
 		}
 
 		return createPersistedCRDTDoc( entityState.ydoc );
-	}
-
-	/**
-	 * Check if sync is enabled (i.e., if there are any provider creators registered).
-	 *
-	 * @return {boolean} Whether sync is enabled.
-	 */
-	function isSyncEnabled(): boolean {
-		return getProviderCreators().length > 0;
 	}
 
 	return {

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -42,7 +42,7 @@ interface EntityState {
  */
 export function createSyncManager(): SyncManager {
 	const entityStates: Map< EntityID, EntityState > = new Map();
-	const undoManager = createUndoManager();
+	let undoManager: ReturnType< typeof createUndoManager > | undefined;
 
 	/**
 	 * Load an entity for syncing and manage its lifecycle.
@@ -99,6 +99,10 @@ export function createSyncManager(): SyncManager {
 			void updateEntityRecord( objectType, objectId );
 		};
 
+		// Lazily create the undo manager when the first entity is loaded.
+		if ( ! undoManager ) {
+			undoManager = createUndoManager();
+		}
 		undoManager.addToScope( recordMap );
 
 		const entityState: EntityState = {
@@ -309,9 +313,11 @@ export function createSyncManager(): SyncManager {
 
 	return {
 		createMeta: createEntityMeta,
-		isSyncEnabled,
 		load: loadEntity,
-		undoManager,
+		// undoManager is undefined until the first entity is loaded.
+		get undoManager() {
+			return undoManager;
+		},
 		unload: unloadEntity,
 		update: updateCRDTDoc,
 	};

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -60,9 +60,7 @@ export function createSyncManager(): SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	): Promise< void > {
-		const providerCreators: ProviderCreator[] = getProviderCreators();
-
-		if ( 0 === providerCreators.length ) {
+		if ( ! isSyncEnabled() ) {
 			return; // No provider creators, so syncing is effectively disabled.
 		}
 
@@ -74,6 +72,8 @@ export function createSyncManager(): SyncManager {
 
 		const ydoc = createYjsDoc( { objectType } );
 		const recordMap = ydoc.getMap( RECORD_KEY );
+
+		const providerCreators: ProviderCreator[] = getProviderCreators();
 
 		// Clean up providers and in-memory state when the entity is unloaded.
 		const unload = (): void => {
@@ -298,8 +298,18 @@ export function createSyncManager(): SyncManager {
 		return createPersistedCRDTDoc( entityState.ydoc );
 	}
 
+	/**
+	 * Check if sync is enabled (i.e., if there are any provider creators registered).
+	 *
+	 * @return {boolean} Whether sync is enabled.
+	 */
+	function isSyncEnabled(): boolean {
+		return getProviderCreators().length > 0;
+	}
+
 	return {
 		createMeta: createEntityMeta,
+		isSyncEnabled,
 		load: loadEntity,
 		undoManager,
 		unload: unloadEntity,

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -81,7 +81,6 @@ export interface SyncManager {
 		objectType: ObjectType,
 		objectId: ObjectID
 	) => Record< string, string >;
-	isSyncEnabled: () => boolean;
 	load: (
 		syncConfig: SyncConfig,
 		objectType: ObjectType,
@@ -89,7 +88,8 @@ export interface SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	) => Promise< void >;
-	undoManager: SyncUndoManager;
+	// undoManager is undefined until the first entity is loaded.
+	undoManager: SyncUndoManager | undefined;
 	unload: ( objectType: ObjectType, objectId: ObjectID ) => void;
 	update: (
 		objectType: ObjectType,

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -81,6 +81,7 @@ export interface SyncManager {
 		objectType: ObjectType,
 		objectId: ObjectID
 	) => Record< string, string >;
+	isSyncEnabled: () => boolean;
 	load: (
 		syncConfig: SyncConfig,
 		objectType: ObjectType,


### PR DESCRIPTION
## What?

Move the collaborative editing code out of experiments and into the Gutenberg plugin default experience.

## Why?

As we move toward collaborative editing being included in WP 7, we want to have the related code available by default in the Gutenberg plugin. 

## How?

This PR removes the experiment and puts the code behind `IS_GUTENBERG_PLUGIN` instead.

## Testing Instructions

We do not currently include a default provider which means this code will not impact the experience at the moment. Testing this change just involves making sure the experiment is no longer available and nothing is broken.
