### PR TITLE
Block Bindings: Fix 'useSelect' warnings for attribute controls

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -19,7 +19,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useContext, useMemo } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
@@ -69,7 +69,6 @@ function AttributeBindingMenu( { attribute, binding, blockName, isWritable } ) {
 		getAllSources,
 		getSourceFieldsList,
 		hasCompatibleFields,
-		invalidationKey,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -106,6 +105,7 @@ function AttributeBindingMenu( { attribute, binding, blockName, isWritable } ) {
 				getAllSources: getAllBlockBindingsSources,
 				getSourceFieldsList: getBlockBindingsSourceFieldsList,
 				hasCompatibleFields: allCompatibleFieldKeys.length > 0,
+				// Trigger a re-render when sources/fields change.
 				invalidationKey:
 					allCompatibleFieldKeys.join( '' ) + sourceNames.join( '' ),
 			};
@@ -113,35 +113,27 @@ function AttributeBindingMenu( { attribute, binding, blockName, isWritable } ) {
 		[ attribute, blockName, blockContext ]
 	);
 
-	const compatibleFields = useMemo( () => {
-		void invalidationKey; // Avoids react-hooks/exhaustive-deps warning this is unnecessary.
-		if ( ! hasCompatibleFields ) {
-			return {};
-		}
-		return Object.entries( getAllSources() ).reduce(
-			( sourceFields, [ sourceName, source ] ) => {
-				const fieldsList = getSourceFieldsList( source, blockContext );
-				if ( ! fieldsList?.length ) {
+	const compatibleFields = hasCompatibleFields
+		? Object.entries( getAllSources() ).reduce(
+				( sourceFields, [ sourceName, source ] ) => {
+					const fieldsList = getSourceFieldsList(
+						source,
+						blockContext
+					);
+					if ( ! fieldsList?.length ) {
+						return sourceFields;
+					}
+					const compatibleFieldsList = fieldsList.filter(
+						( field ) => field.type === attributeType
+					);
+					if ( compatibleFieldsList.length ) {
+						sourceFields[ sourceName ] = compatibleFieldsList;
+					}
 					return sourceFields;
-				}
-				const compatibleFieldsList = fieldsList.filter(
-					( field ) => field.type === attributeType
-				);
-				if ( compatibleFieldsList.length ) {
-					sourceFields[ sourceName ] = compatibleFieldsList;
-				}
-				return sourceFields;
-			},
-			{}
-		);
-	}, [
-		attributeType,
-		blockContext,
-		getAllSources,
-		getSourceFieldsList,
-		hasCompatibleFields,
-		invalidationKey,
-	] );
+				},
+				{}
+		  )
+		: {};
 
 	// Keep UI enabled only when there are fields to connect to.
 	isWritable &&= hasCompatibleFields;

--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -19,7 +19,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
@@ -42,46 +42,64 @@ export default function BlockBindingsAttributeControl( {
 	const isMobile = useViewportMatch( 'medium', '<' );
 
 	const blockContext = useContext( BlockContext );
-	const compatibleFields = useSelect(
+	const selected = useSelect(
 		( select ) => {
 			const {
 				getAllBlockBindingsSources,
 				getBlockBindingsSourceFieldsList,
 				getBlockType,
 			} = unlock( select( blocksStore ) );
-
 			const _attributeType =
 				getBlockType( blockName ).attributes?.[ attribute ]?.type;
-			const attributeType =
-				_attributeType === 'rich-text' ? 'string' : _attributeType;
 
-			const sourceFields = {};
-			Object.entries( getAllBlockBindingsSources() ).forEach(
-				( [ sourceName, source ] ) => {
-					const fieldsList = getBlockBindingsSourceFieldsList(
-						source,
-						blockContext
-					);
-					if ( ! fieldsList?.length ) {
-						return;
-					}
-					const compatibleFieldsList = fieldsList.filter(
-						( field ) => field.type === attributeType
-					);
-					if ( compatibleFieldsList.length ) {
-						sourceFields[ sourceName ] = compatibleFieldsList;
-					}
-				}
-			);
-			return sourceFields;
+			return {
+				attributeType:
+					_attributeType === 'rich-text' ? 'string' : _attributeType,
+				getBlockBindingsSourceFieldsList,
+				registeredSources: getAllBlockBindingsSources(),
+			};
 		},
-		[ attribute, blockName, blockContext ]
+		[ attribute, blockName ]
 	);
 
-	const { canUpdateBlockBindings } = useSelect( ( select ) => ( {
-		canUpdateBlockBindings:
-			select( blockEditorStore ).getSettings().canUpdateBlockBindings,
-	} ) );
+	const {
+		attributeType,
+		getBlockBindingsSourceFieldsList,
+		registeredSources,
+	} = selected;
+	const compatibleFields = useMemo( () => {
+		const sourceFields = {};
+		Object.entries( registeredSources ).forEach(
+			( [ sourceName, source ] ) => {
+				const fieldsList = getBlockBindingsSourceFieldsList(
+					source,
+					blockContext
+				);
+				if ( ! fieldsList?.length ) {
+					return;
+				}
+				const compatibleFieldsList = fieldsList.filter(
+					( field ) => field.type === attributeType
+				);
+				if ( compatibleFieldsList.length ) {
+					sourceFields[ sourceName ] = compatibleFieldsList;
+				}
+			}
+		);
+		return sourceFields;
+	}, [
+		attributeType,
+		blockContext,
+		getBlockBindingsSourceFieldsList,
+		registeredSources,
+	] );
+
+	const { canUpdateBlockBindings } = useSelect( ( select ) => {
+		return {
+			canUpdateBlockBindings:
+				select( blockEditorStore ).getSettings().canUpdateBlockBindings,
+		};
+	}, [] );
 
 	const hasCompatibleFields = Object.keys( compatibleFields ).length > 0;
 

--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -33,50 +33,96 @@ import { store as blockEditorStore } from '../../store';
 
 const { Menu } = unlock( componentsPrivateApis );
 
-export default function BlockBindingsAttributeControl( {
-	attribute,
-	binding,
-	blockName,
-} ) {
+export default function BlockBindingsAttributeControl( props ) {
+	const { attribute, binding } = props;
 	const { updateBlockBindings } = useBlockBindingsUtils();
-	const isMobile = useViewportMatch( 'medium', '<' );
+	const { canUpdateBlockBindings } = useSelect( ( select ) => ( {
+		canUpdateBlockBindings:
+			select( blockEditorStore ).getSettings().canUpdateBlockBindings,
+	} ) );
 
+	return (
+		<ToolsPanelItem
+			hasValue={ () => !! binding }
+			label={ attribute }
+			onDeselect={ () => {
+				if ( !! binding ) {
+					updateBlockBindings( {
+						[ attribute ]: undefined,
+					} );
+				}
+			} }
+		>
+			<AttributeBindingMenu
+				{ ...props }
+				isWritable={ canUpdateBlockBindings }
+			/>
+		</ToolsPanelItem>
+	);
+}
+
+function AttributeBindingMenu( { attribute, binding, blockName, isWritable } ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
 	const blockContext = useContext( BlockContext );
-	const selected = useSelect(
+	const {
+		attributeType,
+		getAllSources,
+		getSourceFieldsList,
+		hasCompatibleFields,
+		invalidationKey,
+	} = useSelect(
 		( select ) => {
 			const {
 				getAllBlockBindingsSources,
 				getBlockBindingsSourceFieldsList,
 				getBlockType,
 			} = unlock( select( blocksStore ) );
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
 
+			let _attributeType =
+				getBlockType( blockName ).attributes?.[ attribute ]?.type;
+			if ( _attributeType === 'rich-text' ) {
+				_attributeType = 'string';
+			}
+
+			const allSources = getAllBlockBindingsSources();
+			const sourceNames = Object.keys( allSources );
+			const allCompatibleFieldKeys = sourceNames.reduce(
+				( compatibleFieldKeys, sourceName ) => {
+					const fieldsList = getBlockBindingsSourceFieldsList(
+						allSources[ sourceName ],
+						blockContext
+					);
+					for ( const field of fieldsList ) {
+						if ( field.type === _attributeType ) {
+							compatibleFieldKeys.push( field.args.key );
+						}
+					}
+					return compatibleFieldKeys;
+				},
+				[]
+			);
 			return {
-				attributeType:
-					_attributeType === 'rich-text' ? 'string' : _attributeType,
-				getBlockBindingsSourceFieldsList,
-				registeredSources: getAllBlockBindingsSources(),
+				attributeType: _attributeType,
+				getAllSources: getAllBlockBindingsSources,
+				getSourceFieldsList: getBlockBindingsSourceFieldsList,
+				hasCompatibleFields: allCompatibleFieldKeys.length > 0,
+				invalidationKey:
+					allCompatibleFieldKeys.join( '' ) + sourceNames.join( '' ),
 			};
 		},
-		[ attribute, blockName ]
+		[ attribute, blockName, blockContext ]
 	);
 
-	const {
-		attributeType,
-		getBlockBindingsSourceFieldsList,
-		registeredSources,
-	} = selected;
 	const compatibleFields = useMemo( () => {
-		const sourceFields = {};
-		Object.entries( registeredSources ).forEach(
-			( [ sourceName, source ] ) => {
-				const fieldsList = getBlockBindingsSourceFieldsList(
-					source,
-					blockContext
-				);
+		void invalidationKey; // Avoids react-hooks/exhaustive-deps warning this is unnecessary.
+		if ( ! hasCompatibleFields ) {
+			return {};
+		}
+		return Object.entries( getAllSources() ).reduce(
+			( sourceFields, [ sourceName, source ] ) => {
+				const fieldsList = getSourceFieldsList( source, blockContext );
 				if ( ! fieldsList?.length ) {
-					return;
+					return sourceFields;
 				}
 				const compatibleFieldsList = fieldsList.filter(
 					( field ) => field.type === attributeType
@@ -84,28 +130,21 @@ export default function BlockBindingsAttributeControl( {
 				if ( compatibleFieldsList.length ) {
 					sourceFields[ sourceName ] = compatibleFieldsList;
 				}
-			}
+				return sourceFields;
+			},
+			{}
 		);
-		return sourceFields;
 	}, [
 		attributeType,
 		blockContext,
-		getBlockBindingsSourceFieldsList,
-		registeredSources,
+		getAllSources,
+		getSourceFieldsList,
+		hasCompatibleFields,
+		invalidationKey,
 	] );
 
-	const { canUpdateBlockBindings } = useSelect( ( select ) => {
-		return {
-			canUpdateBlockBindings:
-				select( blockEditorStore ).getSettings().canUpdateBlockBindings,
-		};
-	}, [] );
-
-	const hasCompatibleFields = Object.keys( compatibleFields ).length > 0;
-
-	// Lock the UI when the user can't update bindings or there are no fields to connect to.
-	const isAttributeReadOnly =
-		! canUpdateBlockBindings || ! hasCompatibleFields;
+	// Keep UI enabled only when there are fields to connect to.
+	isWritable &&= hasCompatibleFields;
 
 	const { source: boundSourceName, args } = binding || {};
 	const source = getBlockBindingsSource( boundSourceName );
@@ -126,7 +165,7 @@ export default function BlockBindingsAttributeControl( {
 		displayText = __( 'Source not registered' );
 	} else {
 		displayText =
-			compatibleFields?.[ boundSourceName ]?.find( ( field ) =>
+			compatibleFields[ boundSourceName ]?.find( ( field ) =>
 				fastDeepEqual( field.args, args )
 			)?.label ||
 			source?.label ||
@@ -134,59 +173,41 @@ export default function BlockBindingsAttributeControl( {
 	}
 
 	return (
-		<ToolsPanelItem
-			hasValue={ () => !! binding }
-			label={ attribute }
-			onDeselect={
-				!! hasCompatibleFields &&
-				( () => {
-					updateBlockBindings( {
-						[ attribute ]: undefined,
-					} );
-				} )
-			}
-		>
-			<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
-				<Menu.TriggerButton
-					render={ <Item /> }
-					disabled={ ! hasCompatibleFields }
-				>
-					<VStack
-						className="block-editor-bindings__item"
-						spacing={ 0 }
+		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+			<Menu.TriggerButton
+				render={ <Item /> }
+				disabled={ ! hasCompatibleFields }
+			>
+				<VStack className="block-editor-bindings__item" spacing={ 0 }>
+					<Text truncate>{ attribute }</Text>
+					<Text
+						truncate
+						variant={ isValid ? 'muted' : undefined }
+						isDestructive={ ! isValid }
 					>
-						<Text truncate>{ attribute }</Text>
-						<Text
-							truncate
-							variant={ isValid ? 'muted' : undefined }
-							isDestructive={ ! isValid }
-						>
-							{ displayText }
-						</Text>
-					</VStack>
-				</Menu.TriggerButton>
-				{ ! isAttributeReadOnly && (
-					<Menu.Popover gutter={ isMobile ? 8 : 36 }>
-						<Menu
-							placement={
-								isMobile ? 'bottom-start' : 'left-start'
-							}
-						>
-							{ Object.entries( compatibleFields ).map(
-								( [ sourceKey, fields ] ) => (
-									<BlockBindingsSourceFieldsList
-										key={ sourceKey }
-										args={ binding?.args }
-										attribute={ attribute }
-										sourceKey={ sourceKey }
-										fields={ fields }
-									/>
-								)
-							) }
-						</Menu>
-					</Menu.Popover>
+						{ displayText }
+					</Text>
+				</VStack>
+			</Menu.TriggerButton>
+			<Menu.Popover gutter={ isMobile ? 8 : 36 }>
+				{ isWritable && (
+					<Menu
+						placement={ isMobile ? 'bottom-start' : 'left-start' }
+					>
+						{ Object.entries( compatibleFields ).map(
+							( [ sourceKey, fields ] ) => (
+								<BlockBindingsSourceFieldsList
+									key={ sourceKey }
+									args={ binding?.args }
+									attribute={ attribute }
+									sourceKey={ sourceKey }
+									fields={ fields }
+								/>
+							)
+						) }
+					</Menu>
 				) }
-			</Menu>
-		</ToolsPanelItem>
+			</Menu.Popover>
+		</Menu>
 	);
 }


### PR DESCRIPTION
## What?
This is a follow-up to #73579.

PR refactors values returned by the `useSelect` hook in `BlockBindingsAttributeControl` component and fixes the warning. Now the `compatibleFields` is derived outside the `mapSelect` callback.

## Testing Instructions
> Some confidence should be provided by e2e tests. Additionally, perform some smoke testing of Block Bindings.

## Screenshots or screencast <!-- if applicable -->

<img width="1047" height="542" alt="CleanShot 2026-01-09 at 13 01 21" src="https://github.com/user-attachments/assets/20f417ee-540b-4ffd-8ee0-4b728dafe717" />