### PR TITLE
DataViews: Use regular casing for bulk selection count

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Use regular casing for bulk selection count. [#74573](https://github.com/WordPress/gutenberg/pull/74573)
+
 ## 11.2.0 (2026-01-16)
 
 ### Code Quality

--- a/packages/dataviews/src/components/dataviews-bulk-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/style.scss
@@ -4,9 +4,6 @@
 
 .dataviews-bulk-actions-footer__item-count {
 	color: $gray-900;
-	font-weight: $font-weight-medium;
-	font-size: 11px;
-	text-transform: uppercase;
 }
 
 .dataviews-bulk-actions-footer__container {


### PR DESCRIPTION
## What?

Update the DataViews bulk selection count text to use regular checkbox label casing.

## Why?
The all-caps, smaller item-count text looks misaligned next to bulk action buttons.

## How?
Remove the uppercase/11px/medium-weight overrides from the bulk action item-count so it inherits the standard DataViews typography.

## Testing Instructions
1. Open a screen using DataViews with bulk selection (e.g. product list).
2. Select one or more rows.
3. Confirm the “X items selected” text is no longer all-caps and aligns better with the bulk action buttons.

### Testing Instructions for Keyboard
1. Tab to the table.
2. Use Space to toggle selection.
3. Confirm the item-count text updates and remains readable.

## Screenshots or screencast

<img width="1018" height="695" alt="image" src="https://github.com/user-attachments/assets/96985014-9f88-411a-bdba-9eacbaa2c043" />
