### PR TITLE
Add list view inspector tab for pattern editing

### DIFF
--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -5,6 +5,9 @@ import { createContext, useContext } from '@wordpress/element';
 
 export const mayDisplayControlsKey = Symbol( 'mayDisplayControls' );
 export const mayDisplayParentControlsKey = Symbol( 'mayDisplayParentControls' );
+export const mayDisplayPatternEditingControlsKey = Symbol(
+	'mayDisplayPatternEditingControls'
+);
 export const blockEditingModeKey = Symbol( 'blockEditingMode' );
 export const blockBindingsKey = Symbol( 'blockBindings' );
 export const isPreviewModeKey = Symbol( 'isPreviewMode' );

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -13,6 +13,7 @@ import {
 	useBlockEditContext,
 	mayDisplayControlsKey,
 	mayDisplayParentControlsKey,
+	mayDisplayPatternEditingControlsKey,
 	blockEditingModeKey,
 	blockBindingsKey,
 	isPreviewModeKey,
@@ -33,6 +34,7 @@ export { useBlockEditContext };
 export default function BlockEdit( {
 	mayDisplayControls,
 	mayDisplayParentControls,
+	mayDisplayPatternEditingControls,
 	blockEditingMode,
 	isPreviewMode,
 	// The remaining props are passed through the BlockEdit filters and are thus
@@ -69,6 +71,8 @@ export default function BlockEdit( {
 					// usage outside of the package (this context is exposed).
 					[ mayDisplayControlsKey ]: mayDisplayControls,
 					[ mayDisplayParentControlsKey ]: mayDisplayParentControls,
+					[ mayDisplayPatternEditingControlsKey ]:
+						mayDisplayPatternEditingControls,
 					[ blockEditingModeKey ]: blockEditingMode,
 					[ blockBindingsKey ]: bindings,
 					[ isPreviewModeKey ]: isPreviewMode,
@@ -82,6 +86,7 @@ export default function BlockEdit( {
 					__unstableLayoutClassNames,
 					mayDisplayControls,
 					mayDisplayParentControls,
+					mayDisplayPatternEditingControls,
 					blockEditingMode,
 					bindings,
 					isPreviewMode,

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -72,7 +72,8 @@ export default function BlockEdit( {
 					[ mayDisplayControlsKey ]: mayDisplayControls,
 					[ mayDisplayParentControlsKey ]: mayDisplayParentControls,
 					[ mayDisplayPatternEditingControlsKey ]:
-						mayDisplayPatternEditingControls,
+						mayDisplayPatternEditingControls &&
+						blockEditingMode !== 'disabled',
 					[ blockEditingModeKey ]: blockEditingMode,
 					[ blockBindingsKey ]: bindings,
 					[ isPreviewModeKey ]: isPreviewMode,

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -36,14 +36,12 @@ function StyleInspectorSlots( {
 	blockName,
 	showAdvancedControls = true,
 	showPositionControls = true,
-	showListControls = false,
 	showBindingsControls = true,
 } ) {
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
 	return (
 		<>
 			<InspectorControls.Slot />
-			{ showListControls && <InspectorControls.Slot group="list" /> }
 			<InspectorControls.Slot
 				group="color"
 				label={ __( 'Color' ) }
@@ -377,11 +375,9 @@ const BlockInspectorSingleBlock = ( {
 					) }
 					<ContentTab contentClientIds={ contentClientIds } />
 					<InspectorControls.Slot group="content" />
+					<InspectorControls.Slot group="list" />
 					{ ! isSectionBlock && (
-						<StyleInspectorSlots
-							blockName={ blockName }
-							showListControls
-						/>
+						<StyleInspectorSlots blockName={ blockName } />
 					) }
 					{ isSectionBlock &&
 						isBlockSynced &&

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -106,6 +106,7 @@ function BlockListBlock( {
 	const {
 		mayDisplayControls,
 		mayDisplayParentControls,
+		isSelectionWithinCurrentSection,
 		themeSupportsLayout,
 		...context
 	} = useContext( PrivateBlockContext );
@@ -135,6 +136,7 @@ function BlockListBlock( {
 			}
 			mayDisplayControls={ mayDisplayControls }
 			mayDisplayParentControls={ mayDisplayParentControls }
+			mayDisplayPatternEditingControls={ isSelectionWithinCurrentSection }
 			blockEditingMode={ context.blockEditingMode }
 			isPreviewMode={ context.isPreviewMode }
 		/>
@@ -231,6 +233,7 @@ function BlockListBlock( {
 			value={ {
 				wrapperProps: updatedWrapperProps,
 				isAligned,
+				isSelectionWithinCurrentSection,
 				...context,
 			} }
 		>

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -195,6 +195,7 @@ function BlockListBlock( {
 		isParentSelected,
 		order,
 		mayDisplayControls,
+		mayDisplayPatternEditingControls,
 		blockEditingMode,
 	} = useSelect(
 		( select ) => {
@@ -263,6 +264,7 @@ function BlockListBlock( {
 						getMultiSelectedBlockClientIds().every(
 							( id ) => getBlockName( id ) === name
 						) ),
+				mayDisplayPatternEditingControls: false, // Section/pattern editing not yet supported on native
 				blockEditingMode: getBlockEditingMode( clientId ),
 			};
 		},
@@ -403,6 +405,9 @@ function BlockListBlock( {
 							}
 							wrapperProps={ wrapperProps }
 							mayDisplayControls={ mayDisplayControls }
+							mayDisplayPatternEditingControls={
+								mayDisplayPatternEditingControls
+							}
 							blockEditingMode={ blockEditingMode }
 						/>
 						<View onLayout={ onLayout } />

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -88,22 +88,20 @@ export default function useInspectorControlsTabs(
 		hasContentFills ||
 		!! ( contentClientIds && contentClientIds.length > 0 );
 
-	const hasListTab = hasListFills && ! isSectionBlock;
+	if ( hasContentTab ) {
+		tabs.push( TAB_CONTENT );
+	}
 
 	// Add the tabs in the order that they will default to if available.
 	// List View > Content > Settings > Styles.
-	if ( hasListTab ) {
+	if ( hasListFills ) {
 		tabs.push( TAB_LIST_VIEW );
-	}
-
-	if ( hasContentTab ) {
-		tabs.push( TAB_CONTENT );
 	}
 
 	if (
 		( settingsFills.length ||
 			// Advanded fills who up in settings tab if available or they blend into the default tab, if there's only one tab.
-			( advancedFills.length && ( hasContentTab || hasListTab ) ) ) &&
+			( advancedFills.length && ( hasContentTab || hasListFills ) ) ) &&
 		! isSectionBlock
 	) {
 		tabs.push( TAB_SETTINGS );

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -84,9 +84,14 @@ export default function useInspectorControlsTabs(
 		...( hasListFills && hasStyleFills > 1 ? advancedFills : [] ),
 	];
 
+	// When the block fields experiment is active, only rely on `hasContentFills`
+	// to determine whether the content tab to be shown. The tab purely uses slot
+	// fills in this situation.
+	const shouldShowBlockFields =
+		window?.__experimentalContentOnlyInspectorFields;
 	const hasContentTab =
 		hasContentFills ||
-		!! ( contentClientIds && contentClientIds.length > 0 );
+		( ! shouldShowBlockFields && contentClientIds?.length );
 
 	if ( hasContentTab ) {
 		tabs.push( TAB_CONTENT );

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -15,6 +15,7 @@ import { useEffect, useContext } from '@wordpress/element';
 import {
 	useBlockEditContext,
 	mayDisplayControlsKey,
+	mayDisplayPatternEditingControlsKey,
 } from '../block-edit/context';
 import groups from './groups';
 
@@ -23,7 +24,6 @@ export function PrivateInspectorControlsFill( {
 	group = 'default',
 	__experimentalGroup,
 	resetAllFilter,
-	forceDisplayControls,
 } ) {
 	if ( __experimentalGroup ) {
 		deprecated(
@@ -43,7 +43,14 @@ export function PrivateInspectorControlsFill( {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
-	if ( ! forceDisplayControls && ! context[ mayDisplayControlsKey ] ) {
+	const shouldDisplayForPatternEditing =
+		context[ mayDisplayPatternEditingControlsKey ] &&
+		( group === 'list' || group === 'content' );
+
+	if (
+		! context[ mayDisplayControlsKey ] &&
+		! shouldDisplayForPatternEditing
+	) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -19,7 +19,7 @@ import {
 } from '../block-edit/context';
 import groups from './groups';
 
-export function PrivateInspectorControlsFill( {
+export default function InspectorControlsFill( {
 	children,
 	group = 'default',
 	__experimentalGroup,
@@ -68,23 +68,6 @@ export function PrivateInspectorControlsFill( {
 				} }
 			</Fill>
 		</StyleProvider>
-	);
-}
-
-export default function InspectorControlsFill( {
-	children,
-	group = 'default',
-	__experimentalGroup,
-	resetAllFilter,
-} ) {
-	return (
-		<PrivateInspectorControlsFill
-			group={ group }
-			__experimentalGroup={ __experimentalGroup }
-			resetAllFilter={ resetAllFilter }
-		>
-			{ children }
-		</PrivateInspectorControlsFill>
 	);
 }
 

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -22,7 +22,7 @@ import useBlockDisplayInformation from '../../components/use-block-display-infor
 const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
 import { PrivateBlockContext } from '../../components/block-list/private-block-context';
-import { PrivateInspectorControlsFill } from '../../components/inspector-controls/fill';
+import InspectorControls from '../../components/inspector-controls/fill';
 
 // controls
 import RichText from './rich-text';
@@ -213,19 +213,19 @@ const withBlockFields = createHigherOrderComponent(
 					isSelectionWithinCurrentSection &&
 						( isSectionBlock ||
 							blockEditingMode === 'contentOnly' ) && (
-							<PrivateInspectorControlsFill group="content">
+							<InspectorControls group="content">
 								<BlockFields
 									{ ...props }
 									blockType={ blockType }
 									isCollapsed
 								/>
-							</PrivateInspectorControlsFill>
+							</InspectorControls>
 						)
 				}
 				{ ! isSelectionWithinCurrentSection && isSelected && (
-					<PrivateInspectorControlsFill group="content">
+					<InspectorControls group="content">
 						<BlockFields { ...props } blockType={ blockType } />
-					</PrivateInspectorControlsFill>
+					</InspectorControls>
 				) }
 			</>
 		);

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -1,13 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { privateApis as blocksPrivateApis } from '@wordpress/blocks';
+import {
+	privateApis as blocksPrivateApis,
+	getBlockType,
+} from '@wordpress/blocks';
 import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { useContext, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -15,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import BlockIcon from '../../components/block-icon';
 import useBlockDisplayTitle from '../../components/block-title/use-block-display-title';
@@ -49,7 +52,6 @@ function createConfiguredControl( ControlComponent, config = {} ) {
  * @param {Object}   props
  * @param {string}   props.clientId      The clientId of the block.
  * @param {Object}   props.blockType     The blockType definition.
- * @param {Object}   props.attributes    The block's attribute values.
  * @param {Function} props.setAttributes Action to set the block's attributes.
  * @param {boolean}  props.isCollapsed   Whether the DataForm is rendered as 'collapsed' with only the first field
  *                                       displayed by default. When collapsed a dropdown is displayed to allow
@@ -59,7 +61,6 @@ function createConfiguredControl( ControlComponent, config = {} ) {
 function BlockFields( {
 	clientId,
 	blockType,
-	attributes,
 	setAttributes,
 	isCollapsed = false,
 } ) {
@@ -70,6 +71,11 @@ function BlockFields( {
 	const blockInformation = useBlockDisplayInformation( clientId );
 
 	const blockTypeFields = blockType?.[ fieldsKey ];
+
+	const attributes = useSelect(
+		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
+		[ clientId ]
+	);
 
 	const computedForm = useMemo( () => {
 		if ( ! isCollapsed ) {
@@ -187,53 +193,34 @@ function BlockFields( {
 	);
 }
 
-const withBlockFields = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const {
-			blockType,
-			isSelectionWithinCurrentSection,
-			isSectionBlock,
-			blockEditingMode,
-			isSelected,
-		} = useContext( PrivateBlockContext );
+function hasBlockFieldsSupport( blockName ) {
+	return !! (
+		window?.__experimentalContentOnlyInspectorFields &&
+		getBlockType( blockName )?.[ fieldsKey ]
+	);
+}
 
-		const shouldShowBlockFields =
-			window?.__experimentalContentOnlyInspectorFields;
-		const blockTypeFields = blockType?.[ fieldsKey ];
+export function BlockFieldsPanel( props ) {
+	const { blockType, isSelectionWithinCurrentSection } =
+		useContext( PrivateBlockContext );
 
-		if ( ! shouldShowBlockFields || ! blockTypeFields?.length ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
+	return (
+		<InspectorControls group="content">
+			<BlockFields
+				{ ...props }
+				blockType={ blockType }
+				isCollapsed={ isSelectionWithinCurrentSection }
+			/>
+		</InspectorControls>
+	);
+}
 
-		return (
-			<>
-				<BlockEdit key="edit" { ...props } />
-				{
-					// Display the controls of all inner blocks for section/pattern editing.
-					isSelectionWithinCurrentSection &&
-						( isSectionBlock ||
-							blockEditingMode === 'contentOnly' ) && (
-							<InspectorControls group="content">
-								<BlockFields
-									{ ...props }
-									blockType={ blockType }
-									isCollapsed
-								/>
-							</InspectorControls>
-						)
-				}
-				{ ! isSelectionWithinCurrentSection && isSelected && (
-					<InspectorControls group="content">
-						<BlockFields { ...props } blockType={ blockType } />
-					</InspectorControls>
-				) }
-			</>
-		);
-	}
-);
-
-addFilter(
-	'editor.BlockEdit',
-	'core/content-only-controls/block-fields',
-	withBlockFields
-);
+/**
+ * Export block support definition.
+ */
+export default {
+	edit: BlockFieldsPanel,
+	hasSupport: hasBlockFieldsSupport,
+	attributeKeys: [],
+	supportsPatternEditing: true,
+};

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -213,10 +213,7 @@ const withBlockFields = createHigherOrderComponent(
 					isSelectionWithinCurrentSection &&
 						( isSectionBlock ||
 							blockEditingMode === 'contentOnly' ) && (
-							<PrivateInspectorControlsFill
-								group="content"
-								forceDisplayControls
-							>
+							<PrivateInspectorControlsFill group="content">
 								<BlockFields
 									{ ...props }
 									blockType={ blockType }

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -14,7 +14,7 @@ import './lock';
 import allowedBlocks from './allowed-blocks';
 import anchor from './anchor';
 import ariaLabel from './aria-label';
-import './block-fields';
+import blockFields from './block-fields';
 import customClassName from './custom-class-name';
 import './generated-class-name';
 import style from './style';
@@ -56,6 +56,7 @@ createBlockEditFilter(
 		blockBindingsPanel,
 		childLayout,
 		allowedBlocks,
+		blockFields,
 		listView,
 		autoInspectorControls,
 	].filter( Boolean )

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -12,7 +12,7 @@ import { useContext } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { PrivateListView } from '../components/list-view';
-import { PrivateInspectorControlsFill } from '../components/inspector-controls/fill';
+import InspectorControls from '../components/inspector-controls/fill';
 import { PrivateBlockContext } from '../components/block-list/private-block-context';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
@@ -36,7 +36,7 @@ export function hasListViewSupport( nameOrType ) {
  * @return {Element|null} List view inspector controls or null.
  */
 export function ListViewPanel( { clientId, name } ) {
-	const { isSelectionWithinCurrentSection, isSelected } =
+	const { isSelectionWithinCurrentSection } =
 		useContext( PrivateBlockContext );
 	const isEnabled = hasListViewSupport( name );
 	const { hasChildren, blockTitle } = useSelect(
@@ -48,30 +48,15 @@ export function ListViewPanel( { clientId, name } ) {
 		[ clientId, name ]
 	);
 
-	const notSelected = ! isSelected && ! isSelectionWithinCurrentSection;
-
-	if ( notSelected || ! isEnabled ) {
+	if ( ! isEnabled ) {
 		return null;
 	}
 
-	if ( isSelectionWithinCurrentSection ) {
-		return (
-			<PrivateInspectorControlsFill group="list">
-				<PanelBody title={ blockTitle }>
-					<PrivateListView
-						rootClientId={ clientId }
-						isExpanded
-						description={ blockTitle }
-						showAppender
-					/>
-				</PanelBody>
-			</PrivateInspectorControlsFill>
-		);
-	}
+	const showBlockTitle = isSelectionWithinCurrentSection;
 
 	return (
-		<PrivateInspectorControlsFill group="list">
-			<PanelBody title={ null }>
+		<InspectorControls group="list">
+			<PanelBody title={ showBlockTitle ? blockTitle : undefined }>
 				{ ! hasChildren && (
 					<p className="block-editor-block-inspector__no-blocks">
 						{ __( 'No items yet.' ) }
@@ -84,7 +69,7 @@ export function ListViewPanel( { clientId, name } ) {
 					showAppender
 				/>
 			</PanelBody>
-		</PrivateInspectorControlsFill>
+		</InspectorControls>
 	);
 }
 
@@ -95,5 +80,5 @@ export default {
 	edit: ListViewPanel,
 	hasSupport: hasListViewSupport,
 	attributeKeys: [],
-	forceDisplayControls: true,
+	supportsPatternEditing: true,
 };

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -56,7 +56,7 @@ export function ListViewPanel( { clientId, name } ) {
 
 	if ( isSelectionWithinCurrentSection ) {
 		return (
-			<PrivateInspectorControlsFill group="list" forceDisplayControls>
+			<PrivateInspectorControlsFill group="list">
 				<PanelBody title={ blockTitle }>
 					<PrivateListView
 						rootClientId={ clientId }

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -39,16 +39,39 @@ export function ListViewPanel( { clientId, name } ) {
 	const { isSelectionWithinCurrentSection } =
 		useContext( PrivateBlockContext );
 	const isEnabled = hasListViewSupport( name );
-	const { hasChildren, blockTitle } = useSelect(
-		( select ) => ( {
-			hasChildren:
-				!! select( blockEditorStore ).getBlockCount( clientId ),
-			blockTitle: select( blocksStore ).getBlockType( name )?.title,
-		} ),
-		[ clientId, name ]
+	const { hasChildren, blockTitle, isNestedListView } = useSelect(
+		( select ) => {
+			const { getBlockCount, getBlockParents, getBlockName } =
+				select( blockEditorStore );
+
+			// When the ListView is shown in a section, avoid showing List Views
+			// for both parent and child blocks that have support. In this situation
+			// the parent will show the child anyway in its List.
+			// Search parents to see if there's one that also has support, and if so
+			// skip rendering.
+			// This matches closely the logic in the `BlockCard` component.
+			let _isNestedListView = false;
+			if ( isSelectionWithinCurrentSection ) {
+				const parents = getBlockParents( clientId, true );
+				_isNestedListView = parents.find( ( parentId ) => {
+					const parentName = getBlockName( parentId );
+					return (
+						parentName === 'core/navigation' ||
+						hasBlockSupport( parentName, 'listView' )
+					);
+				} );
+			}
+
+			return {
+				hasChildren: !! getBlockCount( clientId ),
+				blockTitle: select( blocksStore ).getBlockType( name )?.title,
+				isNestedListView: _isNestedListView,
+			};
+		},
+		[ clientId, name, isSelectionWithinCurrentSection ]
 	);
 
-	if ( ! isEnabled ) {
+	if ( ! isEnabled || isNestedListView ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -5,13 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore, hasBlockSupport } from '@wordpress/blocks';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import InspectorControls from '../components/inspector-controls';
 import { store as blockEditorStore } from '../store';
 import { PrivateListView } from '../components/list-view';
+import { PrivateInspectorControlsFill } from '../components/inspector-controls/fill';
+import { PrivateBlockContext } from '../components/block-list/private-block-context';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
 
@@ -34,6 +36,8 @@ export function hasListViewSupport( nameOrType ) {
  * @return {Element|null} List view inspector controls or null.
  */
 export function ListViewPanel( { clientId, name } ) {
+	const { isSelectionWithinCurrentSection, isSelected } =
+		useContext( PrivateBlockContext );
 	const isEnabled = hasListViewSupport( name );
 	const { hasChildren, blockTitle } = useSelect(
 		( select ) => ( {
@@ -44,12 +48,29 @@ export function ListViewPanel( { clientId, name } ) {
 		[ clientId, name ]
 	);
 
-	if ( ! isEnabled ) {
+	const notSelected = ! isSelected && ! isSelectionWithinCurrentSection;
+
+	if ( notSelected || ! isEnabled ) {
 		return null;
 	}
 
+	if ( isSelectionWithinCurrentSection ) {
+		return (
+			<PrivateInspectorControlsFill group="list" forceDisplayControls>
+				<PanelBody title={ blockTitle }>
+					<PrivateListView
+						rootClientId={ clientId }
+						isExpanded
+						description={ blockTitle }
+						showAppender
+					/>
+				</PanelBody>
+			</PrivateInspectorControlsFill>
+		);
+	}
+
 	return (
-		<InspectorControls group="list">
+		<PrivateInspectorControlsFill group="list">
 			<PanelBody title={ null }>
 				{ ! hasChildren && (
 					<p className="block-editor-block-inspector__no-blocks">
@@ -63,7 +84,7 @@ export function ListViewPanel( { clientId, name } ) {
 					showAppender
 				/>
 			</PanelBody>
-		</InspectorControls>
+		</PrivateInspectorControlsFill>
 	);
 }
 
@@ -74,4 +95,5 @@ export default {
 	edit: ListViewPanel,
 	hasSupport: hasListViewSupport,
 	attributeKeys: [],
+	forceDisplayControls: true,
 };

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -534,8 +534,10 @@ export function createBlockEditFilter( features ) {
 						hasSupport,
 						attributeKeys = [],
 						shareWithChildBlocks,
+						forceDisplayControls,
 					} = feature;
 					const shouldDisplayControls =
+						forceDisplayControls ||
 						context[ mayDisplayControlsKey ] ||
 						( context[ mayDisplayParentControlsKey ] &&
 							shareWithChildBlocks );

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -19,6 +19,7 @@ import {
 	useBlockEditContext,
 	mayDisplayControlsKey,
 	mayDisplayParentControlsKey,
+	mayDisplayPatternEditingControlsKey,
 } from '../components/block-edit/context';
 import { useSettings } from '../components';
 import { useSettingsForBlockElement } from '../components/global-styles/hooks';
@@ -534,10 +535,11 @@ export function createBlockEditFilter( features ) {
 						hasSupport,
 						attributeKeys = [],
 						shareWithChildBlocks,
-						forceDisplayControls,
+						supportsPatternEditing,
 					} = feature;
 					const shouldDisplayControls =
-						forceDisplayControls ||
+						( supportsPatternEditing &&
+							context[ mayDisplayPatternEditingControlsKey ] ) ||
 						context[ mayDisplayControlsKey ] ||
 						( context[ mayDisplayParentControlsKey ] &&
 							shareWithChildBlocks );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #74567 - Displays the List inspector tab for Pattern Editing when a section is selected.

One caveat with this PR - when in a pattern and selecting a block from the List tab it doesn't drill down into that block like it does normally. Should it? I'm not sure, as if a child block can be selected it takes the user out of the 'pattern editing' experience. At the very least the user would need an affordance to re-select the main pattern. 

## How?
Technically, I think this PR moves much closer to what's described in the [Block Attribute groups issue](https://github.com/WordPress/gutenberg/issues/73845), where blocks don't have to do anything special to work with patterns, the editor controls showing the Inspector items in the correct way whether the block is within a pattern or not.

To accomplish that I've removed a previous `forceDisplayControls` hack for the InspectorControlFill, and now the editor uses a `mayDisplayPatternEditingControls` context value to let the Inspector Controls know whether it should render.

A similar approach is used for block hooks too.

As part of this I've also ported `BlockFields` to a block hook, and simplified it quite a bit. (I could probably move this into a separate PR, but it's dependent on this one).

## Testing Instructions
Prerequisite: Enable the Pattern Editing and BlockFields experiments

1. Insert a pattern into the editor (preferably one that contains List, Buttons, Social or Navigation to be able test it properly)
2. With the pattern selected, note that there's now a List tab for rearranging blocks like List, Buttons, Social or Navigation

## Screenshots or screencast <!-- if applicable -->
<img width="280" height="866" alt="Screenshot 2026-01-13 at 5 22 57 pm" src="https://github.com/user-attachments/assets/acd562b4-db08-4be1-8ed5-c1e9fd7c27ab" />
