### PR TITLE
Notes: Enable floating notes in template lock mode

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -80,7 +80,7 @@ function NotesSidebarContent( {
 	);
 }
 
-function NotesSidebar( { postId, mode } ) {
+function NotesSidebar( { postId } ) {
 	// Enum: 'closed' | 'creating' | 'open'
 	const [ newNoteFormState, setNewNoteFormState ] = useState( 'closed' );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
@@ -89,7 +89,7 @@ function NotesSidebar( { postId, mode } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
-	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
+	const showFloatingSidebar = isLargeViewport;
 
 	const { clientId, blockCommentId, isDistractionFree } = useSelect(
 		( select ) => {
@@ -130,8 +130,7 @@ function NotesSidebar( { postId, mode } ) {
 	const currentThread = blockCommentId
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
-	const showAllNotesSidebar =
-		resultComments.length > 0 || ! showFloatingSidebar;
+	const showAllNotesSidebar = resultComments.length > 0;
 
 	async function openTheSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );
@@ -228,12 +227,10 @@ function NotesSidebar( { postId, mode } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const { postId, mode, editorMode } = useSelect( ( select ) => {
-		const { getCurrentPostId, getRenderingMode, getEditorMode } =
-			select( editorStore );
+	const { postId, editorMode } = useSelect( ( select ) => {
+		const { getCurrentPostId, getEditorMode } = select( editorStore );
 		return {
 			postId: getCurrentPostId(),
-			mode: getRenderingMode(),
 			editorMode: getEditorMode(),
 		};
 	}, [] );
@@ -249,7 +246,7 @@ export default function NotesSidebarContainer() {
 
 	return (
 		<PostTypeSupportCheck supportKeys="editor.notes">
-			<NotesSidebar postId={ postId } mode={ mode } />
+			<NotesSidebar postId={ postId } />
 		</PostTypeSupportCheck>
 	);
 }


### PR DESCRIPTION
Fixes #73659

## What?

I tried enabling floating notes in template lock mode.

As far as I could tell from my testing, I didn't notice any particular issues. If the note is long, there's space below the canvas, so you can access the note by scrolling down.

As a result, the "All notes" button will always be hidden if there are no notes for that post yet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/38577468-1a61-4c83-8842-26d3214cf1e5


