### PR TITLE
Fully resolve moment-timezone import, improve build optimization

### DIFF
--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -3,7 +3,7 @@
  */
 import type { Moment } from 'moment';
 import momentLib from 'moment';
-import 'moment-timezone/moment-timezone';
+import 'moment-timezone/moment-timezone.js';
 import 'moment-timezone/moment-timezone-utils.js';
 
 /**


### PR DESCRIPTION
Follow-up to #74530 which also fully resolves the `moment-timezone/moment-timezone` import so that it has a `.js` extension and is compatible with strict Node.js ESM resolution.

This one import is special because the Gutenberg build tooling defines an alias for it, which points to an optimized build with limited subset of timezone data (1970-2030). I'm also improving this build code that defines an esbuild module alias. We don't need `createRequire`, it's better to use the esbuild internal resolver, exposed as the `build.resolve` function. And the result doesn't need to be cached, esbuild does its own internal caching.

I plan to add also some `date` documentation about how to define the timezone optimization in your own project, like Calypso or Jetpack. But first I'd like to think about whether we can do the optimization better: instead of defining two aliases, can we define just one? That would be simpler to document.

## How to test
Apply this patch, run `npm run build` and verify that the `build/scripts/date/index.js` bundle contains the `moment-timezone/builds/moment-timezone-with-data-1970-2030.js` data.