### PR TITLE
Feature : Recursive allowedBlocks rule in InnerBlocks

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -568,6 +568,19 @@ _Returns_
 
 Returns the currently hovered block.
 
+### getInheritedAllowedBlocks
+
+Returns the inherited allowedBlocks from the nearest ancestor that has inheritAllowedBlocks enabled. Returns null if no ancestor has this setting.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `Array?`: The inherited allowed blocks array, or null if none.
+
 ### getInserterItems
 
 Determines the items that appear in the inserter. Includes both static items (e.g. a regular block type) and dynamic items (e.g. a reusable block).

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -76,6 +76,26 @@ The previous code block restricts all blocks, so only child blocks explicitly re
 
 If `allowedBlocks` is set to `true`, all blocks are allowed. `false` means no blocks are allowed.
 
+### `inheritAllowedBlocks`
+
+-   **Type:** `Boolean`
+-   **Default:** `false`
+
+When set to `true`, the `allowedBlocks` restriction is applied recursively to all nested InnerBlocks within child blocks. This ensures that blocks inserted at any nesting level must be in the `allowedBlocks` list.
+
+```jsx
+const ALLOWED_BLOCKS = [ 'core/paragraph', 'core/heading', 'core/group' ];
+...
+<InnerBlocks
+    allowedBlocks={ ALLOWED_BLOCKS }
+    inheritAllowedBlocks
+/>
+```
+
+In the example above, even if `core/group` normally allows any blocks as children, when nested inside this parent block it will only allow `core/paragraph`, `core/heading`, and `core/group`.
+
+**Note:** If a child block explicitly sets its own `allowedBlocks`, it will override the inherited restriction rather than merge with it.
+
 ### `orientation`
 
 -   **Type:** `"horizontal"|"vertical"|undefined`

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -56,6 +56,7 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
+		inheritAllowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,
 		directInsert,
@@ -81,6 +82,7 @@ function UncontrolledInnerBlocks( props ) {
 		clientId,
 		parentLock,
 		allowedBlocks,
+		inheritAllowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,
 		directInsert,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -44,6 +44,7 @@ function useShallowMemo( value ) {
  * @param {string}               parentLock
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
+ * @param {boolean}              inheritAllowedBlocks       Whether to inherit the allowed blocks from the parent.
  * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter, in the format {blockName}/{variationName}.
  * @param {?WPDirectInsertBlock} defaultBlock               The default block to insert: [ blockName, { blockAttributes } ].
  * @param {?boolean}             directInsert               If a default block should be inserted directly by the appender.
@@ -65,6 +66,7 @@ export default function useNestedSettingsUpdate(
 	clientId,
 	parentLock,
 	allowedBlocks,
+	inheritAllowedBlocks,
 	prioritizedInserterBlocks,
 	defaultBlock,
 	directInsert,
@@ -98,6 +100,7 @@ export default function useNestedSettingsUpdate(
 	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
+			inheritAllowedBlocks,
 			prioritizedInserterBlocks: _prioritizedInserterBlocks,
 			templateLock: _templateLock,
 		};
@@ -175,6 +178,7 @@ export default function useNestedSettingsUpdate(
 	}, [
 		clientId,
 		_allowedBlocks,
+		inheritAllowedBlocks,
 		_prioritizedInserterBlocks,
 		_templateLock,
 		defaultBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1763,6 +1763,23 @@ const canInsertBlockTypeUnmemoized = (
 		}
 	}
 
+	// Check for inherited allowedBlocks from ancestors with inheritAllowedBlocks enabled.
+	// Override the existing allowedBlocks for the current block with the ones provided for the parent.
+	const inheritedAllowedBlocks = getInheritedAllowedBlocks(
+		state,
+		rootClientId
+	);
+
+	if ( inheritedAllowedBlocks ) {
+		const isInheritedAllowed = checkAllowList(
+			inheritedAllowedBlocks,
+			blockName
+		);
+		if ( isInheritedAllowed === false ) {
+			return false;
+		}
+	}
+
 	const blockAllowedParentBlocks = blockType.parent;
 	const hasBlockAllowedParent = checkAllowList(
 		blockAllowedParentBlocks,
@@ -2754,6 +2771,35 @@ export const __experimentalGetPatternTransformItems = createRegistrySelector(
 export function getBlockListSettings( state, clientId ) {
 	return state.blockListSettings[ clientId ];
 }
+
+/**
+ * Returns the inherited allowedBlocks from the nearest ancestor that has
+ * inheritAllowedBlocks enabled. Returns null if no ancestor has this setting.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @return {Array?} The inherited allowed blocks array, or null if none.
+ */
+export const getInheritedAllowedBlocks = createSelector(
+	( state, rootClientId ) => {
+		if ( ! rootClientId ) {
+			return null;
+		}
+
+		// Traverse up the tree starting from the parent
+		const parents = getBlockParents( state, rootClientId, true ); // ascending order (closest first)
+
+		for ( const parentId of parents ) {
+			const settings = getBlockListSettings( state, parentId );
+			if ( settings?.inheritAllowedBlocks && settings?.allowedBlocks ) {
+				return settings.allowedBlocks;
+			}
+		}
+		return null;
+	},
+	( state ) => [ state.blocks.parents, state.blockListSettings ]
+);
 
 /**
  * Returns the editor settings.

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3293,6 +3293,242 @@ describe( 'selectors', () => {
 				)
 			).toBe( false );
 		} );
+
+		it( 'should inherit allowedBlocks from ancestor with inheritAllowedBlocks', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-ancestor' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'block1' ] ],
+						[ 'block1', [ 'block2' ] ],
+					] ),
+				},
+				blockListSettings: {
+					block1: {
+						allowedBlocks: [
+							'core/test-block-ancestor',
+							'core/test-block-a',
+						],
+						inheritAllowedBlocks: true,
+					},
+					block2: {},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+			};
+			// core/test-block-b should be denied because it's not in the inherited allowedBlocks
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block2' )
+			).toBe( false );
+			// core/test-block-a should be allowed because it's in the inherited allowedBlocks
+			expect(
+				canInsertBlockType( state, 'core/test-block-a', 'block2' )
+			).toBe( true );
+		} );
+
+		it( 'should allow child explicit allowedBlocks to override inherited ones', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-ancestor' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'block1' ] ],
+						[ 'block1', [ 'block2' ] ],
+					] ),
+				},
+				blockListSettings: {
+					block1: {
+						allowedBlocks: [
+							'core/test-block-ancestor',
+							'core/test-block-a',
+						],
+						inheritAllowedBlocks: true,
+					},
+					block2: {
+						// Child explicitly sets its own allowedBlocks, overriding inheritance
+						allowedBlocks: [ 'core/test-block-b' ],
+					},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+			};
+			// core/test-block-b should be allowed because child has explicit allowedBlocks
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block2' )
+			).toBe( true );
+			// core/test-block-a should be denied because child overrides with its own list
+			expect(
+				canInsertBlockType( state, 'core/test-block-a', 'block2' )
+			).toBe( false );
+		} );
+
+		it( 'should not inherit allowedBlocks when inheritAllowedBlocks is false', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-ancestor' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'block1' ] ],
+						[ 'block1', [ 'block2' ] ],
+					] ),
+				},
+				blockListSettings: {
+					block1: {
+						allowedBlocks: [
+							'core/test-block-ancestor',
+							'core/test-block-a',
+						],
+						// inheritAllowedBlocks not set or false
+					},
+					block2: {},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+			};
+			// Should allow any block because inheritance is not enabled
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block2' )
+			).toBe( true );
+		} );
+
+		it( 'should inherit allowedBlocks even if child has allowedBlocks: true', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-ancestor' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'block1' ] ],
+						[ 'block1', [ 'block2' ] ],
+					] ),
+				},
+				blockListSettings: {
+					block1: {
+						allowedBlocks: [ 'core/test-block-ancestor' ],
+						inheritAllowedBlocks: true,
+					},
+					block2: {
+						allowedBlocks: true,
+					},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+			};
+			// core/test-block-b should be denied by ancestor
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block2' )
+			).toBe( false );
+		} );
+
+		it( 'should inherit allowedBlocks deeper down the tree (grandchild)', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-ancestor' },
+							block3: { name: 'core/test-block-ancestor' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+							block2: {},
+							block3: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							block2: 'block1',
+							block3: 'block2',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'block1' ] ],
+						[ 'block1', [ 'block2' ] ],
+						[ 'block2', [ 'block3' ] ],
+					] ),
+				},
+				blockListSettings: {
+					block1: {
+						allowedBlocks: [ 'core/test-block-ancestor' ],
+						inheritAllowedBlocks: true,
+					},
+					block2: {
+						allowedBlocks: true, // Group
+					},
+					block3: {
+						allowedBlocks: true, // Nested Group
+					},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+			};
+			// core/test-block-b should be denied by ancestor block1
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block3' )
+			).toBe( false );
+		} );
 	} );
 
 	describe( 'canInsertBlocks', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes https://github.com/WordPress/gutenberg/issues/72803
- Restricts the allowedBlocks for blocks that are used in InnerBlocks without explicitly mentioning them for each block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Reduces effort to define allowedBlocks for each nested block in an InnerBlock by inheriting parent's rule.
- Allows wider restriction on block usage with minimal effort.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- New `boolean` attribute for InnerBlocks : `inheritAllowedBlocks`
- When added as true, the `canInsertBlockTypeUnmemoized` function checks if the block is to be allowed or not.
- The function calls the new `getInheritedAllowedBlocks` function internally to verify the parent-child relation.
- The block is then visible / hidden based on that.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a block that uses InnerBlock
2. Set the allowedBlocks to the following
```
const ALLOWED_BLOCKS = [
	'core/heading',
	'core/group'
];

<InnerBlocks
	allowedBlocks={ ALLOWED_BLOCKS }
	template={ [
		[ 'core/paragraph', {
			placeholder: __( 'Add content here. Only allowed blocks can be inserted...', 'inherit-allowed-blocks-demo' )
		} ],
	] }
	renderAppender={ InnerBlocks.ButtonBlockAppender }
/>
```
3. Use the block in the editor, and add a `Group` block, select the orientation, then you can add `Paragraph` element
4. Modify the InnerBlocks as follows:
```
<InnerBlocks
	allowedBlocks={ ALLOWED_BLOCKS }
	template={ [
		[ 'core/paragraph', {
			placeholder: __( 'Add content here. Only allowed blocks can be inserted...', 'inherit-allowed-blocks-demo' )
		} ],
	] }
        inheritAllowedBlocks={ true }
	renderAppender={ InnerBlocks.ButtonBlockAppender }
/>
```
5. Follow the step 3 again and now you won't be able to add `Paragraph` element within the `Group` block.