### PR TITLE
UI: Remove individual experimental tags from Storybook

### DIFF
--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -5,7 +5,6 @@ import { Badge } from '../index';
 const meta: Meta< typeof Badge > = {
 	title: 'Design System/Components/Badge',
 	component: Badge,
-	tags: [ 'status-experimental' ],
 };
 export default meta;
 

--- a/packages/ui/src/box/stories/index.story.tsx
+++ b/packages/ui/src/box/stories/index.story.tsx
@@ -5,7 +5,6 @@ import { Box } from '../box';
 const meta: Meta< typeof Box > = {
 	title: 'Design System/Components/Box',
 	component: Box,
-	tags: [ 'status-experimental' ],
 };
 export default meta;
 

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -5,7 +5,6 @@ import { Box } from '../../box';
 const meta: Meta< typeof Stack > = {
 	title: 'Design System/Components/Stack',
 	component: Stack,
-	tags: [ 'status-experimental' ],
 };
 export default meta;
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/74189#discussion_r2658281489

## What?

Removes individual experimental tags from Storybook.

## Why?

In #74551, we added introductory docs to the `@wordpress/ui` package section in Storybook, so that we can set expectations that the package itself is still somewhat experimental.

## Testing Instructions

See the affected components in Storybook and verify that the experimental tags are removed.