### PR TITLE
Publishing next packages: remove commit hash from version

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -375,7 +375,7 @@ async function publishPackagesToNpm( {
 		);
 
 		await command(
-			`npx lerna version pre${ minimumVersionBump } --preid next.${ beforeCommitHash } --no-private ${ yesFlag }`,
+			`npx lerna version pre${ minimumVersionBump } --preid next --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -375,7 +375,7 @@ async function publishPackagesToNpm( {
 		);
 
 		await command(
-			`npx lerna version pre${ minimumVersionBump } --preid next --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
+			`npx lerna version pre${ minimumVersionBump } --preid next.v --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',


### PR DESCRIPTION
Currently the `next` packages are published with a version string like:
```
7.37.1-next.06ee73755.0
```
There is the `--preid` string that says `next.06ee73755`, it includes the git commit SHA, and there is the `.0` suffix which is a prerelease version auto-incremented by Lerna.

The problem with this is that it's not clear which of two adjacent `next` releases has higher precedence. Is it `7.37.1-next.06ee73755.0` or `7.37.1-next.ba3aee3a2.0`? The [semver rules](https://semver.org/#spec-item-11) say that the two hash strings are to be compared as strings, in lexicographic order. That means that the `06ee73755` version is considered older than `ba3aee3a2` because `'0' < 'b'`. But it fact they were published in the opposite order! Upgrades in consumer `package.json` files will be unreliable, as we noticed in https://github.com/Automattic/jetpack/pull/46397#issuecomment-3739543035

This patch changes the versioning to:
```
7.37.1-next.0+06ee73755
```
The part that matters for comparisons is the `.0` suffix which is auto-incremented by Lerna on each release. And the SHA commit is only after the `+` sign.

