### PR TITLE
Duotone: defer metadata init

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -13,13 +13,13 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-// Set up metadata prior to rendering any blocks.
+// Remove the Core metadata setup.
+// In the Gutenberg version, we don't need to set up metadata prior to rendering any blocks,
+// since the computation gets deferred until it's needed.
 if ( class_exists( 'WP_Duotone' ) ) {
 	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_styles_presets' ) );
 	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_style_block_names' ) );
 }
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
 
 // Add classnames to blocks using duotone support.
 if ( function_exists( 'wp_render_duotone_support' ) ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -42,7 +42,7 @@ class WP_Duotone_Gutenberg {
 	 * Block names from global, theme, and custom styles that use duotone presets and the slug of
 	 * the preset they are using.
 	 *
-	 * This property shouldn't be accessed directly, but rather via global_styles_block_names().
+	 * This property shouldn't be accessed directly, but rather via {@see self::global_styles_block_names()}.
 	 * This ensures that it gets initialized correctly before use.
 	 *
 	 * Example:
@@ -74,7 +74,7 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array|null
+	 * @var array<string, string>|null
 	 */
 	private static $__global_styles_presets = null;
 
@@ -137,7 +137,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Simple getter for `$__global_styles_block_names`, to ensure it's initialized on demand.
 	 *
-	 * @return array The styles block names.
+	 * @return array<string, string> The styles block names.
 	 */
 	private static function global_styles_block_names() {
 		if ( is_null( self::$__global_styles_block_names ) ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -51,7 +51,7 @@ class WP_Duotone_Gutenberg {
 	 *       …
 	 *  ]
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	private static $__global_styles_block_names = null;
 
@@ -91,7 +91,7 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array|null
+	 * @var array
 	 */
 	private static $used_global_styles_presets = array();
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -51,7 +51,7 @@ class WP_Duotone_Gutenberg {
 	 *       …
 	 *  ]
 	 *
-	 * @var array|null
+	 * @var null|array<string, string>
 	 */
 	private static $__global_styles_block_names = null;
 
@@ -74,7 +74,7 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array<string, string>|null
+	 * @var null|array<string, array<string, string|string[]>>
 	 */
 	private static $__global_styles_presets = null;
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -42,6 +42,9 @@ class WP_Duotone_Gutenberg {
 	 * Block names from global, theme, and custom styles that use duotone presets and the slug of
 	 * the preset they are using.
 	 *
+	 * This property shouldn't be accessed directly, but rather via global_styles_block_names().
+	 * This ensures that it gets initialized correctly before use.
+	 *
 	 * Example:
 	 *  [
 	 *      'core/featured-image' => 'blue-orange',
@@ -50,10 +53,13 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @var array
 	 */
-	private static $global_styles_block_names = array();
+	private static $__global_styles_block_names = null;
 
 	/**
 	 * An array of duotone filter data from global, theme, and custom presets.
+	 *
+	 * This property shouldn't be accessed directly, but rather via global_styles_presets().
+	 * This ensures that it gets initialized correctly before use.
 	 *
 	 * Example:
 	 *  [
@@ -68,9 +74,9 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array
+	 * @var array|null
 	 */
-	private static $global_styles_presets = array();
+	private static $__global_styles_presets = null;
 
 	/**
 	 * All of the duotone filter data from presets for CSS custom properties on
@@ -85,7 +91,7 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	private static $used_global_styles_presets = array();
 
@@ -127,6 +133,30 @@ class WP_Duotone_Gutenberg {
 	 * @var array
 	 */
 	private static $block_css_declarations = array();
+
+	/**
+	 * Simple getter for `$__global_styles_block_names`, to ensure it's initialized on demand.
+	 *
+	 * @return array The styles block names.
+	 */
+	private static function global_styles_block_names() {
+		if ( is_null( self::$__global_styles_block_names ) ) {
+			self::set_global_style_block_names();
+		}
+		return self::$__global_styles_block_names;
+	}
+
+	/**
+	 * Simple getter for `$__global_styles_presets`, to ensure it's initialized on demand.
+	 *
+	 * @return array The styles presets.
+	 */
+	private static function global_styles_presets() {
+		if ( is_null( self::$__global_styles_presets ) ) {
+			self::set_global_styles_presets();
+		}
+		return self::$__global_styles_presets;
+	}
 
 	/**
 	 * Direct port of colord's clamp function. Using min/max instead of
@@ -468,7 +498,7 @@ class WP_Duotone_Gutenberg {
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
-		return array_key_exists( $filter_id, self::$global_styles_presets );
+		return array_key_exists( $filter_id, self::global_styles_presets() );
 	}
 
 	/**
@@ -723,7 +753,7 @@ class WP_Duotone_Gutenberg {
 	 * @param string $filter_value     The filter CSS value. e.g. 'url(#wp-duotone-blue-orange)' or 'unset'.
 	 */
 	private static function enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value ) {
-		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
+		if ( ! array_key_exists( $filter_id, self::global_styles_presets() ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
 				__( 'The duotone id "%s" is not registered in theme.json settings', 'gutenberg' ),
@@ -732,8 +762,8 @@ class WP_Duotone_Gutenberg {
 			_doing_it_wrong( __METHOD__, $error_message, '6.3.0' );
 			return;
 		}
-		self::$used_global_styles_presets[ $filter_id ] = self::$global_styles_presets[ $filter_id ];
-		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, self::$global_styles_presets[ $filter_id ] );
+		self::$used_global_styles_presets[ $filter_id ] = self::global_styles_presets()[ $filter_id ];
+		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, self::global_styles_presets()[ $filter_id ] );
 	}
 
 	/**
@@ -775,17 +805,19 @@ class WP_Duotone_Gutenberg {
 		$tree              = gutenberg_get_global_settings();
 		$presets_by_origin = $tree['color']['duotone'] ?? array();
 
+		self::$__global_styles_presets = array();
+
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
 				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
 
-				self::$global_styles_presets[ $filter_id ] = $preset;
+				self::$__global_styles_presets[ $filter_id ] = $preset;
 			}
 		}
 	}
 
 	/**
-	 * Scrape all block names from global styles and store in self::$global_styles_block_names
+	 * Scrape all block names from global styles and store in self::$__global_styles_block_names
 	 *
 	 * @since 6.3.0
 	 */
@@ -794,6 +826,8 @@ class WP_Duotone_Gutenberg {
 		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		$block_nodes = $tree->get_styles_block_nodes();
 		$theme_json  = $tree->get_raw_data();
+
+		self::$__global_styles_block_names = array();
 
 		foreach ( $block_nodes as $block_node ) {
 			// This block definition doesn't include any duotone settings. Skip it.
@@ -812,7 +846,7 @@ class WP_Duotone_Gutenberg {
 			$slug = self::get_slug_from_attribute( $duotone_attr );
 
 			if ( $slug && $slug !== $duotone_attr ) {
-				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
+				self::$__global_styles_block_names[ $block_node['name'] ] = $slug;
 			}
 		}
 	}
@@ -835,7 +869,7 @@ class WP_Duotone_Gutenberg {
 
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
-		$has_global_styles_duotone = array_key_exists( $block['blockName'], self::$global_styles_block_names );
+		$has_global_styles_duotone = array_key_exists( $block['blockName'], self::global_styles_block_names() );
 
 		if (
 			! $duotone_selector ||
@@ -885,7 +919,7 @@ class WP_Duotone_Gutenberg {
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
 		} elseif ( $has_global_styles_duotone ) {
-			$slug         = self::$global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
+			$slug         = self::global_styles_block_names()[ $block['blockName'] ]; // e.g. 'blue-orange'.
 			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.
 			$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--blue-orange)'.
 
@@ -1004,14 +1038,14 @@ class WP_Duotone_Gutenberg {
 	 * @return array The editor settings with duotone SVGs and CSS custom properties.
 	 */
 	public static function add_editor_settings( $settings ) {
-		if ( ! empty( self::$global_styles_presets ) ) {
+		if ( ! empty( self::global_styles_presets() ) ) {
 			if ( ! isset( $settings['styles'] ) ) {
 				$settings['styles'] = array();
 			}
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'assets'         => self::get_svg_definitions( self::$global_styles_presets ),
+				'assets'         => self::get_svg_definitions( self::global_styles_presets() ),
 				// The 'svgs' type is new in 6.3 and requires the corresponding JS changes in the EditorStyles component to work.
 				'__unstableType' => 'svgs',
 				// These styles not generated by global styles, so this must be false or they will be stripped out in gutenberg_get_block_editor_settings.
@@ -1020,7 +1054,7 @@ class WP_Duotone_Gutenberg {
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'css'            => self::get_global_styles_presets( self::$global_styles_presets ),
+				'css'            => self::get_global_styles_presets( self::global_styles_presets() ),
 				// This must be set and must be something other than 'theme' or they will be stripped out in the post editor <Editor> component.
 				'__unstableType' => 'presets',
 				// These styles are no longer generated by global styles, so this must be false or they will be stripped out in gutenberg_get_block_editor_settings.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -53,7 +53,7 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @var null|array<string, string>
 	 */
-	private static $__global_styles_block_names = null;
+	private static $global_styles_block_names = null;
 
 	/**
 	 * An array of duotone filter data from global, theme, and custom presets.
@@ -76,7 +76,7 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @var null|array<string, array<string, string|string[]>>
 	 */
-	private static $__global_styles_presets = null;
+	private static $global_styles_presets = null;
 
 	/**
 	 * All of the duotone filter data from presets for CSS custom properties on
@@ -135,27 +135,27 @@ class WP_Duotone_Gutenberg {
 	private static $block_css_declarations = array();
 
 	/**
-	 * Simple getter for `$__global_styles_block_names`, to ensure it's initialized on demand.
+	 * Simple getter for `$global_styles_block_names`, to ensure it's initialized on demand.
 	 *
 	 * @return array<string, string> The styles block names.
 	 */
 	private static function global_styles_block_names() {
-		if ( is_null( self::$__global_styles_block_names ) ) {
+		if ( is_null( self::$global_styles_block_names ) ) {
 			self::set_global_style_block_names();
 		}
-		return self::$__global_styles_block_names;
+		return self::$global_styles_block_names;
 	}
 
 	/**
-	 * Simple getter for `$__global_styles_presets`, to ensure it's initialized on demand.
+	 * Simple getter for `$global_styles_presets`, to ensure it's initialized on demand.
 	 *
 	 * @return array<string, array<string, string|string[]>> The styles presets.
 	 */
 	private static function global_styles_presets() {
-		if ( is_null( self::$__global_styles_presets ) ) {
+		if ( is_null( self::$global_styles_presets ) ) {
 			self::set_global_styles_presets();
 		}
-		return self::$__global_styles_presets;
+		return self::$global_styles_presets;
 	}
 
 	/**
@@ -805,19 +805,19 @@ class WP_Duotone_Gutenberg {
 		$tree              = gutenberg_get_global_settings();
 		$presets_by_origin = $tree['color']['duotone'] ?? array();
 
-		self::$__global_styles_presets = array();
+		self::$global_styles_presets = array();
 
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
 				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
 
-				self::$__global_styles_presets[ $filter_id ] = $preset;
+				self::$global_styles_presets[ $filter_id ] = $preset;
 			}
 		}
 	}
 
 	/**
-	 * Scrape all block names from global styles and store in self::$__global_styles_block_names
+	 * Scrape all block names from global styles and store in self::$global_styles_block_names
 	 *
 	 * @since 6.3.0
 	 */
@@ -827,7 +827,7 @@ class WP_Duotone_Gutenberg {
 		$block_nodes = $tree->get_styles_block_nodes();
 		$theme_json  = $tree->get_raw_data();
 
-		self::$__global_styles_block_names = array();
+		self::$global_styles_block_names = array();
 
 		foreach ( $block_nodes as $block_node ) {
 			// This block definition doesn't include any duotone settings. Skip it.
@@ -846,7 +846,7 @@ class WP_Duotone_Gutenberg {
 			$slug = self::get_slug_from_attribute( $duotone_attr );
 
 			if ( $slug && $slug !== $duotone_attr ) {
-				self::$__global_styles_block_names[ $block_node['name'] ] = $slug;
+				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
 			}
 		}
 	}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -149,7 +149,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Simple getter for `$__global_styles_presets`, to ensure it's initialized on demand.
 	 *
-	 * @return array The styles presets.
+	 * @return array<string, array<string, string|string[]>> The styles presets.
 	 */
 	private static function global_styles_presets() {
 		if ( is_null( self::$__global_styles_presets ) ) {


### PR DESCRIPTION
## What?
Currently, the Duotone metadata initialization runs on `wp_loaded`. This PR changes it to instead run the first time the metadata is needed.

## Why?
Computing the Duotone metadata requires running `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`, which performs a number of expensive operations across several large JSON tree structures that get loaded in from the filesystem. While `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` relies on caching to reduce the amount of work in subsequent calls, it still takes a while to run the first time it's called for a pageview. Consequently, we want it to run as late as possible, so that we can exit before it does, if it's not needed.

This PR defers the Duotone metadata computations so that they happen on-demand. While this isn't enough to avoid the expensive work in most cases, it does mean that in some special cases (such as in some PHP early exit scenarios) they can be completely avoided. It also lays the groundwork for potential future improvements that avoid them in further scenarios.

## How?
This PR adds two getters with the responsibility of initializing the internal class variables, and moves all class code to using the getters instead of accessing the variables directly.

Note that despite these changes, it's still possible to call the setter methods to explicitly initialize the variables, which means that any existing external code that happens to call `WP_Duotone_Gutenberg::set_global_styles_presets` or `WP_Duotone_Gutenberg::set_global_style_block_names` will continue to work correctly.

> **Note to reviewers:** Since we can't rely on PHP 8.4's property hooks yet (which would be my preferred implementation), I decided to add a simple getter with the same name as the class variable, while prepending the class variable with `__` to discourage direct use. I'm happy to consider any other approach, especially if I overlooked a more idiomatic technique.

## Testing Instructions
Smoke-test the Duotone feature and ensure that it continues to work correctly, by adding a Duotone filter to an image block and ensuring the page loads correctly, with the filter correctly applied.
