### PR TITLE
Navigation Overlay: Add default paragraph block

### DIFF
--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -23,6 +23,16 @@ jest.mock( '@wordpress/core-data', () => ( {
 	store: {},
 } ) );
 
+// Mock @wordpress/blocks
+jest.mock( '@wordpress/blocks', () => ( {
+	serialize: jest.fn( ( blocks ) => JSON.stringify( blocks ) ),
+	createBlock: jest.fn( ( name ) => ( {
+		name,
+		attributes: {},
+		innerBlocks: [],
+	} ) ),
+} ) );
+
 describe( 'useCreateOverlayTemplatePart', () => {
 	const mockSaveEntityRecord = jest.fn();
 
@@ -62,6 +72,7 @@ describe( 'useCreateOverlayTemplatePart', () => {
 			expect.objectContaining( {
 				slug: 'overlay',
 				title: 'Overlay',
+				content: expect.any( String ),
 				area: 'navigation-overlay',
 			} ),
 			{ throwOnError: true }
@@ -107,6 +118,7 @@ describe( 'useCreateOverlayTemplatePart', () => {
 			expect.objectContaining( {
 				title: 'Overlay 2',
 				slug: 'overlay-2',
+				content: expect.any( String ),
 				area: 'navigation-overlay',
 			} ),
 			{ throwOnError: true }

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -5,6 +5,7 @@ import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { serialize, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -41,6 +42,7 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 			{
 				slug: cleanSlug,
 				title: uniqueTitle,
+				content: serialize( [ createBlock( 'core/paragraph' ) ] ),
 				area: NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
 			},
 			{ throwOnError: true }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/74587

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The editor canvas isn't loading when creating a new overlay from the Navigation block, as there are no blocks to render in the new blank overlay.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds a default paragraph block to the overlay so the editor canvas has something to render.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a Navigation block
2. Go to the block settings and create a new overlay by clicking the plus icon next to "Overlay template" (Create new overlay template)
3. The editor should load a blank canvas with a single paragraph block (on trunk, the canvas does not load at all)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1713" height="886" alt="image" src="https://github.com/user-attachments/assets/6177468c-5908-437d-8fd4-82e24d7199ea" /> | <img width="1713" height="886" alt="image" src="https://github.com/user-attachments/assets/4b94d79a-7794-4f89-9497-b927ac4427e9" /> |



