### PR TITLE
Customize: Preserve CSS cascade for Additional CSS in classic themes

### DIFF
--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -45,35 +45,43 @@ function gutenberg_enqueue_global_styles() {
 	$stylesheet = gutenberg_get_global_stylesheet();
 
 	/*
-	 * Dequeue the Customizer's custom CSS
-	 * and add it before the global styles custom CSS.
+	 * For block themes, merge Customizer's custom CSS into the global styles stylesheet
+	 * before the global styles custom CSS, ensuring proper cascade order.
+	 * For classic themes, let the Customizer CSS print separately via wp_custom_css_cb()
+	 * at priority 101 in wp_head, preserving its position at the end of the <head>.
 	 */
-	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+	if ( $is_block_theme ) {
+		/*
+		 * Dequeue the Customizer's custom CSS
+		 * and add it before the global styles custom CSS.
+		 */
+		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 
-	/*
-	 * Get the custom CSS from the Customizer and add it to the global stylesheet.
-	 * Always do this in Customizer preview for the sake of live preview since it be empty.
-	 */
-	$custom_css = trim( wp_get_custom_css() );
-	if ( $custom_css || is_customize_preview() ) {
-		if ( is_customize_preview() ) {
-			/*
-			 * When in the Customizer preview, wrap the Custom CSS in milestone comments to allow customize-preview.js
-			 * to locate the CSS to replace for live previewing. Make sure that the milestone comments are omitted from
-			 * the stored Custom CSS if by chance someone tried to add them, which would be highly unlikely, but it
-			 * would break live previewing.
-			 */
-			$before_milestone = '/*BEGIN_CUSTOMIZER_CUSTOM_CSS*/';
-			$after_milestone  = '/*END_CUSTOMIZER_CUSTOM_CSS*/';
-			$custom_css       = str_replace( array( $before_milestone, $after_milestone ), '', $custom_css );
-			$custom_css       = $before_milestone . "\n" . $custom_css . "\n" . $after_milestone;
+		/*
+		 * Get the custom CSS from the Customizer and add it to the global stylesheet.
+		 * Always do this in Customizer preview for the sake of live preview since it be empty.
+		 */
+		$custom_css = trim( wp_get_custom_css() );
+		if ( $custom_css || is_customize_preview() ) {
+			if ( is_customize_preview() ) {
+				/*
+				 * When in the Customizer preview, wrap the Custom CSS in milestone comments to allow customize-preview.js
+				 * to locate the CSS to replace for live previewing. Make sure that the milestone comments are omitted from
+				 * the stored Custom CSS if by chance someone tried to add them, which would be highly unlikely, but it
+				 * would break live previewing.
+				 */
+				$before_milestone = '/*BEGIN_CUSTOMIZER_CUSTOM_CSS*/';
+				$after_milestone  = '/*END_CUSTOMIZER_CUSTOM_CSS*/';
+				$custom_css       = str_replace( array( $before_milestone, $after_milestone ), '', $custom_css );
+				$custom_css       = $before_milestone . "\n" . $custom_css . "\n" . $after_milestone;
+			}
+			$custom_css = "\n" . $custom_css;
 		}
-		$custom_css = "\n" . $custom_css;
-	}
-	$stylesheet .= $custom_css;
+		$stylesheet .= $custom_css;
 
-	// Add the global styles custom CSS at the end.
-	$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+		// Add the global styles custom CSS at the end.
+		$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+	}
 
 	if ( empty( $stylesheet ) ) {
 		return;
@@ -96,6 +104,9 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  */
 function gutenberg_enqueue_global_styles_custom_css() {
 	_deprecated_function( __FUNCTION__, 'Gutenberg 17.8.0', 'gutenberg_enqueue_global_styles' );
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
 
 	// Don't enqueue Customizer's custom CSS separately.
 	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );


### PR DESCRIPTION
## What?

This PR restores the `$is_block_theme` check that was inadvertently removed in #73971 when enabling Global Styles for classic themes. A similar change landed in Core in https://github.com/WordPress/wordpress-develop/pull/10726

## Why?

For classic themes, the Customizer's Additional CSS should continue to be printed separately via `wp_custom_css_cb()` at priority 101 in `wp_head`, preserving its position at the end of the `<head>` for highest CSS specificity.

Without this check, classic themes experience two issues:
1. Live preview in the Customizer doesn't work for Additional CSS changes
2. Additional CSS loses its cascade advantage due to being merged into the global styles stylesheet

For block themes, the Customizer CSS is merged into the global styles stylesheet before the global styles custom CSS, maintaining the intended cascade order.

## How?

Wraps the Customizer CSS merging logic in `gutenberg_enqueue_global_styles()` with an `if ( $is_block_theme )` check, restoring the original behavior for classic themes.

## Testing Instructions

### Classic Theme (Twenty Twenty-One):
1. Activate Twenty Twenty-One theme
2. Go to Customizer > Additional CSS
3. Add: `body { background-color: lime; }`
4. Verify live preview works instantly
5. Save and view frontend - verify lime background is applied
6. Check HTML source - `<style id="wp-custom-css">` should appear near end of `<head>`

### Block Theme (Twenty Twenty-Four):
1. Activate Twenty Twenty-Four theme
2. Go to Customizer > Additional CSS  
3. Add: `body { background-color: lime; }`
4. Verify live preview works instantly
5. Save and view frontend - verify lime background is applied
6. Check HTML source - CSS should be inside `<style id="global-styles-inline-css">`