### PR TITLE
Block Editor: Add autoComplete attribute to prevent browser autocomplete

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -453,6 +453,7 @@ class URLInput extends Component {
 			required: true,
 			type: 'text',
 			name: inputId,
+			autoComplete: 'off',
 			onChange: disabled ? () => {} : this.onChange, // Disable onChange when disabled
 			onFocus: disabled ? () => {} : this.onFocus, // Disable onFocus when disabled
 			placeholder,


### PR DESCRIPTION
## What?

Adds `autoComplete='off'` attribute to the URLInput component to fully prevent browser autocomplete from appearing over Gutenberg's link suggestions.

## Why?

The previous fix in #74305 added the `name` attribute to prevent browser autocomplete, but modern browsers require BOTH a unique `name` attribute AND an explicit `autoComplete='off'` attribute to fully disable autocomplete behavior.

Without `autoComplete='off'`, browsers still show autocomplete suggestions that obscure Gutenberg's search results.

## How?

Added `autoComplete: 'off'` to the `inputProps` object in the URLInput component.

## Testing Instructions

### Before testing
Make sure you have some URL/search history in your browser that would normally trigger autocomplete.

### Steps to test
1. Add or edit a Navigation block
2. Click to add a new link or edit an existing navigation item
3. Start typing in the URL search field
4. Verify that **only** Gutenberg's page/link suggestions appear
5. Verify that the browser's autocomplete dropdown does **not** appear
6. Test in multiple browsers (Chrome, Firefox, Safari) if possible

Browser autocomplete no longer appears over Gutenberg's suggestions when searching for links.

Fixes #74302