### PR TITLE
Add template part context to navigation block

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/index.js
+++ b/packages/block-library/src/navigation-overlay-close/index.js
@@ -2,18 +2,16 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { select } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
+import { isWithinNavigationOverlay } from '../utils/is-within-overlay';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import icon from './icon';
-import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../navigation/constants';
 
 const { name } = metadata;
 
@@ -24,40 +22,6 @@ export const settings = {
 	edit,
 	save,
 };
-
-function isWithinOverlay() {
-	// @wordpress/block-library should not depend on @wordpress/editor.
-	// Blocks can be loaded into a *non-post* block editor, so to avoid
-	// declaring @wordpress/editor as a dependency, we must access its
-	// store by string.
-	// eslint-disable-next-line @wordpress/data-no-store-string-literals
-	const editorStore = select( 'core/editor' );
-
-	// Return false if the editor store is not available.
-	if ( ! editorStore ) {
-		return false;
-	}
-
-	const { getCurrentPostType, getCurrentPostId } = editorStore;
-	const { getEditedEntityRecord } = select( coreStore );
-
-	const postType = getCurrentPostType();
-	const postId = getCurrentPostId();
-
-	if ( postType === 'wp_template_part' && postId ) {
-		const templatePartEntity = getEditedEntityRecord(
-			'postType',
-			'wp_template_part',
-			postId
-		);
-
-		return (
-			templatePartEntity?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA
-		);
-	}
-
-	return false;
-}
 
 export const init = () => {
 	addFilter(
@@ -72,7 +36,7 @@ export const init = () => {
 				return canInsert;
 			}
 
-			return isWithinOverlay();
+			return isWithinNavigationOverlay();
 		}
 	);
 

--- a/packages/block-library/src/navigation-submenu/editor.scss
+++ b/packages/block-library/src/navigation-submenu/editor.scss
@@ -1,6 +1,6 @@
 @use "@wordpress/base-styles/mixins" as *;
 
-.wp-block-navigation-submenu {
+:where(.wp-block-navigation:not(.is-custom-navigation-overlay)) .wp-block-navigation-submenu {
 	display: block;
 
 	.wp-block-navigation__submenu-container {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -77,6 +77,7 @@ import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
+import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import { DEFAULT_BLOCK } from '../constants';
 
 /**
@@ -271,6 +272,12 @@ function Navigation( {
 		hasIcon,
 		icon = 'handle',
 	} = attributes;
+
+	// Check if we're inside a navigation overlay template part.
+	const isNavigationOverlay = useSelect(
+		() => isWithinNavigationOverlay(),
+		[]
+	);
 
 	const ref = attributes.ref;
 
@@ -497,6 +504,7 @@ function Navigation( {
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 				'block-editor-block-content-overlay': hasBlockOverlay,
+				'is-within-navigation-overlay': isNavigationOverlay,
 			},
 			layoutClassNames
 		),

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -504,7 +504,7 @@ function Navigation( {
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 				'block-editor-block-content-overlay': hasBlockOverlay,
-				'is-within-navigation-overlay': isNavigationOverlay,
+				'is-custom-navigation-overlay': isNavigationOverlay,
 			},
 			layoutClassNames
 		),

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -46,8 +46,12 @@
 	background-color: inherit;
 }
 
+// Submenu flyout visibility styles.
+// These control when submenus appear as dropdowns/flyouts in the editor.
+// Don't apply when editing navigation overlay template parts - submenus should always be visible there.
+
 // Only show the flyout on hover if the parent menu item is selected.
-.wp-block-navigation:not(.is-selected):not(.has-child-selected) .has-child:hover {
+:where(.wp-block-navigation:not(.is-custom-navigation-overlay)):not(.is-selected):not(.has-child-selected) .has-child:hover {
 	> .wp-block-navigation__submenu-container {
 		opacity: 0;
 		visibility: hidden;
@@ -55,7 +59,7 @@
 }
 
 // Styles for submenu flyout.
-.has-child {
+:where(.wp-block-navigation:not(.is-custom-navigation-overlay)) .has-child {
 
 	&.is-selected,
 	&.has-child-selected {
@@ -69,7 +73,7 @@
 
 // Show a submenu when generally dragging (is-dragging-components-draggable) if that
 // submenu has children (has-child) and is being dragged within (is-dragging-within).
-.is-dragging-components-draggable .has-child.is-dragging-within {
+:where(.wp-block-navigation:not(.is-custom-navigation-overlay)) .is-dragging-components-draggable .has-child.is-dragging-within {
 	> .wp-block-navigation__submenu-container {
 		opacity: 1;
 		visibility: visible;
@@ -668,4 +672,38 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	top: -$grid-unit-05;
 	right: 0;
 	z-index: 1;
+}
+
+// When editing a navigation overlay template part, apply styles similar to the
+// responsive overlay menu on the frontend so submenus are always visible.
+.is-custom-navigation-overlay {
+	// Hide submenu icons since submenus are always expanded.
+	.wp-block-navigation__submenu-icon {
+		display: none;
+	}
+
+	.wp-block-navigation__submenu-container {
+		padding-top: var(--wp--style--block-gap, 2em);
+		padding-left: 2rem;
+		padding-right: 2rem;
+	}
+
+	// Display navigation items in a column layout.
+	.wp-block-navigation__container,
+	.wp-block-navigation-item,
+	.wp-block-page-list {
+		display: flex;
+		flex-direction: column;
+		align-items: var(--navigation-layout-justification-setting, initial);
+	}
+
+	// Remove background colors inside the overlay menu.
+	// Important needed to override global styles.
+	.wp-block-navigation-item .wp-block-navigation__submenu-container,
+	.wp-block-navigation__container,
+	.wp-block-navigation-item,
+	.wp-block-page-list {
+		color: inherit !important;
+		background: transparent !important;
+	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -156,130 +156,133 @@ $navigation-icon-size: 24px;
 	}
 }
 
-// Styles for submenu flyout.
-// These are separated out with reduced specificity to allow better inheritance from Global Styles.
-.wp-block-navigation .has-child {
-	.wp-block-navigation__submenu-container {
-		background-color: inherit;
-		color: inherit;
-		position: absolute;
-		z-index: 2;
-		display: flex;
-		flex-direction: column;
-		align-items: normal;
+// Submenu flyout visibility styles.
+// These control when submenus appear as dropdowns/flyouts on the frontend.
+// Don't apply when rendering navigation overlay template parts - submenus should always be visible there.
+.wp-block-navigation:where(:not(.is-custom-navigation-overlay)) {
+	// Styles for submenu flyout.
+	// These are separated out with reduced specificity to allow better inheritance from Global Styles.
+	.has-child {
+		.wp-block-navigation__submenu-container {
+			background-color: inherit;
+			color: inherit;
+			position: absolute;
+			z-index: 2;
+			display: flex;
+			flex-direction: column;
+			align-items: normal;
 
-		// Hide until hover or focus within.
-		opacity: 0;
-		@media not (prefers-reduced-motion) {
-			transition: opacity 0.1s linear;
-		}
-		visibility: hidden;
+			// Hide until hover or focus within.
+			opacity: 0;
+			@media not (prefers-reduced-motion) {
+				transition: opacity 0.1s linear;
+			}
+			visibility: hidden;
 
-		// Don't take up space when the menu is collapsed.
-		width: 0;
-		height: 0;
-		overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
+			// Don't take up space when the menu is collapsed.
+			width: 0;
+			height: 0;
+			overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
 
-		// Submenu items.
-		> .wp-block-navigation-item {
-			> .wp-block-navigation-item__content {
-				display: flex;
-				flex-grow: 1;
-				padding: 0.5em 1em;
+			// Submenu items.
+			> .wp-block-navigation-item {
+				> .wp-block-navigation-item__content {
+					display: flex;
+					flex-grow: 1;
+					padding: 0.5em 1em;
 
-				// Right-align the chevron in submenus.
+					// Right-align the chevron in submenus.
+					.wp-block-navigation__submenu-icon {
+						margin-right: 0;
+						margin-left: auto;
+					}
+				}
+			}
+
+			// Spacing in all submenus.
+			.wp-block-navigation-item__content {
+				margin: 0;
+			}
+
+			// Submenu indentation when there's no background.
+			left: -1px; // Border width.
+			top: 100%;
+
+			// Indentation for all submenus.
+			// Nested submenus sit to the left on large breakpoints.
+			// On smaller breakpoints, they open vertically, accordion-style.
+			@include break-medium {
+				.wp-block-navigation__submenu-container {
+					left: 100%;
+					top: -1px; // Border width.
+
+					// Prevent the menu from disappearing when the mouse is over the gap
+					&::before {
+						content: "";
+						position: absolute;
+						right: 100%;
+						height: 100%;
+						display: block;
+						width: 0.5em;
+						background: transparent;
+					}
+				}
+
+				// Push inwards from right edge of submenu.
 				.wp-block-navigation__submenu-icon {
-					margin-right: 0;
-					margin-left: auto;
+					margin-right: 0.25em;
+				}
+
+				// Reset the submenu indicator for horizontal flyouts.
+				.wp-block-navigation__submenu-icon svg {
+					transform: rotate(-90deg);
 				}
 			}
 		}
 
-		// Spacing in all submenus.
-		.wp-block-navigation-item__content {
-			margin: 0;
+		// Custom menu items.
+		// Show submenus on hover unless they open on click.
+		&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
+			visibility: visible;
+			overflow: visible;
+			opacity: 1;
+			width: auto;
+			height: auto;
+			min-width: 200px;
 		}
 
-		// Submenu indentation when there's no background.
-		left: -1px; // Border width.
+		// Keep submenus open when focus is within.
+		&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container {
+			visibility: visible;
+			overflow: visible;
+			opacity: 1;
+			width: auto;
+			height: auto;
+			min-width: 200px;
+		}
+
+		// Show submenus on click.
+		.wp-block-navigation-submenu__toggle[aria-expanded="true"] ~ .wp-block-navigation__submenu-container {
+			visibility: visible;
+			overflow: visible;
+			opacity: 1;
+			width: auto;
+			height: auto;
+			min-width: 200px;
+		}
+	}
+
+	// Submenu indentation when there's a background.
+	&.has-background .has-child .wp-block-navigation__submenu-container {
+		left: 0;
 		top: 100%;
 
-		// Indentation for all submenus.
-		// Nested submenus sit to the left on large breakpoints.
-		// On smaller breakpoints, they open vertically, accordion-style.
+		// There's no border on submenus when there are backgrounds.
 		@include break-medium {
 			.wp-block-navigation__submenu-container {
 				left: 100%;
-				top: -1px; // Border width.
-
-				// Prevent the menu from disappearing when the mouse is over the gap
-				&::before {
-					content: "";
-					position: absolute;
-					right: 100%;
-					height: 100%;
-					display: block;
-					width: 0.5em;
-					background: transparent;
-				}
+				top: 0;
 			}
-
-			// Push inwards from right edge of submenu.
-			.wp-block-navigation__submenu-icon {
-				margin-right: 0.25em;
-			}
-
-			// Reset the submenu indicator for horizontal flyouts.
-			.wp-block-navigation__submenu-icon svg {
-				transform: rotate(-90deg);
-			}
-		}
-	}
-
-	// Custom menu items.
-	// Show submenus on hover unless they open on click.
-	&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
-		visibility: visible;
-		overflow: visible;
-		opacity: 1;
-		width: auto;
-		height: auto;
-		min-width: 200px;
-	}
-
-	// Keep submenus open when focus is within.
-	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container {
-		visibility: visible;
-		overflow: visible;
-		opacity: 1;
-		width: auto;
-		height: auto;
-		min-width: 200px;
-	}
-
-	// Show submenus on click.
-	.wp-block-navigation-submenu__toggle[aria-expanded="true"] ~ .wp-block-navigation__submenu-container {
-		visibility: visible;
-		overflow: visible;
-		opacity: 1;
-		width: auto;
-		height: auto;
-		min-width: 200px;
-	}
-}
-
-// Submenu indentation when there's a background.
-.wp-block-navigation.has-background
-.has-child
-.wp-block-navigation__submenu-container {
-	left: 0;
-	top: 100%;
-
-	// There's no border on submenus when there are backgrounds.
-	@include break-medium {
-		.wp-block-navigation__submenu-container {
-			left: 100%;
-			top: 0;
 		}
 	}
 }
@@ -415,7 +418,8 @@ button.wp-block-navigation-item__content {
 }
 
 // Default background and font color.
-.wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
+// Don't apply when rendering navigation overlay template parts.
+.wp-block-navigation:where(:not(.is-custom-navigation-overlay)):not(.has-background) .wp-block-navigation__submenu-container {
 	// Set a background color for submenus so that they're not transparent.
 	// NOTE TO DEVS - if refactoring this code, please double-check that
 	// submenus have a default background color, this feature has regressed
@@ -425,13 +429,15 @@ button.wp-block-navigation-item__content {
 }
 
 // If we do have a background color selected, inherit it from the navigation block
-.wp-block-navigation.has-background {
+// Don't apply when rendering navigation overlay template parts.
+.wp-block-navigation:where(:not(.is-custom-navigation-overlay)).has-background {
 	.wp-block-navigation__submenu-container {
 		background-color: inherit;
 	}
 }
 
-.wp-block-navigation:not(.has-text-color) {
+// Don't apply when rendering navigation overlay template parts.
+.wp-block-navigation:where(:not(.is-custom-navigation-overlay)):not(.has-text-color) {
 	.wp-block-navigation__submenu-container {
 		// Set a default color for submenu text if none is selected
 		color: #000;
@@ -802,4 +808,21 @@ button.wp-block-navigation-item__content {
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;
+}
+
+// When rendering a navigation overlay template part, submenus should always be visible
+// in a vertical layout, similar to the responsive overlay menu when open.
+.wp-block-navigation.is-custom-navigation-overlay {
+	// Hide submenu icons since submenus are always expanded.
+	.wp-block-navigation__submenu-icon {
+		display: none;
+	}
+
+	// Display navigation items in a column layout.
+	.wp-block-navigation__container,
+	.wp-block-navigation-item,
+	.wp-block-page-list {
+		display: flex;
+		flex-direction: column;
+	}
 }

--- a/packages/block-library/src/utils/is-within-overlay.js
+++ b/packages/block-library/src/utils/is-within-overlay.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../navigation/constants';
+
+/**
+ * Checks if the current editing context is within a navigation overlay template part.
+ *
+ * This utility exists because @wordpress/block-library cannot depend on @wordpress/editor
+ * as a package dependency. Blocks can be loaded into non-post block editors, so we must
+ * access the 'core/editor' store by string literal rather than importing it.
+ *
+ * React components should wrap this in useSelect for reactivity. Non-React contexts
+ * (like filter callbacks) can call this directly.
+ *
+ * @return {boolean} True if editing a navigation overlay template part, false otherwise.
+ */
+export function isWithinNavigationOverlay() {
+	// @wordpress/block-library should not depend on @wordpress/editor.
+	// Blocks can be loaded into a *non-post* block editor, so to avoid
+	// declaring @wordpress/editor as a dependency, we must access its
+	// store by string.
+	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+	const editorStore = select( 'core/editor' );
+
+	// Return false if the editor store is not available.
+	if ( ! editorStore ) {
+		return false;
+	}
+
+	const { getCurrentPostType, getCurrentPostId } = editorStore;
+	const { getEditedEntityRecord } = select( coreStore );
+
+	const postType = getCurrentPostType?.();
+	const postId = getCurrentPostId?.();
+
+	if ( postType === 'wp_template_part' && postId ) {
+		const templatePart = getEditedEntityRecord(
+			'postType',
+			'wp_template_part',
+			postId
+		);
+
+		return templatePart?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA;
+	}
+
+	return false;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
If a navigation block is used inside a navigation overlay, it should be kept open rather than collapsing, when viewed inside the template part editor.

Closes https://github.com/WordPress/gutenberg/issues/74590

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
On the front end, navigation blocks inside the overlay are automatically opened, so we should do the same thing in the editor as well, so they match.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moves the `isWithinNavigationOverlay` selector to a new file and uses that to determine that we are in that editing context. When in that context we update the block so that its open.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
