### PR TITLE
Cover Block: Enable focal point picker for fixed background

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -178,8 +178,7 @@ export default function CoverInspectorControls( {
 		} );
 	};
 
-	const showFocalPointPicker =
-		isVideoBackground || ( isImageBackground && ! isRepeated );
+	const showFocalPointPicker = isVideoBackground || isImageBackground;
 
 	const imperativeFocalPointPreview = ( value ) => {
 		const [ styleOfRef, property ] = mediaElement.current
@@ -269,13 +268,6 @@ export default function CoverInspectorControls( {
 										setAttributes( {
 											focalPoint: newFocalPoint,
 										} )
-									}
-									help={
-										hasParallax
-											? __(
-													'The focal point is used on mobile devices where fixed backgrounds are converted to scrolling.'
-											  )
-											: undefined
 									}
 								/>
 							</ToolsPanelItem>

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -179,8 +179,7 @@ export default function CoverInspectorControls( {
 	};
 
 	const showFocalPointPicker =
-		isVideoBackground ||
-		( isImageBackground && ( ! hasParallax || isRepeated ) );
+		isVideoBackground || ( isImageBackground && ! isRepeated );
 
 	const imperativeFocalPointPreview = ( value ) => {
 		const [ styleOfRef, property ] = mediaElement.current
@@ -270,6 +269,13 @@ export default function CoverInspectorControls( {
 										setAttributes( {
 											focalPoint: newFocalPoint,
 										} )
+									}
+									help={
+										hasParallax
+											? __(
+													'The focal point is used on mobile devices where fixed backgrounds are converted to scrolling.'
+											  )
+											: undefined
 									}
 								/>
 							</ToolsPanelItem>


### PR DESCRIPTION
## What?
Simplifies the focal point picker logic in the Cover block to always show for image and video backgrounds, regardless of fixed or repeated background settings.

## Why?
The focal point picker was previously hidden when "Fixed background" was enabled, which prevented users from controlling image positioning. This was particularly problematic on mobile devices where fixed backgrounds (`background-attachment: fixed`) are often not supported and fall back to scrolling behavior.

Additionally, the previous logic was unnecessarily complex with conditions that didn't reflect actual use cases - focal point is useful for all background types including repeated backgrounds (where it controls the tiling pattern's starting position).

## How?
- Simplified `showFocalPointPicker` logic from complex conditional to: `isVideoBackground || isImageBackground`
- Removed the `! hasParallax` condition that was hiding the picker for fixed backgrounds
- Removed the `isRepeated` condition - focal point works with repeated backgrounds too
- Removed confusing help text that was added in initial version
- The focal point is already applied correctly in both `save.js` (JavaScript) and `index.php` (PHP server-side rendering)

## Testing Instructions

### Before Testing
Ensure you have a Cover block with an image that has distinct focal point areas (e.g., a landscape with sky and ground, or a portrait).

### Steps to Test

**Test 1: Fixed Background (Main Fix)**
1. Create a new post or page
2. Insert a Cover block
3. Add an image as the background
4. In the block sidebar under "Settings" → "Media settings", enable **"Fixed background"**
5. ✅ **Verify:** The "Focal point" control is now visible (previously it was hidden)
6. Adjust the focal point picker to different positions
7. Save and view on desktop - fixed background should work with focal point applied
8. View on mobile device or browser dev tools mobile emulation
9. ✅ **Verify:** Focal point is applied on mobile where fixed background converts to scrolling

**Test 2: Repeated Background**
1. Create a Cover block with an image
2. Enable **"Repeated background"**
3. ✅ **Verify:** Focal point picker is visible
4. Adjust focal point
5. ✅ **Verify:** Focal point controls where the tiling pattern starts

**Test 3: Video Background**
1. Create a Cover block with a video
2. ✅ **Verify:** Focal point picker is visible and works

**Test 4: Normal Image Background**
1. Create a Cover block with an image
2. Don't enable fixed or repeated
3. ✅ **Verify:** Focal point picker is visible and works (existing behavior maintained)

### Expected Results
- Focal point picker is visible for all image and video backgrounds
- No confusing help text appears
- Focal point adjustments are saved and applied correctly in all scenarios
- Simplified logic makes the feature more consistent and predictable

## Screencast
https://github.com/user-attachments/assets/d777bd23-7437-4869-b1bf-d31252a01685

## Related
Fixes #52898