### PR TITLE
Media Editor: Add a simple media editor package and integrate into the editor package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1854,6 +1854,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/media-editor",
+		"slug": "packages-media-editor",
+		"markdown_source": "../packages/media-editor/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/media-fields",
 		"slug": "packages-media-fields",
 		"markdown_source": "../packages/media-fields/README.md",

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -46,6 +46,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalExtensibleSiteEditor = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditor = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -246,6 +246,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-media-editor',
+		__( 'Media Editor', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables editing media items (attachments) directly in the block editor with a dedicated media preview and metadata panel.', 'gutenberg' ),
+			'id'    => 'gutenberg-media-editor',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/package-lock.json
+++ b/package-lock.json
@@ -53236,6 +53236,8 @@
 				"@wordpress/interface": "file:../interface",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",
+				"@wordpress/media-editor": "file:../media-editor",
+				"@wordpress/media-fields": "file:../media-fields",
 				"@wordpress/media-utils": "file:../media-utils",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/patterns": "file:../patterns",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17551,6 +17551,10 @@
 			"resolved": "packages/list-reusable-blocks",
 			"link": true
 		},
+		"node_modules/@wordpress/media-editor": {
+			"resolved": "packages/media-editor",
+			"link": true
+		},
 		"node_modules/@wordpress/media-fields": {
 			"resolved": "packages/media-fields",
 			"link": true
@@ -53835,6 +53839,25 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/media-editor": {
+			"name": "@wordpress/media-editor",
+			"version": "0.1.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/components": "file:../components",
+				"@wordpress/dataviews": "file:../dataviews",
+				"@wordpress/element": "file:../element",
+				"@wordpress/i18n": "file:../i18n"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/media-fields": {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -304,29 +304,41 @@ export default function Image( {
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true } = context;
 
-	const image = useSelect(
-		( select ) =>
-			id && isSingleSelected
-				? select( coreStore ).getEntityRecord(
-						'postType',
-						'attachment',
-						id,
-						{ context: 'view' }
-				  )
-				: null,
+	const { image, canUserEdit } = useSelect(
+		( select ) => {
+			const imageRecord =
+				id && isSingleSelected
+					? select( coreStore ).getEntityRecord(
+							'postType',
+							'attachment',
+							id,
+							{ context: 'view' }
+					  )
+					: null;
+
+			// Check edit permissions. When the media editor experiment is enabled,
+			// use getEntityRecordPermissions which checks via canUser API.
+			// Only check when the image is selected to avoid unnecessary API requests.
+			let canEdit = false;
+			if ( id && isSingleSelected && window?.__experimentalMediaEditor ) {
+				const { getEntityRecordPermissions } = unlock(
+					select( coreStore )
+				);
+				const permissions = getEntityRecordPermissions(
+					'postType',
+					'attachment',
+					id
+				);
+				canEdit = permissions?.update || false;
+			}
+
+			return {
+				image: imageRecord,
+				canUserEdit: canEdit,
+			};
+		},
 		[ id, isSingleSelected ]
 	);
-
-	// Check edit permission from the entity's _links without making an additional API request.
-	// If image data isn't loaded yet, show the button (it will be hidden later if no permission).
-	// This maintains consistent toolbar positioning.
-	const isLoadingImageData = id && isSingleSelected && ! image;
-	const allowedMethods = image?._links?.self?.[ 0 ]?.targetHints?.allow;
-	const canUserEdit = isLoadingImageData
-		? true // Show button while loading to reserve toolbar space
-		: allowedMethods?.includes( 'PUT' ) ||
-		  allowedMethods?.includes( 'PATCH' ) ||
-		  false;
 
 	const { canInsertCover, imageEditing, imageSizes, maxWidth } = useSelect(
 		( select ) => {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -317,6 +317,17 @@ export default function Image( {
 		[ id, isSingleSelected ]
 	);
 
+	// Check edit permission from the entity's _links without making an additional API request.
+	// If image data isn't loaded yet, show the button (it will be hidden later if no permission).
+	// This maintains consistent toolbar positioning.
+	const isLoadingImageData = id && isSingleSelected && ! image;
+	const allowedMethods = image?._links?.self?.[ 0 ]?.targetHints?.allow;
+	const canUserEdit = isLoadingImageData
+		? true // Show button while loading to reserve toolbar space
+		: allowedMethods?.includes( 'PUT' ) ||
+		  allowedMethods?.includes( 'PATCH' ) ||
+		  false;
+
 	const { canInsertCover, imageEditing, imageSizes, maxWidth } = useSelect(
 		( select ) => {
 			const { getBlockRootClientId, canInsertBlockType, getSettings } =
@@ -730,6 +741,7 @@ export default function Image( {
 	const editMediaButton = window?.__experimentalMediaEditor &&
 		id &&
 		isSingleSelected &&
+		canUserEdit &&
 		! isExternalImage( id, url ) &&
 		! isEditingImage &&
 		onNavigateToEntityRecord && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -338,6 +338,7 @@ export default function Image( {
 		[ clientId ]
 	);
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
+	const onNavigateToEntityRecord = getSettings().onNavigateToEntityRecord;
 
 	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } =
@@ -725,6 +726,26 @@ export default function Image( {
 
 	const hasDataFormBlockFields =
 		window?.__experimentalContentOnlyInspectorFields;
+
+	const editMediaButton = window?.__experimentalMediaEditor &&
+		id &&
+		isSingleSelected &&
+		! isExternalImage( id, url ) &&
+		! isEditingImage &&
+		onNavigateToEntityRecord && (
+			<BlockControls group="other">
+				<ToolbarButton
+					onClick={ () => {
+						onNavigateToEntityRecord( {
+							postId: id,
+							postType: 'attachment',
+						} );
+					} }
+				>
+					{ __( 'Edit media' ) }
+				</ToolbarButton>
+			</BlockControls>
+		);
 
 	const controls = (
 		<>
@@ -1199,6 +1220,7 @@ export default function Image( {
 
 	return (
 		<>
+			{ editMediaButton }
 			{ mediaReplaceFlow }
 			{ controls }
 			{ featuredImageControl }

--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -12,6 +12,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import {
+	ATTACHMENT_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
@@ -21,6 +22,7 @@ import {
 const { useLocation } = unlock( routerPrivateApis );
 
 const postTypesWithoutParentTemplate = [
+	ATTACHMENT_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
@@ -45,6 +47,11 @@ function getPostType( name ) {
 		postType = 'page';
 	} else if ( name === 'post-item' || name === 'posts' ) {
 		postType = 'post';
+	} else if (
+		name === 'attachment-item' &&
+		window?.__experimentalMediaEditor
+	) {
+		postType = ATTACHMENT_POST_TYPE;
 	}
 
 	return postType;

--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -47,10 +47,7 @@ function getPostType( name ) {
 		postType = 'page';
 	} else if ( name === 'post-item' || name === 'posts' ) {
 		postType = 'post';
-	} else if (
-		name === 'attachment-item' &&
-		window?.__experimentalMediaEditor
-	) {
+	} else if ( name === 'attachment-item' ) {
 		postType = ATTACHMENT_POST_TYPE;
 	}
 

--- a/packages/edit-site/src/components/site-editor-routes/attachment-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/attachment-item.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+
+export const attachmentItemRoute = {
+	name: 'attachment-item',
+	path: '/attachment/:postId',
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Media' ) }
+				backPath="/"
+				// Empty content - no sidebar list needed for attachments
+				content={ null }
+			/>
+		),
+		mobile: <Editor />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/index.js
+++ b/packages/edit-site/src/components/site-editor-routes/index.js
@@ -20,10 +20,12 @@ import { templatesRoute } from './templates';
 import { templateItemRoute } from './template-item';
 import { pagesRoute } from './pages';
 import { pageItemRoute } from './page-item';
+import { attachmentItemRoute } from './attachment-item';
 import { stylebookRoute } from './stylebook';
 import { notFoundRoute } from './notfound';
 
 const routes = [
+	...( window?.__experimentalMediaEditor ? [ attachmentItemRoute ] : [] ),
 	pageItemRoute,
 	pagesRoute,
 	templateItemRoute,

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -9,6 +9,9 @@ import { privateApis as patternPrivateApis } from '@wordpress/patterns';
  */
 import { unlock } from '../lock-unlock';
 
+// Attachments / media
+export const ATTACHMENT_POST_TYPE = 'attachment';
+
 // Navigation
 export const NAVIGATION_POST_TYPE = 'wp_navigation';
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -87,6 +87,8 @@
 		"@wordpress/interface": "file:../interface",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/media-editor": "file:../media-editor",
+		"@wordpress/media-fields": "file:../media-fields",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/patterns": "file:../patterns",

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -102,8 +102,12 @@ export default function EditorInterface( {
 	const secondarySidebarLabel = isListViewOpened
 		? __( 'Document Overview' )
 		: __( 'Block Library' );
+	const shouldShowMediaEditor = !! isAttachment;
 	const shouldShowStylesCanvas =
-		showStylebook || stylesPath?.startsWith( '/revisions' );
+		! isAttachment &&
+		( showStylebook || stylesPath?.startsWith( '/revisions' ) );
+	const shouldShowBlockEditor =
+		! shouldShowMediaEditor && ! shouldShowStylesCanvas;
 
 	// Local state for save panel.
 	// Note 'truthy' callback implies an open panel.
@@ -159,39 +163,35 @@ export default function EditorInterface( {
 					{ ! isDistractionFree && ! isPreviewMode && (
 						<EditorNotices />
 					) }
-					{ isAttachment && <MediaPreview { ...iframeProps } /> }
-					{ ! isAttachment && (
+					{ shouldShowMediaEditor && (
+						<MediaPreview { ...iframeProps } />
+					) }
+					{ shouldShowStylesCanvas && <StylesCanvas /> }
+					{ shouldShowBlockEditor && (
 						<>
-							{ shouldShowStylesCanvas ? (
-								<StylesCanvas />
-							) : (
-								<>
-									{ ! isPreviewMode && mode === 'text' && (
-										<TextEditor
-											// We should auto-focus the canvas (title) on load.
-											// eslint-disable-next-line jsx-a11y/no-autofocus
-											autoFocus={ autoFocus }
-										/>
-									) }
-									{ ! isPreviewMode &&
-										! isLargeViewport &&
-										mode === 'visual' && (
-											<BlockToolbar hideDragHandle />
-										) }
-									{ ( isPreviewMode ||
-										mode === 'visual' ) && (
-										<VisualEditor
-											contentRef={ contentRef }
-											disableIframe={ disableIframe }
-											// We should auto-focus the canvas (title) on load.
-											// eslint-disable-next-line jsx-a11y/no-autofocus
-											autoFocus={ autoFocus }
-											iframeProps={ iframeProps }
-										/>
-									) }
-									{ children }
-								</>
+							{ ! isPreviewMode && mode === 'text' && (
+								<TextEditor
+									// We should auto-focus the canvas (title) on load.
+									// eslint-disable-next-line jsx-a11y/no-autofocus
+									autoFocus={ autoFocus }
+								/>
 							) }
+							{ ! isPreviewMode &&
+								! isLargeViewport &&
+								mode === 'visual' && (
+									<BlockToolbar hideDragHandle />
+								) }
+							{ ( isPreviewMode || mode === 'visual' ) && (
+								<VisualEditor
+									contentRef={ contentRef }
+									disableIframe={ disableIframe }
+									// We should auto-focus the canvas (title) on load.
+									// eslint-disable-next-line jsx-a11y/no-autofocus
+									autoFocus={ autoFocus }
+									iframeProps={ iframeProps }
+								/>
+							) }
+							{ children }
 						</>
 					) }
 				</>

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -28,6 +28,7 @@ import SavePublishPanels from '../save-publish-panels';
 import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import StylesCanvas from '../styles-canvas';
+import { MediaPreview } from '../media';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -56,6 +57,7 @@ export default function EditorInterface( {
 } ) {
 	const {
 		mode,
+		isAttachment,
 		isInserterOpened,
 		isListViewOpened,
 		isDistractionFree,
@@ -66,7 +68,8 @@ export default function EditorInterface( {
 		showStylebook,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
-		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
+		const { getEditorSettings, getPostTypeLabel, getCurrentPostType } =
+			select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
 		);
@@ -90,6 +93,9 @@ export default function EditorInterface( {
 			postTypeLabel: getPostTypeLabel(),
 			stylesPath: getStylesPath(),
 			showStylebook: getShowStylebook(),
+			isAttachment:
+				getCurrentPostType() === 'attachment' &&
+				window?.__experimentalMediaEditor,
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -138,6 +144,7 @@ export default function EditorInterface( {
 			}
 			editorNotices={ <EditorNotices /> }
 			secondarySidebar={
+				! isAttachment &&
 				! isPreviewMode &&
 				mode === 'visual' &&
 				( ( isInserterOpened && <InserterSidebar /> ) ||
@@ -152,34 +159,39 @@ export default function EditorInterface( {
 					{ ! isDistractionFree && ! isPreviewMode && (
 						<EditorNotices />
 					) }
-
-					{ shouldShowStylesCanvas ? (
-						<StylesCanvas />
-					) : (
+					{ isAttachment && <MediaPreview { ...iframeProps } /> }
+					{ ! isAttachment && (
 						<>
-							{ ! isPreviewMode && mode === 'text' && (
-								<TextEditor
-									// We should auto-focus the canvas (title) on load.
-									// eslint-disable-next-line jsx-a11y/no-autofocus
-									autoFocus={ autoFocus }
-								/>
-							) }
-							{ ! isPreviewMode &&
-								! isLargeViewport &&
-								mode === 'visual' && (
-									<BlockToolbar hideDragHandle />
-								) }
-							{ ( isPreviewMode || mode === 'visual' ) && (
-								<VisualEditor
-									contentRef={ contentRef }
-									disableIframe={ disableIframe }
-									// We should auto-focus the canvas (title) on load.
-									// eslint-disable-next-line jsx-a11y/no-autofocus
-									autoFocus={ autoFocus }
-									iframeProps={ iframeProps }
-								/>
-							) }
-							{ children }
+							{ shouldShowStylesCanvas ? (
+								<StylesCanvas />
+							) : (
+								<>
+									{ ! isPreviewMode && mode === 'text' && (
+										<TextEditor
+											// We should auto-focus the canvas (title) on load.
+											// eslint-disable-next-line jsx-a11y/no-autofocus
+											autoFocus={ autoFocus }
+										/>
+									) }
+									{ ! isPreviewMode &&
+										! isLargeViewport &&
+										mode === 'visual' && (
+											<BlockToolbar hideDragHandle />
+										) }
+									{ ( isPreviewMode ||
+										mode === 'visual' ) && (
+										<VisualEditor
+											contentRef={ contentRef }
+											disableIframe={ disableIframe }
+											// We should auto-focus the canvas (title) on load.
+											// eslint-disable-next-line jsx-a11y/no-autofocus
+											autoFocus={ autoFocus }
+											iframeProps={ iframeProps }
+										/>
+									) }
+									{ children }
+								</>
+							) }{ ' ' }
 						</>
 					) }
 				</>

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -191,7 +191,7 @@ export default function EditorInterface( {
 									) }
 									{ children }
 								</>
-							) }{ ' ' }
+							) }
 						</>
 					) }
 				</>

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -207,7 +207,7 @@ function Header( {
 					/>
 				) }
 				{ customSaveButton }
-				<MoreMenu />
+				{ ! isAttachment && <MoreMenu /> }
 			</motion.div>
 		</div>
 	);

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -25,6 +25,7 @@ import PreviewDropdown from '../preview-dropdown';
 import ZoomOutToggle from '../zoom-out-toggle';
 import { store as editorStore } from '../../store';
 import {
+	ATTACHMENT_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
@@ -64,6 +65,7 @@ function Header( {
 		hasBlockSelection,
 		hasSectionRootClientId,
 		isStylesCanvasActive,
+		isAttachment,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -89,6 +91,9 @@ function Header( {
 			isStylesCanvasActive:
 				!! getStylesPath()?.startsWith( '/revisions' ) ||
 				getShowStylebook(),
+			isAttachment:
+				getCurrentPostType() === ATTACHMENT_POST_TYPE &&
+				window?.__experimentalMediaEditor,
 		};
 	}, [] );
 
@@ -98,6 +103,7 @@ function Header( {
 
 	const disablePreviewOption =
 		[
+			ATTACHMENT_POST_TYPE,
 			NAVIGATION_POST_TYPE,
 			TEMPLATE_PART_POST_TYPE,
 			PATTERN_POST_TYPE,
@@ -133,9 +139,13 @@ function Header( {
 				className="editor-header__toolbar"
 				transition={ { type: 'tween' } }
 			>
-				<DocumentTools
-					disableBlockTools={ isStylesCanvasActive || isTextEditor }
-				/>
+				{ ! isAttachment && (
+					<DocumentTools
+						disableBlockTools={
+							isStylesCanvasActive || isTextEditor
+						}
+					/>
+				) }
 				{ hasFixedToolbar && isLargeViewport && (
 					<CollapsibleBlockToolbar
 						isCollapsed={ isBlockToolsCollapsed }

--- a/packages/editor/src/components/media/index.js
+++ b/packages/editor/src/components/media/index.js
@@ -1,0 +1,2 @@
+export { default as MediaPreview } from './preview';
+export { default as MediaMetadataPanel } from './metadata-panel';

--- a/packages/editor/src/components/media/metadata-panel.js
+++ b/packages/editor/src/components/media/metadata-panel.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { MediaEditorProvider, MediaForm } from '@wordpress/media-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import usePostFields from '../post-fields';
+import PostCardPanel from '../post-card-panel';
+import PostPanelSection from '../post-panel-section';
+
+/**
+ * Media metadata panel for the editor sidebar.
+ * Displays a form for editing media properties with PostCardPanel header.
+ *
+ * @param {Object}   props                   - Component props.
+ * @param {Function} props.onActionPerformed - Callback when an action is performed.
+ * @return {Element} The MediaMetadataPanel component.
+ */
+export default function MediaMetadataPanel( { onActionPerformed } ) {
+	const { media, postType, postId } = useSelect( ( select ) => {
+		const _postType = select( editorStore ).getCurrentPostType();
+		const _postId = select( editorStore ).getCurrentPostId();
+		const currentPost = select( coreStore ).getEditedEntityRecord(
+			'postType',
+			_postType,
+			_postId
+		);
+		return {
+			media: currentPost,
+			postType: _postType,
+			postId: _postId,
+		};
+	}, [] );
+
+	const { editPost } = useDispatch( editorStore );
+	const fields = usePostFields( { postType: 'attachment' } );
+
+	const settings = useMemo(
+		() => ( {
+			fields,
+		} ),
+		[ fields ]
+	);
+
+	const handleUpdate = ( updates ) => {
+		editPost( updates );
+	};
+
+	return (
+		<PostPanelSection className="editor-media-metadata-panel">
+			<MediaEditorProvider
+				value={ media }
+				settings={ settings }
+				onChange={ handleUpdate }
+			>
+				<MediaForm
+					header={
+						<PostCardPanel
+							postType={ postType }
+							postId={ postId }
+							onActionPerformed={ onActionPerformed }
+						/>
+					}
+				/>
+			</MediaEditorProvider>
+		</PostPanelSection>
+	);
+}

--- a/packages/editor/src/components/media/metadata-panel.js
+++ b/packages/editor/src/components/media/metadata-panel.js
@@ -29,7 +29,10 @@ export default function MediaMetadataPanel( { onActionPerformed } ) {
 		const currentPost = select( coreStore ).getEditedEntityRecord(
 			'postType',
 			_postType,
-			_postId
+			_postId,
+			{
+				_embed: 'author,wp:attached-to',
+			}
 		);
 		return {
 			media: currentPost,

--- a/packages/editor/src/components/media/preview.js
+++ b/packages/editor/src/components/media/preview.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	MediaEditorProvider,
+	MediaPreview as BaseMediaPreview,
+} from '@wordpress/media-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+/**
+ * Media preview component for the editor.
+ * Connects the base MediaPreview component to the editor store.
+ *
+ * @param {Object} props - Additional props to spread on MediaPreview.
+ * @return {Element} The MediaPreview component.
+ */
+export default function MediaPreview( props ) {
+	const { media } = useSelect( ( select ) => {
+		const currentPost = select( editorStore ).getCurrentPost();
+		return {
+			media: currentPost,
+		};
+	}, [] );
+
+	return (
+		<MediaEditorProvider value={ media }>
+			<BaseMediaPreview { ...props } />
+		</MediaEditorProvider>
+	);
+}

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -9,6 +9,7 @@ import { useViewportMatch } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 
 /**
  * Renders the label for the publish button.
@@ -68,7 +69,10 @@ export default function PublishButtonLabel() {
 	}
 	if ( ! hasPublishAction ) {
 		// For attachments, always show "Save" since they don't have a publish workflow
-		if ( postType === 'attachment' && window?.__experimentalMediaEditor ) {
+		if (
+			postType === ATTACHMENT_POST_TYPE &&
+			window?.__experimentalMediaEditor
+		) {
 			return __( 'Save' );
 		}
 		// TODO: this is because "Submit for review" string is too long in some languages.

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -27,6 +27,7 @@ export default function PublishButtonLabel() {
 		hasNonPostEntityChanges,
 		postStatusHasChanged,
 		postStatus,
+		postType,
 	} = useSelect( ( select ) => {
 		const {
 			isCurrentPostPublished,
@@ -66,6 +67,10 @@ export default function PublishButtonLabel() {
 		return __( 'Saving…' );
 	}
 	if ( ! hasPublishAction ) {
+		// For attachments, always show "Save" since they don't have a publish workflow
+		if ( postType === 'attachment' && window?.__experimentalMediaEditor ) {
+			return __( 'Save' );
+		}
 		// TODO: this is because "Submit for review" string is too long in some languages.
 		// @see https://github.com/WordPress/gutenberg/issues/10475
 		return isSmallerThanMediumViewport

--- a/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
+++ b/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
@@ -9,6 +9,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import PostPublishButton from './index';
 import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 
 const IS_TOGGLE = 'toggle';
 const IS_BUTTON = 'button';
@@ -79,7 +80,7 @@ export default function PostPublishButtonOrToggle( {
 	 * - if it is enabled, we show a TOGGLE
 	 * - if it is disabled, we show a BUTTON
 	 */
-	if ( postType === 'attachment' ) {
+	if ( postType === ATTACHMENT_POST_TYPE ) {
 		component = IS_BUTTON;
 	} else if (
 		isPublished ||

--- a/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
+++ b/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
@@ -30,6 +30,7 @@ export default function PostPublishButtonOrToggle( {
 		isScheduled,
 		postStatus,
 		postStatusHasChanged,
+		postType,
 	} = useSelect( ( select ) => {
 		return {
 			hasPublishAction:
@@ -48,14 +49,18 @@ export default function PostPublishButtonOrToggle( {
 			postStatus:
 				select( editorStore ).getEditedPostAttribute( 'status' ),
 			postStatusHasChanged: select( editorStore ).getPostEdits()?.status,
+			postType: select( editorStore ).getCurrentPostType(),
 		};
 	}, [] );
 
 	/**
 	 * Conditions to show a BUTTON (publish directly) or a TOGGLE (open publish sidebar):
 	 *
-	 * 1) We want to show a BUTTON when the post status is at the _final stage_
-	 * for a particular role (see https://wordpress.org/documentation/article/post-status/):
+	 * 1) Attachments always show a BUTTON since they don't have a publish workflow
+	 *    and should save directly without pre-publish checks.
+	 *
+	 * 2) We want to show a BUTTON when the post status is at the _final stage_
+	 *    for a particular role (see https://wordpress.org/documentation/article/post-status/):
 	 *
 	 * - is published
 	 * - post status has changed explicitly to something different than 'future' or 'publish'
@@ -67,14 +72,16 @@ export default function PostPublishButtonOrToggle( {
 	 * 	 we decided to take into account the viewport in that case.
 	 *  	 See: https://github.com/WordPress/gutenberg/issues/10475
 	 *
-	 * 2) Then, in small viewports, we'll show a TOGGLE.
+	 * 3) Then, in small viewports, we'll show a TOGGLE.
 	 *
-	 * 3) Finally, we'll use the publish sidebar status to decide:
+	 * 4) Finally, we'll use the publish sidebar status to decide:
 	 *
 	 * - if it is enabled, we show a TOGGLE
 	 * - if it is disabled, we show a BUTTON
 	 */
-	if (
+	if ( postType === 'attachment' ) {
+		component = IS_BUTTON;
+	} else if (
 		isPublished ||
 		( postStatusHasChanged &&
 			! [ 'future', 'publish' ].includes( postStatus ) ) ||

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -23,6 +23,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { STATUS_OPTIONS } from '../../components/post-status';
 import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 
 /**
  * Component showing whether the post is saved or not and providing save
@@ -102,7 +103,7 @@ export default function PostSavedState( { forceIsDirty } ) {
 	}, [ isSaving ] );
 
 	// Attachments don't support draft mode, so hide this button.
-	if ( postType === 'attachment' ) {
+	if ( postType === ATTACHMENT_POST_TYPE ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -49,6 +49,7 @@ export default function PostSavedState( { forceIsDirty } ) {
 		showIconLabels,
 		postStatus,
 		postStatusHasChanged,
+		postType,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -77,6 +78,7 @@ export default function PostSavedState( { forceIsDirty } ) {
 				showIconLabels: get( 'core', 'showIconLabels' ),
 				postStatus: getEditedPostAttribute( 'status' ),
 				postStatusHasChanged: !! getPostEdits()?.status,
+				postType: select( editorStore ).getCurrentPostType(),
 			};
 		},
 		[ forceIsDirty ]
@@ -98,6 +100,11 @@ export default function PostSavedState( { forceIsDirty } ) {
 
 		return () => clearTimeout( timeoutId );
 	}, [ isSaving ] );
+
+	// Attachments don't support draft mode, so hide this button.
+	if ( postType === 'attachment' ) {
+		return null;
+	}
 
 	// Once the post has been submitted for review this button
 	// is not needed for the contributor role.

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -23,6 +23,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import withRegistryProvider from './with-registry-provider';
 import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 import useBlockEditorSettings from './use-block-editor-settings';
 import { unlock } from '../../lock-unlock';
 import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
@@ -356,7 +357,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		}
 
 		const isAttachment =
-			post.type === 'attachment' && window?.__experimentalMediaEditor;
+			post.type === ATTACHMENT_POST_TYPE &&
+			window?.__experimentalMediaEditor;
 
 		// Early return for attachments - no block editor needed
 		if ( isAttachment ) {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -355,6 +355,30 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			return null;
 		}
 
+		const isAttachment =
+			post.type === 'attachment' && window?.__experimentalMediaEditor;
+
+		// Early return for attachments - no block editor needed
+		if ( isAttachment ) {
+			return (
+				<EntityProvider kind="root" type="site">
+					<EntityProvider
+						kind="postType"
+						type={ post.type }
+						id={ post.id }
+					>
+						{ children }
+						{ ! settings.isPreviewMode && (
+							<>
+								<EditorKeyboardShortcuts />
+								<KeyboardShortcutHelpModal />
+							</>
+						) }
+					</EntityProvider>
+				</EntityProvider>
+			);
+		}
+
 		return (
 			<EntityProvider kind="root" type="site">
 				<EntityProvider

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -17,10 +17,15 @@ import { sidebars } from './constants';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SidebarHeader = ( _, ref ) => {
-	const postTypeLabel = useSelect(
-		( select ) => select( editorStore ).getPostTypeLabel(),
-		[]
-	);
+	const { postTypeLabel, isAttachment } = useSelect( ( select ) => {
+		const { getPostTypeLabel, getCurrentPostType } = select( editorStore );
+		return {
+			postTypeLabel: getPostTypeLabel(),
+			isAttachment:
+				getCurrentPostType() === 'attachment' &&
+				window?.__experimentalMediaEditor,
+		};
+	}, [] );
 
 	const documentLabel = postTypeLabel
 		? decodeEntities( postTypeLabel )
@@ -36,14 +41,16 @@ const SidebarHeader = ( _, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
-			<Tabs.Tab
-				tabId={ sidebars.block }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.block }
-			>
-				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
-				{ __( 'Block' ) }
-			</Tabs.Tab>
+			{ ! isAttachment && (
+				<Tabs.Tab
+					tabId={ sidebars.block }
+					// Used for focus management in the SettingsSidebar component.
+					data-tab-id={ sidebars.block }
+				>
+					{ /* translators: Text label for the Block Settings Sidebar tab. */ }
+					{ __( 'Block' ) }
+				</Tabs.Tab>
+			) }
 		</Tabs.TabList>
 	);
 };

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -11,6 +11,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 import { sidebars } from './constants';
 
@@ -22,7 +23,7 @@ const SidebarHeader = ( _, ref ) => {
 		return {
 			postTypeLabel: getPostTypeLabel(),
 			isAttachment:
-				getCurrentPostType() === 'attachment' &&
+				getCurrentPostType() === ATTACHMENT_POST_TYPE &&
 				window?.__experimentalMediaEditor,
 		};
 	}, [] );

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -31,6 +31,7 @@ import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
 import TemplateContentPanel from '../template-content-panel';
 import TemplatePartContentPanel from '../template-part-content-panel';
+import { MediaMetadataPanel } from '../media';
 import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-sidebars';
 import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
@@ -53,12 +54,14 @@ const SidebarContent = ( {
 	keyboardShortcut,
 	onActionPerformed,
 	extraPanels,
+	postType,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
 	// need to forward the `Tabs` context so it can be passed through the
 	// underlying slot/fill.
 	const tabsContextValue = useContext( Tabs.Context );
+	const isAttachment = postType === 'attachment';
 
 	// This effect addresses a race condition caused by tabbing from the last
 	// block in the editor into the settings sidebar. Without this effect, the
@@ -111,18 +114,30 @@ const SidebarContent = ( {
 		>
 			<Tabs.Context.Provider value={ tabsContextValue }>
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					<PostSummary onActionPerformed={ onActionPerformed } />
-					<PluginDocumentSettingPanel.Slot />
-					<TemplateContentPanel />
-					<TemplatePartContentPanel />
-					<PostTransformPanel />
-					<PostTaxonomiesPanel />
-					<PatternOverridesPanel />
-					{ extraPanels }
+					{ isAttachment ? (
+						<MediaMetadataPanel
+							onActionPerformed={ onActionPerformed }
+						/>
+					) : (
+						<>
+							<PostSummary
+								onActionPerformed={ onActionPerformed }
+							/>
+							<PluginDocumentSettingPanel.Slot />
+							<TemplateContentPanel />
+							<TemplatePartContentPanel />
+							<PostTransformPanel />
+							<PostTaxonomiesPanel />
+							<PatternOverridesPanel />
+							{ extraPanels }
+						</>
+					) }
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
-					<BlockInspector />
-				</Tabs.TabPanel>
+				{ ! isAttachment && (
+					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
+						<BlockInspector />
+					</Tabs.TabPanel>
+				) }
 			</Tabs.Context.Provider>
 		</PluginSidebar>
 	);
@@ -130,7 +145,7 @@ const SidebarContent = ( {
 
 const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	useAutoSwitchEditorSidebars();
-	const { tabName, keyboardShortcut, showSummary } = useSelect(
+	const { tabName, keyboardShortcut, showSummary, postType } = useSelect(
 		( select ) => {
 			const shortcut = select(
 				keyboardShortcutsStore
@@ -151,6 +166,8 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 					: sidebars.document;
 			}
 
+			const _postType = select( editorStore ).getCurrentPostType();
+
 			return {
 				tabName: _tabName,
 				keyboardShortcut: shortcut,
@@ -158,7 +175,8 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 					TEMPLATE_POST_TYPE,
 					TEMPLATE_PART_POST_TYPE,
 					NAVIGATION_POST_TYPE,
-				].includes( select( editorStore ).getCurrentPostType() ),
+				].includes( _postType ),
+				postType: _postType,
 			};
 		},
 		[]
@@ -187,6 +205,7 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 				showSummary={ showSummary }
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
+				postType={ postType }
 			/>
 		</Tabs>
 	);

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -37,6 +37,7 @@ import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 import {
+	ATTACHMENT_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	TEMPLATE_POST_TYPE,
@@ -61,7 +62,7 @@ const SidebarContent = ( {
 	// need to forward the `Tabs` context so it can be passed through the
 	// underlying slot/fill.
 	const tabsContextValue = useContext( Tabs.Context );
-	const isAttachment = postType === 'attachment';
+	const isAttachment = postType === ATTACHMENT_POST_TYPE;
 
 	// This effect addresses a race condition caused by tabbing from the last
 	// block in the editor into the settings sidebar. Without this effect, the

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -18,6 +18,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import {
+	ATTACHMENT_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 } from '../../store/constants';
@@ -156,6 +157,7 @@ export default function StartPageOptions() {
 			postId: getCurrentPostId(),
 			enabled:
 				choosePatternModalEnabled &&
+				ATTACHMENT_POST_TYPE !== currentPostType &&
 				TEMPLATE_POST_TYPE !== currentPostType &&
 				TEMPLATE_PART_POST_TYPE !== currentPostType,
 		};

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -36,6 +36,18 @@ import {
 	patternTitleField,
 	notesField,
 } from '@wordpress/fields';
+import {
+	altTextField,
+	attachedToField,
+	authorField as mediaAuthorField,
+	captionField,
+	dateAddedField,
+	descriptionField,
+	filenameField,
+	filesizeField,
+	mediaDimensionsField,
+	mimeTypeField,
+} from '@wordpress/media-fields';
 
 /**
  * Internal dependencies
@@ -48,6 +60,7 @@ import { unlock } from '../../lock-unlock';
 declare global {
 	interface Window {
 		__experimentalTemplateActivate?: boolean;
+		__experimentalMediaEditor?: boolean;
 	}
 }
 
@@ -124,6 +137,31 @@ export function setIsReady( kind: string, name: string ) {
 		name,
 	};
 }
+
+/*
+ * Media fields for the attachment post type.
+ *
+ * Field order follows a logical grouping:
+ * 1. Metadata fields in panels (date, author, file info)
+ * 2. Core editable fields (title, alt text, caption, description)
+ *
+ * Note: media_thumbnail is not included as it's shown in the canvas preview
+ */
+const ORDERED_MEDIA_FIELDS = [
+	// Metadata in panels (collapsed by default).
+	dateAddedField,
+	mediaAuthorField,
+	filenameField,
+	mimeTypeField,
+	filesizeField,
+	mediaDimensionsField,
+	attachedToField,
+	// Regular layout fields (always visible).
+	titleField,
+	altTextField,
+	captionField,
+	descriptionField,
+];
 
 export const registerPostTypeSchema =
 	( postType: string ) =>
@@ -206,39 +244,47 @@ export const registerPostTypeSchema =
 			permanentlyDeletePost,
 		].filter( Boolean );
 
-		const fields = [
-			postTypeConfig.supports?.thumbnail &&
-				currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
-				featuredImageField,
-			postTypeConfig.supports?.author && authorField,
-			statusField,
-			! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) && dateField,
-			slugField,
-			postTypeConfig.supports?.[ 'page-attributes' ] && parentField,
-			postTypeConfig.supports?.comments && commentStatusField,
-			postTypeConfig.supports?.trackbacks && pingStatusField,
-			( postTypeConfig.supports?.comments ||
-				postTypeConfig.supports?.trackbacks ) &&
-				discussionField,
-			templateField,
-			passwordField,
-			postTypeConfig.supports?.editor &&
-				postTypeConfig.viewable &&
-				postPreviewField,
-			hasEditorNotesSupport( postTypeConfig.supports ) && notesField,
-		].filter( Boolean );
-		if ( postTypeConfig.supports?.title ) {
-			let _titleField;
-			if ( postType === 'page' ) {
-				_titleField = pageTitleField;
-			} else if ( postType === 'wp_template' ) {
-				_titleField = templateTitleField;
-			} else if ( postType === 'wp_block' ) {
-				_titleField = patternTitleField;
-			} else {
-				_titleField = titleField;
+		// Handle attachment post type separately with media-specific fields
+		let fields;
+
+		if ( postType === 'attachment' ) {
+			fields = ORDERED_MEDIA_FIELDS;
+		} else {
+			fields = [
+				postTypeConfig.supports?.thumbnail &&
+					currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
+					featuredImageField,
+				postTypeConfig.supports?.author && authorField,
+				statusField,
+				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
+					dateField,
+				slugField,
+				postTypeConfig.supports?.[ 'page-attributes' ] && parentField,
+				postTypeConfig.supports?.comments && commentStatusField,
+				postTypeConfig.supports?.trackbacks && pingStatusField,
+				( postTypeConfig.supports?.comments ||
+					postTypeConfig.supports?.trackbacks ) &&
+					discussionField,
+				templateField,
+				passwordField,
+				postTypeConfig.supports?.editor &&
+					postTypeConfig.viewable &&
+					postPreviewField,
+				hasEditorNotesSupport( postTypeConfig.supports ) && notesField,
+			].filter( Boolean );
+			if ( postTypeConfig.supports?.title ) {
+				let _titleField;
+				if ( postType === 'page' ) {
+					_titleField = pageTitleField;
+				} else if ( postType === 'wp_template' ) {
+					_titleField = templateTitleField;
+				} else if ( postType === 'wp_block' ) {
+					_titleField = patternTitleField;
+				} else {
+					_titleField = titleField;
+				}
+				fields.push( _titleField );
 			}
-			fields.push( _titleField );
 		}
 
 		registry.batch( () => {

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -53,7 +53,7 @@ import {
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { DESIGN_POST_TYPES } from '../../store/constants';
+import { ATTACHMENT_POST_TYPE, DESIGN_POST_TYPES } from '../../store/constants';
 import postPreviewField from '../fields/content-preview';
 import { unlock } from '../../lock-unlock';
 
@@ -247,7 +247,7 @@ export const registerPostTypeSchema =
 		// Handle attachment post type separately with media-specific fields
 		let fields;
 
-		if ( postType === 'attachment' ) {
+		if ( postType === ATTACHMENT_POST_TYPE ) {
 			fields = ORDERED_MEDIA_FIELDS;
 		} else {
 			fields = [

--- a/packages/editor/src/store/constants.ts
+++ b/packages/editor/src/store/constants.ts
@@ -19,6 +19,7 @@ export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 export const PATTERN_POST_TYPE = 'wp_block';
 export const NAVIGATION_POST_TYPE = 'wp_navigation';
+export const ATTACHMENT_POST_TYPE = 'attachment';
 export const TEMPLATE_ORIGINS = {
 	custom: 'custom',
 	theme: 'theme',

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -20,6 +20,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import {
+	ATTACHMENT_POST_TYPE,
 	EDIT_MERGE_PROPERTIES,
 	PERMALINK_POSTNAME_REGEX,
 	ONE_MINUTE_IN_MS,
@@ -485,6 +486,11 @@ export function isEditedPostPublishable( state ) {
 	// being saveable. Currently this restriction is imposed at UI.
 	//
 	//  See: <PostPublishButton /> (`isButtonEnabled` assigned by `isSaveable`).
+
+	// Attachments should only be publishable if they have unsaved changes.
+	if ( post.type === ATTACHMENT_POST_TYPE ) {
+		return isEditedPostDirty( state );
+	}
 
 	return (
 		isEditedPostDirty( state ) ||

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -32,6 +32,10 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	if ( willTrash ) {
 		noticeMessage = postType.labels.item_trashed;
 		shouldShowLink = false;
+	} else if ( post.type === 'attachment' ) {
+		// Attachments should always show a simple updated message because they don't have a draft state.
+		noticeMessage = __( 'Media updated.' );
+		shouldShowLink = false;
 	} else if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
 		noticeMessage = __( 'Draft saved.' );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { ATTACHMENT_POST_TYPE } from '../constants';
+
+/**
  * Builds the arguments for a success notification dispatch.
  *
  * @param {Object} data Incoming data to build the arguments from.
@@ -32,7 +37,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	if ( willTrash ) {
 		noticeMessage = postType.labels.item_trashed;
 		shouldShowLink = false;
-	} else if ( post.type === 'attachment' ) {
+	} else if ( post.type === ATTACHMENT_POST_TYPE ) {
 		// Attachments should always show a simple updated message because they don't have a draft state.
 		noticeMessage = __( 'Media updated.' );
 		shouldShowLink = false;

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -2,6 +2,7 @@
 @use "@wordpress/interface/build-style/style.css" as *;
 @use "@wordpress/global-styles-ui/build-style/style.css" as *;
 @use "@wordpress/dataviews/build-style/style.css" as *;
+@use "@wordpress/media-editor/build-style/style.css" as *;
 @use "./components/autocompleters/style.scss" as *;
 @use "./components/collab-sidebar/style.scss" as *;
 @use "./components/collapsible-block-toolbar/style.scss" as *;

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -26,6 +26,8 @@
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
 		{ "path": "../keycodes" },
+		{ "path": "../media-editor" },
+		{ "path": "../media-fields" },
 		{ "path": "../media-utils" },
 		{ "path": "../notices" },
 		{ "path": "../plugins" },

--- a/packages/media-editor/README.md
+++ b/packages/media-editor/README.md
@@ -1,0 +1,132 @@
+# Media Editor
+
+Media editor components for WordPress.
+
+## Installation
+
+```bash
+npm install @wordpress/media-editor --save
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for such language features and APIs, you should include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill) in your code._
+
+## Usage
+
+```jsx
+import {
+	MediaEditorProvider,
+	MediaPreview,
+	MediaForm,
+	type Field,
+} from '@wordpress/media-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+function MyMediaEditor( { mediaId } ) {
+	const media = useSelect(
+		( select ) =>
+			select( coreStore ).getEditedEntityRecord(
+				'postType',
+				'attachment',
+				mediaId
+			),
+		[ mediaId ]
+	);
+
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const handleChange = ( updates ) => {
+		editEntityRecord( 'postType', 'attachment', mediaId, updates );
+	};
+
+	// Define fields using the Field type from @wordpress/dataviews
+	const fields: Field[] = [
+		{ id: 'title', label: 'Title', type: 'text' },
+		{ id: 'alt_text', label: 'Alt Text', type: 'text' },
+		{ id: 'caption', label: 'Caption', type: 'textarea' },
+		{ id: 'description', label: 'Description', type: 'textarea' },
+	];
+
+	return (
+		<MediaEditorProvider
+			value={ media }
+			onChange={ handleChange }
+			settings={ { fields } }
+		>
+			<div style={ { display: 'flex', gap: '24px' } }>
+				<div style={ { flex: 1 } }>
+					<MediaPreview />
+				</div>
+				<div style={ { width: '360px' } }>
+					<MediaForm />
+				</div>
+			</div>
+		</MediaEditorProvider>
+	);
+}
+```
+
+## API
+
+### `<MediaEditorProvider>`
+
+Context provider that supplies media data and actions to child components.
+
+**Props:**
+
+-   `value`: Media object from the WordPress REST API
+-   `onChange`: Callback when media is updated `(updates: Partial<Media>) => void`
+-   `settings`: Optional settings object
+    -   `settings.fields`: Array of field definitions (uses `Field` type from `@wordpress/dataviews`)
+-   `children`: Child components
+
+### `<MediaPreview>`
+
+Displays a preview of the media file. Automatically detects and renders images, videos, audio, or generic files based on MIME type.
+
+**Props:**
+
+Accepts any props that will be spread onto the preview container element (useful for click handlers, accessibility attributes, etc.)
+
+### `<MediaForm>`
+
+Form for editing media metadata using `DataForm` from `@wordpress/dataviews`.
+
+**Props:**
+
+-   `form`: Optional form configuration (uses `Form` type from `@wordpress/dataviews`)
+-   `header`: Optional header content to display above the form
+
+### `useMediaEditorContext()`
+
+Hook to access media editor context. Must be used within a `MediaEditorProvider`.
+
+**Returns:**
+
+-   `media`: Current media object
+-   `onChange`: Update callback function
+-   `fields`: Field definitions array
+
+## TypeScript
+
+This package is written in TypeScript and exports all relevant types:
+
+```typescript
+import type {
+	Media,
+	MediaEditorContextValue,
+	MediaEditorProviderProps,
+	MediaPreviewProps,
+	MediaFormProps,
+	Field,
+	Form,
+} from '@wordpress/media-editor';
+```
+
+## Contributing to this package
+
+This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.
+
+To find out more about contributing to this package or Gutenberg as a whole, please read the project's main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
+
+<br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/media-editor/README.md
+++ b/packages/media-editor/README.md
@@ -74,9 +74,9 @@ Context provider that supplies media data and actions to child components.
 
 **Props:**
 
--   `value`: Media object from the WordPress REST API
--   `onChange`: Callback when media is updated `(updates: Partial<Media>) => void`
--   `settings`: Optional settings object
+-   `value`: (optional) Media object from the WordPress REST API
+-   `onChange`: (optional) Callback when media is updated `(updates: Partial<Media>) => void`. If not provided, the MediaEditor can be used in a read-only mode, which is useful for preview-only scenarios where editing is not needed.
+-   `settings`: (optional) Configuration object
     -   `settings.fields`: Array of field definitions (uses `Field` type from `@wordpress/dataviews`)
 -   `children`: Child components
 

--- a/packages/media-editor/README.md
+++ b/packages/media-editor/README.md
@@ -97,16 +97,6 @@ Form for editing media metadata using `DataForm` from `@wordpress/dataviews`.
 -   `form`: Optional form configuration (uses `Form` type from `@wordpress/dataviews`)
 -   `header`: Optional header content to display above the form
 
-### `useMediaEditorContext()`
-
-Hook to access media editor context. Must be used within a `MediaEditorProvider`.
-
-**Returns:**
-
--   `media`: Current media object
--   `onChange`: Update callback function
--   `fields`: Field definitions array
-
 ## TypeScript
 
 This package is written in TypeScript and exports all relevant types:
@@ -114,7 +104,6 @@ This package is written in TypeScript and exports all relevant types:
 ```typescript
 import type {
 	Media,
-	MediaEditorContextValue,
 	MediaEditorProviderProps,
 	MediaPreviewProps,
 	MediaFormProps,

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -24,13 +24,13 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
-	"main": "build/index.js",
-	"module": "build-module/index.js",
+	"main": "build/index.cjs",
+	"module": "build-module/index.mjs",
 	"exports": {
 		".": {
 			"types": "./build-types/index.d.ts",
-			"import": "./build-module/index.js",
-			"require": "./build/index.js"
+			"import": "./build-module/index.mjs",
+			"require": "./build/index.cjs"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@wordpress/media-editor",
+	"version": "0.1.0",
+	"description": "Media editor components for WordPress.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"media",
+		"editor",
+		"attachment"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/media-editor/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/media-editor"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"exports": {
+		".": {
+			"types": "./build-types/index.d.ts",
+			"import": "./build-module/index.js",
+			"require": "./build/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"react-native": "src/index",
+	"types": "build-types",
+	"sideEffects": [
+		"build-style/**",
+		"src/**/*.scss"
+	],
+	"dependencies": {
+		"@babel/runtime": "^7.16.0",
+		"@wordpress/components": "file:../components",
+		"@wordpress/dataviews": "file:../dataviews",
+		"@wordpress/element": "file:../element",
+		"@wordpress/i18n": "file:../i18n"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/media-editor/src/components/media-editor-provider/index.tsx
+++ b/packages/media-editor/src/components/media-editor-provider/index.tsx
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+import type { Field } from '@wordpress/dataviews';
+import type { ReactNode } from 'react';
+
+/**
+ * Media object from WordPress REST API.
+ */
+export interface Media {
+	id?: number;
+	source_url?: string;
+	mime_type?: string;
+	alt_text?: string;
+	title?: string | { rendered?: string; raw?: string };
+	caption?: string | { rendered?: string; raw?: string };
+	description?: string | { rendered?: string; raw?: string };
+	[ key: string ]: any;
+}
+
+/**
+ * Context value for MediaEditor.
+ */
+export interface MediaEditorContextValue {
+	media?: Media;
+	onChange?: ( updates: Partial< Media > ) => void;
+	fields: Field< Media >[];
+}
+
+/**
+ * Props for MediaEditorProvider.
+ */
+export interface MediaEditorProviderProps {
+	value?: Media;
+	onChange?: ( updates: Partial< Media > ) => void;
+	settings?: {
+		fields?: Field< Media >[];
+	};
+	children: ReactNode;
+}
+
+const MediaEditorContext = createContext< MediaEditorContextValue | undefined >(
+	undefined
+);
+
+export function MediaEditorProvider( {
+	value,
+	onChange,
+	settings = {},
+	children,
+}: MediaEditorProviderProps ) {
+	const contextValue: MediaEditorContextValue = {
+		media: value,
+		onChange,
+		fields: settings.fields || [],
+	};
+
+	return (
+		<MediaEditorContext.Provider value={ contextValue }>
+			{ children }
+		</MediaEditorContext.Provider>
+	);
+}
+
+/**
+ * Hook to access the MediaEditor context.
+ *
+ * Must be used within a MediaEditorProvider component.
+ *
+ * @return Context value with media, onUpdate, isLoading, and fields.
+ */
+export function useMediaEditorContext(): MediaEditorContextValue {
+	const context = useContext( MediaEditorContext );
+	if ( ! context ) {
+		throw new Error(
+			'useMediaEditorContext must be used within MediaEditorProvider'
+		);
+	}
+	return context;
+}

--- a/packages/media-editor/src/components/media-editor-provider/index.tsx
+++ b/packages/media-editor/src/components/media-editor-provider/index.tsx
@@ -32,11 +32,20 @@ export interface MediaEditorContextValue {
  * Props for MediaEditorProvider.
  */
 export interface MediaEditorProviderProps {
+	/** The media object to edit. */
 	value?: Media;
+	/**
+	 * Callback when media is updated.
+	 *
+	 * Optional - if not provided, the MediaEditor can be used in a read-only mode,
+	 * useful for preview-only scenarios.
+	 */
 	onChange?: ( updates: Partial< Media > ) => void;
+	/** Configuration settings for the media editor. */
 	settings?: {
 		fields?: Field< Media >[];
 	};
+	/** Child components. */
 	children: ReactNode;
 }
 
@@ -68,7 +77,7 @@ export function MediaEditorProvider( {
  *
  * Must be used within a MediaEditorProvider component.
  *
- * @return Context value with media, onUpdate, isLoading, and fields.
+ * @return MediaEditorContextValue value with media, onChange, and fields, etc.
  */
 export function useMediaEditorContext(): MediaEditorContextValue {
 	const context = useContext( MediaEditorContext );

--- a/packages/media-editor/src/components/media-form/index.tsx
+++ b/packages/media-editor/src/components/media-form/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { DataForm } from '@wordpress/dataviews';
+import type { Form, Field } from '@wordpress/dataviews';
+import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../media-editor-provider';
+import type { Media } from '../media-editor-provider';
+
+/**
+ * Props for MediaForm component.
+ */
+export interface MediaFormProps {
+	form?: Form;
+	header?: ReactNode;
+}
+
+/**
+ * MediaForm component for editing media metadata.
+ *
+ * Renders a DataForm with fields for editing media properties like
+ * title, alt text, caption, description, etc.
+ *
+ * @param props        - Component props.
+ * @param props.form   - Optional form configuration.
+ * @param props.header - Optional header content to display above the form.
+ * @return The MediaForm component.
+ */
+export default function MediaForm( {
+	form: formOverrides,
+	header,
+}: MediaFormProps ) {
+	const { media, fields, onChange } = useMediaEditorContext();
+
+	if ( ! media || ! onChange ) {
+		return (
+			<div className="media-editor-form media-editor-form--loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	// Default form structure with panel layout
+	const defaultForm: Form = {
+		layout: {
+			type: 'panel',
+		},
+		fields: fields.map( ( field: Field< Media > ) => {
+			// Use regular layout for main editable fields
+			if (
+				[ 'title', 'alt_text', 'caption', 'description' ].includes(
+					field.id
+				)
+			) {
+				return {
+					id: field.id,
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+					},
+				};
+			}
+			return field.id;
+		} ),
+	};
+
+	const form = formOverrides || defaultForm;
+
+	return (
+		<div className="media-editor-form">
+			<VStack spacing={ 4 }>
+				{ header }
+				<DataForm
+					data={ media }
+					fields={ fields }
+					form={ form }
+					onChange={ onChange }
+				/>
+			</VStack>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/media-preview/index.tsx
+++ b/packages/media-editor/src/components/media-preview/index.tsx
@@ -111,7 +111,7 @@ export default function MediaPreview( props: MediaPreviewProps ) {
 	if ( ! mediaUrl ) {
 		return (
 			<div className="media-editor-preview media-editor-preview--empty">
-				<p>No media file available.</p>
+				<p>{ __( 'No media file available.' ) }</p>
 			</div>
 		);
 	}

--- a/packages/media-editor/src/components/media-preview/index.tsx
+++ b/packages/media-editor/src/components/media-preview/index.tsx
@@ -119,7 +119,7 @@ export default function MediaPreview( props: MediaPreviewProps ) {
 	if ( loadingState === 'error' ) {
 		return (
 			<div className="media-editor-preview media-editor-preview--error">
-				<p>Failed to load media file.</p>
+				<p>{ __( 'Failed to load media file.' ) }</p>
 				<p className="media-editor-preview__url">{ mediaUrl }</p>
 			</div>
 		);

--- a/packages/media-editor/src/components/media-preview/index.tsx
+++ b/packages/media-editor/src/components/media-preview/index.tsx
@@ -3,6 +3,7 @@
  */
 import { Spinner } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -79,7 +80,7 @@ function MediaPreviewContent( {
 						rel="noopener noreferrer"
 						className="media-editor-preview__download-link"
 					>
-						View file
+						{ __( 'View file' ) }
 					</a>
 				</div>
 			);

--- a/packages/media-editor/src/components/media-preview/index.tsx
+++ b/packages/media-editor/src/components/media-preview/index.tsx
@@ -18,6 +18,75 @@ export interface MediaPreviewProps {
 }
 
 /**
+ * Props for MediaPreviewContent component.
+ */
+interface MediaPreviewContentProps {
+	mediaType: { type: string };
+	mediaUrl: string;
+	altText?: string;
+	displayTitle?: string;
+	mimeType?: string;
+	onLoad: () => void;
+	onError: () => void;
+	loadingState: 'loading' | 'loaded' | 'error';
+}
+
+function MediaPreviewContent( {
+	mediaType,
+	mediaUrl,
+	altText,
+	displayTitle,
+	mimeType,
+	onLoad,
+	onError,
+	loadingState,
+}: MediaPreviewContentProps ) {
+	switch ( mediaType.type ) {
+		case 'image':
+			return (
+				<img
+					className={ loadingState === 'loaded' ? 'loaded' : '' }
+					src={ mediaUrl }
+					alt={ altText || '' }
+					onLoad={ onLoad }
+					onError={ onError }
+				/>
+			);
+		case 'video':
+			return (
+				<video src={ mediaUrl } controls onError={ onError }>
+					{ displayTitle }
+				</video>
+			);
+		case 'audio':
+			return (
+				<audio src={ mediaUrl } controls onError={ onError }>
+					{ displayTitle }
+				</audio>
+			);
+		default:
+			return (
+				<div className="media-editor-preview__file-info">
+					<p className="media-editor-preview__file-name">
+						{ displayTitle }
+					</p>
+					<p className="media-editor-preview__mime-type">
+						{ mimeType }
+					</p>
+					<a
+						href={ mediaUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						className="media-editor-preview__download-link"
+					>
+						View file
+					</a>
+				</div>
+			);
+	}
+}
+
+/**
  * MediaPreview component displays the media file in the editor canvas.
  * Supports images, videos, audio files, and generic file displays.
  *
@@ -47,14 +116,6 @@ export default function MediaPreview( props: MediaPreviewProps ) {
 		);
 	}
 
-	if ( mediaType.type === 'image' && loadingState === 'loading' ) {
-		return (
-			<div className="media-editor-preview media-editor-preview--loading">
-				<Spinner />
-			</div>
-		);
-	}
-
 	if ( loadingState === 'error' ) {
 		return (
 			<div className="media-editor-preview media-editor-preview--error">
@@ -67,75 +128,26 @@ export default function MediaPreview( props: MediaPreviewProps ) {
 	const displayTitle =
 		typeof title === 'string' ? title : title?.rendered || title?.raw;
 
-	// Render based on media type
-	switch ( mediaType.type ) {
-		case 'image':
-			return (
-				<div
-					{ ...props }
-					className="media-editor-preview media-editor-preview--image"
-				>
-					<img
-						src={ mediaUrl }
-						alt={ altText || '' }
-						onLoad={ () => setLoadingState( 'loaded' ) }
-						onError={ () => setLoadingState( 'error' ) }
-					/>
+	return (
+		<div
+			{ ...props }
+			className={ `media-editor-preview media-editor-preview--${ mediaType.type }` }
+		>
+			{ mediaType.type === 'image' && loadingState === 'loading' && (
+				<div className="media-editor-preview__spinner">
+					<Spinner />
 				</div>
-			);
-		case 'video':
-			return (
-				<div
-					{ ...props }
-					className="media-editor-preview media-editor-preview--video"
-				>
-					<video
-						src={ mediaUrl }
-						controls
-						onError={ () => setLoadingState( 'error' ) }
-					>
-						{ displayTitle }
-					</video>
-				</div>
-			);
-		case 'audio':
-			return (
-				<div
-					{ ...props }
-					className="media-editor-preview media-editor-preview--audio"
-				>
-					<audio
-						src={ mediaUrl }
-						controls
-						onError={ () => setLoadingState( 'error' ) }
-					>
-						{ displayTitle }
-					</audio>
-				</div>
-			);
-		default:
-			return (
-				<div
-					{ ...props }
-					className="media-editor-preview media-editor-preview--file"
-				>
-					<div className="media-editor-preview__file-info">
-						<p className="media-editor-preview__file-name">
-							{ displayTitle }
-						</p>
-						<p className="media-editor-preview__mime-type">
-							{ mimeType }
-						</p>
-						<a
-							href={ mediaUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							className="media-editor-preview__download-link"
-						>
-							View file
-						</a>
-					</div>
-				</div>
-			);
-	}
+			) }
+			<MediaPreviewContent
+				mediaType={ mediaType }
+				mediaUrl={ mediaUrl }
+				altText={ altText }
+				displayTitle={ displayTitle }
+				mimeType={ mimeType }
+				onLoad={ () => setLoadingState( 'loaded' ) }
+				onError={ () => setLoadingState( 'error' ) }
+				loadingState={ loadingState }
+			/>
+		</div>
+	);
 }

--- a/packages/media-editor/src/components/media-preview/index.tsx
+++ b/packages/media-editor/src/components/media-preview/index.tsx
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../media-editor-provider';
+import { getMediaTypeFromMimeType } from '../../utils';
+
+/**
+ * Props for MediaPreview component.
+ */
+export interface MediaPreviewProps {
+	[ key: string ]: any; // TODO: Define specific props as needed, this will likely be for click handlers, accessibility attributes, etc.
+}
+
+/**
+ * MediaPreview component displays the media file in the editor canvas.
+ * Supports images, videos, audio files, and generic file displays.
+ *
+ * @param props - Component props including click handlers and accessibility attributes.
+ * @return The MediaPreview component.
+ */
+export default function MediaPreview( props: MediaPreviewProps ) {
+	const [ loadingState, setLoadingState ] = useState<
+		'loading' | 'loaded' | 'error'
+	>( 'loading' );
+	const { media } = useMediaEditorContext();
+
+	const {
+		source_url: mediaUrl,
+		mime_type: mimeType,
+		alt_text: altText,
+		title,
+	} = media || {};
+
+	const mediaType = getMediaTypeFromMimeType( mimeType );
+
+	if ( ! mediaUrl ) {
+		return (
+			<div className="media-editor-preview media-editor-preview--empty">
+				<p>No media file available.</p>
+			</div>
+		);
+	}
+
+	if ( mediaType.type === 'image' && loadingState === 'loading' ) {
+		return (
+			<div className="media-editor-preview media-editor-preview--loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( loadingState === 'error' ) {
+		return (
+			<div className="media-editor-preview media-editor-preview--error">
+				<p>Failed to load media file.</p>
+				<p className="media-editor-preview__url">{ mediaUrl }</p>
+			</div>
+		);
+	}
+
+	const displayTitle =
+		typeof title === 'string' ? title : title?.rendered || title?.raw;
+
+	// Render based on media type
+	switch ( mediaType.type ) {
+		case 'image':
+			return (
+				<div
+					{ ...props }
+					className="media-editor-preview media-editor-preview--image"
+				>
+					<img
+						src={ mediaUrl }
+						alt={ altText || '' }
+						onLoad={ () => setLoadingState( 'loaded' ) }
+						onError={ () => setLoadingState( 'error' ) }
+					/>
+				</div>
+			);
+		case 'video':
+			return (
+				<div
+					{ ...props }
+					className="media-editor-preview media-editor-preview--video"
+				>
+					<video
+						src={ mediaUrl }
+						controls
+						onError={ () => setLoadingState( 'error' ) }
+					>
+						{ displayTitle }
+					</video>
+				</div>
+			);
+		case 'audio':
+			return (
+				<div
+					{ ...props }
+					className="media-editor-preview media-editor-preview--audio"
+				>
+					<audio
+						src={ mediaUrl }
+						controls
+						onError={ () => setLoadingState( 'error' ) }
+					>
+						{ displayTitle }
+					</audio>
+				</div>
+			);
+		default:
+			return (
+				<div
+					{ ...props }
+					className="media-editor-preview media-editor-preview--file"
+				>
+					<div className="media-editor-preview__file-info">
+						<p className="media-editor-preview__file-name">
+							{ displayTitle }
+						</p>
+						<p className="media-editor-preview__mime-type">
+							{ mimeType }
+						</p>
+						<a
+							href={ mediaUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							className="media-editor-preview__download-link"
+						>
+							View file
+						</a>
+					</div>
+				</div>
+			);
+	}
+}

--- a/packages/media-editor/src/components/media-preview/style.scss
+++ b/packages/media-editor/src/components/media-preview/style.scss
@@ -1,0 +1,76 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-editor-preview {
+	box-sizing: border-box;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-height: 100%;
+	padding: $grid-unit-40;
+	position: relative;
+
+	&--loading {
+		width: 100%;
+		height: 100%;
+	}
+
+	&--image img {
+		max-width: 100%;
+		max-height: 100%;
+		object-fit: contain;
+		width: auto;
+		height: auto;
+	}
+
+	&--video video {
+		max-width: 100%;
+		max-height: 100%;
+		object-fit: contain;
+		width: auto;
+		height: auto;
+	}
+
+	&--audio audio {
+		max-width: 100%;
+	}
+
+	&--file {
+		text-align: center;
+	}
+
+	&__file-info {
+		background: $gray-100;
+		padding: $grid-unit-30;
+		border-radius: 2px;
+	}
+
+	&__file-name {
+		font-weight: 600;
+		margin-bottom: $grid-unit-10;
+	}
+
+	&__mime-type {
+		color: $gray-700;
+		font-size: 0.9em;
+		margin-bottom: $grid-unit-20;
+	}
+
+	&__download-link {
+		display: inline-block;
+		margin-top: $grid-unit-10;
+	}
+
+	&--error,
+	&--empty {
+		color: $gray-700;
+		text-align: center;
+	}
+
+	&__url {
+		font-size: 0.9em;
+		color: $gray-600;
+		word-break: break-all;
+		margin-top: $grid-unit-10;
+	}
+}

--- a/packages/media-editor/src/components/media-preview/style.scss
+++ b/packages/media-editor/src/components/media-preview/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/animations" as *;
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
@@ -10,6 +11,13 @@
 	padding: $grid-unit-40;
 	position: relative;
 
+	&__spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
 	&--loading {
 		width: 100%;
 		height: 100%;
@@ -21,6 +29,11 @@
 		object-fit: contain;
 		width: auto;
 		height: auto;
+		opacity: 0;
+
+		&.loaded {
+			@include animation__fade-in();
+		}
 	}
 
 	&--video video {

--- a/packages/media-editor/src/index.ts
+++ b/packages/media-editor/src/index.ts
@@ -1,15 +1,11 @@
 // Components
-export {
-	MediaEditorProvider,
-	useMediaEditorContext,
-} from './components/media-editor-provider';
+export { MediaEditorProvider } from './components/media-editor-provider';
 export { default as MediaPreview } from './components/media-preview';
 export { default as MediaForm } from './components/media-form';
 
 // Types
 export type {
 	Media,
-	MediaEditorContextValue,
 	MediaEditorProviderProps,
 } from './components/media-editor-provider';
 export type { MediaPreviewProps } from './components/media-preview';

--- a/packages/media-editor/src/index.ts
+++ b/packages/media-editor/src/index.ts
@@ -1,0 +1,19 @@
+// Components
+export {
+	MediaEditorProvider,
+	useMediaEditorContext,
+} from './components/media-editor-provider';
+export { default as MediaPreview } from './components/media-preview';
+export { default as MediaForm } from './components/media-form';
+
+// Types
+export type {
+	Media,
+	MediaEditorContextValue,
+	MediaEditorProviderProps,
+} from './components/media-editor-provider';
+export type { MediaPreviewProps } from './components/media-preview';
+export type { MediaFormProps } from './components/media-form';
+
+// Re-export commonly used dataviews types for convenience
+export type { Field, Form } from '@wordpress/dataviews';

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -1,2 +1,2 @@
 // Import component styles
-@import "./components/media-preview/style.scss";
+@use "./components/media-preview/style.scss" as *;

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -1,0 +1,2 @@
+// Import component styles
+@import "./components/media-preview/style.scss";

--- a/packages/media-editor/src/utils/get-media-type.ts
+++ b/packages/media-editor/src/utils/get-media-type.ts
@@ -1,0 +1,29 @@
+/**
+ * Media type result.
+ */
+export interface MediaType {
+	type: 'image' | 'video' | 'audio' | 'application';
+}
+
+/**
+ * Determines the media type from a MIME type string.
+ *
+ * @param mimeType - The MIME type to check.
+ * @return Object with type property ('image', 'video', 'audio', or 'application').
+ */
+export function getMediaTypeFromMimeType( mimeType?: string ): MediaType {
+	if ( ! mimeType ) {
+		return { type: 'application' };
+	}
+
+	if ( mimeType.startsWith( 'image/' ) ) {
+		return { type: 'image' };
+	}
+	if ( mimeType.startsWith( 'video/' ) ) {
+		return { type: 'video' };
+	}
+	if ( mimeType.startsWith( 'audio/' ) ) {
+		return { type: 'audio' };
+	}
+	return { type: 'application' };
+}

--- a/packages/media-editor/src/utils/index.ts
+++ b/packages/media-editor/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { getMediaTypeFromMimeType } from './get-media-type';
+export type { MediaType } from './get-media-type';

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": [ "gutenberg-env" ]
+	},
+	"references": [
+		{ "path": "../components" },
+		{ "path": "../dataviews" },
+		{ "path": "../element" },
+		{ "path": "../i18n" }
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
 		{ "path": "packages/latex-to-mathml" },
 		{ "path": "packages/lazy-import" },
 		{ "path": "packages/lazy-editor" },
+		{ "path": "packages/media-editor" },
 		{ "path": "packages/media-fields" },
 		{ "path": "packages/media-utils" },
 		{ "path": "packages/notices" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of https://github.com/WordPress/gutenberg/issues/72734

Split out from #73808, this PR proposes adding a simple `media-editor` package and integrating it into the `editor` package so that users can edit media items from within the block editor.

The scope of the media editor in this PR is:

* Allow users to edit metadata (title, alt text, caption, description) of the image item itself, as it exists in the media library, without navigating completely away from the block editor
* Also support this in the site editor

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #72734 for more context. But I'll explain the "why" of the scope for this one here:

* Add a minimal `media-editor` package that just contains a provider, a media preview, and a media form. This allows a simple interface for the provider, while allowing the consumer flexibility to render the components wherever they see fit.
* The changes to the `editor` package are mostly in providing conditionals for supporting saving attachments, and hiding parts of the UI that aren't relevant to attachments. While this adds some complexity to the `editor` package, as demonstrated in the previous exploration (#73808) the value is that it allows a fluidity of movement between editing an image (and its metadata) without leaving the block editor entirely.

It'll be up to follow-up PRs to implement support for a dedicated route for the media editor. One limitation in this PR, for example, is that if you reload the editor while editing a media item, you'll be redirected to the "classic" media editor. Replacing that with this media editor is out of scope for now, until we have something that has feature parity with the existing media editor in core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a media-editor package that exports three things: a provider, a preview, and a form. The provider (based on feedback from @youknowriad in #73808) attempts to use a simple interface that's similar to the block editor provider, i.e. `MediaEditorProvider` accepts props of `values`, `onChange`, and `settings`.
* Update the `editor` package to conditionally hide parts of the UI when the current post is an attachment
* Update the `editor` package to show the `MediaPreview` and `MediaForm`s when the current post is an attachment
* Add a (very) minimal route for the site editor to ensure the site editor is supported (this will need further work in follow-ups)
* Update the `editor` package to use all the recently introduced media fields for the `attachment` post type

Out of scope for this PR: actual image editing/cropping — that'll be for follow-ups. Also, I haven't completely guarded all changes behind the experiment flag. For many of the changes, it seemed safe enough to check against the `attachment` post type without needing to also include the experiment in the check. But let me know if anything seems unsafe.

## Testing Instructions

Enable the experiment introduced in this PR:

<img width="1083" height="63" alt="image" src="https://github.com/user-attachments/assets/aab271cb-c354-463f-b6cd-7b100a1e03d7" />

* Add an image block to a post (and either upload an image or select one from the media library)
* Select the block, and you should see an "Edit media" button in the block toolbar
* Click it and you should be taken to a different view of the Editor, that shows a preview and DataForm for the media metadata
* You should be able to update the title and other metadata fields and save
* Disable the Gutenberg experiment, and you shouldn't see the "Edit media" button in the image block toolbar in either the editor or site editors

## Screenshots or screencast <!-- if applicable -->

<img width="3098" height="2128" alt="image" src="https://github.com/user-attachments/assets/03fd4e3c-1b36-4838-9fb2-ac54a4e8cabe" />

https://github.com/user-attachments/assets/41231f8e-2dac-494c-9d1d-572800e3803a




