### PR TITLE
Block visibility supports: refactor metadata to use nested structure

### DIFF
--- a/backport-changelog/7.0/10629.md
+++ b/backport-changelog/7.0/10629.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/10629
 * https://github.com/WordPress/gutenberg/pull/73994
 * https://github.com/WordPress/gutenberg/pull/74379
 * https://github.com/WordPress/gutenberg/pull/74526
+* https://github.com/WordPress/gutenberg/pull/74602

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -30,6 +30,14 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 	}
 
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
+		// Get viewport configuration from nested structure.
+		$viewport_config = $block_visibility['viewport'] ?? null;
+
+		// If no viewport config, return unchanged.
+		if ( ! is_array( $viewport_config ) || empty( $viewport_config ) ) {
+			return $block_content;
+		}
+
 		/*
 		 * Breakpoints definitions are in several places in WordPress packages.
 		 * The following are taken from: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss
@@ -86,7 +94,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		$hidden_on = array();
 
 		// Collect which breakpoints the block is hidden on (only known breakpoints).
-		foreach ( $block_visibility as $breakpoint => $is_visible ) {
+		foreach ( $viewport_config as $breakpoint => $is_visible ) {
 			if ( false === $is_visible && isset( $breakpoint_queries[ $breakpoint ] ) ) {
 				$hidden_on[] = $breakpoint;
 			}

--- a/packages/block-editor/src/components/block-visibility/modal.js
+++ b/packages/block-editor/src/components/block-visibility/modal.js
@@ -160,18 +160,20 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 			event.preventDefault();
 			const newVisibility = hideEverywhere
 				? false
-				: BLOCK_VISIBILITY_VIEWPORT_ENTRIES.reduce(
-						( acc, [ , { key } ] ) => {
-							if ( viewportChecked[ key ] ) {
-								// Values are inverted to hide the block on the selected viewport.
-								// In the UI, the checkbox is checked (true) when the block is hidden on the selected viewport,
-								// so 'false' means hide the block on the selected viewport.
-								acc[ key ] = false;
-							}
-							return acc;
-						},
-						{}
-				  );
+				: {
+						viewport: BLOCK_VISIBILITY_VIEWPORT_ENTRIES.reduce(
+							( acc, [ , { key } ] ) => {
+								if ( viewportChecked[ key ] ) {
+									// Values are inverted to hide the block on the selected viewport.
+									// In the UI, the checkbox is checked (true) when the block is hidden on the selected viewport,
+									// so 'false' means hide the block on the selected viewport.
+									acc[ key ] = false;
+								}
+								return acc;
+							},
+							{}
+						),
+				  };
 			const attributesByClientId = Object.fromEntries(
 				blocks.map( ( { clientId, attributes } ) => [
 					clientId,

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -52,7 +52,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { mobile: false },
+					blockVisibility: { viewport: { mobile: false } },
 					deviceType: 'mobile',
 				} )
 			);
@@ -66,9 +66,11 @@ describe( 'useBlockVisibility', () => {
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
 					blockVisibility: {
-						mobile: true,
-						tablet: false,
-						desktop: false,
+						viewport: {
+							mobile: true,
+							tablet: false,
+							desktop: false,
+						},
 					},
 					deviceType: 'mobile',
 				} )
@@ -82,7 +84,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { tablet: false },
+					blockVisibility: { viewport: { tablet: false } },
 					deviceType: 'tablet',
 				} )
 			);
@@ -98,7 +100,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { desktop: false },
+					blockVisibility: { viewport: { desktop: false } },
 					deviceType: 'desktop',
 				} )
 			);
@@ -116,7 +118,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { mobile: false },
+					blockVisibility: { viewport: { mobile: false } },
 					deviceType: 'desktop',
 				} )
 			);
@@ -133,9 +135,11 @@ describe( 'useBlockVisibility', () => {
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
 					blockVisibility: {
-						mobile: true,
-						tablet: false,
-						desktop: false,
+						viewport: {
+							mobile: true,
+							tablet: false,
+							desktop: false,
+						},
 					},
 					deviceType: 'desktop',
 				} )
@@ -152,7 +156,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { tablet: false },
+					blockVisibility: { viewport: { tablet: false } },
 					deviceType: 'desktop',
 				} )
 			);
@@ -169,9 +173,11 @@ describe( 'useBlockVisibility', () => {
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
 					blockVisibility: {
-						mobile: false,
-						tablet: true,
-						desktop: false,
+						viewport: {
+							mobile: false,
+							tablet: true,
+							desktop: false,
+						},
 					},
 					deviceType: 'desktop',
 				} )
@@ -188,7 +194,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { desktop: false },
+					blockVisibility: { viewport: { desktop: false } },
 					deviceType: 'desktop',
 				} )
 			);
@@ -205,9 +211,11 @@ describe( 'useBlockVisibility', () => {
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
 					blockVisibility: {
-						mobile: false,
-						tablet: false,
-						desktop: true,
+						viewport: {
+							mobile: false,
+							tablet: false,
+							desktop: true,
+						},
 					},
 					deviceType: 'desktop',
 				} )
@@ -306,7 +314,7 @@ describe( 'useBlockVisibility', () => {
 
 			const { result } = renderHook( () =>
 				useBlockVisibility( {
-					blockVisibility: { desktop: false },
+					blockVisibility: { viewport: { desktop: false } },
 				} )
 			);
 

--- a/packages/block-editor/src/components/block-visibility/test/utils.js
+++ b/packages/block-editor/src/components/block-visibility/test/utils.js
@@ -21,7 +21,9 @@ describe( 'block-visibility utils', () => {
 				{
 					attributes: {
 						metadata: {
-							blockVisibility: {},
+							blockVisibility: {
+								viewport: {},
+							},
 						},
 					},
 				},
@@ -75,7 +77,9 @@ describe( 'block-visibility utils', () => {
 					attributes: {
 						metadata: {
 							blockVisibility: {
-								mobile: false,
+								viewport: {
+									mobile: false,
+								},
 							},
 						},
 					},
@@ -83,7 +87,9 @@ describe( 'block-visibility utils', () => {
 				{
 					attributes: {
 						metadata: {
-							blockVisibility: {},
+							blockVisibility: {
+								viewport: {},
+							},
 						},
 					},
 				},
@@ -105,7 +111,9 @@ describe( 'block-visibility utils', () => {
 				{
 					attributes: {
 						metadata: {
-							blockVisibility: {},
+							blockVisibility: {
+								viewport: {},
+							},
 						},
 					},
 				},
@@ -122,7 +130,9 @@ describe( 'block-visibility utils', () => {
 				attributes: {
 					metadata: {
 						blockVisibility: {
-							mobile: false,
+							viewport: {
+								mobile: false,
+							},
 						},
 					},
 				},
@@ -188,7 +198,9 @@ describe( 'block-visibility utils', () => {
 				{
 					attributes: {
 						metadata: {
-							blockVisibility: {},
+							blockVisibility: {
+								viewport: {},
+							},
 						},
 					},
 				},
@@ -245,7 +257,9 @@ describe( 'block-visibility utils', () => {
 					attributes: {
 						metadata: {
 							blockVisibility: {
-								mobile: false,
+								viewport: {
+									mobile: false,
+								},
 							},
 						},
 					},
@@ -254,7 +268,9 @@ describe( 'block-visibility utils', () => {
 					attributes: {
 						metadata: {
 							blockVisibility: {
-								tablet: false,
+								viewport: {
+									tablet: false,
+								},
 							},
 						},
 					},

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -55,7 +55,7 @@ export default function useBlockVisibility( options = {} ) {
 
 		if (
 			window.__experimentalHideBlocksBasedOnScreenSize &&
-			blockVisibility?.[ currentViewport ] === false
+			blockVisibility?.viewport?.[ currentViewport ] === false
 		) {
 			return true;
 		}

--- a/packages/block-editor/src/components/block-visibility/utils.js
+++ b/packages/block-editor/src/components/block-visibility/utils.js
@@ -27,6 +27,14 @@ function isBlockHiddenForViewport( block, viewport ) {
 		return false;
 	}
 
+	// Get viewport configuration from nested structure.
+	const viewportConfig = blockVisibility.viewport;
+
+	// If no viewport config, block is not hidden for any specific viewport.
+	if ( ! viewportConfig || 'object' !== typeof viewportConfig ) {
+		return false;
+	}
+
 	// Check if the viewport is valid.
 	if (
 		! BLOCK_VISIBILITY_VIEWPORT_ENTRIES.some(
@@ -37,7 +45,7 @@ function isBlockHiddenForViewport( block, viewport ) {
 	}
 
 	// Check if the specific viewport is hidden.
-	return blockVisibility[ viewport ] === false;
+	return viewportConfig[ viewport ] === false;
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -733,11 +733,15 @@ export const isBlockHidden = ( state, clientId ) => {
 	// Check viewport-specific hiding based on current device preview
 	// Only apply when a device is explicitly selected.
 	if ( typeof blockVisibility === 'object' && blockVisibility !== null ) {
-		const settings = getSettings( state );
-		const viewportType =
-			settings[ deviceTypeKey ] ?? BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
-		const viewportKey = viewportType.toLowerCase();
-		return blockVisibility?.[ viewportKey ] === false;
+		const viewportConfig = blockVisibility.viewport;
+		if ( viewportConfig && typeof viewportConfig === 'object' ) {
+			const settings = getSettings( state );
+			const viewportType =
+				settings[ deviceTypeKey ] ??
+				BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
+			const viewportKey = viewportType.toLowerCase();
+			return viewportConfig[ viewportKey ] === false;
+		}
 	}
 
 	return false;
@@ -795,9 +799,13 @@ export const areBlocksHiddenAnywhere = ( state, clientIds ) => {
 		}
 
 		// Check viewport-specific visibility.
-		return BLOCK_VISIBILITY_VIEWPORT_ENTRIES.some(
-			( [ , { key } ] ) => blockVisibility?.[ key ] === false
-		);
+		const viewportConfig = blockVisibility.viewport;
+		if ( viewportConfig && typeof viewportConfig === 'object' ) {
+			return BLOCK_VISIBILITY_VIEWPORT_ENTRIES.some(
+				( [ , { key } ] ) => viewportConfig[ key ] === false
+			);
+		}
+		return false;
 	} );
 };
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1198,14 +1198,16 @@ describe( 'private selectors', () => {
 
 		it( 'returns false when experimental flag is disabled and block has breakpoint visibility', () => {
 			window.__experimentalHideBlocksBasedOnScreenSize = false;
-			const state = createState( { mobile: false, tablet: true } );
+			const state = createState( {
+				viewport: { mobile: false, tablet: true },
+			} );
 			const result = isBlockHidden( state, 'test-block' );
 			expect( result ).toBe( false );
 		} );
 
 		it( 'returns false when Desktop is selected and block has breakpoint visibility', () => {
 			const state = createState(
-				{ mobile: false, tablet: true },
+				{ viewport: { mobile: false, tablet: true } },
 				'Desktop'
 			);
 			const result = isBlockHidden( state, 'test-block' );
@@ -1213,14 +1215,17 @@ describe( 'private selectors', () => {
 		} );
 
 		it( 'returns true when Desktop is selected and block is hidden on desktop', () => {
-			const state = createState( { desktop: false }, 'Desktop' );
+			const state = createState(
+				{ viewport: { desktop: false } },
+				'Desktop'
+			);
 			const result = isBlockHidden( state, 'test-block' );
 			expect( result ).toBe( true );
 		} );
 
 		it( 'returns true when Tablet is selected and block is hidden on tablet', () => {
 			const state = createState(
-				{ mobile: true, tablet: false },
+				{ viewport: { mobile: true, tablet: false } },
 				'Tablet'
 			);
 			const result = isBlockHidden( state, 'test-block' );
@@ -1229,7 +1234,7 @@ describe( 'private selectors', () => {
 
 		it( 'returns true when Mobile is selected and block is hidden on mobile', () => {
 			const state = createState(
-				{ mobile: false, tablet: true },
+				{ viewport: { mobile: false, tablet: true } },
 				'Mobile'
 			);
 			const result = isBlockHidden( state, 'test-block' );
@@ -1238,7 +1243,7 @@ describe( 'private selectors', () => {
 
 		it( 'returns false when Tablet is selected and block is visible on tablet', () => {
 			const state = createState(
-				{ mobile: false, tablet: true },
+				{ viewport: { mobile: false, tablet: true } },
 				'Tablet'
 			);
 			const result = isBlockHidden( state, 'test-block' );
@@ -1295,8 +1300,10 @@ describe( 'private selectors', () => {
 							{
 								metadata: {
 									blockVisibility: {
-										mobile: false,
-										tablet: true,
+										viewport: {
+											mobile: false,
+											tablet: true,
+										},
 									},
 								},
 							},

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -160,7 +160,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile' => false,
+						'viewport' => array(
+							'mobile' => false,
+						),
 					),
 				),
 			),
@@ -193,7 +195,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'tablet' => false,
+						'viewport' => array(
+							'tablet' => false,
+						),
 					),
 				),
 			),
@@ -226,7 +230,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'desktop' => false,
+						'viewport' => array(
+							'desktop' => false,
+						),
 					),
 				),
 			),
@@ -259,8 +265,10 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile'  => false,
-						'desktop' => false,
+						'viewport' => array(
+							'mobile'  => false,
+							'desktop' => false,
+						),
 					),
 				),
 			),
@@ -297,9 +305,11 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile'  => true,
-						'tablet'  => true,
-						'desktop' => true,
+						'viewport' => array(
+							'mobile'  => true,
+							'tablet'  => true,
+							'desktop' => true,
+						),
 					),
 				),
 			),
@@ -324,9 +334,11 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile'  => false,
-						'tablet'  => false,
-						'desktop' => false,
+						'viewport' => array(
+							'mobile'  => false,
+							'tablet'  => false,
+							'desktop' => false,
+						),
 					),
 				),
 			),
@@ -374,9 +386,11 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile'       => false,
-						'unknownBreak' => false,
-						'largeScreen'  => false,
+						'viewport' => array(
+							'mobile'       => false,
+							'unknownBreak' => false,
+							'largeScreen'  => false,
+						),
 					),
 				),
 			),
@@ -405,7 +419,9 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
-						'mobile' => false,
+						'viewport' => array(
+							'mobile' => false,
+						),
 					),
 				),
 			),


### PR DESCRIPTION

## What?

Related to:

- https://github.com/WordPress/gutenberg/issues/72502

Refactors block visibility metadata to use a nested structure where viewport settings are stored under a `viewport` key. 

> [!NOTE]
> The [backport PR](https://github.com/WordPress/wordpress-develop/pull/10629) should be updated once a path is decided upon. 


## Why?

This change prepares the foundation for adding additional visibility sources (e.g., user role, time period) in the future.

See discussion over at: https://github.com/WordPress/gutenberg/issues/72502#issuecomment-3706950043


## How?

- **Structure change**: `blockVisibility: { mobile: false }` → `blockVisibility: { viewport: { mobile: false } }`
- **Unchanged**: `blockVisibility: false` (hidden everywhere) remains the same
- Updated PHP rendering logic to access nested viewport config
- Updated JavaScript components, selectors, and hooks to use nested structure
- Updated all test files to reflect new structure


## Notes on future extensibility

This nested structure enables future extensibility for additional visibility sources:

```javascript
blockVisibility: {
  viewport: { mobile: false, tablet: false },
  userRole: { administrator: false, subscriber: true },
  timePeriod: { start: '2025-01-01', end: '2025-12-31', visible: false }
}
```

Later plugins could register custom sources with each source managing its own configuration schema. Core logic could iterate through registered sources or via filter, e.g., ``apply_filters( 'block_visibility_sources', $sources )``

## Testing Instructions

There should be no regressions from https://github.com/WordPress/gutenberg/pull/74249

Enable experimental flag in `/wp-admin/admin.php?page=gutenberg-experiments` 

<img width="985" height="72" alt="Screenshot 2026-01-02 at 4 28 32 pm" src="https://github.com/user-attachments/assets/8b1f60d9-673b-47b0-91e5-23a1a764d3c6" />

Here's some example HTML:

<details>

<summary>Example HTML</summary>

```html
<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} -->
<p>🔴 Hidden on MOBILE (≤479px) - You should see this on tablet and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"tablet":false}}}} -->
<p>🟡 Hidden on TABLET (480-959px) - You should see this on mobile and desktop only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"desktop":false}}}} -->
<p>🟢 Hidden on DESKTOP (≥960px) - You should see this on mobile and tablet only</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"mobile":false,"desktop":false}}}} -->
<p>🟣 Hidden on MOBILE and DESKTOP - You should only see this on tablet (480-959px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"mobile":false,"tablet":false}}}} -->
<p>🔵 Hidden on MOBILE and TABLET - You should only see this on desktop (≥960px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"tablet":false,"desktop":false}}}} -->
<p>🟠 Hidden on TABLET and DESKTOP - You should only see this on mobile (≤479px)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"mobile":true,"tablet":true,"desktop":true}}}} -->
<p>✅ Visible on ALL breakpoints - You should always see this</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
<p>❌ Completely HIDDEN (boolean false) - You should never see this</p>
<!-- /wp:paragraph -->
```

</details>

Check that the correct blocks hide in the correct viewports, and that there are no regressions from https://github.com/WordPress/gutenberg/pull/74249


