### PR TITLE
Enhance Term List block: pre-select current term on term archive pages

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -46,6 +46,16 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			__( 'Select %s' ),
 			$taxonomy->labels->singular_name
 		);
+		
+		// Pre-select the current term if viewing a term archive page.
+		if ( is_tax( $attributes['taxonomy'] ) || is_category() || is_tag() ) {
+			$current_term = get_queried_object();
+			if ( $current_term && $current_term instanceof WP_Term ) {
+				if ( $current_term->taxonomy === $attributes['taxonomy'] ) {
+					$args['selected'] = $current_term->slug;
+				}
+			}
+		}
 
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -47,15 +47,8 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			$taxonomy->labels->singular_name
 		);
 
-		// Pre-select the current term if viewing a term archive page.
-		if ( is_tax( $attributes['taxonomy'] ) || is_category() || is_tag() ) {
-			$current_term = get_queried_object();
-			if ( $current_term && $current_term instanceof WP_Term ) {
-				if ( $current_term->taxonomy === $attributes['taxonomy'] ) {
-					$args['selected'] = $current_term->slug;
-				}
-			}
-		}
+		// Pre-select the current term using query var.
+		$args['selected'] = get_query_var( $taxonomy->query_var );
 
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -120,7 +120,8 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 				if ( 'escape' === dropdown.dataset.lastkey ) {
 					return;
 				}
-				if ( dropdown.value && dropdown instanceof HTMLSelectElement ) {
+				// Only navigate if a valid term is selected (not the default "Select [taxonomy]" option)
+				if ( dropdown.value && dropdown.value !== '-1' && dropdown instanceof HTMLSelectElement ) {
 					const url = new URL( homeUrl );
 					url.searchParams.set( dropdown.name, dropdown.value );
 					location.href = url.href;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -46,7 +46,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			__( 'Select %s' ),
 			$taxonomy->labels->singular_name
 		);
-		
+
 		// Pre-select the current term if viewing a term archive page.
 		if ( is_tax( $attributes['taxonomy'] ) || is_category() || is_tag() ) {
 			$current_term = get_queried_object();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74597 

Pre-selects the current term in the Terms List block dropdown when viewing a term archive page.

## Why?
Currently, when users select a term from the Terms List block dropdown on archive pages, the page reloads to show posts for that term, but the dropdown resets to the default "Select [taxonomy]" text instead of showing which term is currently active.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Modified block rendering to detect when viewing a term archive page and pre-select the corresponding term in the dropdown.
## Testing Instructions
1. Edit the archive page and add the Term List block 
2. Select the taxonomy and Display as dropdown
3. Check the term archive page and select different terms

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2149c271-4f41-431d-bb19-c511db1142b5


