### PR TITLE
Image Block: Fix image block content tools when multiselecting image blocks

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -788,14 +788,14 @@ export default function Image( {
 					/>
 				</BlockControls>
 			) }
-			{ ! hasDataFormBlockFields && (
+			{ ! hasDataFormBlockFields && isSingleSelected && (
 				<InspectorControls group="content">
 					<ToolsPanel
 						label={ __( 'Media' ) }
 						resetAll={ () => onSelectImage( undefined ) }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ isSingleSelected && ! lockUrlControls && (
+						{ ! lockUrlControls && (
 							<ToolsPanelItem
 								label={ __( 'Image' ) }
 								hasValue={ () => !! url }
@@ -822,47 +822,45 @@ export default function Image( {
 								/>
 							</ToolsPanelItem>
 						) }
-						{ isSingleSelected && (
-							<ToolsPanelItem
+						<ToolsPanelItem
+							label={ __( 'Alternative text' ) }
+							isShownByDefault
+							hasValue={ () => !! alt }
+							onDeselect={ () =>
+								setAttributes( { alt: undefined } )
+							}
+						>
+							<TextareaControl
 								label={ __( 'Alternative text' ) }
-								isShownByDefault
-								hasValue={ () => !! alt }
-								onDeselect={ () =>
-									setAttributes( { alt: undefined } )
-								}
-							>
-								<TextareaControl
-									label={ __( 'Alternative text' ) }
-									value={ alt || '' }
-									onChange={ updateAlt }
-									readOnly={ lockAltControls }
-									help={
-										lockAltControls ? (
-											<>{ lockAltControlsMessage }</>
-										) : (
-											<>
-												<ExternalLink
-													href={
-														// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-														__(
-															'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-														)
-													}
-												>
-													{ __(
-														'Describe the purpose of the image.'
-													) }
-												</ExternalLink>
-												<br />
+								value={ alt || '' }
+								onChange={ updateAlt }
+								readOnly={ lockAltControls }
+								help={
+									lockAltControls ? (
+										<>{ lockAltControlsMessage }</>
+									) : (
+										<>
+											<ExternalLink
+												href={
+													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+													__(
+														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+													)
+												}
+											>
 												{ __(
-													'Leave empty if decorative.'
+													'Describe the purpose of the image.'
 												) }
-											</>
-										)
-									}
-								/>
-							</ToolsPanelItem>
-						) }
+											</ExternalLink>
+											<br />
+											{ __(
+												'Leave empty if decorative.'
+											) }
+										</>
+									)
+								}
+							/>
+						</ToolsPanelItem>
 					</ToolsPanel>
 				</InspectorControls>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed a small issue with the image block UI added in #74201.

If multiple image blocks are selected, the content tab just shows a 'Media' label and empty content/settings tabs.

## How?
The issue seems to be the conditional rendering in the image block. When multiple blocks are selected a `<ToolsPanel>` with nothing in it (just a 'Media' label) is rendered into the Content InspectorControls group. This causes the content tab to show.

All the `<ToolsPanelItem>` components have an `isSingleSelected` solution, so my solution is to hoist this up to wrap the entire `<ToolsPanel>`. Doing this hides the Content and Settings tabs.

## Testing Instructions
1. Add two image blocks to the editor
2. Open the block inspector if not already open
3. Multiselect the image blocks

|Before|After|
|-|-|
| <img width="277" height="634" alt="Screenshot 2026-01-14 at 3 27 21 pm" src="https://github.com/user-attachments/assets/6d582de3-c421-4dcb-8539-728583e50a90" /> | <img width="273" height="656" alt="Screenshot 2026-01-14 at 3 26 53 pm" src="https://github.com/user-attachments/assets/e56ac7c6-4b3f-481b-ae1b-03fe02247c86" /> |

