### PR TITLE
DataViews stories: add custom layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix missing dependencies. [#74310](https://github.com/WordPress/gutenberg/pull/74310)
 - Add details layout to DataForm validation story. [#74445](https://github.com/WordPress/gutenberg/pull/74445)
 - Updated `fast-deep-equal` imports for compatibility with strict Node.js resolution ([#74530](https://github.com/WordPress/gutenberg/pull/74530))
+- Add "custom layout" story via "free form". [#74605](https://github.com/WordPress/gutenberg/pull/74605)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -11,6 +11,7 @@ import LayoutActivityComponent from './layout-activity';
 import LayoutTableComponent from './layout-table';
 import LayoutGridComponent from './layout-grid';
 import LayoutListComponent from './layout-list';
+import LayoutCustomComponent from './layout-custom';
 import InfiniteScrollComponent from './infinite-scroll';
 import WithCardComponent from './with-card';
 import FreeCompositionComponent from './free-composition';
@@ -189,6 +190,10 @@ export const LayoutActivity = {
 			description: 'Whether to display the media field',
 		},
 	},
+};
+
+export const LayoutCustom = {
+	render: LayoutCustomComponent,
 };
 
 export const Empty = {

--- a/packages/dataviews/src/dataviews/stories/layout-custom.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-custom.tsx
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViews from '../index';
+import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
+import type { View } from '../../types';
+import { data, fields } from './fixtures';
+import { LAYOUT_TABLE } from '../../constants';
+
+/**
+ * Custom layout component that renders a simple list of titles.
+ */
+function CustomList( { items }: { items: typeof data } ) {
+	return (
+		<ul style={ { listStyle: 'none', padding: 0, margin: 0 } }>
+			{ items.map( ( item ) => (
+				<li
+					key={ item.id }
+					style={ {
+						padding: '8px 0',
+						borderBottom: '1px solid #ddd',
+					} }
+				>
+					{ item.name.title }
+				</li>
+			) ) }
+		</ul>
+	);
+}
+
+/**
+ * Demonstrates a custom layout using free composition.
+ *
+ * This story shows how to:
+ * - Use `<DataViews>` as a context provider with custom children
+ * - Render your own layout instead of using `<DataViews.Layout />`
+ * - Still leverage DataViews sub-components for search and pagination
+ */
+export const LayoutCustomComponent = () => {
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_TABLE,
+		search: '',
+		page: 1,
+		perPage: 10,
+		filters: [],
+		fields: [],
+	} );
+
+	const { data: processedData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ processedData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			defaultLayouts={ { table: {} } }
+		>
+			<DataViews.Search />
+			<CustomList items={ processedData } />
+			<DataViews.Pagination />
+		</DataViews>
+	);
+};
+
+export default LayoutCustomComponent;

--- a/packages/dataviews/src/dataviews/stories/layout-custom.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-custom.tsx
@@ -13,32 +13,94 @@ import { data, fields } from './fixtures';
 import { LAYOUT_TABLE } from '../../constants';
 
 /**
- * Custom layout component that renders a simple list of titles.
+ * Poster/hero style layout that displays items as large image cards
+ * with overlaid text content.
  */
-function CustomList( { items }: { items: typeof data } ) {
+function PosterGrid( { items }: { items: typeof data } ) {
 	return (
-		<ul style={ { listStyle: 'none', padding: 0, margin: 0 } }>
+		<div
+			style={ {
+				display: 'grid',
+				gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+				gap: '16px',
+				padding: '16px 0',
+			} }
+		>
 			{ items.map( ( item ) => (
-				<li
+				<div
 					key={ item.id }
 					style={ {
-						padding: '8px 0',
-						borderBottom: '1px solid #ddd',
+						position: 'relative',
+						aspectRatio: '4 / 3',
+						borderRadius: '8px',
+						overflow: 'hidden',
+						backgroundImage: `url(${ item.image })`,
+						backgroundSize: 'cover',
+						backgroundPosition: 'center',
 					} }
 				>
-					{ item.name.title }
-				</li>
+					<div
+						style={ {
+							position: 'absolute',
+							bottom: 0,
+							left: 0,
+							right: 0,
+							padding: '48px 16px 16px',
+							background:
+								'linear-gradient(to top, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)',
+							color: 'white',
+						} }
+					>
+						<h3
+							style={ {
+								margin: '0 0 4px',
+								fontSize: '18px',
+								fontWeight: 600,
+								textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+							} }
+						>
+							{ item.name.title }
+						</h3>
+						<p
+							style={ {
+								margin: '0 0 8px',
+								fontSize: '13px',
+								opacity: 0.9,
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								whiteSpace: 'nowrap',
+							} }
+						>
+							{ item.name.description }
+						</p>
+						<div style={ { display: 'flex', gap: '6px' } }>
+							{ item.categories.slice( 0, 2 ).map( ( cat ) => (
+								<span
+									key={ cat }
+									style={ {
+										fontSize: '11px',
+										padding: '2px 8px',
+										borderRadius: '4px',
+										backgroundColor: 'rgba(255,255,255,0.2)',
+									} }
+								>
+									{ cat }
+								</span>
+							) ) }
+						</div>
+					</div>
+				</div>
 			) ) }
-		</ul>
+		</div>
 	);
 }
 
 /**
- * Demonstrates a custom layout using free composition.
+ * Demonstrates a custom poster/hero layout using free composition.
  *
  * This story shows how to:
  * - Use `<DataViews>` as a context provider with custom children
- * - Render your own layout instead of using `<DataViews.Layout />`
+ * - Render a completely custom layout (poster grid) instead of `<DataViews.Layout />`
  * - Still leverage DataViews sub-components for search and pagination
  */
 export const LayoutCustomComponent = () => {
@@ -46,7 +108,7 @@ export const LayoutCustomComponent = () => {
 		type: LAYOUT_TABLE,
 		search: '',
 		page: 1,
-		perPage: 10,
+		perPage: 6,
 		filters: [],
 		fields: [],
 	} );
@@ -66,7 +128,7 @@ export const LayoutCustomComponent = () => {
 			defaultLayouts={ { table: {} } }
 		>
 			<DataViews.Search />
-			<CustomList items={ processedData } />
+			<PosterGrid items={ processedData } />
 			<DataViews.Pagination />
 		</DataViews>
 	);

--- a/packages/dataviews/src/dataviews/stories/layout-custom.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-custom.tsx
@@ -81,7 +81,8 @@ function PosterGrid( { items }: { items: typeof data } ) {
 										fontSize: '11px',
 										padding: '2px 8px',
 										borderRadius: '4px',
-										backgroundColor: 'rgba(255,255,255,0.2)',
+										backgroundColor:
+											'rgba(255,255,255,0.2)',
 									} }
 								>
 									{ cat }

--- a/packages/dataviews/src/dataviews/stories/layout-custom.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-custom.tsx
@@ -127,9 +127,11 @@ export const LayoutCustomComponent = () => {
 			onChangeView={ setView }
 			defaultLayouts={ { table: {} } }
 		>
-			<DataViews.Search />
-			<PosterGrid items={ processedData } />
-			<DataViews.Pagination />
+			<div style={ { padding: '2px' } }>
+				<DataViews.Search />
+				<PosterGrid items={ processedData } />
+				<DataViews.Pagination />
+			</div>
 		</DataViews>
 	);
 };


### PR DESCRIPTION
## What?

This PR adds a new DataViews story: custom layout.

https://github.com/user-attachments/assets/99e91e21-83e0-4262-bf3e-513c0b1355f8

## Why?

It's a common ask from folks. While [extensibility without "free form" is in the roadmap](https://github.com/WordPress/gutenberg/issues/61084), folks can already do this.

## How?

Use the "free form" to create a custom layout.

## Testing Instructions

- Run local storybook (`npm run storybook:dev`).
- Visit DataViews > Layout Custom.
