### PR TITLE
Navigation Overlays: Added default pattern selection modal when creating a navigation overlay

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -204,6 +204,7 @@ $z-layers: (
 	// Ensure modal footer actions appear above modal contents
 	".editor-start-template-options__modal__actions": 1,
 	".editor-start-page-options__modal__actions": 1,
+	".editor-start-navigation-overlay-options__modal__actions": 1,
 
 	// Ensure checkbox + actions don't overlap table header
 	".dataviews-view-table thead": 1,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -33,6 +33,7 @@ import BlockRemovalWarnings from '../block-removal-warnings';
 import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import StartTemplateOptions from '../start-template-options';
+import StartNavigationOverlayOptions from '../start-navigation-overlay-options';
 import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
@@ -387,6 +388,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									<BlockRemovalWarnings />
 									<StartPageOptions />
 									<StartTemplateOptions />
+									<StartNavigationOverlayOptions />
 									<PatternRenameModal />
 									<PatternDuplicateModal />
 								</>

--- a/packages/editor/src/components/start-navigation-overlay-options/index.js
+++ b/packages/editor/src/components/start-navigation-overlay-options/index.js
@@ -1,0 +1,188 @@
+/**
+ * WordPress dependencies
+ */
+import { Flex, FlexItem, Modal, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	__experimentalBlockPatternsList as BlockPatternsList,
+} from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
+import { store as interfaceStore } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from '../../store/constants';
+import { store as editorStore } from '../../store';
+
+/**
+ * Get patterns that match navigation-overlay template parts.
+ *
+ * @return {Array} Array of patterns for navigation-overlay.
+ */
+export function useStartPatterns() {
+	const { patterns, postType, area } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		const { getPatternsByBlockTypes } = select( blockEditorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+
+		const _postType = getCurrentPostType();
+		const _postId = getCurrentPostId();
+		const templatePartRecord = getEditedEntityRecord(
+			'postType',
+			_postType,
+			_postId
+		);
+
+		return {
+			patterns: getPatternsByBlockTypes(
+				'core/template-part/navigation-overlay'
+			),
+			postType: _postType,
+			area: templatePartRecord?.area,
+		};
+	}, [] );
+
+	return useMemo( () => {
+		if (
+			! patterns?.length ||
+			postType !== TEMPLATE_PART_POST_TYPE ||
+			area !== 'navigation-overlay'
+		) {
+			return [];
+		}
+
+		return patterns;
+	}, [ patterns, postType, area ] );
+}
+
+function PatternSelection( { blockPatterns, onChoosePattern } ) {
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
+	}, [] );
+
+	return (
+		<BlockPatternsList
+			blockPatterns={ blockPatterns }
+			onClickPattern={ ( _pattern, blocks ) => {
+				editEntityRecord( 'postType', postType, postId, {
+					blocks,
+					content: ( { blocks: blocksForSerialization = [] } ) =>
+						__unstableSerializeAndClean( blocksForSerialization ),
+				} );
+				onChoosePattern();
+			} }
+		/>
+	);
+}
+
+function StartNavigationOverlayOptionsModal( { onClose } ) {
+	const overlayPatterns = useStartPatterns();
+	const hasPatterns = overlayPatterns.length > 0;
+
+	if ( ! hasPatterns ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="editor-start-navigation-overlay-options__modal"
+			title={ __( 'Choose a pattern' ) }
+			isFullScreen
+			onRequestClose={ onClose }
+		>
+			<div className="editor-start-navigation-overlay-options__modal-content">
+				<PatternSelection
+					blockPatterns={ overlayPatterns }
+					onChoosePattern={ onClose }
+				/>
+			</div>
+			<Flex
+				className="editor-start-navigation-overlay-options__modal__actions"
+				justify="flex-end"
+				expanded={ false }
+			>
+				<FlexItem>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+					>
+						{ __( 'Skip' ) }
+					</Button>
+				</FlexItem>
+			</Flex>
+		</Modal>
+	);
+}
+
+export default function StartNavigationOverlayOptions() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const { isEditedPostDirty, isEditedPostEmpty } = useSelect( editorStore );
+	const { isModalActive } = useSelect( interfaceStore );
+	const { enabled, postId } = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+		const currentPostType = getCurrentPostType();
+		const _postId = getCurrentPostId();
+
+		// Only enable for navigation-overlay template parts.
+		if ( currentPostType !== TEMPLATE_PART_POST_TYPE ) {
+			return {
+				postId: _postId,
+				enabled: false,
+			};
+		}
+
+		const { getEditedEntityRecord } = select( coreStore );
+		const templatePartRecord = getEditedEntityRecord(
+			'postType',
+			currentPostType,
+			_postId
+		);
+
+		return {
+			postId: _postId,
+			enabled: templatePartRecord?.area === 'navigation-overlay',
+		};
+	}, [] );
+
+	// Note: The `postId` ensures the effect re-runs when template parts are switched without remounting the component.
+	useEffect( () => {
+		const isFreshTemplatePart =
+			! isEditedPostDirty() && isEditedPostEmpty();
+		// Prevents immediately opening when features is enabled via preferences modal.
+		const isPreferencesModalActive = isModalActive( 'editor/preferences' );
+		if ( ! enabled || ! isFreshTemplatePart || isPreferencesModalActive ) {
+			return;
+		}
+
+		// Open the modal after the initial render for a new template part.
+		setIsOpen( true );
+	}, [
+		enabled,
+		postId,
+		isEditedPostDirty,
+		isEditedPostEmpty,
+		isModalActive,
+	] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<StartNavigationOverlayOptionsModal
+			onClose={ () => setIsOpen( false ) }
+		/>
+	);
+}

--- a/packages/editor/src/components/start-navigation-overlay-options/style.scss
+++ b/packages/editor/src/components/start-navigation-overlay-options/style.scss
@@ -1,0 +1,48 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/z-index" as *;
+
+$actions-height: 92px;
+
+.editor-start-navigation-overlay-options__modal {
+	.editor-start-navigation-overlay-options__modal__actions {
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+		height: $actions-height;
+		background-color: $white;
+		margin-left: - $grid-unit-40;
+		margin-right: - $grid-unit-40;
+		padding-left: $grid-unit-40;
+		padding-right: $grid-unit-40;
+		border-top: 1px solid $gray-300;
+		z-index: z-index(".editor-start-navigation-overlay-options__modal__actions");
+	}
+
+	.block-editor-block-patterns-list {
+		// Since the actions container is positioned absolutely,
+		// this padding bottom ensures that the content wrapper will properly
+		// detect overflowing content and start showing scrollbars at the right
+		// moment. Without this padding, the content would render under the actions
+		// bar without causing the wrapper to show a scrollbar.
+		padding-bottom: $actions-height;
+	}
+}
+
+.editor-start-navigation-overlay-options__modal-content .block-editor-block-patterns-list {
+	column-count: 2;
+	column-gap: $grid-unit-30;
+
+	@include break-medium() {
+		column-count: 3;
+	}
+
+	@include break-wide() {
+		column-count: 4;
+	}
+
+	.block-editor-block-patterns-list__list-item {
+		break-inside: avoid-column;
+	}
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -51,6 +51,7 @@
 @use "./components/resizable-editor/style.scss" as *;
 @use "./components/save-publish-panels/style.scss" as *;
 @use "./components/start-page-options/style.scss" as *;
+@use "./components/start-navigation-overlay-options/style.scss" as *;
 @use "./components/start-template-options/style.scss" as *;
 @use "./components/sidebar/style.scss" as *;
 @use "./components/site-discussion/style.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See: #74585 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Adds the modal when creating a new navigation overlay to select from existing patterns.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds how `start-page-options` are displayed when creating a page.
- Similarly added `start-navigation-overlay-options` to show modal with available navigation overlay patterns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open site editor.
2. Select patterns.
3. Add navigation overlay template part.
4. When created, it would first ask for a pattern to start from, instead of blank template part.
5. User can choose or start from scratch.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/7f33fae5-f707-44f4-a015-a80f45602039


