### PR TITLE
Block Bindings: Add support for Cover block id and url attrs

### DIFF
--- a/backport-changelog/7.0/10739.md
+++ b/backport-changelog/7.0/10739.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10739
+
+* https://github.com/WordPress/gutenberg/pull/74610

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -660,7 +660,9 @@ function gutenberg_unique_id_from_values( array $data, string $prefix = '' ): st
  * @return string                Filtered block content.
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
-	static $global_styles = null;
+	static $global_styles = array();
+
+	$theme = get_stylesheet();
 
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
@@ -929,8 +931,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check style variation first, then block-specific styles, then fall back to root styles.
 		$block_name = $block['blockName'] ?? '';
-		if ( null === $global_styles ) {
-			$global_styles = gutenberg_get_global_styles();
+		if ( empty( $global_styles[ $theme ] ) ) {
+			$global_styles[ $theme ] = gutenberg_get_global_styles();
 		}
 
 		// Check if the block has an active style variation with a blockGap value.
@@ -942,11 +944,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$registered_styles = $styles_registry->get_registered_styles_for_block( $block_name );
 			$variation_name    = gutenberg_get_block_style_variation_name_from_registered_style( $block_class_name, $registered_styles );
 			if ( $variation_name ) {
-				$variation_block_gap_value = $global_styles['blocks'][ $block_name ]['variations'][ $variation_name ]['spacing']['blockGap'] ?? null;
+				$variation_block_gap_value = $global_styles[ $theme ]['blocks'][ $block_name ]['variations'][ $variation_name ]['spacing']['blockGap'] ?? null;
 			}
 		}
 
-		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+		$global_block_gap_value = $variation_block_gap_value ?? $global_styles[ $theme ]['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles[ $theme ]['spacing']['blockGap'] ?? null;
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -931,6 +931,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check style variation first, then block-specific styles, then fall back to root styles.
 		$block_name = $block['blockName'] ?? '';
+		// We cache global styles on a per-theme basis to ensure that they don't persists across theme switches,
+		// which could lead to invalid styles being generated.
 		if ( empty( $global_styles[ $theme ] ) ) {
 			$global_styles[ $theme ] = gutenberg_get_global_styles();
 		}

--- a/lib/compat/wordpress-7.0/block-bindings.php
+++ b/lib/compat/wordpress-7.0/block-bindings.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Block Bindings: Support for generically setting rich-text block attributes.
+ *
+ * @since 7.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+// The following filter can be removed once the minimum required WordPress version is 7.0 or newer.
+add_filter(
+	'block_bindings_supported_attributes_core/cover',
+	function ( $attributes ) {
+		$attributes[] = 'id';
+		$attributes[] = 'url';
+		return $attributes;
+	},
+	10
+);
+
+function gutenberg_replace_cover_block_img_src( $attribute, $attribute_name, $block_name ) {
+	if ( 'core/cover' === $block_name && 'url' === $attribute_name ) {
+		$attribute['source']    = 'attribute';
+		$attribute['selector']  = 'img';
+		$attribute['attribute'] = 'src';
+	}
+	return $attribute;
+}
+add_filter( 'block_bindings_attribute_replaced_in_markup', 'gutenberg_replace_cover_block_img_src', 10, 3 );
+
+// Remove WP 6.9 Block Bindings compat layer.
+remove_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10 );
+/**
+ * Callback function for the render_block filter.
+ *
+ * Identical to the 6.9 compat layer version, with one addition:
+ * The `block_bindings_attribute_replaced_in_markup` allows specifying attributes that should be
+ * replaced in the block markup.
+ *
+ * @since 7.0.0
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
+function gutenberg_block_bindings_render_block_7_0( $block_content, $block, $instance ) {
+	static $inside_block_bindings_render = false;
+	if ( $inside_block_bindings_render ) {
+		return $block_content;
+	}
+
+	// Process the block bindings and get attributes updated with the values from the sources.
+	$computed_attributes = gutenberg_process_block_bindings( $instance );
+	if ( empty( $computed_attributes ) ) {
+		return $block_content;
+	}
+
+	/*
+	 * Merge the computed attributes with the original attributes.
+	 *
+	 * Note that this is not a recursive merge, meaning that nested attributes --
+	 * such as block bindings metadata -- will be completely replaced.
+	 * This is desirable. At this point, Core has already processed any block
+	 * bindings that it supports. What remains to be processed are only the attributes
+	 * for which support was added later (through the `block_bindings_supported_attributes`
+	 * filter). To do so, we'll run `$instance->render()` once more
+	 * so the block can update its content based on those attributes.
+	 */
+	$instance->attributes = array_merge( $instance->attributes, $computed_attributes );
+
+	/*
+	 * If we're dealing with the Button block, we remove the bindings metadata
+	 * in order to avoid having it reprocessed, which would lead to Core
+	 * capitalizing the wrapper tag (e.g. <DIV>).
+	 */
+	if ( 'core/button' === $instance->name ) {
+		unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
+	}
+
+	/**
+	 * This filter (`gutenberg_block_bindings_render_block`) is called from `WP_Block::render()`.
+	 * To avoid infinite recursion, we set a flag that this filter checks when invoked which tells
+	 * it to exit early.
+	 */
+	$inside_block_bindings_render = true;
+	$block_content                = $instance->render();
+	$inside_block_bindings_render = false;
+
+	$block_type = $instance->block_type;
+
+	if ( ! empty( $computed_attributes ) && ! empty( $block_content ) ) {
+		foreach ( $computed_attributes as $attribute_name => $source_value ) {
+			$attribute                                 = $block_type->attributes[ $attribute_name ];
+			$attribute                                 = apply_filters( 'block_bindings_attribute_replaced_in_markup', $attribute, $attribute_name, $instance->name );
+			$block_type->attributes[ $attribute_name ] = $attribute;
+
+			$block_content = gutenberg_replace_html( $block_content, $attribute_name, $source_value, $block_type );
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_block_bindings_render_block_7_0', 10, 3 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -75,6 +75,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.0/template-activate.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.0/global-styles.php';
+	require __DIR__ . '/compat/wordpress-7.0/block-bindings.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -143,39 +143,6 @@ function CoverEdit( {
 		media?.media_details?.sizes?.[ sizeSlug ]?.source_url ??
 		media?.source_url;
 
-	// User can change the featured image outside of the block, but we still
-	// need to update the block when that happens. This effect should only
-	// run when the featured image changes in that case. All other cases are
-	// handled in their respective callbacks.
-	useEffect( () => {
-		( async () => {
-			if ( ! useFeaturedImage ) {
-				return;
-			}
-
-			const averageBackgroundColor = await getMediaColor( mediaUrl );
-
-			let newOverlayColor = overlayColor.color;
-			if ( ! isUserOverlayColor ) {
-				newOverlayColor = averageBackgroundColor;
-				__unstableMarkNextChangeAsNotPersistent();
-				setOverlayColor( newOverlayColor );
-			}
-
-			const newIsDark = compositeIsDark(
-				dimRatio,
-				newOverlayColor,
-				averageBackgroundColor
-			);
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				isDark: newIsDark,
-				isUserOverlayColor: isUserOverlayColor || false,
-			} );
-		} )();
-		// Update the block only when the featured image changes.
-	}, [ mediaUrl ] );
-
 	// instead of destructuring the attributes
 	// we define the url and background type
 	// depending on the value of the useFeaturedImage flag
@@ -188,14 +155,50 @@ function CoverEdit( {
 		? IMAGE_BACKGROUND_TYPE
 		: originalBackgroundType;
 
+	// User can change the featured image outside of the block, but we still
+	// need to update the block when that happens. This effect should only
+	// run when the featured image changes in that case. All other cases are
+	// handled in their respective callbacks.
+	useEffect( () => {
+		( async () => {
+			if ( ! useFeaturedImage && ! attributes?.metadata?.bindings?.url ) {
+				return;
+			}
+
+			const averageBackgroundColor = await getMediaColor( url );
+
+			let newOverlayColor = overlayColor.color;
+			if ( ! isUserOverlayColor ) {
+				newOverlayColor = averageBackgroundColor;
+				__unstableMarkNextChangeAsNotPersistent();
+				setOverlayColor( newOverlayColor );
+			}
+
+			const newDimRatio = dimRatio === 100 ? 50 : dimRatio;
+
+			const newIsDark = compositeIsDark(
+				newDimRatio,
+				newOverlayColor,
+				averageBackgroundColor
+			);
+
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( {
+				dimRatio: newDimRatio,
+				isDark: newIsDark,
+				isUserOverlayColor: isUserOverlayColor || false,
+			} );
+		} )();
+		// Update the block only when the featured image changes.
+	}, [ url ] );
+
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
 	const onSelectMedia = async ( newMedia ) => {
 		const mediaAttributes = attributesFromMedia( newMedia );
-		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
-			IMAGE_BACKGROUND_TYPE
-		);
+		const isImage =
+			mediaAttributes.backgroundType === IMAGE_BACKGROUND_TYPE;
 
 		const averageBackgroundColor = await getMediaColor(
 			isImage ? newMedia?.url : undefined

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -16,7 +16,7 @@
 function gutenberg_test_block_bindings_registration() {
 	// Define fields list.
 	$upload_dir  = wp_upload_dir();
-	$testing_url = $upload_dir['url'] . '/1024x768_e2e_test_image_size.jpeg';
+	$testing_url = $upload_dir['url'] . '/10x10_e2e_test_image_z9T8jK.png';
 	$fields_list = array(
 		'text_field'          => array(
 			'label' => 'Text Field Label',

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -85,7 +85,7 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 <!-- /wp:paragraph -->
 HTML
 				,
-				'<p class="wp-block-paragraph">test source value</p>',
+				'<p class="wp-block-paragraph">test-source-value</p>',
 			),
 			'button block'    => array(
 				'text',
@@ -95,7 +95,17 @@ HTML
 <!-- /wp:button -->
 HTML
 				,
-				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
+				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test-source-value</a></div>',
+			),
+			'cover block (with bound non-sourced attribute)' => array(
+				'url',
+				<<<HTML
+<!-- wp:cover -->
+<div class="wp-block-cover is-layout-flow wp-block-cover-is-layout-flow"><img class="wp-block-cover__image-background" src="this-should-not-appear.jpg"/></div>
+<!-- /wp:cover -->
+HTML
+				,
+				'<div class="wp-block-cover is-layout-flow wp-block-cover-is-layout-flow"><img class="wp-block-cover__image-background" src="http://test-source-value"/></div>',
 			),
 			'test block'      => array(
 				'myAttribute',
@@ -105,7 +115,7 @@ HTML
 <!-- /wp:test/block -->
 HTML
 				,
-				'<p>test source value</p>',
+				'<p>test-source-value</p>',
 			),
 		);
 	}
@@ -119,7 +129,7 @@ HTML
 	 */
 	public function test_update_block_with_value_from_source( $bound_attribute, $block_content, $expected_result ) {
 		$get_value_callback = function () {
-			return 'test source value';
+			return 'test-source-value';
 		};
 
 		register_block_bindings_source(
@@ -144,7 +154,7 @@ HTML
 		$result = $block->render();
 
 		$this->assertSame(
-			'test source value',
+			'test-source-value',
 			$block->attributes[ $bound_attribute ],
 			"The '{$bound_attribute}' attribute should be updated with the value returned by the source."
 		);

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -555,6 +555,64 @@ test.describe( 'Cover', () => {
 		const overlay = coverBlock.locator( '.wp-block-cover__background' );
 		await expect( overlay ).toBeVisible();
 	} );
+
+	test.describe( 'Block Bindings', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+			// Upload the image so the url_field of the test source resolves.
+			await requestUtils.uploadMedia(
+				path.join(
+					'./test/e2e/assets',
+					'10x10_e2e_test_image_z9T8jK.png'
+				)
+			);
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllMedia();
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+		} );
+
+		test( 'computes overlay color when url attribute is bound', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/cover',
+				attributes: {
+					metadata: {
+						bindings: {
+							url: {
+								source: 'testing/complete-source',
+								args: { key: 'url_field' },
+							},
+						},
+					},
+				},
+			} );
+
+			const coverBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Cover',
+			} );
+
+			// The overlay should be visible because the bound URL
+			// resolves to an image.
+			const overlay = coverBlock.locator( '.wp-block-cover__background' );
+			await expect( overlay ).toBeVisible();
+
+			// The overlay color should be auto-detected from the
+			// bound image (average of ~50% black, ~50% white = gray).
+			// Without the fix, the CSS default for .has-background-dim
+			// (black) would apply instead.
+			await expect( overlay ).toHaveCSS(
+				'background-color',
+				'rgb(179, 179, 179)'
+			);
+		} );
+	} );
 } );
 
 class CoverBlockUtils {

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -604,13 +604,13 @@ test.describe( 'Cover', () => {
 			await expect( overlay ).toBeVisible();
 
 			// The overlay color should be auto-detected from the
-			// bound image (average of ~50% black, ~50% white = gray).
-			// Without the fix, the CSS default for .has-background-dim
-			// (black) would apply instead.
+			// bound image (average of ~50% black, ~50% white = gray),
+			// and the opacity should be set to 0.5.
 			await expect( overlay ).toHaveCSS(
 				'background-color',
 				'rgb(179, 179, 179)'
 			);
+			await expect( overlay ).toHaveCSS( 'opacity', '0.5' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -14,15 +14,15 @@ test.describe( 'Registered sources', () => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
 		await requestUtils.deleteAllMedia();
 		const placeholderMedia = await requestUtils.uploadMedia(
-			path.join( './test/e2e/assets', '10x10_e2e_test_image_z9T8jK.png' )
-		);
-		imagePlaceholderSrc = placeholderMedia.source_url;
-
-		const testingImgMedia = await requestUtils.uploadMedia(
 			path.join(
 				'./test/e2e/assets',
 				'1024x768_e2e_test_image_size.jpeg'
 			)
+		);
+		imagePlaceholderSrc = placeholderMedia.source_url;
+
+		const testingImgMedia = await requestUtils.uploadMedia(
+			path.join( './test/e2e/assets', '10x10_e2e_test_image_z9T8jK.png' )
 		);
 		testingImgSrc = testingImgMedia.source_url;
 	} );


### PR DESCRIPTION
## What?
Add Block Bindings support for the Cover block's `id` and `url` attributes. See https://github.com/WordPress/gutenberg/pull/74109#issuecomment-3745210712 for context.

## Why?
The Cover block is one of the more prominent blocks; adding support for Block Bindings will also unlock Pattern Overrides support for it.

Additionally, the Cover block presents a few problems which, when solved, can also inform the changes needed for other blocks to add support for Block Bindings.

## How?
On the client side, the architecture of the Cover block's Edit component is such that it updates a number of its computed attributes (`dimRatio` etc.) in response to event handlers on specific block controls, e.g. when manually setting a new background image. This doesn't work for Block Bindings, where the attribute is connected to a Block Bindings source through a mechanism that's outside of the block's control.

Instead, this PR adds logic to update those attributes via the block Edit component's `useEffect()` -- which was previously only used to react to an updated featured image (as that is typically also updated "outside" of the block itself). More background and discussion on this are available [here](https://github.com/WordPress/gutenberg/pull/74109#discussion_r2799913469) and [here](https://github.com/WordPress/gutenberg/issues/74639#issuecomment-3915554018).

On the server side, we add some processing of block attributes within the block markup (via the HTML API), similar to what we already had in place for sourced attributes. The difference here is that the Cover block's `id` and `url` attributes aren't actually sourced attributes, but require similar treatment. To this end, the `block_bindings_attribute_replaced_in_markup` filter is introduced.

## Testing Instructions

Use this with https://github.com/WordPress/gutenberg/pull/75625 (which adds a `featured_media.id` and a `featured_media.url` field to the `core/post-data` source).

- Create a new post and set a featured image for it.
- Insert a Cover block, and connect its `id` and `url` attributes to the `core/post-data` source's `featured_image.id` and `featured_image.url` fields.
- Verify that it works both in the editor, and on the frontend.
- Try updating the post's featured image and verify that the Cover block updates accordingly.
- Insert a new Cover block and set its background image manually to a different image. Then, connect it to the `core/post-data` source's `featured_image.*` fields. Verify that it correctly updates the image it shows.

## TODO

- [x] Binding a newly inserted Cover block (that doesn't have its image set manually) adds an overlay that uses the `dimRatio` attribute default value of `100` (=fully opaque). This results in an opaque black overlay that hides the entire image.
  - The default is likely set to that value to show the Cover block as black while loading a newly set image.
- [ ] Figure out what to do if only `url` is bound (but `id` isn't), meaning that the bound image could possibly be external (which [isn't currently supported by the Cover block](https://github.com/WordPress/gutenberg/pull/74109#issuecomment-3745210712)).
  - This isn't really a blocker; it's more of a question of how to flag to the user that if the `url` attribute is bound, the `id` attribute also requires binding to the same source (unless we can find a way where that's not needed).
- [ ] Support parallax case (where the image URL is used as a `background-image` inside a `style` attribute, rather than an `<img src="...">` attribute=. AFAIK, the HTML API cannot yet safely modify `style` attributes (as that's CSS).
  - There's a [solution in `WordPress/php-toolkit`](https://github.com/WordPress/php-toolkit/blob/ab0077a2147dba7da2595682e7e0b098bcc18ad8/components/DataLiberation/CSS/class-cssprocessor.php), but we'd need to copy quite a bit of code over in order to get that to work.

<img width="978" height="521" alt="image" src="https://github.com/user-attachments/assets/45ea2d1d-7ef0-457f-8efc-19707b9e5f03" />


## Follow-up

- [ ] https://github.com/WordPress/gutenberg/pull/75625. This will allow connecting a Cover block's attribute to the current post's featured image in a Block Bindings-native way (and will permit us to remove the custom code from the Cover block that's currently covering this use case).
- [ ] Figure out composite types. Should `core/post-data` return a composite `featured_media` field (which is itself an object with `id` and `url` keys)? Is there precedent for a media type in the Fields API?
- [ ] Reflect bound attribute in new DataForm control in block inspector (display bound image, use purple border to highlight?) ➡️ https://github.com/WordPress/gutenberg/pull/75137
- [ ] Use React 19's `useEffectEvent` once it becomes available (see https://github.com/WordPress/gutenberg/pull/74610#issuecomment-3916024005).