### PR TITLE
List View: Ensure element exists in document before focusing

### DIFF
--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -113,8 +113,10 @@ export function focusListItem( focusClientId, treeGridElement ) {
 			resolve( null );
 		}, 3000 );
 	} ).then( ( element ) => {
-		// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
-		focus.focusable.find( element )?.[ 0 ]?.focus();
+		if ( element && element.isConnected ) {
+			// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
+			focus.focusable.find( element )?.[ 0 ]?.focus();
+		}
 	} );
 }
 


### PR DESCRIPTION
## What?
Follow-up to #74431.

PR fixes a bug reported by @MaggieCabrera - https://github.com/WordPress/gutenberg/pull/74431#discussion_r2690204521. Adds extra checks for the node before trying to move focus.

## Testing Instructions
> open the overlay template selector for the navigation block
