### PR TITLE
Add template part context to navigation block

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/index.js
+++ b/packages/block-library/src/navigation-overlay-close/index.js
@@ -2,17 +2,15 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { select } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
+import { isWithinNavigationOverlay } from '../utils/is-within-overlay';
 import edit from './edit';
 import metadata from './block.json';
 import icon from './icon';
-import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../navigation/constants';
 
 const { name } = metadata;
 
@@ -22,40 +20,6 @@ export const settings = {
 	icon,
 	edit,
 };
-
-function isWithinOverlay() {
-	// @wordpress/block-library should not depend on @wordpress/editor.
-	// Blocks can be loaded into a *non-post* block editor, so to avoid
-	// declaring @wordpress/editor as a dependency, we must access its
-	// store by string.
-	// eslint-disable-next-line @wordpress/data-no-store-string-literals
-	const editorStore = select( 'core/editor' );
-
-	// Return false if the editor store is not available.
-	if ( ! editorStore ) {
-		return false;
-	}
-
-	const { getCurrentPostType, getCurrentPostId } = editorStore;
-	const { getEditedEntityRecord } = select( coreStore );
-
-	const postType = getCurrentPostType();
-	const postId = getCurrentPostId();
-
-	if ( postType === 'wp_template_part' && postId ) {
-		const templatePartEntity = getEditedEntityRecord(
-			'postType',
-			'wp_template_part',
-			postId
-		);
-
-		return (
-			templatePartEntity?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA
-		);
-	}
-
-	return false;
-}
 
 export const init = () => {
 	addFilter(
@@ -70,7 +34,7 @@ export const init = () => {
 				return canInsert;
 			}
 
-			return isWithinOverlay();
+			return isWithinNavigationOverlay();
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -77,6 +77,7 @@ import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
+import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import { DEFAULT_BLOCK } from '../constants';
 
 /**
@@ -271,6 +272,12 @@ function Navigation( {
 		hasIcon,
 		icon = 'handle',
 	} = attributes;
+
+	// Check if we're inside a navigation overlay template part.
+	const isNavigationOverlay = useSelect(
+		() => isWithinNavigationOverlay(),
+		[]
+	);
 
 	const ref = attributes.ref;
 
@@ -497,6 +504,7 @@ function Navigation( {
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 				'block-editor-block-content-overlay': hasBlockOverlay,
+				'is-within-navigation-overlay': isNavigationOverlay,
 			},
 			layoutClassNames
 		),

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -77,7 +77,6 @@ import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
-import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import { DEFAULT_BLOCK } from '../constants';
 
 /**
@@ -272,12 +271,6 @@ function Navigation( {
 		hasIcon,
 		icon = 'handle',
 	} = attributes;
-
-	// Check if we're inside a navigation overlay template part.
-	const isNavigationOverlay = useSelect(
-		() => isWithinNavigationOverlay(),
-		[]
-	);
 
 	const ref = attributes.ref;
 
@@ -504,7 +497,6 @@ function Navigation( {
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 				'block-editor-block-content-overlay': hasBlockOverlay,
-				'is-within-navigation-overlay': isNavigationOverlay,
 			},
 			layoutClassNames
 		),

--- a/packages/block-library/src/utils/is-within-overlay.js
+++ b/packages/block-library/src/utils/is-within-overlay.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../navigation/constants';
+
+/**
+ * Checks if the current editing context is within a navigation overlay template part.
+ *
+ * This utility exists because @wordpress/block-library cannot depend on @wordpress/editor
+ * as a package dependency. Blocks can be loaded into non-post block editors, so we must
+ * access the 'core/editor' store by string literal rather than importing it.
+ *
+ * React components should wrap this in useSelect for reactivity. Non-React contexts
+ * (like filter callbacks) can call this directly.
+ *
+ * @return {boolean} True if editing a navigation overlay template part, false otherwise.
+ */
+export function isWithinNavigationOverlay() {
+	// @wordpress/block-library should not depend on @wordpress/editor.
+	// Blocks can be loaded into a *non-post* block editor, so to avoid
+	// declaring @wordpress/editor as a dependency, we must access its
+	// store by string.
+	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+	const editorStore = select( 'core/editor' );
+
+	// Return false if the editor store is not available.
+	if ( ! editorStore ) {
+		return false;
+	}
+
+	const { getCurrentPostType, getCurrentPostId } = editorStore;
+	const { getEditedEntityRecord } = select( coreStore );
+
+	const postType = getCurrentPostType?.();
+	const postId = getCurrentPostId?.();
+
+	if ( postType === 'wp_template_part' && postId ) {
+		const templatePart = getEditedEntityRecord(
+			'postType',
+			'wp_template_part',
+			postId
+		);
+
+		return templatePart?.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA;
+	}
+
+	return false;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Extracts logic to a util for determining if the navigation block is rendering within a navigation overlay template part.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Refactor because we need it in several places.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Extract existing logic from navigation overlay close block

## Testing Instructions
Check that the overlay close button can still only be inserted within overlay template part areas.

