### PR TITLE
Replace @pmmmwh/react-refresh-webpack-plugin with react-refresh

### DIFF
--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -149,10 +149,11 @@ async function bundleReactRefresh() {
 	const entryDir = path.join( BUILD_DIR, 'react-refresh-entry' );
 	await mkdir( entryDir, { recursive: true } );
 
+	// The entry file uses ReactRefreshRuntime global, so no bundling needed
 	await esbuild.build( {
 		entryPoints: [ path.join( __dirname, 'react-refresh-entry.js' ) ],
 		outfile: path.join( entryDir, 'index.min.js' ),
-		bundle: true,
+		bundle: false,
 		format: 'iife',
 		target: 'es2015',
 		platform: 'browser',

--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -145,14 +145,12 @@ async function bundleReactJsxRuntime() {
 async function bundleReactRefresh() {
 	console.log( '📦 Bundling React Refresh...' );
 
-	// Bundle react-refresh-entry
+	// Bundle react-refresh-entry using react-refresh
 	const entryDir = path.join( BUILD_DIR, 'react-refresh-entry' );
 	await mkdir( entryDir, { recursive: true } );
 
 	await esbuild.build( {
-		entryPoints: [
-			'@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js',
-		],
+		entryPoints: [ path.join( __dirname, 'react-refresh-entry.js' ) ],
 		outfile: path.join( entryDir, 'index.min.js' ),
 		bundle: true,
 		format: 'iife',

--- a/bin/packages/react-refresh-entry.js
+++ b/bin/packages/react-refresh-entry.js
@@ -1,0 +1,11 @@
+/**
+ * React Refresh Entry
+ *
+ * Injects the React Refresh runtime into the global hook for hot module replacement.
+ */
+import RefreshRuntime from 'react-refresh/runtime';
+
+if ( ! globalThis.__reactRefreshInjected ) {
+	RefreshRuntime.injectIntoGlobalHook( globalThis );
+	globalThis.__reactRefreshInjected = true;
+}

--- a/bin/packages/react-refresh-entry.js
+++ b/bin/packages/react-refresh-entry.js
@@ -2,10 +2,15 @@
  * React Refresh Entry
  *
  * Injects the React Refresh runtime into the global hook for hot module replacement.
+ * This file uses the ReactRefreshRuntime global provided by wp-react-refresh-runtime.
  */
-import RefreshRuntime from 'react-refresh/runtime';
 
-if ( ! globalThis.__reactRefreshInjected ) {
-	RefreshRuntime.injectIntoGlobalHook( globalThis );
+/* global ReactRefreshRuntime */
+
+if (
+	typeof ReactRefreshRuntime !== 'undefined' &&
+	! globalThis.__reactRefreshInjected
+) {
+	ReactRefreshRuntime.injectIntoGlobalHook( globalThis );
 	globalThis.__reactRefreshInjected = true;
 }

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -41,6 +41,7 @@
 		"log-performance-results.js",
 		"packages/build-vendors.mjs",
 		"packages/build.mjs",
+		"packages/react-refresh-entry.js",
 		"packages/check-build-type-declaration-files.js",
 		"plugin/cli.js",
 		"plugin/commands/common.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
 				"@inquirer/prompts": "7.2.0",
 				"@octokit/rest": "16.26.0",
 				"@playwright/test": "1.57.0",
-				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@storybook/addon-a11y": "10.1.11",
 				"@storybook/addon-docs": "10.1.11",
 				"@storybook/icons": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"@inquirer/prompts": "7.2.0",
 		"@octokit/rest": "16.26.0",
 		"@playwright/test": "1.57.0",
-		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@storybook/addon-a11y": "10.1.11",
 		"@storybook/addon-docs": "10.1.11",
 		"@storybook/icons": "2.0.1",


### PR DESCRIPTION
## What?

Follow-up to #74396

Replace `@pmmmwh/react-refresh-webpack-plugin` with direct usage of `react-refresh` package for bundling the React Refresh entry point.

## Why?

As noted in https://github.com/WordPress/gutenberg/pull/74396#issuecomment-3749466226, the `@pmmmwh/react-refresh-webpack-plugin` package has `webpack` as a peer dependency. Since we are moving away from Webpack (as seen in the Storybook v10 migration to Vite), we can use the `react-refresh` package directly to eliminate the webpack peer dependency warning and achieve a cleaner separation from Webpack.

The `react-refresh` package is already a direct dependency, so this change simply uses it directly instead of going through the webpack plugin's entry file.

## How?

1. Created a new local entry file at `bin/packages/react-refresh-entry.js` that:

    - Uses the `ReactRefreshRuntime` global provided by `wp-react-refresh-runtime`
    - Injects the refresh runtime into the global hook (same as the webpack plugin did)
    - Guards against double-injection with a `globalThis.__reactRefreshInjected` flag

2. Updated `bin/packages/build-vendors.mjs` to:
    - Use the local entry file instead of `@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js`
    - Build without bundling since the entry file references an external global

3. Removed `@pmmmwh/react-refresh-webpack-plugin` from `package.json`

4. Added `packages/react-refresh-entry.js` to the TypeScript exclude list in `bin/tsconfig.json`

The entry file references the `ReactRefreshRuntime` global (provided by `wp-react-refresh-runtime`) and calls `injectIntoGlobalHook(globalThis)` to enable Fast Refresh during development. This matches the production WordPress build where `react-refresh/runtime` is externalized to `window.ReactRefreshRuntime`.

## Testing Instructions

1. Run `npm install` to update dependencies
2. Run `npm run build` and verify it completes successfully
3. Verify the build output exists:
    - `build/scripts/react-refresh-entry/index.min.js`
    - `build/scripts/react-refresh-entry/index.min.asset.php`
    - `build/scripts/react-refresh-runtime/index.min.js`
    - `build/scripts/react-refresh-runtime/index.min.asset.php`
    -
4. Start wp-env with WP 6.9, not trunk.
5. Open the browser console and verify that `window.ReactRefreshRuntime` is available when `SCRIPT_DEBUG` is enabled
6. Verify no JavaScript errors related to react-refresh in the console
7. Somewhere else, create a test block
    ```bash
    npx @wordpress/create-block@latest test-react-refresh --wp-env
    cd test-react-refresh
    npm run start -- --hot
    ```
8. Update `.wp-env.json` here in Gutenberg. Setting `core` to null means to use the production version, instead of `trunk`.
    ```diff
    - "core": "WordPress/WordPress",
    - "plugins": [ "." ],
    + "core": null,
    + "plugins": [ ".", "/absolute/path/to/test-react-refresh" ],
    ````
9. Run `npm run wp-env start`
10. Register react-refresh scripts for hot reloading in development to ensure that they are loaded from this repo and not from production.

<details><summary>Click to see the diff</summary>

```diff
diff --git a/lib/client-assets.php b/lib/client-assets.php
index cfbbc673b90..d838c6077bb 100644
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -369,6 +369,26 @@ function gutenberg_enqueue_stored_styles( $options = array() ) {
 function gutenberg_register_vendor_scripts( $scripts ) {
 	$extension = SCRIPT_DEBUG ? '.js' : '.min.js';
 
+	// Register react-refresh scripts for hot reloading in development.
+	if ( SCRIPT_DEBUG ) {
+		$react_refresh_runtime_asset = require gutenberg_dir_path() . 'build/scripts/react-refresh-runtime/index.min.asset.php';
+		gutenberg_override_script(
+			$scripts,
+			'wp-react-refresh-runtime',
+			gutenberg_url( 'build/scripts/react-refresh-runtime/index.min.js' ),
+			$react_refresh_runtime_asset['dependencies'],
+			$react_refresh_runtime_asset['version']
+		);
+
+		$react_refresh_entry_asset = require gutenberg_dir_path() . 'build/scripts/react-refresh-entry/index.min.asset.php';
+		gutenberg_override_script(
+			$scripts,
+			'wp-react-refresh-entry',
+			gutenberg_url( 'build/scripts/react-refresh-entry/index.min.js' ),
+			$react_refresh_entry_asset['dependencies'],
+			$react_refresh_entry_asset['version']
+		);
+	}
 	gutenberg_override_script(
 		$scripts,
 		'react',
```

</details>

11. Go to the dev site and verify that Gutenberg and the Test React Refresh plugins are active.
12. Create a post
13. Add the `Test React Refresh` block from the above test plugin
14. Make a change to some js file in `test-react-refresh` above
15. Confirm that the hot reload/replacement works

### Testing Instructions for Keyboard

N/A - This PR does not change the user interface.

## Screenshots or screencast

N/A - This is an internal build tooling change with no visual impact.
