### PR TITLE
Fix deprecations for Storybook component usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
 				"snapshot-diff": "0.10.0",
 				"sprintf-js": "1.1.1",
 				"storybook": "^10.1.11",
-				"storybook-addon-source-link": "2.0.1",
 				"storybook-addon-tag-badges": "3.0.4",
 				"style-loader": "3.2.1",
 				"stylelint-plugin-logical-css": "^1.2.3",
@@ -45615,36 +45614,6 @@
 				"prettier": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/storybook-addon-source-link": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/storybook-addon-source-link/-/storybook-addon-source-link-2.0.1.tgz",
-			"integrity": "sha512-CK8v2dLFk+QtjzNuSsOY+Bc48nzj6SUdpzyq9999kXto/5Bko9XQcG6QY8bqcw21qhXSKH/DA4spYOvpsU6oaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@storybook/addon-docs": "^10.0.0",
-				"@storybook/icons": "^1.4.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependencies": {
-				"storybook": "^10.0.0"
-			}
-		},
-		"node_modules/storybook-addon-source-link/node_modules/@storybook/icons": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.6.0.tgz",
-			"integrity": "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
 			}
 		},
 		"node_modules/storybook-addon-tag-badges": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
 		"snapshot-diff": "0.10.0",
 		"sprintf-js": "1.1.1",
 		"storybook": "^10.1.11",
-		"storybook-addon-source-link": "2.0.1",
 		"storybook-addon-tag-badges": "3.0.4",
 		"style-loader": "3.2.1",
 		"stylelint-plugin-logical-css": "^1.2.3",

--- a/storybook/addons/design-system-theme/manager.ts
+++ b/storybook/addons/design-system-theme/manager.ts
@@ -6,7 +6,7 @@ import { createElement, Fragment } from 'react';
 import { addons, types, useGlobals } from 'storybook/manager-api';
 import { MirrorIcon } from '@storybook/icons';
 import {
-	IconButton,
+	Button,
 	WithTooltip,
 	TooltipMessage,
 	TooltipLinkList,
@@ -76,9 +76,9 @@ const ThemeTool = () => {
 	);
 
 	const button = createElement(
-		IconButton,
-		{ title: 'Design System Theme', active: true },
-		createElement( MirrorIcon ),
+		Button,
+		{ ariaLabel: false },
+		createElement( MirrorIcon, { 'aria-hidden': true } ),
 		'Theme'
 	);
 

--- a/storybook/addons/source-link/manager.ts
+++ b/storybook/addons/source-link/manager.ts
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { createElement } from 'react';
+import { addons, types, useStorybookApi } from 'storybook/manager-api';
+import { JumpToIcon } from '@storybook/icons';
+import { Button } from 'storybook/internal/components';
+
+const ADDON_ID = '@wordpress/storybook-addon-source-link';
+
+const SourceLinkTool = () => {
+	const api = useStorybookApi();
+	const storyData = api.getCurrentStoryData();
+	if ( ! storyData ) {
+		return null;
+	}
+
+	let sourcePath;
+	if ( storyData.parameters?.sourceLink ) {
+		sourcePath = storyData.parameters.sourceLink;
+	} else if ( storyData.importPath ) {
+		// importPath is like "../packages/components/src/button/stories/index.story.tsx"
+		// Convert to component directory path: "packages/components/src/button"
+		sourcePath = storyData.importPath
+			.replace( /^\.\.\//, '' ) // Remove leading "../"
+			.replace( /^\.\//, '' ) // Remove leading "./" (for stories in storybook folder)
+			.replace( /\/stories\/.*$/, '' ); // Remove "/stories/..." suffix
+	}
+
+	if ( ! sourcePath ) {
+		return null;
+	}
+
+	const href = `https://github.com/WordPress/gutenberg/blob/trunk/${ sourcePath }`;
+
+	return createElement(
+		Button,
+		{
+			ariaLabel: 'Open source file',
+			title: 'Open source file',
+			asChild: true,
+		},
+		createElement(
+			'a',
+			{ href },
+			createElement( JumpToIcon, { 'aria-hidden': true } )
+		)
+	);
+};
+
+addons.register( ADDON_ID, () => {
+	addons.add( `${ ADDON_ID }/tool`, {
+		type: types.TOOL,
+		title: 'Source Link',
+		render: SourceLinkTool,
+	} );
+} );

--- a/storybook/addons/source-link/manager.ts
+++ b/storybook/addons/source-link/manager.ts
@@ -12,14 +12,11 @@ const ADDON_ID = '@wordpress/storybook-addon-source-link';
 const SourceLinkTool = () => {
 	const api = useStorybookApi();
 	const storyData = api.getCurrentStoryData();
-	if ( ! storyData ) {
-		return null;
-	}
 
 	let sourcePath;
-	if ( storyData.parameters?.sourceLink ) {
+	if ( storyData?.parameters?.sourceLink ) {
 		sourcePath = storyData.parameters.sourceLink;
-	} else if ( storyData.importPath ) {
+	} else if ( storyData?.importPath ) {
 		// importPath is like "../packages/components/src/button/stories/index.story.tsx"
 		// Convert to component directory path: "packages/components/src/button"
 		sourcePath = storyData.importPath

--- a/storybook/addons/source-link/manager.ts
+++ b/storybook/addons/source-link/manager.ts
@@ -38,11 +38,7 @@ const SourceLinkTool = () => {
 			title: 'Open source file',
 			asChild: true,
 		},
-		createElement(
-			'a',
-			{ href },
-			createElement( JumpToIcon, { 'aria-hidden': true } )
-		)
+		createElement( 'a', { href }, createElement( JumpToIcon ) )
 	);
 };
 

--- a/storybook/addons/source-link/preset.ts
+++ b/storybook/addons/source-link/preset.ts
@@ -1,0 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
+export const managerEntries = [
+	fileURLToPath( import.meta.resolve( './manager.ts' ) ),
+];

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -31,7 +31,7 @@ export default {
 			options: { configureJSX: true },
 		},
 		'@storybook/addon-a11y',
-		'storybook-addon-source-link',
+		import.meta.resolve( './addons/source-link/preset.ts' ),
 		'storybook-addon-tag-badges',
 		import.meta.resolve( './addons/design-system-theme/preset.ts' ),
 	],

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -136,31 +136,6 @@ export const parameters = {
 			],
 		},
 	},
-	sourceLink: {
-		links: {
-			// Disable default links
-			'component-editor': () => undefined,
-			'story-editor': () => undefined,
-			'addon-powered-by': () => undefined,
-			// Custom GitHub link
-			'story-github': ( { importPath } ) => {
-				if ( ! importPath ) {
-					return undefined;
-				}
-				// importPath is like "../packages/components/src/button/stories/index.story.tsx"
-				// Convert to component directory path: "packages/components/src/button"
-				const componentPath = importPath
-					.replace( /^\.\.\//, '' ) // Remove leading "../"
-					.replace( /^\.\//, '' ) // Remove leading "./" (for stories in storybook folder)
-					.replace( /\/stories\/.*$/, '' ); // Remove "/stories/..." suffix
-				return {
-					label: 'View source',
-					href: `https://github.com/WordPress/gutenberg/blob/trunk/${ componentPath }`,
-					icon: 'GithubIcon',
-				};
-			},
-		},
-	},
 };
 
 export const tags = [ 'autodocs' ];

--- a/storybook/stories/playground/index.story.jsx
+++ b/storybook/stories/playground/index.story.jsx
@@ -18,7 +18,7 @@ export const _default = () => {
 };
 
 _default.parameters = {
-	sourceLink: 'storybook/stories/playground/fullpage/index.js',
+	sourceLink: 'storybook/stories/playground/fullpage/index.jsx',
 };
 
 export const Box = () => {
@@ -26,7 +26,7 @@ export const Box = () => {
 };
 
 Box.parameters = {
-	sourceLink: 'storybook/stories/playground/box/index.js',
+	sourceLink: 'storybook/stories/playground/box/index.jsx',
 };
 
 export const UndoRedo = () => {
@@ -34,7 +34,7 @@ export const UndoRedo = () => {
 };
 
 UndoRedo.parameters = {
-	sourceLink: 'storybook/stories/playground/with-undo-redo/index.js',
+	sourceLink: 'storybook/stories/playground/with-undo-redo/index.jsx',
 };
 
 export const ZoomOut = ( props ) => {
@@ -42,7 +42,7 @@ export const ZoomOut = ( props ) => {
 };
 
 ZoomOut.parameters = {
-	sourceLink: 'storybook/stories/playground/zoom-out/index.js',
+	sourceLink: 'storybook/stories/playground/zoom-out/index.jsx',
 };
 ZoomOut.argTypes = {
 	zoomLevel: { control: { type: 'range', min: 10, max: 100, step: 5 } },


### PR DESCRIPTION
## What?

Follow-up to #74396

- Resolves deprecation warnings shown in Storybook
- Replaces `storybook-addon-source-link` with custom addon

Deprecations being resolved:

<img width="1246" height="284" alt="image" src="https://github.com/user-attachments/assets/17517290-35fd-4327-a34e-8da29b95741d" />

## Why?

- There should be no deprecation warnings
- Ensures accessible labeling for buttons
- Regarding the replacement of the third-party addon:
   - Several deprecation warnings come from this addon, which can't be resolved without upstream changes
   - Our usage is already so custom-tailored that it's just as much work to create an addon as it is to customize the existing addon
   - Saves a click by making the button a direct link, rather than opening a tooltip containing a single link

## Testing Instructions

Verify there are no warnings in the DevTools console and that source links continue to work as expected:

1. `npm run storybook:dev`
2. Go to http://localhost:50240/
3. Observe no warnings in DevTools console
4. Click <img width="48" height="36" alt="image" src="https://github.com/user-attachments/assets/b63c4ba4-ccd3-4a89-887d-403f86771fa9" /> ("Open source link") in the toolbar of a Story
5. Observe that it behaves the same as the source link at the equivalent story in the previous version at https://wordpress.github.io/gutenberg/
