### PR TITLE
Add `Tooltip` component to `@wordpress/ui`

### DIFF
--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -36,6 +36,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/routes',
 	'@wordpress/sync',
 	'@wordpress/theme',
+	'@wordpress/ui',
 	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,4 +4,5 @@ export * from './button';
 export * from './form/primitives';
 export * from './icon';
 export * from './stack';
+export * as Tooltip from './tooltip';
 export * from './visually-hidden';

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { Popup } from './popup';
 import { Trigger } from './trigger';
 import { Root } from './root';

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { Popup } from './popup';
+import { Trigger } from './trigger';
+import { Root } from './root';
+import { Provider } from './provider';
+
+export { Provider, Root, Trigger, Popup };

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { Tooltip } from '@base-ui/react/tooltip';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { PopupProps } from './types';
+import resetStyles from '../utils/css/resets.module.css';
+import styles from './style.module.css';
+
+const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
+	{
+		align = 'center',
+		side = 'bottom',
+		sideOffset = 4,
+		children,
+		className,
+		style,
+		...props
+	},
+	ref
+) {
+	return (
+		<Tooltip.Portal>
+			<Tooltip.Positioner
+				align={ align }
+				side={ side }
+				sideOffset={ sideOffset }
+				style={ style }
+				className={ clsx(
+					resetStyles[ 'box-sizing' ],
+					className,
+					styles.positioner
+				) }
+			>
+				<Tooltip.Popup
+					ref={ ref }
+					className={ styles.popup }
+					{ ...props }
+				>
+					{ children }
+				</Tooltip.Popup>
+			</Tooltip.Positioner>
+		</Tooltip.Portal>
+	);
+} );
+
+export { Popup };

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,20 +1,17 @@
-/**
- * External dependencies
- */
 import clsx from 'clsx';
 import { Tooltip } from '@base-ui/react/tooltip';
-
-/**
- * WordPress dependencies
- */
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
 import type { PopupProps } from './types';
+import { unlock } from '../lock-unlock';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	{
@@ -41,13 +38,15 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 					styles.positioner
 				) }
 			>
-				<Tooltip.Popup
-					ref={ ref }
-					className={ styles.popup }
-					{ ...props }
-				>
-					{ children }
-				</Tooltip.Popup>
+				<ThemeProvider color={ { bg: '#1e1e1e' } }>
+					<Tooltip.Popup
+						ref={ ref }
+						className={ styles.popup }
+						{ ...props }
+					>
+						{ children }
+					</Tooltip.Popup>
+				</ThemeProvider>
 			</Tooltip.Positioner>
 		</Tooltip.Portal>
 	);

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -38,6 +38,15 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 					styles.positioner
 				) }
 			>
+				{ /* This should ideally use whatever dark color makes sense,
+				and not be hardcoded to #1e1e1e. The solutions would be to:
+				  - review the design of the tooltip, in case we want to stop
+				    hardcoding it to a dark background
+				  - create new semantic tokens as needed (aliasing either the "inverted
+					  bg" or "perma-dark bg" private tokens) and have Tooltip.Popup use
+				    them;
+				  - remove the hardcoded `bg` setting from the `ThemeProvider` below
+					*/ }
 				<ThemeProvider color={ { bg: '#1e1e1e' } }>
 					<Tooltip.Popup
 						ref={ ref }

--- a/packages/ui/src/tooltip/provider.tsx
+++ b/packages/ui/src/tooltip/provider.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { Tooltip } from '@base-ui/react/tooltip';
+
+/**
+ * Internal dependencies
+ */
+import type { ProviderProps } from './types';
+
+function Provider( { children, ...props }: ProviderProps ) {
+	return <Tooltip.Provider { ...props }>{ children }</Tooltip.Provider>;
+}
+
+export { Provider };

--- a/packages/ui/src/tooltip/provider.tsx
+++ b/packages/ui/src/tooltip/provider.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { Tooltip } from '@base-ui/react/tooltip';
-
-/**
- * Internal dependencies
- */
 import type { ProviderProps } from './types';
 
 function Provider( { children, ...props }: ProviderProps ) {

--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { Tooltip } from '@base-ui/react/tooltip';
+
+/**
+ * Internal dependencies
+ */
+import type { RootProps } from './types';
+
+function Root( props: RootProps ) {
+	return <Tooltip.Root { ...props } />;
+}
+
+export { Root };

--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { Tooltip } from '@base-ui/react/tooltip';
-
-/**
- * Internal dependencies
- */
 import type { RootProps } from './types';
 
 function Root( props: RootProps ) {

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button, Tooltip } from '../..';
+import { Tooltip } from '../..';
 
 const meta: Meta< typeof Tooltip.Root > = {
 	title: 'Design System/Components/Tooltip',
@@ -51,22 +51,22 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
 			} }
 		>
 			<Tooltip.Root>
-				<Tooltip.Trigger render={ <Button>Top</Button> } />
+				<Tooltip.Trigger>Top</Tooltip.Trigger>
 				<Tooltip.Popup side="top">Tooltip on top</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger render={ <Button>Right</Button> } />
+				<Tooltip.Trigger>Right</Tooltip.Trigger>
 				<Tooltip.Popup side="right">Tooltip on right</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger render={ <Button>Bottom</Button> } />
+				<Tooltip.Trigger>Bottom</Tooltip.Trigger>
 				<Tooltip.Popup side="bottom">Tooltip on bottom</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger render={ <Button>Left</Button> } />
+				<Tooltip.Trigger>Left</Tooltip.Trigger>
 				<Tooltip.Popup side="left">Tooltip on left</Tooltip.Popup>
 			</Tooltip.Root>
 		</div>
@@ -83,30 +83,15 @@ export const WithProvider: StoryObj< typeof Tooltip.Root > = {
 		<Tooltip.Provider delay={ 0 }>
 			<div style={ { display: 'flex', gap: '1rem' } }>
 				<Tooltip.Root>
-					<Tooltip.Trigger render={ <Button>First</Button> } />
+					<Tooltip.Trigger>First</Tooltip.Trigger>
 					<Tooltip.Popup>First tooltip</Tooltip.Popup>
 				</Tooltip.Root>
 
 				<Tooltip.Root>
-					<Tooltip.Trigger render={ <Button>Second</Button> } />
+					<Tooltip.Trigger>Second</Tooltip.Trigger>
 					<Tooltip.Popup>Second tooltip</Tooltip.Popup>
 				</Tooltip.Root>
 			</div>
 		</Tooltip.Provider>
-	),
-};
-
-/**
- * Tooltips work seamlessly with Button components using the `render` prop
- * on the trigger.
- */
-export const WithButton: StoryObj< typeof Tooltip.Root > = {
-	render: () => (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				render={ <Button variant="outline">Hover this button</Button> }
-			/>
-			<Tooltip.Popup>This is a tooltip for the button</Tooltip.Popup>
-		</Tooltip.Root>
 	),
 };

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Tooltip } from '../../index';
+
+const meta: Meta< typeof Tooltip.Root > = {
+	title: 'Design System/Components/Tooltip',
+	component: Tooltip.Root,
+	subcomponents: {
+		'Tooltip.Provider': Tooltip.Provider,
+		'Tooltip.Trigger': Tooltip.Trigger,
+		'Tooltip.Popup': Tooltip.Popup,
+	},
+};
+export default meta;
+
+export const Default: StoryObj< typeof Tooltip.Root > = {
+	args: {
+		children: (
+			<>
+				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+				<Tooltip.Popup>Tooltip text</Tooltip.Popup>
+			</>
+		),
+	},
+};
+
+/**
+ * The `disabled` prop prevents the tooltip from showing, and can be used to
+ * show the tooltip conditionally without rendering the underlying react
+ * component conditionally (which could cause reconciliation issues).
+ */
+export const Disabled: StoryObj< typeof Tooltip.Root > = {
+	...Default,
+	args: {
+		...Default.args,
+		disabled: true,
+	},
+};
+
+/**
+ * Use the `side` prop to control where the tooltip appears relative to the
+ * trigger element.
+ */
+export const Positioning: StoryObj< typeof Tooltip.Root > = {
+	render: () => (
+		<div
+			style={ {
+				display: 'flex',
+				gap: '2rem',
+				padding: '4rem',
+				justifyContent: 'center',
+			} }
+		>
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ <Button>Top</Button> } />
+				<Tooltip.Popup side="top">Tooltip on top</Tooltip.Popup>
+			</Tooltip.Root>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ <Button>Right</Button> } />
+				<Tooltip.Popup side="right">Tooltip on right</Tooltip.Popup>
+			</Tooltip.Root>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ <Button>Bottom</Button> } />
+				<Tooltip.Popup side="bottom">Tooltip on bottom</Tooltip.Popup>
+			</Tooltip.Root>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ <Button>Left</Button> } />
+				<Tooltip.Popup side="left">Tooltip on left</Tooltip.Popup>
+			</Tooltip.Root>
+		</div>
+	),
+};
+
+/**
+ * Use `Tooltip.Provider` to control the delay before tooltips appear.
+ * This is useful when you have multiple tooltips and want them to share
+ * the same delay configuration.
+ */
+export const WithProvider: StoryObj< typeof Tooltip.Root > = {
+	render: () => (
+		<Tooltip.Provider delay={ 0 }>
+			<div style={ { display: 'flex', gap: '1rem' } }>
+				<Tooltip.Root>
+					<Tooltip.Trigger render={ <Button>First</Button> } />
+					<Tooltip.Popup>First tooltip</Tooltip.Popup>
+				</Tooltip.Root>
+
+				<Tooltip.Root>
+					<Tooltip.Trigger render={ <Button>Second</Button> } />
+					<Tooltip.Popup>Second tooltip</Tooltip.Popup>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	),
+};
+
+/**
+ * Tooltips work seamlessly with Button components using the `render` prop
+ * on the trigger.
+ */
+export const WithButton: StoryObj< typeof Tooltip.Root > = {
+	render: () => (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={ <Button variant="outline">Hover this button</Button> }
+			/>
+			<Tooltip.Popup>This is a tooltip for the button</Tooltip.Popup>
+		</Tooltip.Root>
+	),
+};

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
-import { Button, Tooltip } from '../../index';
+import { Button, Tooltip } from '../..';
 
 const meta: Meta< typeof Tooltip.Root > = {
 	title: 'Design System/Components/Tooltip',
 	component: Tooltip.Root,
 	subcomponents: {
-		'Tooltip.Provider': Tooltip.Provider,
-		'Tooltip.Trigger': Tooltip.Trigger,
-		'Tooltip.Popup': Tooltip.Popup,
+		Provider: Tooltip.Provider,
+		Trigger: Tooltip.Trigger,
+		Popup: Tooltip.Popup,
 	},
 };
 export default meta;

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -1,0 +1,19 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+	.positioner {
+		z-index: var( --wp-ui-tooltip-z-index, initial );
+	}
+
+	.popup {
+		background-color: var( --wpds-color-bg-surface-neutral-strong );
+		padding: var( --wpds-dimension-base )
+			calc( 2 * var( --wpds-dimension-base ) );
+		border-radius: var( --wpds-border-radius-surface-sm );
+		font-family: var( --wpds-font-family-body );
+		font-size: var( --wpds-font-size-sm );
+		line-height: 1.4;
+		color: var( --wpds-color-fg-content-neutral );
+		box-shadow: var( --wpds-elevation-small );
+	}
+}

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -7,8 +7,8 @@
 
 	.popup {
 		background-color: var( --wpds-color-bg-surface-neutral-strong );
-		padding: var( --wpds-dimension-base )
-			calc( 2 * var( --wpds-dimension-base ) );
+		padding: var( --wpds-dimension-padding-surface-2xs )
+			var( --wpds-dimension-padding-surface-xs );
 		border-radius: var( --wpds-border-radius-surface-sm );
 		font-family: var( --wpds-font-family-body );
 		font-size: var( --wpds-font-size-sm );

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -12,7 +12,7 @@
 		border-radius: var( --wpds-border-radius-surface-sm );
 		font-family: var( --wpds-font-family-body );
 		font-size: var( --wpds-font-size-sm );
-		line-height: 1.4;
+		line-height: 1.4; /* TODO: use DS token for line height */
 		color: var( --wpds-color-fg-content-neutral );
 		box-shadow: var( --wpds-elevation-small );
 	}

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -2,18 +2,19 @@
 
 @layer wp-ui-components {
 	.positioner {
-		z-index: var( --wp-ui-tooltip-z-index, initial );
+		z-index: var(--wp-ui-tooltip-z-index, initial);
 	}
 
 	.popup {
-		background-color: var( --wpds-color-bg-surface-neutral-strong );
-		padding: var( --wpds-dimension-padding-surface-2xs )
-			var( --wpds-dimension-padding-surface-xs );
-		border-radius: var( --wpds-border-radius-surface-sm );
-		font-family: var( --wpds-font-family-body );
-		font-size: var( --wpds-font-size-sm );
+		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		padding:
+			var(--wpds-dimension-padding-surface-2xs)
+			var(--wpds-dimension-padding-surface-xs);
+		border-radius: var(--wpds-border-radius-surface-sm);
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-sm);
 		line-height: 1.4; /* TODO: use DS token for line height */
-		color: var( --wpds-color-fg-content-neutral );
-		box-shadow: var( --wpds-elevation-small );
+		color: var(--wpds-color-fg-content-neutral);
+		box-shadow: var(--wpds-elevation-small);
 	}
 }

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -2,6 +2,16 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import * as Tooltip from '../index';
+import type { ProviderProps } from '../types';
+
+// Test wrapper that sets delay={0} to avoid real-time delays in tests.
+function TestProvider( { children, ...props }: ProviderProps ) {
+	return (
+		<Tooltip.Provider delay={ 0 } { ...props }>
+			{ children }
+		</Tooltip.Provider>
+	);
+}
 
 describe( 'Tooltip', () => {
 	it( 'forwards ref', async () => {
@@ -10,14 +20,14 @@ describe( 'Tooltip', () => {
 		const popupRef = createRef< HTMLDivElement >();
 
 		render(
-			<Tooltip.Provider delay={ 0 }>
+			<TestProvider>
 				<Tooltip.Root>
 					<Tooltip.Trigger ref={ triggerRef }>
 						<span>Hover me</span>
 					</Tooltip.Trigger>
 					<Tooltip.Popup ref={ popupRef }>Tooltip text</Tooltip.Popup>
 				</Tooltip.Root>
-			</Tooltip.Provider>
+			</TestProvider>
 		);
 
 		// Test trigger ref before interaction
@@ -36,12 +46,12 @@ describe( 'Tooltip', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Tooltip.Provider delay={ 0 }>
+			<TestProvider>
 				<Tooltip.Root>
 					<Tooltip.Trigger>Hover me</Tooltip.Trigger>
 					<Tooltip.Popup>Tooltip content</Tooltip.Popup>
 				</Tooltip.Root>
-			</Tooltip.Provider>
+			</TestProvider>
 		);
 
 		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
@@ -59,12 +69,12 @@ describe( 'Tooltip', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Tooltip.Provider delay={ 0 }>
+			<TestProvider>
 				<Tooltip.Root disabled>
 					<Tooltip.Trigger>Hover me</Tooltip.Trigger>
 					<Tooltip.Popup>Tooltip content</Tooltip.Popup>
 				</Tooltip.Root>
-			</Tooltip.Provider>
+			</TestProvider>
 		);
 
 		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -10,12 +10,14 @@ describe( 'Tooltip', () => {
 		const popupRef = createRef< HTMLDivElement >();
 
 		render(
-			<Tooltip.Root>
-				<Tooltip.Trigger ref={ triggerRef }>
-					<span>Hover me</span>
-				</Tooltip.Trigger>
-				<Tooltip.Popup ref={ popupRef }>Tooltip text</Tooltip.Popup>
-			</Tooltip.Root>
+			<Tooltip.Provider delay={ 0 }>
+				<Tooltip.Root>
+					<Tooltip.Trigger ref={ triggerRef }>
+						<span>Hover me</span>
+					</Tooltip.Trigger>
+					<Tooltip.Popup ref={ popupRef }>Tooltip text</Tooltip.Popup>
+				</Tooltip.Root>
+			</Tooltip.Provider>
 		);
 
 		// Test trigger ref before interaction
@@ -34,10 +36,12 @@ describe( 'Tooltip', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Tooltip.Root>
-				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
-				<Tooltip.Popup>Tooltip content</Tooltip.Popup>
-			</Tooltip.Root>
+			<Tooltip.Provider delay={ 0 }>
+				<Tooltip.Root>
+					<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+					<Tooltip.Popup>Tooltip content</Tooltip.Popup>
+				</Tooltip.Root>
+			</Tooltip.Provider>
 		);
 
 		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
@@ -52,17 +56,16 @@ describe( 'Tooltip', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Tooltip.Root disabled>
-				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
-				<Tooltip.Popup>Tooltip content</Tooltip.Popup>
-			</Tooltip.Root>
+			<Tooltip.Provider delay={ 0 }>
+				<Tooltip.Root disabled>
+					<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+					<Tooltip.Popup>Tooltip content</Tooltip.Popup>
+				</Tooltip.Root>
+			</Tooltip.Provider>
 		);
 
 		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
 		await user.hover( trigger );
-
-		// Give it some time to potentially appear
-		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
 
 		expect(
 			screen.queryByText( 'Tooltip content' )

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -47,6 +47,9 @@ describe( 'Tooltip', () => {
 		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
 		await user.hover( trigger );
 
+		// waitFor is used intentionally: even with delay={0}, the popup appearing
+		// is conceptually async (state change → render → portal mount). This also
+		// makes the test resilient to future internal changes in base-ui.
 		await waitFor( () => {
 			expect( screen.getByText( 'Tooltip content' ) ).toBeVisible();
 		} );

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-/**
- * WordPress dependencies
- */
 import { createRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import * as Tooltip from '../index';
 
 describe( 'Tooltip', () => {

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as Tooltip from '../index';
+
+describe( 'Tooltip', () => {
+	it( 'forwards ref', async () => {
+		const user = userEvent.setup();
+		const triggerRef = createRef< HTMLButtonElement >();
+		const popupRef = createRef< HTMLDivElement >();
+
+		render(
+			<Tooltip.Root>
+				<Tooltip.Trigger ref={ triggerRef }>
+					<span>Hover me</span>
+				</Tooltip.Trigger>
+				<Tooltip.Popup ref={ popupRef }>Tooltip text</Tooltip.Popup>
+			</Tooltip.Root>
+		);
+
+		// Test trigger ref before interaction
+		expect( triggerRef.current ).toBeInstanceOf( HTMLButtonElement );
+
+		// Hover over the trigger to open the tooltip
+		await user.hover( triggerRef.current! );
+
+		// Wait for the tooltip popup to appear
+		await waitFor( () => {
+			expect( popupRef.current ).toBeInstanceOf( HTMLDivElement );
+		} );
+	} );
+
+	it( 'shows tooltip on hover', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Tooltip.Root>
+				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+				<Tooltip.Popup>Tooltip content</Tooltip.Popup>
+			</Tooltip.Root>
+		);
+
+		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
+		await user.hover( trigger );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Tooltip content' ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'does not show tooltip when disabled', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Tooltip.Root disabled>
+				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+				<Tooltip.Popup>Tooltip content</Tooltip.Popup>
+			</Tooltip.Root>
+		);
+
+		const trigger = screen.getByRole( 'button', { name: 'Hover me' } );
+		await user.hover( trigger );
+
+		// Give it some time to potentially appear
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+
+		expect(
+			screen.queryByText( 'Tooltip content' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/ui/src/tooltip/trigger.tsx
+++ b/packages/ui/src/tooltip/trigger.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { Tooltip } from '@base-ui/react/tooltip';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { TriggerProps } from './types';
+
+const Trigger = forwardRef< HTMLButtonElement, TriggerProps >(
+	function TooltipTrigger( { children, ...props }, ref ) {
+		return (
+			<Tooltip.Trigger ref={ ref } { ...props }>
+				{ children }
+			</Tooltip.Trigger>
+		);
+	}
+);
+
+export { Trigger };

--- a/packages/ui/src/tooltip/trigger.tsx
+++ b/packages/ui/src/tooltip/trigger.tsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
 import { Tooltip } from '@base-ui/react/tooltip';
-
-/**
- * WordPress dependencies
- */
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { TriggerProps } from './types';
 
 const Trigger = forwardRef< HTMLButtonElement, TriggerProps >(

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+import type { Tooltip } from '@base-ui/react/tooltip';
+
+/**
+ * Internal dependencies
+ */
+import type { ComponentProps } from '../utils/types';
+
+export type RootProps = Pick< Tooltip.Root.Props, 'disabled' | 'children' >;
+
+export type ProviderProps = Pick<
+	Tooltip.Provider.Props,
+	'delay' | 'children'
+>;
+
+export interface TriggerProps extends ComponentProps< 'button' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface PopupProps
+	extends ComponentProps< 'div' >,
+		Pick< Tooltip.Positioner.Props, 'align' | 'side' | 'sideOffset' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import type { ReactNode } from 'react';
 import type { Tooltip } from '@base-ui/react/tooltip';
-
-/**
- * Internal dependencies
- */
 import type { ComponentProps } from '../utils/types';
 
 export type RootProps = Pick< Tooltip.Root.Props, 'disabled' | 'children' >;


### PR DESCRIPTION
## What?

Add `Tooltip` compound component to `@wordpress/ui`

## Why?

This component is a blocker for migrating `IconButton`, which depends on `Tooltip` for displaying accessible labels on hover.

## How?

The component wraps `@base-ui/react/tooltip` and provides:
- `Tooltip.Root` - Container component
- `Tooltip.Provider` - Shared delay configuration
- `Tooltip.Trigger` - Element that triggers the tooltip
- `Tooltip.Popup` - The tooltip content with positioning

## Testing Instructions

See stories in Storybook under **Design System/Components/Tooltip**.

```bash
npm run storybook:dev
```

<img width="915" height="999" alt="image" src="https://github.com/user-attachments/assets/75f18eb3-13b7-472e-94a2-240ff45eb7bc" />

## Tests

```
npm run test:unit packages/ui/src/tooltip/test/
```

