### PR TITLE
Enable components manifest for Storybook

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -32,6 +32,8 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Build Storybook
+              env:
+                  NODE_ENV: test
               run: npm run storybook:build
 
             - name: Install test-runner and Playwright dependencies

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -28,6 +28,8 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Build Storybook
+              env:
+                  NODE_ENV: production
               run: npm run storybook:build
 
             - name: Deploy

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -38,7 +38,9 @@ export default {
 		import.meta.resolve( './addons/design-system-theme/preset.ts' ),
 	],
 	framework: '@storybook/react-vite',
-	docs: {},
+	features: {
+		experimentalComponentsManifest: NODE_ENV === 'production',
+	},
 	typescript: {
 		reactDocgen: 'react-docgen-typescript',
 		// Should match defaults in Storybook except for the propFilter.

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -83,6 +83,9 @@ export default {
 					},
 				},
 			],
+			build: {
+				minify: NODE_ENV === 'production',
+			},
 			define: {
 				// Ensures that `@wordpress/warning` can properly detect dev mode.
 				'globalThis.SCRIPT_DEBUG': JSON.stringify(

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -1,10 +1,12 @@
-import { mergeConfig, transformWithEsbuild } from 'vite';
+import { type InlineConfig, mergeConfig, transformWithEsbuild } from 'vite';
 import react from '@vitejs/plugin-react';
 import type { StorybookConfig } from '@storybook/react-vite';
 
+const { NODE_ENV = 'development' } = process.env;
+
 const stories = [
-	process.env.NODE_ENV !== 'test' ? './stories/**/*.story.@(jsx|tsx)' : '',
-	process.env.NODE_ENV !== 'test' ? './stories/**/*.mdx' : '',
+	NODE_ENV !== 'test' ? './stories/**/*.story.@(jsx|tsx)' : '',
+	NODE_ENV !== 'test' ? './stories/**/*.mdx' : '',
 	'../packages/block-editor/src/**/stories/*.story.@(js|jsx|tsx|mdx)',
 	'../packages/components/src/**/stories/*.story.@(jsx|tsx)',
 	'../packages/components/src/**/stories/*.mdx',
@@ -84,7 +86,7 @@ export default {
 			define: {
 				// Ensures that `@wordpress/warning` can properly detect dev mode.
 				'globalThis.SCRIPT_DEBUG': JSON.stringify(
-					process.env.NODE_ENV === 'development'
+					NODE_ENV === 'development'
 				),
 			},
 			optimizeDeps: {
@@ -94,6 +96,6 @@ export default {
 					},
 				},
 			},
-		} );
+		} satisfies InlineConfig );
 	},
 } satisfies StorybookConfig;

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -5,8 +5,13 @@ import type { StorybookConfig } from '@storybook/react-vite';
 const { NODE_ENV = 'development' } = process.env;
 
 const stories = [
-	NODE_ENV !== 'test' ? './stories/**/*.story.@(jsx|tsx)' : '',
-	NODE_ENV !== 'test' ? './stories/**/*.mdx' : '',
+	// Smoke tests ensure that the stories are rendered without any errors, but
+	// we don't need to test everything:
+	// - `.mdx` documentation is generally plain text and unlikely to break.
+	// - Playground stories are complex renderings of many components, which is
+	//   both slow and redundant with individual component stories.
+	NODE_ENV === 'test' ? '' : './stories/playground/**/*.story.@(jsx|tsx)',
+	NODE_ENV === 'test' ? '' : './stories/**/*.mdx',
 	'../packages/block-editor/src/**/stories/*.story.@(js|jsx|tsx|mdx)',
 	'../packages/components/src/**/stories/*.story.@(jsx|tsx)',
 	'../packages/components/src/**/stories/*.mdx',


### PR DESCRIPTION
## What?

- Enables component manifest output in Storybook builds
- A few other "env" related improvements:
   - Fix consideration of `NODE_ENV` when environment variables were not previously present
   - Enable minification only in production builds (improved developer experience with debuggability and build time)

## Why?

Components manifests are [an experimental feature included in v10.1](https://storybook.js.org/releases/10.1) and specifically [tailored for Storybook's official MCP addon](https://www.npmjs.com/package/@storybook/addon-mcp#docs-tools-experimental). Enabling the components manifest produces a `manifests/components.json` file which includes detailed metadata about components included in the Storybook, which can be useful for subsequent AI MCP server explorations.

## Testing Instructions

Verify that the components manifest is generated when `NODE_ENV` is `'production'`. Typically this would be for the live instance at https://wordpress.github.io/gutenberg/ , but you can also produce this locally with either `storybook:build` or `storybook:dev` commands.

With `storybook:build`:

1. Run `NODE_ENV=production npm run storybook:build`
2. Observe local contents of generated file, e.g. `cat storybook/build/manifests/components.json | head -c250`

With `storybook:dev`

1. Run `NODE_ENV=production npm run storybook:dev`
2. Go to http://localhost:50240/manifests/components.json
3. Observe generated file