### PR TITLE
Infrastructure: Convert storybook to a workspace package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"packages/*",
-				"routes/*"
+				"routes/*",
+				"storybook"
 			],
 			"devDependencies": {
 				"@apidevtools/json-schema-ref-parser": "11.6.4",
@@ -23,10 +24,6 @@
 				"@octokit/rest": "16.26.0",
 				"@playwright/test": "1.57.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
-				"@storybook/addon-a11y": "10.1.11",
-				"@storybook/addon-docs": "10.1.11",
-				"@storybook/icons": "2.0.1",
-				"@storybook/react-vite": "10.1.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "14.3.0",
 				"@testing-library/user-event": "14.4.3",
@@ -98,8 +95,6 @@
 				"simple-git": "3.24.0",
 				"snapshot-diff": "0.10.0",
 				"sprintf-js": "1.1.1",
-				"storybook": "^10.1.11",
-				"storybook-addon-tag-badges": "3.0.4",
 				"style-loader": "3.2.1",
 				"stylelint-plugin-logical-css": "^1.2.3",
 				"typescript": "5.9.3",
@@ -17710,6 +17705,10 @@
 		},
 		"node_modules/@wordpress/shortcode": {
 			"resolved": "packages/shortcode",
+			"link": true
+		},
+		"node_modules/@wordpress/storybook": {
+			"resolved": "storybook",
 			"link": true
 		},
 		"node_modules/@wordpress/style-engine": {
@@ -55494,6 +55493,19 @@
 				"@wordpress/views": "file:../../packages/views",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"
+			}
+		},
+		"storybook": {
+			"name": "@wordpress/storybook",
+			"version": "0.0.0",
+			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"@storybook/addon-a11y": "^10.1.11",
+				"@storybook/addon-docs": "^10.1.11",
+				"@storybook/icons": "^2.0.1",
+				"@storybook/react-vite": "^10.1.11",
+				"storybook": "^10.1.11",
+				"storybook-addon-tag-badges": "^3.0.4"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52488,6 +52488,7 @@
 			"devDependencies": {
 				"@ariakit/test": "^0.4.7",
 				"@storybook/addon-docs": "^10.1.11",
+				"@storybook/react-vite": "^10.1.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@types/jest": "^29.5.14",
 				"@wordpress/jest-console": "file:../jest-console",
@@ -52829,6 +52830,7 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
+				"@storybook/react-vite": "^10.1.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@types/jest": "^29.5.14",
 				"esbuild": "^0.27.2",
@@ -54934,6 +54936,7 @@
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
+				"@storybook/react-vite": "^10.1.11",
 				"@terrazzo/cli": "^0.10.2",
 				"@terrazzo/plugin-css": "^0.10.2",
 				"@terrazzo/token-tools": "^0.10.2",
@@ -54993,6 +54996,7 @@
 			},
 			"devDependencies": {
 				"@storybook/addon-docs": "^10.1.11",
+				"@storybook/react-vite": "^10.1.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.10",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,6 @@
 		"@octokit/rest": "16.26.0",
 		"@playwright/test": "1.57.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
-		"@storybook/addon-a11y": "10.1.11",
-		"@storybook/addon-docs": "10.1.11",
-		"@storybook/icons": "2.0.1",
-		"@storybook/react-vite": "10.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "14.3.0",
 		"@testing-library/user-event": "14.4.3",
@@ -121,8 +117,6 @@
 		"simple-git": "3.24.0",
 		"snapshot-diff": "0.10.0",
 		"sprintf-js": "1.1.1",
-		"storybook": "^10.1.11",
-		"storybook-addon-tag-badges": "3.0.4",
 		"style-loader": "3.2.1",
 		"stylelint-plugin-logical-css": "^1.2.3",
 		"typescript": "5.9.3",
@@ -180,8 +174,8 @@
 		"prepublishOnly": "npm run build",
 		"start": "npm run dev",
 		"prestorybook:build": "npm run build -- --skip-types",
-		"storybook:build": "storybook build -c ./storybook -o ./storybook/build",
-		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c ./storybook -p 50240\"",
+		"storybook:build": "npm run --workspace @wordpress/storybook storybook:build",
+		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && npm run --workspace @wordpress/storybook storybook:dev\"",
 		"storybook:e2e:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && storybook dev -c test/storybook-playwright/storybook -p 50241\"",
 		"test": "npm-run-all lint test:unit",
 		"test:create-block": "bash ./bin/test-create-block.sh",
@@ -253,6 +247,7 @@
 	},
 	"workspaces": [
 		"packages/*",
-		"routes/*"
+		"routes/*",
+		"storybook"
 	]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -102,6 +102,7 @@
 	"devDependencies": {
 		"@ariakit/test": "^0.4.7",
 		"@storybook/addon-docs": "^10.1.11",
+		"@storybook/react-vite": "^10.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/jest": "^29.5.14",
 		"@wordpress/jest-console": "file:../jest-console",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -78,6 +78,7 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
+		"@storybook/react-vite": "^10.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/jest": "^29.5.14",
 		"esbuild": "^0.27.2",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -70,6 +70,7 @@
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {
+		"@storybook/react-vite": "^10.1.11",
 		"@terrazzo/cli": "^0.10.2",
 		"@terrazzo/plugin-css": "^0.10.2",
 		"@terrazzo/token-tools": "^0.10.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,7 @@
 	},
 	"devDependencies": {
 		"@storybook/addon-docs": "^10.1.11",
+		"@storybook/react-vite": "^10.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^20.17.10",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@wordpress/storybook",
+	"version": "0.0.0",
+	"description": "Storybook for WordPress Gutenberg components.",
+	"private": true,
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"storybook"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/storybook/README.md",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/WordPress/gutenberg.git",
+		"directory": "storybook"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"devDependencies": {
+		"@storybook/addon-a11y": "^10.1.11",
+		"@storybook/addon-docs": "^10.1.11",
+		"@storybook/icons": "^2.0.1",
+		"@storybook/react-vite": "^10.1.11",
+		"storybook": "^10.1.11",
+		"storybook-addon-tag-badges": "^3.0.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"storybook:build": "storybook build -c . -o ./build",
+		"storybook:dev": "storybook dev -c . -p 50240"
+	}
+}


### PR DESCRIPTION
## What?

Initially tried as a part of #74143 but everyone thought it would be better to do it separately.

Inspired by #74309

Convert `./storybook` to a workspace package (`@wordpress/storybook`) to isolate Storybook-related configuration and dependencies.

## Why?

-   **Clean up root `package.json`**: Moves Storybook-specific dependencies out of the root, reducing clutter and making the root package.json cleaner.
-   **Better dependency isolation**: Storybook dependencies are now encapsulated within their own package, making it clearer what belongs to Storybook vs the root.
-   **Preparation for pnpm migration**: This workspace structure aligns better with pnpm's workspace management, paving the way for [migration to pnpm](https://github.com/WordPress/gutenberg/discussions/74309). Even if we don't adopt pnpm, this separation is still useful.

## How?

1. Created a new `package.json` in `./storybook` with:
    - Package name: `@wordpress/storybook`
    - Moved Storybook-related dependencies from root:
        - `@storybook/addon-a11y`
        - `@storybook/addon-docs`
        - `@storybook/icons`
        - `@storybook/react-vite`
        - `storybook-addon-tag-badges`
        - `storybook`
    - Added local scripts for `storybook:build` and `storybook:dev`
2. Updated root `package.json`:

    - Added `storybook` to the `workspaces` array
    - Removed Storybook dependencies (now in the workspace package)
    - Updated `storybook:build` and `storybook:dev` scripts to use workspace commands (`npm run --workspace @wordpress/storybook`)
3. Add `@storybook/react-vite` dependency to the packages that have it missing.

## Testing Instructions

1. Run `npm install` to ensure dependencies are correctly resolved
2. Run `npm run storybook:dev` and verify Storybook starts correctly at http://localhost:50240
3. Run `npm run storybook:build` and verify the build completes successfully in `./storybook/build`
4. Verify the CI workflow still works (the `.github/workflows/storybook-check.yml` should work as-is since it uses the root npm scripts)

### Testing Instructions for Keyboard

N/A - This is an infrastructure/configuration change with no UI modifications.

## Screenshots or screencast

N/A - This is an infrastructure/configuration change with no visual changes.
