### PR TITLE
Site Editor: If the route cannot be found treat the canvas mode as view

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -53,7 +53,8 @@ const ANIMATION_DURATION = 0.3;
 
 function Layout() {
 	const { query, name: routeKey, areas, widths } = useLocation();
-	const { canvas = 'view' } = query;
+	// Force canvas to 'view' on notfound route to show the error message and allow navigation.
+	const canvas = routeKey === 'notfound' ? 'view' : query?.canvas ?? 'view';
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const toggleRef = useRef();
 	const navigateRegionsProps = useNavigateRegions();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes a bug uncovered during reviews of #74601 (kudos @talldan for catching it)

In the site editor, if `canvas=edit` is in the query string, then the route to handle when a route cannot be found renders a blank screen.

The fix here is to treat the canvas as `view` mode when rendering the `notfound` route. That way the error message is visible and folks can navigate away.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`canvas=edit` hides the navigation area, and for the `notFoundRoute`, its `content` never gets rendered. If we force this route to always be treated as `view` mode then we can ensure the navigation and content are visible to users.

## How?

* Add a simple check so that if the route is the `notfound` id, then treat the mode as `view` in the site editor's layout.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* In `trunk` go to a route that should show an error, like http://localhost:8888/wp-admin/site-editor.php?p=apples&canvas=edit (because there is no `apples` route)
* Note that in trunk, you'll reach a blank screen
* With this PR you should see the error message in the screenshot below and be able to navigate away
* Double-check that `canvas=edit`, `canvas=view` and there being no query param is all otherwise working as on trunk, especially for routes that are valid.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

A blank screen (I haven't shared a screenshot for hopefully obvious reasons)

### After

<img width="1323" height="644" alt="image" src="https://github.com/user-attachments/assets/41a6baf5-b08a-44a4-b955-89dd7ff8b131" />

