### PR TITLE
Fix: Upload error notices don't appear when repeatedly selecting the same oversized file

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -485,6 +485,9 @@ export function MediaPlaceholder( {
 					{ renderDropZone() }
 					<FormFileUpload
 						onChange={ onUpload }
+						onClick={ ( event ) => {
+							event.currentTarget.value = '';
+						} }
 						accept={ computedAccept }
 						multiple={ !! multiple }
 						render={ ( { openFileDialog } ) => {
@@ -533,6 +536,9 @@ export function MediaPlaceholder( {
 							</Button>
 						) }
 						onChange={ onUpload }
+						onClick={ ( event ) => {
+							event.currentTarget.value = '';
+						} }
 						accept={ computedAccept }
 						multiple={ !! multiple }
 					/>

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -214,6 +214,9 @@ const MediaReplaceFlow = ( {
 								onChange={ ( event ) => {
 									uploadFiles( event, onClose );
 								} }
+								onClick={ ( event ) => {
+									event.currentTarget.value = '';
+								} }
 								accept={ computedAccept }
 								multiple={ !! multiple }
 								render={ ( { openFileDialog } ) => {

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -354,6 +354,9 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 									/>
 									<FormFileUpload
 										onChange={ uploadFiles }
+										onClick={ ( event ) => {
+											event.currentTarget.value = '';
+										} }
 										accept=".vtt,text/vtt"
 										multiple
 										render={ ( { openFileDialog } ) => {

--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -242,6 +242,9 @@ function UploadFonts() {
 						).join( ',' ) }
 						multiple
 						onChange={ onFilesUpload }
+						onClick={ ( event ) => {
+							event.currentTarget.value = '';
+						} }
 						render={ ( { openFileDialog } ) => (
 							<Button
 								__next40pxDefaultSize

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -364,6 +364,9 @@ export function MediaUploadModal( {
 					accept={ acceptTypes }
 					multiple
 					onChange={ handleFileSelect }
+					onClick={ ( event ) => {
+						event.currentTarget.value = '';
+					} }
 					__next40pxDefaultSize
 					render={ ( { openFileDialog } ) => (
 						<Button


### PR DESCRIPTION
## What?
Closes [#74533](https://github.com/WordPress/gutenberg/issues/74533)

## Why?
When a user attempts to upload an oversized file that triggers a validation error, the error notice only appears on the first upload attempt. If the user clicks the upload button again and selects the same file, no error notice is shown, even though the file still exceeds size limits.

## How?
This PR adds onClick handlers to reset the input value before file selection across all upload components.

## Testing Instructions

1. Navigate to a block that supports file uploads (Image, Video, Audio, Gallery, Media & Text, or File block)
2. Click the "Upload" button
3. Select a file that exceeds the upload size limit
4. Observe the error notice appears (e.g., "This file exceeds the maximum upload size for this site")
5. Click the "Upload" button again
6. Select the same oversized file
7. Error notice should appear