### PR TITLE
Fix: Dataview: column header move item in RTL moves in the opposite direction to the arrow

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -25,7 +25,7 @@
 - DataViews: Fix table row multiselection in Firefox [#73945](https://github.com/WordPress/gutenberg/pull/73945)
 - DataViews: `filterSortAndPaginate()` will ignore sorting on non-sortable fields [#73950](https://github.com/WordPress/gutenberg/pull/73950)
 - DataViews: Fix locked fields order when toggling visibility in properties section. [#74326](https://github.com/WordPress/gutenberg/pull/74326)
-- DataViews: Fix Dataviews Table columns reorder in opposite direction on rtl languages. [#74644](https://github.com/WordPress/gutenberg/pull/74644)
+- Dataviews: Fix column header move item in RTL moves in the opposite direction to the arrow. [#74644](https://github.com/WordPress/gutenberg/pull/74644)
 
 ### Enhancements
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -25,6 +25,7 @@
 - DataViews: Fix table row multiselection in Firefox [#73945](https://github.com/WordPress/gutenberg/pull/73945)
 - DataViews: `filterSortAndPaginate()` will ignore sorting on non-sortable fields [#73950](https://github.com/WordPress/gutenberg/pull/73950)
 - DataViews: Fix locked fields order when toggling visibility in properties section. [#74326](https://github.com/WordPress/gutenberg/pull/74326)
+- DataViews: Fix Dataviews Table columns reorder in opposite direction on rtl languages. [#74644](https://github.com/WordPress/gutenberg/pull/74644)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
@@ -6,7 +6,7 @@ import type { ReactNode, Ref, PropsWithoutRef, RefAttributes } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
 import {
 	Button,
@@ -113,6 +113,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	const canInsert =
 		( canInsertLeft || canInsertRight ) && !! hiddenFields.length;
 
+	const isRtl = isRTL();
+
 	return (
 		<Menu>
 			<Menu.TriggerButton
@@ -208,21 +210,29 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							{ canMove && (
 								<Menu.Item
 									prefix={ <Icon icon={ arrowLeft } /> }
-									disabled={ index < 1 }
+									disabled={
+										isRtl
+											? index >=
+											  visibleFieldIds.length - 1
+											: index < 1
+									}
 									onClick={ () => {
+										// In RTL, moving left visually means moving right in the array
+										const targetIndex = isRtl
+											? index + 1
+											: index - 1;
+										const newFields = [
+											...visibleFieldIds,
+										];
+										newFields.splice( index, 1 );
+										newFields.splice(
+											targetIndex,
+											0,
+											fieldId
+										);
 										onChangeView( {
 											...view,
-											fields: [
-												...( visibleFieldIds.slice(
-													0,
-													index - 1
-												) ?? [] ),
-												fieldId,
-												visibleFieldIds[ index - 1 ],
-												...visibleFieldIds.slice(
-													index + 1
-												),
-											],
+											fields: newFields,
 										} );
 									} }
 								>
@@ -235,22 +245,28 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								<Menu.Item
 									prefix={ <Icon icon={ arrowRight } /> }
 									disabled={
-										index >= visibleFieldIds.length - 1
+										isRtl
+											? index < 1
+											: index >=
+											  visibleFieldIds.length - 1
 									}
 									onClick={ () => {
+										// In RTL, moving right visually means moving left in the array
+										const targetIndex = isRtl
+											? index - 1
+											: index + 1;
+										const newFields = [
+											...visibleFieldIds,
+										];
+										newFields.splice( index, 1 );
+										newFields.splice(
+											targetIndex,
+											0,
+											fieldId
+										);
 										onChangeView( {
 											...view,
-											fields: [
-												...( visibleFieldIds.slice(
-													0,
-													index
-												) ?? [] ),
-												visibleFieldIds[ index + 1 ],
-												fieldId,
-												...visibleFieldIds.slice(
-													index + 2
-												),
-											],
+											fields: newFields,
 										} );
 									} }
 								>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes - https://github.com/WordPress/gutenberg/issues/74570

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR solves the issue of dataviews column swapping in opposite direction for rtl languages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR updates the column swapping logic to calculate the indexes to swap based on rtl data.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Change to an RTL language like Arabic
2. With some pages published in your block head to the site editor pages dataview /wp-admin/site-editor.php?p=%2Fpage
3. Ensure you're in table view (the default)
4. Now move a column, like Author, to the right or left
5. You will notice that it is correctly moving based on the direction it shows.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/03a8e1f7-b676-4bc7-967f-af7f4218d6b9


