### PR TITLE
Create Block: Simplify blocks-manifest registration

### DIFF
--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -80,9 +80,9 @@ The following configurable variables are used with the template files. Template 
 
 -   `pluginURI` (no default) – the home page of the plugin.
 -   `version` (default: `'0.1.0'`) – the current version number of the plugin.
--   `requiresAtLeast` (default: `'6.7'`) – the lowest WordPress version that the plugin will work on.
+-   `requiresAtLeast` (default: `'6.8'`) – the lowest WordPress version that the plugin will work on.
 -   `requiresPHP` (default: `'7.4'`) – the minimum required PHP version for use with this plugin.
--   `testedUpTo` (default: `'6.7'`) – the highest WordPress version that the plugin has been tested against.
+-   `testedUpTo` (default: `'6.8'`) – the highest WordPress version that the plugin has been tested against.
 -   `author` (default: `'The WordPress Contributors'`) – the name of the plugin author(s).
 -   `license` (default: `'GPL-2.0-or-later'`) – the short name of the plugin’s license.
 -   `licenseURI` (default: `'https://www.gnu.org/licenses/gpl-2.0.html'`) – a link to the full text of the license.

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -285,7 +285,7 @@ const getDefaultValues = ( projectTemplate, variant ) => {
 		license: 'GPL-2.0-or-later',
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
-		requiresAtLeast: '6.7',
+		requiresAtLeast: '6.8',
 		requiresPHP: '7.4',
 		testedUpTo: '6.7',
 		wpScripts: true,

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -287,7 +287,7 @@ const getDefaultValues = ( projectTemplate, variant ) => {
 		version: '0.1.0',
 		requiresAtLeast: '6.8',
 		requiresPHP: '7.4',
-		testedUpTo: '6.7',
+		testedUpTo: '6.8',
 		wpScripts: true,
 		customScripts: {},
 		wpEnv: false,

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -39,8 +39,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 {{#wpScripts}}
 /**
- * Registers the block using a `blocks-manifest.php` file, which improves the performance of block type registration.
- * Behind the scenes, it also registers all assets so they can be enqueued
+ * Registers the block(s) metadata from the `blocks-manifest.php` and registers the block type(s)
+ * based on the registered block metadata. Behind the scenes, it registers also all assets so they can be enqueued
  * through the block editor in the corresponding context.
  *
  * @see https://make.wordpress.org/core/2025/03/13/more-efficient-block-type-registration-in-6-8/
@@ -58,36 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 {{/wpScripts}}
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 {{#wpScripts}}
-	/**
-	 * Registers the block(s) metadata from the `blocks-manifest.php` and registers the block type(s)
-	 * based on the registered block metadata.
-	 * Added in WordPress 6.8 to simplify the block metadata registration process added in WordPress 6.7.
-	 *
-	 * @see https://make.wordpress.org/core/2025/03/13/more-efficient-block-type-registration-in-6-8/
-	 */
-	if ( function_exists( 'wp_register_block_types_from_metadata_collection' ) ) {
-		wp_register_block_types_from_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
-		return;
-	}
-
-	/**
-	 * Registers the block(s) metadata from the `blocks-manifest.php` file.
-	 * Added to WordPress 6.7 to improve the performance of block type registration.
-	 *
-	 * @see https://make.wordpress.org/core/2024/10/17/new-block-type-registration-apis-to-improve-performance-in-wordpress-6-7/
-	 */
-	if ( function_exists( 'wp_register_block_metadata_collection' ) ) {
-		wp_register_block_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
-	}
-	/**
-	 * Registers the block type(s) in the `blocks-manifest.php` file.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/register_block_type/
-	 */
-	$manifest_data = require __DIR__ . '/build/blocks-manifest.php';
-	foreach ( array_keys( $manifest_data ) as $block_type ) {
-		register_block_type( __DIR__ . "/build/{$block_type}" );
-	}
+	wp_register_block_types_from_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
 {{/wpScripts}}
 {{^wpScripts}}
 	register_block_type( __DIR__ . '/build/{{slug}}' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74645


<!-- In a few words, what is the PR actually doing? -->

## Why?
Simplifies the code generated to register blocks in the main plugin file to default to using the new wp_register_block_types_from_metadata_collection function.

Leaves the links to the update posts in the comments, so that developers building blocks for older WordPress versions can make the necessary changes manually.

## How?
- Updates the requiresAtLeast version to 6.8
- Updates the main plugin code to use only the wp_register_block_types_from_metadata_collection function

## Testing Instructions
1. Generate a new block using create-block
2. Confirm that the new code registers the block correctly in a WordPress 6.8+ install
3. Confirm that the plugin does not activate in a WordPress 6.7 or lower install
