### PR TITLE
Navigation Overlay: insert default pattern on creation

### DIFF
--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { serialize, createBlock } from '@wordpress/blocks';
+import { parse, serialize, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -47,7 +47,11 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		let initialContent = '';
 
 		if ( pattern?.content ) {
-			initialContent = pattern.content;
+			// Parse the pattern content into blocks and serialize it
+			const blocks = parse( pattern.content, {
+				__unstableSkipMigrationLogs: true,
+			} );
+			initialContent = serialize( blocks );
 		} else {
 			// Fallback to empty paragraph if pattern is not found
 			initialContent = serialize( [ createBlock( 'core/paragraph' ) ] );

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { serialize, parse, createBlock } from '@wordpress/blocks';
+import { serialize, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -24,8 +24,11 @@ import { unlock } from '../../lock-unlock';
  */
 export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const getPatternBySlug = useSelect(
-		( select ) => unlock( select( blockEditorStore ) ).getPatternBySlug,
+	const pattern = useSelect(
+		( select ) =>
+			unlock( select( blockEditorStore ) ).getPatternBySlug(
+				'gutenberg/navigation-overlay'
+			),
 		[]
 	);
 
@@ -41,8 +44,6 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		);
 		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
 
-		// Get the navigation overlay pattern
-		const pattern = getPatternBySlug( 'gutenberg/navigation-overlay' );
 		let initialContent = '';
 
 		if ( pattern?.content ) {
@@ -66,7 +67,7 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		);
 
 		return templatePart;
-	}, [ overlayTemplateParts, saveEntityRecord, getPatternBySlug ] );
+	}, [ overlayTemplateParts, saveEntityRecord, pattern ] );
 
 	return createOverlayTemplatePart;
 }

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -46,11 +46,7 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		let initialContent = '';
 
 		if ( pattern?.content ) {
-			// Parse the pattern content into blocks and serialize it
-			const blocks = parse( pattern.content, {
-				__unstableSkipMigrationLogs: true,
-			} );
-			initialContent = serialize( blocks );
+			initialContent = pattern.content;
 		} else {
 			// Fallback to empty paragraph if pattern is not found
 			initialContent = serialize( [ createBlock( 'core/paragraph' ) ] );

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -2,16 +2,18 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { serialize, createBlock } from '@wordpress/blocks';
+import { serialize, parse, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
 import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Hook to create a new overlay template part.
@@ -22,6 +24,10 @@ import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
  */
 export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
+	const getPatternBySlug = useSelect(
+		( select ) => unlock( select( blockEditorStore ) ).getPatternBySlug,
+		[]
+	);
 
 	const createOverlayTemplatePart = useCallback( async () => {
 		// Generate unique name using only overlay area template parts
@@ -35,6 +41,21 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		);
 		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );
 
+		// Get the navigation overlay pattern
+		const pattern = getPatternBySlug( 'gutenberg/navigation-overlay' );
+		let initialContent = '';
+
+		if ( pattern?.content ) {
+			// Parse the pattern content into blocks and serialize it
+			const blocks = parse( pattern.content, {
+				__unstableSkipMigrationLogs: true,
+			} );
+			initialContent = serialize( blocks );
+		} else {
+			// Fallback to empty paragraph if pattern is not found
+			initialContent = serialize( [ createBlock( 'core/paragraph' ) ] );
+		}
+
 		// Create the template part
 		const templatePart = await saveEntityRecord(
 			'postType',
@@ -42,14 +63,14 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 			{
 				slug: cleanSlug,
 				title: uniqueTitle,
-				content: serialize( [ createBlock( 'core/paragraph' ) ] ),
+				content: initialContent,
 				area: NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
 			},
 			{ throwOnError: true }
 		);
 
 		return templatePart;
-	}, [ overlayTemplateParts, saveEntityRecord ] );
+	}, [ overlayTemplateParts, saveEntityRecord, getPatternBySlug ] );
 
 	return createOverlayTemplatePart;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes https://github.com/WordPress/gutenberg/issues/74585

When creating a new navigation overlay template part, the default navigation overlay pattern is now automatically inserted instead of starting with a blank template.

## Why?

Previously, users were presented with a blank template when creating new overlay template parts, making it difficult to get started. This change provides a better starting point by automatically inserting the default pattern structure. This way there's less chance that they miss on inserting the overlay close button and we make sure they have a good starting markup without it being opinionated

## How?

- Updated `useCreateOverlayTemplatePart` hook to retrieve and insert the `gutenberg/navigation-overlay` pattern when creating new overlay template parts
- Falls back to an empty paragraph if the pattern is not found
- Added tests to verify pattern usage and fallback behavior

## Testing Instructions

1. Navigate to a Navigation block and click the "+" button to create a new overlay template part
2. Verify that the editor shows the default navigation overlay pattern (group block with close button and navigation block)
3. If the pattern is unavailable, verify that an empty paragraph is created as a fallback

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


![2026-01-15 12 05 20](https://github.com/user-attachments/assets/612bddbc-91d1-4f41-8cd9-2f614391ad57)
