### PR TITLE
Build: deduplicate and minify embedded styles

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -3,8 +3,12 @@ name: Compressed Size
 on:
     pull_request:
         paths:
-            # Any change to a CSS, Sass, or JavaScript file should run checks.
+            # Any change to a CSS, Sass, or JavaScript/TypeScript file should run checks.
             - '**.js'
+            - '**.ts'
+            - '**.tsx'
+            - '**.cjs'
+            - '**.mjs'
             - '**.css'
             - '**.scss'
             # Changes to any NPM related files could affect the outcome.

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -5,13 +5,15 @@
  */
 import { readFile, writeFile, copyFile, mkdir, unlink } from 'fs/promises';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
 import glob from 'fast-glob';
 import chokidar from 'chokidar';
 import browserslistToEsbuild from 'browserslist-to-esbuild';
-import { sassPlugin, postcssModules } from 'esbuild-sass-plugin';
+import { sassPlugin } from 'esbuild-sass-plugin';
 import postcss from 'postcss';
+import postcssModules from 'postcss-modules';
 import autoprefixer from 'autoprefixer';
 import rtlcss from 'rtlcss';
 import cssnano from 'cssnano';
@@ -133,6 +135,61 @@ function getSassOptions( workingDir ) {
 	};
 }
 
+function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
+	return async function styleType( cssText, _dirname, filePath ) {
+		// Always hash the untransformed code.
+		const hash = createHash( 'sha1' )
+			.update( cssText )
+			.digest( 'hex' )
+			.slice( 0, 10 );
+
+		let moduleExports = null;
+
+		// Transform the code: CSS modules and minification.
+		const plugins = [
+			cssModules &&
+				postcssModules( {
+					generateScopedName: '[contenthash]__[local]',
+					getJSON: ( _, json ) => {
+						moduleExports = json;
+					},
+				} ),
+			minify &&
+				cssnano( {
+					preset: [
+						'default',
+						{ discardComments: { removeAll: true } },
+					],
+				} ),
+		].filter( Boolean );
+
+		const { css } = await postcss( plugins ).process( cssText, {
+			from: filePath,
+			map: false,
+		} );
+
+		let cssModule = `if (!document.head.querySelector("style[data-wp-hash='${ hash }']")) {
+	const style = document.createElement("style");
+	style.setAttribute("data-wp-hash", "${ hash }");
+	style.appendChild(document.createTextNode(${ JSON.stringify( css ) }));
+	document.head.appendChild(style);
+}
+`;
+
+		// The CSS modules transform produces an `exports` object with class name mappings.
+		if ( moduleExports ) {
+			const exportsString = JSON.stringify( moduleExports );
+			cssModule += `export default ${ exportsString };\n`;
+		}
+		return cssModule;
+	};
+}
+
+function inlineStyle( contents ) {
+	// The `contents` is already a JS code created by `compileInlineStyle`.
+	return contents;
+}
+
 /**
  * Create style bundling plugins with the given working directory.
  *
@@ -146,10 +203,8 @@ function createStyleBundlingPlugins( workingDir ) {
 		sassPlugin( {
 			embedded: true,
 			filter: /\.module\.(css|scss)$/,
-			transform: postcssModules( {
-				generateScopedName: '[name]__[local]__[hash:base64:5]',
-			} ),
-			type: 'style',
+			transform: compileInlineStyle( { cssModules: true } ),
+			type: inlineStyle,
 			...sassOptions,
 		} ),
 		// Handle regular CSS/SCSS files
@@ -157,7 +212,8 @@ function createStyleBundlingPlugins( workingDir ) {
 		sassPlugin( {
 			embedded: true,
 			filter: /\.(css|scss)$/,
-			type: 'style',
+			transform: compileInlineStyle(),
+			type: inlineStyle,
 			...sassOptions,
 		} ),
 	];

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -168,7 +168,7 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 			map: false,
 		} );
 
-		let cssModule = `if (!document.head.querySelector("style[data-wp-hash='${ hash }']")) {
+		let cssModule = `if (typeof document !== 'undefined' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
 	const style = document.createElement("style");
 	style.setAttribute("data-wp-hash", "${ hash }");
 	style.appendChild(document.createTextNode(${ JSON.stringify( css ) }));


### PR DESCRIPTION
Improves how we deal with style imports that we inline into the transpiled JS code. Two improvements:
- generate custom JS code for inserting the `style` element. It checks if the `style` element with the given `data-wp-hash` attribute already exists, and prevents inserting duplicate styles. That can reduce style duplication a lot when libraries like `@wordpress/ui` are bundled many times with various chunks (blocks, routes etc.)
- minify the embedded code with `cssnano`. Makes the transpiled JS files smaller.

We're still using `postcss` here for both CSS modules and minification. In the near future I'd like to switch to `lightningcss` but they need to release a bugfixed version first.

## How to test
look at built files for:
- individual packages, like `packages/ui/build-module/form/primitives/fieldset/legend.mjs`
- WP script, like `build/scripts/components/index.js`

and verify that they both contain the new CSS-inserting code with minified CSS literals.