### PR TITLE
components: Fix generated TS types referencing unavailable `csstype`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52471,6 +52471,7 @@
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
@@ -52492,7 +52493,6 @@
 				"@testing-library/jest-dom": "^6.6.3",
 				"@types/jest": "^29.5.14",
 				"@wordpress/jest-console": "file:../jest-console",
-				"csstype": "^3.2.3",
 				"snapshot-diff": "^0.10.0",
 				"storybook": "^10.1.11",
 				"timezone-mock": "^1.3.6"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Code Quality
 
 -   Fix missing dependencies. [#74310](https://github.com/WordPress/gutenberg/pull/74310)
+-   Fix generated TS types referencing unavailable `csstype`. [#74655](https://github.com/WordPress/gutenberg/pull/74655)
 
 ### Breaking Changes
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -84,6 +84,7 @@
 		"change-case": "^4.1.2",
 		"clsx": "^2.1.1",
 		"colord": "^2.7.0",
+		"csstype": "^3.2.3",
 		"date-fns": "^3.6.0",
 		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
@@ -105,7 +106,6 @@
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/jest": "^29.5.14",
 		"@wordpress/jest-console": "file:../jest-console",
-		"csstype": "^3.2.3",
 		"snapshot-diff": "^0.10.0",
 		"storybook": "^10.1.11",
 		"timezone-mock": "^1.3.6"


### PR DESCRIPTION
## What?

Move `csstype` from `devDependencies` to `dependencies` in `@wordpress/components`.

## Why?

The generated type declarations in `build-types/` reference `csstype` via inline imports like `import("csstype").Property.AlignItems`. When consumers install `@wordpress/components`, they don't get `csstype` because it's listed as a `devDependency`.

This causes TypeScript to fail to resolve these type imports. When combined with `skipLibCheck: true` (a common tsconfig setting), TypeScript silently falls back to `any` for the entire module, effectively disabling type checking for all `@wordpress/components` exports.

Example of affected type declaration (`build-types/card/card-header/hook.d.ts`):
```typescript
align?: import("csstype").Property.AlignItems | undefined;
```

## How?

Moved `csstype` from `devDependencies` to `dependencies` in `packages/components/package.json`. This ensures consumers have access to `csstype` for proper type resolution.

## Testing Instructions

1. Create a new project that depends on `@wordpress/components`
2. Create a TypeScript file that imports a component:
   ```tsx
   import { TabPanel, Button } from '@wordpress/components';

   // This should show a type error for 'invalidProp'
   const a = <TabPanel tabs={[]} children={() => null} invalidProp="test" />;
   const b = <Button invalidProp2="test">Click</Button>;
   ```
3. Run `tsc --noEmit` and verify that type errors are reported for the invalid props
4. Previously, these would not error because the types resolved to `any`

### Testing Instructions for Keyboard

N/A - This is a type definition fix with no UI changes.

## Screenshots or screencast

N/A - No visual changes.
