### PR TITLE
Paragraph: Add text column support

### DIFF
--- a/backport-changelog/7.0/10756.md
+++ b/backport-changelog/7.0/10756.md
@@ -1,3 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/10756
 
-* https://github.com/WordPress/gutenberg/pull/[GUTENBERG_PR_NUMBER]
+* https://github.com/WordPress/gutenberg/pull/74656

--- a/backport-changelog/7.0/10756.md
+++ b/backport-changelog/7.0/10756.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10756
+
+* https://github.com/WordPress/gutenberg/pull/[GUTENBERG_PR_NUMBER]

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -599,7 +599,7 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 
 -	**Name:** core/paragraph
 -	**Category:** text
--	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign), ~~className~~
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign, textColumns), ~~className~~
 -	**Attributes:** content, direction, dropCap, placeholder
 
 ## Pattern Placeholder

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -482,7 +482,6 @@ class WP_Theme_JSON_Gutenberg {
 			'letterSpacing'    => null,
 			'lineHeight'       => null,
 			'textAlign'        => null,
-			'textColumns'      => true,
 			'textDecoration'   => null,
 			'textTransform'    => null,
 			'writingMode'      => null,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -482,7 +482,7 @@ class WP_Theme_JSON_Gutenberg {
 			'letterSpacing'    => null,
 			'lineHeight'       => null,
 			'textAlign'        => null,
-			'textColumns'      => null,
+			'textColumns'      => true,
 			'textDecoration'   => null,
 			'textTransform'    => null,
 			'writingMode'      => null,
@@ -790,6 +790,7 @@ class WP_Theme_JSON_Gutenberg {
 		array( 'spacing', 'margin' ),
 		array( 'spacing', 'padding' ),
 		array( 'typography', 'lineHeight' ),
+		array( 'typography', 'textColumns' ),
 	);
 
 	/**

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -57,6 +57,7 @@
 			"fontSize": true,
 			"lineHeight": true,
 			"textAlign": true,
+			"textColumns": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -335,7 +335,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'padding'  => true,
 			),
 			'typography' => array(
-				'lineHeight' => true,
+				'lineHeight'  => true,
+				'textColumns' => true,
 			),
 			'blocks'     => array(
 				'core/paragraph' => array(
@@ -376,7 +377,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'padding'  => true,
 					),
 					'typography' => array(
-						'lineHeight' => false,
+						'lineHeight'  => false,
+						'textColumns' => true,
 					),
 				),
 			),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #27118 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Enables columns support in a paragraph block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is a useful control for the paragraph block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add support for `textColumns` to the block

## Testing Instructions
1. Select a paragraph block
2. Enable columns in the paragraph typography block
3. Confirm that changes to the number of columns are reflected in the frontend and editor


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1357" height="403" alt="Screenshot 2026-01-15 at 14 11 01" src="https://github.com/user-attachments/assets/bb87b7c0-7d2c-4928-a524-71a765cface3" />
