### PR TITLE
Change featured_media value to null on image removal

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -354,7 +354,7 @@ const applyWithDispatch = withDispatch(
 					} );
 			},
 			onRemoveImage() {
-				editPost( { featured_media: 0 } );
+				editPost( { featured_media: null } );
 			},
 		};
 	}


### PR DESCRIPTION
## What?
Closes #74657.

Allow featured_media to be reflected across multiple users.

## Why?
With multiple users potentially editing posts at the same time, it is important to accurately reflect if a featured image has been removed.

## How?
By switching to `null`, rather than `0` the update gets reflected.

## Testing Instructions
1. Open an edit post page with two users.
2. User 1 can set a featured image
3. User 2 should see this new image
4. User 2 can then remove the new image
5. User 1 should see that the image has been removed

## Screenshots or screencast

Before:

https://github.com/user-attachments/assets/097ff8de-a4ca-4bff-b8b7-702646ff311b

After:

https://github.com/user-attachments/assets/2a81b133-c9fc-47d2-8b5d-5e450d2cb653