### PR TITLE
Experiment: Add two-columns layout option for DataForm components

### DIFF
--- a/packages/dataviews/src/components/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/index.tsx
@@ -12,6 +12,7 @@ import FormPanelField from './panel';
 import FormCardField from './card';
 import FormRowField from './row';
 import FormDetailsField from './details';
+import FormTwoColumnsField from './two-columns';
 
 const FORM_FIELD_LAYOUTS = [
 	{
@@ -83,6 +84,19 @@ const FORM_FIELD_LAYOUTS = [
 	{
 		type: 'details',
 		component: FormDetailsField,
+	},
+	{
+		type: 'two-columns',
+		component: FormTwoColumnsField,
+		wrapper: ( { children }: { children: React.ReactNode } ) => (
+			<Stack
+				direction="column"
+				className="dataforms-layouts__wrapper"
+				gap="lg"
+			>
+				{ children }
+			</Stack>
+		),
 	},
 ];
 

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -12,6 +12,7 @@ import type {
 	NormalizedCardLayout,
 	NormalizedRowLayout,
 	NormalizedDetailsLayout,
+	NormalizedTwoColumnsLayout,
 	NormalizedCardSummaryField,
 	CardSummaryField,
 } from '../../types';
@@ -100,6 +101,10 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			type: 'details',
 			summary: layout?.summary ?? '',
 		} satisfies NormalizedDetailsLayout;
+	} else if ( layout?.type === 'two-columns' ) {
+		normalizedLayout = {
+			type: 'two-columns',
+		} satisfies NormalizedTwoColumnsLayout;
 	}
 
 	return normalizedLayout;

--- a/packages/dataviews/src/components/dataform-layouts/two-columns/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/two-columns/index.tsx
@@ -1,0 +1,134 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Card,
+	CardBody,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { useContext, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getFormFieldLayout } from '..';
+import DataFormContext from '../../dataform-context';
+import type {
+	FieldLayoutProps,
+	NormalizedForm,
+	NormalizedLayout,
+} from '../../../types';
+import { DataFormLayout } from '../data-form-layout';
+import { DEFAULT_LAYOUT } from '../normalize-form';
+import './style.scss';
+
+export default function FormTwoColumnsField< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: FieldLayoutProps< Item > ) {
+	const { fields } = useContext( DataFormContext );
+
+	const form: NormalizedForm = useMemo(
+		() => ( {
+			layout: DEFAULT_LAYOUT as NormalizedLayout,
+			fields: field.children ?? [],
+		} ),
+		[ field ]
+	);
+
+	const sizeCard = {
+		blockStart: 'medium' as const,
+		blockEnd: 'medium' as const,
+		inlineStart: 'medium' as const,
+		inlineEnd: 'medium' as const,
+	};
+
+	if ( !! field.children ) {
+		return (
+			<div className="dataforms-layouts-two-columns__field">
+				<div className="dataforms-layouts-two-columns__left">
+					{ ! hideLabelFromVision && field.label && (
+						<Heading level={ 2 } size={ 13 }>
+							{ field.label }
+						</Heading>
+					) }
+					{ field.description && (
+						<div className="dataforms-layouts-two-columns__description">
+							{ field.description }
+						</div>
+					) }
+				</div>
+				<div className="dataforms-layouts-two-columns__right">
+					<Card
+						className="dataforms-layouts-two-columns__card"
+						size={ sizeCard }
+					>
+						<CardBody
+							size={ sizeCard }
+							className="dataforms-layouts-two-columns__card-body"
+						>
+							<DataFormLayout
+								data={ data }
+								form={ form }
+								onChange={ onChange }
+								validity={ validity?.children }
+							/>
+						</CardBody>
+					</Card>
+				</div>
+			</div>
+		);
+	}
+
+	const fieldDefinition = fields.find(
+		( fieldDef ) => fieldDef.id === field.id
+	);
+
+	if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
+		return null;
+	}
+
+	const RegularLayout = getFormFieldLayout( 'regular' )?.component;
+	if ( ! RegularLayout ) {
+		return null;
+	}
+
+	return (
+		<div className="dataforms-layouts-two-columns__field">
+			<div className="dataforms-layouts-two-columns__left">
+				{ ! hideLabelFromVision && fieldDefinition.label && (
+					<Heading level={ 2 } size={ 13 }>
+						{ fieldDefinition.label }
+					</Heading>
+				) }
+				{ field.description && (
+					<div className="dataforms-layouts-two-columns__description">
+						{ field.description }
+					</div>
+				) }
+			</div>
+			<div className="dataforms-layouts-two-columns__right">
+				<Card
+					className="dataforms-layouts-two-columns__card"
+					size={ sizeCard }
+				>
+					<CardBody
+						size={ sizeCard }
+						className="dataforms-layouts-two-columns__card-body"
+					>
+						<RegularLayout
+							data={ data }
+							field={ field }
+							onChange={ onChange }
+							hideLabelFromVision
+							validity={ validity }
+						/>
+					</CardBody>
+				</Card>
+			</div>
+		</div>
+	);
+}

--- a/packages/dataviews/src/components/dataform-layouts/two-columns/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/two-columns/style.scss
@@ -1,0 +1,52 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
+
+.dataforms-layouts-two-columns__field {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+	width: 100%;
+
+	@include break-medium() {
+		flex-direction: row;
+		gap: $grid-unit-30;
+		align-items: flex-start;
+	}
+}
+
+.dataforms-layouts-two-columns__left {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+	width: 100%;
+
+	@include break-medium() {
+		width: 40%;
+		flex-shrink: 0;
+	}
+}
+
+.dataforms-layouts-two-columns__right {
+	width: 100%;
+
+	@include break-medium() {
+		width: 60%;
+		flex: 1;
+	}
+}
+
+.dataforms-layouts-two-columns__description {
+	color: $gray-700;
+	display: block;
+	font-size: $font-size-medium;
+	line-height: 1.5;
+}
+
+.dataforms-layouts-two-columns__card {
+	width: 100%;
+}
+
+.dataforms-layouts-two-columns__card-body {
+	width: 100%;
+}

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -8,6 +8,7 @@ import LayoutMixedComponent from './layout-mixed';
 import LayoutRegularComponent from './layout-regular';
 import LayoutRowComponent from './layout-row';
 import LayoutPanelComponent from './layout-panel';
+import LayoutTwoColumnsComponent from './layout-two-columns';
 import DataAdapterComponent from './data-adapter';
 import ValidationComponent from './validation';
 import VisibilityComponent from './visibility';
@@ -88,6 +89,10 @@ export const LayoutRow = {
 	args: {
 		alignment: 'default',
 	},
+};
+
+export const LayoutTwoColumns = {
+	render: LayoutTwoColumnsComponent,
 };
 
 export const LayoutMixed = {

--- a/packages/dataviews/src/dataform/stories/layout-two-columns.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-two-columns.tsx
@@ -1,0 +1,160 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataForm from '../index';
+import type { Field, Form } from '../../types';
+
+const LayoutTwoColumnsComponent: React.FC = () => {
+	type Fields = {
+		enable_taxes: boolean;
+		enable_coupons: boolean;
+		subscription_type: string;
+		renewal_period: string;
+		payment_method: string;
+	};
+
+	const fields: Field< Fields >[] = [
+		{
+			id: 'enable_taxes',
+			label: 'Enable taxes for your products',
+			description:
+				'Enable taxes for your products to be calculated and displayed in the checkout process.',
+			type: 'boolean',
+		},
+		{
+			id: 'enable_coupons',
+			label: 'Enable coupons',
+			description:
+				'Enable coupons for your products to be used in the checkout process.',
+			type: 'boolean',
+		},
+		{
+			id: 'subscription_type',
+			label: 'Subscription Type',
+			type: 'text',
+			Edit: 'toggleGroup',
+			elements: [
+				{ value: 'monthly', label: 'Monthly' },
+				{ value: 'yearly', label: 'Yearly' },
+				{ value: 'lifetime', label: 'Lifetime' },
+			],
+		},
+		{
+			id: 'renewal_period',
+			label: 'Renewal Period',
+			type: 'text',
+			Edit: 'toggleGroup',
+			elements: [
+				{ value: '30', label: '30 days' },
+				{ value: '60', label: '60 days' },
+				{ value: '90', label: '90 days' },
+			],
+		},
+		{
+			id: 'payment_method',
+			label: 'Payment Method',
+			type: 'text',
+			Edit: 'radio',
+			elements: [
+				{ value: 'credit-card', label: 'Credit Card' },
+				{ value: 'paypal', label: 'PayPal' },
+				{ value: 'bank-transfer', label: 'Bank Transfer' },
+			],
+		},
+	];
+
+	const [ settings, setSettings ] = useState< Fields >( {
+		enable_taxes: false,
+		enable_coupons: false,
+		subscription_type: 'monthly',
+		renewal_period: '30',
+		payment_method: 'credit-card',
+	} );
+
+	const form: Form = useMemo(
+		() => ( {
+			layout: { type: 'two-columns' },
+			fields: [
+				{
+					id: 'taxes-coupons',
+					label: 'Taxes & Coupons',
+					description:
+						'Configure taxes and coupons for your products.',
+					layout: {
+						type: 'two-columns',
+					},
+					children: [
+						{
+							id: 'enable_taxes',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+						{
+							id: 'enable_coupons',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+					],
+				},
+				{
+					id: 'subscriptionSettings',
+					label: 'Subscription Settings',
+					description:
+						'Configure subscription type, renewal period, and payment methods.',
+					layout: {
+						type: 'two-columns',
+					},
+					children: [
+						{
+							id: 'subscription_type',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+						{
+							id: 'renewal_period',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+						{
+							id: 'payment_method',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+					],
+				},
+			],
+		} ),
+		[]
+	);
+
+	return (
+		<DataForm
+			data={ settings }
+			fields={ fields }
+			form={ form }
+			onChange={ ( edits ) =>
+				setSettings( ( prev ) => ( {
+					...prev,
+					...edits,
+				} ) )
+			}
+		/>
+	);
+};
+
+export default LayoutTwoColumnsComponent;

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -6,7 +6,13 @@ import type { Field, FieldValidity } from './field-api';
 /**
  * DataForm layouts.
  */
-export type LayoutType = 'regular' | 'panel' | 'card' | 'row' | 'details';
+export type LayoutType =
+	| 'regular'
+	| 'panel'
+	| 'card'
+	| 'row'
+	| 'details'
+	| 'two-columns';
 export type LabelPosition = 'top' | 'side' | 'none';
 
 export type PanelSummaryField = string | string[];
@@ -106,18 +112,27 @@ export type NormalizedDetailsLayout = {
 	summary: string;
 };
 
+export type TwoColumnsLayout = {
+	type: 'two-columns';
+};
+export type NormalizedTwoColumnsLayout = {
+	type: 'two-columns';
+};
+
 export type Layout =
 	| RegularLayout
 	| PanelLayout
 	| CardLayout
 	| RowLayout
-	| DetailsLayout;
+	| DetailsLayout
+	| TwoColumnsLayout;
 export type NormalizedLayout =
 	| NormalizedRegularLayout
 	| NormalizedPanelLayout
 	| NormalizedCardLayout
 	| NormalizedRowLayout
-	| NormalizedDetailsLayout;
+	| NormalizedDetailsLayout
+	| NormalizedTwoColumnsLayout;
 
 export type NormalizedSummaryField =
 	| NormalizedPanelSummaryField


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
**This is a WIP experiment, not ready for review.**

This PR adds a new `two-columns` layout option for DataForm components. The layout displays form field labels and descriptions on the left side, with form controls contained in a card on the right side.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The two-columns layout provides a more structured and visually organized way to display form fields, particularly useful for forms with longer labels or descriptions. This layout option gives developers more flexibility in how they present form data to users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The implementation consists of three main parts:

1. **Type Definitions** (`packages/dataviews/src/types/dataform.ts`):
   - Added `'two-columns'` to the `LayoutType` union type
   - Created `TwoColumnsLayout` and `NormalizedTwoColumnsLayout` type definitions
   - Extended the `Layout` and `NormalizedLayout` union types to include the new layout

2. **Component Implementation** (`packages/dataviews/src/components/dataform-layouts/two-columns/`):
   - Created `FormTwoColumnsField` component that renders fields in a two-column layout
   - Left column displays the field label (as a heading) and description
   - Right column contains a Card component with the form controls
   - Supports both nested field children and individual field rendering
   - Added corresponding SCSS styles for layout and spacing

3. **Integration**:
   - Registered the new layout in `packages/dataviews/src/components/dataform-layouts/index.tsx`
   - Added normalization logic in `packages/dataviews/src/components/dataform-layouts/normalize-form.ts`
   - Created a Storybook story demonstrating the layout with various field types

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Navigate to Storybook and open the DataForm stories
2. Find and open the `DataForm > Layout Two Columns` story
3. Verify that form fields are displayed in a two-column layout:
   - Left column shows field labels (as headings) and descriptions
   - Right column shows form controls within a card
4. Test with different field types (boolean, text, toggleGroup, radio) to ensure they render correctly
5. Verify that the layout is responsive and maintains proper spacing
6. Test form interactions (changing values, validation) to ensure functionality is preserved

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Navigate to the Storybook story using keyboard navigation
2. Use Tab key to navigate through form fields
3. Verify that focus indicators are visible and properly positioned
4. Test that all form controls (checkboxes, radio buttons, toggle groups) are keyboard accessible
5. Ensure that screen readers can properly announce field labels and descriptions
6. Verify that the visual layout doesn't interfere with keyboard navigation flow

## Screenshots or screencast <!-- if applicable -->

<img width="2680" height="1020" alt="CleanShot 2026-01-15 at 16 44 32@2x" src="https://github.com/user-attachments/assets/00f970f5-5edd-4992-a040-9712c85a5b4a" />
