### PR TITLE
Real-time collaboration: Sync collections

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -339,6 +339,15 @@ export const deleteEntityRecord =
 				} );
 
 				await dispatch( removeItems( kind, name, recordId, true ) );
+
+				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+					if ( entityConfig.syncConfig ) {
+						const objectType = `${ kind }/${ name }`;
+						const objectId = recordId;
+
+						getSyncManager()?.unload( objectType, objectId );
+					}
+				}
 			} catch ( _error ) {
 				hasError = true;
 				error = _error;

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -2,19 +2,19 @@
  * WordPress dependencies
  */
 import { dispatch, select, subscribe } from '@wordpress/data';
-import { AwarenessState, type Y } from '@wordpress/sync';
+import type { Y } from '@wordpress/sync';
 // @ts-ignore No exported types for block editor store selectors.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import { BaseAwarenessState, baseEqualityFieldChecks } from './base-awareness';
 import {
 	AWARENESS_CURSOR_UPDATE_THROTTLE_IN_MS,
 	LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS,
 } from './config';
 import { STORE_NAME as coreStore } from '../name';
-import { generateUserInfo, areUserInfosEqual } from './utils';
 import {
 	areSelectionsStatesEqual,
 	getSelectionState,
@@ -23,10 +23,10 @@ import {
 import type { WPBlockSelection } from '../types';
 import type { EditorState, PostEditorState } from './types';
 
-export class PostEditorAwareness extends AwarenessState< PostEditorState > {
+export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	protected equalityFieldChecks = {
+		...baseEqualityFieldChecks,
 		editorState: this.areEditorStatesEqual,
-		userInfo: areUserInfosEqual,
 	};
 
 	public constructor(
@@ -41,27 +41,7 @@ export class PostEditorAwareness extends AwarenessState< PostEditorState > {
 	public setUp(): void {
 		super.setUp();
 
-		this.setCurrentUserInfo();
 		this.subscribeToUserSelectionChanges();
-	}
-
-	/**
-	 * Set the current user info in the local state.
-	 */
-	private setCurrentUserInfo(): void {
-		const states = this.getStates();
-		const otherUserColors = Array.from( states.entries() )
-			.filter(
-				( [ clientId, state ] ) =>
-					state.userInfo && clientId !== this.clientID
-			)
-			.map( ( [ , state ] ) => state.userInfo.color )
-			.filter( Boolean );
-
-		// Get current user info and set it in local state.
-		const currentUser = select( coreStore ).getCurrentUser();
-		const userInfo = generateUserInfo( currentUser, otherUserColors );
-		this.setLocalStateField( 'userInfo', userInfo );
 	}
 
 	/**

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -462,6 +462,26 @@ export const getEntityRecords =
 				};
 			}
 
+			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+				if ( entityConfig.syncConfig && -1 === query.per_page ) {
+					const objectType = `${ kind }/${ name }`;
+					getSyncManager()?.loadCollection(
+						entityConfig.syncConfig,
+						objectType,
+						{
+							refetchRecords: async () => {
+								dispatch.receiveEntityRecords(
+									kind,
+									name,
+									await apiFetch( { path, parse: true } ),
+									query
+								);
+							},
+						}
+					);
+				}
+			}
+
 			// If we request fields but the result doesn't contain the fields,
 			// explicitly set these fields as "undefined"
 			// that way we consider the query "fulfilled".

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -8,7 +8,12 @@ import fastDeepEqual from 'fast-deep-equal/es6/index.js';
  */
 // @ts-expect-error No exported types.
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
-import { type CRDTDoc, type ObjectData, Y } from '@wordpress/sync';
+import {
+	type CRDTDoc,
+	type ObjectData,
+	type SyncConfig,
+	Y,
+} from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -48,6 +53,7 @@ export type PostChanges = Partial< Post > & {
 export interface YPostRecord extends YMapRecord {
 	author: number;
 	blocks: YBlocks;
+	categories: number[];
 	comment_status: string;
 	date: string | null;
 	excerpt: string;
@@ -67,6 +73,7 @@ export interface YPostRecord extends YMapRecord {
 const allowedPostProperties = new Set< string >( [
 	'author',
 	'blocks',
+	'categories',
 	'comment_status',
 	'date',
 	'excerpt',
@@ -95,7 +102,7 @@ const disallowedPostMetaKeys = new Set< string >( [
  * @param {Partial< ObjectData >} changes
  * @return {void}
  */
-export function defaultApplyChangesToCRDTDoc(
+function defaultApplyChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: ObjectData
 ): void {
@@ -256,7 +263,7 @@ export function applyPostChangesToCRDTDoc(
 	}
 }
 
-export function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
+function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
 	return getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
 }
 
@@ -395,6 +402,15 @@ export function getPostChangesFromCRDTDoc(
 
 	return changes;
 }
+
+/**
+ * This default sync config can be used for entities that are flat maps of
+ * primitive values and do not require custom logic to merge changes.
+ */
+export const defaultSyncConfig: SyncConfig = {
+	applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
+	getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
+};
 
 /**
  * Extract the raw string value from a property that may be a string or an object

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -18,6 +18,8 @@ import {
 /**
  * Internal dependencies
  */
+import { BaseAwareness } from '../awareness/base-awareness';
+import { type BaseState } from '../awareness/types';
 import {
 	mergeCrdtBlocks,
 	type Block,
@@ -407,8 +409,9 @@ export function getPostChangesFromCRDTDoc(
  * This default sync config can be used for entities that are flat maps of
  * primitive values and do not require custom logic to merge changes.
  */
-export const defaultSyncConfig: SyncConfig = {
+export const defaultSyncConfig: SyncConfig< BaseState > = {
 	applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
+	createAwareness: ( ydoc: CRDTDoc ) => new BaseAwareness( ydoc ),
 	getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
 };
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -82,7 +82,7 @@ export interface RecordHandlers {
 	saveRecord: () => Promise< void >;
 }
 
-export interface SyncConfig {
+export interface SyncConfig< State extends object = {} > {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
 		changes: Partial< ObjectData >
@@ -90,7 +90,7 @@ export interface SyncConfig {
 	createAwareness?: (
 		ydoc: Y.Doc,
 		objectId?: ObjectID
-	) => AwarenessState | undefined;
+	) => AwarenessState< State > | undefined;
 	getChangesFromCRDTDoc: (
 		ydoc: Y.Doc,
 		editedRecord: ObjectData

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -66,6 +66,10 @@ export type ProviderCreator = (
 	options: ProviderCreatorOptions
 ) => Promise< ProviderCreatorResult >;
 
+export interface CollectionHandlers {
+	refetchRecords: () => Promise< void >;
+}
+
 export interface RecordHandlers {
 	addUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 	editRecord: (
@@ -85,7 +89,7 @@ export interface SyncConfig {
 	) => void;
 	createAwareness?: (
 		ydoc: Y.Doc,
-		objectId: ObjectID
+		objectId?: ObjectID
 	) => AwarenessState | undefined;
 	getChangesFromCRDTDoc: (
 		ydoc: Y.Doc,
@@ -110,12 +114,17 @@ export interface SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	) => Promise< void >;
+	loadCollection: (
+		syncConfig: SyncConfig,
+		objectType: ObjectType,
+		handlers: CollectionHandlers
+	) => Promise< void >;
 	// undoManager is undefined until the first entity is loaded.
 	undoManager: SyncUndoManager | undefined;
 	unload: ( objectType: ObjectType, objectId: ObjectID ) => void;
 	update: (
 		objectType: ObjectType,
-		objectId: ObjectID,
+		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
 		isSave?: boolean

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -10,6 +10,9 @@ import * as buffer from 'lib0/buffer';
 import {
 	CRDT_DOC_META_PERSISTENCE_KEY,
 	CRDT_DOC_VERSION,
+	CRDT_RECORD_METADATA_MAP_KEY as RECORD_METADATA_KEY,
+	CRDT_RECORD_METADATA_SAVED_AT_KEY as SAVED_AT_KEY,
+	CRDT_RECORD_METADATA_SAVED_BY_KEY as SAVED_BY_KEY,
 	CRDT_STATE_MAP_KEY,
 	CRDT_STATE_VERSION_KEY,
 } from './config';
@@ -34,6 +37,18 @@ export function createYjsDoc( documentMeta: DocumentMeta = {} ): Y.Doc {
 	stateMap.set( CRDT_STATE_VERSION_KEY, CRDT_DOC_VERSION );
 
 	return ydoc;
+}
+
+/**
+ * Record that the entity was saved (persisted to the database) in the CRDT
+ * document record metadata.
+ *
+ * @param {CRDTDoc} ydoc CRDT document.
+ */
+export function markEntityAsSaved( ydoc: CRDTDoc ): void {
+	const recordMeta = ydoc.getMap( RECORD_METADATA_KEY );
+	recordMeta.set( SAVED_AT_KEY, Date.now() );
+	recordMeta.set( SAVED_BY_KEY, ydoc.clientID );
 }
 
 export function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {


### PR DESCRIPTION
## What?

Allow collaborators to receive updates to entity collections in real-time. Closes https://github.com/WordPress/gutenberg/issues/75491.

## Why?

We currently approach syncing entity-by-entity. In other words, we only sync entities that were loaded by ID (e.g., a post with ID `123`). We have no mechanism to sync changes to entity collections. Examples of entity collections in the block editor include:

- Block notes
- Categories and other taxonomies
- Patterns

Syncing entity collections is important if we want to capture entity creation and deletion within a collaborative editing session. It also allows us to capture edits to entities in the collection without specifically opening a connection for each entity.

## How?

To accomplish this, we extend the `SyncManager` to allow entity collections to be loaded. Collections are represented by a CRDT document, but we do not load entity records into it. Instead, we keep track of when the collection was last updated. This is used as a signal to trigger a refetch of the collection and keep the entire collection in sync among peers.

This is the same method we use when syncing a single entity to understand if the entity was saved by a collaborative peer.

This approach assumes that:

1. collections are resolved with `getEntityRecords()`.
2. entity creations and edits use `saveEntityRecord()`.
3. entity deletions use `deleteEntityRecord()`.

This is a common pattern and fits the examples noted above.

## Testing Instructions

1. Check out this PR.
2. Because there is currently no default provider in `trunk`, use [our plugin](https://github.com/Automattic/vip-real-time-collaboration/tree/update/awareness-with-plugin) to provide a local WebSocket provider. This limitation will be addressed soon.
   a. Do not bundle `@wordpress/sync` so it can be used by our plugin: `git cherry-pick 35607c9a2ebc7dcb75b500ec7471c39464704cec`. Restart the Gutenberg build if it is running.
   b. Clone our plugin in a sibling directory to `gutenberg` and use [this branch](https://github.com/Automattic/vip-real-time-collaboration/tree/update/awareness-with-plugin).
   c. `npm run dev` to start a development environment.
3. Open a post in two browsers for collaborative editing.
4. Add, remove, and edit block comments. Add and remove categories. Create patterns.

### Testing Instructions for Keyboard

No UI changes in this PR.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/96ce5567-9ac2-4ce9-b56d-1f41d9c94324
