### PR TITLE
Fix: render a drop target when List View is empty

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -345,7 +345,15 @@ function ListViewComponent(
 
 	// If there are no blocks to show and we're not showing the appender, do not render the list view.
 	if ( ! clientIdsTree.length && ! showAppender ) {
-		return null;
+		return (
+			<div
+				git
+				ref={ dropZoneRef }
+				className="block-editor-list-view__empty-drop-zone"
+			>
+				{ __( 'Drag blocks here' ) }
+			</div>
+		);
 	}
 
 	const describedById =

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -576,3 +576,11 @@ svg {
 .list-view-appender__description {
 	display: none;
 }
+.block-editor-list-view__empty-drop-zone {
+	padding: 12px;
+	margin: 8px;
+	border: 2px dashed #ccc;
+	border-radius: 4px;
+	text-align: center;
+	color: #555;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #74641

Ensure the List View renders a valid drop target when it is empty, so blocks
can be dragged into it instead of the component returning null.

## Why?
When the List View has no blocks and the appender is not shown, the component
returns null and does not render a DOM element. This prevents the existing
List View drop zone from being registered, making it impossible to drag blocks
into an empty List View.

This behavior became more noticeable after recent List View usage changes.

## How?
Render a minimal empty-state container when the List View is empty and attach
the existing List View drop zone ref. This ensures a valid drop target is
present while preserving existing List View behavior.

## Testing Instructions
1. Open a post or page in the editor.
2. Open the List View.
3. Remove all blocks so the List View is empty.
4. Drag a block from the inserter into the List View.
5. Confirm that the block can be dropped successfully.

### Testing Instructions for Keyboard
1. Open a post or page in the editor.
2. Open the List View using the keyboard.
3. Insert a block using the block inserter.
4. Confirm the block appears correctly in the List View.

## Screenshots or screencast <!-- if applicable -->
N/A
