### PR TITLE
Badge: Use stories for "Choosing intent" doc

### DIFF
--- a/packages/ui/src/badge/stories/choosing-intent.mdx
+++ b/packages/ui/src/badge/stories/choosing-intent.mdx
@@ -1,20 +1,11 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-import { Badge } from '../index';
-import '@wordpress/theme/design-tokens.css';
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as ChoosingIntentStories from './choosing-intent.story';
 
-<Meta title="Design System/Components/Badge/Choosing intent" />
+<Meta of={ ChoosingIntentStories } />
 
 # Choosing intent
 
-<div style={ { padding: '2rem', display: 'flex', justifyContent: 'center', gap: '0.5rem', flexWrap: 'wrap', border: '1px solid #e0e0e0', borderRadius: '0.5rem' } }>
-	<Badge intent="high">high</Badge>
-	<Badge intent="medium">medium</Badge>
-	<Badge intent="low">low</Badge>
-	<Badge intent="stable">stable</Badge>
-	<Badge intent="informational">informational</Badge>
-	<Badge intent="draft">draft</Badge>
-	<Badge intent="none">none</Badge>
-</div>
+<Canvas of={ ChoosingIntentStories.AllIntents } />
 
 It can be difficult to determine which badge intent to use because the component's properties are not tied to any specific product view. Those properties should be balanced against the requirements of the view in which the badge appears, all while keeping an eye on high-level consistency (global statuses that appear across multiple views).
 
@@ -36,21 +27,21 @@ Use when there's something for the user to act on.
 * Needs attention as soon as possible
 * _E.g. "Payment declined", "Security issue"_
 
-<Badge intent="high">Payment declined</Badge> <Badge intent="high">Security issue</Badge>
+<Canvas of={ ChoosingIntentStories.High } />
 
 ### `medium` – Important / blocks progress
 
 * Blocks a key task, should be handled soon
 * _E.g. "Approval required", "Review needed"_
 
-<Badge intent="medium">Approval required</Badge> <Badge intent="medium">Review needed</Badge>
+<Canvas of={ ChoosingIntentStories.Medium } />
 
 ### `low` – Worth noticing / non‑urgent
 
 * Good to be aware of; action may be optional or later
 * _E.g. "Pending", "Queued", "Minor issues", "Optional setup"_
 
-<Badge intent="low">Pending</Badge> <Badge intent="low">Queued</Badge>
+<Canvas of={ ChoosingIntentStories.Low } />
 
 ## 3. Informational / draft = special non-final states
 
@@ -59,13 +50,13 @@ Use when there's something for the user to act on.
 * Context only; no clear action
 * _E.g. "Scheduled", "Beta", "Internal only"_
 
-<Badge intent="informational">Scheduled</Badge> <Badge intent="informational">Beta</Badge>
+<Canvas of={ ChoosingIntentStories.Informational } />
 
 ### `draft` – Not final / work in progress
 
 * _E.g. "Draft", "Unpublished", "Work in progress"_
 
-<Badge intent="draft">Draft</Badge> <Badge intent="draft">Unpublished</Badge>
+<Canvas of={ ChoosingIntentStories.Draft } />
 
 ## 4. Stable / none = normal states
 
@@ -74,34 +65,40 @@ Use when there's something for the user to act on.
 * Use when confirming success or "all good" is important in that view
 * _E.g. "Healthy", "Active", "Live"_
 
-<Badge intent="stable">Healthy</Badge> <Badge intent="stable">Active</Badge>
+<Canvas of={ ChoosingIntentStories.Stable } />
 
 ### `none` – Default for normal / background states
 
 * Especially in dense lists where too much color creates visual noise
 * _E.g. "Inactive", "Expired"_
 
-<Badge intent="none">Inactive</Badge> <Badge intent="none">Expired</Badge>
+<Canvas of={ ChoosingIntentStories.None } />
 
 ## Examples
 
-### Comment status:
+### Comment status
 
--   "Approved" → `none`: <Badge intent="none">Approved</Badge>
--   "Approval required" → `medium`: <Badge intent="medium">Approval required</Badge>
+- "Approved" → `none`
+- "Approval required" → `medium`
 
-### Page status:
+<Canvas of={ ChoosingIntentStories.CommentStatus } />
 
--   "Published" → `none`: <Badge intent="none">Published</Badge>
--   "Pending" → `low`: <Badge intent="low">Pending</Badge>
--   "Draft" → `draft`: <Badge intent="draft">Draft</Badge>
--   "Scheduled" → `informational`: <Badge intent="informational">Scheduled</Badge>
--   "Private" → `informational`: <Badge intent="informational">Private</Badge>
+### Page status
 
-### Plugin status:
+- "Published" → `none`
+- "Pending" → `low`
+- "Draft" → `draft`
+- "Scheduled" → `informational`
+- "Private" → `informational`
 
--   "Active" → `stable`: <Badge intent="stable">Active</Badge>
--   "Inactive" → `none`: <Badge intent="none">Inactive</Badge>
+<Canvas of={ ChoosingIntentStories.PageStatus } />
+
+### Plugin status
+
+- "Active" → `stable`
+- "Inactive" → `none`
+
+<Canvas of={ ChoosingIntentStories.PluginStatus } />
 
 ## 5. When in doubt…
 

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge } from '../index';
+import { Stack } from '../../stack';
+
+const meta: Meta< typeof Badge > = {
+	title: 'Design System/Components/Badge/Choosing intent',
+	component: Badge,
+	decorators: [
+		( Story ) => (
+			<Stack direction="row" gap="xs" wrap="wrap">
+				<Story />
+			</Stack>
+		),
+	],
+	parameters: {
+		controls: { disable: true },
+	},
+	tags: [ '!dev' ],
+};
+export default meta;
+
+type Story = StoryObj< typeof Badge >;
+
+export const AllIntents: Story = {
+	render: () => (
+		<>
+			<Badge intent="high">high</Badge>
+			<Badge intent="medium">medium</Badge>
+			<Badge intent="low">low</Badge>
+			<Badge intent="stable">stable</Badge>
+			<Badge intent="informational">informational</Badge>
+			<Badge intent="draft">draft</Badge>
+			<Badge intent="none">none</Badge>
+		</>
+	),
+};
+
+export const High: Story = {
+	render: () => (
+		<>
+			<Badge intent="high">Payment declined</Badge>
+			<Badge intent="high">Security issue</Badge>
+		</>
+	),
+};
+
+export const Medium: Story = {
+	render: () => (
+		<>
+			<Badge intent="medium">Approval required</Badge>
+			<Badge intent="medium">Review needed</Badge>
+		</>
+	),
+};
+
+export const Low: Story = {
+	render: () => (
+		<>
+			<Badge intent="low">Pending</Badge>
+			<Badge intent="low">Queued</Badge>
+		</>
+	),
+};
+
+export const Informational: Story = {
+	render: () => (
+		<>
+			<Badge intent="informational">Scheduled</Badge>
+			<Badge intent="informational">Beta</Badge>
+		</>
+	),
+};
+
+export const Draft: Story = {
+	render: () => (
+		<>
+			<Badge intent="draft">Draft</Badge>
+			<Badge intent="draft">Unpublished</Badge>
+		</>
+	),
+};
+
+export const Stable: Story = {
+	render: () => (
+		<>
+			<Badge intent="stable">Healthy</Badge>
+			<Badge intent="stable">Active</Badge>
+		</>
+	),
+};
+
+export const None: Story = {
+	render: () => (
+		<>
+			<Badge intent="none">Inactive</Badge>
+			<Badge intent="none">Expired</Badge>
+		</>
+	),
+};
+
+export const CommentStatus: Story = {
+	render: () => (
+		<>
+			<Badge intent="none">Approved</Badge>
+			<Badge intent="medium">Approval required</Badge>
+		</>
+	),
+};
+
+export const PageStatus: Story = {
+	render: () => (
+		<>
+			<Badge intent="none">Published</Badge>
+			<Badge intent="low">Pending</Badge>
+			<Badge intent="draft">Draft</Badge>
+			<Badge intent="informational">Scheduled</Badge>
+			<Badge intent="informational">Private</Badge>
+		</>
+	),
+};
+
+export const PluginStatus: Story = {
+	render: () => (
+		<>
+			<Badge intent="stable">Active</Badge>
+			<Badge intent="none">Inactive</Badge>
+		</>
+	),
+};

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof Badge > = {
 	parameters: {
 		controls: { disable: true },
 	},
-	tags: [ '!dev' ],
+	tags: [ '!dev' /* Hide individual story pages from sidebar */ ],
 };
 export default meta;
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/73938#issuecomment-3683597362

## What?

Converts the component rendering in the "Choosing intents" doc for `Badge` to actual stories.

## Why?

This is going to be our preferred approach to render components inside MDX docs.

Why? Most importantly, it ensures correct loading of the required stylesheets, based on the [package-based config](https://github.com/WordPress/gutenberg/blob/trunk/storybook/package-styles/config.js).

As a bonus, all the toolbar tools work on the story canvases, including the theme switcher. "Show code" is also available.

## Testing Instructions

See the doc in Storybook, and check that the included information is the same as before.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="1208" height="1816" alt="Screenshot of doc page, before" src="https://github.com/user-attachments/assets/ab9e0a8c-1c76-4fc7-afa0-f5a364282405" />|<img width="1208" height="1816" alt="Screenshot of doc page, after" src="https://github.com/user-attachments/assets/50e6c1cd-8609-4d39-90e0-de6dc1401726" />|

