### PR TITLE
Block visibility: render blocks when hidden at all viewports (and other changes)

### DIFF
--- a/backport-changelog/7.0/10629.md
+++ b/backport-changelog/7.0/10629.md
@@ -4,3 +4,4 @@ https://github.com/WordPress/wordpress-develop/pull/10629
 * https://github.com/WordPress/gutenberg/pull/74379
 * https://github.com/WordPress/gutenberg/pull/74526
 * https://github.com/WordPress/gutenberg/pull/74602
+* https://github.com/WordPress/gutenberg/pull/74679

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -62,6 +62,11 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			array(
 				'name' => 'Desktop',
 				'slug' => 'desktop',
+				/*
+				 * Note: the last item in the breakpoints array does not technically require a size,
+				 * as the last item's media query is calculated using `width > previous size`.
+				 * It's included for consistency and as a record of the "official"breakpoint size.
+				 */
 				'size' => '960px',
 			),
 		);
@@ -103,16 +108,6 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		// If no breakpoints have visibility set to false, return unchanged.
 		if ( empty( $hidden_on ) ) {
 			return $block_content;
-		}
-
-		/*
-		 * If the block is hidden on all breakpoints,
-		 * do not render the block. If these values ever become user-defined,
-		 * we might need to output the CSS regardless of the breakpoint count.
-		 * For example, if there is one breakpoint defined and it's hidden.
-		 */
-		if ( count( $hidden_on ) === count( $breakpoint_queries ) ) {
-			return '';
 		}
 
 		// Maintain consistent order of breakpoints for class name generation.

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -39,16 +39,16 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		}
 
 		/*
-		 * Breakpoints definitions are in several places in WordPress packages.
+		 * Viewport size definitions are in several places in WordPress packages.
 		 * The following are taken from: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss
 		 * The array is in a future, potential JSON format, and will be centralized
 		 * as the feature is developed.
 		 *
-		 * Breakpoints as array items are defined sequentially. The first item's size is the max value.
+		 * Viewport sizes as array items are defined sequentially. The first item's size is the max value.
 		 * Each subsequent item starts after the previous size (using > operator), and its size is the max.
 		 * The last item starts after the previous size (using > operator), and it has no max.
 		 */
-		$breakpoints = array(
+		$viewport_sizes = array(
 			array(
 				'name' => 'Mobile',
 				'slug' => 'mobile',
@@ -63,34 +63,34 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 				'name' => 'Desktop',
 				'slug' => 'desktop',
 				/*
-				 * Note: the last item in the breakpoints array does not technically require a size,
+				 * Note: the last item in the $viewport_sizes array does not technically require a size,
 				 * as the last item's media query is calculated using `width > previous size`.
-				 * It's included for consistency and as a record of the "official"breakpoint size.
+				 * It's included for consistency and as a record of the "official" breakpoint size.
 				 */
 				'size' => '960px',
 			),
 		);
 
 		/*
-		 * Build media queries from breakpoint definitions using the CSS range syntax.
+		 * Build media queries from viewport size definitions using the CSS range syntax.
 		 * Could be absorbed into the style engine,
 		 * as well as classname building, and declaration of the display property, if required.
 		 */
-		$breakpoint_queries = array();
-		$previous_size      = null;
-		foreach ( $breakpoints as $index => $breakpoint ) {
-			$slug = $breakpoint['slug'];
-			$size = $breakpoint['size'];
+		$viewport_media_queries = array();
+		$previous_size          = null;
+		foreach ( $viewport_sizes as $index => $viewport_size ) {
+			$slug = $viewport_size['slug'];
+			$size = $viewport_size['size'];
 
 			// First item: width <= size.
 			if ( 0 === $index ) {
-				$breakpoint_queries[ $slug ] = "@media (width <= $size)";
-			} elseif ( count( $breakpoints ) - 1 === $index ) {
+				$viewport_media_queries[ $slug ] = "@media (width <= $size)";
+			} elseif ( count( $viewport_sizes ) - 1 === $index ) {
 				// Last item: width > previous size.
-				$breakpoint_queries[ $slug ] = "@media (width > $previous_size)";
+				$viewport_media_queries[ $slug ] = "@media (width > $previous_size)";
 			} else {
 				// Middle items: previous size < width <= size.
-				$breakpoint_queries[ $slug ] = "@media ($previous_size < width <= $size)";
+				$viewport_media_queries[ $slug ] = "@media ($previous_size < width <= $size)";
 			}
 
 			$previous_size = $size;
@@ -98,37 +98,37 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 		$hidden_on = array();
 
-		// Collect which breakpoints the block is hidden on (only known breakpoints).
-		foreach ( $viewport_config as $breakpoint => $is_visible ) {
-			if ( false === $is_visible && isset( $breakpoint_queries[ $breakpoint ] ) ) {
-				$hidden_on[] = $breakpoint;
+		// Collect which viewport the block is hidden on (only known viewport sizes).
+		foreach ( $viewport_config as $viewport_config_size => $is_visible ) {
+			if ( false === $is_visible && isset( $viewport_media_queries[ $viewport_config_size ] ) ) {
+				$hidden_on[] = $viewport_config_size;
 			}
 		}
 
-		// If no breakpoints have visibility set to false, return unchanged.
+		// If no viewport sizes have visibility set to false, return unchanged.
 		if ( empty( $hidden_on ) ) {
 			return $block_content;
 		}
 
-		// Maintain consistent order of breakpoints for class name generation.
+		// Maintain consistent order of viewport sizes for class name generation.
 		sort( $hidden_on );
 
 		$css_rules   = array();
 		$class_names = array();
 
-		foreach ( $hidden_on as $breakpoint ) {
+		foreach ( $hidden_on as $hidden_viewport_size ) {
 			/*
 			 * If these values ever become user-defined,
 			 * they should be sanitized and kebab-cased.
 			 */
-			$visibility_class = 'wp-block-hidden-' . $breakpoint;
+			$visibility_class = 'wp-block-hidden-' . $hidden_viewport_size;
 			$class_names[]    = $visibility_class;
 			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,
 				'declarations' => array(
 					'display' => 'none !important',
 				),
-				'rules_group'  => $breakpoint_queries[ $breakpoint ],
+				'rules_group'  => $viewport_media_queries[ $hidden_viewport_size ],
 			);
 		}
 

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -63,11 +63,11 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 				'name' => 'Desktop',
 				'slug' => 'desktop',
 				/*
-				 * Note: the last item in the $viewport_sizes array does not technically require a size,
+				 * Note: the last item in the $viewport_sizes array does not technically require a 'size' key,
 				 * as the last item's media query is calculated using `width > previous size`.
-				 * It's included for consistency and as a record of the "official" breakpoint size.
+				 * The last item is present for validating the attribute values, and in order to indicate
+				 * that this is the final viewport size, and to calculate the previous media query accordingly.
 				 */
-				'size' => '960px',
 			),
 		);
 
@@ -79,21 +79,18 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 		$viewport_media_queries = array();
 		$previous_size          = null;
 		foreach ( $viewport_sizes as $index => $viewport_size ) {
-			$slug = $viewport_size['slug'];
-			$size = $viewport_size['size'];
-
 			// First item: width <= size.
 			if ( 0 === $index ) {
-				$viewport_media_queries[ $slug ] = "@media (width <= $size)";
-			} elseif ( count( $viewport_sizes ) - 1 === $index ) {
+				$viewport_media_queries[ $viewport_size['slug'] ] = "@media (width <= {$viewport_size['size']})";
+			} elseif ( count( $viewport_sizes ) - 1 === $index && $previous_size ) {
 				// Last item: width > previous size.
-				$viewport_media_queries[ $slug ] = "@media (width > $previous_size)";
+				$viewport_media_queries[ $viewport_size['slug'] ] = "@media (width > $previous_size)";
 			} else {
 				// Middle items: previous size < width <= size.
-				$viewport_media_queries[ $slug ] = "@media ($previous_size < width <= $size)";
+				$viewport_media_queries[ $viewport_size['slug'] ] = "@media ({$previous_size} < width <= {$viewport_size['size']})";
 			}
 
-			$previous_size = $size;
+			$previous_size = $viewport_size['size'] ?? null;
 		}
 
 		$hidden_on = array();

--- a/packages/block-editor/src/components/block-visibility/modal.js
+++ b/packages/block-editor/src/components/block-visibility/modal.js
@@ -118,7 +118,7 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 			return sprintf(
 				// translators: %s: The shortcut key to access the List View.
 				__(
-					'Block visibility settings saved. You can access them via the List View (%s).'
+					'Block visibility settings updated. You can access them via the List View (%s).'
 				),
 				listViewShortcut
 			);
@@ -192,7 +192,7 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 			createSuccessNotice( noticeMessage, {
 				id: hideEverywhere
 					? 'block-visibility-hidden'
-					: 'block-visibility-viewports-saved',
+					: 'block-visibility-viewports-updated',
 				type: 'snackbar',
 			} );
 			onClose();

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -252,16 +252,16 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_support_generated_css_with_multiple_breakpoints() {
+	public function test_block_visibility_support_generated_css_with_two_breakpoints() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/viewport-multiple',
+			'test/viewport-two',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/viewport-multiple',
+			'blockName' => 'test/viewport-two',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -347,7 +347,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '', $result, 'Block content should be empty when all breakpoints are hidden.' );
+		$this->assertSame( '<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all breakpoints in the class attribute.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -147,7 +147,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when no visibility attribute is present.' );
 	}
 
-	public function test_block_visibility_support_generated_css_with_mobile_breakpoint() {
+	public function test_block_visibility_support_generated_css_with_mobile_viewport_size() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -171,7 +171,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
@@ -182,7 +182,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_support_generated_css_with_tablet_breakpoint() {
+	public function test_block_visibility_support_generated_css_with_tablet_viewport_size() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -206,7 +206,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet breakpoint in the class attribute.' );
+		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
@@ -217,7 +217,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_support_generated_css_with_desktop_breakpoint() {
+	public function test_block_visibility_support_generated_css_with_desktop_viewport_size() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -241,7 +241,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop breakpoint in the class attribute.' );
+		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
@@ -252,7 +252,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_support_generated_css_with_two_breakpoints() {
+	public function test_block_visibility_support_generated_css_with_two_viewport_sizes() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -292,7 +292,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_block_visibility_support_generated_css_with_all_breakpoints_visible() {
+	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_visible() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -318,10 +318,10 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when all breakpoints are visible.' );
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when all viewport sizes are visible.' );
 	}
 
-	public function test_block_visibility_support_generated_css_with_all_breakpoints_hidden() {
+	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_hidden() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
@@ -347,7 +347,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all breakpoints in the class attribute.' );
+		$this->assertSame( '<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {
@@ -373,16 +373,16 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility is an empty array.' );
 	}
 
-	public function test_block_visibility_support_generated_css_with_unknown_breakpoints_ignored() {
+	public function test_block_visibility_support_generated_css_with_unknown_viewport_sizes_ignored() {
 		$this->enable_viewport_visibility_experiment();
 
 		$this->register_visibility_block_with_support(
-			'test/viewport-unknown-breakpoints',
+			'test/viewport-unknown-sizes',
 			array( 'visibility' => true )
 		);
 
 		$block = array(
-			'blockName' => 'test/viewport-unknown-breakpoints',
+			'blockName' => 'test/viewport-unknown-sizes',
 			'attrs'     => array(
 				'metadata' => array(
 					'blockVisibility' => array(
@@ -402,7 +402,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			'class="wp-block-hidden-mobile"',
 			$result,
-			'Block should have the visibility class for the mobile breakpoint in the class attribute'
+			'Block should have the visibility class for the mobile viewport size in the class attribute'
 		);
 	}
 


### PR DESCRIPTION

## What?

Related to:

- https://github.com/WordPress/gutenberg/issues/72502

This PR:

1. Replaces "breakpoint" with "viewport" for lexical consistency. 
2. Removes the render block when all viewports are hidden and updates tests.
3. Adds a comment in the `$viewport_sizes` last item to indicate that the final size isn't necessary technically (for now). 

## Why?

1. "Viewport" is used throughout for this feature mostly. See https://github.com/WordPress/gutenberg/pull/73994#discussion_r2619057076
2. To make the render behaviour consistent with what's promised in the UI (see screenshot of the modal below and also https://github.com/WordPress/gutenberg/pull/74249#issuecomment-3737332069)
3. As a courtesy to devs, and as a reminder to come back and question the logic.


<img width="373" height="443" alt="Screenshot 2026-01-16 at 2 40 08 pm" src="https://github.com/user-attachments/assets/97ad154c-d953-42ef-a152-832cfeff0ab1" />



## Testing Instructions

There is only only one logic change on the frontend. The rest is formatting and renaming.

To test manually, enable the experiment:

<img width="998" height="90" alt="Screenshot 2025-12-15 at 10 53 52 am" src="https://github.com/user-attachments/assets/ec7052f1-3758-4f2c-8ad1-93ddd50fd0c5" />

In the editor, hide a block at all breakpoints. 

<img width="373" height="443" alt="Screenshot 2026-01-16 at 2 40 08 pm" src="https://github.com/user-attachments/assets/97ad154c-d953-42ef-a152-832cfeff0ab1" />

Save the post and preview the frontend. 

Inspect the hidden block, It should still be in the DOM but hidden by the `wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet` classes.

Tests should pass.
