### PR TITLE
Block Editor Provider: Fix editor error for contributor role when client-side media experiment is active

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -71,18 +71,19 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 
 		const mediaUploadSettings = useMediaUploadSettings( _settings );
 
-		let settings = _settings;
-
-		if ( window.__experimentalMediaProcessing && _settings.mediaUpload ) {
-			// Create a new variable so that the original props.settings.mediaUpload is not modified.
-			settings = useMemo(
-				() => ( {
+		const settings = useMemo( () => {
+			if (
+				window.__experimentalMediaProcessing &&
+				_settings?.mediaUpload
+			) {
+				// Create a new object so that the original props.settings.mediaUpload is not modified.
+				return {
 					..._settings,
 					mediaUpload: mediaUpload.bind( null, registry ),
-				} ),
-				[ _settings, registry ]
-			);
-		}
+				};
+			}
+			return _settings;
+		}, [ _settings, registry ] );
 
 		const { __experimentalUpdateSettings } = unlock(
 			useDispatch( blockEditorStore )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of: https://github.com/WordPress/gutenberg/issues/74333

Fix an editor error for users with the contributor role when the client-side media experiment is active.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the `useMemo` to mutate `mediaUpload` in `settings` to use the bound function that dispatches `addItems` in the new upload-media package, is called conditionally. This results in an error when attempting to add a post as a contributor user (where the user doesn't have access to `mediaUpload`).

To resolve this issue, ensure the `useMemo` is always called, and place the condition inside the `useMemo` instead. We fall back to returning `_settings`, so (at least in theory) it should be effectively the same as before when the experiment isn't active.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the block editor provider, ensure the `useMemo` is always called, and place conditions inside the hook instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the client-side media processing experiment: 
<img width="1038" height="71" alt="image" src="https://github.com/user-attachments/assets/18727cef-6e2d-4ba7-ba44-0885400de4fc" />

* Create a user with the contributor role
* Log in as that user and go to create a post
* In `trunk` the editor will crash (see screenshot below), but with this PR it should work
* Smoke test uploading as an admin and that it otherwise works as on `trunk`
* Also smoke test that with the experiment disabled, uploading, etc, works fine as on `trunk`

## Screenshots or screencast <!-- if applicable -->

This is the error I was getting:

<img width="3980" height="2010" alt="image" src="https://github.com/user-attachments/assets/0dae65cc-107e-49a5-bad4-5d0f4330839f" />
