### PR TITLE
Inspector tabs: Reset tab selection if the selected tab is no longer present

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -44,7 +44,11 @@ export default function InspectorControlsTabs( {
 
 	// Auto-select first available tab unless user has made a selection
 	useEffect( () => {
-		if ( ! tabs?.length || hasUserSelectionRef.current ) {
+		if (
+			! tabs?.length ||
+			( hasUserSelectionRef.current &&
+				tabs.some( ( tab ) => tab.name === selectedTabId ) )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## What?
Fixes an issue where there can be an unselected tab resulting in an empty block inspector.

The issue happens with the Patttern Editing experiment when using the 'Edit Section' button. That action can change the available block inspector tabs, so it's important that a valid tab remains selected

## How?
Some code was added recently that bypassed resetting the tab selection if the user has selected a tab. This logic didn't take into account that the user selected tab might no longer exist and would try to maintain a non-existent selection.

The fix is to still reset the tab if the select tab no longer exists.

## Testing Instructions
Prerequisite: Enable the Pattern Editing experiment
1. Add an unsynced pattern to a post that contains Button, List, Navigation and/or Social
2. With the pattern selected, open the block inspector and select the List View tab
3. Just above that, click the 'Edit Section' button

Expected: The pattern becomes editable and the 'Settings' inspector tab is shown
Actual: The pattern becomes editable, but the Block Inspector shows no selected tab and no block tools.

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/user-attachments/assets/a2ea293d-5a76-4237-81d1-0a00489bb3ca

#### After

https://github.com/user-attachments/assets/45a0695b-f1df-44aa-9383-1f904f35d920

