### PR TITLE
Feature/extensible tools panels

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import AdvancedControls from './advanced-controls-panel';
@@ -8,6 +13,9 @@ import { default as InspectorControls } from '../inspector-controls';
 const SettingsTab = ( { showAdvancedControls = false } ) => (
 	<>
 		<InspectorControls.Slot />
+		<InspectorControls.Slot group="settings" label={ __( 'Settings' ) } />
+		<InspectorControls.Slot group="display" label={ __( 'Display' ) } />
+		<InspectorControls.Slot group="media" label={ __( 'Media' ) } />
 		<PositionControls />
 		<InspectorControls.Slot group="bindings" />
 		{ showAdvancedControls && (

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -42,8 +42,11 @@ export default function useInspectorControlsTabs(
 		content: contentGroup,
 		default: defaultGroup,
 		dimensions: dimensionsGroup,
+		display: displayGroup,
 		list: listGroup,
+		media: mediaGroup,
 		position: positionGroup,
+		settings: settingsGroup,
 		styles: stylesGroup,
 		typography: typographyGroup,
 		effects: effectsGroup,
@@ -80,6 +83,9 @@ export default function useInspectorControlsTabs(
 
 	const settingsFills = [
 		...( useSlotFills( defaultGroup.name ) || [] ),
+		...( useSlotFills( settingsGroup.name ) || [] ),
+		...( useSlotFills( displayGroup.name ) || [] ),
+		...( useSlotFills( mediaGroup.name ) || [] ),
 		...( useSlotFills( positionGroup.name ) || [] ),
 		...( hasListFills && hasStyleFills > 1 ? advancedFills : [] ),
 	];

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -180,6 +180,90 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 } );
 ```
 
+## InspectorControls Groups
+
+InspectorControls supports a `group` prop that allows you to target specific panels in the block inspector. This enables third-party developers to extend core blocks by adding controls to standardized panels.
+
+### Available Groups
+
+#### Settings Tab Groups
+
+- **`default`** - Renders directly in the Settings tab without a ToolsPanel wrapper
+- **`settings`** - Renders inside a "Settings" ToolsPanel
+- **`display`** - Renders inside a "Display" ToolsPanel
+- **`media`** - Renders inside a "Media" ToolsPanel
+- **`position`** - Position controls panel
+- **`bindings`** - Block bindings panel
+- **`advanced`** - Advanced controls panel
+
+#### Styles Tab Groups
+
+- **`color`** - Color panel
+- **`background`** - Background image panel
+- **`typography`** - Typography panel
+- **`dimensions`** - Dimensions panel
+- **`border`** - Border panel
+- **`effects`** - Effects panel
+- **`styles`** - General styles panel
+
+#### Other Groups
+
+- **`list`** - List view controls
+- **`content`** - Content-specific controls
+- **`filter`** - Filter controls (used in Styles tab)
+
+### Using Groups with ToolsPanelItem
+
+When using groups that render inside a ToolsPanel (like `settings`, `display`, `media`), you should use `ToolsPanelItem` components and provide a `resetAllFilter` function:
+
+```js
+import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+
+function MyBlockEdit( { attributes, setAttributes } ) {
+	return (
+		<>
+			<InspectorControls
+				group="settings"
+				resetAllFilter={ () => ( {
+					width: undefined,
+					height: undefined,
+				} ) }
+			>
+				<ToolsPanelItem
+					label="Width"
+					hasValue={ () => !! attributes.width }
+					onDeselect={ () => setAttributes( { width: undefined } ) }
+					isShownByDefault
+				>
+					<RangeControl
+						label="Width"
+						value={ attributes.width }
+						onChange={ ( value ) => setAttributes( { width: value } ) }
+					/>
+				</ToolsPanelItem>
+			</InspectorControls>
+		</>
+	);
+}
+```
+
+### Namespaced Groups for Block-Specific Panels
+
+You can create block-specific extensible panels using namespaced groups (format: `blockname/panelname`). These require explicitly rendering the slot:
+
+```js
+// In your block's edit component, render the slot:
+<InspectorControls.Slot group="query/filters" label={ __( 'Filters' ) } />
+
+// Your block or third-party code can add controls:
+<InspectorControls group="query/filters">
+	<ToolsPanelItem label="Custom Filter">
+		{ /* Custom filter controls */ }
+	</ToolsPanelItem>
+</InspectorControls>
+```
+
 ## InspectorAdvancedControls
 
 <img src="https://user-images.githubusercontent.com/150562/94028603-df90bf00-fdb3-11ea-9e6f-eb15c5631d85.png" width="280" alt="inspector-advanced-controls">

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -22,6 +22,18 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 	} = useSelect( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const panelId = getSelectedBlockClientId();
+	
+	// Determine if this is a style-based panel (design tools) or attribute-based panel (settings, display, media)
+	const isStylePanel = [
+		'color',
+		'background',
+		'typography',
+		'dimensions',
+		'border',
+		'effects',
+		'filter',
+	].includes( group );
+	
 	const resetAll = useCallback(
 		( resetFilters = [] ) => {
 			const newAttributes = {};
@@ -31,21 +43,35 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 				: [ panelId ];
 
 			clientIds.forEach( ( clientId ) => {
-				const { style } = getBlockAttributes( clientId );
-				let newBlockAttributes = { style };
+				let newBlockAttributes = {};
+				
+				if ( isStylePanel ) {
+					// For style-based panels, work with the style object
+					const { style } = getBlockAttributes( clientId );
+					newBlockAttributes = { style };
 
-				resetFilters.forEach( ( resetFilter ) => {
+					resetFilters.forEach( ( resetFilter ) => {
+						newBlockAttributes = {
+							...newBlockAttributes,
+							...resetFilter( newBlockAttributes ),
+						};
+					} );
+
+					// Enforce a cleaned style object.
 					newBlockAttributes = {
 						...newBlockAttributes,
-						...resetFilter( newBlockAttributes ),
+						style: cleanEmptyObject( newBlockAttributes.style ),
 					};
-				} );
-
-				// Enforce a cleaned style object.
-				newBlockAttributes = {
-					...newBlockAttributes,
-					style: cleanEmptyObject( newBlockAttributes.style ),
-				};
+				} else {
+					// For attribute-based panels, directly apply reset filters
+					resetFilters.forEach( ( resetFilter ) => {
+						const resetAttributes = resetFilter( getBlockAttributes( clientId ) );
+						newBlockAttributes = {
+							...newBlockAttributes,
+							...resetAttributes,
+						};
+					} );
+				}
 
 				newAttributes[ clientId ] = newBlockAttributes;
 			} );
@@ -56,6 +82,7 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			getBlockAttributes,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
+			isStylePanel,
 			panelId,
 			updateBlockAttributes,
 		]

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -17,7 +17,7 @@ import {
 	mayDisplayControlsKey,
 	mayDisplayPatternEditingControlsKey,
 } from '../block-edit/context';
-import groups from './groups';
+import { getGroup } from './groups';
 
 export default function InspectorControlsFill( {
 	children,
@@ -38,7 +38,8 @@ export default function InspectorControlsFill( {
 	}
 
 	const context = useBlockEditContext();
-	const Fill = groups[ group ]?.Fill;
+	const slotFill = getGroup( group );
+	const Fill = slotFill?.Fill;
 	if ( ! Fill ) {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -47,6 +47,31 @@ const groups = {
 	typography: InspectorControlsTypography,
 };
 
+/**
+ * Gets or creates a SlotFill for the given group name.
+ * Supports namespaced groups (e.g., 'query/filters') by dynamically creating SlotFills.
+ *
+ * @param {string} groupName The group name.
+ * @return {Object|null} The SlotFill object or null if invalid.
+ */
+export function getGroup( groupName ) {
+	if ( groups[ groupName ] ) {
+		return groups[ groupName ];
+	}
+
+	// Support namespaced groups for block-specific panels
+	if ( groupName && groupName.includes( '/' ) ) {
+		if ( ! groups[ groupName ] ) {
+			groups[ groupName ] = createSlotFill(
+				`InspectorControls/${ groupName }`
+			);
+		}
+		return groups[ groupName ];
+	}
+
+	return null;
+}
+
 export default groups;
 
 // Private slot for allowed blocks control UI.

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -15,7 +15,10 @@ const InspectorControlsFilter = createSlotFill( 'InspectorControlsFilter' );
 const InspectorControlsDimensions = createSlotFill(
 	'InspectorControlsDimensions'
 );
+const InspectorControlsDisplay = createSlotFill( 'InspectorControlsDisplay' );
+const InspectorControlsMedia = createSlotFill( 'InspectorControlsMedia' );
 const InspectorControlsPosition = createSlotFill( 'InspectorControlsPosition' );
+const InspectorControlsSettings = createSlotFill( 'InspectorControlsSettings' );
 const InspectorControlsTypography = createSlotFill(
 	'InspectorControlsTypography'
 );
@@ -33,11 +36,13 @@ const groups = {
 	color: InspectorControlsColor,
 	content: InspectorControlsContent,
 	dimensions: InspectorControlsDimensions,
+	display: InspectorControlsDisplay,
 	effects: InspectorControlsEffects,
 	filter: InspectorControlsFilter,
 	list: InspectorControlsListView,
+	media: InspectorControlsMedia,
 	position: InspectorControlsPosition,
-	settings: InspectorControlsDefault, // Alias for default.
+	settings: InspectorControlsSettings,
 	styles: InspectorControlsStyles,
 	typography: InspectorControlsTypography,
 };

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -10,7 +10,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import BlockSupportToolsPanel from './block-support-tools-panel';
 import BlockSupportSlotContainer from './block-support-slot-container';
-import groups from './groups';
+import { getGroup } from './groups';
 
 export default function InspectorControlsSlot( {
 	__experimentalGroup,
@@ -30,7 +30,7 @@ export default function InspectorControlsSlot( {
 		);
 		group = __experimentalGroup;
 	}
-	const slotFill = groups[ group ];
+	const slotFill = getGroup( group );
 	const fills = useSlotFills( slotFill?.name );
 
 	if ( ! slotFill ) {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -11,7 +11,6 @@ import {
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
 	Placeholder,
@@ -55,7 +54,6 @@ import { createUpgradedEmbedBlock } from '../embed/util';
 import { isExternalImage } from './edit';
 import { Caption } from '../utils/caption';
 import { MediaControl } from '../utils/media-control';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
 	MIN_SIZE,
 	ALLOWED_MEDIA_TYPES,
@@ -555,8 +553,6 @@ export default function Image( {
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
 
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
 	const dimensionsControl =
 		isResizable &&
 		( SIZED_LAYOUTS.includes( parentLayoutType ) ? (
@@ -602,13 +598,6 @@ export default function Image( {
 				unitsOptions={ dimensionsUnitsOptions }
 			/>
 		) );
-
-	const resetSettings = () => {
-		setAttributes( {
-			lightbox: undefined,
-		} );
-		updateImage( DEFAULT_MEDIA_SIZE_SLUG );
-	};
 
 	const arePatternOverridesEnabled =
 		metadata?.bindings?.__default?.source === 'core/pattern-overrides';
@@ -788,82 +777,78 @@ export default function Image( {
 					/>
 				</BlockControls>
 			) }
-			{ ! hasDataFormBlockFields && isSingleSelected && (
-				<InspectorControls group="content">
-					<ToolsPanel
-						label={ __( 'Media' ) }
-						resetAll={ () => onSelectImage( undefined ) }
-						dropdownMenuProps={ dropdownMenuProps }
+		{ ! hasDataFormBlockFields && isSingleSelected && (
+			<InspectorControls
+				group="media"
+				resetAllFilter={ () => ( {
+					url: undefined,
+					alt: undefined,
+					id: undefined,
+				} ) }
+			>
+				{ ! lockUrlControls && (
+					<ToolsPanelItem
+						label={ __( 'Image' ) }
+						hasValue={ () => !! url }
+						onDeselect={ () => onSelectImage( undefined ) }
+						isShownByDefault
 					>
-						{ ! lockUrlControls && (
-							<ToolsPanelItem
-								label={ __( 'Image' ) }
-								hasValue={ () => !! url }
-								onDeselect={ () => onSelectImage( undefined ) }
-								isShownByDefault
-							>
-								<MediaControl
-									mediaId={ id }
-									mediaUrl={ url }
-									alt={ alt }
-									filename={
-										image?.media_details?.sizes?.full
-											?.file ||
-										image?.slug ||
-										getFilename( url )
-									}
-									allowedTypes={ ALLOWED_MEDIA_TYPES }
-									onSelect={ onSelectImage }
-									onSelectURL={ onSelectURL }
-									onError={ onUploadError }
-									onReset={ () => onSelectImage( undefined ) }
-									isUploading={ !! temporaryURL }
-									emptyLabel={ __( 'Add image' ) }
-								/>
-							</ToolsPanelItem>
-						) }
-						<ToolsPanelItem
-							label={ __( 'Alternative text' ) }
-							isShownByDefault
-							hasValue={ () => !! alt }
-							onDeselect={ () =>
-								setAttributes( { alt: undefined } )
+						<MediaControl
+							mediaId={ id }
+							mediaUrl={ url }
+							alt={ alt }
+							filename={
+								image?.media_details?.sizes?.full?.file ||
+								image?.slug ||
+								getFilename( url )
 							}
-						>
-							<TextareaControl
-								label={ __( 'Alternative text' ) }
-								value={ alt || '' }
-								onChange={ updateAlt }
-								readOnly={ lockAltControls }
-								help={
-									lockAltControls ? (
-										<>{ lockAltControlsMessage }</>
-									) : (
-										<>
-											<ExternalLink
-												href={
-													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-													__(
-														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-													)
-												}
-											>
-												{ __(
-													'Describe the purpose of the image.'
-												) }
-											</ExternalLink>
-											<br />
-											{ __(
-												'Leave empty if decorative.'
-											) }
-										</>
-									)
-								}
-							/>
-						</ToolsPanelItem>
-					</ToolsPanel>
-				</InspectorControls>
-			) }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							onSelect={ onSelectImage }
+							onSelectURL={ onSelectURL }
+							onError={ onUploadError }
+							onReset={ () => onSelectImage( undefined ) }
+							isUploading={ !! temporaryURL }
+							emptyLabel={ __( 'Add image' ) }
+						/>
+					</ToolsPanelItem>
+				) }
+				<ToolsPanelItem
+					label={ __( 'Alternative text' ) }
+					isShownByDefault
+					hasValue={ () => !! alt }
+					onDeselect={ () => setAttributes( { alt: undefined } ) }
+				>
+					<TextareaControl
+						label={ __( 'Alternative text' ) }
+						value={ alt || '' }
+						onChange={ updateAlt }
+						readOnly={ lockAltControls }
+						help={
+							lockAltControls ? (
+								<>{ lockAltControlsMessage }</>
+							) : (
+								<>
+									<ExternalLink
+										href={
+											// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+											__(
+												'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+											)
+										}
+									>
+										{ __(
+											'Describe the purpose of the image.'
+										) }
+									</ExternalLink>
+									<br />
+									{ __( 'Leave empty if decorative.' ) }
+								</>
+							)
+						}
+					/>
+				</ToolsPanelItem>
+			</InspectorControls>
+		) }
 			<InspectorControls
 				group="dimensions"
 				resetAllFilter={ ( attrs ) => ( {
@@ -903,22 +888,21 @@ export default function Image( {
 					</ToolsPanelItem>
 				) }
 			</InspectorControls>
-			{ !! imageSizeOptions.length && (
-				<InspectorControls>
-					<ToolsPanel
-						label={ __( 'Settings' ) }
-						resetAll={ resetSettings }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						<ResolutionTool
-							value={ sizeSlug }
-							defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
-							onChange={ updateImage }
-							options={ imageSizeOptions }
-						/>
-					</ToolsPanel>
-				</InspectorControls>
-			) }
+		{ !! imageSizeOptions.length && (
+			<InspectorControls
+				group="settings"
+				resetAllFilter={ () => ( {
+					sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
+				} ) }
+			>
+				<ResolutionTool
+					value={ sizeSlug }
+					defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
+					onChange={ updateImage }
+					options={ imageSizeOptions }
+				/>
+			</InspectorControls>
+		) }
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -791,7 +791,12 @@ export default function Image( {
 						label={ __( 'Image' ) }
 						hasValue={ () => !! url }
 						onDeselect={ () => onSelectImage( undefined ) }
+						resetAllFilter={ () => ( {
+							url: undefined,
+							id: undefined,
+						} ) }
 						isShownByDefault
+						panelId={ clientId }
 					>
 						<MediaControl
 							mediaId={ id }
@@ -817,6 +822,10 @@ export default function Image( {
 					isShownByDefault
 					hasValue={ () => !! alt }
 					onDeselect={ () => setAttributes( { alt: undefined } ) }
+					resetAllFilter={ () => ( {
+						alt: undefined,
+					} ) }
+					panelId={ clientId }
 				>
 					<TextareaControl
 						label={ __( 'Alternative text' ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -777,87 +777,87 @@ export default function Image( {
 					/>
 				</BlockControls>
 			) }
-		{ ! hasDataFormBlockFields && isSingleSelected && (
-			<InspectorControls
-				group="media"
-				resetAllFilter={ () => ( {
-					url: undefined,
-					alt: undefined,
-					id: undefined,
-				} ) }
-			>
-				{ ! lockUrlControls && (
+			{ ! hasDataFormBlockFields && isSingleSelected && (
+				<InspectorControls
+					group="media"
+					resetAllFilter={ () => ( {
+						url: undefined,
+						alt: undefined,
+						id: undefined,
+					} ) }
+				>
+					{ ! lockUrlControls && (
+						<ToolsPanelItem
+							label={ __( 'Image' ) }
+							hasValue={ () => !! url }
+							onDeselect={ () => onSelectImage( undefined ) }
+							resetAllFilter={ () => ( {
+								url: undefined,
+								id: undefined,
+							} ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
+							<MediaControl
+								mediaId={ id }
+								mediaUrl={ url }
+								alt={ alt }
+								filename={
+									image?.media_details?.sizes?.full?.file ||
+									image?.slug ||
+									getFilename( url )
+								}
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								onSelect={ onSelectImage }
+								onSelectURL={ onSelectURL }
+								onError={ onUploadError }
+								onReset={ () => onSelectImage( undefined ) }
+								isUploading={ !! temporaryURL }
+								emptyLabel={ __( 'Add image' ) }
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
-						label={ __( 'Image' ) }
-						hasValue={ () => !! url }
-						onDeselect={ () => onSelectImage( undefined ) }
-						resetAllFilter={ () => ( {
-							url: undefined,
-							id: undefined,
-						} ) }
+						label={ __( 'Alternative text' ) }
 						isShownByDefault
+						hasValue={ () => !! alt }
+						onDeselect={ () => setAttributes( { alt: undefined } ) }
+						resetAllFilter={ () => ( {
+							alt: undefined,
+						} ) }
 						panelId={ clientId }
 					>
-						<MediaControl
-							mediaId={ id }
-							mediaUrl={ url }
-							alt={ alt }
-							filename={
-								image?.media_details?.sizes?.full?.file ||
-								image?.slug ||
-								getFilename( url )
+						<TextareaControl
+							label={ __( 'Alternative text' ) }
+							value={ alt || '' }
+							onChange={ updateAlt }
+							readOnly={ lockAltControls }
+							help={
+								lockAltControls ? (
+									<>{ lockAltControlsMessage }</>
+								) : (
+									<>
+										<ExternalLink
+											href={
+												// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+												__(
+													'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+												)
+											}
+										>
+											{ __(
+												'Describe the purpose of the image.'
+											) }
+										</ExternalLink>
+										<br />
+										{ __( 'Leave empty if decorative.' ) }
+									</>
+								)
 							}
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							onSelect={ onSelectImage }
-							onSelectURL={ onSelectURL }
-							onError={ onUploadError }
-							onReset={ () => onSelectImage( undefined ) }
-							isUploading={ !! temporaryURL }
-							emptyLabel={ __( 'Add image' ) }
 						/>
 					</ToolsPanelItem>
-				) }
-				<ToolsPanelItem
-					label={ __( 'Alternative text' ) }
-					isShownByDefault
-					hasValue={ () => !! alt }
-					onDeselect={ () => setAttributes( { alt: undefined } ) }
-					resetAllFilter={ () => ( {
-						alt: undefined,
-					} ) }
-					panelId={ clientId }
-				>
-					<TextareaControl
-						label={ __( 'Alternative text' ) }
-						value={ alt || '' }
-						onChange={ updateAlt }
-						readOnly={ lockAltControls }
-						help={
-							lockAltControls ? (
-								<>{ lockAltControlsMessage }</>
-							) : (
-								<>
-									<ExternalLink
-										href={
-											// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-											__(
-												'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-											)
-										}
-									>
-										{ __(
-											'Describe the purpose of the image.'
-										) }
-									</ExternalLink>
-									<br />
-									{ __( 'Leave empty if decorative.' ) }
-								</>
-							)
-						}
-					/>
-				</ToolsPanelItem>
-			</InspectorControls>
-		) }
+				</InspectorControls>
+			) }
 			<InspectorControls
 				group="dimensions"
 				resetAllFilter={ ( attrs ) => ( {
@@ -897,25 +897,25 @@ export default function Image( {
 					</ToolsPanelItem>
 				) }
 			</InspectorControls>
-		{ !! imageSizeOptions.length && (
-			<InspectorControls
-				group="settings"
-				resetAllFilter={ () => ( {
-					sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
-				} ) }
-			>
-				<ResolutionTool
-					value={ sizeSlug }
-					defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
-					onChange={ updateImage }
-					options={ imageSizeOptions }
-					panelId={ clientId }
+			{ !! imageSizeOptions.length && (
+				<InspectorControls
+					group="settings"
 					resetAllFilter={ () => ( {
 						sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
 					} ) }
-				/>
-			</InspectorControls>
-		) }
+				>
+					<ResolutionTool
+						value={ sizeSlug }
+						defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
+						onChange={ updateImage }
+						options={ imageSizeOptions }
+						panelId={ clientId }
+						resetAllFilter={ () => ( {
+							sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
+						} ) }
+					/>
+				</InspectorControls>
+			) }
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -909,6 +909,10 @@ export default function Image( {
 					defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
 					onChange={ updateImage }
 					options={ imageSizeOptions }
+					panelId={ clientId }
+					resetAllFilter={ () => ( {
+						sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
+					} ) }
 				/>
 			</InspectorControls>
 		) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -689,16 +689,20 @@ function Navigation( {
 								/>
 							) }
 
-							<ToolsPanelItem
-								hasValue={ () => overlayMenu !== 'mobile' }
-								label={ __( 'Overlay Visibility' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										overlayMenu: 'mobile',
-									} )
-								}
-								isShownByDefault
-							>
+						<ToolsPanelItem
+							hasValue={ () => overlayMenu !== 'mobile' }
+							label={ __( 'Overlay Visibility' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									overlayMenu: 'mobile',
+								} )
+							}
+							resetAllFilter={ () => ( {
+								overlayMenu: 'mobile',
+							} ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 								<OverlayVisibilityControl
 									overlayMenu={ overlayMenu }
 									setAttributes={ setAttributes }
@@ -712,17 +716,22 @@ function Navigation( {
 							<h3 className="wp-block-navigation__submenu-header">
 								{ __( 'Submenus' ) }
 							</h3>
-							<ToolsPanelItem
-								hasValue={ () => openSubmenusOnClick }
-								label={ __( 'Open on click' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										openSubmenusOnClick: false,
-										showSubmenuIcon: true,
-									} )
-								}
-								isShownByDefault
-							>
+						<ToolsPanelItem
+							hasValue={ () => openSubmenusOnClick }
+							label={ __( 'Open on click' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									openSubmenusOnClick: false,
+									showSubmenuIcon: true,
+								} )
+							}
+							resetAllFilter={ () => ( {
+								openSubmenusOnClick: false,
+								showSubmenuIcon: true,
+							} ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 								<ToggleControl
 									checked={ openSubmenusOnClick }
 									onChange={ ( value ) => {
@@ -737,17 +746,21 @@ function Navigation( {
 								/>
 							</ToolsPanelItem>
 
-							<ToolsPanelItem
-								hasValue={ () => ! showSubmenuIcon }
-								label={ __( 'Show arrow' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										showSubmenuIcon: true,
-									} )
-								}
-								isDisabled={ attributes.openSubmenusOnClick }
-								isShownByDefault
-							>
+						<ToolsPanelItem
+							hasValue={ () => ! showSubmenuIcon }
+							label={ __( 'Show arrow' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									showSubmenuIcon: true,
+								} )
+							}
+							resetAllFilter={ () => ( {
+								showSubmenuIcon: true,
+							} ) }
+							isDisabled={ attributes.openSubmenusOnClick }
+							isShownByDefault
+							panelId={ clientId }
+						>
 								<ToggleControl
 									checked={ showSubmenuIcon }
 									onChange={ ( value ) => {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,7 +32,6 @@ import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToggleControl,
 	Spinner,
@@ -76,7 +75,6 @@ import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
-import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { DEFAULT_BLOCK } from '../constants';
 
 /**
@@ -654,141 +652,128 @@ function Navigation( {
 		`overlay-menu-preview`
 	);
 
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
 	const stylingInspectorControls = (
 		<>
-			<InspectorControls>
-				{ ( ! isOverlayExperimentEnabled || hasSubmenus ) && (
-					<ToolsPanel
-						label={ __( 'Display' ) }
-						resetAll={ () => {
-							setAttributes( {
-								showSubmenuIcon: true,
-								openSubmenusOnClick: false,
-								overlayMenu: 'mobile',
-								hasIcon: true,
-								icon: 'handle',
-							} );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						{ ! isOverlayExperimentEnabled && (
-							<>
-								{ isResponsive && (
-									<OverlayMenuPreviewButton
-										isResponsive={ isResponsive }
-										overlayMenuPreview={
-											overlayMenuPreview
-										}
-										setOverlayMenuPreview={
-											setOverlayMenuPreview
-										}
-										hasIcon={ hasIcon }
-										icon={ icon }
-										setAttributes={ setAttributes }
-										overlayMenuPreviewClasses={
-											overlayMenuPreviewClasses
-										}
-										overlayMenuPreviewId={
-											overlayMenuPreviewId
-										}
-										containerStyle={ {
-											gridColumn: 'span 2',
-										} }
-									/>
-								) }
-
-								<ToolsPanelItem
-									hasValue={ () => overlayMenu !== 'mobile' }
-									label={ __( 'Overlay Visibility' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											overlayMenu: 'mobile',
-										} )
+			{ ( ! isOverlayExperimentEnabled || hasSubmenus ) && (
+				<InspectorControls
+					group="display"
+					resetAllFilter={ () => ( {
+						showSubmenuIcon: true,
+						openSubmenusOnClick: false,
+						overlayMenu: 'mobile',
+						hasIcon: true,
+						icon: 'handle',
+					} ) }
+				>
+					{ ! isOverlayExperimentEnabled && (
+						<>
+							{ isResponsive && (
+								<OverlayMenuPreviewButton
+									isResponsive={ isResponsive }
+									overlayMenuPreview={ overlayMenuPreview }
+									setOverlayMenuPreview={
+										setOverlayMenuPreview
 									}
-									isShownByDefault
-								>
-									<OverlayVisibilityControl
-										overlayMenu={ overlayMenu }
-										setAttributes={ setAttributes }
-									/>
-								</ToolsPanelItem>
-							</>
-						) }
+									hasIcon={ hasIcon }
+									icon={ icon }
+									setAttributes={ setAttributes }
+									overlayMenuPreviewClasses={
+										overlayMenuPreviewClasses
+									}
+									overlayMenuPreviewId={
+										overlayMenuPreviewId
+									}
+									containerStyle={ {
+										gridColumn: 'span 2',
+									} }
+								/>
+							) }
 
-						{ hasSubmenus && (
-							<>
-								<h3 className="wp-block-navigation__submenu-header">
-									{ __( 'Submenus' ) }
-								</h3>
-								<ToolsPanelItem
-									hasValue={ () => openSubmenusOnClick }
+							<ToolsPanelItem
+								hasValue={ () => overlayMenu !== 'mobile' }
+								label={ __( 'Overlay Visibility' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										overlayMenu: 'mobile',
+									} )
+								}
+								isShownByDefault
+							>
+								<OverlayVisibilityControl
+									overlayMenu={ overlayMenu }
+									setAttributes={ setAttributes }
+								/>
+							</ToolsPanelItem>
+						</>
+					) }
+
+					{ hasSubmenus && (
+						<>
+							<h3 className="wp-block-navigation__submenu-header">
+								{ __( 'Submenus' ) }
+							</h3>
+							<ToolsPanelItem
+								hasValue={ () => openSubmenusOnClick }
+								label={ __( 'Open on click' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										openSubmenusOnClick: false,
+										showSubmenuIcon: true,
+									} )
+								}
+								isShownByDefault
+							>
+								<ToggleControl
+									checked={ openSubmenusOnClick }
+									onChange={ ( value ) => {
+										setAttributes( {
+											openSubmenusOnClick: value,
+											...( value && {
+												showSubmenuIcon: true,
+											} ), // Make sure arrows are shown when we toggle this on.
+										} );
+									} }
 									label={ __( 'Open on click' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											openSubmenusOnClick: false,
-											showSubmenuIcon: true,
-										} )
-									}
-									isShownByDefault
-								>
-									<ToggleControl
-										checked={ openSubmenusOnClick }
-										onChange={ ( value ) => {
-											setAttributes( {
-												openSubmenusOnClick: value,
-												...( value && {
-													showSubmenuIcon: true,
-												} ), // Make sure arrows are shown when we toggle this on.
-											} );
-										} }
-										label={ __( 'Open on click' ) }
-									/>
-								</ToolsPanelItem>
+								/>
+							</ToolsPanelItem>
 
-								<ToolsPanelItem
-									hasValue={ () => ! showSubmenuIcon }
+							<ToolsPanelItem
+								hasValue={ () => ! showSubmenuIcon }
+								label={ __( 'Show arrow' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										showSubmenuIcon: true,
+									} )
+								}
+								isDisabled={ attributes.openSubmenusOnClick }
+								isShownByDefault
+							>
+								<ToggleControl
+									checked={ showSubmenuIcon }
+									onChange={ ( value ) => {
+										setAttributes( {
+											showSubmenuIcon: value,
+										} );
+									} }
+									disabled={ attributes.openSubmenusOnClick }
 									label={ __( 'Show arrow' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											showSubmenuIcon: true,
-										} )
-									}
-									isDisabled={
-										attributes.openSubmenusOnClick
-									}
-									isShownByDefault
-								>
-									<ToggleControl
-										checked={ showSubmenuIcon }
-										onChange={ ( value ) => {
-											setAttributes( {
-												showSubmenuIcon: value,
-											} );
-										} }
-										disabled={
-											attributes.openSubmenusOnClick
-										}
-										label={ __( 'Show arrow' ) }
-									/>
-								</ToolsPanelItem>
+								/>
+							</ToolsPanelItem>
 
-								{ submenuAccessibilityNotice && (
-									<Notice
-										spokenMessage={ null }
-										status="warning"
-										isDismissible={ false }
-										className="wp-block-navigation__submenu-accessibility-notice"
-									>
-										{ submenuAccessibilityNotice }
-									</Notice>
-								) }
-							</>
-						) }
-					</ToolsPanel>
-				) }
-			</InspectorControls>
+							{ submenuAccessibilityNotice && (
+								<Notice
+									spokenMessage={ null }
+									status="warning"
+									isDismissible={ false }
+									className="wp-block-navigation__submenu-accessibility-notice"
+								>
+									{ submenuAccessibilityNotice }
+								</Notice>
+							) }
+						</>
+					) }
+				</InspectorControls>
+			) }
 			{ isOverlayExperimentEnabled && (
 				<InspectorControls>
 					<OverlayPanel

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -689,20 +689,20 @@ function Navigation( {
 								/>
 							) }
 
-						<ToolsPanelItem
-							hasValue={ () => overlayMenu !== 'mobile' }
-							label={ __( 'Overlay Visibility' ) }
-							onDeselect={ () =>
-								setAttributes( {
+							<ToolsPanelItem
+								hasValue={ () => overlayMenu !== 'mobile' }
+								label={ __( 'Overlay Visibility' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										overlayMenu: 'mobile',
+									} )
+								}
+								resetAllFilter={ () => ( {
 									overlayMenu: 'mobile',
-								} )
-							}
-							resetAllFilter={ () => ( {
-								overlayMenu: 'mobile',
-							} ) }
-							isShownByDefault
-							panelId={ clientId }
-						>
+								} ) }
+								isShownByDefault
+								panelId={ clientId }
+							>
 								<OverlayVisibilityControl
 									overlayMenu={ overlayMenu }
 									setAttributes={ setAttributes }
@@ -716,22 +716,22 @@ function Navigation( {
 							<h3 className="wp-block-navigation__submenu-header">
 								{ __( 'Submenus' ) }
 							</h3>
-						<ToolsPanelItem
-							hasValue={ () => openSubmenusOnClick }
-							label={ __( 'Open on click' ) }
-							onDeselect={ () =>
-								setAttributes( {
+							<ToolsPanelItem
+								hasValue={ () => openSubmenusOnClick }
+								label={ __( 'Open on click' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										openSubmenusOnClick: false,
+										showSubmenuIcon: true,
+									} )
+								}
+								resetAllFilter={ () => ( {
 									openSubmenusOnClick: false,
 									showSubmenuIcon: true,
-								} )
-							}
-							resetAllFilter={ () => ( {
-								openSubmenusOnClick: false,
-								showSubmenuIcon: true,
-							} ) }
-							isShownByDefault
-							panelId={ clientId }
-						>
+								} ) }
+								isShownByDefault
+								panelId={ clientId }
+							>
 								<ToggleControl
 									checked={ openSubmenusOnClick }
 									onChange={ ( value ) => {
@@ -746,21 +746,21 @@ function Navigation( {
 								/>
 							</ToolsPanelItem>
 
-						<ToolsPanelItem
-							hasValue={ () => ! showSubmenuIcon }
-							label={ __( 'Show arrow' ) }
-							onDeselect={ () =>
-								setAttributes( {
+							<ToolsPanelItem
+								hasValue={ () => ! showSubmenuIcon }
+								label={ __( 'Show arrow' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										showSubmenuIcon: true,
+									} )
+								}
+								resetAllFilter={ () => ( {
 									showSubmenuIcon: true,
-								} )
-							}
-							resetAllFilter={ () => ( {
-								showSubmenuIcon: true,
-							} ) }
-							isDisabled={ attributes.openSubmenusOnClick }
-							isShownByDefault
-							panelId={ clientId }
-						>
+								} ) }
+								isDisabled={ attributes.openSubmenusOnClick }
+								isShownByDefault
+								panelId={ clientId }
+							>
 								<ToggleControl
 									checked={ showSubmenuIcon }
 									onChange={ ( value ) => {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -6,7 +6,6 @@ import {
 	SelectControl,
 	Notice,
 	__experimentalVStack as VStack,
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -16,6 +15,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -37,7 +37,6 @@ import {
 	useTaxonomies,
 	useOrderByOptions,
 } from '../../utils';
-import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 
 export default function QueryInspectorControls( props ) {
 	const { attributes, setQuery, isSingular } = props;
@@ -177,7 +176,6 @@ export default function QueryInspectorControls( props ) {
 		showSearchControl ||
 		showParentControl ||
 		showFormatControl;
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const showPostCountControl = isControlAllowed(
 		allowedControls,
@@ -196,18 +194,15 @@ export default function QueryInspectorControls( props ) {
 	return (
 		<>
 			{ showSettingsPanel && (
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setQuery( {
-							postType: 'post',
-							order: 'desc',
-							orderBy: 'date',
-							sticky: '',
-							inherit: true,
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
+				<InspectorControls
+					group="settings"
+					resetAllFilter={ () => ( {
+						postType: 'post',
+						order: 'desc',
+						orderBy: 'date',
+						sticky: '',
+						inherit: true,
+					} ) }
 				>
 					{ showInheritControl && (
 						<ToolsPanelItem
@@ -330,22 +325,18 @@ export default function QueryInspectorControls( props ) {
 									setQuery( { sticky: value } )
 								}
 							/>
-						</ToolsPanelItem>
-					) }
-				</ToolsPanel>
-			) }
-			{ ! inherit && showDisplayPanel && (
-				<ToolsPanel
-					className="block-library-query-toolspanel__display"
-					label={ __( 'Display' ) }
-					resetAll={ () => {
-						setQuery( {
-							offset: 0,
-							pages: 0,
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
+					</ToolsPanelItem>
+				) }
+			</InspectorControls>
+		) }
+		{ ! inherit && showDisplayPanel && (
+			<InspectorControls
+				group="display"
+				resetAllFilter={ () => ( {
+					offset: 0,
+					pages: 0,
+				} ) }
+			>
 					<ToolsPanelItem
 						label={ __( 'Items per page' ) }
 						hasValue={ () => perPage > 0 }
@@ -371,26 +362,24 @@ export default function QueryInspectorControls( props ) {
 						hasValue={ () => pages > 0 }
 						onDeselect={ () => setQuery( { pages: 0 } ) }
 					>
-						<PagesControl pages={ pages } onChange={ setQuery } />
-					</ToolsPanelItem>
-				</ToolsPanel>
-			) }
-			{ ! inherit && showFiltersPanel && (
-				<ToolsPanel
-					className="block-library-query-toolspanel__filters" // unused but kept for backward compatibility
-					label={ __( 'Filters' ) }
-					resetAll={ () => {
-						setQuery( {
-							author: '',
-							parents: [],
-							search: '',
-							taxQuery: null,
-							format: [],
-						} );
-						setQuerySearch( '' );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
+					<PagesControl pages={ pages } onChange={ setQuery } />
+				</ToolsPanelItem>
+			</InspectorControls>
+		) }
+		{ ! inherit && showFiltersPanel && (
+			<InspectorControls
+				group="query/filters"
+				resetAllFilter={ () => {
+					setQuerySearch( '' );
+					return {
+						author: '',
+						parents: [],
+						search: '',
+						taxQuery: null,
+						format: [],
+					};
+				} }
+			>
 					{ showTaxControl && (
 						<ToolsPanelItem
 							label={ __( 'Taxonomies' ) }
@@ -465,10 +454,10 @@ export default function QueryInspectorControls( props ) {
 								onChange={ setQuery }
 								query={ query }
 							/>
-						</ToolsPanelItem>
-					) }
-				</ToolsPanel>
-			) }
-		</>
-	);
+					</ToolsPanelItem>
+				) }
+			</InspectorControls>
+		) }
+	</>
+);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -39,7 +39,7 @@ import {
 } from '../../utils';
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, isSingular } = props;
+	const { attributes, setQuery, isSingular, clientId } = props;
 	const { query } = attributes;
 	const {
 		order,
@@ -204,13 +204,15 @@ export default function QueryInspectorControls( props ) {
 						inherit: true,
 					} ) }
 				>
-					{ showInheritControl && (
-						<ToolsPanelItem
-							hasValue={ () => ! inherit }
-							label={ __( 'Query type' ) }
-							onDeselect={ () => setQuery( { inherit: true } ) }
-							isShownByDefault
-						>
+				{ showInheritControl && (
+					<ToolsPanelItem
+						hasValue={ () => ! inherit }
+						label={ __( 'Query type' ) }
+						onDeselect={ () => setQuery( { inherit: true } ) }
+						resetAllFilter={ () => ( { inherit: true } ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
 							<VStack spacing={ 4 }>
 								<ToggleGroupControl
 									__next40pxDefaultSize
@@ -255,13 +257,15 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-					{ showPostTypeControl && (
-						<ToolsPanelItem
-							hasValue={ () => postType !== 'post' }
-							label={ postTypeControlLabel }
-							onDeselect={ () => onPostTypeChange( 'post' ) }
-							isShownByDefault
-						>
+				{ showPostTypeControl && (
+					<ToolsPanelItem
+						hasValue={ () => postType !== 'post' }
+						label={ postTypeControlLabel }
+						onDeselect={ () => onPostTypeChange( 'post' ) }
+						resetAllFilter={ () => ( { postType: 'post' } ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
 							{ postTypesSelectOptions.length > 2 ? (
 								<SelectControl
 									__next40pxDefaultSize
@@ -294,17 +298,22 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-					{ showOrderControl && (
-						<ToolsPanelItem
-							hasValue={ () =>
-								order !== 'desc' || orderBy !== 'date'
-							}
-							label={ __( 'Order by' ) }
-							onDeselect={ () =>
-								setQuery( { order: 'desc', orderBy: 'date' } )
-							}
-							isShownByDefault
-						>
+				{ showOrderControl && (
+					<ToolsPanelItem
+						hasValue={ () =>
+							order !== 'desc' || orderBy !== 'date'
+						}
+						label={ __( 'Order by' ) }
+						onDeselect={ () =>
+							setQuery( { order: 'desc', orderBy: 'date' } )
+						}
+						resetAllFilter={ () => ( {
+							order: 'desc',
+							orderBy: 'date',
+						} ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
 							<OrderControl
 								{ ...{ order, orderBy, orderByOptions } }
 								onChange={ setQuery }
@@ -312,13 +321,15 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-					{ showStickyControl && (
-						<ToolsPanelItem
-							hasValue={ () => !! sticky }
-							label={ __( 'Sticky posts' ) }
-							onDeselect={ () => setQuery( { sticky: '' } ) }
-							isShownByDefault
-						>
+				{ showStickyControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! sticky }
+						label={ __( 'Sticky posts' ) }
+						onDeselect={ () => setQuery( { sticky: '' } ) }
+						resetAllFilter={ () => ( { sticky: '' } ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
 							<StickyControl
 								value={ sticky }
 								onChange={ ( value ) =>
@@ -337,31 +348,36 @@ export default function QueryInspectorControls( props ) {
 					pages: 0,
 				} ) }
 			>
-					<ToolsPanelItem
-						label={ __( 'Items per page' ) }
-						hasValue={ () => perPage > 0 }
-					>
+				<ToolsPanelItem
+					label={ __( 'Items per page' ) }
+					hasValue={ () => perPage > 0 }
+					panelId={ clientId }
+				>
 						<PerPageControl
 							perPage={ perPage }
 							offset={ offset }
 							onChange={ setQuery }
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Offset' ) }
-						hasValue={ () => offset > 0 }
-						onDeselect={ () => setQuery( { offset: 0 } ) }
-					>
+				<ToolsPanelItem
+					label={ __( 'Offset' ) }
+					hasValue={ () => offset > 0 }
+					onDeselect={ () => setQuery( { offset: 0 } ) }
+					resetAllFilter={ () => ( { offset: 0 } ) }
+					panelId={ clientId }
+				>
 						<OffsetControl
 							offset={ offset }
 							onChange={ setQuery }
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Max pages to show' ) }
-						hasValue={ () => pages > 0 }
-						onDeselect={ () => setQuery( { pages: 0 } ) }
-					>
+				<ToolsPanelItem
+					label={ __( 'Max pages to show' ) }
+					hasValue={ () => pages > 0 }
+					onDeselect={ () => setQuery( { pages: 0 } ) }
+					resetAllFilter={ () => ( { pages: 0 } ) }
+					panelId={ clientId }
+				>
 					<PagesControl pages={ pages } onChange={ setQuery } />
 				</ToolsPanelItem>
 			</InspectorControls>
@@ -380,46 +396,52 @@ export default function QueryInspectorControls( props ) {
 					};
 				} }
 			>
-					{ showTaxControl && (
-						<ToolsPanelItem
-							label={ __( 'Taxonomies' ) }
-							hasValue={ () =>
-								Object.values( taxQuery || {} ).some(
-									( value ) =>
-										Object.values( value || {} ).some(
-											( termIds ) => !! termIds?.length
-										)
-								)
-							}
-							onDeselect={ () => setQuery( { taxQuery: null } ) }
-						>
+				{ showTaxControl && (
+					<ToolsPanelItem
+						label={ __( 'Taxonomies' ) }
+						hasValue={ () =>
+							Object.values( taxQuery || {} ).some(
+								( value ) =>
+									Object.values( value || {} ).some(
+										( termIds ) => !! termIds?.length
+									)
+							)
+						}
+						onDeselect={ () => setQuery( { taxQuery: null } ) }
+						resetAllFilter={ () => ( { taxQuery: null } ) }
+						panelId={ clientId }
+					>
 							<TaxonomyControls
 								onChange={ setQuery }
 								query={ query }
 							/>
 						</ToolsPanelItem>
 					) }
-					{ showAuthorControl && (
-						<ToolsPanelItem
-							hasValue={ () => !! authorIds }
-							label={ __( 'Authors' ) }
-							onDeselect={ () => setQuery( { author: '' } ) }
-						>
+				{ showAuthorControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! authorIds }
+						label={ __( 'Authors' ) }
+						onDeselect={ () => setQuery( { author: '' } ) }
+						resetAllFilter={ () => ( { author: '' } ) }
+						panelId={ clientId }
+					>
 							<AuthorControl
 								value={ authorIds }
 								onChange={ setQuery }
 							/>
 						</ToolsPanelItem>
 					) }
-					{ showSearchControl && (
-						<ToolsPanelItem
-							hasValue={ () => !! querySearch }
-							label={ __( 'Keyword' ) }
-							onDeselect={ () => {
-								setQuery( { search: '' } );
-								setQuerySearch( '' );
-							} }
-						>
+				{ showSearchControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! querySearch }
+						label={ __( 'Keyword' ) }
+						onDeselect={ () => {
+							setQuery( { search: '' } );
+							setQuerySearch( '' );
+						} }
+						resetAllFilter={ () => ( { search: '' } ) }
+						panelId={ clientId }
+					>
 							<TextControl
 								__next40pxDefaultSize
 								label={ __( 'Keyword' ) }
@@ -431,12 +453,14 @@ export default function QueryInspectorControls( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ showParentControl && (
-						<ToolsPanelItem
-							hasValue={ () => !! parents?.length }
-							label={ __( 'Parents' ) }
-							onDeselect={ () => setQuery( { parents: [] } ) }
-						>
+				{ showParentControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! parents?.length }
+						label={ __( 'Parents' ) }
+						onDeselect={ () => setQuery( { parents: [] } ) }
+						resetAllFilter={ () => ( { parents: [] } ) }
+						panelId={ clientId }
+					>
 							<ParentControl
 								parents={ parents }
 								postType={ postType }
@@ -444,12 +468,14 @@ export default function QueryInspectorControls( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ showFormatControl && (
-						<ToolsPanelItem
-							hasValue={ () => !! format?.length }
-							label={ __( 'Formats' ) }
-							onDeselect={ () => setQuery( { format: [] } ) }
-						>
+				{ showFormatControl && (
+					<ToolsPanelItem
+						hasValue={ () => !! format?.length }
+						label={ __( 'Formats' ) }
+						onDeselect={ () => setQuery( { format: [] } ) }
+						resetAllFilter={ () => ( { format: [] } ) }
+						panelId={ clientId }
+					>
 							<FormatControls
 								onChange={ setQuery }
 								query={ query }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -204,15 +204,15 @@ export default function QueryInspectorControls( props ) {
 						inherit: true,
 					} ) }
 				>
-				{ showInheritControl && (
-					<ToolsPanelItem
-						hasValue={ () => ! inherit }
-						label={ __( 'Query type' ) }
-						onDeselect={ () => setQuery( { inherit: true } ) }
-						resetAllFilter={ () => ( { inherit: true } ) }
-						isShownByDefault
-						panelId={ clientId }
-					>
+					{ showInheritControl && (
+						<ToolsPanelItem
+							hasValue={ () => ! inherit }
+							label={ __( 'Query type' ) }
+							onDeselect={ () => setQuery( { inherit: true } ) }
+							resetAllFilter={ () => ( { inherit: true } ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 							<VStack spacing={ 4 }>
 								<ToggleGroupControl
 									__next40pxDefaultSize
@@ -257,15 +257,15 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-				{ showPostTypeControl && (
-					<ToolsPanelItem
-						hasValue={ () => postType !== 'post' }
-						label={ postTypeControlLabel }
-						onDeselect={ () => onPostTypeChange( 'post' ) }
-						resetAllFilter={ () => ( { postType: 'post' } ) }
-						isShownByDefault
-						panelId={ clientId }
-					>
+					{ showPostTypeControl && (
+						<ToolsPanelItem
+							hasValue={ () => postType !== 'post' }
+							label={ postTypeControlLabel }
+							onDeselect={ () => onPostTypeChange( 'post' ) }
+							resetAllFilter={ () => ( { postType: 'post' } ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 							{ postTypesSelectOptions.length > 2 ? (
 								<SelectControl
 									__next40pxDefaultSize
@@ -298,22 +298,22 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-				{ showOrderControl && (
-					<ToolsPanelItem
-						hasValue={ () =>
-							order !== 'desc' || orderBy !== 'date'
-						}
-						label={ __( 'Order by' ) }
-						onDeselect={ () =>
-							setQuery( { order: 'desc', orderBy: 'date' } )
-						}
-						resetAllFilter={ () => ( {
-							order: 'desc',
-							orderBy: 'date',
-						} ) }
-						isShownByDefault
-						panelId={ clientId }
-					>
+					{ showOrderControl && (
+						<ToolsPanelItem
+							hasValue={ () =>
+								order !== 'desc' || orderBy !== 'date'
+							}
+							label={ __( 'Order by' ) }
+							onDeselect={ () =>
+								setQuery( { order: 'desc', orderBy: 'date' } )
+							}
+							resetAllFilter={ () => ( {
+								order: 'desc',
+								orderBy: 'date',
+							} ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 							<OrderControl
 								{ ...{ order, orderBy, orderByOptions } }
 								onChange={ setQuery }
@@ -321,127 +321,127 @@ export default function QueryInspectorControls( props ) {
 						</ToolsPanelItem>
 					) }
 
-				{ showStickyControl && (
-					<ToolsPanelItem
-						hasValue={ () => !! sticky }
-						label={ __( 'Sticky posts' ) }
-						onDeselect={ () => setQuery( { sticky: '' } ) }
-						resetAllFilter={ () => ( { sticky: '' } ) }
-						isShownByDefault
-						panelId={ clientId }
-					>
+					{ showStickyControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! sticky }
+							label={ __( 'Sticky posts' ) }
+							onDeselect={ () => setQuery( { sticky: '' } ) }
+							resetAllFilter={ () => ( { sticky: '' } ) }
+							isShownByDefault
+							panelId={ clientId }
+						>
 							<StickyControl
 								value={ sticky }
 								onChange={ ( value ) =>
 									setQuery( { sticky: value } )
 								}
 							/>
-					</ToolsPanelItem>
-				) }
-			</InspectorControls>
-		) }
-		{ ! inherit && showDisplayPanel && (
-			<InspectorControls
-				group="display"
-				resetAllFilter={ () => ( {
-					offset: 0,
-					pages: 0,
-				} ) }
-			>
-				<ToolsPanelItem
-					label={ __( 'Items per page' ) }
-					hasValue={ () => perPage > 0 }
-					panelId={ clientId }
+						</ToolsPanelItem>
+					) }
+				</InspectorControls>
+			) }
+			{ ! inherit && showDisplayPanel && (
+				<InspectorControls
+					group="display"
+					resetAllFilter={ () => ( {
+						offset: 0,
+						pages: 0,
+					} ) }
 				>
+					<ToolsPanelItem
+						label={ __( 'Items per page' ) }
+						hasValue={ () => perPage > 0 }
+						panelId={ clientId }
+					>
 						<PerPageControl
 							perPage={ perPage }
 							offset={ offset }
 							onChange={ setQuery }
 						/>
 					</ToolsPanelItem>
-				<ToolsPanelItem
-					label={ __( 'Offset' ) }
-					hasValue={ () => offset > 0 }
-					onDeselect={ () => setQuery( { offset: 0 } ) }
-					resetAllFilter={ () => ( { offset: 0 } ) }
-					panelId={ clientId }
-				>
+					<ToolsPanelItem
+						label={ __( 'Offset' ) }
+						hasValue={ () => offset > 0 }
+						onDeselect={ () => setQuery( { offset: 0 } ) }
+						resetAllFilter={ () => ( { offset: 0 } ) }
+						panelId={ clientId }
+					>
 						<OffsetControl
 							offset={ offset }
 							onChange={ setQuery }
 						/>
 					</ToolsPanelItem>
-				<ToolsPanelItem
-					label={ __( 'Max pages to show' ) }
-					hasValue={ () => pages > 0 }
-					onDeselect={ () => setQuery( { pages: 0 } ) }
-					resetAllFilter={ () => ( { pages: 0 } ) }
-					panelId={ clientId }
-				>
-					<PagesControl pages={ pages } onChange={ setQuery } />
-				</ToolsPanelItem>
-			</InspectorControls>
-		) }
-		{ ! inherit && showFiltersPanel && (
-			<InspectorControls
-				group="query/filters"
-				resetAllFilter={ () => {
-					setQuerySearch( '' );
-					return {
-						author: '',
-						parents: [],
-						search: '',
-						taxQuery: null,
-						format: [],
-					};
-				} }
-			>
-				{ showTaxControl && (
 					<ToolsPanelItem
-						label={ __( 'Taxonomies' ) }
-						hasValue={ () =>
-							Object.values( taxQuery || {} ).some(
-								( value ) =>
-									Object.values( value || {} ).some(
-										( termIds ) => !! termIds?.length
-									)
-							)
-						}
-						onDeselect={ () => setQuery( { taxQuery: null } ) }
-						resetAllFilter={ () => ( { taxQuery: null } ) }
+						label={ __( 'Max pages to show' ) }
+						hasValue={ () => pages > 0 }
+						onDeselect={ () => setQuery( { pages: 0 } ) }
+						resetAllFilter={ () => ( { pages: 0 } ) }
 						panelId={ clientId }
 					>
+						<PagesControl pages={ pages } onChange={ setQuery } />
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
+			{ ! inherit && showFiltersPanel && (
+				<InspectorControls
+					group="query/filters"
+					resetAllFilter={ () => {
+						setQuerySearch( '' );
+						return {
+							author: '',
+							parents: [],
+							search: '',
+							taxQuery: null,
+							format: [],
+						};
+					} }
+				>
+					{ showTaxControl && (
+						<ToolsPanelItem
+							label={ __( 'Taxonomies' ) }
+							hasValue={ () =>
+								Object.values( taxQuery || {} ).some(
+									( value ) =>
+										Object.values( value || {} ).some(
+											( termIds ) => !! termIds?.length
+										)
+								)
+							}
+							onDeselect={ () => setQuery( { taxQuery: null } ) }
+							resetAllFilter={ () => ( { taxQuery: null } ) }
+							panelId={ clientId }
+						>
 							<TaxonomyControls
 								onChange={ setQuery }
 								query={ query }
 							/>
 						</ToolsPanelItem>
 					) }
-				{ showAuthorControl && (
-					<ToolsPanelItem
-						hasValue={ () => !! authorIds }
-						label={ __( 'Authors' ) }
-						onDeselect={ () => setQuery( { author: '' } ) }
-						resetAllFilter={ () => ( { author: '' } ) }
-						panelId={ clientId }
-					>
+					{ showAuthorControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! authorIds }
+							label={ __( 'Authors' ) }
+							onDeselect={ () => setQuery( { author: '' } ) }
+							resetAllFilter={ () => ( { author: '' } ) }
+							panelId={ clientId }
+						>
 							<AuthorControl
 								value={ authorIds }
 								onChange={ setQuery }
 							/>
 						</ToolsPanelItem>
 					) }
-				{ showSearchControl && (
-					<ToolsPanelItem
-						hasValue={ () => !! querySearch }
-						label={ __( 'Keyword' ) }
-						onDeselect={ () => {
-							setQuery( { search: '' } );
-							setQuerySearch( '' );
-						} }
-						resetAllFilter={ () => ( { search: '' } ) }
-						panelId={ clientId }
-					>
+					{ showSearchControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! querySearch }
+							label={ __( 'Keyword' ) }
+							onDeselect={ () => {
+								setQuery( { search: '' } );
+								setQuerySearch( '' );
+							} }
+							resetAllFilter={ () => ( { search: '' } ) }
+							panelId={ clientId }
+						>
 							<TextControl
 								__next40pxDefaultSize
 								label={ __( 'Keyword' ) }
@@ -453,14 +453,14 @@ export default function QueryInspectorControls( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-				{ showParentControl && (
-					<ToolsPanelItem
-						hasValue={ () => !! parents?.length }
-						label={ __( 'Parents' ) }
-						onDeselect={ () => setQuery( { parents: [] } ) }
-						resetAllFilter={ () => ( { parents: [] } ) }
-						panelId={ clientId }
-					>
+					{ showParentControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! parents?.length }
+							label={ __( 'Parents' ) }
+							onDeselect={ () => setQuery( { parents: [] } ) }
+							resetAllFilter={ () => ( { parents: [] } ) }
+							panelId={ clientId }
+						>
 							<ParentControl
 								parents={ parents }
 								postType={ postType }
@@ -468,22 +468,22 @@ export default function QueryInspectorControls( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-				{ showFormatControl && (
-					<ToolsPanelItem
-						hasValue={ () => !! format?.length }
-						label={ __( 'Formats' ) }
-						onDeselect={ () => setQuery( { format: [] } ) }
-						resetAllFilter={ () => ( { format: [] } ) }
-						panelId={ clientId }
-					>
+					{ showFormatControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! format?.length }
+							label={ __( 'Formats' ) }
+							onDeselect={ () => setQuery( { format: [] } ) }
+							resetAllFilter={ () => ( { format: [] } ) }
+							panelId={ clientId }
+						>
 							<FormatControls
 								onChange={ setQuery }
 								query={ query }
 							/>
-					</ToolsPanelItem>
-				) }
-			</InspectorControls>
-		) }
-	</>
-);
+						</ToolsPanelItem>
+					) }
+				</InspectorControls>
+			) }
+		</>
+	);
 }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -142,17 +142,18 @@ export default function QueryContent( {
 				setAttributes={ setAttributes }
 				clientId={ clientId }
 			/>
-			<InspectorControls>
-				<QueryInspectorControls
-					name={ name }
-					attributes={ attributes }
-					setQuery={ updateQuery }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-					isSingular={ isSingular }
-				/>
-			</InspectorControls>
-			<InspectorControls group="advanced">
+		<InspectorControls>
+			<QueryInspectorControls
+				name={ name }
+				attributes={ attributes }
+				setQuery={ updateQuery }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+				isSingular={ isSingular }
+			/>
+		</InspectorControls>
+		<InspectorControls.Slot group="query/filters" label={ __( 'Filters' ) } />
+		<InspectorControls group="advanced">
 				<HTMLElementControl
 					tagName={ TagName }
 					onChange={ ( value ) =>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -22,7 +22,6 @@ import {
 	Placeholder,
 	Button,
 	DropZone,
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -46,7 +45,6 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { MIN_SIZE } from '../image/constants';
 import { MediaControl, MediaControlPreview } from '../utils/media-control';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -69,7 +67,6 @@ const SiteLogo = ( {
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const { toggleSelection } = useDispatch( blockEditorStore );
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// Check if we're in contentOnly mode
 	const blockEditingMode = useBlockEditingMode();
@@ -283,94 +280,95 @@ const SiteLogo = ( {
 
 	return (
 		<>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					dropdownMenuProps={ dropdownMenuProps }
+			<InspectorControls
+				group="settings"
+				resetAllFilter={ () => ( {
+					width: undefined,
+					isLink: true,
+					linkTarget: '_self',
+					shouldSyncIcon: false,
+				} ) }
+			>
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => !! width }
+					label={ __( 'Image width' ) }
+					onDeselect={ () => setAttributes( { width: undefined } ) }
 				>
+					<RangeControl
+						__next40pxDefaultSize
+						label={ __( 'Image width' ) }
+						onChange={ ( newWidth ) =>
+							setAttributes( { width: newWidth } )
+						}
+						min={ minWidth }
+						max={ maxWidthBuffer }
+						initialPosition={ Math.min(
+							defaultWidth,
+							maxWidthBuffer
+						) }
+						value={ width || '' }
+						disabled={ ! isResizable }
+					/>
+				</ToolsPanelItem>
+
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => ! isLink }
+					label={ __( 'Link image to home' ) }
+					onDeselect={ () => setAttributes( { isLink: true } ) }
+				>
+					<ToggleControl
+						label={ __( 'Link image to home' ) }
+						onChange={ () =>
+							setAttributes( { isLink: ! isLink } )
+						}
+						checked={ isLink }
+					/>
+				</ToolsPanelItem>
+
+				{ isLink && (
 					<ToolsPanelItem
 						isShownByDefault
-						hasValue={ () => !! width }
-						label={ __( 'Image width' ) }
+						hasValue={ () => linkTarget === '_blank' }
+						label={ __( 'Open in new tab' ) }
 						onDeselect={ () =>
-							setAttributes( { width: undefined } )
+							setAttributes( { linkTarget: '_self' } )
 						}
 					>
-						<RangeControl
-							__next40pxDefaultSize
-							label={ __( 'Image width' ) }
-							onChange={ ( newWidth ) =>
-								setAttributes( { width: newWidth } )
+						<ToggleControl
+							label={ __( 'Open in new tab' ) }
+							onChange={ ( value ) =>
+								setAttributes( {
+									linkTarget: value ? '_blank' : '_self',
+								} )
 							}
-							min={ minWidth }
-							max={ maxWidthBuffer }
-							initialPosition={ Math.min(
-								defaultWidth,
-								maxWidthBuffer
-							) }
-							value={ width || '' }
-							disabled={ ! isResizable }
+							checked={ linkTarget === '_blank' }
 						/>
 					</ToolsPanelItem>
+				) }
 
+				{ canUserEdit && (
 					<ToolsPanelItem
 						isShownByDefault
-						hasValue={ () => ! isLink }
-						label={ __( 'Link image to home' ) }
-						onDeselect={ () => setAttributes( { isLink: true } ) }
+						hasValue={ () => !! shouldSyncIcon }
+						label={ __( 'Use as Site Icon' ) }
+						onDeselect={ () => {
+							setAttributes( { shouldSyncIcon: false } );
+							setIcon( undefined );
+						} }
 					>
 						<ToggleControl
-							label={ __( 'Link image to home' ) }
-							onChange={ () =>
-								setAttributes( { isLink: ! isLink } )
-							}
-							checked={ isLink }
+							label={ __( 'Use as Site Icon' ) }
+							onChange={ ( value ) => {
+								setAttributes( { shouldSyncIcon: value } );
+								setIcon( value ? logoId : undefined );
+							} }
+							checked={ !! shouldSyncIcon }
+							help={ syncSiteIconHelpText }
 						/>
 					</ToolsPanelItem>
-
-					{ isLink && (
-						<ToolsPanelItem
-							isShownByDefault
-							hasValue={ () => linkTarget === '_blank' }
-							label={ __( 'Open in new tab' ) }
-							onDeselect={ () =>
-								setAttributes( { linkTarget: '_self' } )
-							}
-						>
-							<ToggleControl
-								label={ __( 'Open in new tab' ) }
-								onChange={ ( value ) =>
-									setAttributes( {
-										linkTarget: value ? '_blank' : '_self',
-									} )
-								}
-								checked={ linkTarget === '_blank' }
-							/>
-						</ToolsPanelItem>
-					) }
-
-					{ canUserEdit && (
-						<ToolsPanelItem
-							isShownByDefault
-							hasValue={ () => !! shouldSyncIcon }
-							label={ __( 'Use as Site Icon' ) }
-							onDeselect={ () => {
-								setAttributes( { shouldSyncIcon: false } );
-								setIcon( undefined );
-							} }
-						>
-							<ToggleControl
-								label={ __( 'Use as Site Icon' ) }
-								onChange={ ( value ) => {
-									setAttributes( { shouldSyncIcon: value } );
-									setIcon( value ? logoId : undefined );
-								} }
-								checked={ !! shouldSyncIcon }
-								help={ syncSiteIconHelpText }
-							/>
-						</ToolsPanelItem>
-					) }
-				</ToolsPanel>
+				) }
 			</InspectorControls>
 			{ canEditImage &&
 				! isEditingImage &&
@@ -447,7 +445,6 @@ export default function LogoEdit( {
 	}, [] );
 	const { getSettings } = useSelect( blockEditorStore );
 	const [ temporaryURL, setTemporaryURL ] = useState();
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -608,55 +605,50 @@ export default function LogoEdit( {
 	const blockProps = useBlockProps( { className: classes } );
 
 	const mediaInspectorPanel = ( canUserEdit || logoUrl ) && (
-		<InspectorControls>
-			<ToolsPanel
-				label={ __( 'Media' ) }
-				dropdownMenuProps={ dropdownMenuProps }
-			>
-				{ ! canUserEdit ? (
-					<div
-						className="block-library-site-logo__inspector-media-replace-container"
-						style={ { gridColumn: '1 / -1' } }
-					>
-						<MediaControlPreview
-							url={ mediaItemData?.source_url }
-							alt={ mediaItemData?.alt_text }
-							filename={
-								mediaItemData?.media_details?.sizes?.full
-									?.file || mediaItemData?.slug
-							}
-							itemGroupProps={ {
-								isBordered: true,
-								className:
-									'block-library-site-logo__inspector-readonly-logo-preview',
-							} }
-							className="block-library-site-logo__inspector-media-replace-title"
-						/>
-					</div>
-				) : (
-					<ToolsPanelItem
-						hasValue={ () => !! logoUrl }
-						label={ __( 'Logo' ) }
-						isShownByDefault
-					>
-						<MediaControl
-							mediaId={ siteLogoId }
-							mediaUrl={ logoUrl }
-							alt={ mediaItemData?.alt_text }
-							filename={
-								mediaItemData?.media_details?.sizes?.full
-									?.file || mediaItemData?.slug
-							}
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							onSelect={ onSelectLogo }
-							onError={ onUploadError }
-							onReset={ onRemoveLogo }
-							isUploading={ !! temporaryURL }
-							emptyLabel={ __( 'Choose logo' ) }
-						/>
-					</ToolsPanelItem>
-				) }
-			</ToolsPanel>
+		<InspectorControls group="media">
+			{ ! canUserEdit ? (
+				<div
+					className="block-library-site-logo__inspector-media-replace-container"
+					style={ { gridColumn: '1 / -1' } }
+				>
+					<MediaControlPreview
+						url={ mediaItemData?.source_url }
+						alt={ mediaItemData?.alt_text }
+						filename={
+							mediaItemData?.media_details?.sizes?.full?.file ||
+							mediaItemData?.slug
+						}
+						itemGroupProps={ {
+							isBordered: true,
+							className:
+								'block-library-site-logo__inspector-readonly-logo-preview',
+						} }
+						className="block-library-site-logo__inspector-media-replace-title"
+					/>
+				</div>
+			) : (
+				<ToolsPanelItem
+					hasValue={ () => !! logoUrl }
+					label={ __( 'Logo' ) }
+					isShownByDefault
+				>
+					<MediaControl
+						mediaId={ siteLogoId }
+						mediaUrl={ logoUrl }
+						alt={ mediaItemData?.alt_text }
+						filename={
+							mediaItemData?.media_details?.sizes?.full?.file ||
+							mediaItemData?.slug
+						}
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onSelect={ onSelectLogo }
+						onError={ onUploadError }
+						onReset={ onRemoveLogo }
+						isUploading={ !! temporaryURL }
+						emptyLabel={ __( 'Choose logo' ) }
+					/>
+				</ToolsPanelItem>
+			) }
 		</InspectorControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -289,12 +289,14 @@ const SiteLogo = ( {
 					shouldSyncIcon: false,
 				} ) }
 			>
-				<ToolsPanelItem
-					isShownByDefault
-					hasValue={ () => !! width }
-					label={ __( 'Image width' ) }
-					onDeselect={ () => setAttributes( { width: undefined } ) }
-				>
+			<ToolsPanelItem
+				isShownByDefault
+				hasValue={ () => !! width }
+				label={ __( 'Image width' ) }
+				onDeselect={ () => setAttributes( { width: undefined } ) }
+				resetAllFilter={ () => ( { width: undefined } ) }
+				panelId={ clientId }
+			>
 					<RangeControl
 						__next40pxDefaultSize
 						label={ __( 'Image width' ) }
@@ -312,12 +314,14 @@ const SiteLogo = ( {
 					/>
 				</ToolsPanelItem>
 
-				<ToolsPanelItem
-					isShownByDefault
-					hasValue={ () => ! isLink }
-					label={ __( 'Link image to home' ) }
-					onDeselect={ () => setAttributes( { isLink: true } ) }
-				>
+			<ToolsPanelItem
+				isShownByDefault
+				hasValue={ () => ! isLink }
+				label={ __( 'Link image to home' ) }
+				onDeselect={ () => setAttributes( { isLink: true } ) }
+				resetAllFilter={ () => ( { isLink: true } ) }
+				panelId={ clientId }
+			>
 					<ToggleControl
 						label={ __( 'Link image to home' ) }
 						onChange={ () =>
@@ -328,14 +332,16 @@ const SiteLogo = ( {
 				</ToolsPanelItem>
 
 				{ isLink && (
-					<ToolsPanelItem
-						isShownByDefault
-						hasValue={ () => linkTarget === '_blank' }
-						label={ __( 'Open in new tab' ) }
-						onDeselect={ () =>
-							setAttributes( { linkTarget: '_self' } )
-						}
-					>
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => linkTarget === '_blank' }
+					label={ __( 'Open in new tab' ) }
+					onDeselect={ () =>
+						setAttributes( { linkTarget: '_self' } )
+					}
+					resetAllFilter={ () => ( { linkTarget: '_self' } ) }
+					panelId={ clientId }
+				>
 						<ToggleControl
 							label={ __( 'Open in new tab' ) }
 							onChange={ ( value ) =>
@@ -349,15 +355,17 @@ const SiteLogo = ( {
 				) }
 
 				{ canUserEdit && (
-					<ToolsPanelItem
-						isShownByDefault
-						hasValue={ () => !! shouldSyncIcon }
-						label={ __( 'Use as Site Icon' ) }
-						onDeselect={ () => {
-							setAttributes( { shouldSyncIcon: false } );
-							setIcon( undefined );
-						} }
-					>
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => !! shouldSyncIcon }
+					label={ __( 'Use as Site Icon' ) }
+					onDeselect={ () => {
+						setAttributes( { shouldSyncIcon: false } );
+						setIcon( undefined );
+					} }
+					resetAllFilter={ () => ( { shouldSyncIcon: false } ) }
+					panelId={ clientId }
+				>
 						<ToggleControl
 							label={ __( 'Use as Site Icon' ) }
 							onChange={ ( value ) => {
@@ -627,11 +635,13 @@ export default function LogoEdit( {
 					/>
 				</div>
 			) : (
-				<ToolsPanelItem
-					hasValue={ () => !! logoUrl }
-					label={ __( 'Logo' ) }
-					isShownByDefault
-				>
+			<ToolsPanelItem
+				hasValue={ () => !! logoUrl }
+				label={ __( 'Logo' ) }
+				isShownByDefault
+				resetAllFilter={ () => ( { url: undefined } ) }
+				panelId={ clientId }
+			>
 					<MediaControl
 						mediaId={ siteLogoId }
 						mediaUrl={ logoUrl }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -60,6 +60,7 @@ const SiteLogo = ( {
 	iconId,
 	setIcon,
 	canUserEdit,
+	clientId,
 } ) => {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideAligned = [ 'wide', 'full' ].includes( align );
@@ -289,14 +290,14 @@ const SiteLogo = ( {
 					shouldSyncIcon: false,
 				} ) }
 			>
-			<ToolsPanelItem
-				isShownByDefault
-				hasValue={ () => !! width }
-				label={ __( 'Image width' ) }
-				onDeselect={ () => setAttributes( { width: undefined } ) }
-				resetAllFilter={ () => ( { width: undefined } ) }
-				panelId={ clientId }
-			>
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => !! width }
+					label={ __( 'Image width' ) }
+					onDeselect={ () => setAttributes( { width: undefined } ) }
+					resetAllFilter={ () => ( { width: undefined } ) }
+					panelId={ clientId }
+				>
 					<RangeControl
 						__next40pxDefaultSize
 						label={ __( 'Image width' ) }
@@ -314,34 +315,32 @@ const SiteLogo = ( {
 					/>
 				</ToolsPanelItem>
 
-			<ToolsPanelItem
-				isShownByDefault
-				hasValue={ () => ! isLink }
-				label={ __( 'Link image to home' ) }
-				onDeselect={ () => setAttributes( { isLink: true } ) }
-				resetAllFilter={ () => ( { isLink: true } ) }
-				panelId={ clientId }
-			>
+				<ToolsPanelItem
+					isShownByDefault
+					hasValue={ () => ! isLink }
+					label={ __( 'Link image to home' ) }
+					onDeselect={ () => setAttributes( { isLink: true } ) }
+					resetAllFilter={ () => ( { isLink: true } ) }
+					panelId={ clientId }
+				>
 					<ToggleControl
 						label={ __( 'Link image to home' ) }
-						onChange={ () =>
-							setAttributes( { isLink: ! isLink } )
-						}
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 						checked={ isLink }
 					/>
 				</ToolsPanelItem>
 
 				{ isLink && (
-				<ToolsPanelItem
-					isShownByDefault
-					hasValue={ () => linkTarget === '_blank' }
-					label={ __( 'Open in new tab' ) }
-					onDeselect={ () =>
-						setAttributes( { linkTarget: '_self' } )
-					}
-					resetAllFilter={ () => ( { linkTarget: '_self' } ) }
-					panelId={ clientId }
-				>
+					<ToolsPanelItem
+						isShownByDefault
+						hasValue={ () => linkTarget === '_blank' }
+						label={ __( 'Open in new tab' ) }
+						onDeselect={ () =>
+							setAttributes( { linkTarget: '_self' } )
+						}
+						resetAllFilter={ () => ( { linkTarget: '_self' } ) }
+						panelId={ clientId }
+					>
 						<ToggleControl
 							label={ __( 'Open in new tab' ) }
 							onChange={ ( value ) =>
@@ -355,17 +354,17 @@ const SiteLogo = ( {
 				) }
 
 				{ canUserEdit && (
-				<ToolsPanelItem
-					isShownByDefault
-					hasValue={ () => !! shouldSyncIcon }
-					label={ __( 'Use as Site Icon' ) }
-					onDeselect={ () => {
-						setAttributes( { shouldSyncIcon: false } );
-						setIcon( undefined );
-					} }
-					resetAllFilter={ () => ( { shouldSyncIcon: false } ) }
-					panelId={ clientId }
-				>
+					<ToolsPanelItem
+						isShownByDefault
+						hasValue={ () => !! shouldSyncIcon }
+						label={ __( 'Use as Site Icon' ) }
+						onDeselect={ () => {
+							setAttributes( { shouldSyncIcon: false } );
+							setIcon( undefined );
+						} }
+						resetAllFilter={ () => ( { shouldSyncIcon: false } ) }
+						panelId={ clientId }
+					>
 						<ToggleControl
 							label={ __( 'Use as Site Icon' ) }
 							onChange={ ( value ) => {
@@ -399,6 +398,7 @@ export default function LogoEdit( {
 	className,
 	setAttributes,
 	isSelected,
+	clientId,
 } ) {
 	const { width, shouldSyncIcon } = attributes;
 	const {
@@ -580,6 +580,7 @@ export default function LogoEdit( {
 					setIcon={ setIcon }
 					iconId={ siteIconId }
 					canUserEdit={ canUserEdit }
+					clientId={ clientId }
 				/>
 				{ canUserEdit && <DropZone onFilesDrop={ onFilesDrop } /> }
 			</>
@@ -635,13 +636,13 @@ export default function LogoEdit( {
 					/>
 				</div>
 			) : (
-			<ToolsPanelItem
-				hasValue={ () => !! logoUrl }
-				label={ __( 'Logo' ) }
-				isShownByDefault
-				resetAllFilter={ () => ( { url: undefined } ) }
-				panelId={ clientId }
-			>
+				<ToolsPanelItem
+					hasValue={ () => !! logoUrl }
+					label={ __( 'Logo' ) }
+					isShownByDefault
+					resetAllFilter={ () => ( { url: undefined } ) }
+					panelId={ clientId }
+				>
 					<MediaControl
 						mediaId={ siteLogoId }
 						mediaUrl={ logoUrl }


### PR DESCRIPTION
## What?
Closes #67814

This PR implements a standardized, extensible ToolsPanel system for InspectorControls, enabling third-party developers to easily add controls to core blocks' settings panels.

**Core Infrastructure:**
- Adds new `settings`, `display`, and `media` groups to InspectorControls
- Implements namespaced group support for block-specific extensible panels (e.g., `query/filters`)
- Updates Settings tab to automatically render new groups with ToolsPanel wrappers
- Fixes tab detection and resetAll functionality for attribute-based panels

**Block Migrations:**
- Image block → Media and Settings panels
- Site Logo block → Media and Settings panels
- Navigation block → Display panel
- Query block → Settings, Display, and Filters (namespaced) panels

## Why?

Currently, core blocks render ToolsPanels directly, making it difficult for third-party developers to extend these panels with additional controls. Each block implements its own panel structure, leading to:

1. **Inconsistent extensibility** - No standardized way to add controls to existing panels
2. **Code duplication** - Every block reimplements ToolsPanel setup
3. **Limited third-party integration** - Plugins can't easily extend core block settings

This PR establishes a pattern similar to the existing design tools (color, typography, etc.) where blocks use InspectorControls groups that automatically render inside ToolsPanels, making them extensible via the slot/fill mechanism.

## How?

### Core Infrastructure Changes

1. **New Groups** (`packages/block-editor/src/components/inspector-controls/groups.js`):
   - Added `InspectorControlsSettings`, `InspectorControlsDisplay`, and `InspectorControlsMedia` slot/fill pairs
   - Implemented `getGroup()` function to dynamically create namespaced groups

2. **Namespaced Group Support** (`packages/block-editor/src/components/inspector-controls/slot.js` & `fill.js`):
   - Modified to use `getGroup()` for dynamic slot/fill creation
   - Enables block-specific groups like `query/filters` that can be extended

3. **Settings Tab Updates** (`packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js`):
   - Added slots for `settings`, `display`, and `media` groups with labels
   - These automatically wrap content in ToolsPanels via `BlockSupportToolsPanel`

4. **Tab Detection** (`packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js`):
   - Updated to check for fills in new groups when determining if Settings tab should show

5. **Reset Functionality** (`packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js`):
   - Enhanced to handle both style-based resets (design tools) and attribute-based resets (settings panels)

### Block Migrations

Migrated blocks follow this pattern:

**Before:**
```jsx
<InspectorControls>
    <ToolsPanel label="Settings" resetAll={...} dropdownMenuProps={...}>
        <ToolsPanelItem>...</ToolsPanelItem>
    </ToolsPanel>
</InspectorControls>
```

**After:**
```jsx
<InspectorControls group="settings" resetAllFilter={() => ({...})}>
    <ToolsPanelItem panelId={clientId} resetAllFilter={() => ({...})}>
        ...
    </ToolsPanelItem>
</InspectorControls>
```

Key changes:
- Replace `<ToolsPanel>` with `<InspectorControls group="settings">`
- Change `resetAll` to `resetAllFilter` (returns object instead of calling setAttributes)
- Add `panelId={clientId}` to each ToolsPanelItem
- Add individual `resetAllFilter` to each ToolsPanelItem
- Remove `useToolsPanelDropdownMenuProps` hook usage

### Documentation

- Updated `packages/block-editor/src/components/inspector-controls/README.md` with comprehensive group documentation
- Includes usage examples, available groups, and namespaced group patterns

## Testing Instructions

### 1. Test Image Block Media Panel
1. Create a new post/page
2. Insert an Image block and upload/select an image
3. With the block selected, open the Settings tab in the sidebar
4. Verify the "Media" panel appears with:
   - Image selection control
   - Alternative text field
   - Individual reset buttons (x) for each control
   - Three-dot dropdown menu (if optional controls exist)
5. Test "Reset all" functionality

### 2. Test Image Block Settings Panel
1. With an Image block selected
2. In the Settings tab, verify the "Settings" panel appears
3. Check that the Resolution dropdown is present
4. Test reset functionality

### 3. Test Site Logo Block
1. Insert a Site Logo block
2. In the Settings tab, verify:
   - "Media" panel with logo upload control
   - "Settings" panel with width, link, and sync controls
3. Test all reset buttons and "Reset all" functionality

### 4. Test Navigation Block Display Panel
1. Insert a Navigation block
2. In the Settings tab, verify the "Display" panel appears with:
   - Overlay visibility control
   - Submenu settings (if submenus exist)
3. Test reset functionality

### 5. Test Query Block Panels
1. Insert a Query Loop block
2. In the Settings tab, verify three panels:
   - "Settings" panel (Query type, Post type, Order by, Sticky posts)
   - "Display" panel (Items per page, Offset, Max pages)
   - "Filters" panel (Taxonomies, Authors, Keyword, etc.)
3. Test all reset functionality

### 6. Test Third-Party Extensibility
1. Add this code to test extending the Media panel:
```jsx
import { InspectorControls } from '@wordpress/block-editor';
import { ToolsPanelItem, TextControl } from '@wordpress/components';

// In a plugin, extend the Image block's Media panel
wp.hooks.addFilter(
    'editor.BlockEdit',
    'my-plugin/extend-image-media',
    (BlockEdit) => (props) => {
        if (props.name !== 'core/image') {
            return <BlockEdit {...props} />;
        }
        return (
            <>
                <BlockEdit {...props} />
                <InspectorControls group="media">
                    <ToolsPanelItem
                        label="Custom Field"
                        hasValue={() => !!props.attributes.customField}
                        onDeselect={() => props.setAttributes({ customField: undefined })}
                        panelId={props.clientId}
                    >
                        <TextControl
                            label="Custom Field"
                            value={props.attributes.customField || ''}
                            onChange={(value) => props.setAttributes({ customField: value })}
                        />
                    </ToolsPanelItem>
                </InspectorControls>
            </>
        );
    }
);
```
2. Verify the custom control appears in the Image block's Media panel

## Follow-up Work

This PR establishes the foundation. Follow-up PRs will migrate the remaining 53 blocks that currently use direct ToolsPanel rendering.
