### PR TITLE
Enable minification in esbuild config

### DIFF
--- a/packages/dataviews/build.cjs
+++ b/packages/dataviews/build.cjs
@@ -36,4 +36,10 @@ esbuild.build( {
 	jsx: 'automatic',
 	logLevel: 'info',
 	format: 'esm',
+	sourcemap: false,
+	minify: true,
+	// Optional but sometimes helps ensure aggressive simplification:
+	minifySyntax: true,
+	minifyWhitespace: true,
+	minifyIdentifiers: true,
 } );


### PR DESCRIPTION
Added minification options (minify, minifySyntax, minifyWhitespace, minifyIdentifiers) and disabled sourcemaps in the esbuild configuration to produce smaller, optimized builds.

<img width="793" height="724" alt="Screenshot 2026-01-16 at 10 23 26" src="https://github.com/user-attachments/assets/fdbfcdc1-cd05-4032-b2c5-170e06fe0d22" />
