### PR TITLE
Fix E2E tests: Update function names to include wp_ prefix

### DIFF
--- a/lib/remove-core-enqueue-scripts.php
+++ b/lib/remove-core-enqueue-scripts.php
@@ -8,5 +8,5 @@
  * @package gutenberg
  */
 
-remove_action( 'admin_enqueue_scripts', 'font_library_wp_admin_enqueue_scripts' );
-remove_action( 'admin_enqueue_scripts', 'site_editor_v2_wp_admin_enqueue_scripts' );
+remove_action( 'admin_enqueue_scripts', 'wp_font_library_wp_admin_enqueue_scripts' );
+remove_action( 'admin_enqueue_scripts', 'wp_site_editor_v2_wp_admin_enqueue_scripts' );


### PR DESCRIPTION
## What?
Updates function names in remove-core-enqueue-scripts.php to use the wp_ prefix. The function names changed in the latest Core commit.

## Testing instructions

- destroy and recreate your local environment
- Load the fonts page (it should load without errors)