### PR TITLE
Navigation Overlay: Update overlay control labels

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -75,9 +75,10 @@ import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
+import { DEFAULT_BLOCK } from '../constants';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
-import { DEFAULT_BLOCK } from '../constants';
+import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 
 /**
  * Component that renders the Add page button for the Navigation block.
@@ -139,6 +140,10 @@ function ColorTools( {
 		setDetectedOverlayBackgroundColor,
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
+
+	// Detect if we're editing inside an overlay template part.
+	const isWithinOverlay = useSelect( () => isWithinNavigationOverlay(), [] );
+
 	// Turn on contrast checker for web only since it's not supported on mobile yet.
 	const enableContrastChecking = Platform.OS === 'web';
 	useEffect( () => {
@@ -179,48 +184,57 @@ function ColorTools( {
 	if ( ! colorGradientSettings.hasColorsOrGradients ) {
 		return null;
 	}
+
+	const colorSettings = [
+		{
+			colorValue: textColor.color,
+			label: __( 'Text' ),
+			onColorChange: setTextColor,
+			resetAllFilter: () => setTextColor(),
+			clearable: true,
+			enableAlpha: true,
+		},
+		{
+			colorValue: backgroundColor.color,
+			label: __( 'Background' ),
+			onColorChange: setBackgroundColor,
+			resetAllFilter: () => setBackgroundColor(),
+			clearable: true,
+			enableAlpha: true,
+		},
+	];
+
+	// Only show overlay controls when using the default overlay.
+	if ( ! hasCustomOverlay ) {
+		colorSettings.push(
+			{
+				colorValue: overlayTextColor.color,
+				label: isWithinOverlay
+					? __( 'Submenu text' )
+					: __( 'Submenu & overlay text' ),
+				onColorChange: setOverlayTextColor,
+				resetAllFilter: () => setOverlayTextColor(),
+				clearable: true,
+				enableAlpha: true,
+			},
+			{
+				colorValue: overlayBackgroundColor.color,
+				label: isWithinOverlay
+					? __( 'Submenu background' )
+					: __( 'Submenu & overlay background' ),
+				onColorChange: setOverlayBackgroundColor,
+				resetAllFilter: () => setOverlayBackgroundColor(),
+				clearable: true,
+				enableAlpha: true,
+			}
+		);
+	}
+
 	return (
 		<>
 			<ColorGradientSettingsDropdown
 				__experimentalIsRenderedInSidebar
-				settings={ [
-					{
-						colorValue: textColor.color,
-						label: __( 'Text' ),
-						onColorChange: setTextColor,
-						resetAllFilter: () => setTextColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: backgroundColor.color,
-						label: __( 'Background' ),
-						onColorChange: setBackgroundColor,
-						resetAllFilter: () => setBackgroundColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: overlayTextColor.color,
-						label: hasCustomOverlay
-							? __( 'Submenu text' )
-							: __( 'Submenu & overlay text' ),
-						onColorChange: setOverlayTextColor,
-						resetAllFilter: () => setOverlayTextColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-					{
-						colorValue: overlayBackgroundColor.color,
-						label: hasCustomOverlay
-							? __( 'Submenu background' )
-							: __( 'Submenu & overlay background' ),
-						onColorChange: setOverlayBackgroundColor,
-						resetAllFilter: () => setOverlayBackgroundColor(),
-						clearable: true,
-						enableAlpha: true,
-					},
-				] }
+				settings={ colorSettings }
 				panelId={ clientId }
 				{ ...colorGradientSettings }
 				gradients={ [] }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/74097

Conditionally removes "overlay" from control labels when editing inside an overlay template part.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a custom overlay template part is selected, the Navigation block's overlay background colour controls no longer apply to the overlay itself, they only affect submenus. Showing controls labelled "Submenu & overlay background" in this context is misleading, as they don't actually control the overlay's appearance.

Then, when editing blocks inside an overlay template part, the same controls appear, but again only affect submenus within that overlay. The "overlay" terminology is confusing in this context since users are already editing the overlay itself.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR:
  - Hides the overlay controls entirely when they don't apply (custom overlay selected)
  - Uses more accurate labels when editing inside an overlay template part

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Custom overlay hides controls:

  1. Create a new Navigation block
  2. In the block settings, go to the Styles panel
  3. Verify you see "Submenu & overlay text" and "Submenu & overlay background" controls in the colour settings
  4. In the Overlay panel, create a custom overlay template part
  5. Verify the "Submenu & overlay text" and "Submenu & overlay background" controls are now hidden
  6. Switch back to the default overlay
  7. Verify the controls reappear

Labels change when editing inside overlay:

  1. Create a Navigation block with default overlay (or ensure one exists)
  2. Navigate to Appearance > Editor > Template Parts
  3. Find and edit a Navigation Overlay template part
  4. Add or select a Navigation block inside the overlay template part
  5. Open the block's colour settings
  6. Verify the controls show "Submenu text" and "Submenu background" (without "overlay")
  7. Exit the overlay template part editor and edit the Navigation block in a regular page/template
  8. Verify the controls show "Submenu & overlay text" and "Submenu & overlay background"

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1716" height="747" alt="Screenshot 2026-01-16 at 14 28 06" src="https://github.com/user-attachments/assets/64f71c29-41af-4477-90dc-5a05f8d73546" /> | <img width="1716" height="747" alt="Screenshot 2026-01-16 at 14 19 40" src="https://github.com/user-attachments/assets/11fffa68-9cd3-44ea-afbc-8ed17a39b51e" /> |


