### PR TITLE
Components: Add `@types/react` to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52440,6 +52440,7 @@
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -62,6 +62,7 @@
 		"@floating-ui/react-dom": "2.0.8",
 		"@types/gradient-parser": "1.1.0",
 		"@types/highlight-words-core": "1.2.1",
+		"@types/react": "^18.3.27",
 		"@use-gesture/react": "^10.3.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",


### PR DESCRIPTION
## What?

Follow-up to #74655

Add `@types/react` to `dependencies` in `@wordpress/components`.

## Why?

As noted by @manzoorwanijk in the discussion following #74655, `@types/react` also needs to be added as a dependency since it's referenced in the generated type declarations.

The `build-types/` directory contains references to React types like `React.ReactNode`, `React.ElementType`, and `React.Ref` which require `@types/react` to be available.

## How?

Added `@types/react: ^18.3.27` to `dependencies` in `packages/components/package.json`, matching the version used by `@wordpress/element`.

## Testing Instructions

1. Verify that the `@types/react` dependency is correctly added
2. Run `npm install` to ensure no dependency conflicts

### Testing Instructions for Keyboard

N/A - This is a dependency addition with no UI changes.

## Screenshots or screencast

N/A - No visual changes.