### PR TITLE
Fix sync manager test types

### DIFF
--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -86,11 +86,13 @@ describe( 'SyncManager', () => {
 		};
 
 		mockHandlers = {
+			addUndoMeta: jest.fn(),
 			editRecord: jest.fn(),
 			getEditedRecord: jest.fn( async () =>
 				Promise.resolve( mockRecord )
 			),
 			refetchRecord: jest.fn( async () => Promise.resolve() ),
+			restoreUndoMeta: jest.fn(),
 			saveRecord: jest.fn( async () => Promise.resolve() ),
 		};
 	} );
@@ -486,7 +488,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation(
 				async (
 					_objectType: string,
-					_objectId: string,
+					_objectId: string | null,
 					ydoc: Y.Doc
 				) => {
 					capturedDoc = ydoc;
@@ -539,7 +541,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation(
 				async (
 					_objectType: string,
-					_objectId: string,
+					_objectId: string | null,
 					ydoc: Y.Doc
 				) => {
 					capturedDoc = ydoc;
@@ -583,7 +585,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation(
 				async (
 					_objectType: string,
-					_objectId: string,
+					_objectId: string | null,
 					ydoc: Y.Doc
 				) => {
 					capturedDoc = ydoc;
@@ -631,7 +633,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation(
 				async (
 					_objectType: string,
-					_objectId: string,
+					_objectId: string | null,
 					ydoc: Y.Doc
 				) => {
 					capturedDoc = ydoc;
@@ -680,7 +682,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation(
 				async (
 					_objectType: string,
-					_objectId: string,
+					_objectId: string | null,
 					ydoc: Y.Doc
 				) => {
 					capturedDoc = ydoc;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes TypeScript compilation errors in sync package test mocks.

## Why?
PR #74075 targets the `wpvip/rtc-plugin` branch and is failing in the compressed-size-action workflow. This workflow builds both the base branch and PR branch separately to compare bundle sizes. The base branch has TypeScript compilation errors that prevent it from building successfully.

The sync manager test mocks were missing required handler methods (`addUndoMeta`, `restoreUndoMeta`) and used incorrect type signatures for the provider creator's `objectId` parameter (`string` instead of `string | null`).

## How?
Updated `/packages/sync/src/test/manager.ts`:

1. Added missing methods to `mockHandlers`:
   - `addUndoMeta: jest.fn()`
   - `restoreUndoMeta: jest.fn()`

2. Changed provider creator mock signatures from:
   ```typescript
   async (_objectType: string, _objectId: string, ydoc: Y.Doc) => { ... }
   ```

   To:
   ```typescript
   async (_objectType: string, _objectId: string | null, ydoc: Y.Doc) => { ... }
   ```

The nullable `objectId` matches the `ProviderCreator` type definition, which supports both entity-level syncing (with an objectId) and collection-level syncing (where objectId is null).

## Testing Instructions
1. Check out this branch
2. Run `npm run build` and verify it completes successfully
3. Run `npm run test:unit -- packages/sync/src/test/manager.ts` and verify all 20 tests pass

### Testing Instructions for Keyboard
Not applicable - this PR only fixes test type definitions and does not change the user interface.

## Screenshots or screencast
Not applicable - this PR only fixes TypeScript compilation errors.
