### PR TITLE
Build: Simplify wp-build bundling and add workspace node_modules to SASS paths

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -125,6 +125,10 @@ function getSassOptions( workingDir ) {
 		loadPaths: [
 			// Package's own node_modules (for pnpm isolated deps)
 			path.join( workingDir, 'node_modules' ),
+			// All workspace package node_modules (for pnpm's non-hoisted deps)
+			...PACKAGES.map( ( pkg ) =>
+				path.join( PACKAGES_DIR, pkg, 'node_modules' )
+			),
 			// Root node_modules (for npm hoisted deps)
 			path.join( ROOT_DIR, 'node_modules' ),
 			// For local imports like @use "mixins"
@@ -1614,48 +1618,23 @@ async function buildAll( baseUrlExpression ) {
 		};
 	} );
 
-	// Bundle boot, route, and theme packages from node_modules when pages exist
+	// Bundle boot, route, theme, and private-apis packages when pages exist
 	if ( pageData.length > 0 ) {
-		try {
-			const { createRequire } = await import( 'module' );
-			const require = createRequire( import.meta.url );
+		const externalPackages = [ 'boot', 'route', 'theme', 'private-apis' ];
+		for ( const pkgName of externalPackages ) {
+			const result = await bundlePackage( pkgName, {
+				// Use PACKAGES_DIR (default) since these are workspace packages
+				handlePrefix: 'wp',
+				scriptGlobal: 'wp',
+				packageNamespace: 'wordpress',
+			} );
 
-			// Resolve the @wordpress packages directory from node_modules
-			const bootPackageJson = require.resolve(
-				'@wordpress/boot/package.json',
-				{ paths: [ ROOT_DIR ] }
-			);
-			const wordpressPackagesDir = path.dirname(
-				path.dirname( bootPackageJson )
-			);
-
-			// Bundle boot, route, theme, and private-apis packages
-			const externalPackages = [
-				'boot',
-				'route',
-				'theme',
-				'private-apis',
-			];
-			for ( const pkgName of externalPackages ) {
-				const result = await bundlePackage( pkgName, {
-					sourceDir: wordpressPackagesDir,
-					handlePrefix: 'wp',
-					scriptGlobal: 'wp',
-					packageNamespace: 'wordpress',
-				} );
-
-				if ( result && result.modules ) {
-					modules.push( ...result.modules );
-				}
-				if ( result && result.scripts ) {
-					scripts.push( ...result.scripts );
-				}
+			if ( result && result.modules ) {
+				modules.push( ...result.modules );
 			}
-		} catch ( error ) {
-			console.warn(
-				'\n⚠️  Warning: Could not bundle WordPress packages for pages:',
-				error.message
-			);
+			if ( result && result.scripts ) {
+				scripts.push( ...result.scripts );
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?

Follow-up to #74434, inspired by #74309

Simplify the bundling logic for WordPress packages in `wp-build` and add workspace package `node_modules` to SASS load paths.

## Why?

1. **Simplify bundlePackage logic**: #73379 added logic to bundle packages like `boot`, `route`, `theme`, and `private-apis` for pages. The implementation uses `require.resolve` to find `@wordpress/boot/package.json` and derive the packages directory from there. It doesn't work when used in pnpm and is unnecessarily complex since these are workspace packages that can be bundled directly from `PACKAGES_DIR`.

2. **Complete SASS load paths for pnpm**: #74434 added support for the working directory's `node_modules`, but when building within the Gutenberg monorepo with pnpm, dependencies may be installed in individual workspace package `node_modules` directories rather than being hoisted. Adding all workspace package `node_modules` to the load paths ensures SASS can find dependencies regardless of where pnpm installs them.

## How?

1. **Simplified bundlePackage**: Removed the `require.resolve` approach and the `sourceDir` option. The `bundlePackage` function now uses `PACKAGES_DIR` by default for workspace packages, which is the correct behavior.

2. **Added workspace package node_modules to SASS load paths**: Added all workspace package `node_modules` directories to the SASS `loadPaths` array.

## Testing Instructions

1. Start the development environment:
   ```bash
   npm run build && npm run wp-env start
   ```

2. Navigate to the Site Editor:
   ```
   http://localhost:8888/wp-admin/admin.php?page=site-editor-v2
   ```

3. Verify that routes work correctly:
   - Click on different navigation items (Templates, Patterns, etc.)
   - Verify pages load without errors
   - Check the browser console for any JavaScript errors

4. Run the build to verify SASS compilation works:
   ```bash
   npm run build
   ```

### Testing Instructions for Keyboard

N/A - This is a build tooling change with no direct UI impact.

## Screenshots or screencast

N/A
