### PR TITLE
Add stories for Colors component

### DIFF
--- a/packages/block-editor/src/components/colors/stories/index.story.jsx
+++ b/packages/block-editor/src/components/colors/stories/index.story.jsx
@@ -7,7 +7,7 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { withColors } from '../index';
+import { withColors, createCustomColorsHOC } from '../index';
 
 export default {
 	title: 'BlockEditor/Colors',
@@ -78,6 +78,64 @@ export const Default = {
 					}
 				/>
 			</BlockEditorProvider>
+		);
+	},
+};
+
+/**
+ * A custom component to demonstrate createCustomColorsHOC.
+ */
+function CustomBox( { backgroundColor, setBackgroundColor } ) {
+	return (
+		<div
+			style={ {
+				backgroundColor: backgroundColor?.color,
+				padding: '20px',
+				border: '1px solid #ccc',
+				textAlign: 'center',
+			} }
+		>
+			<p>
+				<strong>Current Slug: </strong>
+				{ backgroundColor?.slug || 'none' }
+			</p>
+			<button onClick={ () => setBackgroundColor( 'cyan' ) }>
+				Set Cyan
+			</button>
+			<button onClick={ () => setBackgroundColor( 'magenta' ) }>
+				Set Magenta
+			</button>
+			<button onClick={ () => setBackgroundColor( undefined ) }>
+				Clear
+			</button>
+		</div>
+	);
+}
+
+const CUSTOM_PALETTE = [
+	{ name: 'Cyan', slug: 'cyan', color: '#00ffff' },
+	{ name: 'Magenta', slug: 'magenta', color: '#ff00ff' },
+];
+
+const WrappedCustomBox =
+	createCustomColorsHOC( CUSTOM_PALETTE )( 'backgroundColor' )( CustomBox );
+
+export const CustomPalette = {
+	render: function Template() {
+		const [ attributes, setAttributes ] = useState( {} );
+
+		return (
+			<div>
+				<WrappedCustomBox
+					attributes={ attributes }
+					setAttributes={ ( newAttrs ) =>
+						setAttributes( ( prev ) => ( {
+							...prev,
+							...newAttrs,
+						} ) )
+					}
+				/>
+			</div>
 		);
 	},
 };

--- a/packages/block-editor/src/components/colors/stories/index.story.jsx
+++ b/packages/block-editor/src/components/colors/stories/index.story.jsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { BlockEditorProvider } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { withColors } from '../index';
+
+export default {
+	title: 'BlockEditor/Colors',
+	component: withColors,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Higher-Order Component (HOC) that injects color props.',
+			},
+		},
+	},
+};
+
+/**
+ * A simple component to demonstrate withColors HOC.
+ */
+function SimpleBox( { backgroundColor, setBackgroundColor } ) {
+	return (
+		<div
+			style={ {
+				backgroundColor: backgroundColor?.color,
+				padding: '20px',
+				border: '1px solid #ccc',
+				textAlign: 'center',
+			} }
+		>
+			<p>
+				<strong>Current Slug: </strong>
+				{ backgroundColor?.slug || 'none' }
+			</p>
+			<button onClick={ () => setBackgroundColor( 'red' ) }>
+				Set Red
+			</button>
+			<button onClick={ () => setBackgroundColor( 'blue' ) }>
+				Set Blue
+			</button>
+			<button onClick={ () => setBackgroundColor( undefined ) }>
+				Clear
+			</button>
+		</div>
+	);
+}
+
+const WrappedBox = withColors( 'backgroundColor' )( SimpleBox );
+
+export const Default = {
+	render: function Template() {
+		const [ attributes, setAttributes ] = useState( {} );
+
+		return (
+			<BlockEditorProvider
+				settings={ {
+					colors: [
+						{ name: 'Red', slug: 'red', color: 'red' },
+						{ name: 'Blue', slug: 'blue', color: 'blue' },
+					],
+				} }
+			>
+				<WrappedBox
+					attributes={ attributes }
+					setAttributes={ ( newAttrs ) =>
+						setAttributes( ( prev ) => ( {
+							...prev,
+							...newAttrs,
+						} ) )
+					}
+				/>
+			</BlockEditorProvider>
+		);
+	},
+};

--- a/packages/block-editor/src/components/colors/stories/index.story.jsx
+++ b/packages/block-editor/src/components/colors/stories/index.story.jsx
@@ -26,7 +26,7 @@ export default {
 /**
  * A simple component to demonstrate withColors HOC.
  */
-function SimpleBox( { backgroundColor, setBackgroundColor } ) {
+function SimpleBox( { backgroundColor, setBackgroundColor, demoColors = [] } ) {
 	return (
 		<div
 			style={ {
@@ -37,21 +37,31 @@ function SimpleBox( { backgroundColor, setBackgroundColor } ) {
 			} }
 		>
 			<p>
-				<strong>Current Slug: </strong>
-				{ backgroundColor?.slug || 'none' }
+				<strong>Current Color: </strong>
+				{ backgroundColor?.color || 'none' }
 			</p>
-			<button onClick={ () => setBackgroundColor( 'red' ) }>
-				Set Red
-			</button>
-			<button onClick={ () => setBackgroundColor( 'blue' ) }>
-				Set Blue
-			</button>
-			<button onClick={ () => setBackgroundColor( undefined ) }>
-				Clear
-			</button>
+
+			<div>
+				{ demoColors.map( ( color ) => (
+					<button
+						key={ color.slug }
+						onClick={ () => setBackgroundColor( color.color ) }
+					>
+						Set { color.name }
+					</button>
+				) ) }
+				<button onClick={ () => setBackgroundColor( undefined ) }>
+					Clear
+				</button>
+			</div>
 		</div>
 	);
 }
+
+const GLOBAL_COLORS = [
+	{ name: 'Red', slug: 'red', color: 'red' },
+	{ name: 'Blue', slug: 'blue', color: 'blue' },
+];
 
 const WrappedBox = withColors( 'backgroundColor' )( SimpleBox );
 
@@ -62,10 +72,7 @@ export const Default = {
 		return (
 			<BlockEditorProvider
 				settings={ {
-					colors: [
-						{ name: 'Red', slug: 'red', color: 'red' },
-						{ name: 'Blue', slug: 'blue', color: 'blue' },
-					],
+					colors: GLOBAL_COLORS,
 				} }
 			>
 				<WrappedBox
@@ -76,41 +83,12 @@ export const Default = {
 							...newAttrs,
 						} ) )
 					}
+					demoColors={ GLOBAL_COLORS }
 				/>
 			</BlockEditorProvider>
 		);
 	},
 };
-
-/**
- * A custom component to demonstrate createCustomColorsHOC.
- */
-function CustomBox( { backgroundColor, setBackgroundColor } ) {
-	return (
-		<div
-			style={ {
-				backgroundColor: backgroundColor?.color,
-				padding: '20px',
-				border: '1px solid #ccc',
-				textAlign: 'center',
-			} }
-		>
-			<p>
-				<strong>Current Slug: </strong>
-				{ backgroundColor?.slug || 'none' }
-			</p>
-			<button onClick={ () => setBackgroundColor( 'cyan' ) }>
-				Set Cyan
-			</button>
-			<button onClick={ () => setBackgroundColor( 'magenta' ) }>
-				Set Magenta
-			</button>
-			<button onClick={ () => setBackgroundColor( undefined ) }>
-				Clear
-			</button>
-		</div>
-	);
-}
 
 const CUSTOM_PALETTE = [
 	{ name: 'Cyan', slug: 'cyan', color: '#00ffff' },
@@ -118,7 +96,7 @@ const CUSTOM_PALETTE = [
 ];
 
 const WrappedCustomBox =
-	createCustomColorsHOC( CUSTOM_PALETTE )( 'backgroundColor' )( CustomBox );
+	createCustomColorsHOC( CUSTOM_PALETTE )( 'backgroundColor' )( SimpleBox );
 
 export const CustomPalette = {
 	parameters: {
@@ -141,6 +119,7 @@ export const CustomPalette = {
 							...newAttrs,
 						} ) )
 					}
+					demoColors={ CUSTOM_PALETTE }
 				/>
 			</div>
 		);

--- a/packages/block-editor/src/components/colors/stories/index.story.jsx
+++ b/packages/block-editor/src/components/colors/stories/index.story.jsx
@@ -17,7 +17,7 @@ export default {
 			canvas: { sourceState: 'shown' },
 			description: {
 				component:
-					'Higher-Order Component (HOC) that injects color props.',
+					'Higher-Order Component (HOC) that injects color props. \n\n **Default Usage:** The component above demonstrates the standard usage, where it retrieves its color palette (Red and Blue) dynamically from the global Block Editor settings.',
 			},
 		},
 	},
@@ -121,6 +121,13 @@ const WrappedCustomBox =
 	createCustomColorsHOC( CUSTOM_PALETTE )( 'backgroundColor' )( CustomBox );
 
 export const CustomPalette = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'This shows `createCustomColorsHOC`. It uses a hardcoded, static palette (Cyan and Magenta) that is isolated from the global theme settings.',
+			},
+		},
+	},
 	render: function Template() {
 		const [ attributes, setAttributes ] = useState( {} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #67165 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR adds storybook for Colors component of Block Editor


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the Colors storybook

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<img width="400" height="789" alt="image" src="https://github.com/user-attachments/assets/5ca3ab37-3f46-4bf3-b14f-675d7f61542a" />

<img width="400" height="785" alt="image" src="https://github.com/user-attachments/assets/2689a419-8dcc-4068-a6e2-8eb523ad1208" />

