### PR TITLE
Fix image block breakage when alt text contains < issue solved  #74691 

### DIFF
--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -13,6 +13,7 @@ import {
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 } from '@wordpress/block-editor';
+import { escapeAttribute } from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
@@ -60,10 +61,13 @@ export default function save( { attributes } ) {
 		[ `wp-image-${ id }` ]: !! id,
 	} );
 
+	// ✅ FIX: Escape alt text to prevent malformed HTML for non-unfiltered users
+	const safeAlt = alt ? escapeAttribute( alt ) : undefined;
+
 	const image = (
 		<img
 			src={ url }
-			alt={ alt }
+			alt={ safeAlt }
 			className={ imageClasses || undefined }
 			style={ {
 				...borderProps.style,


### PR DESCRIPTION
## What?
Closes #74691

This PR fixes an issue where adding a `<` character to the image alt text causes
the Image block to become invalid and trigger a block recovery message for users
without the `unfiltered_html` capability.

## Why?
For non-admin users (such as Authors or Contributors), alt text containing a `<`
character is not properly escaped during block serialization. This results in
malformed HTML being saved and causes Gutenberg to display a block recovery error
when the post is reloaded.

This behavior does not occur with other special characters like `>` or `&`,
leading to inconsistent and unexpected editor behavior.

## How?
The fix ensures that the image alt attribute is safely escaped before being
serialized in the Image block `save` function. By escaping the alt text, special
characters such as `<` are converted into valid HTML entities, preventing
malformed markup while preserving existing behavior for all user roles.

## Testing Instructions
1. Log in as a user without the `unfiltered_html` capability (e.g. Author).
2. Create a new post or page.
3. Insert an Image block.
4. Set the image alt text to: `This is < cool`.
5. Save the post.
6. Reload the editor.

### Expected result
- The Image block renders normally.
- No block recovery message is shown.

### Actual result (before fix)
- The Image block becomes invalid and shows a block recovery message.

### Testing Instructions for Keyboard
1. Use `Tab` to navigate to the Image block.
2. Press `Enter` to select the block.
3. Use `Tab` to focus the alt text field.
4. Type `This is < cool`.
5. Use `Tab` to navigate to the Save button and press `Enter`.
6. Reload the editor using keyboard navigation.

The Image block should remain valid and render correctly.

## Screenshots or screencast

| Before | After |
| - | - |
| Block recovery message displayed | Image block renders correctly |

Unlinked contributors: niranjanbaviskar.

Co-authored-by: Mustafabharmal <mustafabharmal@git.wordpress.org>
Co-authored-by: t-hamano <wildworks@git.wordpress.org>
Co-authored-by: dsas <dsas@git.wordpress.org>
