### PR TITLE
Add custom head code snippets feature to Site Editor

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -284,6 +284,12 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 						return $css_validation_result;
 					}
 				}
+			if ( isset( $request['styles']['headCode'] ) ) {
+				$head_code_validation_result = $this->validate_custom_head_code( $request['styles']['headCode'] );
+				if ( is_wp_error( $head_code_validation_result ) ) {
+					return $head_code_validation_result;
+				}
+			}
 				$config['styles'] = $request['styles'];
 			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
@@ -332,8 +338,19 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 		$config                           = array();
 		$theme_json                       = null;
 		if ( $is_global_styles_user_theme_json ) {
+			// Store headCode separately before WP_Theme_JSON processes it
+			$head_code_backup = $raw_config['styles']['headCode'] ?? null;
+			
 			$theme_json = new WP_Theme_JSON_Gutenberg( $raw_config, 'custom' );
 			$config     = $theme_json->get_raw_data();
+			
+			// Restore headCode if it was present
+			if ( $head_code_backup !== null ) {
+				if ( ! isset( $config['styles'] ) ) {
+					$config['styles'] = array();
+				}
+				$config['styles']['headCode'] = $head_code_backup;
+			}
 		}
 
 		// Base fields for every post.
@@ -452,6 +469,10 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 
 		if ( current_user_can( 'edit_css' ) ) {
 			$rels[] = 'https://api.w.org/action-edit-css';
+		}
+
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$rels[] = 'https://api.w.org/action-edit-head-code';
 		}
 
 		return $rels;
@@ -699,6 +720,39 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 				array( 'status' => 400 )
 			);
 		}
+		return true;
+	}
+
+	/**
+	 * Validate custom head code.
+	 *
+	 * Checks capability and sanitizes the input. Unlike CSS, head code can contain
+	 * HTML markup, but only for users with unfiltered_html capability.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $head_code Head code to validate.
+	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
+	 */
+	protected function validate_custom_head_code( $head_code ) {
+		// Check if user has permission to edit unfiltered HTML.
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			return new WP_Error(
+				'rest_custom_head_code_unauthorized',
+				__( 'You do not have permission to edit custom head code.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// On multisite, only Super Admins can edit custom head code.
+		if ( is_multisite() && ! is_super_admin() ) {
+			return new WP_Error(
+				'rest_custom_head_code_unauthorized',
+				__( 'Only Super Admins can edit custom head code on multisite.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		return true;
 	}
 }

--- a/lib/compat/wordpress-6.9/custom-head-code.php
+++ b/lib/compat/wordpress-6.9/custom-head-code.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Custom Head Code functionality for Site Editor.
+ *
+ * Allows users to add custom code snippets to the HTML <head> element
+ * through the Site Editor interface, similar to Additional CSS.
+ *
+ * @package gutenberg
+ * @since 6.9.0
+ */
+
+/**
+ * Renders custom head code in the head section.
+ *
+ * Retrieves custom head code from Global Styles and outputs it in the <head>
+ * section via the wp_head hook. Only users with 'unfiltered_html' capability
+ * can add custom head code. On multisite, only Super Admins can use this feature.
+ *
+ * @since 6.9.0
+ */
+function gutenberg_custom_head_code_cb() {
+	$head_code = gutenberg_get_custom_head_code();
+	
+	if ( empty( $head_code ) ) {
+		return;
+	}
+
+	// Output the custom head code.
+	echo wp_unslash( $head_code );
+	echo "\n";
+}
+
+/**
+ * Gets the custom head code from Global Styles.
+ *
+ * Retrieves the custom head code stored in the Global Styles post type
+ * under the 'styles.headCode' property.
+ *
+ * @since 6.9.0
+ *
+ * @return string Custom head code, or empty string if not set.
+ */
+function gutenberg_get_custom_head_code() {
+	// Get the user's global styles post directly from the database
+	$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
+	
+	if ( empty( $user_cpt ) ) {
+		return '';
+	}
+	
+	// Check if it's an array (contains 'ID' and 'post_content')
+	if ( is_array( $user_cpt ) ) {
+		$config = json_decode( $user_cpt['post_content'], true );
+	} else {
+		$config = json_decode( $user_cpt->post_content, true );
+	}
+	
+	// Return the headCode if it exists
+	return $config['styles']['headCode'] ?? '';
+}
+
+/**
+ * Checks if the current user can edit custom head code.
+ *
+ * On multisite, only Super Admins can edit custom head code.
+ * On single site, users need the 'unfiltered_html' capability.
+ *
+ * @since 6.9.0
+ *
+ * @return bool True if the user can edit custom head code, false otherwise.
+ */
+function gutenberg_can_edit_custom_head_code() {
+	// On multisite, only Super Admins can edit custom head code.
+	if ( is_multisite() && ! is_super_admin() ) {
+		return false;
+	}
+
+	// Check for unfiltered_html capability.
+	return current_user_can( 'unfiltered_html' );
+}
+
+// Hook into wp_head at priority 102 (after CSS at 101).
+add_action( 'wp_head', 'gutenberg_custom_head_code_cb', 102 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -96,6 +96,7 @@ require __DIR__ . '/compat/plugin/fonts.php';
 
 // WordPress 6.9 compat.
 require __DIR__ . '/compat/wordpress-6.9/customizer-preview-custom-css.php';
+require __DIR__ . '/compat/wordpress-6.9/custom-head-code.php';
 require __DIR__ . '/compat/wordpress-6.9/command-palette.php';
 require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
 

--- a/packages/editor/src/components/global-styles/menu.js
+++ b/packages/editor/src/components/global-styles/menu.js
@@ -14,11 +14,11 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useGlobalStyles } from './hooks';
 
 /**
- * Action menu with Reset, Welcome Guide, and Additional CSS.
+ * Action menu with Reset, Welcome Guide, Additional CSS, and Custom Head Code.
  *
  * @param {Object}   props                  Component props.
  * @param {boolean}  props.hideWelcomeGuide Whether to hide the Welcome Guide option.
- * @param {Function} props.onChangePath     Callback for navigation to different paths (e.g., '/css').
+ * @param {Function} props.onChangePath     Callback for navigation to different paths (e.g., '/css', '/head-code').
  * @return {JSX.Element} The Global Styles Action Menu component.
  */
 export function GlobalStylesActionMenu( {
@@ -38,7 +38,7 @@ export function GlobalStylesActionMenu( {
 		setUser( { styles: {}, settings: {} } );
 	};
 	const { toggle } = useDispatch( preferencesStore );
-	const { canEditCSS } = useSelect( ( select ) => {
+	const { canEditCSS, canEditHeadCode } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
 			select( coreStore );
 
@@ -49,10 +49,15 @@ export function GlobalStylesActionMenu( {
 
 		return {
 			canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
+			canEditHeadCode:
+				!! globalStyles?._links?.[ 'wp:action-edit-head-code' ],
 		};
 	}, [] );
 	const loadCustomCSS = () => {
 		onChangePath( '/css' );
+	};
+	const loadCustomHeadCode = () => {
+		onChangePath( '/head-code' );
 	};
 
 	return (
@@ -67,6 +72,11 @@ export function GlobalStylesActionMenu( {
 						{ canEditCSS && (
 							<MenuItem onClick={ loadCustomCSS }>
 								{ __( 'Additional CSS' ) }
+							</MenuItem>
+						) }
+						{ canEditHeadCode && (
+							<MenuItem onClick={ loadCustomHeadCode }>
+								{ __( 'Custom Head Code' ) }
 							</MenuItem>
 						) }
 						{ ! hideWelcomeGuide && (

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -34,6 +34,7 @@ import { ScreenShadows, ScreenShadowsEdit } from './screen-shadows';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
 import ScreenCSS from './screen-css';
+import ScreenHeadCode from './screen-head-code';
 import ScreenRevisions from './screen-revisions';
 import FontSizes from './font-sizes/font-sizes';
 import FontSize from './font-sizes/font-size';
@@ -197,6 +198,9 @@ export function GlobalStylesUI( {
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/css">
 						<ScreenCSS />
+					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/head-code">
+						<ScreenHeadCode />
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/revisions/:revisionId?">
 						<ScreenRevisions />

--- a/packages/global-styles-ui/src/index.ts
+++ b/packages/global-styles-ui/src/index.ts
@@ -5,6 +5,7 @@ export { TypographyVariations } from './typography-variations';
 
 // Ideally this should just be a core-data selector.
 export { default as useGlobalStylesRevisions } from './screen-revisions/use-global-styles-revisions';
+export { default as ScreenHeadCode } from './screen-head-code';
 
 // Font Library exports
 export { FontLibrary } from './font-library/font-library';

--- a/packages/global-styles-ui/src/screen-head-code.tsx
+++ b/packages/global-styles-ui/src/screen-head-code.tsx
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	TextareaControl,
+	Notice,
+	// @ts-expect-error: Not typed yet.
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from './screen-header';
+import { useStyle } from './hooks';
+
+function ScreenHeadCode() {
+	// Get user-only styles (should not decode/encode to preserve raw head code)
+	const [ style ] = useStyle( '', undefined, 'user', false );
+	// Get all styles (inherited + user) for context and the setter
+	const [ , setStyle ] = useStyle(
+		'',
+		undefined,
+		'user',
+		false
+	);
+
+	// Get the head code from the user style (not inherited)
+	const customHeadCode = style?.headCode || '';
+
+	function handleOnChange( newValue ) {
+		setStyle( {
+			...style,
+			headCode: newValue,
+		} );
+	}
+
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Custom Head Code' ) }
+				description={
+					__(
+						'Add custom HTML, JavaScript, or meta tags that will be inserted in the <head> section of your site.'
+					)
+				}
+			/>
+			<div className="global-styles-ui-screen-head-code">
+				<VStack spacing={ 3 }>
+					<Notice
+						status="warning"
+						isDismissible={ false }
+					>
+						<strong>{ __( 'Warning:' ) }</strong>{ ' ' }
+						{ __(
+							'Custom head code is a powerful customization tool. Malicious or incorrect code can break your site or pose security risks. Always ensure you have a recent backup before saving changes.'
+						) }
+					</Notice>
+
+					<TextareaControl
+						label={ __( 'Custom Head Code' ) }
+						value={ customHeadCode }
+						onChange={ handleOnChange }
+						rows={ 20 }
+						className="global-styles-ui-screen-head-code__textarea"
+						placeholder={ __(
+							'<!-- Example: <meta name="description" content="My site description"> <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script> -->'
+						) }
+						spellCheck={ false }
+					/>
+				</VStack>
+			</div>
+		</>
+	);
+}
+
+export default ScreenHeadCode;

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -270,3 +270,15 @@
 .global-styles-ui-gradient-palette-panel {
 	padding: variables.$grid-unit-20;
 }
+
+/* Custom Head Code Screen Styles */
+.global-styles-ui-screen-head-code {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	margin: 16px;
+}
+
+.global-styles-ui-screen-head-code__textarea {
+	font-family: monospace;
+}


### PR DESCRIPTION
## What?

Adds the ability to insert custom HTML, JavaScript, or meta tags in the site's `<head>` section through the Site Editor interface, similar to the existing Additional CSS feature.

## Why?

Users frequently need to add custom code to the `<head>` section for:
- SEO meta tags (description, keywords, Open Graph)
- Analytics and tracking scripts (Google Analytics, Facebook Pixel)
- Custom web fonts (Google Fonts, Adobe Fonts)
- Site verification codes (Google Search Console, Bing)
- Favicon and app icon links

Currently, this requires manually editing theme files or using plugins. This feature provides a built-in, user-friendly solution accessible directly from the Site Editor.

## How?

### Backend (PHP)
- **New file:** `lib/compat/wordpress-6.9/custom-head-code.php`
  - `gutenberg_custom_head_code_cb()` - Outputs head code via `wp_head` hook at priority 102
  - `gutenberg_get_custom_head_code()` - Retrieves head code directly from Global Styles post
  - `gutenberg_can_edit_custom_head_code()` - Capability checks
- **Modified:** `lib/class-wp-rest-global-styles-controller-gutenberg.php`
  - Added `validate_custom_head_code()` method for REST API validation
  - Preserve headCode through WP_Theme_JSON processing in responses
  - Added `wp:action-edit-head-code` capability link

### Frontend (React/TypeScript)
- **New file:** `packages/global-styles-ui/src/screen-head-code.tsx`
  - ScreenHeadCode component with textarea for code input
  - Warning notice about security risks
  - Saves when clicking the top-right Save button
- **Modified:** `packages/editor/src/components/global-styles/menu.js`
  - Added "Custom Head Code" menu item (only visible to authorized users)
- **Modified:** `packages/global-styles-ui/src/global-styles-ui.tsx`
  - Registered `/head-code` route

### Security
- Requires `unfiltered_html` capability (Administrators and Super Admins)
- On multisite: Super Admin only
- Validates permissions in REST API before saving
- Warning notice informs users about security implications
- Data stored in Global Styles (`wp_global_styles` custom post type)

### Data Flow
1. User navigates to Site Editor → Styles → ⋮ → Custom Head Code
2. Component loads existing headCode from Global Styles (user styles)
3. User edits code in textarea
4. User clicks Save button to save via REST API with validation
5. On frontend, `gutenberg_custom_head_code_cb()` retrieves and outputs code in `<head>`

## Testing Instructions

### Prerequisites
- WordPress installation (MAMP or similar)
- User account with Administrator role (or Super Admin on multisite)

### Test 1: Access and UI
1. Go to **Appearance → Editor → Styles**
2. Click the **three-dot menu (⋮)** in the top right
3. Verify **"Custom Head Code"** appears in the menu
4. Click it and verify the screen loads with:
   - Warning notice about security risks
   - Large textarea (20 rows)
   - "Custom Head Code" label

### Test 2: Save and Persist
1. Add code to the textarea:
   ```html
   <meta name="description" content="My awesome WordPress site">
   <meta name="keywords" content="WordPress, Gutenberg">
   ```
2. Click the **Save** button (top right)
3. Refresh the page
4. Navigate back to Custom Head Code
5. Verify your code is still there

### Test 3: Frontend Output
1. Add some head code (e.g., meta tags or a comment)
2. Save the changes
3. Visit your site's homepage (frontend)
4. Right-click → **View Page Source**
5. Search for your custom code in the `<head>` section
6. Verify it appears just before the closing `</head>` tag

### Test 4: Capability Restrictions
1. Log out and log in as an **Editor** (or any role without `unfiltered_html`)
2. Go to Site Editor → Styles → ⋮
3. Verify **"Custom Head Code"** does NOT appear in the menu

### Test 5: Multiple Code Types
Test with various code types:

**Meta tags:**
```html
<meta name="author" content="John Doe">
<meta property="og:title" content="My Site">
```

**Analytics script:**
```html
<!-- Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
```

Verify all code types save correctly and appear in the frontend source.

## Screenshots
<img width="540" height="1048" alt="custom-head-code" src="https://github.com/user-attachments/assets/11620bae-1353-42cd-9a2a-35456bb48969" />

## Related
Fixes #52091