### PR TITLE
Add UploadSaveLockWrapper to manage save locks during uploads

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -19,6 +19,7 @@ import { BlockRefsProvider } from './block-refs-provider';
 import { unlock } from '../../lock-unlock';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import useMediaUploadSettings from './use-media-upload-settings';
+import useUploadSaveLock from './use-upload-save-lock';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
@@ -121,7 +122,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 					settings={ mediaUploadSettings }
 					useSubRegistry={ false }
 				>
-					{ children }
+					<UploadSaveLockWrapper>{ children }</UploadSaveLockWrapper>
 				</MediaUploadProvider>
 			);
 		}
@@ -129,6 +130,18 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		return children;
 	}
 );
+
+/**
+ * Wrapper component that manages post save locks based on upload state.
+ * Must be rendered inside MediaUploadProvider to access the upload-media store.
+ *
+ * @param {Object} props          Component props.
+ * @param {Object} props.children Children elements.
+ */
+function UploadSaveLockWrapper( { children } ) {
+	useUploadSaveLock();
+	return children;
+}
 
 export const BlockEditorProvider = ( props ) => {
 	return (

--- a/packages/block-editor/src/components/provider/use-upload-save-lock.js
+++ b/packages/block-editor/src/components/provider/use-upload-save-lock.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as uploadStore } from '@wordpress/upload-media';
+import { store as editorStore } from '@wordpress/editor';
+
+const LOCK_NAME = 'upload-in-progress';
+
+/**
+ * A hook that locks post saving and autosaving while media uploads are in progress.
+ * This prevents users from publishing or saving while files are still uploading.
+ */
+export default function useUploadSaveLock() {
+	const isUploading = useSelect(
+		( select ) => select( uploadStore ).isUploading(),
+		[]
+	);
+
+	const {
+		lockPostSaving,
+		unlockPostSaving,
+		lockPostAutosaving,
+		unlockPostAutosaving,
+	} = useDispatch( editorStore );
+
+	useEffect( () => {
+		if ( isUploading ) {
+			lockPostSaving( LOCK_NAME );
+			lockPostAutosaving( LOCK_NAME );
+		} else {
+			unlockPostSaving( LOCK_NAME );
+			unlockPostAutosaving( LOCK_NAME );
+		}
+	}, [
+		isUploading,
+		lockPostSaving,
+		unlockPostSaving,
+		lockPostAutosaving,
+		unlockPostAutosaving,
+	] );
+}

--- a/packages/block-editor/src/components/provider/use-upload-save-lock.js
+++ b/packages/block-editor/src/components/provider/use-upload-save-lock.js
@@ -1,43 +1,49 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useRegistry } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as uploadStore } from '@wordpress/upload-media';
-import { store as editorStore } from '@wordpress/editor';
 
 const LOCK_NAME = 'upload-in-progress';
 
 /**
  * A hook that locks post saving and autosaving while media uploads are in progress.
  * This prevents users from publishing or saving while files are still uploading.
+ *
+ * Note: This hook dynamically accesses the editor store to avoid creating a
+ * circular dependency between block-editor and editor packages. The lock
+ * functionality only activates when the editor store is available.
  */
 export default function useUploadSaveLock() {
-	const isUploading = useSelect(
-		( select ) => select( uploadStore ).isUploading(),
-		[]
-	);
+	const registry = useRegistry();
 
-	const {
-		lockPostSaving,
-		unlockPostSaving,
-		lockPostAutosaving,
-		unlockPostAutosaving,
-	} = useDispatch( editorStore );
+	const { isUploading, hasEditorStore } = useSelect( ( select ) => {
+		// Check if the editor store is registered to avoid errors
+		// in contexts where it's not available (e.g., standalone block editor).
+		const stores = registry.stores;
+		const editorStoreExists = !! stores[ 'core/editor' ];
+
+		return {
+			isUploading: select( uploadStore ).isUploading(),
+			hasEditorStore: editorStoreExists,
+		};
+	}, [] );
 
 	useEffect( () => {
-		if ( isUploading ) {
-			lockPostSaving( LOCK_NAME );
-			lockPostAutosaving( LOCK_NAME );
-		} else {
-			unlockPostSaving( LOCK_NAME );
-			unlockPostAutosaving( LOCK_NAME );
+		if ( ! hasEditorStore ) {
+			return;
 		}
-	}, [
-		isUploading,
-		lockPostSaving,
-		unlockPostSaving,
-		lockPostAutosaving,
-		unlockPostAutosaving,
-	] );
+
+		const { dispatch } = registry;
+		const editorDispatch = dispatch( 'core/editor' );
+
+		if ( isUploading ) {
+			editorDispatch.lockPostSaving( LOCK_NAME );
+			editorDispatch.lockPostAutosaving( LOCK_NAME );
+		} else {
+			editorDispatch.unlockPostSaving( LOCK_NAME );
+			editorDispatch.unlockPostAutosaving( LOCK_NAME );
+		}
+	}, [ isUploading, hasEditorStore, registry ] );
 }


### PR DESCRIPTION
## What?

Closes #74554

Adds an `UploadSaveLockWrapper` component to the block editor provider that uses the `useUploadSaveLock` hook to properly manage post save locks based on upload state.

## Why?

When the Client Side Media Processing experiment is enabled, the save button stays disabled after batch uploads complete. This happens because the save lock isn't being properly released when uploads finish.

As noted in #74501, after dragging and dropping images to upload onto an image or gallery block, the save/publish button remains unavailable even after all uploads conclude.

## How?

This PR introduces an `UploadSaveLockWrapper` component that:
- Wraps the block editor children when the `__experimentalMediaProcessing` flag is enabled
- Uses the `useUploadSaveLock` hook to track upload state from the `upload-media` store
- Must be rendered inside `MediaUploadProvider` to access the upload-media store
- Properly locks/unlocks the post save functionality based on whether uploads are in progress

## Testing Instructions

1. Enable the Client Side Media Processing experiment (Gutenberg → Experiments)
2. Create and publish a new post
3. Add an Image or Gallery block
4. Drag and drop multiple images to upload
5. Wait for all uploads to complete
6. Verify the Save/Update button becomes enabled after uploads finish

### Testing Instructions for Keyboard

1. Same as above, but use keyboard navigation to access the media upload interface
2. Verify focus management and save button accessibility after uploads complete