### PR TITLE
Media: Load vips-heif.wasm from external plugin for licensing compatibility

### DIFF
--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -24,6 +24,29 @@ function gutenberg_get_all_image_sizes(): array {
 }
 
 /**
+ * Checks if HEIF image support is available.
+ *
+ * HEIF support requires an external plugin that provides the vips-heif.wasm module
+ * due to licensing requirements (LGPL-3.0 for libheif is incompatible with GPLv2).
+ *
+ * Plugins can enable HEIF support by:
+ * 1. Filtering 'gutenberg_heif_support_available' to return true
+ * 2. Registering the vips-heif.wasm module URL via JavaScript
+ *
+ * @return bool Whether HEIF support is available.
+ */
+function gutenberg_is_heif_support_available(): bool {
+	/**
+	 * Filters whether HEIF image support is available.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param bool $available Whether HEIF support is available. Default false.
+	 */
+	return (bool) apply_filters( 'gutenberg_heif_support_available', false );
+}
+
+/**
  * Returns the default output format mapping for the supported image formats.
  *
  * @return array<string,string> Map of input formats to output formats.
@@ -35,8 +58,12 @@ function gutenberg_get_default_image_output_formats() {
 		'image/gif',
 		'image/webp',
 		'image/avif',
-		'image/heic',
 	);
+
+	// Only include HEIC if HEIF support is available.
+	if ( gutenberg_is_heif_support_available() ) {
+		$input_formats[] = 'image/heic';
+	}
 
 	$output_formats = array();
 
@@ -72,12 +99,13 @@ function gutenberg_media_processing_filter_rest_index( WP_REST_Response $respons
 	$gif_interlaced = (bool) apply_filters( 'image_save_progressive', false, 'image/gif' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 	if ( current_user_can( 'upload_files' ) ) {
-		$response->data['image_sizes']          = gutenberg_get_all_image_sizes();
-		$response->data['image_size_threshold'] = $image_size_threshold;
-		$response->data['image_output_formats'] = (object) $default_image_output_formats;
-		$response->data['jpeg_interlaced']      = $jpeg_interlaced;
-		$response->data['png_interlaced']       = $png_interlaced;
-		$response->data['gif_interlaced']       = $gif_interlaced;
+		$response->data['image_sizes']            = gutenberg_get_all_image_sizes();
+		$response->data['image_size_threshold']   = $image_size_threshold;
+		$response->data['image_output_formats']   = (object) $default_image_output_formats;
+		$response->data['jpeg_interlaced']        = $jpeg_interlaced;
+		$response->data['png_interlaced']         = $png_interlaced;
+		$response->data['gif_interlaced']         = $gif_interlaced;
+		$response->data['heif_support_available'] = gutenberg_is_heif_support_available();
 	}
 
 	return $response;

--- a/packages/vips/README.md
+++ b/packages/vips/README.md
@@ -69,6 +69,29 @@ _Returns_
 
 -   `Promise< boolean >`: Whether the image has an alpha channel.
 
+### isWasmModuleAvailable
+
+Checks if a WASM module has been registered.
+
+_Parameters_
+
+-   _moduleName_ `string`: The WASM module filename (e.g., 'vips-heif.wasm').
+
+_Returns_
+
+-   `boolean`: Whether the module is available.
+
+### registerWasmModule
+
+Registers a WASM module URL for dynamic loading.
+
+This allows external plugins to provide WASM modules (like vips-heif.wasm) that may have different licensing requirements.
+
+_Parameters_
+
+-   _moduleName_ `string`: The WASM module filename (e.g., 'vips-heif.wasm').
+-   _moduleUrl_ `string`: The URL where the WASM module can be loaded from.
+
 ### resizeImage
 
 Resizes an image using vips.

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -7,10 +7,39 @@ import Vips from 'wasm-vips';
 import VipsModule from 'wasm-vips/vips.wasm';
 
 // @ts-expect-error
-import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
-
-// @ts-expect-error
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
+
+/**
+ * Registry for dynamically loaded WASM modules.
+ * Allows external plugins to register WASM module URLs.
+ */
+const wasmModuleRegistry: Record< string, string > = {};
+
+/**
+ * Registers a WASM module URL for dynamic loading.
+ *
+ * This allows external plugins to provide WASM modules (like vips-heif.wasm)
+ * that may have different licensing requirements.
+ *
+ * @param moduleName The WASM module filename (e.g., 'vips-heif.wasm').
+ * @param moduleUrl  The URL where the WASM module can be loaded from.
+ */
+export function registerWasmModule(
+	moduleName: string,
+	moduleUrl: string
+): void {
+	wasmModuleRegistry[ moduleName ] = moduleUrl;
+}
+
+/**
+ * Checks if a WASM module has been registered.
+ *
+ * @param moduleName The WASM module filename (e.g., 'vips-heif.wasm').
+ * @return Whether the module is available.
+ */
+export function isWasmModuleAvailable( moduleName: string ): boolean {
+	return moduleName in wasmModuleRegistry;
+}
 
 /**
  * Internal dependencies
@@ -60,11 +89,16 @@ async function getVips(): Promise< typeof Vips > {
 	vipsInstance = await Vips( {
 		locateFile: ( fileName: string ) => {
 			if ( fileName.endsWith( 'vips.wasm' ) ) {
-				fileName = VipsModule;
+				return location + VipsModule;
 			} else if ( fileName.endsWith( 'vips-heif.wasm' ) ) {
-				fileName = VipsHeifModule;
+				// HEIF module is loaded from external plugin via registry
+				if ( wasmModuleRegistry[ 'vips-heif.wasm' ] ) {
+					return wasmModuleRegistry[ 'vips-heif.wasm' ];
+				}
+				// Return empty string if not registered - vips will handle gracefully
+				return '';
 			} else if ( fileName.endsWith( 'vips-jxl.wasm' ) ) {
-				fileName = VipsJxlModule;
+				return location + VipsJxlModule;
 			}
 
 			return location + fileName;


### PR DESCRIPTION
## Summary

This PR enables HEIF/HEIC image support to be provided by a separate WordPress plugin rather than bundling the `vips-heif.wasm` module directly in core. This addresses the licensing incompatibility between libheif (LGPL-3.0) and WordPress (GPLv2+).

**Changes:**
- Remove static `vips-heif.wasm` import from `@wordpress/vips`
- Add `wasmModuleRegistry` for dynamic WASM module registration
- Add `registerWasmModule()` and `isWasmModuleAvailable()` exports to `@wordpress/vips`
- Update `locateFile()` to check registry for HEIF module
- Add `gutenberg_is_heif_support_available()` function with `gutenberg_heif_support_available` filter hook
- Add `heif_support_available` field to REST API index
- Make `image/heic` format conditional on HEIF availability

**Architecture:**
```
WordPress Core (GPLv2+)
└── @wordpress/vips
    ├── vips.wasm (bundled)
    ├── vips-jxl.wasm (bundled)
    └── registerWasmModule() API ──► External Plugin (LGPL-3.0)
                                      └── vips-heif.wasm
```

External plugins can provide HEIF support by:
1. Filtering `gutenberg_heif_support_available` to return `true`
2. Calling `wp.vips.registerWasmModule('vips-heif.wasm', url)` via inline script

## Test plan

- [ ] Without HEIF plugin: HEIC files should be rejected with clear messaging
- [ ] Without HEIF plugin: Other formats (JPEG, PNG, WebP, AVIF) work normally
- [ ] With HEIF plugin activated: HEIC uploads should process successfully
- [ ] REST API `/wp-json/` should include `heif_support_available: false` by default
- [ ] `image/heic` should not appear in `image_output_formats` when HEIF support unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)