### PR TITLE
Media & Text: Revert "Fixed Media & Text Block - Image not rendered properly on frontend when inside stack (#68610)"

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -108,6 +108,7 @@
 
 /* Image fill for versions 8 and onwards */
 .wp-block-media-text.is-image-fill-element > .wp-block-media-text__media {
+	position: relative;
 	height: 100%;
 	min-height: 250px;
 }
@@ -118,6 +119,7 @@
 }
 
 .wp-block-media-text.is-image-fill-element > .wp-block-media-text__media img {
+	position: absolute;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;


### PR DESCRIPTION
Fixes #73809

This PR reverts commit a4a5b07b4432d28ad4eb3646435bbaf9a8f9796e.

## What?

We've removed the absolute positioning style from the img element in the Media & Text block to fix the stack layout issue reported in #68609:

| Before #68609 was applied | After #68609 applied |
|--------|--------|
| <img width="992" height="353" alt="image" src="https://github.com/user-attachments/assets/13d38c92-10fd-4a58-abea-153e48fb69d4" /> | <img width="990" height="345" alt="image" src="https://github.com/user-attachments/assets/6411ecc7-dfa5-48f8-acf9-66c99a830105" /> |

However, this approach introduced an unintended problem: since the image was no longer absolutely positioned, enabling "Crop image to fill" no longer caused the image height to change with the content:

| Before #68609 was applied | After #68609 applied |
|--------|--------|
| <img width="991" height="395" alt="image" src="https://github.com/user-attachments/assets/bcd83ba5-3738-4bd4-989a-0ef0e181f8a3" /> | <img width="992" height="627" alt="image" src="https://github.com/user-attachments/assets/4c183209-85c9-4128-827b-41916804c0d7" /> |

Since issue #68610 seems to cause more problems than it aims to solve, let's revert #68610 and backport it to the 6.9 minor release.

Note that the issue reported in issue #68609 is likely due to the behavior of the Stack layout itself. This issue can be resolved by setting the Justification option in the Stack block to "Stretch Items".

<img width="1289" height="414" alt="stretch" src="https://github.com/user-attachments/assets/43071718-4614-4579-b66f-cae971d0a749" />

## Testing Instructions
- Insert a Media & Text block.
- Attach a portrait image.
- Add some paragraphs inside the media content.
- Enable the "Crop image to fill".
- Make sure the image height fits the content.
