### PR TITLE
Updated Typo in Rest API File

### DIFF
--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -34,7 +34,7 @@ if ( ! gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 
 /**
  * Registers the Registered Templates Parts REST API routes.
- * The template activation experiement does not, however, register the routes for the wp_template_part post type,
+ * The template activation experiment does not, however, register the routes for the wp_template_part post type,
  * so we need to register the routes for that post type here.
  * See: lib/compat/wordpress-7.0/template-activate.php
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Updated Typo in `rest-api.php`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Used `experiment` instead of `experiement` in  `rest-api.php`  Line No 37

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open `rest-api.php` 
2. Go to Line No 37 and See typo
