### PR TITLE
Comment Edit Link: Migrate to text-align block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -207,8 +207,8 @@ Displays a link to edit the comment in the WordPress Dashboard. This link is onl
 -	**Name:** core/comment-edit-link
 -	**Category:** theme
 -	**Ancestor:** core/comment-template
--	**Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** linkTarget, textAlign
+-	**Supports:** anchor, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** linkTarget
 
 ## Comment Reply Link
 

--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -12,9 +12,6 @@
 		"linkTarget": {
 			"type": "string",
 			"default": "_self"
-		},
-		"textAlign": {
-			"type": "string"
 		}
 	},
 	"supports": {
@@ -40,6 +37,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/comment-edit-link/deprecated.js
+++ b/packages/block-library/src/comment-edit-link/deprecated.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		linkTarget: {
+			type: 'string',
+			default: '_self',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+	usesContext: [ 'commentId' ],
+	supports: {
+		anchor: true,
+		html: false,
+		color: {
+			link: true,
+			gradients: true,
+			text: false,
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/comment-edit-link/edit.js
+++ b/packages/block-library/src/comment-edit-link/edit.js
@@ -1,17 +1,7 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -23,29 +13,16 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
-export default function Edit( {
-	attributes: { linkTarget, textAlign },
-	setAttributes,
-} ) {
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+export default function Edit( props ) {
+	const { attributes, setAttributes } = props;
+	const { linkTarget } = attributes;
+	useDeprecatedTextAlign( props );
+	const blockProps = useBlockProps();
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const blockControls = (
-		<BlockControls group="block">
-			<AlignmentControl
-				value={ textAlign }
-				onChange={ ( newAlign ) =>
-					setAttributes( { textAlign: newAlign } )
-				}
-			/>
-		</BlockControls>
-	);
 	const inspectorControls = (
 		<InspectorControls>
 			<ToolsPanel
@@ -81,7 +58,6 @@ export default function Edit( {
 
 	return (
 		<>
-			{ blockControls }
 			{ inspectorControls }
 			<div { ...blockProps }>
 				<a

--- a/packages/block-library/src/comment-edit-link/index.js
+++ b/packages/block-library/src/comment-edit-link/index.js
@@ -9,6 +9,7 @@ import { commentEditLink as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 	example: {},
 };
 

--- a/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-edit-link {"textAlign":"left"} /-->
+
+<!-- wp:comment-edit-link {"textAlign":"center"} /-->
+
+<!-- wp:comment-edit-link {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.json
@@ -1,0 +1,41 @@
+[
+	{
+		"name": "core/comment-edit-link",
+		"isValid": true,
+		"attributes": {
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-edit-link",
+		"isValid": true,
+		"attributes": {
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/comment-edit-link",
+		"isValid": true,
+		"attributes": {
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/comment-edit-link",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-edit-link",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/comment-edit-link",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__comment-edit-link__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:comment-edit-link {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:comment-edit-link {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:comment-edit-link {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Comment Edit Link` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Comment Edit Link`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Comment Edit Link` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Comment Edit Link` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Comment Edit Link` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Comment Edit Link` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

