### PR TITLE
Remove react-refresh bundling

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -373,7 +373,8 @@ function gutenberg_register_vendor_scripts( $scripts ) {
 		$scripts,
 		'react',
 		gutenberg_url( 'build/scripts/vendors/react' . $extension ),
-		// See https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react.
+		// WordPress Core in `wp_register_development_scripts` sets `wp-react-refresh-entry` as a dependency to `react` when `SCRIPT_DEBUG` is true.
+		// We need to preserve that here.
 		SCRIPT_DEBUG ? array( 'wp-react-refresh-entry', 'wp-polyfill' ) : array( 'wp-polyfill' ),
 		'18'
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
 				"react": "18.3.1",
 				"react-docgen-typescript": "2.2.2",
 				"react-dom": "18.3.1",
-				"react-refresh": "0.14.0",
 				"react-scanner": "1.2.0",
 				"reassure": "0.7.1",
 				"resize-observer-polyfill": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"@inquirer/prompts": "7.2.0",
 				"@octokit/rest": "16.26.0",
 				"@playwright/test": "1.57.0",
-				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "14.3.0",
 				"@testing-library/user-event": "14.4.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
 		"react": "18.3.1",
 		"react-docgen-typescript": "2.2.2",
 		"react-dom": "18.3.1",
-		"react-refresh": "0.14.0",
 		"react-scanner": "1.2.0",
 		"reassure": "0.7.1",
 		"resize-observer-polyfill": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"@inquirer/prompts": "7.2.0",
 		"@octokit/rest": "16.26.0",
 		"@playwright/test": "1.57.0",
-		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "14.3.0",
 		"@testing-library/user-event": "14.4.3",


### PR DESCRIPTION
## What?

Supersedes #74618

As discussed in https://github.com/WordPress/wordpress-develop/pull/10725#discussion_r2693509643, it removes the `@pmmmwh/react-refresh-webpack-plugin` dependency and the react-refresh bundling logic from Gutenberg.

## Why?

WordPress Core now bundles `react-refresh` after https://github.com/WordPress/wordpress-develop/pull/10725. Since react-refresh is a standard library with nothing special about its usage in Gutenberg, there's no need to maintain a duplicate bundling setup here.

## How?

- Removed the `bundleReactRefresh()` function from `bin/packages/build-vendors.mjs`
- Removed `@pmmmwh/react-refresh-webpack-plugin` and `react-refresh` from `devDependencies`

## Testing Instructions

1. Run `npm install` to update dependencies
2. Run `npm run build` to verify the build succeeds without react-refresh bundling
3. Confirm that `build/react-refresh-entry/` and `build/react-refresh-runtime/` directories are no longer generated

### Testing Instructions for Keyboard

N/A - No UI changes.

## Screenshots or screencast

N/A - No UI changes.
