### PR TITLE
Fix: add border-box sizing for verse block

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -5,10 +5,6 @@
 $button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
 $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 
-:where(.wp-block-search) {
-	box-sizing: border-box;
-}
-
 .wp-block-search__button {
 	margin-left: $button-spacing-x;
 	word-break: normal;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -5,6 +5,10 @@
 $button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
 $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 
+:where(.wp-block-search) {
+	box-sizing: border-box;
+}
+
 .wp-block-search__button {
 	margin-left: $button-spacing-x;
 	word-break: normal;

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,4 +1,5 @@
 pre.wp-block-verse {
+	box-sizing: border-box;
 	overflow: auto;
 	white-space: pre-wrap;
 


### PR DESCRIPTION
## What?
Closes #74717

Adds `box-sizing: border-box` for the Verse block.

## Why?
The Verse block can overflow and not respect container max-width when padding is applied. `box-sizing: border-box` ensures sizing stays within the container.

## How?
Adds `box-sizing: border-box` to `pre.wp-block-verse`.

## Testing Instructions
1. Create a post/page.
2. Add a Group block and set a narrow max-width (or constrained layout).
3. Insert a Verse block inside it.
4. Apply left/right padding to the Verse block.
5. Add long text and confirm it stays within max-width without overflow.
