### PR TITLE
Verse Block: Add align support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1082,7 +1082,7 @@ Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](http
 
 -	**Name:** core/verse
 -	**Category:** text
--	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content, textAlign
 
 ## Video

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -20,6 +20,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "wide", "full" ],
 		"anchor": true,
 		"background": {
 			"backgroundImage": true,


### PR DESCRIPTION
Stacks on #74717

## Why?
Verse block acts just like any other paragraph-like block, so alignment supports could be useful in any case.

## How?
Adding `align` supports to the block

## Testing Instructions
1. Add a Verse block
2. Set the width to wide width or full width

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1235" height="761" alt="Image" src="https://github.com/user-attachments/assets/a0e0b42b-3c04-42bd-91c5-05f7db1fee5a" />|<img width="1247" height="777" alt="image" src="https://github.com/user-attachments/assets/84e1a8b3-4504-4000-852e-91fa574550a3" />|

## Contributors

Dont forget to add, for doing some effort towards this issue:

```
Co-authored-by: Shekhar0109 <shekh0109@git.wordpress.org>
```
