### PR TITLE
Verse Block: Add new textAlign support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1082,8 +1082,8 @@ Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](http
 
 -	**Name:** core/verse
 -	**Category:** text
--	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content, textAlign
+-	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
+-	**Attributes:** content
 
 ## Video
 

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -14,9 +14,6 @@
 			"selector": "pre",
 			"__unstablePreserveWhiteSpace": true,
 			"role": "content"
-		},
-		"textAlign": {
-			"type": "string"
 		}
 	},
 	"supports": {
@@ -46,6 +43,7 @@
 			"fontSize": true,
 			"__experimentalFontFamily": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,

--- a/packages/block-library/src/verse/deprecated.js
+++ b/packages/block-library/src/verse/deprecated.js
@@ -154,12 +154,13 @@ const v3 = {
 		);
 	},
 	migrate: migrateTextAlign,
-	isEligible( attributes, innerBlocks, { block } ) {
-		// Only migrate blocks that have the v3 structure (with has-text-align-* class).
-		// Older v1/v2 blocks used different structures and should be handled by their own deprecations.
-		const hasTextAlignClass =
-			block?.originalContent?.includes( 'has-text-align-' );
-		return !! attributes.textAlign && hasTextAlignClass;
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
 	},
 };
 

--- a/packages/block-library/src/verse/deprecated.js
+++ b/packages/block-library/src/verse/deprecated.js
@@ -37,6 +37,7 @@ const v1 = {
 			/>
 		);
 	},
+	migrate: migrateTextAlign,
 };
 
 const v2 = {
@@ -80,9 +81,11 @@ const v2 = {
 			</pre>
 		);
 	},
-	migrate: migrateFontFamily,
-	isEligible( { style } ) {
-		return style?.typography?.fontFamily;
+	migrate( attributes ) {
+		return migrateTextAlign( migrateFontFamily( attributes ) );
+	},
+	isEligible( { style, textAlign } ) {
+		return style?.typography?.fontFamily || !! textAlign;
 	},
 };
 
@@ -151,13 +154,12 @@ const v3 = {
 		);
 	},
 	migrate: migrateTextAlign,
-	isEligible( attributes ) {
-		return (
-			!! attributes.textAlign ||
-			!! attributes.className?.match(
-				/\bhas-text-align-(left|center|right)\b/
-			)
-		);
+	isEligible( attributes, innerBlocks, { block } ) {
+		// Only migrate blocks that have the v3 structure (with has-text-align-* class).
+		// Older v1/v2 blocks used different structures and should be handled by their own deprecations.
+		const hasTextAlignClass =
+			block?.originalContent?.includes( 'has-text-align-' );
+		return !! attributes.textAlign && hasTextAlignClass;
 	},
 };
 

--- a/packages/block-library/src/verse/deprecated.js
+++ b/packages/block-library/src/verse/deprecated.js
@@ -12,6 +12,7 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
 
 const v1 = {
 	attributes: {
@@ -85,6 +86,81 @@ const v2 = {
 	},
 };
 
+const v3 = {
+	attributes: {
+		content: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'pre',
+			__unstablePreserveWhiteSpace: true,
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+	supports: {
+		anchor: true,
+		background: {
+			backgroundImage: true,
+			backgroundSize: true,
+		},
+		color: {
+			gradients: true,
+			link: true,
+		},
+		dimensions: {
+			minHeight: true,
+		},
+		typography: {
+			fontSize: true,
+			__experimentalFontFamily: true,
+			lineHeight: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalWritingMode: true,
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			width: true,
+			color: true,
+			style: true,
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	save( { attributes } ) {
+		const { textAlign, content } = attributes;
+
+		const className = clsx( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} );
+
+		return (
+			<pre { ...useBlockProps.save( { className } ) }>
+				<RichText.Content value={ content } />
+			</pre>
+		);
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
+
 /**
  * New deprecations need to be placed first
  * for them to have higher priority.
@@ -93,4 +169,4 @@ const v2 = {
  *
  * See block-deprecation.md
  */
-export default [ v2, v1 ];
+export default [ v3, v2, v1 ];

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -1,67 +1,48 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	RichText,
-	BlockControls,
-	AlignmentToolbar,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
-export default function VerseEdit( {
-	attributes,
-	setAttributes,
-	mergeBlocks,
-	onRemove,
-	insertBlocksAfter,
-	style,
-} ) {
-	const { textAlign, content } = attributes;
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
+/**
+ * Internal dependencies
+ */
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
+
+export default function VerseEdit( props ) {
+	const {
+		attributes,
+		setAttributes,
+		mergeBlocks,
+		onRemove,
+		insertBlocksAfter,
 		style,
-	} );
+	} = props;
+	const { content } = attributes;
+	useDeprecatedTextAlign( props );
+	const blockProps = useBlockProps( { style } );
 
 	return (
-		<>
-			<BlockControls>
-				<AlignmentToolbar
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-			</BlockControls>
-			<RichText
-				tagName="pre"
-				identifier="content"
-				preserveWhiteSpace
-				value={ content }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
-				aria-label={ __( 'Verse text' ) }
-				placeholder={ __( 'Write verse…' ) }
-				onRemove={ onRemove }
-				onMerge={ mergeBlocks }
-				textAlign={ textAlign }
-				{ ...blockProps }
-				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
-			/>
-		</>
+		<RichText
+			tagName="pre"
+			identifier="content"
+			preserveWhiteSpace
+			value={ content }
+			onChange={ ( nextContent ) => {
+				setAttributes( {
+					content: nextContent,
+				} );
+			} }
+			aria-label={ __( 'Verse text' ) }
+			placeholder={ __( 'Write verse…' ) }
+			onRemove={ onRemove }
+			onMerge={ mergeBlocks }
+			{ ...blockProps }
+			__unstablePastePlainText
+			__unstableOnSplitAtDoubleLineEnd={ () =>
+				insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+			}
+		/>
 	);
 }

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -1,22 +1,13 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { textAlign, content } = attributes;
-
-	const className = clsx( {
-		[ `has-text-align-${ textAlign }` ]: textAlign,
-	} );
+	const { content } = attributes;
 
 	return (
-		<pre { ...useBlockProps.save( { className } ) }>
+		<pre { ...useBlockProps.save() }>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v1.json
@@ -4,7 +4,11 @@
 		"isValid": true,
 		"attributes": {
 			"content": "A <em>verse</em>…<br>And more!",
-			"textAlign": "left"
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:verse {"textAlign":"left"} -->
+<!-- wp:verse {"style":{"typography":{"textAlign":"left"}}} -->
 <pre class="wp-block-verse has-text-align-left">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v3.html
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v3.html
@@ -1,0 +1,11 @@
+<!-- wp:verse {"textAlign":"left"} -->
+<pre class="wp-block-verse has-text-align-left">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->
+
+<!-- wp:verse {"textAlign":"center"} -->
+<pre class="wp-block-verse has-text-align-center">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->
+
+<!-- wp:verse {"textAlign":"right"} -->
+<pre class="wp-block-verse has-text-align-right">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v3.json
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v3.json
@@ -1,0 +1,41 @@
+[
+	{
+		"name": "core/verse",
+		"isValid": true,
+		"attributes": {
+			"content": "A <em>verse</em>…<br>And more!",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/verse",
+		"isValid": true,
+		"attributes": {
+			"content": "A <em>verse</em>…<br>And more!",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/verse",
+		"isValid": true,
+		"attributes": {
+			"content": "A <em>verse</em>…<br>And more!",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v3.parsed.json
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v3.parsed.json
@@ -1,0 +1,49 @@
+[
+	{
+		"blockName": "core/verse",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<pre class=\"wp-block-verse has-text-align-left\">A <em>verse</em>…<br>And more!</pre>\n",
+		"innerContent": [
+			"\n<pre class=\"wp-block-verse has-text-align-left\">A <em>verse</em>…<br>And more!</pre>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/verse",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<pre class=\"wp-block-verse has-text-align-center\">A <em>verse</em>…<br>And more!</pre>\n",
+		"innerContent": [
+			"\n<pre class=\"wp-block-verse has-text-align-center\">A <em>verse</em>…<br>And more!</pre>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/verse",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<pre class=\"wp-block-verse has-text-align-right\">A <em>verse</em>…<br>And more!</pre>\n",
+		"innerContent": [
+			"\n<pre class=\"wp-block-verse has-text-align-right\">A <em>verse</em>…<br>And more!</pre>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v3.serialized.html
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v3.serialized.html
@@ -1,11 +1,11 @@
 <!-- wp:verse {"style":{"typography":{"textAlign":"left"}}} -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse has-text-align-left">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->
 
 <!-- wp:verse {"style":{"typography":{"textAlign":"center"}}} -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse has-text-align-center">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->
 
 <!-- wp:verse {"style":{"typography":{"textAlign":"right"}}} -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse has-text-align-right">A <em>verse</em>…<br>And more!</pre>
 <!-- /wp:verse -->

--- a/test/integration/fixtures/blocks/core__verse__deprecated-v3.serialized.html
+++ b/test/integration/fixtures/blocks/core__verse__deprecated-v3.serialized.html
@@ -1,0 +1,11 @@
+<!-- wp:verse {"style":{"typography":{"textAlign":"left"}}} -->
+<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->
+
+<!-- wp:verse {"style":{"typography":{"textAlign":"center"}}} -->
+<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->
+
+<!-- wp:verse {"style":{"typography":{"textAlign":"right"}}} -->
+<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->


### PR DESCRIPTION
I was working in #74723 to add a `Verse` alignment improvement, and then I found #60763 that is also improving `textAlign`, so I'm also adding this GB for this purpose, so I can leave the Verse block ready in both regards.

## Testing Instructions
1. Taking Playground instance: https://playground.wordpress.net/?gutenberg-branch=trunk&gutenberg-pr=74724
2. Create a new Post
3. Add a Verse block
4. Edit the text alignment and check if everything is in order.

## Screencast

https://github.com/user-attachments/assets/b75e4777-e9a5-48cb-b1e9-b64d7caeeaf7
