### PR TITLE
Allow grid layout to use theme blockGap values for columns calculation

### DIFF
--- a/backport-changelog/7.0/10766.md
+++ b/backport-changelog/7.0/10766.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/10766
+
+* https://github.com/WordPress/gutenberg/pull/74725
+

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -475,7 +475,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 	} elseif ( 'grid' === $layout_type ) {
 		// Deal with block gap first so it can be used for responsive computation.
-		$responsive_gap_value = '1.2rem';
+		$responsive_gap_value = $fallback_gap_value;
 		if ( $has_block_gap_support && isset( $gap_value ) ) {
 			$combined_gap_value = '';
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
@@ -871,6 +871,15 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		$block_gap             = $global_settings['spacing']['blockGap'] ?? null;
 		$has_block_gap_support = isset( $block_gap );
+
+		// Get default blockGap value from global styles for use in layouts like grid.
+		// Check block-specific styles first, then fall back to root styles.
+		$block_name                   = $block['blockName'] ?? '';
+		$block_specific_global_styles = gutenberg_get_global_styles( array( 'blocks', $block_name, 'spacing', 'blockGap' ) );
+		$global_block_gap_value       = ! empty( $block_specific_global_styles ) ? $block_specific_global_styles : gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
+		if ( ! empty( $global_block_gap_value ) ) {
+			$fallback_gap_value = $global_block_gap_value;
+		}
 
 		/*
 		 * We generate a unique ID based on all the data required to obtain the

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -899,7 +899,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Check block-specific styles first, then fall back to root styles.
 		$block_name                   = $block['blockName'] ?? '';
 		$block_specific_global_styles = gutenberg_get_global_styles( array( 'blocks', $block_name, 'spacing', 'blockGap' ) );
-		$global_block_gap_value       = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
+
+		// Validate that the value is in the expected format (string or array with 'top'/'left' properties).
+		if ( ! is_string( $block_specific_global_styles ) && ! isset( $block_specific_global_styles['top'] ) && ! isset( $block_specific_global_styles['left'] ) ) {
+			$block_specific_global_styles = null;
+		}
+
+		$global_block_gap_value = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
+
+		// Validate the fallback value as well.
+		if ( ! is_string( $global_block_gap_value ) && ! isset( $global_block_gap_value['top'] ) && ! isset( $global_block_gap_value['left'] ) ) {
+			$global_block_gap_value = null;
+		}
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -217,7 +217,7 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param bool                 $has_block_gap_support         Optional. Whether the theme has support for the block gap. Default false.
  * @param string|string[]|null $gap_value                     Optional. The block gap value to apply. Default null.
  * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
- * @param string|array         $fallback_gap_value     Optional. The block gap value to apply. Default '0.5em'.
+ * @param string|array         $fallback_gap_value            Optional. The block gap value to apply. If it's an array expected properties are "top" and/or "left". Default '0.5em'.
  * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
  * @return string CSS styles on success. Else, empty string.
  */

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -217,7 +217,7 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param bool                 $has_block_gap_support         Optional. Whether the theme has support for the block gap. Default false.
  * @param string|string[]|null $gap_value                     Optional. The block gap value to apply. Default null.
  * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
- * @param string               $fallback_gap_value            Optional. The block gap value to apply. Default '0.5em'.
+ * @param string|array         $fallback_gap_value     Optional. The block gap value to apply. Default '0.5em'.
  * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
  * @return string CSS styles on success. Else, empty string.
  */
@@ -411,7 +411,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
+					if ( is_array( $fallback_gap_value ) ) {
+						$fallback_value = $fallback_gap_value[ $gap_side ] ?? reset( $fallback_gap_value );
+					} else {
+						$fallback_value = $fallback_gap_value;
+					}
+					$process_value = $gap_value[ $gap_side ] ?? $fallback_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -474,8 +479,16 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
-		// Deal with block gap first so it can be used for responsive computation.
-		$responsive_gap_value = $fallback_gap_value || '1.2rem';
+		/*
+		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
+		 * is the relevant one for computation of responsive grid columns.
+		 */
+		if ( is_array( $fallback_gap_value ) ) {
+			$responsive_gap_value = $fallback_gap_value['left'] ?? reset( $fallback_gap_value );
+		} else {
+			$responsive_gap_value = $fallback_gap_value;
+		}
+
 		if ( $has_block_gap_support && isset( $gap_value ) ) {
 			$combined_gap_value = '';
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
@@ -483,7 +496,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
+					if ( is_array( $fallback_gap_value ) ) {
+						$fallback_value = $fallback_gap_value[ $gap_side ] ?? reset( $fallback_gap_value );
+					} else {
+						$fallback_value = $fallback_gap_value;
+					}
+					$process_value = $gap_value[ $gap_side ] ?? $fallback_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -876,15 +894,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Check block-specific styles first, then fall back to root styles.
 		$block_name                   = $block['blockName'] ?? '';
 		$block_specific_global_styles = gutenberg_get_global_styles( array( 'blocks', $block_name, 'spacing', 'blockGap' ) );
-		// If the value is an array, use the first value.
-		if ( is_array( $block_specific_global_styles ) ) {
-			$block_specific_global_styles = $block_specific_global_styles['top'] ?? null;
-		}
-		$global_block_gap_value = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
-		// If the value is an array, use the first value.
-		if ( is_array( $global_block_gap_value ) ) {
-			$global_block_gap_value = $global_block_gap_value['top'] ?? null;
-		}
+		$global_block_gap_value       = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
+
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -475,7 +475,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 	} elseif ( 'grid' === $layout_type ) {
 		// Deal with block gap first so it can be used for responsive computation.
-		$responsive_gap_value = $fallback_gap_value;
+		$responsive_gap_value = $fallback_gap_value || '1.2rem';
 		if ( $has_block_gap_support && isset( $gap_value ) ) {
 			$combined_gap_value = '';
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
@@ -876,8 +876,16 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Check block-specific styles first, then fall back to root styles.
 		$block_name                   = $block['blockName'] ?? '';
 		$block_specific_global_styles = gutenberg_get_global_styles( array( 'blocks', $block_name, 'spacing', 'blockGap' ) );
-		$global_block_gap_value       = ! empty( $block_specific_global_styles ) ? $block_specific_global_styles : gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
-		if ( ! empty( $global_block_gap_value ) ) {
+		// If the value is an array, use the first value.
+		if ( is_array( $block_specific_global_styles ) ) {
+			$block_specific_global_styles = $block_specific_global_styles['top'] ?? null;
+		}
+		$global_block_gap_value = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
+		// If the value is an array, use the first value.
+		if ( is_array( $global_block_gap_value ) ) {
+			$global_block_gap_value = $global_block_gap_value['top'] ?? null;
+		}
+		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;
 		}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -515,6 +515,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$responsive_gap_value = $gap_value;
 		}
 
+		// Ensure 0 values have a unit so they work in calc().
+		if ( '0' === $responsive_gap_value || 0 === $responsive_gap_value ) {
+			$responsive_gap_value = '0px';
+		}
+
 		if ( ! empty( $layout['columnCount'] ) && ! empty( $layout['minimumColumnWidth'] ) ) {
 			$max_value       = 'max(' . $layout['minimumColumnWidth'] . ', (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
 			$layout_styles[] = array(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -897,20 +897,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check block-specific styles first, then fall back to root styles.
-		$block_name                   = $block['blockName'] ?? '';
-		$block_specific_global_styles = gutenberg_get_global_styles( array( 'blocks', $block_name, 'spacing', 'blockGap' ) );
-
-		// Validate that the value is in the expected format (string or array with 'top'/'left' properties).
-		if ( ! is_string( $block_specific_global_styles ) && ! isset( $block_specific_global_styles['top'] ) && ! isset( $block_specific_global_styles['left'] ) ) {
-			$block_specific_global_styles = null;
-		}
-
-		$global_block_gap_value = $block_specific_global_styles ?? gutenberg_get_global_styles( array( 'spacing', 'blockGap' ) );
-
-		// Validate the fallback value as well.
-		if ( ! is_string( $global_block_gap_value ) && ! isset( $global_block_gap_value['top'] ) && ! isset( $global_block_gap_value['left'] ) ) {
-			$global_block_gap_value = null;
-		}
+		$block_name             = $block['blockName'] ?? '';
+		$global_styles          = gutenberg_get_global_styles();
+		$global_block_gap_value = $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? ( $global_styles['spacing']['blockGap'] ?? null );
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -30,6 +30,7 @@ import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
 import { useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
+import { globalStylesDataKey } from '../store/private-keys';
 
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );
@@ -367,6 +368,7 @@ function BlockWithLayoutStyles( {
 	block: BlockListBlock,
 	props,
 	blockGapSupport,
+	globalBlockGapValue,
 	layoutClasses,
 } ) {
 	const { name, attributes } = props;
@@ -393,6 +395,7 @@ function BlockWithLayoutStyles( {
 		layout: usedLayout,
 		style: attributes?.style,
 		hasBlockGapSupport,
+		globalBlockGapValue,
 	} );
 
 	// Attach a `wp-container-` id-based class name as well as a layout class name such as `is-layout-flex`.
@@ -447,7 +450,15 @@ export const withLayoutStyles = createHigherOrderComponent(
 						'spacing.blockGap'
 					);
 
-					return { blockGapSupport };
+					// Get default blockGap value from global styles for use in layouts like grid.
+					// Check block-specific styles first, then fall back to root styles.
+					const settings = getSettings();
+					const globalStyles = settings[ globalStylesDataKey ];
+					const globalBlockGapValue =
+						globalStyles?.blocks?.[ name ]?.spacing?.blockGap ??
+						globalStyles?.spacing?.blockGap;
+
+					return { blockGapSupport, globalBlockGapValue };
 				},
 				[ blockSupportsLayout, clientId ]
 			);

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -161,9 +161,14 @@ export default {
 		const rules = [];
 
 		if ( minimumColumnWidth && columnCount > 0 ) {
-			const maxValue = `max(${ minimumColumnWidth }, ( 100% - (${
-				blockGapValue || fallbackGapValue
-			}*${ columnCount - 1 }) ) / ${ columnCount })`;
+			let blockGapToUse = blockGapValue || fallbackGapValue;
+			// Ensure 0 values have a unit so they work in calc().
+			if ( blockGapToUse === '0' || blockGapToUse === 0 ) {
+				blockGapToUse = '0px';
+			}
+			const maxValue = `max(${ minimumColumnWidth }, ( 100% - (${ blockGapToUse }*${
+				columnCount - 1
+			}) ) / ${ columnCount })`;
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(${ maxValue }, 1fr))`,
 				`container-type: inline-size`

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -148,9 +148,14 @@ export default {
 				: undefined;
 
 		// Use the global blockGap value for grid column calculations when available
-		const fallbackGapValue = globalBlockGapValue
-			? getGapCSSValue( globalBlockGapValue, '0.5em' )
-			: '1.2rem';
+		// If the gap value has both top and left (separated by space), use the left value for horizontal calculations
+		let fallbackGapValue = '1.2rem';
+		if ( globalBlockGapValue ) {
+			const processedGap = getGapCSSValue( globalBlockGapValue, '0.5em' );
+			const gapParts = processedGap.split( ' ' );
+			fallbackGapValue =
+				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
+		}
 
 		let output = '';
 		const rules = [];

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -113,6 +113,7 @@ export default {
 		style,
 		blockName,
 		hasBlockGapSupport,
+		globalBlockGapValue,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
 		const {
@@ -146,12 +147,17 @@ export default {
 				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
 				: undefined;
 
+		// Use the global blockGap value for grid column calculations when available
+		const fallbackGapValue = globalBlockGapValue
+			? getGapCSSValue( globalBlockGapValue, '0.5em' )
+			: '1.2rem';
+
 		let output = '';
 		const rules = [];
 
 		if ( minimumColumnWidth && columnCount > 0 ) {
 			const maxValue = `max(${ minimumColumnWidth }, ( 100% - (${
-				blockGapValue || '1.2rem'
+				blockGapValue || fallbackGapValue
 			}*${ columnCount - 1 }) ) / ${ columnCount })`;
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(${ maxValue }, 1fr))`,

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -522,7 +522,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_output' => '<div class="wp-block-group is-horizontal is-nowrap is-layout-flex wp-container-core-group-is-layout-7c467009 wp-block-group-is-layout-flex"></div>',
+				'expected_output' => '<div class="wp-block-group is-horizontal is-nowrap is-layout-flex wp-container-core-group-is-layout-ee7b5020 wp-block-group-is-layout-flex"></div>',
 			),
 			'single wrapper block layout with grid type'   => array(
 				'args'            => array(
@@ -541,7 +541,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_output' => '<div class="wp-block-group is-layout-grid wp-container-core-group-is-layout-b8d196d0 wp-block-group-is-layout-grid"></div>',
+				'expected_output' => '<div class="wp-block-group is-layout-grid wp-container-core-group-is-layout-9d260ee2 wp-block-group-is-layout-grid"></div>',
 			),
 		);
 	}
@@ -696,7 +696,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-88585e05',
+				'expected_class'   => 'wp-container-core-group-is-layout-e322cd19',
 			),
 			'default type block gap 24px'      => array(
 				'block_attributes' => array(
@@ -709,7 +709,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-b7442c2d',
+				'expected_class'   => 'wp-container-core-group-is-layout-918747b6',
 			),
 			'constrained type justified left'  => array(
 				'block_attributes' => array(
@@ -718,7 +718,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'left',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-2bc87c5a',
+				'expected_class'   => 'wp-container-core-group-is-layout-8c890d92',
 			),
 			'constrained type justified right' => array(
 				'block_attributes' => array(
@@ -727,7 +727,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'right',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-b4e6f329',
+				'expected_class'   => 'wp-container-core-group-is-layout-07b51d56',
 			),
 			'flex type horizontal'             => array(
 				'block_attributes' => array(
@@ -737,7 +737,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'flexWrap'    => 'nowrap',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-5a57f1ed',
+				'expected_class'   => 'wp-container-core-group-is-layout-67f0b8e2',
 			),
 			'flex type vertical'               => array(
 				'block_attributes' => array(
@@ -746,7 +746,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'orientation' => 'vertical',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-38bdbeba',
+				'expected_class'   => 'wp-container-core-group-is-layout-8cf370e7',
 			),
 			'grid type'                        => array(
 				'block_attributes' => array(
@@ -754,7 +754,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-0202eb5e',
+				'expected_class'   => 'wp-container-core-group-is-layout-9649a0d9',
 			),
 			'grid type 3 columns'              => array(
 				'block_attributes' => array(
@@ -763,7 +763,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-35c51620',
+				'expected_class'   => 'wp-container-core-group-is-layout-29f43435',
 			),
 		);
 	}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -672,9 +672,19 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$processor = new WP_HTML_Tag_Processor( $output );
 		$processor->next_tag();
 
-		$this->assertTrue(
-			$processor->has_class( $expected_class ),
-			"Expected class '$expected_class' not found in the rendered output, probably because of a different hash."
+		// Extract the actual container class from the output for better error messages.
+		$actual_class = '';
+		foreach ( $processor->class_list() as $class_name ) {
+			if ( str_starts_with( $class_name, 'wp-container-core-group-is-layout-' ) ) {
+				$actual_class = $class_name;
+				break;
+			}
+		}
+
+		$this->assertEquals(
+			$expected_class,
+			$actual_class,
+			'Expected class not found in the rendered output, probably because of a different hash.'
 		);
 	}
 

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -706,7 +706,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-e322cd19',
+				'expected_class'   => 'wp-container-core-group-is-layout-a6248535',
 			),
 			'default type block gap 24px'      => array(
 				'block_attributes' => array(
@@ -719,7 +719,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-918747b6',
+				'expected_class'   => 'wp-container-core-group-is-layout-61b496ee',
 			),
 			'constrained type justified left'  => array(
 				'block_attributes' => array(
@@ -728,7 +728,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'left',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-8c890d92',
+				'expected_class'   => 'wp-container-core-group-is-layout-54d22900',
 			),
 			'constrained type justified right' => array(
 				'block_attributes' => array(
@@ -737,7 +737,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'right',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-07b51d56',
+				'expected_class'   => 'wp-container-core-group-is-layout-2910ada7',
 			),
 			'flex type horizontal'             => array(
 				'block_attributes' => array(
@@ -747,7 +747,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'flexWrap'    => 'nowrap',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-67f0b8e2',
+				'expected_class'   => 'wp-container-core-group-is-layout-f5d79bea',
 			),
 			'flex type vertical'               => array(
 				'block_attributes' => array(
@@ -756,7 +756,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'orientation' => 'vertical',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-8cf370e7',
+				'expected_class'   => 'wp-container-core-group-is-layout-2c90304e',
 			),
 			'grid type'                        => array(
 				'block_attributes' => array(
@@ -764,7 +764,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-9649a0d9',
+				'expected_class'   => 'wp-container-core-group-is-layout-5a23bf8e',
 			),
 			'grid type 3 columns'              => array(
 				'block_attributes' => array(
@@ -773,7 +773,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-29f43435',
+				'expected_class'   => 'wp-container-core-group-is-layout-cda6dc4f',
 			),
 		);
 	}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -522,7 +522,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_output' => '<div class="wp-block-group is-horizontal is-nowrap is-layout-flex wp-container-core-group-is-layout-67f0b8e2 wp-block-group-is-layout-flex"></div>',
+				'expected_output' => '<div class="wp-block-group is-horizontal is-nowrap is-layout-flex wp-container-core-group-is-layout-7c467009 wp-block-group-is-layout-flex"></div>',
 			),
 			'single wrapper block layout with grid type'   => array(
 				'args'            => array(
@@ -541,7 +541,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_output' => '<div class="wp-block-group is-layout-grid wp-container-core-group-is-layout-9649a0d9 wp-block-group-is-layout-grid"></div>',
+				'expected_output' => '<div class="wp-block-group is-layout-grid wp-container-core-group-is-layout-b8d196d0 wp-block-group-is-layout-grid"></div>',
 			),
 		);
 	}
@@ -696,7 +696,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-c5c7d83f',
+				'expected_class'   => 'wp-container-core-group-is-layout-88585e05',
 			),
 			'default type block gap 24px'      => array(
 				'block_attributes' => array(
@@ -709,7 +709,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-634f0b9d',
+				'expected_class'   => 'wp-container-core-group-is-layout-b7442c2d',
 			),
 			'constrained type justified left'  => array(
 				'block_attributes' => array(
@@ -718,7 +718,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'left',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-12dd3699',
+				'expected_class'   => 'wp-container-core-group-is-layout-2bc87c5a',
 			),
 			'constrained type justified right' => array(
 				'block_attributes' => array(
@@ -727,7 +727,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'justifyContent' => 'right',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-f1f2ed93',
+				'expected_class'   => 'wp-container-core-group-is-layout-b4e6f329',
 			),
 			'flex type horizontal'             => array(
 				'block_attributes' => array(
@@ -737,7 +737,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'flexWrap'    => 'nowrap',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-2487dcaa',
+				'expected_class'   => 'wp-container-core-group-is-layout-5a57f1ed',
 			),
 			'flex type vertical'               => array(
 				'block_attributes' => array(
@@ -746,7 +746,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'orientation' => 'vertical',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-fe9cc265',
+				'expected_class'   => 'wp-container-core-group-is-layout-38bdbeba',
 			),
 			'grid type'                        => array(
 				'block_attributes' => array(
@@ -754,7 +754,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-478b6e6b',
+				'expected_class'   => 'wp-container-core-group-is-layout-0202eb5e',
 			),
 			'grid type 3 columns'              => array(
 				'block_attributes' => array(
@@ -763,7 +763,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_class'   => 'wp-container-core-group-is-layout-d3b710ac',
+				'expected_class'   => 'wp-container-core-group-is-layout-35c51620',
 			),
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #74569.

The bug was caused by the grid layout not having access to the theme blockGap values. This PR fixes it by retrieving those values from `settings[ globalStylesDataKey ]`. If a global spacing is set for the block type, that will be used, otherwise we fall back to the theme spacing.

Once #74529 is merged we might have to look at how to include block style variations too.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate a theme with a blockGap different from 1.2rem, or change the value for the theme you're using (this can be done in the Global styles UI).
2. Add a Grid block to a page and set both an explicit column count and min column width for it.
3. The correct number of columns should display provided the screen is wide enough.

<img width="1292" height="343" alt="Screenshot 2026-01-19 at 11 53 36 am" src="https://github.com/user-attachments/assets/edd95430-9778-4a6d-a449-40eab4369e52" />

