### PR TITLE
AspectRatioDropdown: List theme aspect ratios as decimal values

### DIFF
--- a/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
@@ -111,7 +111,9 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 								onClose();
 							} }
 							value={ aspect }
-							aspectRatios={ themeRatios }
+							aspectRatios={ themeRatios.map(
+								presetRatioAsNumber
+							) }
 						/>
 					) }
 					{ showDefaultRatios && (


### PR DESCRIPTION
## What?
This PR fixes the bug with custom theme aspect ratios (Issue #66077) in the image cropper tool by mapping the theme ratios as decimal values in the `AspectRatioDropdown` component (Same as is already done for the default aspect ratios)
<!-- In a few words, what is the PR actually doing? -->

## Why?
Fixes #66077

## How?
Map theme aspect ratios as calculated decimal values (16:9 = 1.777) the same way that is already done for default aspect ratios.

## Testing Instructions
1. Add a [custom aspect ratio](https://developer.wordpress.org/news/2024/08/05/registering-custom-aspect-ratios-in-wordpress-6-6/) to your `theme.json`. Example below. 
2. Open a post or page.
3. Insert Image block and select a image.
4. Open the cropping tool.
5. Open the Aspect Ratio dropdown and observe your custom theme ratio in the list.
6. Select the custom ratio.
7. Observe that the crop area changes to reflect your selection.

## Example of custom theme aspect ratio in theme.json:
```json
"dimensions": {
  "aspectRatios": [
    {
      "name": "Ultra Wide - 21:9",
      "slug": "21-9",
      "ratio": "21/9"
    }
  ]
},
```

## Screencast before fix:
https://github.com/user-attachments/assets/11f2f364-334a-4447-8641-c7a14290082e

## Screencast after fix:
https://github.com/user-attachments/assets/5d768ee6-c72c-488d-9aa0-2d4be36d9b79

