### PR TITLE
Core backport for gutenberg_filter_global_styles_post: Protect from KSES mangling

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,8 +197,6 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -195,10 +195,6 @@ jobs:
                       php: '8.1'
                     - event: 'pull_request'
                       php: '8.2'
-                    - event: 'pull_request'
-                      multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,6 +197,8 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -195,6 +195,10 @@ jobs:
                       php: '8.1'
                     - event: 'pull_request'
                       php: '8.2'
+                    - event: 'pull_request'
+                      multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -304,7 +304,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 			 * JSON encode the data stored in post content.
 			 * Escape characters that are likely to be mangled by HTML filters: "<>&".
 			 *
-			 * This data is later re-encoded by {@see wp_filter_global_styles_post()}.
+			 * This data is later re-encoded by {@see gutenberg_filter_global_styles_post()}.
 			 * The escaping is also applied here as a precaution.
 			 */
 			$changes->post_content = wp_json_encode( $config, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -319,56 +319,6 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 			}
 		}
 
-		/*
-		 * @todo Remove this when supported WordPress version is >= 7.0
-		 */
-		$filter_priority = has_filter( 'content_save_pre', 'wp_filter_global_styles_post' );
-		assert( false !== $filter_priority, 'Expected to find wp_filter_global_styles_post filter.' );
-		if ( false !== $filter_priority ) {
-			remove_filter( 'content_save_pre', 'wp_filter_global_styles_post', $filter_priority );
-			add_filter(
-				'content_save_pre',
-				/**
-				 * Sanitizes global styles user content removing unsafe rules.
-				 *
-				 * This function was updated in WordPress 7.0
-				 *
-				 * The version here replaces it with the corrected 7.0 version.
-				 * This function is taken from r61503.
-				 *
-				 * @see https://core.trac.wordpress.org/browser/trunk/src/wp-includes/kses.php?rev=61503
-				 *
-				 * @param string $data Post content to filter.
-				 * @return string Filtered post content with unsafe rules removed.
-				 */
-				function ( $data ) {
-					$decoded_data        = json_decode( wp_unslash( $data ), true );
-					$json_decoding_error = json_last_error();
-					if (
-						JSON_ERROR_NONE === $json_decoding_error &&
-						is_array( $decoded_data ) &&
-						isset( $decoded_data['isGlobalStylesUserThemeJSON'] ) &&
-						$decoded_data['isGlobalStylesUserThemeJSON']
-					) {
-						unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
-
-						$data_to_encode = WP_Theme_JSON::remove_insecure_properties( $decoded_data, 'custom' );
-
-						$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
-						/**
-						 * JSON encode the data stored in post content.
-						 * Escape characters that are likely to be mangled by HTML filters: "<>&".
-						 *
-						 * This matches the escaping in {@see WP_REST_Global_Styles_Controller::prepare_item_for_database()}.
-						 */
-						return wp_slash( wp_json_encode( $data_to_encode, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
-					}
-					return $data;
-				},
-				$filter_priority
-			);
-		}
-
 		return $changes;
 	}
 

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -702,37 +702,6 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
 	protected function validate_custom_css( $css ) {
-		/*
-		 * This is a feature check for a fix in WordPress 7.0.
-		 *
-		 * This block contains the fallback behavior for WordPress versions prior to 7.0. This
-		 * restricts CSS content disallow text that is susceptible to mangling by post
-		 * content filters.
-		 *
-		 * This checks the JSON encoding of the `&` character. It is expected to be Unicode escaped
-		 * in the JSON content after filtering by `wp_filter_global_styles_post()`.
-		 *
-		 * @see https://core.trac.wordpress.org/changeset/61486
-		 *
-		 * This block should be removed when the minimum supported WordPress version is >= 7.0.
-		 */
-		if ( false !== strpos(
-			'&',
-			wp_filter_global_styles_post(
-				'{"isGlobalStylesUserThemeJSON":true,"version":3,"styles":{"css":"&"}}',
-				'custom'
-			)
-		) ) {
-			if ( preg_match( '#(?:</?\w+)|&#', $css ) ) {
-				return new WP_Error(
-					'rest_custom_css_illegal_markup',
-					__( 'Markup is not allowed in CSS.', 'gutenberg' ),
-					array( 'status' => 400 )
-				);
-			}
-			return true;
-		}
-
 		$length = strlen( $css );
 		for (
 			$at = strcspn( $css, '<' );

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -323,6 +323,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 		 * @todo Remove this when supported WordPress version is >= 7.0
 		 */
 		$filter_priority = has_filter( 'content_save_pre', 'wp_filter_global_styles_post' );
+		assert( false !== $filter_priority, 'Expected to find wp_filter_global_styles_post filter.' );
 		if ( false !== $filter_priority ) {
 			remove_filter( 'content_save_pre', 'wp_filter_global_styles_post', $filter_priority );
 			add_filter(

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -319,6 +319,55 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 			}
 		}
 
+		/*
+		 * @todo Remove this when supported WordPress version is >= 7.0
+		 */
+		$filter_priority = has_filter( 'content_save_pre', 'wp_filter_global_styles_post' );
+		if ( false !== $filter_priority ) {
+			remove_filter( 'content_save_pre', 'wp_filter_global_styles_post', $filter_priority );
+			add_filter(
+				'content_save_pre',
+				/**
+				 * Sanitizes global styles user content removing unsafe rules.
+				 *
+				 * This function was updated in WordPress 7.0
+				 *
+				 * The version here replaces it with the corrected 7.0 version.
+				 * This function is taken from r61503.
+				 *
+				 * @see https://core.trac.wordpress.org/browser/trunk/src/wp-includes/kses.php?rev=61503
+				 *
+				 * @param string $data Post content to filter.
+				 * @return string Filtered post content with unsafe rules removed.
+				 */
+				function ( $data ) {
+					$decoded_data        = json_decode( wp_unslash( $data ), true );
+					$json_decoding_error = json_last_error();
+					if (
+						JSON_ERROR_NONE === $json_decoding_error &&
+						is_array( $decoded_data ) &&
+						isset( $decoded_data['isGlobalStylesUserThemeJSON'] ) &&
+						$decoded_data['isGlobalStylesUserThemeJSON']
+					) {
+						unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
+
+						$data_to_encode = WP_Theme_JSON::remove_insecure_properties( $decoded_data, 'custom' );
+
+						$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
+						/**
+						 * JSON encode the data stored in post content.
+						 * Escape characters that are likely to be mangled by HTML filters: "<>&".
+						 *
+						 * This matches the escaping in {@see WP_REST_Global_Styles_Controller::prepare_item_for_database()}.
+						 */
+						return wp_slash( wp_json_encode( $data_to_encode, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
+					}
+					return $data;
+				},
+				$filter_priority
+			);
+		}
+
 		return $changes;
 	}
 

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -702,6 +702,37 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
 	protected function validate_custom_css( $css ) {
+		/*
+		 * This is a feature check for a fix in WordPress 7.0.
+		 *
+		 * This block contains the fallback behavior for WordPress versions prior to 7.0. This
+		 * restricts CSS content disallow text that is susceptible to mangling by post
+		 * content filters.
+		 *
+		 * This checks the JSON encoding of the `&` character. It is expected to be Unicode escaped
+		 * in the JSON content after filtering by `wp_filter_global_styles_post()`.
+		 *
+		 * @see https://core.trac.wordpress.org/changeset/61486
+		 *
+		 * This block should be removed when the minimum supported WordPress version is >= 7.0.
+		 */
+		if ( false !== strpos(
+			'&',
+			wp_filter_global_styles_post(
+				'{"isGlobalStylesUserThemeJSON":true,"version":3,"styles":{"css":"&"}}',
+				'custom'
+			)
+		) ) {
+			if ( preg_match( '#(?:</?\w+)|&#', $css ) ) {
+				return new WP_Error(
+					'rest_custom_css_illegal_markup',
+					__( 'Markup is not allowed in CSS.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+			return true;
+		}
+
 		$length = strlen( $css );
 		for (
 			$at = strcspn( $css, '<' );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -38,7 +38,7 @@ function gutenberg_filter_global_styles_post( $data ) {
 		 * JSON encode the data stored in post content.
 		 * Escape characters that are likely to be mangled by HTML filters: "<>&".
 		 *
-		 * This matches the escaping in {@see WP_REST_Global_Styles_Controller::prepare_item_for_database()}.
+		 * This matches the escaping in {@see WP_REST_Global_Styles_Controller_Gutenberg::prepare_item_for_database()}.
 		 */
 		return wp_slash( wp_json_encode( $data_to_encode, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
 	}

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -34,7 +34,13 @@ function gutenberg_filter_global_styles_post( $data ) {
 		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data, 'custom' );
 
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
-		return wp_slash( wp_json_encode( $data_to_encode ) );
+		/**
+		 * JSON encode the data stored in post content.
+		 * Escape characters that are likely to be mangled by HTML filters: "<>&".
+		 *
+		 * This matches the escaping in {@see WP_REST_Global_Styles_Controller::prepare_item_for_database()}.
+		 */
+		return wp_slash( wp_json_encode( $data_to_encode, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
 	}
 	return $data;
 }


### PR DESCRIPTION
## What?

This completes the backport https://github.com/WordPress/gutenberg/pull/74371 of https://core.trac.wordpress.org/changeset/61486 by including the filter update.

This fixes a CI failure.

Work on this test failure (multisite, previous WordPress major) from #74371:

```
There was 1 failure:

1) WP_REST_Global_Styles_Controller_Gutenberg_Test::test_update_allows_valid_css_with_more_syntax
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '@property --animate {
-	syntax: "<custom-ident>";
+	syntax: "";
 	inherits: true;
 	initial-value: false;
 }
-h1::before { content: "fun & games"; }'
+h1::before { content: "fun &amp; games"; }'
```

## Why?

Completes backport of the fix from https://core.trac.wordpress.org/changeset/61486.


## Testing Instructions

This is covered by CI and can be seen passing:

https://github.com/WordPress/gutenberg/actions/runs/21215207121/job/61034658478


