### PR TITLE
Fix: Escape less-than character in HTML attributes to prevent block recovery errors

### DIFF
--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -20,7 +20,7 @@ import type { NavigateOptions } from '../types';
 
 const INVALID_HTML_ATTRIBUTE = {
 	raw: '/ "\'><=invalid_path',
-	escaped: "/ &quot;'&gt;<=invalid_path",
+	escaped: "/ &quot;'&gt;&lt;=invalid_path",
 };
 
 const PATHS = {

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -63,7 +63,7 @@ describe( 'element', () => {
 			);
 
 			expect( result ).toBe(
-				'<a href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;&gt;" style="background-color:red">' +
+				'<a href="/index.php?foo=bar&amp;qux=&lt;&quot;scary&quot;&gt;" style="background-color:red">' +
 					'&lt;"WordPress" &amp; Friends>' +
 					'</a>'
 			);

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -578,7 +578,7 @@ describe( 'renderAttributes()', () => {
 			} );
 
 			expect( result ).toBe(
-				' style="background:url(&quot;foo.png&quot;)" href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;&gt;"'
+				' style="background:url(&quot;foo.png&quot;)" href="/index.php?foo=bar&amp;qux=&lt;&quot;scary&quot;&gt;"'
 			);
 		} );
 

--- a/packages/escape-html/README.md
+++ b/packages/escape-html/README.md
@@ -49,6 +49,9 @@ split HTML strings. This is a WordPress specific fix
 Note that if a resolution for Trac#45387 comes to fruition, it is no longer
 necessary for `__unstableEscapeGreaterThan` to be used.
 
+Note we also escape the less-than symbol to prevent HTML injection vulnerabilities
+and parsing issues, particularly for users without the unfiltered_html capability.
+
 See: <https://core.trac.wordpress.org/ticket/45387>
 
 _Parameters_

--- a/packages/escape-html/src/index.ts
+++ b/packages/escape-html/src/index.ts
@@ -69,6 +69,9 @@ export function escapeLessThan( value: string ): string {
  * Note that if a resolution for Trac#45387 comes to fruition, it is no longer
  * necessary for `__unstableEscapeGreaterThan` to be used.
  *
+ * Note we also escape the less-than symbol to prevent HTML injection vulnerabilities
+ * and parsing issues, particularly for users without the unfiltered_html capability.
+ *
  * See: https://core.trac.wordpress.org/ticket/45387
  *
  * @param value Attribute value.
@@ -77,7 +80,7 @@ export function escapeLessThan( value: string ): string {
  */
 export function escapeAttribute( value: string ): string {
 	return __unstableEscapeGreaterThan(
-		escapeQuotationMark( escapeAmpersand( value ) )
+		escapeLessThan( escapeQuotationMark( escapeAmpersand( value ) ) )
 	);
 }
 

--- a/packages/escape-html/src/test/index.ts
+++ b/packages/escape-html/src/test/index.ts
@@ -68,6 +68,7 @@ describe( 'escapeGreaterThan', () => {
 describe( 'escapeAttribute', () => {
 	testEscapeAmpersand( escapeAttribute );
 	testEscapeQuotationMark( escapeAttribute );
+	testEscapeLessThan( escapeAttribute );
 	testUnstableEscapeGreaterThan( escapeAttribute );
 } );
 


### PR DESCRIPTION

## What?
Closes #74691
Fixes the `escapeAttribute` function to properly escape the less-than (`<`) character in HTML attribute values, preventing block recovery errors when users without `unfiltered_html` capability use `<` in alt text.

## Why?

When users (authors, contributors, or blog admins on multisite) add a `<` character to image alt text, WordPress server-side sanitization (KSES) strips the content after the `<`, breaking the block structure and triggering recovery mode.

This happened because `escapeAttribute` was only escaping `&`, `"`, and `>` characters, but not `<`.

**Affected Blocks:**
- Image
- Cover
- Media & Text
- Any block using HTML attributes with user-generated content

## How?

Updated the `escapeAttribute` function in `@wordpress/escape-html` to include `escapeLessThan()` in the escaping chain, ensuring consistent behavior with WordPress's `esc_attr()` function.

**Before:**
```typescript
export function escapeAttribute( value: string ): string {
	return __unstableEscapeGreaterThan(
		escapeQuotationMark( escapeAmpersand( value ) )
	);
}
```

**After:**
```typescript
export function escapeAttribute( value: string ): string {
	return __unstableEscapeGreaterThan(
		escapeLessThan( escapeQuotationMark( escapeAmpersand( value ) ) )
	);
}
```

## Testing Instructions

- Set up a test environment with a user that has Author role (lacks `unfiltered_html` capability)

### Test Case 1: Image Block
1. Log in as an Author user
2. Create a new post
3. Add an Image block
4. In the alt text field (sidebar or media library), enter: `This < will cause bugs`
5. Save the post
6. Reload the page
7. The image block should display correctly without a block recovery message

### Test Case 2: Cover Block
1. Add a Cover block with an image
2. In the sidebar, add alt text: `Photo < description`
3. Save and reload
4. Block should work correctly

### Test Case 3: Media & Text Block
1. Add a Media & Text block with an image
2. Add alt text: `Media < content`
3. Save and reload
4. Block should work correctly

### Test Case 4: Other Special Characters
Test that other characters still work:
- `This > is cool` → should display correctly 
- `This & that` → should display correctly 
- `This "quoted" text` → should display correctly 


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="723" height="252" alt="image" src="https://github.com/user-attachments/assets/645c5d67-0d47-4334-a585-caa014eccab7" />| <img width="1219" height="478" alt="image" src="https://github.com/user-attachments/assets/f10e6b20-8054-4443-9993-388ca1b97f28" />|


