### PR TITLE
Make format control restrictions experimental

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -49,6 +49,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditor = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-restrict-formatting-in-content-only-mode' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalRestrictFormattingInContentOnlyMode = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -258,6 +258,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-restrict-formatting-in-content-only-mode',
+		__( 'Restrict formatting controls in Content Only mode', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Restricts RichText formatting controls when in Content Only mode to provide a simpler, more focused editing experience while maintaining essential content functionality.', 'gutenberg' ),
+			'id'    => 'gutenberg-restrict-formatting-in-content-only-mode',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -352,7 +352,9 @@ export function RichTextWrapper(
 		identifier,
 		allowedFormats: adjustedAllowedFormats,
 		withoutInteractiveFormatting,
-		disableNoneEssentialFormatting: isContentOnly,
+		disableNoneEssentialFormatting:
+			isContentOnly &&
+			window?.__experimentalRestrictFormattingInContentOnlyMode,
 	} );
 
 	function addEditorOnlyFormats( value ) {

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -67,6 +67,8 @@ function getPrefixedSelectKeys( selected, prefix ) {
  * @param {Array}   options.allowedFormats                 Allowed formats
  * @param {boolean} options.withoutInteractiveFormatting   Whether to clean the interactive formatting or not.
  * @param {boolean} options.disableNoneEssentialFormatting Whether to disable none-essential formatting or not.
+ *                                                         This option is pnly available when "Restrict formatting
+ *                                                         controls in Content Only mode" experimental setting is enabled.
  */
 export function useFormatTypes( {
 	clientId,
@@ -88,7 +90,11 @@ export function useFormatTypes( {
 					return false;
 				}
 
-				if ( disableNoneEssentialFormatting && ! isEssential ) {
+				if (
+					disableNoneEssentialFormatting &&
+					! isEssential &&
+					window?.__experimentalRestrictFormattingInContentOnlyMode
+				) {
 					return false;
 				}
 

--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -58,7 +58,8 @@ export default function RichTextControl( {
 		identifier: field.id,
 		allowedFormats: adjustedAllowedFormats,
 		withoutInteractiveFormatting: fieldConfig?.withoutInteractiveFormatting,
-		disableNoneEssentialFormatting: true,
+		disableNoneEssentialFormatting:
+			window?.__experimentalRestrictFormattingInContentOnlyMode,
 	} );
 
 	function addEditorOnlyFormats( value ) {


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/pull/71058

## What?

This PR puts the inline formatting control restriction behind an experimental flag.

## Why?

#71058 introduced the `essentialFormatKey` with `Symbol()` to only allow basic fomats in contentOnly mode.  This API is private, so consumers can't mark their own inline formats as "essential". This has led to some users finding this behavior to be a bug, as reported in #74168 and #74345. Personally, I think this API should be developed as an experimental feature until it is stabilized, otherwise it will have a huge impact on consumers.

## How?

Adds a news `__experimentalRestrictFormattingInContentOnlyMode` flag to make this feature experimental.

## Testing Instructions

### Pattern Override

- Create a synced pattern containing a Paragraph block.
- In the block's Advanced settings, toggle "Enable Overrides".
- Insert this pattern into a new Page.
- Attempt to apply any of the inline formats.
  - When the "Restrict formatting controls in Content Only mode" setting is enabled: Only the bold, italic, and link formats are displayed.
  - When the "Restrict formatting controls in Content Only mode" setting is disabled: All available formats are displayed.

### templateLock: contentOnly

```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Hello World</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

- Attempt to apply any of the inline formats to the Paragraph block inside the Group block.
  - When the "Restrict formatting controls in Content Only mode" setting is enabled: Only the bold, italic, and link formats are displayed.
  - When the "Restrict formatting controls in Content Only mode" setting is disabled: All available formats are displayed.


