### PR TITLE
Update wp-build documentation to describe 'wpPlugin.name'

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update documentation to describe `wpPlugin.name`
+
 ## 0.6.0 (2026-01-16)
 
 ### Breaking Changes

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -136,6 +136,18 @@ Files to copy with optional PHP transformations:
 
 Configure your root `package.json` with a `wpPlugin` object to control global namespace and externalization behavior:
 
+### `wpPlugin.name`
+
+Name used to prefix genereated PHP functions. Must follow function name rules in PHP, i.e. valid name starts with a letter or underscore, followed by any number of letters, numbers, or underscores.
+
+```json
+{
+	"wpPlugin": {
+		"name": "myPlugin"
+	}
+}
+```
+
 ### `wpPlugin.scriptGlobal`
 
 The global variable name for your packages (e.g., `"wp"`, `"myPlugin"`). Set to `false` to disable global exposure:
@@ -339,6 +351,7 @@ This configuration:
 ```json
 {
 	"wpPlugin": {
+		"name": "acme",
 		"scriptGlobal": "acme",
 		"packageNamespace": "acme"
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
As a follow-up to https://github.com/WordPress/gutenberg/pull/74490, which includes:

> All generated page functions now include the `{{PREFIX}}` (from `wpPlugin.name`) at the beginning

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`name` was undocumented, but it's important for plugins generating files using wp-build; otherwise we default to `gutenberg` prefix for functions, which conflicts with Gutenberg plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
