### PR TITLE
Fix wp-theme dependencies in the build.

### DIFF
--- a/packages/theme/src/style.scss
+++ b/packages/theme/src/style.scss
@@ -1,0 +1,6 @@
+/**
+ * WordPress Design System theme styles.
+ * This exports the design tokens (CSS custom properties) for use across WordPress packages.
+ */
+
+@use "./prebuilt/css/design-tokens.css";

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, copyFile, mkdir, unlink } from 'fs/promises';
+import { readFile, writeFile, copyFile, mkdir, unlink, stat } from 'fs/promises';
 import path from 'path';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
@@ -699,18 +699,21 @@ async function inferStyleDependencies( scriptDependencies, packageName ) {
 
 			// ONLY include if it has wpScript: true (which means it builds styles)
 			if ( depPackageJson.wpScript === true ) {
-				// Double-check the style file actually exists
-				const styleFile = path.join(
-					BUILD_DIR,
-					'styles',
+				// Double-check the package has build-style directory (will be registered)
+				// Checking just for the output file isn't sufficient since packages
+				// may have orphaned build outputs without proper source setup
+				const buildStyleDir = path.join(
+					PACKAGES_DIR,
 					shortName,
-					'style.css'
+					'build-style'
 				);
 				try {
-					await readFile( styleFile );
-					styleDeps.push( scriptHandle );
+					const stats = await stat( buildStyleDir );
+					if ( stats.isDirectory() ) {
+						styleDeps.push( scriptHandle );
+					}
 				} catch {
-					// Style file doesn't exist, skip it
+					// build-style directory doesn't exist, skip it
 				}
 			}
 		} catch {

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, copyFile, mkdir, unlink, stat } from 'fs/promises';
+import { readFile, writeFile, copyFile, mkdir, unlink } from 'fs/promises';
 import path from 'path';
 import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
@@ -699,21 +699,18 @@ async function inferStyleDependencies( scriptDependencies, packageName ) {
 
 			// ONLY include if it has wpScript: true (which means it builds styles)
 			if ( depPackageJson.wpScript === true ) {
-				// Double-check the package has build-style directory (will be registered)
-				// Checking just for the output file isn't sufficient since packages
-				// may have orphaned build outputs without proper source setup
-				const buildStyleDir = path.join(
-					PACKAGES_DIR,
+				// Double-check the style file actually exists
+				const styleFile = path.join(
+					BUILD_DIR,
+					'styles',
 					shortName,
-					'build-style'
+					'style.css'
 				);
 				try {
-					const stats = await stat( buildStyleDir );
-					if ( stats.isDirectory() ) {
-						styleDeps.push( scriptHandle );
-					}
+					await readFile( styleFile );
+					styleDeps.push( scriptHandle );
 				} catch {
-					// build-style directory doesn't exist, skip it
+					// Style file doesn't exist, skip it
 				}
 			}
 		} catch {


### PR DESCRIPTION
  ## What?
  Fixes WordPress notice about unregistered `wp-theme` style dependency.

  ## Why?
  The `@wordpress/theme` package was causing a WordPress notice: "The style with the handle 'wp-edit-site' was enqueued with dependencies that are not registered: wp-theme"

  This occurred because:
  1. Packages like `@wordpress/dataviews` import `@wordpress/theme` for its design tokens in their SCSS files
  2. The build system automatically inferred `wp-theme` as a style dependency for packages that use it
  3. However, `@wordpress/theme` wasn't being registered in the style registry because it lacked a `packages/theme/build-style/` directory
  4. This resulted in `wp-theme` being listed as a dependency but never registered, causing the WordPress notice

  ## How?
  Added a `packages/theme/src/style.scss` file that imports the design tokens CSS. This allows the `@wordpress/theme` package to follow the standard build pattern:
  - The SCSS file imports `./prebuilt/css/design-tokens.css`
  - The build process generates `packages/theme/build-style/style.css`
  - The build system automatically registers `wp-theme` in the style registry
  - Other packages can now properly depend on `wp-theme` styles

  ## Testing Instructions
  1. Start your local WordPress environment with the Gutenberg plugin active
  2. Navigate to the Site Editor (wp-admin → Appearance → Editor)
  3. Check the browser console and PHP error logs
  4. Verify there are no WordPress notices about `wp-theme` being an unregistered dependency
  5. Check that the site editor loads correctly with all styles applied

