### PR TITLE
Fix 2 - Accordion: Text in a closed accordion panel cannot be found via the browser search

### DIFF
--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -48,7 +48,9 @@ function block_core_accordion_item_render( $attributes, $content ) {
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-accordion-panel' ) ) ) {
 				$p->set_attribute( 'id', $unique_id . '-panel' );
 				$p->set_attribute( 'aria-labelledby', $unique_id );
+				$p->remove_attribute( 'role' );
 				$p->set_attribute( 'data-wp-bind--hidden', 'state.hiddenAttribute' );
+				$p->set_attribute( 'data-wp-bind--role', 'state.panelRole' );
 				$p->set_attribute( 'data-wp-on--beforematch', 'actions.handleBeforeMatch' );
 
 				// Only modify content if all directives have been set.

--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -48,7 +48,8 @@ function block_core_accordion_item_render( $attributes, $content ) {
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-accordion-panel' ) ) ) {
 				$p->set_attribute( 'id', $unique_id . '-panel' );
 				$p->set_attribute( 'aria-labelledby', $unique_id );
-				$p->set_attribute( 'data-wp-bind--inert', '!state.isOpen' );
+				$p->set_attribute( 'data-wp-bind--hidden', 'state.hiddenAttribute' );
+				$p->set_attribute( 'data-wp-on--beforematch', 'actions.handleBeforeMatch' );
 
 				// Only modify content if all directives have been set.
 				$content = $p->get_updated_html();

--- a/packages/block-library/src/accordion-panel/style.scss
+++ b/packages/block-library/src/accordion-panel/style.scss
@@ -1,7 +1,6 @@
 .wp-block-accordion-panel {
 
 	// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
-	&[inert],
 	&[aria-hidden="true"] {
 		display: none;
 		margin-block-start: 0;

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -25,13 +25,6 @@ const { actions } = store(
 				);
 				return accordionItem?.isOpen ? null : 'until-found';
 			},
-			get panelRole() {
-				const { id, accordionItems } = getContext();
-				const accordionItem = accordionItems.find(
-					( item ) => item.id === id
-				);
-				return accordionItem?.isOpen ? 'region' : null;
-			},
 		},
 		actions: {
 			toggle: () => {

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -18,6 +18,20 @@ const { actions } = store(
 				);
 				return accordionItem ? accordionItem.isOpen : false;
 			},
+			get hiddenAttribute() {
+				const { id, accordionItems } = getContext();
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
+				return accordionItem?.isOpen ? null : 'until-found';
+			},
+			get panelRole() {
+				const { id, accordionItems } = getContext();
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
+				return accordionItem?.isOpen ? 'region' : null;
+			},
 		},
 		actions: {
 			toggle: () => {
@@ -126,6 +140,17 @@ const { actions } = store(
 				window.setTimeout( () => {
 					targetElement.scrollIntoView();
 				}, 0 );
+			},
+			handleBeforeMatch: () => {
+				const context = getContext();
+				const { id, accordionItems } = context;
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
+
+				if ( accordionItem ) {
+					accordionItem.isOpen = true;
+				}
 			},
 		},
 		callbacks: {

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -25,6 +25,13 @@ const { actions } = store(
 				);
 				return accordionItem?.isOpen ? null : 'until-found';
 			},
+			get panelRole() {
+				const { id, accordionItems } = getContext();
+				const accordionItem = accordionItems.find(
+					( item ) => item.id === id
+				);
+				return accordionItem?.isOpen ? 'region' : null;
+			},
 		},
 		actions: {
 			toggle: () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73443

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR adds the ability to search content inside closed accordion panel with improved accessibility

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Used `beforematch` event listener and `hidden="until-found"` attribute to add the functionality.
- Added dynamic binding for `role` attribute. It is now 'region' only when the panel is open. When closed, the attribute is removed to prevent screen readers from announcing empty landmarks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a test post with an Accordion block.
2. Add text "Hidden Treasure" inside the panel.
3. Close the panel.
4. Use browser search (Ctrl+F) to search for "Hidden Treasure".
5. Verify that the browser finds the text and potentially opens the panel

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1440" height="791" alt="Screenshot 2026-01-19 at 3 54 22 PM" src="https://github.com/user-attachments/assets/aef05e82-ff9f-4607-a401-b35596c56d73" />

