### PR TITLE
Duotone: lazily load settings

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -13,14 +13,6 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-// Remove the Core metadata setup (for older versions of Core).
-// In newer versions, we don't need to set up metadata prior to rendering any blocks,
-// since the computation gets deferred until it's needed.
-if ( class_exists( 'WP_Duotone' ) ) {
-	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_styles_presets' ) );
-	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_style_block_names' ) );
-}
-
 // Add classnames to blocks using duotone support.
 if ( function_exists( 'wp_render_duotone_support' ) ) {
 	// Deprecated render function.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -13,13 +13,13 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-// Set up metadata prior to rendering any blocks.
+// Remove the Core metadata setup (for older versions of Core).
+// In newer versions, we don't need to set up metadata prior to rendering any blocks,
+// since the computation gets deferred until it's needed.
 if ( class_exists( 'WP_Duotone' ) ) {
 	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_styles_presets' ) );
 	remove_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_style_block_names' ) );
 }
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_styles_presets' ), 10 );
-add_action( 'wp_loaded', array( 'WP_Duotone_Gutenberg', 'set_global_style_block_names' ), 10 );
 
 // Add classnames to blocks using duotone support.
 if ( function_exists( 'wp_render_duotone_support' ) ) {
@@ -30,7 +30,7 @@ if ( class_exists( 'WP_Duotone' ) ) {
 	remove_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ) );
 	remove_filter( 'render_block_core/image', array( 'WP_Duotone', 'restore_image_outer_container' ) );
 }
-add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
+add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 3 );
 add_filter( 'render_block_core/image', array( 'WP_Duotone_Gutenberg', 'restore_image_outer_container' ), 10, 1 );
 
 // Enqueue styles.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -954,7 +954,7 @@ class WP_Duotone_Gutenberg {
 
 		// Like the layout hook, this assumes the hook only applies to blocks with a single wrapper.
 		$tags = new WP_HTML_Tag_Processor( $block_content );
-		if ( $tags->next_tag() ) {
+		if ( $tags->next_tag() && isset( $filter_id ) ) {
 			$tags->add_class( $filter_id );
 		}
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -882,7 +882,7 @@ class WP_Duotone_Gutenberg {
 	 * @return string Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block, $wp_block ) {
-		if ( empty( $block_content ) || ! $block['blockName'] ) {
+		if ( ! $block['blockName'] ) {
 			return $block_content;
 		}
 		$duotone_selector = self::get_selector( $wp_block->block_type );

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -48,7 +48,7 @@ class WP_Duotone_Gutenberg {
 	 *       …
 	 *  ]
 	 *
-	 * @var null|array<string, string>
+	 * @var ?array<string, string>
 	 */
 	private static $global_styles_block_names;
 
@@ -68,7 +68,7 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var null|array<string, array<string, string|string[]>>
+	 * @var ?array<string, array<string, string|string[]>>
 	 */
 	private static $global_styles_presets;
 
@@ -671,7 +671,7 @@ class WP_Duotone_Gutenberg {
 		 * If the experimental duotone support was set, that value is to be
 		 * treated as a selector and requires scoping.
 		 */
-		$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+		$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'] ?? false;
 		if ( $experimental_duotone ) {
 			$root_selector = wp_get_block_css_selector( $block_type );
 			return is_string( $experimental_duotone )
@@ -785,7 +785,7 @@ class WP_Duotone_Gutenberg {
 
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
+		$presets_by_origin = $tree['color']['duotone'] ?? array();
 
 		self::$global_styles_presets = array();
 		foreach ( $presets_by_origin as $presets ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -648,7 +648,7 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @param WP_Block_Type $block_type Block type to check for support.
 	 *
-	 * @return string|null The CSS selector or null if there is no support.
+	 * @return string|null The CSS selector. Null if there is no support or the $block_type is not a WP_Block_Type.
 	 */
 	private static function get_selector( $block_type ) {
 		if ( ! ( $block_type instanceof WP_Block_Type ) ) {
@@ -776,7 +776,7 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @since 6.3.0
 	 *
-	 * @return array An array of global styles presets, keyed on the filter ID.
+	 * @return array<string, array<string, string|string[]>> An array of global styles presets, keyed on the filter ID.
 	 */
 	private static function get_all_global_styles_presets() {
 		if ( isset( self::$global_styles_presets ) ) {
@@ -808,6 +808,7 @@ class WP_Duotone_Gutenberg {
 	 * @deprecated
 	 */
 	public static function set_global_styles_presets() {
+		_deprecated_function( __METHOD__, 'Gutenberg 22.5.0' );
 		self::get_all_global_styles_presets();
 	}
 
@@ -868,6 +869,7 @@ class WP_Duotone_Gutenberg {
 	 * @deprecated
 	 */
 	public static function set_global_style_block_names() {
+		_deprecated_function( __METHOD__, 'Gutenberg 22.5.0' );
 		self::get_all_global_style_block_names();
 	}
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -48,9 +48,9 @@ class WP_Duotone_Gutenberg {
 	 *       …
 	 *  ]
 	 *
-	 * @var array
+	 * @var null|array<string, string>
 	 */
-	private static $global_styles_block_names = array();
+	private static $global_styles_block_names;
 
 	/**
 	 * An array of duotone filter data from global, theme, and custom presets.
@@ -68,9 +68,9 @@ class WP_Duotone_Gutenberg {
 	 *      …
 	 *  ]
 	 *
-	 * @var array
+	 * @var null|array<string, array<string, string|string[]>>
 	 */
-	private static $global_styles_presets = array();
+	private static $global_styles_presets;
 
 	/**
 	 * All of the duotone filter data from presets for CSS custom properties on
@@ -476,7 +476,7 @@ class WP_Duotone_Gutenberg {
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
-		return array_key_exists( $filter_id, self::$global_styles_presets );
+		return array_key_exists( $filter_id, self::get_all_global_styles_presets() );
 	}
 
 	/**
@@ -646,39 +646,41 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Get the CSS selector for a block type.
 	 *
-	 * @param string $block_name The block name.
+	 * @param WP_Block_Type $block_type Block type to check for support.
 	 *
-	 * @return ?string The CSS selector or null if there is no support.
+	 * @return string|null The CSS selector or null if there is no support.
 	 */
-	private static function get_selector( $block_name ) {
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-
-		if ( $block_type && $block_type instanceof WP_Block_Type ) {
-			// Backwards compatibility with `supports.color.__experimentalDuotone`
-			// is provided via the `block_type_metadata_settings` filter. If
-			// `supports.filter.duotone` has not been set and the experimental
-			// property has been, the experimental property value is copied into
-			// `supports.filter.duotone`.
-			$duotone_support = $block_type->supports['filter']['duotone'] ?? false;
-			if ( ! $duotone_support ) {
-				return null;
-			}
-
-			// If the experimental duotone support was set, that value is to be
-			// treated as a selector and requires scoping.
-			$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'] ?? false;
-			if ( $experimental_duotone ) {
-				$root_selector = wp_get_block_css_selector( $block_type );
-				return is_string( $experimental_duotone )
-					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
-					: $root_selector;
-			}
-
-			// Regular filter.duotone support uses filter.duotone selectors with fallbacks.
-			return wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
+	private static function get_selector( $block_type ) {
+		if ( ! ( $block_type instanceof WP_Block_Type ) ) {
+			return null;
 		}
 
-		return null;
+		/*
+		 * Backward compatibility with `supports.color.__experimentalDuotone`
+		 * is provided via the `block_type_metadata_settings` filter. If
+		 * `supports.filter.duotone` has not been set and the experimental
+		 * property has been, the experimental property value is copied into
+		 * `supports.filter.duotone`.
+		 */
+		$duotone_support = block_has_support( $block_type, array( 'filter', 'duotone' ) );
+		if ( ! $duotone_support ) {
+			return null;
+		}
+
+		/*
+		 * If the experimental duotone support was set, that value is to be
+		 * treated as a selector and requires scoping.
+		 */
+		$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+		if ( $experimental_duotone ) {
+			$root_selector = wp_get_block_css_selector( $block_type );
+			return is_string( $experimental_duotone )
+				? WP_Theme_JSON::scope_selector( $root_selector, $experimental_duotone )
+				: $root_selector;
+		}
+
+		// Regular filter.duotone support uses filter.duotone selectors with fallbacks.
+		return wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
 	}
 
 	/**
@@ -731,7 +733,8 @@ class WP_Duotone_Gutenberg {
 	 * @param string $filter_value     The filter CSS value. e.g. 'url(#wp-duotone-blue-orange)' or 'unset'.
 	 */
 	private static function enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value ) {
-		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
+		$global_styles_presets = self::get_all_global_styles_presets();
+		if ( ! array_key_exists( $filter_id, $global_styles_presets ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
 				__( 'The duotone id "%s" is not registered in theme.json settings', 'gutenberg' ),
@@ -740,8 +743,8 @@ class WP_Duotone_Gutenberg {
 			_doing_it_wrong( __METHOD__, $error_message, '6.3.0' );
 			return;
 		}
-		self::$used_global_styles_presets[ $filter_id ] = self::$global_styles_presets[ $filter_id ];
-		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, self::$global_styles_presets[ $filter_id ] );
+		self::$used_global_styles_presets[ $filter_id ] = $global_styles_presets[ $filter_id ];
+		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $global_styles_presets[ $filter_id ] );
 	}
 
 	/**
@@ -752,14 +755,9 @@ class WP_Duotone_Gutenberg {
 	 * @param WP_Block_Type $block_type Block Type.
 	 */
 	public static function register_duotone_support( $block_type ) {
-		$has_duotone_support = false;
-		if ( $block_type instanceof WP_Block_Type ) {
-			// Previous `color.__experimentalDuotone` support flag is migrated
-			// to `filter.duotone` via `block_type_metadata_settings` filter.
-			$has_duotone_support = $block_type->supports['filter']['duotone'] ?? null;
-		}
-
-		if ( $has_duotone_support ) {
+		// Previous `color.__experimentalDuotone` support flag is migrated
+		// to `filter.duotone` via `block_type_metadata_settings` filter.
+		if ( block_has_support( $block_type, array( 'filter', 'duotone' ), null ) ) {
 			if ( ! $block_type->attributes ) {
 				$block_type->attributes = array();
 			}
@@ -777,12 +775,19 @@ class WP_Duotone_Gutenberg {
 	 * We only want to process this one time. On block render we'll access and output only the needed presets for that page.
 	 *
 	 * @since 6.3.0
+	 *
+	 * @return array An array of global styles presets, keyed on the filter ID.
 	 */
-	public static function set_global_styles_presets() {
+	private static function get_all_global_styles_presets() {
+		if ( isset( self::$global_styles_presets ) ) {
+			return self::$global_styles_presets;
+		}
+
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = $tree['color']['duotone'] ?? array();
+		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
 
+		self::$global_styles_presets = array();
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
 				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
@@ -790,18 +795,40 @@ class WP_Duotone_Gutenberg {
 				self::$global_styles_presets[ $filter_id ] = $preset;
 			}
 		}
+
+		return self::$global_styles_presets;
+	}
+
+	/**
+	 * Ensure all possible duotone presets are ready.
+	 * This function is deprecated, as it's no longer necessary to handle this manually.
+	 * It is kept to ensure external users of this method don't break.
+	 *
+	 * @since 6.3.0
+	 * @deprecated
+	 */
+	public static function set_global_styles_presets() {
+		self::get_all_global_styles_presets();
 	}
 
 	/**
 	 * Scrape all block names from global styles and store in self::$global_styles_block_names
 	 *
 	 * @since 6.3.0
+	 *
+	 * @return null|array<string, string> An array of global style block slugs, keyed on the block name.
 	 */
-	public static function set_global_style_block_names() {
+	private static function get_all_global_style_block_names() {
+		if ( isset( self::$global_styles_block_names ) ) {
+			return self::$global_styles_block_names;
+		}
+
 		// Get the per block settings from the theme.json.
 		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		$block_nodes = $tree->get_styles_block_nodes();
 		$theme_json  = $tree->get_raw_data();
+
+		self::$global_styles_block_names = array();
 
 		foreach ( $block_nodes as $block_node ) {
 			// This block definition doesn't include any duotone settings. Skip it.
@@ -828,6 +855,20 @@ class WP_Duotone_Gutenberg {
 				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
 			}
 		}
+
+		return self::$global_styles_block_names;
+	}
+
+	/**
+	 * Ensure all possible global style block names are ready.
+	 * This function is deprecated, as it's no longer necessary to handle this manually.
+	 * It is kept to ensure external users of this method don't break.
+	 *
+	 * @since 6.3.0
+	 * @deprecated
+	 */
+	public static function set_global_style_block_names() {
+		self::get_all_global_style_block_names();
 	}
 
 	/**
@@ -835,25 +876,28 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @since 6.3.0
 	 *
-	 * @param  string $block_content Rendered block content.
-	 * @param  array  $block         Block object.
-	 * @return string                Filtered block content.
+	 * @param  string   $block_content Rendered block content.
+	 * @param  array    $block         Block object.
+	 * @param  WP_Block $wp_block      The block instance.
+	 * @return string Filtered block content.
 	 */
-	public static function render_duotone_support( $block_content, $block ) {
-		if ( null === $block['blockName'] ) {
+	public static function render_duotone_support( $block_content, $block, $wp_block ) {
+		if ( empty( $block_content ) || ! $block['blockName'] ) {
+			return $block_content;
+		}
+		$duotone_selector = self::get_selector( $wp_block->block_type );
+
+		if ( ! $duotone_selector ) {
 			return $block_content;
 		}
 
-		$duotone_selector = self::get_selector( $block['blockName'] );
+		$global_styles_block_names = self::get_all_global_style_block_names();
 
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
-		$has_global_styles_duotone = array_key_exists( $block['blockName'], self::$global_styles_block_names );
+		$has_global_styles_duotone = array_key_exists( $block['blockName'], $global_styles_block_names );
 
-		if (
-			! $duotone_selector ||
-			( ! $has_duotone_attribute && ! $has_global_styles_duotone )
-		) {
+		if ( ! $has_duotone_attribute && ! $has_global_styles_duotone ) {
 			return $block_content;
 		}
 
@@ -898,7 +942,7 @@ class WP_Duotone_Gutenberg {
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
 		} elseif ( $has_global_styles_duotone ) {
-			$slug         = self::$global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
+			$slug         = $global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
 			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.
 			$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--blue-orange)'.
 
@@ -1017,14 +1061,15 @@ class WP_Duotone_Gutenberg {
 	 * @return array The editor settings with duotone SVGs and CSS custom properties.
 	 */
 	public static function add_editor_settings( $settings ) {
-		if ( ! empty( self::$global_styles_presets ) ) {
+		$global_styles_presets = self::get_all_global_styles_presets();
+		if ( ! empty( $global_styles_presets ) ) {
 			if ( ! isset( $settings['styles'] ) ) {
 				$settings['styles'] = array();
 			}
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'assets'         => self::get_svg_definitions( self::$global_styles_presets ),
+				'assets'         => self::get_svg_definitions( $global_styles_presets ),
 				// The 'svgs' type is new in 6.3 and requires the corresponding JS changes in the EditorStyles component to work.
 				'__unstableType' => 'svgs',
 				// These styles not generated by global styles, so this must be false or they will be stripped out in gutenberg_get_block_editor_settings.
@@ -1033,7 +1078,7 @@ class WP_Duotone_Gutenberg {
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'css'            => self::get_global_styles_presets( self::$global_styles_presets ),
+				'css'            => self::get_global_styles_presets( $global_styles_presets ),
 				// This must be set and must be something other than 'theme' or they will be stripped out in the post editor <Editor> component.
 				'__unstableType' => 'presets',
 				// These styles are no longer generated by global styles, so this must be false or they will be stripped out in gutenberg_get_block_editor_settings.

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -73,7 +73,9 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		 */
 		$wp_duotone                      = new WP_Duotone_Gutenberg();
 		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'block_css_declarations' );
-		$block_css_declarations_property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$block_css_declarations_property->setAccessible( true );
+		}
 		$previous_value = $block_css_declarations_property->getValue();
 		$block_css_declarations_property->setValue( $wp_duotone, array() );
 		WP_Duotone_Gutenberg::render_duotone_support( '', $block, $wp_block );
@@ -81,7 +83,9 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 
 		// Reset the property.
 		$block_css_declarations_property->setValue( $wp_duotone, $previous_value );
-		$block_css_declarations_property->setAccessible( false );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$block_css_declarations_property->setAccessible( false );
+		}
 
 		$this->assertNotEmpty( $actual );
 	}

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -20,9 +20,10 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '<figure class="wp-block-image size-full wp-duotone-blue-orange"><img src="/my-image.jpg" /></figure>';
-		$this->assertSame( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$this->assertSame( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 	public function test_gutenberg_render_duotone_support_css() {
@@ -30,9 +31,10 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'unset' ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-unset-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 	public function test_gutenberg_render_duotone_support_custom() {
@@ -40,9 +42,10 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => array( '#FFFFFF', '#000000' ) ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-ffffff-000000-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
+		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 


### PR DESCRIPTION
## What?
Currently, the Duotone metadata initialization runs on `wp_loaded`. This PR changes it to instead run the first time the metadata is needed, by implementing the approach in the Core changeset https://core.trac.wordpress.org/changeset/56226.

This PR replaces #74591.

## Why?
Per the Core change, regarding the Core `WP_Duotone`:

> [The existing] implementation caused a severe performance regression, as duotone styling data was loaded unnecessarily for requests that did not require such data, such as REST API calls or actions within the wp-admin interface.

As `WP_Duotone_Gutenberg` was implemented following the same approach, but was never updated, it kept the same performance issues. This PR updates its approach to match the one in Core.

## How?
As in the Core change, this PR refactors the `WP_Duotone_Gutenberg` class to lazily load the global styles and `theme.json` data, only when a block that supports duotone is encountered.

`render_duotone_support()` was changed to take a third parameter to reuse the existing `WP_Block_Type` object passed to the filter, to save it being looked up again.

The code has also got improved type checking, via the use of the util function `block_has_support`, and improved type documentation beyond the Core change.

Unlike in the Core change, the `set_global_styles_presets()` and `set_global_style_block_names()` functions are preserved, as they are public and may be in use by external code (albeit unlikely). They're now marked as deprecated to avoid new usage. Please let me know if you'd rather see them removed altogether, and I'll be happy to make the change.

## Testing Instructions
Smoke-test the Duotone feature and ensure that it continues to work correctly, by adding a Duotone filter to an image block and ensuring the page loads correctly, with the filter correctly applied.

Also ensure that the PHP unit tests work correctly, as they needed some small updates to match the changed function signature for `render_duotone_support()`.
