### PR TITLE
iAPI Router: Prevent router regions with `data-wp-key` from being recreated on navigation

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -13,6 +13,8 @@
 	<div
 		data-wp-interactive="router-regions"
 		data-wp-router-region="region-1"
+		data-wp-key="region-1"
+		data-wp-run="callbacks.nope"
 	>
 		<p
 			data-testid="region-1-text"

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -11,6 +11,7 @@
 <section>
 	<h2>Region 1</h2>
 	<div
+		data-testid="region-1"
 		data-wp-interactive="router-regions"
 		data-wp-router-region="region-1"
 	>
@@ -54,6 +55,7 @@
 <section>
 	<h2>Region 2</h2>
 	<div
+		data-testid="region-2"
 		data-wp-key="region-2"
 		data-wp-interactive="router-regions"
 		data-wp-router-region="region-2"

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -13,8 +13,6 @@
 	<div
 		data-wp-interactive="router-regions"
 		data-wp-router-region="region-1"
-		data-wp-key="region-1"
-		data-wp-run="callbacks.nope"
 	>
 		<p
 			data-testid="region-1-text"
@@ -56,8 +54,10 @@
 <section>
 	<h2>Region 2</h2>
 	<div
+		data-wp-key="region-2"
 		data-wp-interactive="router-regions"
 		data-wp-router-region="region-2"
+		data-wp-run="callbacks.nope"
 	>
 		<p
 			data-testid="region-2-text"
@@ -115,6 +115,7 @@
 	<!-- Router region inside data-wp-interactive -->
 	<div
 		data-testid="valid-inside-interactive"
+		data-wp-key="valid-inside-interactive"
 		data-wp-interactive="router-regions"
 		data-wp-router-region="valid-inside-interactive"
 		data-wp-context='{ "counter": { "value": 0 } }'
@@ -133,6 +134,7 @@
 		<!-- Router region inside data-wp-router-region -->
 		<div
 			data-testid="valid-inside-router-region"
+			data-wp-key="valid-inside-router-region"
 			data-wp-interactive="router-regions"
 			data-wp-router-region="valid-inside-router-region"
 			data-wp-context='{ "counter": { "value": 0 } }'
@@ -194,6 +196,7 @@
 			data-wp-interactive="router-regions"
 			data-wp-router-region='$region_data'
 			data-testid="$region_id"
+			data-wp-key="$region_id"
 			$has_directives
 		>
 			<div $context_data>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
@@ -64,5 +64,8 @@ const { state } = store( 'router-regions', {
 		init() {
 			state.initCount += 1;
 		},
+		nope() {
+			// This function does nothing.
+		},
 	},
 } );

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent router regions with data-wp-key from being recreated on navigation. ([#74750](https://github.com/WordPress/gutenberg/pull/74750))
+
 ## 2.38.0 (2026-01-16)
 
 ## 2.36.0 (2025-11-26)

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -23,7 +23,7 @@ const {
 	populateServerData,
 	batch,
 	routerRegions,
-	cloneElement,
+	h: createElement,
 	navigationSignal,
 } = privateApis(
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
@@ -117,7 +117,7 @@ const cloneRouterRegionContent = ( vdom: any ) => {
 			: allPriorityLevels;
 
 	return priorityLevels.length > 0
-		? cloneElement( vdom, {
+		? createElement( vdom.type, {
 				...vdom.props,
 				priorityLevels,
 		  } )

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -491,4 +491,95 @@ test.describe( 'Router regions', () => {
 		await expect( region7 ).toBeVisible();
 		await expect( region8 ).toBeVisible();
 	} );
+
+	test( 'with `data-wp-key` and other directives should not be recreated on first navigation', async ( {
+		page,
+	} ) => {
+		const region2 = page.getByTestId( 'region-2-ssr' ).locator( '..' );
+		const validInsideInteractive = page.getByTestId(
+			'valid-inside-interactive'
+		);
+		const validInsideRouterRegion = page.getByTestId(
+			'valid-inside-router-region'
+		);
+
+		// Add tags to know whether the region elements were replaced.
+		await region2.evaluate( ( el ) => {
+			el.dataset.tag = 'region-2';
+		} );
+		await validInsideInteractive.evaluate( ( el ) => {
+			el.dataset.tag = 'valid-inside-interactive';
+		} );
+		await validInsideRouterRegion.evaluate( ( el ) => {
+			el.dataset.tag = 'valid-inside-router-region';
+		} );
+
+		// Navigate to the next page.
+		await page.getByTestId( 'next' ).click();
+		await expect( page ).toHaveTitle(
+			'router regions – page 2 – gutenberg'
+		);
+
+		// Regions with `data-wp-key` and other directives should not be recreated.
+		await expect( region2 ).toHaveAttribute( 'data-tag', 'region-2' );
+		await expect( validInsideInteractive ).toHaveAttribute(
+			'data-tag',
+			'valid-inside-interactive'
+		);
+		await expect( validInsideRouterRegion ).toHaveAttribute(
+			'data-tag',
+			'valid-inside-router-region'
+		);
+	} );
+
+	test( 'with `data-wp-key`, `attachTo`, and other directives should not be recreated on first navigation', async ( {
+		page,
+		interactivityUtils: utils,
+	} ) => {
+		await page.goto(
+			utils.getLink( 'router regions - page 1 - attachTo' )
+		);
+
+		const bodyLocator = page.locator( 'body' );
+		const regionsLocator = page.locator( '#regions-with-attach-to' );
+
+		const region3 = bodyLocator.getByTestId( 'region3' );
+		const region4 = regionsLocator.getByTestId( 'region4' );
+		const region5 = bodyLocator.getByTestId( 'region5' );
+		const region6 = regionsLocator.getByTestId( 'region6' );
+
+		const regions: Record< string, Locator > = {
+			region3,
+			region4,
+			region5,
+			region6,
+		};
+
+		// The text of this element is used to check a navigation is completed.
+		const region1Ssr = page.getByTestId( 'region-1-ssr' );
+
+		await expect( region1Ssr ).toHaveText( 'content from page 1' );
+
+		// Navigate to "Page attachTo 1".
+		await page.getByTestId( 'next' ).click();
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo1' );
+
+		// Add tags to know whether the region elements were replaced.
+		for ( const regionId in regions ) {
+			const region = regions[ regionId ];
+			await region.evaluate( ( el, id ) => {
+				el.dataset.tag = id;
+			}, regionId );
+		}
+
+		// Navigate to "Page attachTo 2".
+		await page.getByTestId( 'next' ).click();
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo2' );
+
+		// Regions with `data-wp-key` and other directives should not be recreated.
+		for ( const regionId in regions ) {
+			const region = regions[ regionId ];
+			await expect( region ).toHaveAttribute( 'data-tag', regionId );
+		}
+	} );
 } );

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -127,29 +127,16 @@ test.describe( 'Router regions', () => {
 
 		await expect( counter ).toHaveText( '0' );
 
-		// Adds a tag to know whether the counter element was replaced.
-		await counter.evaluate( ( ref ) => {
-			if ( ref instanceof HTMLElement ) {
-				ref.dataset.tag = 'state-counter';
-			}
-		} );
-
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '3' );
-
-		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
 
 		await page.getByTestId( 'next' ).click();
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '6' );
 
-		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
-
 		await page.getByTestId( 'back' ).click();
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '9' );
-
-		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
 	} );
 
 	test( 'should preserve context across pages', async ( { page } ) => {
@@ -492,10 +479,34 @@ test.describe( 'Router regions', () => {
 		await expect( region8 ).toBeVisible();
 	} );
 
-	test( 'with `data-wp-key` and other directives should not be recreated on first navigation', async ( {
+	test( 'should be preserved on first navigation without `data-wp-key`', async ( {
 		page,
 	} ) => {
-		const region2 = page.getByTestId( 'region-2-ssr' ).locator( '..' );
+		const region1 = page.getByTestId( 'region-1' );
+		const region1Text = page.getByTestId( 'region-1-text' );
+		await expect( region1Text ).toHaveText( 'hydrated' );
+
+		// Adds a tag to know whether the counter element was replaced.
+		await region1.evaluate( ( ref ) => {
+			if ( ref instanceof HTMLElement ) {
+				ref.dataset.tag = 'region-1';
+			}
+		} );
+
+		// Navigate to the next page.
+		await page.getByTestId( 'next' ).click();
+		await expect( page ).toHaveTitle(
+			'router regions – page 2 – gutenberg'
+		);
+
+		// The region element should retain the same attributes when it doesn't change.
+		await expect( region1 ).toHaveAttribute( 'data-tag', 'region-1' );
+	} );
+
+	test( 'should be preserved on first navigation with `data-wp-key` and other directives ', async ( {
+		page,
+	} ) => {
+		const region2 = page.getByTestId( 'region-2' );
 		const validInsideInteractive = page.getByTestId(
 			'valid-inside-interactive'
 		);
@@ -532,7 +543,7 @@ test.describe( 'Router regions', () => {
 		);
 	} );
 
-	test( 'with `data-wp-key`, `attachTo`, and other directives should not be recreated on first navigation', async ( {
+	test( 'should be preserved on first navigation with `data-wp-key` and `attachTo`', async ( {
 		page,
 		interactivityUtils: utils,
 	} ) => {

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -124,18 +124,32 @@ test.describe( 'Router regions', () => {
 
 	test( 'should preserve state across pages', async ( { page } ) => {
 		const counter = page.getByTestId( 'state-counter' );
+
 		await expect( counter ).toHaveText( '0' );
+
+		// Adds a tag to know whether the counter element was replaced.
+		await counter.evaluate( ( ref ) => {
+			if ( ref instanceof HTMLElement ) {
+				ref.dataset.tag = 'state-counter';
+			}
+		} );
 
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '3' );
+
+		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
 
 		await page.getByTestId( 'next' ).click();
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '6' );
 
+		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
+
 		await page.getByTestId( 'back' ).click();
 		await counter.click( { clickCount: 3, delay: 50 } );
 		await expect( counter ).toHaveText( '9' );
+
+		await expect( counter ).toHaveAttribute( 'data-tag', 'state-counter' );
 	} );
 
 	test( 'should preserve context across pages', async ( { page } ) => {


### PR DESCRIPTION
## What?

Fixes a bug with [router regions](https://github.com/WordPress/gutenberg/blob/fix/iapi-router-region-with-key-on-navigate/packages/interactivity-router/README.md#data-wp-router-region) that arises on the first navigation. If these router regions have a `data-wp-key` directive along with other directives, the router region element and all its descendants are removed from the DOM and re-added, even when the content remains the same.

## Why?

The bug affects all router regions being used in core blocks ([Query](https://github.com/WordPress/gutenberg/blob/4860c0a7acdffe0d22cb095ecc300ebd9782a54b/packages/block-library/src/query/index.php#L32-L36) and [Image](https://github.com/WordPress/gutenberg/blob/4860c0a7acdffe0d22cb095ecc300ebd9782a54b/packages/block-library/src/image/index.php#L328-L329) blocks), as they all use the `data-wp-key` directive. Other third-party blocks could probably be affected as well.

## How?

The issue occurs when the router regions are processed in the `@wordpress/interactivity-router`'s internal `renderPage()` function, specifically in the [`cloneRouterRegionContent()`](https://github.com/WordPress/gutenberg/blob/4860c0a7acdffe0d22cb095ecc300ebd9782a54b/packages/interactivity-router/src/index.ts#L106-L125) function. That function kind of recreates what the internal `Directives` component is doing [here](https://github.com/WordPress/gutenberg/blob/4860c0a7acdffe0d22cb095ecc300ebd9782a54b/packages/interactivity/src/hooks.tsx#L330-L340) to support different priority levels for directives.

The previous implementation used `cloneElement()`, which propagated the `key` from the parent `Directives` element to the newly cloned element. That caused the router region to be treated as a different element from the one initially rendered, without the key.

The bug fix simply replaces `clonedElement()` with `h()` (renamed as `createElement()` for clarification), so the key is not propagated. This is what the `Directives` component already does. 

## Testing Instructions

1. Configure a Query block so it is paginated in the frontend.
2. Under "Advanced", ensure "Reload Full Page" is disabled.
3. Visit the homepage (or where the Query block is rendered).
4. Open the browser dev tools.
5. In the "Elements" view, select the Query block element.
6. Save it to a global variable.
7. Click on "Next page".
8. Ensure navigation worked.
9. Compare the element saved in the global variable with the current Query block element.
10. In this PR's branch, they should be the same. In `trunk`, this check should fail.
