### PR TITLE
Preserve whitespace when unwrapping empty phrasing elements

### DIFF
--- a/packages/dom/src/dom/clean-node-list.js
+++ b/packages/dom/src/dom/clean-node-list.js
@@ -52,9 +52,14 @@ export default function cleanNodeList( nodeList, doc, schema, inline ) {
 					} = schema[ tag ];
 
 					// If the node is empty and it's supposed to have children,
-					// remove the node.
+					// remove the node. For phrasing content, unwrap instead to
+					// preserve any whitespace content (e.g. <b> </b> between words).
 					if ( children && ! allowEmpty && isEmpty( node ) ) {
-						remove( node );
+						if ( isPhrasingContent( node ) ) {
+							unwrap( node );
+						} else {
+							remove( node );
+						}
 						return;
 					}
 

--- a/packages/dom/src/dom/test/clean-node-list.js
+++ b/packages/dom/src/dom/test/clean-node-list.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import removeInvalidHTML from '../remove-invalid-html';
+
+describe( 'cleanNodeList', () => {
+	it( 'should preserve whitespace when unwrapping empty phrasing elements', () => {
+		const schema = {
+			p: { children: { '#text': {} } },
+		};
+		// Whitespace inside <b> should be preserved when <b> is unwrapped.
+		const input = '<p>some text<b> </b>more text</p>';
+		const output = '<p>some text more text</p>';
+		expect( removeInvalidHTML( input, schema, false ) ).toEqual( output );
+	} );
+
+	it( 'should preserve whitespace in various phrasing elements', () => {
+		const schema = {
+			p: { children: { '#text': {} } },
+		};
+		// Test with different phrasing elements.
+		expect(
+			removeInvalidHTML(
+				'<p>hello<strong> </strong>world</p>',
+				schema,
+				false
+			)
+		).toEqual( '<p>hello world</p>' );
+		expect(
+			removeInvalidHTML( '<p>hello<em> </em>world</p>', schema, false )
+		).toEqual( '<p>hello world</p>' );
+		expect(
+			removeInvalidHTML( '<p>hello<sup> </sup>world</p>', schema, false )
+		).toEqual( '<p>hello world</p>' );
+	} );
+
+	it( 'should remove truly empty elements without whitespace', () => {
+		const schema = {
+			p: { children: { '#text': {} } },
+		};
+		const input = '<p>some text<b></b>more text</p>';
+		const output = '<p>some textmore text</p>';
+		expect( removeInvalidHTML( input, schema, false ) ).toEqual( output );
+	} );
+
+	it( 'should remove empty block elements entirely (not unwrap)', () => {
+		const schema = {
+			figure: {
+				children: {
+					img: {},
+				},
+			},
+		};
+		// Block elements like figure should be removed, not unwrapped.
+		const input = '<figure> </figure>';
+		const output = '';
+		expect( removeInvalidHTML( input, schema, false ) ).toEqual( output );
+	} );
+} );


### PR DESCRIPTION
Fixes [#74740](https://github.com/WordPress/gutenberg/issues/74740)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
 It adds tests and fixes whitespace preservation in phrasing content elements during paste operations.

<!-- In a few words, what is the PR actually doing? -->

## Why?
When pasting content from MS Word with formatted whitespace (e.g., <b> </b>), the whitespace was being lost, causing words to merge together. This happened because empty phrasing elements were being removed entirely instead of being unwrapped to preserve their whitespace content.

## How?
Modified `clean-node-list.js` to differentiate between element types:

- Phrasing content elements (<b>, <strong>, <em>) are unwrapped to preserve whitespace
- Block elements (<figure>, <div>) are still removed entirely
- Added 4 regression tests to verify the behavior

## Testing Instructions

- Copy text with formatted whitespace from MS Word (select only a space and apply bold formatting)
- Paste into Gutenberg editor
- Verify the space is preserved between words
- Run npm run test:unit -- packages/dom/ to verify all tests pass

 
## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/35b5740f-0e74-4a40-b922-53330869d8bc



