### PR TITLE
Pattern Editing: Prevent double-click editing for template parts and synced patterns

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -31,6 +32,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 		hasMultiSelection,
 		isSectionBlock,
 		editedContentOnlySection,
+		getBlock,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		insertAfterBlock,
@@ -294,12 +296,22 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 */
 			function onDoubleClick( event ) {
 				const isSection = isSectionBlock( clientId );
+				const block = getBlock( clientId );
+				const isSyncedPattern = isReusableBlock( block );
+				const isTemplatePartBlock = isTemplatePart( block );
 				const isAlreadyEditing = editedContentOnlySection === clientId;
 
-				if ( isSection && ! isAlreadyEditing ) {
-					event.preventDefault();
-					editContentOnlySection( clientId );
+				if (
+					! isSection ||
+					isAlreadyEditing ||
+					isSyncedPattern ||
+					isTemplatePartBlock
+				) {
+					return;
 				}
+
+				event.preventDefault();
+				editContentOnlySection( clientId );
 			}
 
 			// Only add double-click listener if experimental flag is enabled
@@ -319,6 +331,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			clientId,
 			isSelected,
 			getBlockRootClientId,
+			getBlock,
+			isReusableBlock,
+			isTemplatePart,
 			insertAfterBlock,
 			removeBlock,
 			isZoomOut,


### PR DESCRIPTION
## What?
I noticed that #73736 updated the 'Edit section' button so that clicking it from a template part or synced pattern navigates to the isolated editor instead of the inline editing.

Users can also double-click to edit a template part or synced pattern, and it doesn't look like that is still triggering the inline editing.

This PR updates the double-click so that it doesn't trigger inline editing for template parts or synced patterns.

A thought is that maybe double click should go to the isolated editor? That is possible. I seem to recall there was a reason for not doing that. Template Parts and Synced Patterns have an 'overlay' that means two clicks are needed to access an inner block, and if a user does that too quickly it triggers a navigation. I tested and found it doesn't work so well. For now I'm leaving that out.

## How?
Adds an early return based on the block type.

## Testing Instructions
#### Synced Pattern
1. Insert a synced pattern into the editor
2. Double click it.

In this PR: nothing happens
In trunk: It initiates inline editing of a block

#### Template part
1. Open a template like 'Blog Home'
4. Double click on a template part block like the header

In this PR: nothing happens
In trunk: It initiates inline editing of a block