### PR TITLE
Remove the apiFetch named export

### DIFF
--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -157,7 +157,7 @@ export interface ApiFetch {
  * @param options The options for the fetch.
  * @return A promise representing the request processed via the registered middlewares.
  */
-export const apiFetch: ApiFetch = ( options ) => {
+const apiFetch: ApiFetch = ( options ) => {
 	// creates a nested function chain that calls all middlewares and finally the `fetchHandler`,
 	// converting `middlewares = [ m1, m2, m3 ]` into:
 	// ```

--- a/packages/api-fetch/src/test/exports.test.ts
+++ b/packages/api-fetch/src/test/exports.test.ts
@@ -1,11 +1,7 @@
-import apiFetch, { apiFetch as namedApiFetch } from '../index';
+import apiFetch from '..';
 
 describe( 'apiFetch exports', () => {
 	it( 'default export is callable', () => {
 		expect( typeof apiFetch ).toBe( 'function' );
-	} );
-
-	it( 'named export is callable', () => {
-		expect( typeof namedApiFetch ).toBe( 'function' );
 	} );
 } );


### PR DESCRIPTION
This reverts #74576 because the named `apiFetch` export doesn't really work at runtime. See the https://github.com/WordPress/gutenberg/pull/74576#issuecomment-3759660909 comment for details.

I'm keeping the rename of the `apiFetch` interface to `ApiFetch`.

We'll need to fix #59087 differently: by providing correct type definitions for both ESM and CJS modules in `build-types`.