### PR TITLE
Add <mark> tag feature parity on Frontend and Editor

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -375,6 +375,11 @@ function filterRange( node, range, filter ) {
  * browser will litter the content with non breaking spaces, among other issues.
  * See packages/rich-text/src/component/use-default-style.js.
  *
+ * IMPORTANT: This function now correctly preserves whitespace at inline element
+ * boundaries (like <mark>, <strong>, <em>, etc.) to fix issue #74628.
+ * Only the root element's leading/trailing whitespace is trimmed, not the
+ * whitespace at the boundaries of inline child elements.
+ *
  * @see
  * https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space
  *
@@ -390,17 +395,35 @@ function collapseWhiteSpace( element, isRoot = true ) {
 		if ( node.nodeType === node.TEXT_NODE ) {
 			let newNodeValue = node.nodeValue;
 
+			// Replace newlines, tabs, carriage returns, and form feeds with spaces.
 			if ( /[\n\t\r\f]/.test( newNodeValue ) ) {
 				newNodeValue = newNodeValue.replace( /[\n\t\r\f]+/g, ' ' );
 			}
 
+			// Collapse multiple consecutive spaces to a single space.
 			if ( newNodeValue.indexOf( '  ' ) !== -1 ) {
 				newNodeValue = newNodeValue.replace( / {2,}/g, ' ' );
 			}
 
-			if ( i === 0 && newNodeValue.startsWith( ' ' ) ) {
+			// FIX FOR ISSUE #74628:
+			// Only trim leading whitespace if this is the root element AND
+			// this is the first text node. Previously, this was trimming
+			// leading spaces from the first child of ANY element, which
+			// incorrectly removed spaces at the start of inline elements
+			// like <mark>, <strong>, <em>, etc.
+			//
+			// Example that was broken:
+			//   "outer text<mark> inner text</mark>"
+			// Was incorrectly rendered as:
+			//   "outer text<mark>inner text</mark>"
+			// Because the space at the start of " inner text" was trimmed.
+			if ( isRoot && i === 0 && newNodeValue.startsWith( ' ' ) ) {
 				newNodeValue = newNodeValue.slice( 1 );
-			} else if (
+			}
+
+			// Only trim trailing whitespace at the root level AND
+			// only for the last text node.
+			if (
 				isRoot &&
 				i === nodes.length - 1 &&
 				newNodeValue.endsWith( ' ' )
@@ -410,6 +433,8 @@ function collapseWhiteSpace( element, isRoot = true ) {
 
 			node.nodeValue = newNodeValue;
 		} else if ( node.nodeType === node.ELEMENT_NODE ) {
+			// Pass isRoot=false for child elements so their boundary
+			// whitespace is preserved.
 			node.replaceWith( collapseWhiteSpace( node, false ) );
 		}
 	} );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -375,11 +375,6 @@ function filterRange( node, range, filter ) {
  * browser will litter the content with non breaking spaces, among other issues.
  * See packages/rich-text/src/component/use-default-style.js.
  *
- * IMPORTANT: This function now correctly preserves whitespace at inline element
- * boundaries (like <mark>, <strong>, <em>, etc.) to fix issue #74628.
- * Only the root element's leading/trailing whitespace is trimmed, not the
- * whitespace at the boundaries of inline child elements.
- *
  * @see
  * https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space
  *
@@ -405,24 +400,11 @@ function collapseWhiteSpace( element, isRoot = true ) {
 				newNodeValue = newNodeValue.replace( / {2,}/g, ' ' );
 			}
 
-			// FIX FOR ISSUE #74628:
-			// Only trim leading whitespace if this is the root element AND
-			// this is the first text node. Previously, this was trimming
-			// leading spaces from the first child of ANY element, which
-			// incorrectly removed spaces at the start of inline elements
-			// like <mark>, <strong>, <em>, etc.
-			//
-			// Example that was broken:
-			//   "outer text<mark> inner text</mark>"
-			// Was incorrectly rendered as:
-			//   "outer text<mark>inner text</mark>"
-			// Because the space at the start of " inner text" was trimmed.
 			if ( isRoot && i === 0 && newNodeValue.startsWith( ' ' ) ) {
 				newNodeValue = newNodeValue.slice( 1 );
 			}
 
-			// Only trim trailing whitespace at the root level AND
-			// only for the last text node.
+			// Only trim trailing whitespace at the root level
 			if (
 				isRoot &&
 				i === nodes.length - 1 &&
@@ -433,8 +415,7 @@ function collapseWhiteSpace( element, isRoot = true ) {
 
 			node.nodeValue = newNodeValue;
 		} else if ( node.nodeType === node.ELEMENT_NODE ) {
-			// Pass isRoot=false for child elements so their boundary
-			// whitespace is preserved.
+			// Pass isRoot=false for child elements so their boundary so whitespace is preserved.
 			node.replaceWith( collapseWhiteSpace( node, false ) );
 		}
 	} );


### PR DESCRIPTION
## What?
Ref https://github.com/WordPress/gutenberg/issues/74628

## Why?
The <mark> tag behaves inconsistently on editor and frontend where the space is trimmed in editor but not on frontend.

## How?
Add logic to keep space instead of trimming it.

## Testing Instructions
1. Add a paragraph block with some text.
2. Use the highlight tool for some text which includes the single space.
3. Save the post and reload the page..