### PR TITLE
Update/create block interactive template

### DIFF
--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -19,8 +19,8 @@ module.exports = {
 		render: 'file:./render.php',
 		example: {},
 		customScripts: {
-			build: 'wp-scripts build --experimental-modules',
-			start: 'wp-scripts start --experimental-modules',
+			build: 'wp-scripts build --experimental-modules --blocks-manifest',
+			start: 'wp-scripts start --experimental-modules --blocks-manifest',
 		},
 	},
 	variants: {

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -46,6 +46,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+	if ( function_exists( 'wp_register_block_types_from_metadata_collection' ) ) {
+		wp_register_block_types_from_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
+	} else {
+		register_block_type_from_metadata( __DIR__ . '/build' );
+	}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -48,8 +48,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 	if ( function_exists( 'wp_register_block_types_from_metadata_collection' ) ) {
 		wp_register_block_types_from_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
-	} else {
-		register_block_type_from_metadata( __DIR__ . '/build' );
 	}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/74701

<!-- In a few words, what is the PR actually doing? -->
Update the interactive block template to use the new `wp_register_block_types_from_metadata_collection`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improvement to developer experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Following similar to https://github.com/WordPress/gutenberg/blob/trunk/packages/create-block/lib/templates/plugin/%24slug.php.mustache `create-block` update to `wp_register_block_types_from_metadata_collection`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
```bash
cd packages/create-block
node index.js --template ../create-block-interactive-template/ 
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
