### PR TITLE
Navigation: Don't use a nav tag for navigation blocks inside overlays

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -453,8 +453,12 @@ function Navigation( {
 
 	const navRef = useRef();
 
-	// The standard HTML5 tag for the block wrapper.
-	const TagName = 'nav';
+	// Detect if we're editing inside an overlay template part.
+	const isWithinOverlay = useSelect( () => isWithinNavigationOverlay(), [] );
+
+	// Use div wrapper if this navigation block is within an overlay template part.
+	// Otherwise, use nav as the standard HTML5 tag.
+	const TagName = isWithinOverlay ? 'div' : 'nav';
 
 	// "placeholder" shown if:
 	// - there is no ref attribute pointing to a Navigation Post.
@@ -490,9 +494,6 @@ function Navigation( {
 			),
 		[ clientId ]
 	);
-
-	// Check if this navigation block is inside an overlay template part.
-	const isWithinOverlay = useSelect( () => isWithinNavigationOverlay(), [] );
 
 	// Force overlayMenu to 'never' if within an overlay template part
 	// to prevent overlays within overlays.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -968,8 +968,13 @@ class WP_Navigation_Block_Renderer {
 
 		static::handle_view_script_module_loading( $attributes, $block, $inner_blocks );
 
+		// Use div wrapper if this navigation block is within an overlay template part.
+		$is_within_overlay = $attributes['_isWithinOverlayTemplatePart'] ?? false;
+		$tag_name          = $is_within_overlay ? 'div' : 'nav';
+
 		return sprintf(
-			'<nav %1$s>%2$s</nav>',
+			'<%1$s %2$s>%3$s</%1$s>',
+			$tag_name,
 			static::get_nav_attributes( $attributes, $inner_blocks ),
 			static::get_inner_block_markup( $attributes, $inner_blocks )
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #74583

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For accessibility reasons we shouldn't have nested navigation blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Detect whether the block is inside the navigation overlay and if it is, use a `div` tag, not a `nav` tag.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the navigation overlay experiment
2. Set a navigation block to use a custom overlay and add a navigation block to the overlay
3. Open the overlay in the frontend and check that the navigation block in the overlay doesn't use a nav element

