### PR TITLE
Handle deleted navigation overlays

### DIFF
--- a/packages/block-library/src/navigation/edit/deleted-overlay-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-overlay-warning.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { Notice, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Warning displayed when a selected overlay template part has been deleted.
+ *
+ * @param {Object}   props            Component props.
+ * @param {Function} props.onClear    Callback to clear the overlay selection.
+ * @param {Function} props.onCreate   Callback to create a new overlay.
+ * @param {boolean}  props.isCreating Whether a new overlay is being created.
+ * @return {JSX.Element} The deleted overlay warning component.
+ */
+function DeletedOverlayWarning( { onClear, onCreate, isCreating = false } ) {
+	const message = createInterpolateElement(
+		__(
+			'The selected overlay template part is missing or has been deleted. <clearButton>Clear selection</clearButton> or <createButton>create a new overlay</createButton>.'
+		),
+		{
+			clearButton: (
+				<Button
+					__next40pxDefaultSize
+					onClick={ onClear }
+					variant="link"
+					disabled={ isCreating }
+					accessibleWhenDisabled
+				/>
+			),
+			createButton: (
+				<Button
+					__next40pxDefaultSize
+					onClick={ onCreate }
+					variant="link"
+					disabled={ isCreating }
+					accessibleWhenDisabled
+					isBusy={ isCreating }
+				/>
+			),
+		}
+	);
+
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			className="wp-block-navigation__deleted-overlay-warning"
+		>
+			{ message }
+		</Notice>
+	);
+}
+
+export default DeletedOverlayWarning;

--- a/packages/block-library/src/navigation/edit/deleted-overlay-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-overlay-warning.js
@@ -17,7 +17,7 @@ import { createInterpolateElement } from '@wordpress/element';
 function DeletedOverlayWarning( { onClear, onCreate, isCreating = false } ) {
 	const message = createInterpolateElement(
 		__(
-			'The selected overlay template part is missing or has been deleted. <clearButton>Clear selection</clearButton> or <createButton>create a new overlay</createButton>.'
+			'The selected overlay template part is missing or has been deleted. <clearButton>Reset to default overlay</clearButton> or <createButton>create a new overlay</createButton>.'
 		),
 		{
 			clearButton: (

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -716,3 +716,7 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 		opacity: 0.5;
 	}
 }
+
+.wp-block-navigation__deleted-overlay-warning {
+	margin-top: $grid-unit-15;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74586

Adds a warning message when an overlay template part is deleted.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If users delete overlay template parts we need to warn them in the associated navigation block, so they are aware of why the block has changed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Add a warning message to the component.
2. Fallback to the default overlay in the frontend.

## Testing Instructions
1. Enable the navigation overlay experiment
2. Add a custom overlay to a navigation block
3. Open the pattern editor screen and delete the navigation you just created
4. Go back to the navigation block and confirm that you see a warning message beneath the overlay selection telling you that it's been deleted

## Screenshots or screencast <!-- if applicable -->
<img width="1243" height="609" alt="Screenshot 2026-01-20 at 12 41 57" src="https://github.com/user-attachments/assets/c5472ef7-002c-4973-994a-83d3c2857a41" />
