### PR TITLE
Fix: can't disable textColumns UI

### DIFF
--- a/backport-changelog/7.0/10756.md
+++ b/backport-changelog/7.0/10756.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10756
 
 * https://github.com/WordPress/gutenberg/pull/74656
+* https://github.com/WordPress/gutenberg/pull/74767

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -482,6 +482,7 @@ class WP_Theme_JSON_Gutenberg {
 			'letterSpacing'    => null,
 			'lineHeight'       => null,
 			'textAlign'        => null,
+			'textColumns'      => null,
 			'textDecoration'   => null,
 			'textTransform'    => null,
 			'writingMode'      => null,


### PR DESCRIPTION
Follow-up to #74656

## What?

This PR fixes the problem that the textColumn UI is unexpectedlly enabled even thought the `settings.typography.textColumn` is false.

## Why?

See https://github.com/WordPress/gutenberg/pull/74656#discussion_r2706558087


## Testing Instructions

- Activate Emptytheme and update `theme.json` with the following code:
  ```json
  {
  	"version": 3,
  	"settings": {
  		"appearanceTools": true,
  		"layout": {
  			"contentSize": "840px",
  			"wideSize": "1100px"
  		},
  		"typography": {
  			"textColumns": false
  		}
  	}
  }
  ```
- Open a post and insert a Paragraph block
- Open the Typography options dropdown
- Confirm that there is no ”Columns” setting

