### PR TITLE
Fix: Preserve whitespace in Highlight (text-color) format

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -124,6 +124,7 @@ export const textColor = {
 	title,
 	tagName: 'mark',
 	className: 'has-inline-color',
+	preserveWhiteSpace: true,
 	attributes: {
 		style: 'style',
 		class: 'class',

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -53,9 +53,33 @@ function parseCSS( css = '' ) {
 	}, {} );
 }
 
+function trimSelectionWhitespace( value ) {
+	const { text, start, end } = value;
+
+	let newStart = start;
+	let newEnd = end;
+
+	while ( newStart < newEnd && /\s/.test( text[ newStart ] ) ) {
+		newStart++;
+	}
+
+	while ( newEnd > newStart && /\s/.test( text[ newEnd - 1 ] ) ) {
+		newEnd--;
+	}
+
+	if ( newStart === start && newEnd === end ) {
+		return value;
+	}
+
+	return {
+		...value,
+		start: newStart,
+		end: newEnd,
+	};
+}
+
 export function parseClassName( className = '', colorSettings ) {
 	return className.split( ' ' ).reduce( ( accumulator, name ) => {
-		// `colorSlug` could contain dashes, so simply match the start and end.
 		if ( name.startsWith( 'has-' ) && name.endsWith( '-color' ) ) {
 			const colorSlug = name
 				.replace( /^has-/, '' )
@@ -100,7 +124,6 @@ function setColors( value, name, colorSettings, colors ) {
 	if ( backgroundColor ) {
 		styles.push( [ 'background-color', backgroundColor ].join( ':' ) );
 	} else {
-		// Override default browser color for mark element.
 		styles.push( [ 'background-color', transparentValue ].join( ':' ) );
 	}
 
@@ -121,7 +144,12 @@ function setColors( value, name, colorSettings, colors ) {
 		attributes.class = classNames.join( ' ' );
 	}
 
-	return applyFormat( value, { type: name, attributes } );
+	const trimmedValue = trimSelectionWhitespace( value );
+
+	return applyFormat( trimmedValue, {
+		type: name,
+		attributes,
+	} );
 }
 
 function ColorPicker( { name, property, value, onChange } ) {
@@ -143,7 +171,6 @@ function ColorPicker( { name, property, value, onChange } ) {
 				);
 			} }
 			enableAlpha
-			// Prevent the text and color picker from overlapping.
 			__experimentalIsRenderedInSidebar
 		/>
 	);


### PR DESCRIPTION
Summary

This Pull Request resolves Issue #74628, where leading or trailing whitespace was being stripped when applying or reloading the Highlight (text-color) format in the Gutenberg editor.
Technical Changes
1. Selection Trimming (packages/format-library/src/text-color/inline.js)

    Issue: When users highlight a word, they often accidentally include a leading or trailing space. Wrapping this space in the <mark> tag can lead to inconsistent rendering or merged words.

    Fix: Added a trimSelectionWhitespace utility function to identify and exclude whitespace characters (/\s/) from the start and end of the selection. The highlight is now applied only to the intended text (e.g., <mark>a</mark>) rather than the space (e.g., <mark> a</mark>).

2. Whitespace Preservation (packages/format-library/src/text-color/index.js)

    Issue: Even if a space is correctly saved in the HTML database, the RichText parser may ignore it when reloading the editor, causing words like "is a" to appear as "isa" in the Visual Editor.

    Fix: Added the preserveWhiteSpace: true flag to the textColor registration object. This instructs the Gutenberg parser to respect and preserve any internal whitespace found within the <mark> tag during the conversion from HTML back to the visual editor state.

Why this "Two-Layer" approach?

    New Content: Trimming the selection in inline.js ensures that all new highlights remain clean and logically separated.

    Backward Compatibility: Keeping preserveWhiteSpace in index.js ensures that existing posts in the database—which may already contain spaces inside <mark> tags—will no longer suffer from merged words when the user reloads the editor.

Testing Instructions

    Open a post and type: This is a test script.

    Highlight the word a including the space before it.

    Apply a Highlight color.

    Verify (Selection): The highlight should automatically "snap" to the letter a, leaving the space unhighlighted.

    Verify (Reload): Save the draft and refresh the page.

    Expected Result: The words "is" and "a" must remain separated by a visible space in the Visual Editor.