### PR TITLE
Navigation Overlay: Add sidebar preview

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -300,7 +300,14 @@ function Navigation( {
 	);
 
 	const recursionId = `navigationMenu/${ ref }`;
-	const hasAlreadyRendered = useHasRecursion( recursionId );
+	const recursionDetected = useHasRecursion( recursionId );
+
+	// Skip recursion check when in preview mode.
+	const isPreviewMode = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings.isPreviewMode;
+	}, [] );
+	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;
 
 	const blockEditingMode = useBlockEditingMode();
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -302,27 +302,23 @@ function Navigation( {
 	const recursionId = `navigationMenu/${ ref }`;
 
 	// Skip recursion check when in preview mode.
-	const isPreviewMode = useSelect( ( select ) => {
-		const settings = select( blockEditorStore ).getSettings();
-		return settings.isPreviewMode;
-	}, [] );
 	const recursionDetected = useHasRecursion( recursionId );
+	const { isPreviewMode, onNavigateToEntityRecord, currentTheme } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const settings = getSettings();
+			return {
+				isPreviewMode: settings.isPreviewMode,
+				onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
+				// Needed to construct the template part ID for the overlay preview.
+				currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
+			};
+		},
+		[]
+	);
 	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;
 
 	const blockEditingMode = useBlockEditingMode();
-
-	const { onNavigateToEntityRecord } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return {
-			onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
-		};
-	}, [] );
-
-	const currentTheme = useSelect(
-		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
-		[]
-	);
 
 	const isOverlayExperimentEnabled =
 		typeof window !== 'undefined' &&

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -300,13 +300,13 @@ function Navigation( {
 	);
 
 	const recursionId = `navigationMenu/${ ref }`;
-	const recursionDetected = useHasRecursion( recursionId );
 
 	// Skip recursion check when in preview mode.
 	const isPreviewMode = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return settings.isPreviewMode;
 	}, [] );
+	const recursionDetected = useHasRecursion( recursionId );
 	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;
 
 	const blockEditingMode = useBlockEditingMode();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -312,6 +312,11 @@ function Navigation( {
 		};
 	}, [] );
 
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+
 	const isOverlayExperimentEnabled =
 		typeof window !== 'undefined' &&
 		window.__experimentalNavigationOverlays === true;
@@ -829,6 +834,7 @@ function Navigation( {
 						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
 						overlayMenuPreviewId={ overlayMenuPreviewId }
 						isResponsive={ isResponsive }
+						currentTheme={ currentTheme }
 					/>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import OverlayTemplatePartSelector from './overlay-template-part-selector';
 import OverlayVisibilityControl from './overlay-visibility-control';
 import OverlayMenuPreviewButton from './overlay-menu-preview-button';
+import OverlayPreview from './overlay-preview';
 
 /**
  * Overlay Panel component for Navigation block.
@@ -29,6 +30,7 @@ import OverlayMenuPreviewButton from './overlay-menu-preview-button';
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
+ * @param {string}   props.currentTheme              Current theme stylesheet name.
  * @return {JSX.Element|null}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -43,6 +45,7 @@ export default function OverlayPanel( {
 	overlayMenuPreviewClasses,
 	overlayMenuPreviewId,
 	isResponsive,
+	currentTheme,
 } ) {
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
@@ -70,6 +73,13 @@ export default function OverlayPanel( {
 						overlay={ overlay }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+					/>
+				) }
+
+				{ overlayMenu !== 'never' && overlay && (
+					<OverlayPreview
+						overlay={ overlay }
+						currentTheme={ currentTheme }
 					/>
 				) }
 			</VStack>

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -3,11 +3,12 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
-import { Spinner } from '@wordpress/components';
+import { Spinner, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ import { createTemplatePartId } from '../../template-part/edit/utils/create-temp
  * @return {JSX.Element|null} The overlay preview component or null if no overlay is selected.
  */
 export default function OverlayPreview( { overlay, currentTheme } ) {
+	const [ isExpanded, setIsExpanded ] = useState( false );
+
 	const templatePartId = useMemo( () => {
 		if ( ! overlay || ! currentTheme ) {
 			return null;
@@ -112,22 +115,43 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 	}
 
 	return (
-		<div
-			className="wp-block-navigation__overlay-preview"
-			aria-label={ __( 'Navigation Overlay template part preview' ) }
-			role="region"
-		>
-			<BlockPreview.Async
-				placeholder={
-					<div className="wp-block-navigation__overlay-preview-placeholder" />
+		<div>
+			<div
+				className={ `wp-block-navigation__overlay-preview${
+					isExpanded
+						? ' wp-block-navigation__overlay-preview--expanded'
+						: ''
+				}` }
+				aria-label={ __( 'Navigation Overlay template part preview' ) }
+				role="region"
+			>
+				<BlockPreview.Async
+					placeholder={
+						<div className="wp-block-navigation__overlay-preview-placeholder" />
+					}
+				>
+					<BlockPreview
+						blocks={ blocks }
+						viewportWidth={ 400 }
+						minHeight={ 200 }
+					/>
+				</BlockPreview.Async>
+			</div>
+			<Button
+				__next40pxDefaultSize
+				variant="tertiary"
+				onClick={ () => setIsExpanded( ! isExpanded ) }
+				icon={ isExpanded ? chevronUp : chevronDown }
+				iconPosition="right"
+				className="wp-block-navigation__overlay-preview-toggle"
+				aria-label={
+					isExpanded
+						? __( 'Collapse navigation overlay preview' )
+						: __( 'Expand navigation overlay preview' )
 				}
 			>
-				<BlockPreview
-					blocks={ blocks }
-					viewportWidth={ 400 }
-					minHeight={ 200 }
-				/>
-			</BlockPreview.Async>
+				{ isExpanded ? __( 'Collapse' ) : __( 'Expand' ) }
+			</Button>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BlockPreview } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
+
+/**
+ * Component that displays a read-only visual preview of the selected overlay template part.
+ *
+ * @param {Object} props              Component props.
+ * @param {string} props.overlay      The overlay template part slug.
+ * @param {string} props.currentTheme The current theme stylesheet name.
+ * @return {JSX.Element|null} The overlay preview component or null if no overlay is selected.
+ */
+export default function OverlayPreview( { overlay, currentTheme } ) {
+	const templatePartId = useMemo( () => {
+		if ( ! overlay || ! currentTheme ) {
+			return null;
+		}
+		return createTemplatePartId( currentTheme, overlay );
+	}, [ currentTheme, overlay ] );
+
+	const { content, editedBlocks, hasResolved } = useSelect(
+		( select ) => {
+			if ( ! templatePartId ) {
+				return {
+					content: null,
+					editedBlocks: null,
+					hasResolved: true,
+				};
+			}
+
+			const { getEditedEntityRecord, hasFinishedResolution } =
+				select( coreStore );
+
+			const editedRecord = getEditedEntityRecord(
+				'postType',
+				'wp_template_part',
+				templatePartId,
+				{ context: 'view' }
+			);
+
+			return {
+				content: editedRecord?.content,
+				editedBlocks: editedRecord?.blocks,
+				hasResolved: hasFinishedResolution( 'getEditedEntityRecord', [
+					'postType',
+					'wp_template_part',
+					templatePartId,
+					{ context: 'view' },
+				] ),
+			};
+		},
+		[ templatePartId ]
+	);
+
+	const blocks = useMemo( () => {
+		if ( ! templatePartId ) {
+			return null;
+		}
+
+		if ( editedBlocks ) {
+			return editedBlocks;
+		}
+
+		if ( ! content || typeof content !== 'string' ) {
+			return [];
+		}
+
+		return parse( content );
+	}, [ templatePartId, editedBlocks, content ] );
+
+	if ( ! overlay ) {
+		return null;
+	}
+
+	if ( ! hasResolved ) {
+		return (
+			<div className="wp-block-navigation__overlay-preview-loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( ! blocks || blocks.length === 0 ) {
+		return (
+			<div className="wp-block-navigation__overlay-preview-empty">
+				{ __( 'This overlay is empty.' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="wp-block-navigation__overlay-preview">
+			<BlockPreview.Async
+				placeholder={
+					<div className="wp-block-navigation__overlay-preview-placeholder" />
+				}
+			>
+				<BlockPreview
+					blocks={ blocks }
+					viewportWidth={ 400 }
+					minHeight={ 200 }
+				/>
+			</BlockPreview.Async>
+		</div>
+	);
+}

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -30,13 +30,14 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 		return createTemplatePartId( currentTheme, overlay );
 	}, [ currentTheme, overlay ] );
 
-	const { content, editedBlocks, hasResolved } = useSelect(
+	const { content, editedBlocks, hasResolved, recordExists } = useSelect(
 		( select ) => {
 			if ( ! templatePartId ) {
 				return {
 					content: null,
 					editedBlocks: null,
 					hasResolved: true,
+					recordExists: false,
 				};
 			}
 
@@ -59,6 +60,7 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 					templatePartId,
 					{ context: 'view' },
 				] ),
+				recordExists: !! editedRecord,
 			};
 		},
 		[ templatePartId ]
@@ -88,6 +90,15 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 		return (
 			<div className="wp-block-navigation__overlay-preview-loading">
 				<Spinner />
+			</div>
+		);
+	}
+
+	// Show message if the overlay template part has been deleted.
+	if ( hasResolved && ! recordExists ) {
+		return (
+			<div className="wp-block-navigation__overlay-preview-empty">
+				{ __( 'This overlay template part no longer exists.' ) }
 			</div>
 		);
 	}

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -3,12 +3,11 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
-import { Spinner, Button } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
-import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -24,8 +23,6 @@ import { createTemplatePartId } from '../../template-part/edit/utils/create-temp
  * @return {JSX.Element|null} The overlay preview component or null if no overlay is selected.
  */
 export default function OverlayPreview( { overlay, currentTheme } ) {
-	const [ isExpanded, setIsExpanded ] = useState( false );
-
 	const templatePartId = useMemo( () => {
 		if ( ! overlay || ! currentTheme ) {
 			return null;
@@ -115,43 +112,22 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 	}
 
 	return (
-		<div>
-			<div
-				className={ `wp-block-navigation__overlay-preview${
-					isExpanded
-						? ' wp-block-navigation__overlay-preview--expanded'
-						: ''
-				}` }
-				aria-label={ __( 'Navigation Overlay template part preview' ) }
-				role="region"
-			>
-				<BlockPreview.Async
-					placeholder={
-						<div className="wp-block-navigation__overlay-preview-placeholder" />
-					}
-				>
-					<BlockPreview
-						blocks={ blocks }
-						viewportWidth={ 400 }
-						minHeight={ 200 }
-					/>
-				</BlockPreview.Async>
-			</div>
-			<Button
-				__next40pxDefaultSize
-				variant="tertiary"
-				onClick={ () => setIsExpanded( ! isExpanded ) }
-				icon={ isExpanded ? chevronUp : chevronDown }
-				iconPosition="right"
-				className="wp-block-navigation__overlay-preview-toggle"
-				aria-label={
-					isExpanded
-						? __( 'Collapse navigation overlay preview' )
-						: __( 'Expand navigation overlay preview' )
+		<div
+			className="wp-block-navigation__overlay-preview"
+			aria-label={ __( 'Navigation Overlay template part preview' ) }
+			role="region"
+		>
+			<BlockPreview.Async
+				placeholder={
+					<div className="wp-block-navigation__overlay-preview-placeholder" />
 				}
 			>
-				{ isExpanded ? __( 'Collapse' ) : __( 'Expand' ) }
-			</Button>
+				<BlockPreview
+					blocks={ blocks }
+					viewportWidth={ 400 }
+					minHeight={ 200 }
+				/>
+			</BlockPreview.Async>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -101,7 +101,11 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 	}
 
 	return (
-		<div className="wp-block-navigation__overlay-preview">
+		<div
+			className="wp-block-navigation__overlay-preview"
+			aria-label={ __( 'Navigation Overlay template part preview' ) }
+			role="region"
+		>
 			<BlockPreview.Async
 				placeholder={
 					<div className="wp-block-navigation__overlay-preview-placeholder" />

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -69,15 +69,15 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 			return null;
 		}
 
-		if ( editedBlocks ) {
+		if ( editedBlocks && editedBlocks.length > 0 ) {
 			return editedBlocks;
 		}
 
-		if ( ! content || typeof content !== 'string' ) {
-			return [];
+		if ( content && typeof content === 'string' ) {
+			return parse( content );
 		}
 
-		return parse( content );
+		return [];
 	}, [ templatePartId, editedBlocks, content ] );
 
 	if ( ! overlay ) {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -675,19 +675,9 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-top: $grid-unit-20;
 	border: 1px solid $gray-300;
 	border-radius: 2px;
-	overflow: hidden;
+	overflow-y: auto;
 	max-height: 200px;
 	background: $white;
-
-	&--expanded {
-		max-height: none;
-	}
-}
-
-.wp-block-navigation__overlay-preview-toggle {
-	width: 100%;
-	justify-content: center;
-	margin-top: $grid-unit-10;
 }
 
 .wp-block-navigation__overlay-preview-loading {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -676,8 +676,18 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	border: 1px solid $gray-300;
 	border-radius: 2px;
 	overflow: hidden;
-	min-height: 200px;
+	max-height: 200px;
 	background: $white;
+
+	&--expanded {
+		max-height: none;
+	}
+}
+
+.wp-block-navigation__overlay-preview-toggle {
+	width: 100%;
+	justify-content: center;
+	margin-top: $grid-unit-10;
 }
 
 .wp-block-navigation__overlay-preview-loading {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -669,3 +669,50 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	right: 0;
 	z-index: 1;
 }
+
+// Overlay Preview styles
+.wp-block-navigation__overlay-preview {
+	margin-top: $grid-unit-20;
+	border: 1px solid $gray-300;
+	border-radius: 2px;
+	overflow: hidden;
+	min-height: 200px;
+	background: $white;
+}
+
+.wp-block-navigation__overlay-preview-loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 200px;
+	background: $gray-100;
+}
+
+.wp-block-navigation__overlay-preview-empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 200px;
+	padding: $grid-unit-20;
+	text-align: center;
+	color: $gray-700;
+	background: $gray-100;
+	font-style: italic;
+}
+
+.wp-block-navigation__overlay-preview-placeholder {
+	width: 100%;
+	height: 200px;
+	background: $gray-100;
+	animation: wp-block-navigation-overlay-preview-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes wp-block-navigation-overlay-preview-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
  https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

  ## What?
  Closes https://github.com/WordPress/gutenberg/issues/74096

  Adds a read-only visual preview of the selected Navigation Overlay directly within the Navigation block sidebar.

  ## Why?
  Navigation Overlays are inherently visual and can vary significantly in structure and content. As multiple overlays are introduced, this sidebar provides a fast, reliable way to understand which overlay is being configured and what it contains, without switching modes or making edits.

  ## How?
  This PR introduces a new `OverlayPreview` component that uses the `BlockPreview` component to render a read-only preview of the selected overlay template part.

 **New Component:** `packages/block-library/src/navigation/edit/overlay-preview.js`
 - Fetches overlay template part using `getEditedEntityRecord` with `context: 'view'`
 - Parses blocks from the template part content
 - Renders preview using `BlockPreview.Async` with 400px viewport width
 - Handles three states: loading (spinner), empty (message), and content (preview)

 **Integration:** Modified `overlay-panel.js`
 - Added `OverlayPreview` component after the `OverlayTemplatePartSelector`
 - Preview only renders when `overlayMenu !== 'never'` and an overlay is selected
 - Added `currentTheme` prop

 **Prop Threading:** Modified `edit/index.js`
 - Added `useSelect` hook to fetch current theme stylesheet
 - Passed `currentTheme` to `OverlayPanel`

 **Styling:** Added styles to `editor.scss`
 - Preview container with border and rounded corners
 - Loading state with centered spinner
 - Empty state with friendly message
 - Placeholder with pulse animation during async loading

  The implementation follows the pattern demonstrated in prototype PR #73389 and the Design sidebar pattern used in template part editing.

  ## Testing Instructions

Make sure the Navigation Overlay experiment is enabled in Gutenberg - Experiments.

  **Steps:**
  1. Open a post or page in the block editor
  2. Insert a Navigation block
  3. In the block settings sidebar, locate the "Overlay" panel
  4. Set the Overlay visibility to "Mobile" or "Always"
  5. From the "Overlay template" dropdown, select "Create new overlay template"
  6. Add some blocks to the overlay (e.g., navigation, paragraph, heading)
  7. Go back to your Navigation block 
  8. Open the Navigation block settings sidebar again
  9. You should see a visual preview of your overlay below the template selector
  10. Try selecting a different overlay from the dropdown
  11. The preview updates to show the selected overlay's content
  12. Set the Overlay visibility to "Never"
  13. The preview should disappear
  14. Select an empty overlay (or create a new one without adding blocks)
  15. Preview shows "This overlay is empty." message

  ## Screenshots or screencast

  |Before|After|
  |-|-|
  |<img width="621" height="663" alt="image" src="https://github.com/user-attachments/assets/8ff40f09-e851-4387-a080-bc045bf6faa8" />|<img width="621" height="663" alt="image" src="https://github.com/user-attachments/assets/01a73efb-9e32-40bb-b427-60403256b9e2" />|







