### PR TITLE
Site Editor Pages: trigger quick edit via primary action

### DIFF
--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -7,6 +7,7 @@ import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { PATTERN_TYPES } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 export const useSetActiveTemplateAction = () => {
 	const activeTheme = useSelect( ( select ) =>
@@ -96,5 +97,37 @@ export const useEditPostAction = () => {
 			},
 		} ),
 		[ history ]
+	);
+};
+
+export const useQuickEditAction = () => {
+	const history = useHistory();
+	const { path } = useLocation();
+	return useMemo(
+		() => ( {
+			id: 'quick-edit',
+			label: __( 'Quick Edit' ),
+			isPrimary: true,
+			icon: pencil,
+			isEligible( post ) {
+				if ( ! window.__experimentalQuickEditDataViews ) {
+					return false;
+				}
+				if ( post.status === 'trash' ) {
+					return false;
+				}
+				return post.type === 'page';
+			},
+			callback( items ) {
+				const post = items[ 0 ];
+				history.navigate(
+					addQueryArgs( path, {
+						postId: post.id,
+						quickEdit: true,
+					} )
+				);
+			},
+		} ),
+		[ history, path ]
 	);
 };

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -76,13 +76,13 @@ export const useSetActiveTemplateAction = () => {
 	);
 };
 
-export const useEditPostAction = () => {
+export const useEditPostAction = ( viewType ) => {
 	const history = useHistory();
 	return useMemo(
 		() => ( {
 			id: 'edit-post',
 			label: __( 'Edit' ),
-			isPrimary: true,
+			isPrimary: viewType !== 'table',
 			icon: pencil,
 			isEligible( post ) {
 				if ( post.status === 'trash' ) {
@@ -96,11 +96,11 @@ export const useEditPostAction = () => {
 				history.navigate( `/${ post.type }/${ post.id }?canvas=edit` );
 			},
 		} ),
-		[ history ]
+		[ history, viewType ]
 	);
 };
 
-export const useQuickEditAction = () => {
+export const useQuickEditAction = ( viewType ) => {
 	const history = useHistory();
 	const { path } = useLocation();
 	return useMemo(
@@ -110,6 +110,10 @@ export const useQuickEditAction = () => {
 			isPrimary: true,
 			icon: pencil,
 			isEligible( post ) {
+				if ( viewType !== 'table' ) {
+					return false;
+				}
+
 				if ( ! window.__experimentalQuickEditDataViews ) {
 					return false;
 				}
@@ -128,6 +132,6 @@ export const useQuickEditAction = () => {
 				);
 			},
 		} ),
-		[ history, path ]
+		[ history, path, viewType ]
 	);
 };

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -76,11 +76,18 @@ function PostEditForm( { postType, postId } ) {
 
 	useEffect( () => {
 		if ( hasFinishedResolution && formRef.current ) {
-			const firstInput = formRef.current.querySelector(
-				'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled])'
+			const firstTabbable = formRef.current.querySelector(
+				'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [tabindex="0"]'
 			);
-			if ( firstInput ) {
-				firstInput.focus( { focusVisible: true } );
+			if ( firstTabbable ) {
+				firstTabbable.focus( { focusVisible: true } );
+				// Fallback: add class for browsers that don't support focusVisible option.
+				firstTabbable.classList.add( 'is-focus-visible' );
+				firstTabbable.addEventListener(
+					'blur',
+					() => firstTabbable.classList.remove( 'is-focus-visible' ),
+					{ once: true }
+				);
 			}
 		}
 	}, [ postId, hasFinishedResolution ] );

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -11,8 +11,11 @@ import { __ } from '@wordpress/i18n';
 import { DataForm } from '@wordpress/dataviews';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useMemo, useEffect } from '@wordpress/element';
+import { closeSmall } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { addQueryArgs } from '@wordpress/url';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -23,6 +26,7 @@ import { unlock } from '../../lock-unlock';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 
 const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const fieldsWithBulkEditSupport = [
 	'title',
@@ -34,6 +38,8 @@ const fieldsWithBulkEditSupport = [
 
 function PostEditForm( { postType, postId } ) {
 	const ids = useMemo( () => postId.split( ',' ), [ postId ] );
+	const history = useHistory();
+	const { path } = useLocation();
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
 			const args = [ 'postType', postType, ids[ 0 ] ];
@@ -174,9 +180,28 @@ function PostEditForm( { postType, postId } ) {
 		} );
 	}, [ fields, settings ] );
 
+	const closeQuickEdit = () => {
+		history.navigate(
+			addQueryArgs( path, {
+				quickEdit: undefined,
+			} )
+		);
+	};
+
 	return (
 		<VStack spacing={ 4 }>
-			<PostCardPanel postType={ postType } postId={ ids } />
+			<PostCardPanel
+				postType={ postType }
+				postId={ ids }
+				actions={
+					<Button
+						size="small"
+						icon={ closeSmall }
+						label={ __( 'Close' ) }
+						onClick={ closeQuickEdit }
+					/>
+				}
+			/>
 			{ hasFinishedResolution && (
 				<DataForm
 					data={ ids.length === 1 ? record : multiEdits }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -12,7 +12,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs } from '@wordpress/url';
@@ -40,6 +40,8 @@ function PostEditForm( { postType, postId } ) {
 	const ids = useMemo( () => postId.split( ',' ), [ postId ] );
 	const history = useHistory();
 	const { path } = useLocation();
+	const formRef = useRef( null );
+
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
 			const args = [ 'postType', postType, ids[ 0 ] ];
@@ -61,6 +63,18 @@ function PostEditForm( { postType, postId } ) {
 		[ postType, ids ]
 	);
 	const [ multiEdits, setMultiEdits ] = useState( {} );
+
+	useEffect( () => {
+		if ( hasFinishedResolution && formRef.current ) {
+			const firstInput = formRef.current.querySelector(
+				'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled])'
+			);
+			if ( firstInput ) {
+				firstInput.focus( { focusVisible: true } );
+			}
+		}
+	}, [ postId, hasFinishedResolution ] );
+
 	const { editEntityRecord } = useDispatch( coreDataStore );
 	const _fields = usePostFields( { postType } );
 	const fields = useMemo(
@@ -203,12 +217,14 @@ function PostEditForm( { postType, postId } ) {
 				}
 			/>
 			{ hasFinishedResolution && (
-				<DataForm
-					data={ ids.length === 1 ? record : multiEdits }
-					fields={ fieldsWithDependency }
-					form={ form }
-					onChange={ onChange }
-				/>
+				<div ref={ formRef }>
+					<DataForm
+						data={ ids.length === 1 ? record : multiEdits }
+						fields={ fieldsWithDependency }
+						form={ form }
+						onChange={ onChange }
+					/>
+				</div>
 			) }
 		</VStack>
 	);

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -41,6 +41,16 @@ function PostEditForm( { postType, postId } ) {
 	const history = useHistory();
 	const { path } = useLocation();
 	const formRef = useRef( null );
+	const containerRef = useRef( null );
+	const previousFocusRef = useRef( null );
+
+	// Store the element to restore focus to when closing.
+	useEffect( () => {
+		if ( containerRef.current ) {
+			previousFocusRef.current =
+				containerRef.current.ownerDocument.activeElement;
+		}
+	}, [ postId ] );
 
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -195,6 +205,10 @@ function PostEditForm( { postType, postId } ) {
 	}, [ fields, settings ] );
 
 	const closeQuickEdit = () => {
+		// Restore focus to the element that opened QuickEdit.
+		if ( previousFocusRef.current ) {
+			previousFocusRef.current.focus();
+		}
 		history.navigate(
 			addQueryArgs( path, {
 				quickEdit: undefined,
@@ -203,7 +217,7 @@ function PostEditForm( { postType, postId } ) {
 	};
 
 	return (
-		<VStack spacing={ 4 }>
+		<VStack ref={ containerRef } spacing={ 4 }>
 			<PostCardPanel
 				postType={ postType }
 				postId={ ids }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { DataForm } from '@wordpress/dataviews';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
+import { useFocusReturn } from '@wordpress/compose';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
@@ -42,16 +43,7 @@ function PostEditForm( { postType, postId } ) {
 	const history = useHistory();
 	const { path } = useLocation();
 	const formRef = useRef( null );
-	const containerRef = useRef( null );
-	const previousFocusRef = useRef( null );
-
-	// Store the element to restore focus to when closing.
-	useEffect( () => {
-		if ( containerRef.current ) {
-			previousFocusRef.current =
-				containerRef.current.ownerDocument.activeElement;
-		}
-	}, [ postId ] );
+	const focusReturnRef = useFocusReturn();
 
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -81,6 +73,7 @@ function PostEditForm( { postType, postId } ) {
 			if ( firstTabbable ) {
 				firstTabbable.focus( { focusVisible: true } );
 				// Fallback: add class for browsers that don't support focusVisible option.
+				// This is a browser quirk: they won't add the focus styles when the user is using the mouse.
 				firstTabbable.classList.add( 'is-focus-visible' );
 				firstTabbable.addEventListener(
 					'blur',
@@ -211,10 +204,6 @@ function PostEditForm( { postType, postId } ) {
 	}, [ fields, settings ] );
 
 	const closeQuickEdit = () => {
-		// Restore focus to the element that opened QuickEdit.
-		if ( previousFocusRef.current ) {
-			previousFocusRef.current.focus();
-		}
 		history.navigate(
 			addQueryArgs( path, {
 				quickEdit: undefined,
@@ -223,7 +212,7 @@ function PostEditForm( { postType, postId } ) {
 	};
 
 	return (
-		<VStack ref={ containerRef } spacing={ 4 }>
+		<VStack ref={ focusReturnRef } spacing={ 4 }>
 			<PostCardPanel
 				postType={ postType }
 				postId={ ids }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -10,6 +10,7 @@ import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
 import { DataForm } from '@wordpress/dataviews';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { focus } from '@wordpress/dom';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
@@ -76,9 +77,7 @@ function PostEditForm( { postType, postId } ) {
 
 	useEffect( () => {
 		if ( hasFinishedResolution && formRef.current ) {
-			const firstTabbable = formRef.current.querySelector(
-				'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [tabindex="0"]'
-			);
+			const firstTabbable = focus.tabbable.find( formRef.current )[ 0 ];
 			if ( firstTabbable ) {
 				firstTabbable.focus( { focusVisible: true } );
 				// Fallback: add class for browsers that don't support focusVisible option.

--- a/packages/edit-site/src/components/post-edit/style.scss
+++ b/packages/edit-site/src/components/post-edit/style.scss
@@ -3,6 +3,12 @@
 
 .edit-site-post-edit {
 	padding: $grid-unit-30;
+
+	// Fallback for programmatic focus when :focus-visible doesn't apply.
+	.is-focus-visible {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		outline: 3px solid transparent; // For Windows High Contrast mode.
+	}
 }
 
 .dataforms-layouts-panel__field-dropdown {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -29,7 +29,7 @@ import {
 
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
-import { useEditPostAction } from '../dataviews-actions';
+import { useQuickEditAction } from '../dataviews-actions';
 import { defaultLayouts, getDefaultView } from './view-utils';
 import useNotesCount from './use-notes-count';
 
@@ -231,10 +231,10 @@ export default function PostList( { postType } ) {
 		postType,
 		context: 'list',
 	} );
-	const editAction = useEditPostAction();
+	const quickEditAction = useQuickEditAction();
 	const actions = useMemo(
-		() => [ editAction, ...postTypeActions ],
-		[ postTypeActions, editAction ]
+		() => [ quickEditAction, ...postTypeActions ],
+		[ postTypeActions, quickEditAction ]
 	);
 
 	const [ showAddPostModal, setShowAddPostModal ] = useState( false );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -97,7 +97,8 @@ export default function PostList( { postType } ) {
 			setSelection( items );
 			history.navigate(
 				addQueryArgs( path, {
-					postId: items.join( ',' ),
+					postId: items.length === 0 ? undefined : items.join( ',' ),
+					...( items.length === 0 && { quickEdit: undefined } ),
 				} )
 			);
 		},

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -29,7 +29,7 @@ import {
 
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
-import { useQuickEditAction } from '../dataviews-actions';
+import { useEditPostAction, useQuickEditAction } from '../dataviews-actions';
 import { defaultLayouts, getDefaultView } from './view-utils';
 import useNotesCount from './use-notes-count';
 
@@ -235,10 +235,11 @@ export default function PostList( { postType } ) {
 		postType,
 		context: 'list',
 	} );
-	const quickEditAction = useQuickEditAction();
+	const editAction = useEditPostAction( view.type );
+	const quickEditAction = useQuickEditAction( view.type );
 	const actions = useMemo(
-		() => [ quickEditAction, ...postTypeActions ],
-		[ postTypeActions, quickEditAction ]
+		() => [ quickEditAction, editAction, ...postTypeActions ],
+		[ postTypeActions, quickEditAction, editAction ]
 	);
 
 	const [ showAddPostModal, setShowAddPostModal ] = useState( false );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -88,6 +88,10 @@ export default function PostList( { postType } ) {
 	} );
 
 	const [ selection, setSelection ] = useState( postId?.split( ',' ) ?? [] );
+	// Sync selection with postId query param (e.g., when QuickEdit action updates postId).
+	useEffect( () => {
+		setSelection( postId?.split( ',' ) ?? [] );
+	}, [ postId ] );
 	const onChangeSelection = useCallback(
 		( items ) => {
 			setSelection( items );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -13,7 +13,6 @@ import { useSelect } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { drawerRight } from '@wordpress/icons';
 import { useEvent, usePrevious } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { useView } from '@wordpress/views';
@@ -26,7 +25,6 @@ import {
 	OPERATOR_IS_NONE,
 	OPERATOR_BEFORE,
 	OPERATOR_AFTER,
-	LAYOUT_LIST,
 } from '../../utils/constants';
 
 import AddNewPostModal from '../add-new-post';
@@ -52,7 +50,7 @@ function getItemLevel( item ) {
 
 export default function PostList( { postType } ) {
 	const { path, query } = useLocation();
-	const { activeView = 'all', postId, quickEdit = false } = query;
+	const { activeView = 'all', postId } = query;
 	const history = useHistory();
 	const postTypeObject = useSelect(
 		( select ) => {
@@ -303,25 +301,6 @@ export default function PostList( { postType } ) {
 				getItemId={ getItemId }
 				getItemLevel={ getItemLevel }
 				defaultLayouts={ defaultLayouts }
-				header={
-					window.__experimentalQuickEditDataViews &&
-					view.type !== LAYOUT_LIST &&
-					postType === 'page' && (
-						<Button
-							size="compact"
-							isPressed={ quickEdit }
-							icon={ drawerRight }
-							label={ __( 'Details' ) }
-							onClick={ () => {
-								history.navigate(
-									addQueryArgs( path, {
-										quickEdit: quickEdit ? undefined : true,
-									} )
-								);
-							} }
-						/>
-					)
-				}
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -81,7 +81,15 @@ export const pagesRoute = {
 			const isList = await isListView( query );
 			const hasQuickEdit = ! isList && !! query.quickEdit;
 			return hasQuickEdit ? (
-				<PostEdit postType="page" postId={ query.postId } />
+				<PostEdit
+					// Intentionally force remounting PostEdit when postId changes,
+					// so useFocusReturn captures the new trigger element.
+					// Try clicking a different QuickEdit button when PostEdit is mounted, then, close PostEdit.
+					// The expected result is that focus returns to the last QuickEdit button.
+					key={ query.postId }
+					postType="page"
+					postId={ query.postId }
+				/>
 			) : undefined;
 		},
 	},

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -35,12 +35,14 @@ const { Badge } = unlock( componentsPrivateApis );
  * @param {string}          [props.postType]          - The post type string.
  * @param {string|string[]} [props.postId]            - The post id or list of post ids.
  * @param {Function}        [props.onActionPerformed] - A callback function for when a quick action is performed.
+ * @param {React.ReactNode} [props.actions]           - Additional actions to render in the header.
  * @return {React.ReactNode} The rendered component.
  */
 export default function PostCardPanel( {
 	postType,
 	postId,
 	onActionPerformed,
+	actions,
 } ) {
 	const postIds = useMemo(
 		() => ( Array.isArray( postId ) ? postId : [ postId ] ),
@@ -125,6 +127,7 @@ export default function PostCardPanel( {
 						onActionPerformed={ onActionPerformed }
 					/>
 				) }
+				{ actions }
 			</HStack>
 			{ postIds.length > 1 && (
 				<Text className="editor-post-card-panel__description">


### PR DESCRIPTION
## What?

This PR updates how QuickEdit is triggered in SiteEditor's Pages.

https://github.com/user-attachments/assets/fa08df96-6c91-4e29-b9e6-2b4a079a28de


## Why?

To explore better approaches to opening the panel (since the click row to select was removed a few weeks ago) and make the QuickEdit stable.

## How?

- Remove the drawer icon next to the view config (cog icon).
- Add a QuickEdit primary action in the table view. The Edit action is still present but it's no longer primary.
- When clicking the QuickEdit button, the focus moves to the form. When closing the form, the focus moves back to the QuickEdit button. Even it's not a modal, it acts like one.

## Testing Instructions

- Enable the QuickEdit experiment
- Visit Site Editor > Pages.
- Switch to table.
- Interact with the QuickEdit button.
