### PR TITLE
Pattern Editing: Update template part to use tabs

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -332,7 +332,6 @@ const BlockInspectorSingleBlock = ( {
 		renderedBlockClientId
 	);
 	const isBlockSynced = blockInformation.isSynced;
-	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
 	const isSectionBlockSelected =
 		window?.__experimentalContentOnlyPatternInsertion &&
 		selectedBlockClientId === renderedBlockClientId;
@@ -358,17 +357,19 @@ const BlockInspectorSingleBlock = ( {
 				<EditContents clientId={ renderedBlockClientId } />
 			) }
 			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
-			{ shouldShowTabs && (
-				<InspectorControlsTabs
-					hasBlockStyles={ hasBlockStyles }
-					clientId={ renderedBlockClientId }
-					blockName={ blockName }
-					tabs={ availableTabs }
-					isSectionBlock={ isSectionBlock }
-					contentClientIds={ contentClientIds }
-				/>
+			{ hasMultipleTabs && (
+				<>
+					<InspectorControlsTabs
+						hasBlockStyles={ hasBlockStyles }
+						clientId={ renderedBlockClientId }
+						blockName={ blockName }
+						tabs={ availableTabs }
+						isSectionBlock={ isSectionBlock }
+						contentClientIds={ contentClientIds }
+					/>
+				</>
 			) }
-			{ ! shouldShowTabs && (
+			{ ! hasMultipleTabs && (
 				<>
 					{ hasBlockStyles && (
 						<BlockStyles clientId={ renderedBlockClientId } />
@@ -379,15 +380,6 @@ const BlockInspectorSingleBlock = ( {
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots blockName={ blockName } />
 					) }
-					{ isSectionBlock &&
-						isBlockSynced &&
-						isSectionBlockSelected && (
-							<>
-								<InspectorControls.Slot />
-								{ /* Allow AdvancedControls so users can adjust local attributes (e.g. additional CSS classes, HTML element). */ }
-								<AdvancedControls />
-							</>
-						) }
 				</>
 			) }
 			<SkipToSelectedBlock key="back" />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -77,7 +77,6 @@ function StyleInspectorSlots( {
 function BlockInspector() {
 	const {
 		selectedBlockCount,
-		selectedBlockClientId,
 		renderedBlockName,
 		renderedBlockClientId,
 		blockType,
@@ -119,7 +118,6 @@ function BlockInspector() {
 
 		return {
 			selectedBlockCount: getSelectedBlockCount(),
-			selectedBlockClientId: _selectedBlockClientId,
 			renderedBlockClientId: _renderedBlockClientId,
 			renderedBlockName: _renderedBlockName,
 			blockType: _blockType,
@@ -257,7 +255,6 @@ function BlockInspector() {
 		>
 			<BlockInspectorSingleBlock
 				renderedBlockClientId={ renderedBlockClientId }
-				selectedBlockClientId={ selectedBlockClientId }
 				blockName={ blockType.name }
 				isSectionBlock={ isSectionBlock }
 				availableTabs={ availableTabs }
@@ -309,10 +306,6 @@ const BlockInspectorSingleBlock = ( {
 	// The block that is displayed in the inspector. This is the block whose
 	// controls and information are shown to the user.
 	renderedBlockClientId,
-	// The actual block that is selected in the editor. This may or may not
-	// be the same as the rendered block (e.g., when a child block is selected
-	// but its parent section block is the main one rendered in the inspector).
-	selectedBlockClientId,
 	blockName,
 	isSectionBlock,
 	availableTabs,
@@ -332,9 +325,6 @@ const BlockInspectorSingleBlock = ( {
 		renderedBlockClientId
 	);
 	const isBlockSynced = blockInformation.isSynced;
-	const isSectionBlockSelected =
-		window?.__experimentalContentOnlyPatternInsertion &&
-		selectedBlockClientId === renderedBlockClientId;
 
 	return (
 		<div className="block-editor-block-inspector">

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -107,7 +107,7 @@ export default function useInspectorControlsTabs(
 		( settingsFills.length ||
 			// Advanded fills who up in settings tab if available or they blend into the default tab, if there's only one tab.
 			( advancedFills.length && ( hasContentTab || hasListFills ) ) ) &&
-		! isSectionBlock
+		( ! isSectionBlock || blockName === 'core/template-part' )
 	) {
 		tabs.push( TAB_SETTINGS );
 	}

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -104,10 +104,9 @@ export default function useInspectorControlsTabs(
 	}
 
 	if (
-		( settingsFills.length ||
-			// Advanded fills who up in settings tab if available or they blend into the default tab, if there's only one tab.
-			( advancedFills.length && ( hasContentTab || hasListFills ) ) ) &&
-		( ! isSectionBlock || blockName === 'core/template-part' )
+		settingsFills.length ||
+		// Advanced fills show up in settings tab if available or they blend into the default tab, if there's only one tab.
+		( advancedFills.length && ( hasContentTab || hasListFills ) )
 	) {
 		tabs.push( TAB_SETTINGS );
 	}

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -47,31 +47,30 @@ export default function InspectorControlsFill( {
 		return null;
 	}
 
-	const shouldDisplayForPatternEditing =
-		context[ mayDisplayPatternEditingControlsKey ] &&
-		PATTERN_EDITING_GROUPS.includes( group );
+	// During pattern editing:
+	// - All blocks can show pattern editing groups (content, list).
+	// - Template parts can show a settings tab (default, settings, advanced groups).
+	// - Other blocks cannot show a settings tab.
+	if ( context[ mayDisplayPatternEditingControlsKey ] ) {
+		// Template parts are allowed to show a settings tab to allow access to the
+		// 'Design' and 'Advanced' panels.
+		const isTemplatePart = context.name === 'core/template-part';
+		const isTemplatePartGroup = TEMPLATE_PART_GROUPS.includes( group );
+		const isPatternEditingGroup = PATTERN_EDITING_GROUPS.includes( group );
 
-	// For pattern editing, the template part is the only block that can display the settings tab.
-	// This is to allow it to show 'Design' and 'Advanced' panels.
-	const shouldDisplayTemplatePartSettings =
-		context[ mayDisplayPatternEditingControlsKey ] &&
-		context.name === 'core/template-part' &&
-		TEMPLATE_PART_GROUPS.includes( group );
+		const canShowGroup =
+			( isTemplatePart && isTemplatePartGroup ) || isPatternEditingGroup;
 
-	if (
-		! context[ mayDisplayControlsKey ] &&
-		! shouldDisplayForPatternEditing &&
-		! shouldDisplayTemplatePartSettings
-	) {
-		return null;
+		if ( ! canShowGroup ) {
+			return null;
+		}
 	}
 
-	const hideNonTemplatePartSettings =
-		context[ mayDisplayPatternEditingControlsKey ] &&
-		context.name !== 'core/template-part' &&
-		TEMPLATE_PART_GROUPS.includes( group );
-
-	if ( hideNonTemplatePartSettings ) {
+	// Outside pattern editing, use the standard rules for displaying controls.
+	if (
+		! context[ mayDisplayPatternEditingControlsKey ] &&
+		! context[ mayDisplayControlsKey ]
+	) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -19,6 +19,9 @@ import {
 } from '../block-edit/context';
 import groups from './groups';
 
+const PATTERN_EDITING_GROUPS = [ 'content', 'list' ];
+const TEMPLATE_PART_GROUPS = [ 'default', 'settings', 'advanced' ];
+
 export default function InspectorControlsFill( {
 	children,
 	group = 'default',
@@ -43,14 +46,32 @@ export default function InspectorControlsFill( {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
+
 	const shouldDisplayForPatternEditing =
 		context[ mayDisplayPatternEditingControlsKey ] &&
-		( group === 'list' || group === 'content' );
+		PATTERN_EDITING_GROUPS.includes( group );
+
+	// For pattern editing, the template part is the only block that can display the settings tab.
+	// This is to allow it to show 'Design' and 'Advanced' panels.
+	const shouldDisplayTemplatePartSettings =
+		context[ mayDisplayPatternEditingControlsKey ] &&
+		context.name === 'core/template-part' &&
+		TEMPLATE_PART_GROUPS.includes( group );
 
 	if (
 		! context[ mayDisplayControlsKey ] &&
-		! shouldDisplayForPatternEditing
+		! shouldDisplayForPatternEditing &&
+		! shouldDisplayTemplatePartSettings
 	) {
+		return null;
+	}
+
+	const hideNonTemplatePartSettings =
+		context[ mayDisplayPatternEditingControlsKey ] &&
+		context.name !== 'core/template-part' &&
+		TEMPLATE_PART_GROUPS.includes( group );
+
+	if ( hideNonTemplatePartSettings ) {
 		return null;
 	}
 

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -324,7 +324,7 @@ export default function TemplatePartEdit( {
 					} }
 				</BlockSettingsMenuControls>
 
-				<InspectorControls>
+				<InspectorControls group="settings">
 					<TemplatesList
 						area={ area }
 						clientId={ clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #74726

## What?
In a past change, the template part block was forced not to show block inspector tabs. At the time it didn't have as much content as it does now.

Today (with the pattern editing experiment enabled) the inspector can show List Views for every Navigation, Buttons or Social Icons block as well as the possibility of showing block fields in the future. Tabs are now the right choice, so this PR implements that.

## How?
A lot of the changes remove the additional code that forced the template part to use one tab, so there's a lot of tidying.

The `InspectorControlsFill` component has some additional code added to it to control when blocks can render fills for certain inspector groups. This is required because for pattern editing the expectation is that only the template part's settings or advanced controls should display, the settings or advanced controls for inner blocks of a pattern need to be prevented from displaying.

Unsynced patterns are also another concern, the top-level block in an unsynced pattern also should not show its settings (otherwise it allows for changing the layout), so the `name === 'core/template-part'` test seems to be necessary.

## Testing Instructions
Prerequisite: Enable the Pattern Editing experiment

1. Open the site editor
2. Edit up a template like 'Blog Home'
3. Select either the Header or Footer template part
4. Open the block inspector

Expected: It should display its content in tabs
In trunk: Everything is in one tab

#### Other testing:
Test other blocks - they should work the same as in trunk
Test with the experiment disabled - everything should work the same as in trunk

## Screenshots or screencast <!-- if applicable -->
#### Before
<div>
<img align="top" width="200" alt="Image" src="https://github.com/user-attachments/assets/b1ff780e-c6c5-4f31-bc69-f9e21babe86a" />
<img align="top" width="200" alt="Image" src="https://github.com/user-attachments/assets/3af3232a-0210-4e1f-a5ea-fbfb660e419d" />
</div>

#### After
<div>
<img align="top" width="200" alt="Screenshot 2026-01-21 at 10 41 47 am" src="https://github.com/user-attachments/assets/ae233644-cf5f-4fb4-ae50-3433db814542" />
<img align="top" width="200" alt="Screenshot 2026-01-21 at 10 41 57 am" src="https://github.com/user-attachments/assets/9e1d4bfe-5676-47db-a90f-26bc7698ee49" />
<img align="top" width="200" alt="Screenshot 2026-01-21 at 10 42 11 am" src="https://github.com/user-attachments/assets/1b8549f7-d8b4-49dc-96c0-42825afc9056" />
</div>