### PR TITLE
List Item: Show content instead of block name in List View

### DIFF
--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -34,6 +34,18 @@ export const settings = {
 	},
 	transforms,
 	[ unlock( privateApis ).requiresWrapperOnCopy ]: true,
+	__experimentalLabel( attributes, { context } ) {
+		const { content } = attributes;
+
+		const customName = attributes?.metadata?.name;
+		const hasContent = content?.trim().length > 0;
+
+		// In the list view, use the block's content as the label.
+		// If the content is empty, fall back to the default label.
+		if ( context === 'list-view' && ( customName || hasContent ) ) {
+			return customName || content;
+		}
+	},
 };
 
 if ( window.__experimentalContentOnlyInspectorFields ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the List Block so that it shows its content in List View instead of the block name.

## Why?
Based on feedback here - https://github.com/WordPress/gutenberg/pull/74574#issuecomment-3748390960

If you're focused on List View, it's hard to tell List Items apart. This change makes it easier to arrange list items solely in List View.

## How?
Follows the exact same approach as #74163

## Testing Instructions
1. Insert a Pattern that includes a List ('Call to Action' > 'Services, subscriber only section' is the one shown in screenshots)
2. Select the pattern
3. Open the List View sidebar, and/or the block inspector to the List View tab
4. Observe the List Items now show their content in List View

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="272" height="309" alt="Screenshot 2026-01-21 at 11 54 14 am" src="https://github.com/user-attachments/assets/a43b4613-0a94-42fd-8e08-102ed0dd562b" /> | <img width="270" height="302" alt="Screenshot 2026-01-21 at 11 53 43 am" src="https://github.com/user-attachments/assets/c0a0533a-62a1-49de-93d6-f9d3216a1e2e" /> |
