### PR TITLE
Ensure grid column never exceeds parent's width

### DIFF
--- a/backport-changelog/7.0/10766.md
+++ b/backport-changelog/7.0/10766.md
@@ -1,4 +1,5 @@
 https://github.com/WordPress/wordpress-develop/pull/10766
 
 * https://github.com/WordPress/gutenberg/pull/74725
+* https://github.com/WordPress/gutenberg/pull/74795
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -521,7 +521,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['columnCount'] ) && ! empty( $layout['minimumColumnWidth'] ) ) {
-			$max_value       = 'max(' . $layout['minimumColumnWidth'] . ', (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
+			$max_value       = 'max(min(' . $layout['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array(

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -166,7 +166,7 @@ export default {
 			if ( blockGapToUse === '0' || blockGapToUse === 0 ) {
 				blockGapToUse = '0px';
 			}
-			const maxValue = `max(${ minimumColumnWidth }, ( 100% - (${ blockGapToUse }*${
+			const maxValue = `max(min( ${ minimumColumnWidth }, 100%), ( 100% - (${ blockGapToUse }*${
 				columnCount - 1
 			}) ) / ${ columnCount })`;
 			rules.push(

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -33,7 +33,7 @@ describe( 'getLayoutStyle', () => {
 		expect( result ).toBe( expected );
 	} );
 	it( 'should return `grid-template-columns` with max() function if both minimumColumnWidth and columnCount are provided', () => {
-		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(12rem, ( 100% - (1.2rem*2) ) / 3), 1fr)); container-type: inline-size; }`;
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(min( 12rem, 100%), ( 100% - (1.2rem*2) ) / 3), 1fr)); container-type: inline-size; }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69060

Pulls in the changes from #69059 and adds the same fix on the editor side.

Makes sure that each grid column never exceeds 100% of its parent width.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add the following markup to a post:
```
<!-- wp:group {"align":"full","layout":{"type":"grid","columnCount":2,"minimumColumnWidth":"793px"}} -->
<div class="wp-block-group alignfull"><!-- wp:group {"style":{"color":{"background":"#ff0000"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"20px","right":"20px"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group has-background" style="background-color:#ff0000;padding-top:var(--wp--preset--spacing--30);padding-right:20px;padding-bottom:var(--wp--preset--spacing--30);padding-left:20px"><!-- wp:paragraph -->
<p>On mobile this column gets wider than its container</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#ff0000"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"20px","right":"20px"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group has-background" style="background-color:#ff0000;padding-top:var(--wp--preset--spacing--30);padding-right:20px;padding-bottom:var(--wp--preset--spacing--30);padding-left:20px"><!-- wp:paragraph -->
<p>On mobile this column gets wider than its container</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
and view it on a narrow (700px or less) screen. With this PR, the columns shouldn't cause an overflow.
<img width="503" height="795" alt="Screenshot 2026-01-21 at 3 11 51 pm" src="https://github.com/user-attachments/assets/34e38273-63a9-48c1-bed2-4e9874961d55" />


