### PR TITLE
Try/add cropping tools to the media editor package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60766,9 +60766,13 @@
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/components": "file:../components",
+				"@wordpress/compose": "file:../compose",
 				"@wordpress/dataviews": "file:../dataviews",
 				"@wordpress/element": "file:../element",
-				"@wordpress/i18n": "file:../i18n"
+				"@wordpress/i18n": "file:../i18n",
+				"@wordpress/icons": "file:../icons",
+				"@wordpress/image-cropper": "file:../image-cropper",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/editor/src/components/attachment-editor-provider/index.js
+++ b/packages/editor/src/components/attachment-editor-provider/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { MediaEditorProvider } from '@wordpress/media-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
+
+/**
+ * Provides MediaEditor context for attachment post types.
+ * Wraps both the editor content and sidebar so they can share editing state.
+ * MediaEditorProvider automatically provides ImageCropper context for image attachments.
+ *
+ * @param {Object} props          - Component props
+ * @param {*}      props.children - Child components
+ * @return {Element} Provider component or passthrough for non-attachments
+ */
+export default function AttachmentEditorProvider( { children } ) {
+	const { media, isAttachment } = useSelect( ( select ) => {
+		const _postType = select( editorStore ).getCurrentPostType();
+		const _postId = select( editorStore ).getCurrentPostId();
+		const _isAttachment =
+			_postType === ATTACHMENT_POST_TYPE &&
+			window?.__experimentalMediaEditor;
+
+		let currentPost = null;
+		if ( _isAttachment ) {
+			currentPost = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				_postType,
+				_postId
+			);
+		}
+
+		return {
+			media: currentPost,
+			isAttachment: _isAttachment,
+		};
+	}, [] );
+
+	const { editPost } = useDispatch( editorStore );
+
+	const handleUpdate = ( updates ) => {
+		editPost( updates );
+	};
+
+	// Only wrap with provider for attachments
+	if ( ! isAttachment ) {
+		return children;
+	}
+
+	return (
+		<MediaEditorProvider value={ media } onChange={ handleUpdate }>
+			{ children }
+		</MediaEditorProvider>
+	);
+}

--- a/packages/editor/src/components/attachment-save-button/index.js
+++ b/packages/editor/src/components/attachment-save-button/index.js
@@ -1,0 +1,149 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useImageEditing } from '@wordpress/media-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Save button for attachment editing that handles both entity edits and image cropping.
+ * Enables the save button when either the entity has been edited OR the cropper is dirty.
+ *
+ * Based on the ciab-admin implementation.
+ *
+ * @return {Element} The save button component
+ */
+export default function AttachmentSaveButton() {
+	const [ isProcessing, setIsProcessing ] = useState( false );
+	const {
+		postId,
+		hasEntityEdits,
+		isSaving,
+		media,
+		onNavigateToEntityRecord,
+	} = useSelect( ( select ) => {
+		const { getCurrentPostId, isEditedPostDirty, isSavingPost } =
+			select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+		const { getSettings } = select( blockEditorStore );
+
+		const id = getCurrentPostId();
+		return {
+			postId: id,
+			hasEntityEdits: isEditedPostDirty(),
+			isSaving: isSavingPost(),
+			media: getEditedEntityRecord( 'postType', 'attachment', id ),
+			onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
+		};
+	}, [] );
+
+	const { isDirty: isCropperDirty, getModifiers, reset } = useImageEditing();
+
+	const { savePost } = useDispatch( editorStore );
+	const { editMediaEntity } = unlock( useDispatch( coreStore ) );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const handleSave = useCallback( async () => {
+		setIsProcessing( true );
+
+		try {
+			// If cropper is dirty, get modifiers and use editMediaEntity
+			if ( isCropperDirty && media?.source_url ) {
+				const modifiers = getModifiers();
+
+				if ( modifiers.length > 0 ) {
+					// Call editMediaEntity with modifiers
+					const response = await editMediaEntity(
+						postId,
+						{
+							src: media.source_url,
+							modifiers,
+						},
+						{ throwOnError: true }
+					);
+
+					if ( response && response.id ) {
+						// editMediaEntity returns a NEW attachment with a new ID
+						// Navigate to edit the new attachment without a full page reload
+						if ( onNavigateToEntityRecord ) {
+							onNavigateToEntityRecord( {
+								postId: response.id,
+								postType: 'attachment',
+							} );
+						}
+
+						// Reset the cropper to clean state
+						reset();
+
+						createSuccessNotice( __( 'Media saved' ), {
+							type: 'snackbar',
+							id: 'attachment-save-success',
+						} );
+					}
+				}
+			} else if ( hasEntityEdits ) {
+				// If only entity has edits (no cropper changes), use standard save
+				await savePost();
+
+				createSuccessNotice( __( 'Media saved' ), {
+					type: 'snackbar',
+					id: 'attachment-save-success',
+				} );
+			}
+		} catch ( error ) {
+			createErrorNotice(
+				__( 'Could not save attachment. Please try again.' ),
+				{
+					type: 'snackbar',
+					id: 'attachment-save-error',
+				}
+			);
+			// eslint-disable-next-line no-console
+			console.error( 'Error saving attachment:', error );
+		} finally {
+			setIsProcessing( false );
+		}
+	}, [
+		isCropperDirty,
+		hasEntityEdits,
+		media,
+		postId,
+		getModifiers,
+		reset,
+		editMediaEntity,
+		onNavigateToEntityRecord,
+		savePost,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+
+	// Button is enabled if entity has edits OR cropper is dirty
+	const isDisabled =
+		isSaving || isProcessing || ( ! hasEntityEdits && ! isCropperDirty );
+
+	return (
+		<Button
+			variant="primary"
+			size="compact"
+			onClick={ handleSave }
+			disabled={ isDisabled }
+			isBusy={ isSaving || isProcessing }
+			accessibleWhenDisabled
+			__experimentalIsFocusable
+		>
+			{ __( 'Save' ) }
+		</Button>
+	);
+}

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -10,10 +10,14 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import {
+	TEMPLATE_POST_TYPE,
+	ATTACHMENT_POST_TYPE,
+} from '../../store/constants';
 import EditorInterface from '../editor-interface';
 import { ExperimentalEditorProvider } from '../provider';
 import AttachmentEditorProvider from '../attachment-editor-provider';
+import AttachmentSaveButton from '../attachment-save-button';
 import Sidebar from '../sidebar';
 import NotesSidebar from '../collab-sidebar';
 import GlobalStylesSidebar from '../global-styles-sidebar';
@@ -43,6 +47,7 @@ function Editor( {
 		error,
 		isBlockTheme,
 		showGlobalStyles,
+		isAttachment,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -90,6 +95,9 @@ function Editor( {
 					userCanEditGlobalStyles &&
 					( currentPostType === 'wp_template' ||
 						renderingMode === 'template-locked' ),
+				isAttachment:
+					currentPostType === ATTACHMENT_POST_TYPE &&
+					window?.__experimentalMediaEditor,
 			};
 		},
 		[ postType, postId, templateId ]
@@ -118,7 +126,16 @@ function Editor( {
 					useSubRegistry={ false }
 				>
 					<AttachmentEditorProvider>
-						<EditorInterface { ...props }>
+						<EditorInterface
+							{ ...props }
+							customSaveButton={
+								isAttachment ? (
+									<AttachmentSaveButton />
+								) : (
+									props.customSaveButton
+								)
+							}
+						>
 							{ extraContent }
 						</EditorInterface>
 						{ children }

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -13,6 +13,7 @@ import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import EditorInterface from '../editor-interface';
 import { ExperimentalEditorProvider } from '../provider';
+import AttachmentEditorProvider from '../attachment-editor-provider';
 import Sidebar from '../sidebar';
 import NotesSidebar from '../collab-sidebar';
 import GlobalStylesSidebar from '../global-styles-sidebar';
@@ -116,17 +117,19 @@ function Editor( {
 					initialEdits={ initialEdits }
 					useSubRegistry={ false }
 				>
-					<EditorInterface { ...props }>
-						{ extraContent }
-					</EditorInterface>
-					{ children }
-					<Sidebar
-						onActionPerformed={ onActionPerformed }
-						extraPanels={ extraSidebarPanels }
-					/>
-					<NotesSidebar />
-					{ isBlockTheme && <GlobalStylesRenderer /> }
-					{ showGlobalStyles && <GlobalStylesSidebar /> }
+					<AttachmentEditorProvider>
+						<EditorInterface { ...props }>
+							{ extraContent }
+						</EditorInterface>
+						{ children }
+						<Sidebar
+							onActionPerformed={ onActionPerformed }
+							extraPanels={ extraSidebarPanels }
+						/>
+						<NotesSidebar />
+						{ isBlockTheme && <GlobalStylesRenderer /> }
+						{ showGlobalStyles && <GlobalStylesSidebar /> }
+					</AttachmentEditorProvider>
 				</ExperimentalEditorProvider>
 			) }
 		</>

--- a/packages/editor/src/components/media/crop-panel.js
+++ b/packages/editor/src/components/media/crop-panel.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { MediaEditForm, useMediaEditorContext } from '@wordpress/media-editor';
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelSection from '../post-panel-section';
+import { sidebars } from '../sidebar/constants';
+
+/**
+ * Media crop panel for the editor sidebar.
+ * Displays the editing controls (zoom, rotate, flip, aspect ratio).
+ * The actual cropper canvas is rendered in the main editor area via MediaPreview.
+ *
+ * @return {Element} The MediaCropPanel component.
+ */
+export default function MediaCropPanel() {
+	return (
+		<PostPanelSection className="editor-media-crop-panel">
+			<MediaCropPanelContent />
+		</PostPanelSection>
+	);
+}
+
+/**
+ * Internal component that has access to MediaEditorContext.
+ * Sets editing mode when the panel is mounted and clears it when unmounted.
+ */
+function MediaCropPanelContent() {
+	const { setIsEditingImage } = useMediaEditorContext();
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+
+	// Engage editing mode when this panel is shown
+	useEffect( () => {
+		setIsEditingImage( true );
+
+		// Clean up: exit editing mode when unmounting
+		return () => {
+			setIsEditingImage( false );
+		};
+	}, [ setIsEditingImage ] );
+
+	const handleCancel = () => {
+		// Switch back to the Document tab
+		enableComplementaryArea( 'core', sidebars.document );
+	};
+
+	// Only render the controls panel - the canvas is rendered in MediaPreview
+	return <MediaEditForm onCancel={ handleCancel } />;
+}

--- a/packages/editor/src/components/media/crop-panel.js
+++ b/packages/editor/src/components/media/crop-panel.js
@@ -3,14 +3,11 @@
  */
 import { MediaEditForm, useMediaEditorContext } from '@wordpress/media-editor';
 import { useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
-import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
 import PostPanelSection from '../post-panel-section';
-import { sidebars } from '../sidebar/constants';
 
 /**
  * Media crop panel for the editor sidebar.
@@ -29,27 +26,19 @@ export default function MediaCropPanel() {
 
 /**
  * Internal component that has access to MediaEditorContext.
- * Sets editing mode when the panel is mounted and clears it when unmounted.
+ * Sets editing mode when the panel is mounted.
+ * Crop edits persist across tab switches and are ephemeral until the attachment is saved.
  */
 function MediaCropPanelContent() {
 	const { setIsEditingImage } = useMediaEditorContext();
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	// Engage editing mode when this panel is shown
 	useEffect( () => {
 		setIsEditingImage( true );
-
-		// Clean up: exit editing mode when unmounting
-		return () => {
-			setIsEditingImage( false );
-		};
+		// Intentionally no cleanup - preserves crop state when switching tabs
+		// Crop edits remain ephemeral until the attachment is saved
 	}, [ setIsEditingImage ] );
 
-	const handleCancel = () => {
-		// Switch back to the Document tab
-		enableComplementaryArea( 'core', sidebars.document );
-	};
-
 	// Only render the controls panel - the canvas is rendered in MediaPreview
-	return <MediaEditForm onCancel={ handleCancel } />;
+	return <MediaEditForm />;
 }

--- a/packages/editor/src/components/media/index.js
+++ b/packages/editor/src/components/media/index.js
@@ -1,2 +1,3 @@
 export { default as MediaPreview } from './preview';
 export { default as MediaMetadataPanel } from './metadata-panel';
+export { default as MediaCropPanel } from './crop-panel';

--- a/packages/editor/src/components/media/preview.js
+++ b/packages/editor/src/components/media/preview.js
@@ -6,11 +6,18 @@ import {
 	MediaEditorCanvas,
 	useMediaEditorContext,
 } from '@wordpress/media-editor';
+import { useSelect } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import { sidebars } from '../sidebar/constants';
 
 /**
  * Media preview component for the editor.
- * Conditionally renders MediaEditorCanvas when in editing mode,
- * otherwise shows the normal preview.
+ * Conditionally renders MediaEditorCanvas when in editing mode AND the Crop tab is active.
+ * This allows crop edits to persist when switching between tabs.
  *
  * Uses MediaEditorContext from AttachmentEditorProvider.
  *
@@ -20,11 +27,17 @@ import {
 export default function MediaPreview( props ) {
 	const { isEditingImage } = useMediaEditorContext();
 
-	// If in editing mode, show the cropper canvas
-	if ( isEditingImage ) {
+	const isCropTabActive = useSelect( ( select ) => {
+		const activeComplementaryArea =
+			select( interfaceStore ).getActiveComplementaryArea( 'core' );
+		return activeComplementaryArea === sidebars.crop;
+	}, [] );
+
+	// Show canvas only when editing AND Crop tab is active
+	// This preserves crop state when switching to other tabs
+	if ( isEditingImage && isCropTabActive ) {
 		return <MediaEditorCanvas />;
 	}
 
-	// Otherwise show the normal preview
 	return <BaseMediaPreview { ...props } />;
 }

--- a/packages/editor/src/components/media/preview.js
+++ b/packages/editor/src/components/media/preview.js
@@ -2,34 +2,29 @@
  * WordPress dependencies
  */
 import {
-	MediaEditorProvider,
 	MediaPreview as BaseMediaPreview,
+	MediaEditorCanvas,
+	useMediaEditorContext,
 } from '@wordpress/media-editor';
-import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { store as editorStore } from '../../store';
 
 /**
  * Media preview component for the editor.
- * Connects the base MediaPreview component to the editor store.
+ * Conditionally renders MediaEditorCanvas when in editing mode,
+ * otherwise shows the normal preview.
+ *
+ * Uses MediaEditorContext from AttachmentEditorProvider.
  *
  * @param {Object} props - Additional props to spread on MediaPreview.
  * @return {Element} The MediaPreview component.
  */
 export default function MediaPreview( props ) {
-	const { media } = useSelect( ( select ) => {
-		const currentPost = select( editorStore ).getCurrentPost();
-		return {
-			media: currentPost,
-		};
-	}, [] );
+	const { isEditingImage } = useMediaEditorContext();
 
-	return (
-		<MediaEditorProvider value={ media }>
-			<BaseMediaPreview { ...props } />
-		</MediaEditorProvider>
-	);
+	// If in editing mode, show the cropper canvas
+	if ( isEditingImage ) {
+		return <MediaEditorCanvas />;
+	}
+
+	// Otherwise show the normal preview
+	return <BaseMediaPreview { ...props } />;
 }

--- a/packages/editor/src/components/media/style.scss
+++ b/packages/editor/src/components/media/style.scss
@@ -1,0 +1,5 @@
+// Zero out padding from PostPanelSection for crop panel
+// ToolsPanel and action buttons provide their own padding
+.editor-media-crop-panel.editor-post-panel__section {
+	padding: 0;
+}

--- a/packages/editor/src/components/sidebar/constants.js
+++ b/packages/editor/src/components/sidebar/constants.js
@@ -1,4 +1,5 @@
 export const sidebars = {
 	document: 'edit-post/document',
 	block: 'edit-post/block',
+	crop: 'edit-post/crop',
 };

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -6,6 +6,7 @@ import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -18,18 +19,33 @@ import { sidebars } from './constants';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SidebarHeader = ( _, ref ) => {
-	const { postTypeLabel, isAttachment, isRevisionsMode } = useSelect(
+	const { postTypeLabel, isAttachment, isImageAttachment, isRevisionsMode } = useSelect(
 		( select ) => {
-			const { getPostTypeLabel, getCurrentPostType } =
+			const { getPostTypeLabel, getCurrentPostType, getCurrentPostId } =
 				select( editorStore );
 			const { isRevisionsMode: _isRevisionsMode } = unlock(
 				select( editorStore )
 			);
+			const currentPostType = getCurrentPostType();
+			const _isAttachment =
+				currentPostType === ATTACHMENT_POST_TYPE &&
+				window?.__experimentalMediaEditor;
+
+			let _isImageAttachment = false;
+			if ( _isAttachment ) {
+				const media = select( coreStore ).getEditedEntityRecord(
+					'postType',
+					currentPostType,
+					getCurrentPostId()
+				);
+				_isImageAttachment =
+					media?.mime_type?.split( '/' )[ 0 ] === 'image';
+			}
+
 			return {
 				postTypeLabel: getPostTypeLabel(),
-				isAttachment:
-					getCurrentPostType() === ATTACHMENT_POST_TYPE &&
-					window?.__experimentalMediaEditor,
+				isAttachment: _isAttachment,
+				isImageAttachment: _isImageAttachment,
 				isRevisionsMode: _isRevisionsMode(),
 			};
 		},
@@ -55,6 +71,15 @@ const SidebarHeader = ( _, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
+			{ isImageAttachment && (
+				<Tabs.Tab
+					tabId={ sidebars.crop }
+					// Used for focus management in the SettingsSidebar component.
+					data-tab-id={ sidebars.crop }
+				>
+					{ __( 'Crop' ) }
+				</Tabs.Tab>
+			) }
 			{ ! isAttachment && (
 				<Tabs.Tab
 					tabId={ sidebars.block }

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -19,8 +19,8 @@ import { sidebars } from './constants';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SidebarHeader = ( _, ref ) => {
-	const { postTypeLabel, isAttachment, isImageAttachment, isRevisionsMode } = useSelect(
-		( select ) => {
+	const { postTypeLabel, isAttachment, isImageAttachment, isRevisionsMode } =
+		useSelect( ( select ) => {
 			const { getPostTypeLabel, getCurrentPostType, getCurrentPostId } =
 				select( editorStore );
 			const { isRevisionsMode: _isRevisionsMode } = unlock(
@@ -48,9 +48,7 @@ const SidebarHeader = ( _, ref ) => {
 				isImageAttachment: _isImageAttachment,
 				isRevisionsMode: _isRevisionsMode(),
 			};
-		},
-		[]
-	);
+		}, [] );
 
 	let documentLabel;
 	if ( isRevisionsMode ) {

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -5,6 +5,8 @@ import {
 	BlockInspector,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Platform,
@@ -15,9 +17,8 @@ import {
 } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
 import TemplateContentPanel from '../template-content-panel';
 import TemplatePartContentPanel from '../template-part-content-panel';
-import { MediaMetadataPanel } from '../media';
+import { MediaMetadataPanel, MediaCropPanel } from '../media';
 import RevisionBlockDiffPanel from '../revision-block-diff';
 import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-sidebars';
 import { sidebars } from './constants';
@@ -67,6 +68,25 @@ const SidebarContent = ( {
 	const isRevisionsMode = useSelect( ( select ) => {
 		return unlock( select( editorStore ) ).isRevisionsMode();
 	} );
+
+	const { isImageAttachment } = useSelect(
+		( select ) => {
+			if ( ! isAttachment ) {
+				return { isImageAttachment: false };
+			}
+
+			const media = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				select( editorStore ).getCurrentPostId()
+			);
+			return {
+				isImageAttachment:
+					media?.mime_type?.split( '/' )[ 0 ] === 'image',
+			};
+		},
+		[ isAttachment, postType ]
+	);
 
 	// This effect addresses a race condition caused by tabbing from the last
 	// block in the editor into the settings sidebar. Without this effect, the
@@ -142,6 +162,11 @@ const SidebarContent = ( {
 						</>
 					) }
 				</Tabs.TabPanel>
+				{ isImageAttachment && (
+					<Tabs.TabPanel tabId={ sidebars.crop } focusable={ false }>
+						<MediaCropPanel />
+					</Tabs.TabPanel>
+				) }
 				{ ! isAttachment && (
 					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 						<BlockInspector />
@@ -166,6 +191,7 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 			const _isEditorSidebarOpened = [
 				sidebars.block,
 				sidebars.document,
+				sidebars.crop,
 			].includes( sidebar );
 			let _tabName = sidebar;
 			if ( ! _isEditorSidebarOpened ) {

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -5,6 +5,7 @@
 @use "@wordpress/fields/build-style/style.css" as *;
 @use "@wordpress/media-editor/build-style/style.css" as *;
 @use "./components/autocompleters/style.scss" as *;
+@use "./components/media/style.scss" as *;
 @use "./components/collab-sidebar/style.scss" as *;
 @use "./components/collaborators-presence/avatar/styles.scss" as *;
 @use "./components/collaborators-presence/avatar-group/styles.scss" as *;

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -43,9 +43,13 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/dataviews": "file:../dataviews",
 		"@wordpress/element": "file:../element",
-		"@wordpress/i18n": "file:../i18n"
+		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/icons": "file:../icons",
+		"@wordpress/image-cropper": "file:../image-cropper",
+		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/media-editor/src/components/cropping-panel/aspect-ratio-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/aspect-ratio-control.tsx
@@ -9,15 +9,13 @@ import { useImageCropper } from '@wordpress/image-cropper';
  * Internal dependencies
  */
 import { getCommonAspectRatios } from '../../utils/aspect-ratio';
-import { useMediaEditorContext } from '../media-editor-provider';
 
 /**
  * AspectRatioControl component provides a dropdown to select aspect ratio presets.
  * Includes Original, 1:1, 16:9, 4:3, 3:2, 3:4, 2:3
  */
 export default function AspectRatioControl() {
-	const { media } = useMediaEditorContext();
-	const { cropperState, setCropperState } = useImageCropper();
+	const { cropperState, setCropperState, resetState } = useImageCropper();
 	const aspectRatio = cropperState.aspectRatio;
 
 	const aspectRatios = getCommonAspectRatios();
@@ -25,17 +23,27 @@ export default function AspectRatioControl() {
 	const handleAspectRatioChange = ( value: string ) => {
 		const numValue = parseFloat( value );
 		if ( ! isNaN( numValue ) ) {
-			// If "Original" (value 0), calculate from media dimensions
-			if ( numValue === 0 && media?.source_url ) {
-				// Use natural aspect ratio from media
-				// For now, set to free aspect (aspectRatio: 1)
-				// TODO: Calculate actual media aspect ratio
-				setCropperState( { aspectRatio: 1 } );
-			} else {
+			// If "Original" (value 0), use the natural aspect ratio from reset state
+			if ( numValue === 0 && resetState?.aspectRatio ) {
+				setCropperState( { aspectRatio: resetState.aspectRatio } );
+			} else if ( numValue !== 0 ) {
 				setCropperState( { aspectRatio: numValue } );
 			}
 		}
 	};
+
+	// Determine which option to show as selected
+	// If current aspect ratio matches the natural ratio (original OR rotated), show "Original"
+	const tolerance = 0.01;
+	const naturalRatio = resetState?.aspectRatio || 0;
+	const rotatedNaturalRatio = naturalRatio ? 1 / naturalRatio : 0;
+	const matchesOriginal =
+		naturalRatio && Math.abs( aspectRatio - naturalRatio ) < tolerance;
+	const matchesRotated =
+		rotatedNaturalRatio &&
+		Math.abs( aspectRatio - rotatedNaturalRatio ) < tolerance;
+	const displayValue =
+		matchesOriginal || matchesRotated ? '0' : String( aspectRatio );
 
 	const options = aspectRatios.map( ( ratio ) => ( {
 		label: ratio.label,
@@ -47,7 +55,7 @@ export default function AspectRatioControl() {
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			label={ __( 'Aspect Ratio' ) }
-			value={ String( aspectRatio ) }
+			value={ displayValue }
 			options={ options }
 			onChange={ handleAspectRatioChange }
 		/>

--- a/packages/media-editor/src/components/cropping-panel/aspect-ratio-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/aspect-ratio-control.tsx
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * Internal dependencies
+ */
+import { getCommonAspectRatios } from '../../utils/aspect-ratio';
+import { useMediaEditorContext } from '../media-editor-provider';
+
+/**
+ * AspectRatioControl component provides a dropdown to select aspect ratio presets.
+ * Includes Original, 1:1, 16:9, 4:3, 3:2, 3:4, 2:3
+ */
+export default function AspectRatioControl() {
+	const { media } = useMediaEditorContext();
+	const { cropperState, setCropperState } = useImageCropper();
+	const aspectRatio = cropperState.aspectRatio;
+
+	const aspectRatios = getCommonAspectRatios();
+
+	const handleAspectRatioChange = ( value: string ) => {
+		const numValue = parseFloat( value );
+		if ( ! isNaN( numValue ) ) {
+			// If "Original" (value 0), calculate from media dimensions
+			if ( numValue === 0 && media?.source_url ) {
+				// Use natural aspect ratio from media
+				// For now, set to free aspect (aspectRatio: 1)
+				// TODO: Calculate actual media aspect ratio
+				setCropperState( { aspectRatio: 1 } );
+			} else {
+				setCropperState( { aspectRatio: numValue } );
+			}
+		}
+	};
+
+	const options = aspectRatios.map( ( ratio ) => ( {
+		label: ratio.label,
+		value: String( ratio.value ),
+	} ) );
+
+	return (
+		<SelectControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Aspect Ratio' ) }
+			value={ String( aspectRatio ) }
+			options={ options }
+			onChange={ handleAspectRatioChange }
+		/>
+	);
+}

--- a/packages/media-editor/src/components/cropping-panel/flip-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/flip-control.tsx
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { flipHorizontal, flipVertical } from '@wordpress/icons';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * FlipControl component provides buttons to flip the image horizontally or vertically.
+ * Uses regular buttons (not toggle) that flip the image each time they're clicked.
+ */
+export default function FlipControl() {
+	const { cropperState, setCropperState } = useImageCropper();
+	const flip = cropperState.flip;
+
+	const handleFlipHorizontal = () => {
+		setCropperState( {
+			flip: {
+				...flip,
+				horizontal: ! flip.horizontal,
+			},
+		} );
+	};
+
+	const handleFlipVertical = () => {
+		setCropperState( {
+			flip: {
+				...flip,
+				vertical: ! flip.vertical,
+			},
+		} );
+	};
+
+	return (
+		<HStack
+			className="media-editor-flip-control"
+			justify="space-between"
+			spacing={ 2 }
+		>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				icon={ flipHorizontal }
+				onClick={ handleFlipHorizontal }
+				className="media-editor-flip-control__button"
+			>
+				{ __( 'Horizontal' ) }
+			</Button>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				icon={ flipVertical }
+				onClick={ handleFlipVertical }
+				className="media-editor-flip-control__button"
+			>
+				{ __( 'Vertical' ) }
+			</Button>
+		</HStack>
+	);
+}

--- a/packages/media-editor/src/components/cropping-panel/flip-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/flip-control.tsx
@@ -1,14 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { flipHorizontal, flipVertical } from '@wordpress/icons';
 import { useImageCropper } from '@wordpress/image-cropper';
 
 /**
  * FlipControl component provides buttons to flip the image horizontally or vertically.
- * Uses regular buttons (not toggle) that flip the image each time they're clicked.
+ * Uses action buttons (not toggles) that flip the image each time they're clicked.
  */
 export default function FlipControl() {
 	const { cropperState, setCropperState } = useImageCropper();
@@ -33,29 +38,34 @@ export default function FlipControl() {
 	};
 
 	return (
-		<HStack
-			className="media-editor-flip-control"
-			justify="space-between"
-			spacing={ 2 }
-		>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				icon={ flipHorizontal }
-				onClick={ handleFlipHorizontal }
-				className="media-editor-flip-control__button"
+		<VStack spacing={ 2 }>
+			<Heading level={ 3 } className="media-editor-flip-control__heading">
+				{ __( 'Flip' ) }
+			</Heading>
+			<HStack
+				className="media-editor-flip-control"
+				justify="space-between"
+				spacing={ 2 }
 			>
-				{ __( 'Horizontal' ) }
-			</Button>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				icon={ flipVertical }
-				onClick={ handleFlipVertical }
-				className="media-editor-flip-control__button"
-			>
-				{ __( 'Vertical' ) }
-			</Button>
-		</HStack>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					icon={ flipHorizontal }
+					onClick={ handleFlipHorizontal }
+					className="media-editor-flip-control__button"
+				>
+					{ __( 'Horizontal' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					icon={ flipVertical }
+					onClick={ handleFlipVertical }
+					className="media-editor-flip-control__button"
+				>
+					{ __( 'Vertical' ) }
+				</Button>
+			</HStack>
+		</VStack>
 	);
 }

--- a/packages/media-editor/src/components/cropping-panel/index.tsx
+++ b/packages/media-editor/src/components/cropping-panel/index.tsx
@@ -1,0 +1,154 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useImageCropper } from '@wordpress/image-cropper';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ZoomControl from './zoom-control';
+import AspectRatioControl from './aspect-ratio-control';
+import RotationControl from './rotation-control';
+import FlipControl from './flip-control';
+
+/**
+ * CroppingPanel component provides a tools panel with cropping controls.
+ * Uses ToolsPanel for consistent WordPress UI patterns.
+ * Split into two panels: Crop Area (zoom, aspect ratio) and Position (rotate, flip).
+ */
+export default function CroppingPanel() {
+	const { cropperState, setCropperState, reset, resetState } =
+		useImageCropper();
+
+	const resetCropArea = useCallback( () => {
+		setCropperState( {
+			zoom: resetState?.zoom ?? 1,
+			aspectRatio: resetState?.aspectRatio ?? 1,
+		} );
+	}, [ setCropperState, resetState ] );
+
+	const resetPosition = useCallback( () => {
+		setCropperState( {
+			flip: resetState?.flip ?? {
+				horizontal: false,
+				vertical: false,
+			},
+			rotation: resetState?.rotation ?? 0,
+		} );
+	}, [ setCropperState, resetState ] );
+
+	return (
+		<div className="media-editor-cropping-panel">
+			<ToolsPanel
+				label={ __( 'Crop area' ) }
+				resetAll={ resetCropArea }
+				className="media-editor-cropping-panel__tools"
+				panelId="crop-area"
+			>
+				<ToolsPanelItem
+					hasValue={ () =>
+						cropperState.zoom !== ( resetState?.zoom ?? 1 )
+					}
+					label={ __( 'Zoom' ) }
+					onDeselect={ () =>
+						setCropperState( { zoom: resetState?.zoom ?? 1 } )
+					}
+					isShownByDefault
+					panelId="crop-area"
+				>
+					<ZoomControl />
+				</ToolsPanelItem>
+
+				<ToolsPanelItem
+					hasValue={ () =>
+						cropperState.aspectRatio !==
+						( resetState?.aspectRatio ?? 1 )
+					}
+					label={ __( 'Aspect Ratio' ) }
+					onDeselect={ () =>
+						setCropperState( {
+							aspectRatio: resetState?.aspectRatio ?? 1,
+						} )
+					}
+					isShownByDefault
+					panelId="crop-area"
+				>
+					<AspectRatioControl />
+				</ToolsPanelItem>
+			</ToolsPanel>
+
+			<ToolsPanel
+				label={ __( 'Position' ) }
+				resetAll={ resetPosition }
+				className="media-editor-cropping-panel__tools"
+				panelId="position"
+			>
+				<ToolsPanelItem
+					hasValue={ () =>
+						cropperState.rotation !== ( resetState?.rotation ?? 0 )
+					}
+					label={ __( 'Rotate' ) }
+					onDeselect={ () =>
+						setCropperState( {
+							rotation: resetState?.rotation ?? 0,
+						} )
+					}
+					isShownByDefault
+					panelId="position"
+				>
+					<RotationControl />
+				</ToolsPanelItem>
+
+				<ToolsPanelItem
+					hasValue={ () => {
+						const defaultFlip = {
+							horizontal: false,
+							vertical: false,
+						};
+						const resetFlip = resetState?.flip ?? defaultFlip;
+						return (
+							cropperState.flip.horizontal !==
+								resetFlip.horizontal ||
+							cropperState.flip.vertical !== resetFlip.vertical
+						);
+					} }
+					label={ __( 'Flip' ) }
+					onDeselect={ () =>
+						setCropperState( {
+							flip: resetState?.flip ?? {
+								horizontal: false,
+								vertical: false,
+							},
+						} )
+					}
+					isShownByDefault
+					panelId="position"
+				>
+					<FlipControl />
+				</ToolsPanelItem>
+			</ToolsPanel>
+
+			<HStack
+				justify="flex-end"
+				className="media-editor-cropping-panel__reset"
+			>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					isDestructive
+					onClick={ reset }
+				>
+					{ __( 'Reset all' ) }
+				</Button>
+			</HStack>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { rotateLeft, rotateRight } from '@wordpress/icons';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * RotationControl component provides buttons to rotate the image by 90 degrees.
+ * Includes rotate left and rotate right buttons.
+ */
+export default function RotationControl() {
+	const { cropperState, setCropperState } = useImageCropper();
+	const rotation = cropperState.rotation;
+
+	const handleRotateLeft = () => {
+		setCropperState( { rotation: rotation - 90 } );
+	};
+
+	const handleRotateRight = () => {
+		setCropperState( { rotation: rotation + 90 } );
+	};
+
+	return (
+		<HStack
+			className="media-editor-rotation-control"
+			justify="space-between"
+			spacing={ 2 }
+		>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				icon={ rotateLeft }
+				onClick={ handleRotateLeft }
+				className="media-editor-rotation-control__button"
+			>
+				{ __( '90° left' ) }
+			</Button>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				icon={ rotateRight }
+				onClick={ handleRotateRight }
+				className="media-editor-rotation-control__button"
+			>
+				{ __( '90° right' ) }
+			</Button>
+		</HStack>
+	);
+}

--- a/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
@@ -10,21 +10,81 @@ import {
 import { __ } from '@wordpress/i18n';
 import { rotateLeft, rotateRight } from '@wordpress/icons';
 import { useImageCropper } from '@wordpress/image-cropper';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Checks if a rotation is a quarter turn (90° or 270°).
+ *
+ * @param rotation - The rotation value to check
+ * @return True if the rotation is 90° or 270°
+ */
+function isQuarterTurn( rotation: number ): boolean {
+	const normalized = ( ( rotation % 360 ) + 360 ) % 360;
+	return normalized % 180 === 90;
+}
 
 /**
  * RotationControl component provides buttons to rotate the image by 90 degrees.
  * Includes rotate left and rotate right buttons with a visual label.
  */
 export default function RotationControl() {
-	const { cropperState, setCropperState } = useImageCropper();
+	const { cropperState, setCropperState, resetState } = useImageCropper();
 	const rotation = cropperState.rotation;
 
+	/**
+	 * Checks if the aspect ratio should be flipped during rotation.
+	 * If the user is using the natural aspect ratio and hasn't zoomed,
+	 * flip the aspect ratio to match the rotated image orientation.
+	 */
+	const maybeFlipAspectRatio = useCallback(
+		( updatedRotation: number ) => {
+			if ( ! resetState?.aspectRatio || ! cropperState.mediaSize ) {
+				return;
+			}
+
+			const original = resetState.aspectRatio;
+			const rotated = 1 / original;
+			const tolerance = 0.01;
+
+			const matchesOriginal =
+				Math.abs( cropperState.aspectRatio - original ) < tolerance;
+			const matchesRotated =
+				Math.abs( cropperState.aspectRatio - rotated ) < tolerance;
+
+			if (
+				cropperState.zoom === 1 &&
+				( matchesOriginal || matchesRotated )
+			) {
+				const newAspectRatio = isQuarterTurn( updatedRotation )
+					? rotated
+					: original;
+
+				if (
+					Math.abs( newAspectRatio - cropperState.aspectRatio ) >
+					tolerance
+				) {
+					// Reset crop position to center when flipping aspect ratio
+					// This prevents unwanted zooming/cropping during rotation
+					setCropperState( {
+						aspectRatio: newAspectRatio,
+						crop: { x: 0, y: 0 },
+					} );
+				}
+			}
+		},
+		[ cropperState, resetState, setCropperState ]
+	);
+
 	const handleRotateLeft = () => {
-		setCropperState( { rotation: rotation - 90 } );
+		const newRotation = rotation - 90;
+		setCropperState( { rotation: newRotation } );
+		maybeFlipAspectRatio( newRotation );
 	};
 
 	const handleRotateRight = () => {
-		setCropperState( { rotation: rotation + 90 } );
+		const newRotation = rotation + 90;
+		setCropperState( { rotation: newRotation } );
+		maybeFlipAspectRatio( newRotation );
 	};
 
 	return (

--- a/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/rotation-control.tsx
@@ -1,14 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { rotateLeft, rotateRight } from '@wordpress/icons';
 import { useImageCropper } from '@wordpress/image-cropper';
 
 /**
  * RotationControl component provides buttons to rotate the image by 90 degrees.
- * Includes rotate left and rotate right buttons.
+ * Includes rotate left and rotate right buttons with a visual label.
  */
 export default function RotationControl() {
 	const { cropperState, setCropperState } = useImageCropper();
@@ -23,29 +28,37 @@ export default function RotationControl() {
 	};
 
 	return (
-		<HStack
-			className="media-editor-rotation-control"
-			justify="space-between"
-			spacing={ 2 }
-		>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				icon={ rotateLeft }
-				onClick={ handleRotateLeft }
-				className="media-editor-rotation-control__button"
+		<VStack spacing={ 2 }>
+			<Heading
+				level={ 3 }
+				className="media-editor-rotation-control__heading"
 			>
-				{ __( '90° left' ) }
-			</Button>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				icon={ rotateRight }
-				onClick={ handleRotateRight }
-				className="media-editor-rotation-control__button"
+				{ __( 'Rotate' ) }
+			</Heading>
+			<HStack
+				className="media-editor-rotation-control"
+				justify="space-between"
+				spacing={ 2 }
 			>
-				{ __( '90° right' ) }
-			</Button>
-		</HStack>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					icon={ rotateLeft }
+					onClick={ handleRotateLeft }
+					className="media-editor-rotation-control__button"
+				>
+					{ __( '90° left' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					icon={ rotateRight }
+					onClick={ handleRotateRight }
+					className="media-editor-rotation-control__button"
+				>
+					{ __( '90° right' ) }
+				</Button>
+			</HStack>
+		</VStack>
 	);
 }

--- a/packages/media-editor/src/components/cropping-panel/style.scss
+++ b/packages/media-editor/src/components/cropping-panel/style.scss
@@ -1,0 +1,29 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-editor-cropping-panel {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+}
+
+.media-editor-cropping-panel__tools {
+	border: 1px solid $gray-300;
+	border-radius: 2px;
+}
+
+.media-editor-cropping-panel__reset {
+	padding-top: $grid-unit-10;
+}
+
+.media-editor-rotation-control,
+.media-editor-flip-control {
+	width: 100%;
+}
+
+.media-editor-rotation-control__button,
+.media-editor-flip-control__button {
+	flex: 1;
+	justify-content: center;
+}

--- a/packages/media-editor/src/components/cropping-panel/style.scss
+++ b/packages/media-editor/src/components/cropping-panel/style.scss
@@ -6,15 +6,23 @@
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-20;
-}
 
-.media-editor-cropping-panel__tools {
-	border: 1px solid $gray-300;
-	border-radius: 2px;
+	// Style for heading labels within control items (action buttons)
+	.media-editor-rotation-control__heading,
+	.media-editor-flip-control__heading {
+		margin-bottom: 0;
+	}
 }
 
 .media-editor-cropping-panel__reset {
-	padding-top: $grid-unit-10;
+	padding: 0 $grid-unit-20;
+
+	// Make the button fill available width
+	button {
+		flex-grow: 1;
+		flex-basis: 0;
+		justify-content: center;
+	}
 }
 
 .media-editor-rotation-control,

--- a/packages/media-editor/src/components/cropping-panel/zoom-control.tsx
+++ b/packages/media-editor/src/components/cropping-panel/zoom-control.tsx
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * ZoomControl component provides a slider to control image zoom level.
+ * Range: 1-5 (100%-500%)
+ */
+export default function ZoomControl() {
+	const { cropperState, setCropperState } = useImageCropper();
+	const zoom = cropperState.zoom;
+
+	const handleZoomChange = ( value: number | undefined ) => {
+		if ( value !== undefined ) {
+			setCropperState( { zoom: value } );
+		}
+	};
+
+	return (
+		<RangeControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Zoom' ) }
+			value={ zoom }
+			onChange={ handleZoomChange }
+			min={ 1 }
+			max={ 5 }
+			step={ 0.1 }
+			withInputField={ false }
+			help={ `${ Math.round( zoom * 100 ) }%` }
+		/>
+	);
+}

--- a/packages/media-editor/src/components/cropping-toolbar/index.tsx
+++ b/packages/media-editor/src/components/cropping-toolbar/index.tsx
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	rotateLeft,
+	rotateRight,
+	flipHorizontal,
+	flipVertical,
+} from '@wordpress/icons';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * CroppingToolbar component provides a compact horizontal toolbar layout
+ * for image editing controls. Alternative to CroppingPanel for toolbar scenarios.
+ */
+export default function CroppingToolbar() {
+	const { cropperState, setCropperState } = useImageCropper();
+	const { rotation, flip } = cropperState;
+
+	const handleRotateLeft = () => {
+		setCropperState( { rotation: rotation - 90 } );
+	};
+
+	const handleRotateRight = () => {
+		setCropperState( { rotation: rotation + 90 } );
+	};
+
+	const handleFlipHorizontal = () => {
+		setCropperState( {
+			flip: {
+				...flip,
+				horizontal: ! flip.horizontal,
+			},
+		} );
+	};
+
+	const handleFlipVertical = () => {
+		setCropperState( {
+			flip: {
+				...flip,
+				vertical: ! flip.vertical,
+			},
+		} );
+	};
+
+	return (
+		<div className="media-editor-cropping-toolbar">
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ rotateLeft }
+					label={ __( 'Rotate left' ) }
+					onClick={ handleRotateLeft }
+				/>
+				<ToolbarButton
+					icon={ rotateRight }
+					label={ __( 'Rotate right' ) }
+					onClick={ handleRotateRight }
+				/>
+				<ToolbarButton
+					icon={ flipHorizontal }
+					label={ __( 'Flip horizontal' ) }
+					onClick={ handleFlipHorizontal }
+					isPressed={ flip.horizontal }
+				/>
+				<ToolbarButton
+					icon={ flipVertical }
+					label={ __( 'Flip vertical' ) }
+					onClick={ handleFlipVertical }
+					isPressed={ flip.vertical }
+				/>
+			</ToolbarGroup>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/cropping-toolbar/style.scss
+++ b/packages/media-editor/src/components/cropping-toolbar/style.scss
@@ -1,0 +1,23 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-editor-cropping-toolbar {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	padding: $grid-unit-10;
+	background: #fff;
+	border: 1px solid $gray-300;
+	border-radius: 2px;
+
+	.components-toolbar-group {
+		margin: 0;
+		border: none;
+	}
+
+	.components-toolbar-button {
+		min-width: $button-size;
+		height: $button-size;
+		padding: 0;
+	}
+}

--- a/packages/media-editor/src/components/image-cropper/index.tsx
+++ b/packages/media-editor/src/components/image-cropper/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { ImageCropper as ImageCropperComponent } from '@wordpress/image-cropper';
+
+/**
+ * Internal dependencies
+ */
+
+interface ImageCropperProps {
+	src: string;
+	width?: number;
+	height?: number;
+}
+
+/**
+ * ImageCropper component wraps the ImageCropperComponent from @wordpress/image-cropper.
+ * Provides consistent styling and integration with media-editor.
+ *
+ * @param {Object}  props        - Component props
+ * @param {string}  props.src    - Source URL of the image to crop
+ * @param {number=} props.width  - Optional width for the container
+ * @param {number=} props.height - Optional height for the container
+ * @return {Element} ImageCropper component
+ */
+export default function ImageCropper( {
+	src,
+	width,
+	height,
+}: ImageCropperProps ) {
+	return (
+		<div
+			className={ clsx( 'media-editor-image-cropper' ) }
+			style={ {
+				width: width || '100%',
+				height: height || 'auto',
+			} }
+		>
+			<ImageCropperComponent src={ src } />
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/image-cropper/style.scss
+++ b/packages/media-editor/src/components/image-cropper/style.scss
@@ -1,0 +1,13 @@
+.media-editor-image-cropper {
+	position: relative;
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	// Override image-cropper defaults to fit within media-editor
+	.image-cropper {
+		width: 100%;
+		height: 100%;
+	}
+}

--- a/packages/media-editor/src/components/media-edit-form/index.tsx
+++ b/packages/media-editor/src/components/media-edit-form/index.tsx
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../media-editor-provider';
+import useImageEditing from '../../hooks/use-image-editing';
+import CroppingPanel from '../cropping-panel';
+
+export interface MediaEditFormProps {
+	onCancel?: () => void;
+}
+
+/**
+ * MediaEditForm component provides editing controls when in image editing mode.
+ * This is a sibling component to MediaForm and only renders when editing an image.
+ *
+ * @param {Object}   props          - Component props
+ * @param {Function} props.onCancel - Optional callback when Cancel is clicked
+ */
+export default function MediaEditForm( { onCancel }: MediaEditFormProps ) {
+	const { isEditingImage } = useMediaEditorContext();
+	const { saveEdits, cancelEdits } = useImageEditing();
+
+	// Only render when editing an image
+	if ( ! isEditingImage ) {
+		return null;
+	}
+
+	const handleApply = async () => {
+		await saveEdits();
+	};
+
+	const handleCancel = () => {
+		cancelEdits();
+		onCancel?.();
+	};
+
+	return (
+		<div className="media-editor-edit-form">
+			<CroppingPanel />
+			<div className="media-editor-edit-form__actions">
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ handleCancel }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ handleApply }
+				>
+					{ __( 'Apply' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/media-edit-form/index.tsx
+++ b/packages/media-editor/src/components/media-edit-form/index.tsx
@@ -1,64 +1,27 @@
 /**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { useMediaEditorContext } from '../media-editor-provider';
-import useImageEditing from '../../hooks/use-image-editing';
 import CroppingPanel from '../cropping-panel';
-
-export interface MediaEditFormProps {
-	onCancel?: () => void;
-}
 
 /**
  * MediaEditForm component provides editing controls when in image editing mode.
  * This is a sibling component to MediaForm and only renders when editing an image.
  *
- * @param {Object}   props          - Component props
- * @param {Function} props.onCancel - Optional callback when Cancel is clicked
+ * Crop edits are ephemeral and only applied to the preview until the attachment is saved.
+ * CroppingPanel includes a "Reset all" button to discard changes.
  */
-export default function MediaEditForm( { onCancel }: MediaEditFormProps ) {
+export default function MediaEditForm() {
 	const { isEditingImage } = useMediaEditorContext();
-	const { saveEdits, cancelEdits } = useImageEditing();
 
 	// Only render when editing an image
 	if ( ! isEditingImage ) {
 		return null;
 	}
 
-	const handleApply = async () => {
-		await saveEdits();
-	};
-
-	const handleCancel = () => {
-		cancelEdits();
-		onCancel?.();
-	};
-
 	return (
 		<div className="media-editor-edit-form">
 			<CroppingPanel />
-			<div className="media-editor-edit-form__actions">
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					onClick={ handleCancel }
-				>
-					{ __( 'Cancel' ) }
-				</Button>
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					onClick={ handleApply }
-				>
-					{ __( 'Apply' ) }
-				</Button>
-			</div>
 		</div>
 	);
 }

--- a/packages/media-editor/src/components/media-edit-form/style.scss
+++ b/packages/media-editor/src/components/media-edit-form/style.scss
@@ -5,13 +5,19 @@
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-20;
-	padding: $grid-unit-20 0;
 }
 
 .media-editor-edit-form__actions {
 	display: flex;
 	gap: $grid-unit-15;
-	justify-content: flex-end;
-	padding-top: $grid-unit-20;
+	justify-content: space-between;
+	padding: $grid-unit-20;
 	border-top: 1px solid $gray-200;
+
+	// Make each button take up half the width
+	button {
+		flex-grow: 1;
+		flex-basis: 0;
+		justify-content: center;
+	}
 }

--- a/packages/media-editor/src/components/media-edit-form/style.scss
+++ b/packages/media-editor/src/components/media-edit-form/style.scss
@@ -1,0 +1,17 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-editor-edit-form {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+	padding: $grid-unit-20 0;
+}
+
+.media-editor-edit-form__actions {
+	display: flex;
+	gap: $grid-unit-15;
+	justify-content: flex-end;
+	padding-top: $grid-unit-20;
+	border-top: 1px solid $gray-200;
+}

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -7,57 +7,76 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
-import { ImageCropper as ImageCropperComponent } from '@wordpress/image-cropper';
-import { useState, useEffect } from '@wordpress/element';
+import {
+	ImageCropper as ImageCropperComponent,
+	useImageCropper,
+	type MediaSize,
+} from '@wordpress/image-cropper';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useMediaEditorContext } from '../media-editor-provider';
 
+const DEFAULT_CONTAINER_STYLE = {
+	minHeight: '100%',
+	minWidth: '100%',
+	maxWidth: '100%',
+	maxHeight: '100%',
+};
+
 /**
  * MediaEditorCanvas component renders the image cropper when in editing mode.
  * This is a sibling component to MediaPreview and only renders when editing an image.
  *
- * Note: ImageCropperProvider is provided by AttachmentEditorProvider at a higher level,
+ * Note: ImageCropperProvider is provided internally by MediaEditorProvider,
  * so both this component and the sidebar controls can access the same cropper state.
  */
 export default function MediaEditorCanvas() {
 	const { media, isEditingImage } = useMediaEditorContext();
-	const [ contentResizeListener, { width: clientWidth } ] =
-		useResizeObserver();
-	const [ naturalDimensions, setNaturalDimensions ] = useState< {
-		width: number;
-		height: number;
-	} | null >( null );
+	const { setResetState, isDirty, cropperState, setCropperState } =
+		useImageCropper();
 
 	const isLoading = ! media?.source_url;
 	const imageUrl = media?.source_url || '';
 
-	// Load the image to get natural dimensions
-	useEffect( () => {
-		if ( ! imageUrl ) {
-			return;
-		}
+	/**
+	 * Handles the image load event to initialize the cropper with the natural aspect ratio.
+	 * Sets the reset state so that the cropper starts with the full image selected.
+	 */
+	const handleOnLoad = useCallback(
+		( loadedMediaSize: MediaSize ) => {
+			// If the cropper is already dirty (has been edited), preserve the existing state
+			if ( isDirty ) {
+				// Restore the current crop position
+				setCropperState( { crop: cropperState.crop } );
+				return;
+			}
 
-		const img = new Image();
-		img.onload = () => {
-			setNaturalDimensions( {
-				width: img.naturalWidth,
-				height: img.naturalHeight,
-			} );
-		};
-		img.src = imageUrl;
-	}, [ imageUrl ] );
+			// Set the initial reset state with the natural aspect ratio
+			const newResetState = {
+				aspectRatio:
+					loadedMediaSize.naturalWidth /
+					loadedMediaSize.naturalHeight,
+				crop: {
+					x: 0,
+					y: 0,
+					width: loadedMediaSize.naturalWidth,
+					height: loadedMediaSize.naturalHeight,
+				},
+				zoom: 1,
+				rotation: 0,
+				flip: {
+					horizontal: false,
+					vertical: false,
+				},
+			};
 
-	// Calculate height based on aspect ratio
-	let containerHeight = 400; // Default fallback
-	if ( naturalDimensions && clientWidth ) {
-		containerHeight =
-			( clientWidth * naturalDimensions.height ) /
-			naturalDimensions.width;
-	}
+			setResetState( newResetState );
+		},
+		[ isDirty, setResetState, cropperState, setCropperState ]
+	);
 
 	// Only render when editing an image
 	if ( ! isEditingImage || media?.mime_type?.split( '/' )[ 0 ] !== 'image' ) {
@@ -65,29 +84,26 @@ export default function MediaEditorCanvas() {
 	}
 
 	return (
-		<>
-			{ contentResizeListener }
-			<div
-				className={ clsx( 'media-editor-canvas', {
-					'is-loading': isLoading || ! naturalDimensions,
-				} ) }
-			>
-				{ isLoading || ! naturalDimensions ? (
-					<div className="media-editor-canvas__spinner">
-						<Spinner />
-					</div>
-				) : (
-					<div
-						className="media-editor-canvas__crop-area"
-						style={ {
-							width: clientWidth || '100%',
-							height: containerHeight,
-						} }
-					>
-						<ImageCropperComponent src={ imageUrl } />
-					</div>
-				) }
-			</div>
-		</>
+		<div
+			className={ clsx( 'media-editor-canvas', {
+				'is-loading': isLoading,
+			} ) }
+		>
+			{ isLoading ? (
+				<div className="media-editor-canvas__spinner">
+					<Spinner />
+				</div>
+			) : (
+				<div
+					className="media-editor-canvas__crop-area"
+					style={ DEFAULT_CONTAINER_STYLE }
+				>
+					<ImageCropperComponent
+						src={ imageUrl }
+						onLoad={ handleOnLoad }
+					/>
+				</div>
+			) }
+		</div>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import { ImageCropper as ImageCropperComponent } from '@wordpress/image-cropper';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../media-editor-provider';
+
+/**
+ * MediaEditorCanvas component renders the image cropper when in editing mode.
+ * This is a sibling component to MediaPreview and only renders when editing an image.
+ *
+ * Note: ImageCropperProvider is provided by AttachmentEditorProvider at a higher level,
+ * so both this component and the sidebar controls can access the same cropper state.
+ */
+export default function MediaEditorCanvas() {
+	const { media, isEditingImage } = useMediaEditorContext();
+	const [ contentResizeListener, { width: clientWidth } ] =
+		useResizeObserver();
+	const [ naturalDimensions, setNaturalDimensions ] = useState< {
+		width: number;
+		height: number;
+	} | null >( null );
+
+	const isLoading = ! media?.source_url;
+	const imageUrl = media?.source_url || '';
+
+	// Load the image to get natural dimensions
+	useEffect( () => {
+		if ( ! imageUrl ) {
+			return;
+		}
+
+		const img = new Image();
+		img.onload = () => {
+			setNaturalDimensions( {
+				width: img.naturalWidth,
+				height: img.naturalHeight,
+			} );
+		};
+		img.src = imageUrl;
+	}, [ imageUrl ] );
+
+	// Calculate height based on aspect ratio
+	let containerHeight = 400; // Default fallback
+	if ( naturalDimensions && clientWidth ) {
+		containerHeight =
+			( clientWidth * naturalDimensions.height ) /
+			naturalDimensions.width;
+	}
+
+	// Only render when editing an image
+	if ( ! isEditingImage || media?.mime_type?.split( '/' )[ 0 ] !== 'image' ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ contentResizeListener }
+			<div
+				className={ clsx( 'media-editor-canvas', {
+					'is-loading': isLoading || ! naturalDimensions,
+				} ) }
+			>
+				{ isLoading || ! naturalDimensions ? (
+					<div className="media-editor-canvas__spinner">
+						<Spinner />
+					</div>
+				) : (
+					<div
+						className="media-editor-canvas__crop-area"
+						style={ {
+							width: clientWidth || '100%',
+							height: containerHeight,
+						} }
+					>
+						<ImageCropperComponent src={ imageUrl } />
+					</div>
+				) }
+			</div>
+		</>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-canvas/style.scss
+++ b/packages/media-editor/src/components/media-editor-canvas/style.scss
@@ -2,15 +2,13 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .media-editor-canvas {
-	position: relative;
-	width: 100%;
-	min-height: 400px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: #f0f0f0;
-	padding: $grid-unit-40;
 	box-sizing: border-box;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-height: 100%;
+	padding: $grid-unit-40;
+	position: relative;
 
 	&.is-loading {
 		min-height: 300px;
@@ -26,6 +24,7 @@
 
 .media-editor-canvas__crop-area {
 	position: relative;
-	max-width: 100%;
-	margin: 0 auto;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
 }

--- a/packages/media-editor/src/components/media-editor-canvas/style.scss
+++ b/packages/media-editor/src/components/media-editor-canvas/style.scss
@@ -1,0 +1,31 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.media-editor-canvas {
+	position: relative;
+	width: 100%;
+	min-height: 400px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #f0f0f0;
+	padding: $grid-unit-40;
+	box-sizing: border-box;
+
+	&.is-loading {
+		min-height: 300px;
+	}
+}
+
+.media-editor-canvas__spinner {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: $grid-unit-60;
+}
+
+.media-editor-canvas__crop-area {
+	position: relative;
+	max-width: 100%;
+	margin: 0 auto;
+}

--- a/packages/media-editor/src/components/media-editor-provider/index.tsx
+++ b/packages/media-editor/src/components/media-editor-provider/index.tsx
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useContext } from '@wordpress/element';
+import { createContext, useContext, useState } from '@wordpress/element';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
+import { ImageCropperProvider } from '@wordpress/image-cropper';
 
 /**
  * Media object from WordPress REST API.
@@ -26,6 +27,9 @@ export interface MediaEditorContextValue {
 	media?: Media;
 	onChange?: ( updates: Partial< Media > ) => void;
 	fields: Field< Media >[];
+	isEditingImage: boolean;
+	setIsEditingImage: ( editing: boolean ) => void;
+	onSaveImage?: ( media: Media ) => Promise< void >;
 }
 
 /**
@@ -41,6 +45,12 @@ export interface MediaEditorProviderProps {
 	 * useful for preview-only scenarios.
 	 */
 	onChange?: ( updates: Partial< Media > ) => void;
+	/**
+	 * Callback when an edited image is saved.
+	 *
+	 * Optional - called after image editing is complete, useful for server persistence.
+	 */
+	onSaveImage?: ( media: Media ) => Promise< void >;
 	/** Configuration settings for the media editor. */
 	settings?: {
 		fields?: Field< Media >[];
@@ -56,18 +66,31 @@ const MediaEditorContext = createContext< MediaEditorContextValue | undefined >(
 export function MediaEditorProvider( {
 	value,
 	onChange,
+	onSaveImage,
 	settings = {},
 	children,
 }: MediaEditorProviderProps ) {
+	const [ isEditingImage, setIsEditingImage ] = useState( false );
+
 	const contextValue: MediaEditorContextValue = {
 		media: value,
 		onChange,
 		fields: settings.fields || [],
+		isEditingImage,
+		setIsEditingImage,
+		onSaveImage,
 	};
+
+	// Detect if this is an image media type
+	const isImage = value?.mime_type?.split( '/' )[ 0 ] === 'image';
 
 	return (
 		<MediaEditorContext.Provider value={ contextValue }>
-			{ children }
+			{ isImage ? (
+				<ImageCropperProvider>{ children }</ImageCropperProvider>
+			) : (
+				children
+			) }
 		</MediaEditorContext.Provider>
 	);
 }

--- a/packages/media-editor/src/hooks/use-image-editing.ts
+++ b/packages/media-editor/src/hooks/use-image-editing.ts
@@ -10,6 +10,18 @@ import { useImageCropper } from '@wordpress/image-cropper';
 import { useMediaEditorContext } from '../components/media-editor-provider';
 
 /**
+ * Checks if a rotation is a quarter turn (90° or 270°).
+ *
+ * @param rotation - The rotation value to check
+ * @return True if the rotation is 90° or 270°
+ */
+function isQuarterTurn( rotation: number ): boolean {
+	// Normalize rotation to 0-360 range
+	const normalized = ( ( rotation % 360 ) + 360 ) % 360;
+	return normalized % 180 === 90;
+}
+
+/**
  * Hook for managing image editing state and actions.
  * Combines MediaEditorContext and ImageCropperContext to provide a unified API.
  *
@@ -25,6 +37,7 @@ export default function useImageEditing() {
 		isDirty,
 		reset: resetCropper,
 		getCroppedImage,
+		resetState,
 	} = useImageCropper();
 
 	/**
@@ -109,17 +122,75 @@ export default function useImageEditing() {
 	);
 
 	/**
+	 * Checks if the aspect ratio should be flipped during rotation.
+	 * If the user is using the natural aspect ratio and hasn't zoomed,
+	 * flip the aspect ratio to match the rotated image orientation.
+	 *
+	 * @param updatedRotation - The new rotation value
+	 */
+	const maybeFlipAspectRatio = useCallback(
+		( updatedRotation: number ) => {
+			// Need resetState to get the natural aspect ratio
+			if ( ! resetState?.aspectRatio || ! cropperState.mediaSize ) {
+				return;
+			}
+
+			const original = resetState.aspectRatio;
+			const rotated = 1 / original;
+			const tolerance = 0.01;
+
+			/*
+			 * Only flip the aspect ratio if:
+			 * 1. Zoom is still at default (1)
+			 * 2. Current aspect ratio matches either the original or rotated natural ratio
+			 *    (meaning the user hasn't explicitly chosen a different preset)
+			 */
+			const matchesOriginal =
+				Math.abs( cropperState.aspectRatio - original ) < tolerance;
+			const matchesRotated =
+				Math.abs( cropperState.aspectRatio - rotated ) < tolerance;
+
+			if (
+				cropperState.zoom === 1 &&
+				( matchesOriginal || matchesRotated )
+			) {
+				/*
+				 * If rotating to 90° or 270°, use the rotated aspect ratio.
+				 * If rotating to 0° or 180°, use the original aspect ratio.
+				 * This makes the crop area rotate with the image.
+				 */
+				const newAspectRatio = isQuarterTurn( updatedRotation )
+					? rotated
+					: original;
+
+				if (
+					Math.abs( newAspectRatio - cropperState.aspectRatio ) >
+					tolerance
+				) {
+					// Reset crop position to center when flipping aspect ratio
+					// This prevents unwanted zooming/cropping during rotation
+					setCropperState( {
+						aspectRatio: newAspectRatio,
+						crop: { x: 0, y: 0 },
+					} );
+				}
+			}
+		},
+		[ cropperState, resetState, setCropperState ]
+	);
+
+	/**
 	 * Rotates the image by the specified angle.
 	 *
 	 * @param angle - Rotation angle in degrees
 	 */
 	const rotate = useCallback(
 		( angle: number ) => {
-			setCropperState( ( prev ) => ( {
-				rotation: prev.rotation + angle,
-			} ) );
+			const newRotation = cropperState.rotation + angle;
+			setCropperState( { rotation: newRotation } );
+			maybeFlipAspectRatio( newRotation );
 		},
-		[ setCropperState ]
+		[ cropperState.rotation, setCropperState, maybeFlipAspectRatio ]
 	);
 
 	/**

--- a/packages/media-editor/src/hooks/use-image-editing.ts
+++ b/packages/media-editor/src/hooks/use-image-editing.ts
@@ -1,0 +1,172 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useImageCropper } from '@wordpress/image-cropper';
+
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../components/media-editor-provider';
+
+/**
+ * Hook for managing image editing state and actions.
+ * Combines MediaEditorContext and ImageCropperContext to provide a unified API.
+ *
+ * @return Object with state and actions for image editing
+ */
+export default function useImageEditing() {
+	const { media, onChange, onSaveImage, isEditingImage, setIsEditingImage } =
+		useMediaEditorContext();
+
+	const {
+		cropperState,
+		setCropperState,
+		isDirty,
+		reset: resetCropper,
+		getCroppedImage,
+	} = useImageCropper();
+
+	/**
+	 * Starts editing mode.
+	 */
+	const startEditing = useCallback( () => {
+		setIsEditingImage( true );
+	}, [ setIsEditingImage ] );
+
+	/**
+	 * Saves the edited image.
+	 * 1. Gets the cropped image blob URL
+	 * 2. Updates media via onChange callback
+	 * 3. Optionally calls onSaveImage for server persistence
+	 * 4. Exits editing mode
+	 */
+	const saveEdits = useCallback( async () => {
+		if ( ! media?.source_url ) {
+			return;
+		}
+
+		try {
+			// Get the cropped image as a blob URL
+			const croppedImageUrl = await getCroppedImage( media.source_url );
+
+			if ( croppedImageUrl && onChange ) {
+				// Update the media object with the new image URL
+				const updatedMedia = {
+					...media,
+					source_url: croppedImageUrl,
+				};
+
+				// Call onChange to update the media in the parent component
+				onChange( updatedMedia );
+
+				// Optionally call onSaveImage for server persistence
+				if ( onSaveImage ) {
+					await onSaveImage( updatedMedia );
+				}
+			}
+
+			// Exit editing mode
+			setIsEditingImage( false );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Error saving edited image:', error );
+		}
+	}, [ media, onChange, onSaveImage, getCroppedImage, setIsEditingImage ] );
+
+	/**
+	 * Cancels editing and resets changes.
+	 * 1. Resets the cropper state
+	 * 2. Exits editing mode
+	 */
+	const cancelEdits = useCallback( () => {
+		resetCropper();
+		setIsEditingImage( false );
+	}, [ resetCropper, setIsEditingImage ] );
+
+	/**
+	 * Sets the zoom level.
+	 *
+	 * @param zoom - Zoom level (1-5)
+	 */
+	const setZoom = useCallback(
+		( zoom: number ) => {
+			setCropperState( { zoom } );
+		},
+		[ setCropperState ]
+	);
+
+	/**
+	 * Sets the aspect ratio.
+	 *
+	 * @param aspectRatio - Aspect ratio value
+	 */
+	const setAspectRatio = useCallback(
+		( aspectRatio: number ) => {
+			setCropperState( { aspectRatio } );
+		},
+		[ setCropperState ]
+	);
+
+	/**
+	 * Rotates the image by the specified angle.
+	 *
+	 * @param angle - Rotation angle in degrees
+	 */
+	const rotate = useCallback(
+		( angle: number ) => {
+			setCropperState( ( prev ) => ( {
+				rotation: prev.rotation + angle,
+			} ) );
+		},
+		[ setCropperState ]
+	);
+
+	/**
+	 * Flips the image horizontally or vertically.
+	 *
+	 * @param horizontal - Whether to flip horizontally
+	 * @param vertical   - Whether to flip vertically
+	 */
+	const flip = useCallback(
+		( horizontal?: boolean, vertical?: boolean ) => {
+			setCropperState( ( prev ) => ( {
+				flip: {
+					horizontal:
+						horizontal !== undefined
+							? horizontal
+							: prev.flip.horizontal,
+					vertical:
+						vertical !== undefined ? vertical : prev.flip.vertical,
+				},
+			} ) );
+		},
+		[ setCropperState ]
+	);
+
+	/**
+	 * Resets all transformations to their original state.
+	 */
+	const reset = useCallback( () => {
+		resetCropper();
+	}, [ resetCropper ] );
+
+	return {
+		// State
+		isEditingImage,
+		isDirty,
+		cropperState,
+
+		// Actions
+		startEditing,
+		saveEdits,
+		cancelEdits,
+
+		// Transform controls
+		setZoom,
+		setAspectRatio,
+		rotate,
+		flip,
+		reset,
+	};
+}

--- a/packages/media-editor/src/hooks/use-image-editing.ts
+++ b/packages/media-editor/src/hooks/use-image-editing.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useImageCropper } from '@wordpress/image-cropper';
+import { useImageCropper, normalizeRotation } from '@wordpress/image-cropper';
 
 /**
  * Internal dependencies
@@ -222,6 +222,72 @@ export default function useImageEditing() {
 		resetCropper();
 	}, [ resetCropper ] );
 
+	/**
+	 * Gets the modifiers array for server-side image processing.
+	 * Builds the modifiers from the current cropper state in the format
+	 * expected by the WordPress REST API's editMediaEntity endpoint.
+	 *
+	 * @return Array of modifier objects for editMediaEntity
+	 */
+	const getModifiers = useCallback( () => {
+		if ( ! cropperState ) {
+			return [];
+		}
+
+		const modifiers = [];
+
+		// Add flip modifier if needed
+		if (
+			cropperState.flip &&
+			( cropperState.flip.horizontal || cropperState.flip.vertical )
+		) {
+			modifiers.push( {
+				type: 'flip',
+				args: {
+					flip: {
+						horizontal: Number( cropperState.flip.horizontal ),
+						vertical: Number( cropperState.flip.vertical ),
+					},
+				},
+			} );
+		}
+
+		// Add rotation modifier if needed
+		const normalizedRotation = normalizeRotation(
+			cropperState.rotation || 0
+		);
+		if ( normalizedRotation > 0 ) {
+			modifiers.push( {
+				type: 'rotate',
+				args: {
+					angle: normalizedRotation,
+				},
+			} );
+		}
+
+		// Add crop modifier if needed
+		// The crop script may return some very small, sub-pixel values when the image was not cropped.
+		// Crop only when the new size has changed by more than 0.1%.
+		if (
+			cropperState.croppedArea?.width &&
+			cropperState.croppedArea?.height &&
+			( cropperState.croppedArea.width < 99.9 ||
+				cropperState.croppedArea.height < 99.9 )
+		) {
+			modifiers.push( {
+				type: 'crop',
+				args: {
+					left: cropperState.croppedArea.x, // Horizontal position from the left as a percentage
+					top: cropperState.croppedArea.y, // Vertical position from the top as a percentage
+					width: cropperState.croppedArea.width, // Width as a percentage
+					height: cropperState.croppedArea.height, // Height as a percentage
+				},
+			} );
+		}
+
+		return modifiers;
+	}, [ cropperState ] );
+
 	return {
 		// State
 		isEditingImage,
@@ -232,6 +298,7 @@ export default function useImageEditing() {
 		startEditing,
 		saveEdits,
 		cancelEdits,
+		getModifiers,
 
 		// Transform controls
 		setZoom,

--- a/packages/media-editor/src/index.ts
+++ b/packages/media-editor/src/index.ts
@@ -1,7 +1,22 @@
 // Components
-export { MediaEditorProvider } from './components/media-editor-provider';
+export {
+	MediaEditorProvider,
+	useMediaEditorContext,
+} from './components/media-editor-provider';
 export { default as MediaPreview } from './components/media-preview';
 export { default as MediaForm } from './components/media-form';
+export { default as MediaEditorCanvas } from './components/media-editor-canvas';
+export { default as MediaEditForm } from './components/media-edit-form';
+export { default as ImageCropper } from './components/image-cropper';
+export { default as CroppingToolbar } from './components/cropping-toolbar';
+export { default as CroppingPanel } from './components/cropping-panel';
+
+// Hooks
+export { default as useImageEditing } from './hooks/use-image-editing';
+
+// Utilities
+export * from './utils/aspect-ratio';
+export * from './utils/image-processing';
 
 // Types
 export type {

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -1,2 +1,7 @@
 // Import component styles
 @use "./components/media-preview/style.scss" as *;
+@use "./components/media-editor-canvas/style.scss" as *;
+@use "./components/media-edit-form/style.scss" as *;
+@use "./components/image-cropper/style.scss" as *;
+@use "./components/cropping-toolbar/style.scss" as *;
+@use "./components/cropping-panel/style.scss" as *;

--- a/packages/media-editor/src/utils/aspect-ratio.ts
+++ b/packages/media-editor/src/utils/aspect-ratio.ts
@@ -1,0 +1,92 @@
+/**
+ * Type definition for aspect ratio.
+ */
+export interface AspectRatio {
+	/** Display label (e.g., "16:9", "1:1") */
+	label: string;
+	/** Numeric value of the ratio (width/height) */
+	value: number;
+}
+
+/**
+ * Calculates the aspect ratio of an image.
+ *
+ * @param width  - Image width in pixels
+ * @param height - Image height in pixels
+ * @return The aspect ratio (width/height)
+ */
+export function getImageAspectRatio( width: number, height: number ): number {
+	if ( height === 0 ) {
+		return 1;
+	}
+	return width / height;
+}
+
+/**
+ * Returns common aspect ratio presets.
+ *
+ * @return Array of aspect ratio objects
+ */
+export function getCommonAspectRatios(): AspectRatio[] {
+	return [
+		{ label: 'Original', value: 0 }, // 0 means use original aspect ratio
+		{ label: '1:1', value: 1 },
+		{ label: '16:9', value: 16 / 9 },
+		{ label: '4:3', value: 4 / 3 },
+		{ label: '3:2', value: 3 / 2 },
+		{ label: '3:4', value: 3 / 4 },
+		{ label: '2:3', value: 2 / 3 },
+	];
+}
+
+/**
+ * Converts a ratio string to a numeric value.
+ *
+ * @param ratio - Ratio string (e.g., "16:9")
+ * @return The numeric ratio value (width/height)
+ */
+export function ratioToNumber( ratio: string ): number {
+	const parts = ratio.split( ':' );
+	if ( parts.length !== 2 ) {
+		return 1;
+	}
+	const width = parseFloat( parts[ 0 ] );
+	const height = parseFloat( parts[ 1 ] );
+	if ( isNaN( width ) || isNaN( height ) || height === 0 ) {
+		return 1;
+	}
+	return width / height;
+}
+
+/**
+ * Finds the closest matching ratio from a list of presets.
+ *
+ * @param actual - The actual aspect ratio to match
+ * @param ratios - Array of preset aspect ratios
+ * @return The closest matching ratio, or the first ratio if none match
+ */
+export function findClosestRatio(
+	actual: number,
+	ratios: AspectRatio[]
+): AspectRatio {
+	if ( ratios.length === 0 ) {
+		return { label: '1:1', value: 1 };
+	}
+
+	let closest = ratios[ 0 ];
+	let minDiff = Math.abs( actual - closest.value );
+
+	for ( const ratio of ratios ) {
+		// Skip "Original" (value 0) when finding closest match
+		if ( ratio.value === 0 ) {
+			continue;
+		}
+		const diff = Math.abs( actual - ratio.value );
+		if ( diff < minDiff ) {
+			minDiff = diff;
+			closest = ratio;
+		}
+	}
+
+	return closest;
+}

--- a/packages/media-editor/src/utils/image-processing.ts
+++ b/packages/media-editor/src/utils/image-processing.ts
@@ -1,0 +1,45 @@
+/**
+ * Image processing utilities for the media editor.
+ * These utilities handle canvas operations for cropping and transforming images.
+ *
+ * Note: getCroppedImage is available through the useImageCropper hook
+ * from @wordpress/image-cropper, not exported here.
+ */
+
+/**
+ * Converts a canvas to a Blob.
+ *
+ * @param canvas   - The canvas element to convert
+ * @param mimeType - The MIME type for the output (default: 'image/jpeg')
+ * @return Promise resolving to the Blob
+ */
+export function canvasToBlob(
+	canvas: HTMLCanvasElement,
+	mimeType: string = 'image/jpeg'
+): Promise< Blob > {
+	return new Promise( ( resolve, reject ) => {
+		canvas.toBlob( ( blob ) => {
+			if ( blob ) {
+				resolve( blob );
+			} else {
+				reject( new Error( 'Failed to convert canvas to blob' ) );
+			}
+		}, mimeType );
+	} );
+}
+
+/**
+ * Creates an HTMLImageElement from a URL.
+ *
+ * @param url - The URL of the image to load
+ * @return Promise resolving to the loaded image
+ */
+export function createImageFromUrl( url: string ): Promise< HTMLImageElement > {
+	return new Promise( ( resolve, reject ) => {
+		const image = new Image();
+		image.addEventListener( 'load', () => resolve( image ) );
+		image.addEventListener( 'error', ( error ) => reject( error ) );
+		image.setAttribute( 'crossOrigin', 'anonymous' );
+		image.src = url;
+	} );
+}

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -6,8 +6,11 @@
 	},
 	"references": [
 		{ "path": "../components" },
+		{ "path": "../compose" },
 		{ "path": "../dataviews" },
 		{ "path": "../element" },
-		{ "path": "../i18n" }
+		{ "path": "../i18n" },
+		{ "path": "../icons" },
+		{ "path": "../image-cropper" }
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of: #72734 

Add image cropping to the experimental media editor

🚧 🚧 🚧 Note: this is not yet ready for review, it's mostly Claude-assisted at the moment and I haven't looked over the code closely 🚧 🚧 🚧 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's essential for editing media, and the features in this PR round out the media editor experiment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add the `image-cropper` as a dependency of the `media-editor` package
* Add components and utilities to the `media-editor` package to handle cropping
* Import the components and hook them up in the `editor` package to enable editing images

## To-do

* [ ] Wire up toolbar controls
* [ ] Fix saving the media
* [x] Fix rotation and aspect ratios
* [ ] Update the Zoom control to also have an input / unit control
* [ ] Review the actual code
* [x] See about possibly removing the Cancel / Apply buttons

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

TBC, but activate the media editor experiment, add an Image block (with an image that exists in your site) and click the Edit Media button in the block toolbar. Then, have a play around.

## Screenshots or screencast <!-- if applicable -->

<img width="1257" height="837" alt="image" src="https://github.com/user-attachments/assets/9edfe844-9007-44bf-857b-525ed92c9b4b" />

