### PR TITLE
List View support: show full block titles

### DIFF
--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { store as blocksStore, hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport } from '@wordpress/blocks';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -14,6 +14,7 @@ import { store as blockEditorStore } from '../store';
 import { PrivateListView } from '../components/list-view';
 import InspectorControls from '../components/inspector-controls/fill';
 import { PrivateBlockContext } from '../components/block-list/private-block-context';
+import useBlockDisplayTitle from '../components/block-title/use-block-display-title.js';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
 
@@ -39,7 +40,7 @@ export function ListViewPanel( { clientId, name } ) {
 	const { isSelectionWithinCurrentSection } =
 		useContext( PrivateBlockContext );
 	const isEnabled = hasListViewSupport( name );
-	const { hasChildren, blockTitle, isNestedListView } = useSelect(
+	const { hasChildren, isNestedListView } = useSelect(
 		( select ) => {
 			const { getBlockCount, getBlockParents, getBlockName } =
 				select( blockEditorStore );
@@ -64,12 +65,15 @@ export function ListViewPanel( { clientId, name } ) {
 
 			return {
 				hasChildren: !! getBlockCount( clientId ),
-				blockTitle: select( blocksStore ).getBlockType( name )?.title,
 				isNestedListView: _isNestedListView,
 			};
 		},
-		[ clientId, name, isSelectionWithinCurrentSection ]
+		[ clientId, isSelectionWithinCurrentSection ]
 	);
+	const title = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
 
 	if ( ! isEnabled || isNestedListView ) {
 		return null;
@@ -79,7 +83,7 @@ export function ListViewPanel( { clientId, name } ) {
 
 	return (
 		<InspectorControls group="list">
-			<PanelBody title={ showBlockTitle ? blockTitle : undefined }>
+			<PanelBody title={ showBlockTitle ? title : undefined }>
 				{ ! hasChildren && (
 					<p className="block-editor-block-inspector__no-blocks">
 						{ __( 'No items yet.' ) }
@@ -88,7 +92,7 @@ export function ListViewPanel( { clientId, name } ) {
 				<PrivateListView
 					rootClientId={ clientId }
 					isExpanded
-					description={ blockTitle }
+					description={ title }
 					showAppender
 				/>
 			</PanelBody>

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -14,7 +14,7 @@ import { store as blockEditorStore } from '../store';
 import { PrivateListView } from '../components/list-view';
 import InspectorControls from '../components/inspector-controls/fill';
 import { PrivateBlockContext } from '../components/block-list/private-block-context';
-import useBlockDisplayTitle from '../components/block-title/use-block-display-title.js';
+import useBlockDisplayTitle from '../components/block-title/use-block-display-title';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a small change for the List View block support.

When this feature is shown in a pattern, the panels for this feature show the block title (to help distinguish blocks when there's more than one block with support).

This title doesn't take into account if the user names the block. If the pattern contains multiple of the same block, it may cause some usability issues. This PR addresses the issue, if the user names the blocks in the pattern those names will now be shown in the panel title.

## Why?
Naming blocks in patterns is a nice way to improve usability for users.

## How?
Uses the `useBlockDisplayTitle` hook to get the full name.

## Testing Instructions
Prerequisite: Enable the 'Pattern Editing' experiment
1. Create a new post and add the following pattern (in the code editor):
<details><summary>Expand here to get block markup</summary>

```html
<!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/services-subscriber-only-section","name":"Services, subscriber only section"},"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}}} -->
<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center"} -->
<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"xx-large"} -->
<h2 class="wp-block-heading has-xx-large-font-size">Subscribe to get unlimited access</h2>
<!-- /wp:heading -->

<!-- wp:list {"metadata":{"name":"Benefits List"},"className":"is-style-checkmark-list","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"padding":{"left":"var:preset|spacing|30"}}}} -->
<ul style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)" class="wp-block-list is-style-checkmark-list"><!-- wp:list-item {"fontSize":"medium"} -->
<li class="has-medium-font-size">Get access to our paid articles and weekly newsletter.</li>
<!-- /wp:list-item -->

<!-- wp:list-item {"fontSize":"medium"} -->
<li class="has-medium-font-size">Join our IRL events.</li>
<!-- /wp:list-item -->

<!-- wp:list-item {"fontSize":"medium"} -->
<li class="has-medium-font-size">An elegant addition of home decor collection.</li>
<!-- /wp:list-item -->

<!-- wp:list-item {"fontSize":"medium"} -->
<li class="has-medium-font-size">Join our forums.</li>
<!-- /wp:list-item -->

<!-- wp:list-item {"fontSize":"medium"} -->
<li class="has-medium-font-size">Get a free tote bag.</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:buttons {"metadata":{"name":"Call to Action Buttons"},"layout":{"type":"flex","justifyContent":"left","flexWrap":"nowrap"}} -->
<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button">Subscribe</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">View plans</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"fontSize":"small"} -->
<p class="has-small-font-size">Cancel or pause anytime.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"verticalAlignment":"center"} -->
<div class="wp-block-column is-vertically-aligned-center"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/themes/twentytwentyfive/assets/images/services-subscriber-photo.webp" alt="Smartphones capturing a scenic wildflower meadow with trees"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->
```

</details> 

2. Back in the Visual Editor, select the pattern
3. Open the Block Inspector and switch to the List View tab

In this PR: Observe the panels containing List View show the blocks as they are named ('Benefits List', 'Call to Action Buttons').
In trunk: The panels only show the block title ( 'List', 'Buttons' ).

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="278" height="490" alt="Screenshot 2026-01-21 at 3 25 19 pm" src="https://github.com/user-attachments/assets/91b01a81-f51e-443a-b55e-81c94e20514b" /> |  <img width="273" height="474" alt="Screenshot 2026-01-21 at 3 24 51 pm" src="https://github.com/user-attachments/assets/7342dd32-d6f9-454a-a2e7-d71f3677452a" /> |
