### PR TITLE
[WP 6.9.1] Update browsers list data (#74312)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20002,9 +20002,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001731",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-			"integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+			"version": "1.0.30001762",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+			"integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
 			"funding": [
 				{
 					"type": "opencollective",


### PR DESCRIPTION
## What?

This PR cherry-picks #74312 into the `wp/6.9` branch so we can unblock preparations for the 6.9.1 release.

## Why?

When I submitted a PR to `wp/6.9` branch, I noticed that some unit tests fail due to the old browserslist data.

https://github.com/WordPress/gutenberg/actions/runs/21203296192/job/60993667721?pr=74799

## Testing Instructions

All CI statuses should be ✅.