### PR TITLE
[WP 6.9] Build Tools: Update caniuse-lite to the latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20001,9 +20001,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001731",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-			"integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+			"version": "1.0.30001765",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+			"integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
 			"funding": [
 				{
 					"type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
 				"benchmark": "2.1.4",
 				"browserslist": "4.25.1",
 				"browserslist-to-esbuild": "2.1.1",
-				"caniuse-lite": "1.0.30001731",
 				"chalk": "4.1.1",
 				"change-case": "4.1.2",
 				"chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
 		"benchmark": "2.1.4",
 		"browserslist": "4.25.1",
 		"browserslist-to-esbuild": "2.1.1",
-		"caniuse-lite": "1.0.30001731",
 		"chalk": "4.1.1",
 		"change-case": "4.1.2",
 		"chokidar": "^4.0.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When I submitted a PR to the `wp/6.9` branch, I noticed that some unit tests fail due to the old browserslist data.

https://github.com/WordPress/gutenberg/actions/runs/21203296192/job/60993667721?pr=74799

We need to update caniuse-lite version so that we can unblock preparations for the 6.9.1 release.

## How? 

I just run `npx update-browserslist-db@latest`

## Testing Instructions

All CI statuses should be ✅.