### PR TITLE
Update performance results endpoint to codevitals.run

### DIFF
--- a/bin/log-performance-results.js
+++ b/bin/log-performance-results.js
@@ -75,7 +75,7 @@ const data = new TextEncoder().encode(
 );
 
 const options = {
-	hostname: 'codehealth.vercel.app',
+	hostname: 'codevitals.run',
 	port: 443,
 	path: '/api/log?token=' + token,
 	method: 'POST',


### PR DESCRIPTION
## What?
Switch the performance metrics publishing endpoint from codehealth.vercel.app to codevitals.run.

## Why?
CodeVitals hosting is moving, so let's use a different agnostic the url. The former was just the original url we were using before using the right domain.

## How?
Updated the hostname in `bin/log-performance-results.js` that publishes performance results from the test suite.

The API path, authentication mechanism, and data format remain unchanged.