### PR TITLE
Move selectLabelText to shared utility

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -43,6 +43,7 @@ import {
 	InvalidDraftDisplay,
 	useEnableLinkStatusValidation,
 	useIsDraggingWithin,
+	selectLabelText,
 } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
@@ -243,7 +244,7 @@ export default function NavigationLinkEdit( {
 		// If the label looks like a URL, focus and select the label text.
 		if ( isURL( prependHTTP( label ) ) && /^.+\.[a-z]+/.test( label ) ) {
 			// Focus and select the label text.
-			selectLabelText();
+			selectLabelText( ref );
 		} else {
 			// If the link was just created, we want to select the block so the inspector controls
 			// are accurate.
@@ -266,21 +267,6 @@ export default function NavigationLinkEdit( {
 			}
 		}
 	}, [ url, isLinkOpen, isNewLink, label ] );
-
-	/**
-	 * Focus the Link label text and select it.
-	 */
-	function selectLabelText() {
-		ref.current.focus();
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
-		const selection = defaultView.getSelection();
-		const range = ownerDocument.createRange();
-		// Get the range of the current ref contents so we can add this range to the selection.
-		range.selectNodeContents( ref.current );
-		selection.removeAllRanges();
-		selection.addRange( range );
-	}
 
 	/**
 	 * Removes the current link if set.

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -17,3 +17,4 @@ export { useIsInvalidLink } from './use-is-invalid-link';
 export { InvalidDraftDisplay } from './invalid-draft-display';
 export { useEnableLinkStatusValidation } from './use-enable-link-status-validation';
 export { useIsDraggingWithin } from './use-is-dragging-within';
+export { selectLabelText } from './select-label-text';

--- a/packages/block-library/src/navigation-link/shared/select-label-text.js
+++ b/packages/block-library/src/navigation-link/shared/select-label-text.js
@@ -1,0 +1,16 @@
+/**
+ * Focus the Link label text and select it.
+ *
+ * @param {Object} ref - React ref object pointing to the label element.
+ */
+export function selectLabelText( ref ) {
+	ref.current.focus();
+	const { ownerDocument } = ref.current;
+	const { defaultView } = ownerDocument;
+	const selection = defaultView.getSelection();
+	const range = ownerDocument.createRange();
+	// Get the range of the current ref contents so we can add this range to the selection.
+	range.selectNodeContents( ref.current );
+	selection.removeAllRanges();
+	selection.addRange( range );
+}

--- a/packages/block-library/src/navigation-link/shared/select-label-text.js
+++ b/packages/block-library/src/navigation-link/shared/select-label-text.js
@@ -1,7 +1,7 @@
 /**
  * Focus the Link label text and select it.
  *
- * @param {Object} ref - React ref object pointing to the label element.
+ * @param {Object} ref React ref object pointing to the label element.
  */
 export function selectLabelText( ref ) {
 	ref.current.focus();

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -41,6 +41,7 @@ import {
 	InvalidDraftDisplay,
 	useEnableLinkStatusValidation,
 	useIsDraggingWithin,
+	selectLabelText,
 } from '../navigation-link/shared';
 import {
 	getColors,
@@ -208,25 +209,10 @@ export default function NavigationSubmenuEdit( {
 				/^.+\.[a-z]+/.test( label )
 			) {
 				// Focus and select the label text.
-				selectLabelText();
+				selectLabelText( ref );
 			}
 		}
 	}, [ url ] );
-
-	/**
-	 * Focus the Link label text and select it.
-	 */
-	function selectLabelText() {
-		ref.current.focus();
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
-		const selection = defaultView.getSelection();
-		const range = ownerDocument.createRange();
-		// Get the range of the current ref contents so we can add this range to the selection.
-		range.selectNodeContents( ref.current );
-		selection.removeAllRanges();
-		selection.addRange( range );
-	}
 
 	const {
 		textColor,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Move selectLabelText to shared utility.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To share more code between navigation link and navigation submenu blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move selectLabelText to shared utility,

## Testing Instructions
Check that the label text for navigation link and submenu blocks is selected when inserting a new link.
