### PR TITLE
Storybook: Fix missing props from component stories

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Build Storybook
               env:
-                  NODE_OPTIONS: --max-old-space-size=4096
+                  NODE_OPTIONS: --max-old-space-size=8192
                   NODE_ENV: test
               run: npm run storybook:build
 

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -33,6 +33,7 @@ jobs:
 
             - name: Build Storybook
               env:
+                  NODE_OPTIONS: --max-old-space-size=4096
                   NODE_ENV: test
               run: npm run storybook:build
 

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -29,6 +29,7 @@ jobs:
 
             - name: Build Storybook
               env:
+                  NODE_OPTIONS: --max-old-space-size=4096
                   NODE_ENV: production
               run: npm run storybook:build
 

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -29,7 +29,7 @@ jobs:
 
             - name: Build Storybook
               env:
-                  NODE_OPTIONS: --max-old-space-size=4096
+                  NODE_OPTIONS: --max-old-space-size=8192
                   NODE_ENV: production
               run: npm run storybook:build
 

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -51,6 +51,7 @@ export default {
 		// Should match defaults in Storybook except for the propFilter.
 		// https://github.com/storybookjs/storybook/blob/3e34a288c8fabc7d5b5cc43b28ae9d674c48e3ea/code/core/src/core-server/presets/common-preset.ts#L162-L168
 		reactDocgenTypescriptOptions: {
+			EXPERIMENTAL_useProjectService: true,
 			shouldExtractLiteralValuesFromEnum: true,
 			shouldRemoveUndefinedFromOptional: true,
 			propFilter: ( prop ) => {


### PR DESCRIPTION
## What?

Fixes an issue where most props details are missing from Storybook component stories.

Related: https://wordpress.slack.com/archives/C02QB2JS7/p1768612969553299

## Why?

Fixes a regression from recent upgrade in #74396

## How?

Enables `EXPERIMENTAL_useProjectService` in TypeScript React Docgen options.

Related: https://github.com/storybookjs/storybook/issues/30015

## Testing Instructions

Verify local Storybook stories contain props details:

1. `npm run storybook:dev`
2. Go to http://localhost:50240/?path=/docs/design-system-components-button--docs
3. Scroll down to see full props details
4. Compare to https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs