### PR TITLE
Fix: Save button disabled after image upload with client-side media processing

### DIFF
--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -78,9 +78,18 @@ export default function mediaUpload( {
 		allowedTypes,
 		filesList,
 		onFileChange: ( file ) => {
-			if ( ! imageIsUploading ) {
-				setSaveLock();
-			} else {
+			// Check if any files are still uploading by looking for blob URLs without IDs.
+			// This pattern is consistent with how the gallery block detects uploads in progress.
+			const isUploadInProgress = file.some(
+				( item ) => ! item.id && item.url?.indexOf( 'blob:' ) === 0
+			);
+
+			// Set the save lock when upload starts, clear it when all files are processed.
+			if ( isUploadInProgress ) {
+				if ( ! imageIsUploading ) {
+					setSaveLock();
+				}
+			} else if ( imageIsUploading ) {
 				clearSaveLock();
 			}
 			onFileChange?.( file );


### PR DESCRIPTION
Fixes #73654

This PR resolves an issue where the Save/Publish button becomes permanently disabled after uploading images when the "Client-side media processing" experimental feature is enabled.

## What was the problem?

When client-side media processing is enabled, the media upload flow triggers the `onFileChange` callback multiple times as files are processed (resize, compress, etc.). The existing code used a simple toggle mechanism for the save lock:

```javascript
onFileChange: ( file ) => {
    if ( ! imageIsUploading ) {
        setSaveLock();
    } else {
        clearSaveLock();
    }
    // ...
}
```

This approach failed because:
1. If `onFileChange` was called an **odd number of times**, the lock would remain engaged
2. Intermediate processing steps could trigger unexpected callback sequences

## What changed?

The fix implements **state-based lock management** instead of toggle-based, matching the pattern used in the Gallery block:

```javascript
onFileChange: ( file ) => {
    // Check if any files are still uploading by looking for blob URLs without IDs
    const isUploadInProgress = file.some(
        ( item ) => ! item.id && item.url?.indexOf( 'blob:' ) === 0
    );

    // Set the save lock when upload starts, clear it when all files are processed
    if ( isUploadInProgress ) {
        if ( ! imageIsUploading ) {
            setSaveLock();
        }
    } else if ( imageIsUploading ) {
        clearSaveLock();
    }
    // ...
}
```

**Key improvements:**
1. **Precise upload detection**: Only considers files as "uploading" if they have both no ID AND a blob URL
2. **Lock management**: Lock is set once when upload starts, cleared once when complete

## Testing Instructions

### Prerequisites
1. Enable "Client-side media processing" in Gutenberg Experiments

### Test Case :  Image Upload
1. Create a new post
2. Add an image block
3. Upload an image via drag & drop
4. Verify: Save/Publish button becomes enabled after upload completes
5. Verify: Post can be saved successfully

### Test Case: Without Client-side Processing
1. Disable "Client-side media processing"
2. Create a new post
3. Upload an image
4. Verify: Upload works normally (regression test)
5. Verify: Save button functions correctly

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before

https://github.com/user-attachments/assets/1c1a684a-d5a3-4b4d-ab30-367610a654dd 

After

https://github.com/user-attachments/assets/a74ada5d-eb5a-429d-812e-d3f1206c9ec5



