### PR TITLE
DataViews: Adjust table primary media field styles

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Code Quality
 
 - DataViews: Move filtering logic in field types. [#74733](https://github.com/WordPress/gutenberg/pull/74733)
+- DataViews: Adjust table primary media field styles. [#74813](https://github.com/WordPress/gutenberg/pull/74813)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -258,6 +258,8 @@
 
 .dataviews-column-primary__media {
 	max-width: 60px;
+	min-width: $grid-unit-40;
+	min-height: $grid-unit-40;
 	overflow: hidden;
 	position: relative;
 	flex-shrink: 0;
@@ -265,8 +267,8 @@
 	border-radius: $radius-medium;
 
 	img {
-		width: 100%;
-		height: 100%;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
 		object-fit: cover;
 	}
 

--- a/packages/dataviews/src/dataviews-picker/stories/fixtures.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/fixtures.tsx
@@ -326,9 +326,7 @@ export const fields: Field< SpaceObject >[] = [
 			</Stack>
 		),
 		render: ( { item } ) => {
-			return (
-				<img src={ item.image } alt="" style={ { width: '100%' } } />
-			);
+			return <img src={ item.image } alt="" />;
 		},
 	},
 	{

--- a/packages/dataviews/src/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/dataviews/stories/fixtures.tsx
@@ -377,9 +377,7 @@ export const fields: Field< SpaceObject >[] = [
 			</Stack>
 		),
 		render: ( { item } ) => {
-			return (
-				<img src={ item.image } alt="" style={ { width: '100%' } } />
-			);
+			return <img src={ item.image } alt="" />;
 		},
 	},
 	{

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -1,34 +1,15 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-.dataviews-view-grid__media,
-.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media,
-.dataviews-view-list__media-wrapper {
-	.fields-controls__featured-image-image,
-	.fields-controls__featured-image-placeholder {
-		width: 100%;
-		height: 100%;
-		display: block;
-		border-radius: $radius-medium;
-	}
-
-	.fields-controls__featured-image-placeholder {
-		box-shadow: none;
-		background: $gray-100;
-	}
+.fields-controls__featured-image-image,
+.fields-controls__featured-image-placeholder {
+	width: 100%;
+	height: 100%;
+	display: block;
+	border-radius: $radius-medium;
 }
 
-.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media {
-	.fields-controls__featured-image-image,
-	.fields-controls__featured-image-placeholder {
-		width: 32px;
-		height: 32px;
-	}
-}
-
-.dataforms-layouts-panel__field-control {
-	.fields-controls__featured-image-image {
-		width: 16px;
-		height: 16px;
-	}
+.fields-controls__featured-image-placeholder {
+	box-shadow: none;
+	background: $gray-100;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When featured image field was introduced some styles involving DataViews and DataForm styles were added. This was [mentioned](https://github.com/WordPress/gutenberg/pull/64496/files#r1813135126) by @oandregal back then, and he also mentioned it [here](https://github.com/WordPress/gutenberg/pull/73537#discussion_r2631725494), when I moved around some styles (without updating them). Fields shouldn't contain specific styles targeting internal classnames, as they are not public API.

This PR updates the `table` layout styles and removes the mentioned featured image styles.

The visible changes are minimal and in most cases we have identical results. 

The changes are: 
1. In quick edit for featured image the width instead of being `16px` is constraint by the existing button `min-height: 32px`, which means the width might be a bit bigger in some cases. I believe that's perfectly fine and especially right now in trunk that we don't see this change, as we use the `regular` dataform layout. The change would be visible if we used `panel` layout, which is something you can also check by updating [this line](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/post-edit/index.js#L85) to `panel` (and probably commenting out the `labelPosition` prop). Below there are before/after screenshots for the `panel` layout.






|Before|After|
|-|-|
|<img width="1107" height="736" alt="quick-edit-before" src="https://github.com/user-attachments/assets/c081830c-dd74-472f-ba31-92ddda12a4f0" />|<img width="1107" height="736" alt="quick-edit-after" src="https://github.com/user-attachments/assets/ede546be-f09a-48d4-977b-5c72997c06c0" />|

2. This PR affects the primary media column in general and I think the styles for featured image had the intention to style primary images in general (what this PR does). You can see the differences in [storybook](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataviews--layout-table) and compare with your local build of storybook (`npm run storybook:dev`). 

|Before|After|
|-|-|
|<img width="1107" height="736" alt="story-before" src="https://github.com/user-attachments/assets/8118cb90-929f-4820-80dd-5ace5914705c" />|<img width="1107" height="736" alt="story-after" src="https://github.com/user-attachments/assets/47794ade-b271-4666-804a-730fd6fdf83b" />|




## Testing Instructions
1. Ensure that visually everything is acceptable (in most cases is identical)
2. Focus on primary media field (for templates is the preview which is identical) and the `featured image` field specifically.
3. Test and compare all different layouts (table, grid, list, etc..).
