### PR TITLE
Show submenu colors but remove the word overlay

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -203,31 +203,31 @@ function ColorTools( {
 		},
 	];
 
-	// Only show overlay controls when using the default overlay.
-	if ( ! hasCustomOverlay ) {
-		colorSettings.push(
-			{
-				colorValue: overlayTextColor.color,
-				label: isWithinOverlay
+	// Only show overlay controls when not in an overlay template.
+	colorSettings.push(
+		{
+			colorValue: overlayTextColor.color,
+			label:
+				hasCustomOverlay || isWithinOverlay
 					? __( 'Submenu text' )
 					: __( 'Submenu & overlay text' ),
-				onColorChange: setOverlayTextColor,
-				resetAllFilter: () => setOverlayTextColor(),
-				clearable: true,
-				enableAlpha: true,
-			},
-			{
-				colorValue: overlayBackgroundColor.color,
-				label: isWithinOverlay
+			onColorChange: setOverlayTextColor,
+			resetAllFilter: () => setOverlayTextColor(),
+			clearable: true,
+			enableAlpha: true,
+		},
+		{
+			colorValue: overlayBackgroundColor.color,
+			label:
+				hasCustomOverlay || isWithinOverlay
 					? __( 'Submenu background' )
 					: __( 'Submenu & overlay background' ),
-				onColorChange: setOverlayBackgroundColor,
-				resetAllFilter: () => setOverlayBackgroundColor(),
-				clearable: true,
-				enableAlpha: true,
-			}
-		);
-	}
+			onColorChange: setOverlayBackgroundColor,
+			resetAllFilter: () => setOverlayBackgroundColor(),
+			clearable: true,
+			enableAlpha: true,
+		}
+	);
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74775

Change the logic for when to add submenu and overlay colors. We shouldn't show overlay colors for navigation blocks in the overlay, or navigation blocks with a custom overlays.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When a navigation block has a custom overlay, or is in an overlay, the "overlay" colors don't do anything, so we should remove the word "overlay" from the labels.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Small logic change.

## Testing Instructions
1. Add a navigation block
2. Confirm that the color labels mention both submenus and overlays
3. Add a custom overlay and confirm that the labels no longer mention overlays
4. Edit the overlay and select the navigation block inside it.
5. Confirm that the color options on this block no longer mention overlay either.
egressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="277" height="189" alt="Screenshot 2026-01-21 at 15 40 32" src="https://github.com/user-attachments/assets/497bc340-876f-49b6-a9bf-f4859d987d4d" />
