### PR TITLE
Real-time collaboration: Update provider types

### DIFF
--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -72,7 +72,7 @@ export interface ProviderCreatorResult {
 	on: ProviderOn;
 }
 
-export type SyncConnectionStatus = 'connected' | 'disconnected';
+export type SyncConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
 /**
  * Sync connection error object.


### PR DESCRIPTION
## What?

Update `SyncConnectionStatus` to handle other possible websocket provider events. See `vip-real-time-collaboration` changes where we use this status: https://github.com/Automattic/vip-real-time-collaboration/pull/143.

## Why?

We didn't include a 'connecting' status, but our testing provider emits that event.