### PR TITLE
Try storing global styles in static var in layout render

### DIFF
--- a/backport-changelog/7.0/10766.md
+++ b/backport-changelog/7.0/10766.md
@@ -2,4 +2,5 @@ https://github.com/WordPress/wordpress-develop/pull/10766
 
 * https://github.com/WordPress/gutenberg/pull/74725
 * https://github.com/WordPress/gutenberg/pull/74795
+* https://github.com/WordPress/gutenberg/pull/74828
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -631,6 +631,8 @@ function gutenberg_unique_id_from_values( array $data, string $prefix = '' ): st
  * @return string                Filtered block content.
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
+	static $global_styles = null;
+
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
 	// If there is any value in style -> layout, the block has a child layout.
@@ -897,8 +899,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check block-specific styles first, then fall back to root styles.
-		$block_name             = $block['blockName'] ?? '';
-		$global_styles          = gutenberg_get_global_styles();
+		$block_name = $block['blockName'] ?? '';
+		if ( null === $global_styles ) {
+			$global_styles = gutenberg_get_global_styles();
+		}
 		$global_block_gap_value = $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? ( $global_styles['spacing']['blockGap'] ?? null );
 
 		if ( null !== $global_block_gap_value ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -439,7 +439,8 @@ export const withLayoutStyles = createHigherOrderComponent(
 					const { getSettings, getBlockSettings } = unlock(
 						select( blockEditorStore )
 					);
-					const { disableLayoutStyles } = getSettings();
+					const settings = getSettings();
+					const { disableLayoutStyles } = settings;
 
 					if ( disableLayoutStyles ) {
 						return;
@@ -452,7 +453,6 @@ export const withLayoutStyles = createHigherOrderComponent(
 
 					// Get default blockGap value from global styles for use in layouts like grid.
 					// Check block-specific styles first, then fall back to root styles.
-					const settings = getSettings();
 					const globalStyles = settings[ globalStylesDataKey ];
 					const globalBlockGapValue =
 						globalStyles?.blocks?.[ name ]?.spacing?.blockGap ??


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/74725#issuecomment-3781561844

Test that #74725 still works.
