### PR TITLE
WP 6.9: Run PHP unit tests only on WP6.9

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -187,9 +187,10 @@ jobs:
                 event: ['${{ github.event_name }}']
                 php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
                 multisite: [false, true]
-                wordpress: ['', 'previous major version']
+                # Special matrix for wp/6.9 branch. Only run tests on a pinned specific WordPress version.
+                wordpress: ['6.9']
                 exclude:
-                    # On PRs: Only test PHP 8.3, single-site, latest WP
+                    # On PRs: Only test PHP 8.3, single-site
                     - event: 'pull_request'
                       php: '7.2'
                     - event: 'pull_request'
@@ -204,17 +205,6 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
-                    # On trunk/releases: Only test previous WP version with specific PHP versions
-                    - php: '7.3'
-                      wordpress: 'previous major version'
-                    - php: '8.0'
-                      wordpress: 'previous major version'
-                    - php: '8.1'
-                      wordpress: 'previous major version'
-                    - php: '8.2'
-                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
## What?

When I backported some PRs to the `wp/6.9` branch for the 6.9.1 release, I noticed the following error in the main branch:

https://github.com/WordPress/gutenberg/actions/runs/21205767027/job/61002308258

<img width="765" height="267" alt="image" src="https://github.com/user-attachments/assets/84f9b9b7-8f77-4522-8645-33e69846b357" />

```
Your server is running PHP version 7.2.34 but WordPress 7.0-alpha-61504 requires at least 7.4.
```

In WordPress 7.0, the minimum PHP version was bumped to 7.4, which is why we're getting this error.

For the `wp/6.9` branch, I don't think there's any need to test the nightly version (WordPress 7.0) in the first place, so I think it's best to pin the WordPress version at 6.9.

## Testing Instructions

All CI checks should be ✅ on the main branch after this PR is merged.