### PR TITLE
Storybook: Configure TypeScript project references.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Code Quality
 
 -   Add `displayName` to components to improve debugging and fix Storybook source code. [#74716](https://github.com/WordPress/gutenberg/pull/74716)
--   Storybook: Configure TypeScript project references. [#74835](https://github.com/WordPress/gutenberg/pull/74835)
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Code Quality
 
 -   Add `displayName` to components to improve debugging and fix Storybook source code. [#74716](https://github.com/WordPress/gutenberg/pull/74716)
+-   Storybook: Configure TypeScript project references. [#74835](https://github.com/WordPress/gutenberg/pull/74835)
 
 ### Internal
 

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -6,5 +6,16 @@
 		"rootDir": ".",
 		"noEmit": true
 	},
-	"include": [ "**/*.tsx", "**/*.ts" ]
+	"include": [ "**/*.tsx", "**/*.ts" ],
+	"references": [
+		{ "path": "../packages/components" },
+		{ "path": "../packages/block-editor" },
+		{ "path": "../packages/icons" },
+		{ "path": "../packages/dataviews" },
+		{ "path": "../packages/fields" },
+		{ "path": "../packages/image-cropper" },
+		{ "path": "../packages/media-fields" },
+		{ "path": "../packages/theme" },
+		{ "path": "../packages/ui" }
+	]
 }


### PR DESCRIPTION
## What?

Attempts to get the source panel to display properly without using `displayName`.

## Why?

I found that one of the reasons why component names are not displayed correctly is #74640. This might be because the execution directory has changed as a result of the storybook being converted into a package.

## How?

- I tried to display the correct component name by defining the `references` field in `tsconfig.json`.
- In production builds, continue to use `terser` as before to fix incorrect callback functions like `onChange={function FAe(){}}`.

~Additionally, the important changes in this PR are as follows. The other differences are due to the reversion of #74716.~

- ~[storybook/main.ts](https://github.com/WordPress/gutenberg/pull/74835/changes#diff-430691f4143ab1ea4755c4a6b516c06d9f93219263be8e69f3963ee4ca121977)~
- ~[storybook/tsconfig.json](https://github.com/WordPress/gutenberg/pull/74835/changes#diff-96acf82c1cbbd919a5a1c1b34e6e93da7dba8591dfd159d60105f43790ffc522)~
- ~[storybook/package.json](https://github.com/WordPress/gutenberg/pull/74835/changes#diff-9dff916c44fa99f82c4d398dd1c1abaf99f3598689f430e75910720e451185d4)~

## Testing Instructions

Test in both development and production builds:

- `npm run storybook:dev`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run storybook:build && npx serve ./storybook/build`

Make sure:

- For all components, the component name in the source panel is correct.
- The callback function name is correct (`onChange={() => {}}`, not `onChange={function FAe(){}}` ). See https://github.com/WordPress/gutenberg/pull/74716#pullrequestreview-3673779605
- All props are displayed correctly. See #74807.