### PR TITLE
Dataviews: Fix actions visibility on smaller viewpoints and for lone action with isPrimary as true

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fix primary action visibility in table layout when the action doesn't support bulk operations, and fix compact action menu not visible on mobile when there is only one action. [#74836](https://github.com/WordPress/gutenberg/pull/74836)
 - DataViews: Use regular casing for bulk selection count. [#74573](https://github.com/WordPress/gutenberg/pull/74573)
 
 ### Code Quality

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -200,6 +200,8 @@ export default function ItemActions< Item >( {
 		};
 	}, [ actions, item ] );
 
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+
 	if ( isCompact ) {
 		return (
 			<CompactItemActions
@@ -226,7 +228,10 @@ export default function ItemActions< Item >( {
 				actions={ primaryActions }
 				registry={ registry }
 			/>
-			{ primaryActions.length < eligibleActions.length && (
+			{ ( primaryActions.length < eligibleActions.length ||
+				// Since we hide primary actions on mobile, we need to show the menu
+				// there if there are any actions at all.
+				isMobileViewport ) && (
 				<CompactItemActions
 					item={ item }
 					actions={ eligibleActions }

--- a/packages/dataviews/src/components/dataviews-layouts/activity/activity-item.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/activity-item.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { VisuallyHidden } from '@wordpress/components';
 import { useRef, useContext, useMemo } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -67,6 +68,7 @@ function ActivityItem< Item >(
 		};
 	}, [ actions, item ] );
 
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const density = view.layout?.density ?? 'balanced';
 	const mediaContent =
 		showMedia && density !== 'compact' && mediaField?.render ? (
@@ -183,7 +185,12 @@ function ActivityItem< Item >(
 						/>
 					) }
 				</Stack>
-				{ primaryActions.length < eligibleActions.length && (
+				{ ( primaryActions.length < eligibleActions.length ||
+					// Since we hide primary actions on mobile, we need to show the menu
+					// there if there are any actions at all.
+					( isMobileViewport &&
+						// At the same time, only show the menu if there are actions to show.
+						eligibleActions.length > 0 ) ) && (
 					<div className="dataviews-view-activity__item-actions">
 						<ItemActions
 							item={ item }

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -97,17 +97,22 @@
 				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
 			}
 		}
+
+		// Show action buttons on hover/focus for all rows
+		&:focus-within,
+		&.is-hovered,
+		&:hover {
+			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+				opacity: 1;
+			}
+		}
 	}
 
-	// Show interactive elements on focus
+	// Additional styles when bulk actions are available
 	&.has-bulk-actions {
 		tr {
 			&:focus-within,
 			&:hover {
-				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
-					opacity: 1;
-				}
-
 				.dataviews-view-table__actions-column--sticky {
 					background-color: var(--wp-dataviews-color-background, $white);
 				}

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -637,6 +637,7 @@ describe( 'DataViews component', () => {
 			{
 				id: 'edit',
 				label: 'Edit',
+				isPrimary: true,
 				callback: () => {},
 			},
 		];

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -13,7 +13,12 @@ import { useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViews from '../index';
-import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../constants';
+import {
+	LAYOUT_ACTIVITY,
+	LAYOUT_GRID,
+	LAYOUT_LIST,
+	LAYOUT_TABLE,
+} from '../../constants';
 import type { Action, View } from '../../types';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
 
@@ -37,6 +42,7 @@ const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {},
 	[ LAYOUT_GRID ]: {},
 	[ LAYOUT_LIST ]: {},
+	[ LAYOUT_ACTIVITY ]: {},
 };
 
 const fields = [
@@ -147,6 +153,10 @@ function DataViewWrapper( {
 // jest.useFakeTimers();
 
 // Tests run against a DataView which is 500px wide.
+const mockUseViewportMatch = jest.fn(
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	( _viewport: string, _operator: string ) => false
+);
 jest.mock( '@wordpress/compose', () => {
 	return {
 		...jest.requireActual( '@wordpress/compose' ),
@@ -160,6 +170,8 @@ jest.mock( '@wordpress/compose', () => {
 			}, 0 );
 			return () => {};
 		} ),
+		useViewportMatch: ( viewport: string, operator: string ): boolean =>
+			mockUseViewportMatch( viewport, operator ),
 	};
 } );
 
@@ -614,6 +626,58 @@ describe( 'DataViews component', () => {
 					actions={ actions }
 				/>
 			);
+			expect(
+				screen.getAllByRole( 'button', { name: 'Actions' } ).length
+			).toEqual( 3 );
+		} );
+	} );
+
+	describe( 'actions on mobile viewport', () => {
+		const testActions: Action< Data >[] = [
+			{
+				id: 'edit',
+				label: 'Edit',
+				callback: () => {},
+			},
+		];
+
+		beforeEach( () => {
+			// Simulate mobile viewport
+			mockUseViewportMatch.mockImplementation(
+				( viewport: string, operator: string ) =>
+					viewport === 'medium' && operator === '<'
+			);
+		} );
+
+		afterEach( () => {
+			mockUseViewportMatch.mockImplementation( () => false );
+		} );
+
+		it( 'should show actions dropdown on mobile even when there is only one action in table layout', () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						type: LAYOUT_TABLE,
+					} }
+					actions={ testActions }
+				/>
+			);
+			// On mobile, the dropdown should be visible even with only primary actions
+			expect(
+				screen.getAllByRole( 'button', { name: 'Actions' } ).length
+			).toEqual( 3 );
+		} );
+
+		it( 'should show actions dropdown on mobile even when there is only one action in activity layout', () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						type: LAYOUT_ACTIVITY,
+					} }
+					actions={ testActions }
+				/>
+			);
+			// On mobile, the dropdown should be visible even with only primary actions
 			expect(
 				screen.getAllByRole( 'button', { name: 'Actions' } ).length
 			).toEqual( 3 );


### PR DESCRIPTION
## What?

Closes #74810

Fixes primary action visibility in the DataViews table layout when the action doesn't support bulk operations. It also fixes the compact action menu not being visible on mobile, where there is only one action, apart from the primary action, also being hidden.

## Why?

Two related issues existed:

1. **Primary actions invisible on hover**: When an action has `isPrimary: true` but not `supportsBulk: true`, the primary action button is invisible on row hover. This happened because the CSS hover styles that set `opacity: 1` were only applied inside `.has-bulk-actions`, which requires at least one action to have `supportsBulk: true`.

2. **No action menu on mobile**: On mobile viewports, `PrimaryActions` returns `null` (since buttons don't fit well on small screens). However, the dropdown menu was only shown when `primaryActions.length < eligibleActions.length`. This meant that if the only action is primary, users had no way to access it on mobile.

## How?

1. **CSS fix**: Moved the hover/focus styles for action buttons outside of the `.has-bulk-actions` block so they apply to all table rows regardless of whether bulk actions are available.

2. **Mobile fix**: Added an `isMobileViewport` check to always show the compact actions menu on mobile when there are eligible actions. This fix is applied to both the table layout (`ItemActions` component) and the activity layout (`ActivityItem` component).

## Testing Instructions

1. Open any DataViews story and `npm run storybook:dev`
2. Ensure that there is only one action and it has `isPrimary: true` and does not have `supportsBulk: true`
3. Hover over a row in the table view
4. Verify the primary action button appears on hover
5. Resize the viewport to mobile width
6. Verify the actions dropdown menu (three dots) appears

### Testing Instructions for Keyboard

1. Open the DataViews story
2. Use Tab to navigate to a table row
3. Verify the primary action button becomes visible when the row receives focus

## Screenshots or screencast

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Desktop</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/7523ed0a-c95d-4e38-b702-665c53ebee06

</td>
            <td>

https://github.com/user-attachments/assets/ccf47224-50df-4374-9c47-98ffd4ad864c

</td>
        </tr>
        <tr>
            <th colspan="2">Mobile</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/fbede15f-5ea7-45de-934d-529c38518fcf

</td>
            <td>

https://github.com/user-attachments/assets/676382cf-7f11-4fce-a815-6a79a36b55f9

</td>
        </tr>
        </tr>
        <tr>
            <th colspan="2">Activity</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/1b1708a1-83b8-4262-b56d-0b052e854319

</td>
            <td>

https://github.com/user-attachments/assets/1133b6cb-2622-4e39-ac20-4a1b3a83cd42

</td>
        </tr>
    </tbody>
</table>