### PR TITLE
Block Visibility: fix failing unit test

### DIFF
--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1158,6 +1158,7 @@ describe( 'private selectors', () => {
 	describe( 'isBlockHiddenAtViewport', () => {
 		beforeAll( () => {
 			registerBlockType( 'core/test-block-with-visibility', {
+				apiVersion: 3,
 				save: () => null,
 				category: 'text',
 				title: 'Test Block With Visibility',


### PR DESCRIPTION
Follow-up to #74517

## What?

After #74057, if `registerBlockType` is executed without using `apiVersion: 3`, a warning log will be output to the browser console, and the unit test will fail.

## Testing Instructions

All CI checks should be ✅.