### PR TITLE
Pattern Editing and Block Fields: Highlight selected block

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import {
 	privateApis as blocksPrivateApis,
 	getBlockType,
@@ -73,7 +72,7 @@ function BlockFields( {
 
 	const blockContext = useContext( BlockContext );
 
-	const { attributes, selectedBlockClientIds } = useSelect(
+	const attributes = useSelect(
 		( select ) => {
 			const _attributes =
 				select( blockEditorStore ).getBlockAttributes( clientId );
@@ -82,26 +81,21 @@ function BlockFields( {
 			}
 
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			const computedAttributes = Object.entries(
-				_attributes.metadata.bindings
-			).reduce( ( acc, [ attribute, binding ] ) => {
-				const source = getBlockBindingsSource( binding.source );
-				if ( ! source ) {
-					return acc;
-				}
-				const values = source.getValues( {
-					select,
-					context: blockContext,
-					bindings: { [ attribute ]: binding },
-				} );
-				return { ...acc, ...values };
-			}, _attributes );
-
-			return {
-				attributes: computedAttributes,
-				selectedBlockClientIds:
-					select( blockEditorStore ).getSelectedBlockClientIds(),
-			};
+			return Object.entries( _attributes.metadata.bindings ).reduce(
+				( acc, [ attribute, binding ] ) => {
+					const source = getBlockBindingsSource( binding.source );
+					if ( ! source ) {
+						return acc;
+					}
+					const values = source.getValues( {
+						select,
+						context: blockContext,
+						bindings: { [ attribute ]: binding },
+					} );
+					return { ...acc, ...values };
+				},
+				_attributes
+			);
 		},
 		[ blockContext, clientId ]
 	);
@@ -192,10 +186,7 @@ function BlockFields( {
 
 	return (
 		<div
-			className={ clsx( 'block-editor-block-fields__container', {
-				'is-selected':
-					isMultiBlock && selectedBlockClientIds.includes( clientId ),
-			} ) }
+			className="block-editor-block-fields__container"
 			onMouseEnter={
 				isMultiBlock
 					? () => debouncedToggleBlockHighlight( clientId, true )

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -6,7 +6,6 @@ import {
 } from '@wordpress/blocks';
 import { useDebounce } from '@wordpress/compose';
 import {
-	Button,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
@@ -208,33 +207,15 @@ function BlockFields( {
 				<HStack spacing={ 1 }>
 					{ isCollapsed && (
 						<>
-							<Button
-								__next40pxDefaultSize
-								className="block-editor-block-fields__selection-button"
-								onHoverIn={ () =>
-									debouncedToggleBlockHighlight(
-										clientId,
-										true
-									)
-								}
-								onHoverOut={ () =>
-									debouncedToggleBlockHighlight(
-										clientId,
-										false
-									)
-								}
-								onClick={ () => selectBlock( clientId ) }
-							>
-								<BlockIcon
-									className="block-editor-block-fields__header-icon"
-									icon={ blockInformation?.icon }
-								/>
-								<h2 className="block-editor-block-fields__header-title">
-									<Truncate numberOfLines={ 1 }>
-										{ blockTitle }
-									</Truncate>
-								</h2>
-							</Button>
+							<BlockIcon
+								className="block-editor-block-fields__header-icon"
+								icon={ blockInformation?.icon }
+							/>
+							<h2 className="block-editor-block-fields__header-title">
+								<Truncate numberOfLines={ 1 }>
+									{ blockTitle }
+								</Truncate>
+							</h2>
 							<FieldsDropdownMenu
 								fields={ dataFormFields }
 								visibleFields={ form.fields }

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -50,16 +50,18 @@ function createConfiguredControl( ControlComponent, config = {} ) {
  * @param {string}   props.clientId      The clientId of the block.
  * @param {Object}   props.blockType     The blockType definition.
  * @param {Function} props.setAttributes Action to set the block's attributes.
- * @param {boolean}  props.isCollapsed   Whether the DataForm is rendered as 'collapsed' with only the first field
- *                                       displayed by default. When collapsed a dropdown is displayed to allow
- *                                       displaying additional fields. The block's title is displayed as the title.
- *                                       The collapsed mode is often used when multiple BlockForms are shown together.
+ * @param {boolean}  props.isMultiBlock  Whether forms for multiple blocks are shown at the same time.
+ *                                       This changes the behavior of the component:
+ *                                       - Only the first field is shown for each block.
+ *                                       - A dropdown is rendered allowing display of additional fields.
+ *                                       - Hovering the block fields highlights the block in the canvas
+ *                                       - Focusing a block field soft-selects the block in the canvas.
  */
 function BlockFields( {
 	clientId,
 	blockType,
 	setAttributes,
-	isCollapsed = false,
+	isMultiBlock = false,
 } ) {
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -112,7 +114,7 @@ function BlockFields( {
 	);
 
 	const computedForm = useMemo( () => {
-		if ( ! isCollapsed ) {
+		if ( ! isMultiBlock ) {
 			return blockType?.[ formKey ];
 		}
 
@@ -121,7 +123,7 @@ function BlockFields( {
 			...blockType?.[ formKey ],
 			fields: [ blockType?.[ formKey ]?.fields?.[ 0 ] ],
 		};
-	}, [ blockType, isCollapsed ] );
+	}, [ blockType, isMultiBlock ] );
 
 	const [ form, setForm ] = useState( computedForm );
 
@@ -191,21 +193,33 @@ function BlockFields( {
 	return (
 		<div
 			className={ clsx( 'block-editor-block-fields__container', {
-				'is-selected': selectedBlockClientIds.includes( clientId ),
+				'is-selected':
+					isMultiBlock && selectedBlockClientIds.includes( clientId ),
 			} ) }
-			onMouseEnter={ () =>
-				debouncedToggleBlockHighlight( clientId, true )
+			onMouseEnter={
+				isMultiBlock
+					? () => debouncedToggleBlockHighlight( clientId, true )
+					: undefined
 			}
 			onMouseLeave={ () =>
-				debouncedToggleBlockHighlight( clientId, false )
+				isMultiBlock
+					? debouncedToggleBlockHighlight( clientId, false )
+					: undefined
 			}
-			onFocus={ () => {
-				selectBlock( clientId, null /* null to avoid focus */ );
-			} }
+			onFocus={
+				isMultiBlock
+					? () => {
+							selectBlock(
+								clientId,
+								null /* null to avoid focus on the block in the canvas */
+							);
+					  }
+					: undefined
+			}
 		>
 			<div className="block-editor-block-fields__header">
 				<HStack spacing={ 1 }>
-					{ isCollapsed && (
+					{ isMultiBlock && (
 						<>
 							<BlockIcon
 								className="block-editor-block-fields__header-icon"
@@ -223,7 +237,7 @@ function BlockFields( {
 							/>
 						</>
 					) }
-					{ ! isCollapsed && (
+					{ ! isMultiBlock && (
 						<h2 className="block-editor-block-fields__header-title">
 							{ __( 'Content' ) }
 						</h2>
@@ -256,7 +270,7 @@ export function BlockFieldsPanel( props ) {
 			<BlockFields
 				{ ...props }
 				blockType={ blockType }
-				isCollapsed={ isSelectionWithinCurrentSection }
+				isMultiBlock={ isSelectionWithinCurrentSection }
 			/>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -1,23 +1,19 @@
-/**
- * WordPress dependencies
- */
+import clsx from 'clsx';
 import {
 	privateApis as blocksPrivateApis,
 	getBlockType,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { useDebounce } from '@wordpress/compose';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { useContext, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import BlockContext from '../../components/block-context';
@@ -76,7 +72,7 @@ function BlockFields( {
 
 	const blockContext = useContext( BlockContext );
 
-	const attributes = useSelect(
+	const { attributes, selectedBlockClientIds } = useSelect(
 		( select ) => {
 			const _attributes =
 				select( blockEditorStore ).getBlockAttributes( clientId );
@@ -85,23 +81,35 @@ function BlockFields( {
 			}
 
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			return Object.entries( _attributes.metadata.bindings ).reduce(
-				( acc, [ attribute, binding ] ) => {
-					const source = getBlockBindingsSource( binding.source );
-					if ( ! source ) {
-						return acc;
-					}
-					const values = source.getValues( {
-						select,
-						context: blockContext,
-						bindings: { [ attribute ]: binding },
-					} );
-					return { ...acc, ...values };
-				},
-				_attributes
-			);
+			const computedAttributes = Object.entries(
+				_attributes.metadata.bindings
+			).reduce( ( acc, [ attribute, binding ] ) => {
+				const source = getBlockBindingsSource( binding.source );
+				if ( ! source ) {
+					return acc;
+				}
+				const values = source.getValues( {
+					select,
+					context: blockContext,
+					bindings: { [ attribute ]: binding },
+				} );
+				return { ...acc, ...values };
+			}, _attributes );
+
+			return {
+				attributes: computedAttributes,
+				selectedBlockClientIds:
+					select( blockEditorStore ).getSelectedBlockClientIds(),
+			};
 		},
 		[ blockContext, clientId ]
+	);
+	const { selectBlock, toggleBlockHighlight } =
+		useDispatch( blockEditorStore );
+
+	const debouncedToggleBlockHighlight = useDebounce(
+		toggleBlockHighlight,
+		50
 	);
 
 	const computedForm = useMemo( () => {
@@ -182,20 +190,51 @@ function BlockFields( {
 	};
 
 	return (
-		<div className="block-editor-block-fields__container">
+		<div
+			className={ clsx( 'block-editor-block-fields__container', {
+				'is-selected': selectedBlockClientIds.includes( clientId ),
+			} ) }
+			onMouseEnter={ () =>
+				debouncedToggleBlockHighlight( clientId, true )
+			}
+			onMouseLeave={ () =>
+				debouncedToggleBlockHighlight( clientId, false )
+			}
+			onFocus={ () => {
+				selectBlock( clientId, null /* null to avoid focus */ );
+			} }
+		>
 			<div className="block-editor-block-fields__header">
 				<HStack spacing={ 1 }>
 					{ isCollapsed && (
 						<>
-							<BlockIcon
-								className="block-editor-block-fields__header-icon"
-								icon={ blockInformation?.icon }
-							/>
-							<h2 className="block-editor-block-fields__header-title">
-								<Truncate numberOfLines={ 1 }>
-									{ blockTitle }
-								</Truncate>
-							</h2>
+							<Button
+								__next40pxDefaultSize
+								className="block-editor-block-fields__selection-button"
+								onHoverIn={ () =>
+									debouncedToggleBlockHighlight(
+										clientId,
+										true
+									)
+								}
+								onHoverOut={ () =>
+									debouncedToggleBlockHighlight(
+										clientId,
+										false
+									)
+								}
+								onClick={ () => selectBlock( clientId ) }
+							>
+								<BlockIcon
+									className="block-editor-block-fields__header-icon"
+									icon={ blockInformation?.icon }
+								/>
+								<h2 className="block-editor-block-fields__header-title">
+									<Truncate numberOfLines={ 1 }>
+										{ blockTitle }
+									</Truncate>
+								</h2>
+							</Button>
 							<FieldsDropdownMenu
 								fields={ dataFormFields }
 								visibleFields={ form.fields }

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -13,17 +13,7 @@
 		 * Add border for the entire content controls and remove the similar border
 		 * for tools panel.
 		 */
-		border-top: $border-width solid $gray-200;
-	}
-
-	&.is-selected {
-		.block-editor-block-fields__header-icon svg {
-			fill: var(--wp-admin-theme-color);
-		}
-
-		.block-editor-block-fields__header-title {
-			color: var(--wp-admin-theme-color);
-		}
+		border-block-start: $border-width solid $gray-200;
 	}
 }
 

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -15,17 +15,8 @@
 		 */
 		border-top: $border-width solid $gray-200;
 	}
-}
 
-.block-editor-block-fields__selection-button {
-	padding: 0;
-	height: auto;
-
-	&:hover .block-editor-block-fields__header-title {
-		color: var(--wp-admin-theme-color);
-	}
-
-	.is-selected & {
+	&.is-selected {
 		.block-editor-block-fields__header-icon svg {
 			fill: var(--wp-admin-theme-color);
 		}

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -5,17 +5,34 @@
 @use "./rich-text/styles.scss" as *;
 
 .block-editor-block-fields__container {
-	padding: 0 $grid-unit-20;
+	padding: 0 $grid-unit-20 $grid-unit-20;
 
 	&:first-of-type {
 		padding-block-start: $grid-unit-10;
-		// Add border for the entire content controls and remove the similar border
-		// for tools panel.
+		/*
+		 * Add border for the entire content controls and remove the similar border
+		 * for tools panel.
+		 */
 		border-top: $border-width solid $gray-200;
 	}
+}
 
-	&:last-of-type {
-		padding-block-end: $grid-unit-20;
+.block-editor-block-fields__selection-button {
+	padding: 0;
+	height: auto;
+
+	&:hover .block-editor-block-fields__header-title {
+		color: var(--wp-admin-theme-color);
+	}
+
+	.is-selected & {
+		.block-editor-block-fields__header-icon svg {
+			fill: var(--wp-admin-theme-color);
+		}
+
+		.block-editor-block-fields__header-title {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 }
 
@@ -26,10 +43,11 @@
 
 .block-editor-block-fields__header-icon {
 	flex: 0 0 $icon-size;
+	margin-inline-end: $grid-unit-05;
 }
 
 .block-editor-block-fields__header-title {
 	flex: 1;
-	// Override the default margin on a h2 element.
+	/* Override the default margin on a h2 element. */
 	margin: 0 !important;
 }

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -34,7 +34,6 @@
 
 .block-editor-block-fields__header-icon {
 	flex: 0 0 $icon-size;
-	margin-inline-end: $grid-unit-05;
 }
 
 .block-editor-block-fields__header-title {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The aim of this PR is to try to build more of a connection between the block in the canvas, and the fields in the block inspector.

To do that, there are a few things it implements:

#### 1. When a block is selected in the canvas show the block icon and title in a blue color in the inspector:
<img width="270" height="344" alt="Screenshot 2026-01-22 at 2 42 41 pm" src="https://github.com/user-attachments/assets/c7233f3d-537a-48ff-baa8-6f5e8b7086ec" />

#### 2. When hovering block fields in the inspector, highlight/outline the block in the canvas:

https://github.com/user-attachments/assets/ee8b553a-b7c8-49fe-b393-a62190ec30e8

#### 3. When focusing a block field in the inspector, select the block in the canvas (without transferring focus):

https://github.com/user-attachments/assets/5bc17db7-63d3-4a61-8b59-440a1d3f3d4d

## Why?
Currently when a pattern shows a lot of block fields, or the canvas is busy it can be hard to see what's being edited

## Testing Instructions
Prerequisite: Enabled both the Pattern Editing and Block Fields experiments

1. Insert a pattern
2. Open the block inspector and interact with the fields
3. Observe that on hover the block in the canvas is highlighted
4. Observe that one focusing a field (or any related UI) the block is select in the canvas (without transferring focus)
5. Select blocks within the pattern in the canvas
6. Observe that when changing block selection, the selection block has a blue color in the inspector.
