### PR TITLE
Breadcrumbs: Fix placeholder separator preview

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -159,7 +159,15 @@ export default function BreadcrumbEdit( {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
-			<nav { ...blockProps }>
+			<nav
+				{ ...blockProps }
+				style={ {
+					'--separator': `"${ separator
+						.replace( /\\/g, '\\\\' )
+						.replace( /"/g, '\\"' ) }"`,
+					...blockProps.style,
+				} }
+			>
 				<ol>
 					{ placeholderItems.map( ( text, index ) => (
 						<li key={ index }>
@@ -278,7 +286,7 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			{ status === 'loading' && (
+			{ status === 'loading' && ! showPlaceholder && (
 				<div { ...blockProps }>
 					<Spinner />
 				</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/74824

There was a regression introduced [here](https://github.com/WordPress/gutenberg/pull/74344), that led to the separator not being applied properly when we were showing the placeholder preview of Breadcrumbs block. 

The placeholder preview is shown in a few conditions like when we're rendering the block inside some templates that are more generic (will be used for various objects like `archives`). In all other cases the actual server side rendered block is shown, which is actually the final result that will appear in the front end, and there is no issue for this.

This PR fixes that by adding the `separator` css var in the placeholder preview too. Additionally I noticed that we also rendered the loading spinner even when we show the preview, which we don't need to.

## Testing Instructions
1. In site editor go to some templates like `archives, blog` etc..
2. Insert the Breadcrumbs block
3. Update the separator and observe that your change is previewed
4. Also check the front end, although I made no changes there.

