### PR TITLE
E2e tests: remove `switchToLegacyCanvas` from multi select and a11y suite

### DIFF
--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -22,12 +22,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		pageUtils,
 		editor,
 	} ) => {
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
-
 		// On a new post, initial focus is set on the Post title.
 		await expect(
-			page.locator( 'role=textbox[name=/Add title/i]' )
+			editor.canvas.locator( 'role=textbox[name=/Add title/i]' )
 		).toBeFocused();
 		// Navigate to the 'Editor settings' region.
 		await pageUtils.pressKeys( 'ctrl+`' );
@@ -50,11 +47,7 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 	test( 'should constrain tabbing within a modal', async ( {
 		page,
 		pageUtils,
-		editor,
 	} ) => {
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
-
 		// Open keyboard shortcuts modal.
 		await pageUtils.pressKeys( 'access+h' );
 

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1252,9 +1252,6 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		page,
 		editor,
 	} ) => {
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
-
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: '<strong>1</strong>[' },
@@ -1264,7 +1261,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			attributes: { content: ']2' },
 		} );
 		// Focus and move the caret to the end.
-		const secondParagraphBlock = page
+		const secondParagraphBlock = editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: ']2' } );
 		const secondParagraphBlockBox =
@@ -1277,9 +1274,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		} );
 
 		await page.keyboard.press( 'ArrowLeft' );
-		const strongText = page
-			.getByRole( 'region', { name: 'Editor content' } )
-			.getByText( '1', { exact: true } );
+		const strongText = editor.canvas.getByText( '1', { exact: true } );
 		const strongBox = await strongText.boundingBox();
 		// Focus and move the caret to the end.
 		await strongText.click( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Preparatory work for #74042.

These changes a very straightforward. Other suites require some changes, there's legitimate issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need all e2e tests to run with the iframe, unless it's specifically to test something without it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove and fix locators.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Everything should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
