### PR TITLE
Enable build-blocks-manifest by default

### DIFF
--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -133,6 +133,34 @@ async function build() {
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );
 
+		// Step 7.5: Build blocks manifests
+		console.log( '\n📦 Building blocks manifests...' );
+		const blocksDirs = [
+			{
+				input: 'build/scripts/block-library',
+				output: 'build/scripts/block-library/blocks-manifest.php',
+			},
+			{
+				input: 'build/scripts/edit-widgets/blocks',
+				output: 'build/scripts/edit-widgets/blocks/blocks-manifest.php',
+			},
+			{
+				input: 'build/scripts/widgets/blocks',
+				output: 'build/scripts/widgets/blocks/blocks-manifest.php',
+			},
+		];
+		for ( const { input, output } of blocksDirs ) {
+			await exec(
+				'wp-scripts',
+				[
+					'build-blocks-manifest',
+					`--input=${ input }`,
+					`--output=${ output }`,
+				],
+				{ silent: true }
+			);
+		}
+
 		// Step 8: Build workspace :wp targets
 		console.log( '\n📦 Building workspace :wp targets...' );
 		await exec(

--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -159,6 +159,34 @@ async function dev() {
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [ './bin/packages/build-vendors.mjs' ] );
 
+		// Step 6.5: Build blocks manifests (initial)
+		console.log( '\n📦 Building blocks manifests...' );
+		const blocksDirs = [
+			{
+				input: 'build/scripts/block-library',
+				output: 'build/scripts/block-library/blocks-manifest.php',
+			},
+			{
+				input: 'build/scripts/edit-widgets/blocks',
+				output: 'build/scripts/edit-widgets/blocks/blocks-manifest.php',
+			},
+			{
+				input: 'build/scripts/widgets/blocks',
+				output: 'build/scripts/widgets/blocks/blocks-manifest.php',
+			},
+		];
+		for ( const { input, output } of blocksDirs ) {
+			await exec(
+				'wp-scripts',
+				[
+					'build-blocks-manifest',
+					`--input=${ input }`,
+					`--output=${ output }`,
+				],
+				{ silent: true }
+			);
+		}
+
 		const setupTime = Date.now() - startTime;
 		console.log(
 			`\n✅ Initial build completed! (${ Math.round(

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -10,7 +10,6 @@
  * with the built result from the plugin.
  */
 function gutenberg_reregister_core_block_types() {
-	// Blocks directory may not exist if working from a fresh clone.
 	$blocks_dirs = array(
 		__DIR__ . '/../build/scripts/block-library/',
 		__DIR__ . '/../build/scripts/edit-widgets/blocks/',
@@ -18,31 +17,22 @@ function gutenberg_reregister_core_block_types() {
 	);
 
 	foreach ( $blocks_dirs as $blocks_dir ) {
-		if ( ! is_dir( $blocks_dir ) ) {
-			continue;
-		}
+		$manifest_path = $blocks_dir . 'blocks-manifest.php';
+		$blocks        = require $manifest_path;
 
-		// Scan for block directories (those with block.json).
-		$block_json_files = glob( $blocks_dir . '*/block.json' );
-
-		foreach ( $block_json_files as $block_json_file ) {
-			$block_folder      = dirname( $block_json_file );
-			$block_name_folder = basename( $block_folder );
-
-			// Read block.json to get block name.
-			$metadata = json_decode( file_get_contents( $block_json_file ), true );
+		foreach ( $blocks as $block_name_folder => $metadata ) {
 			if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) ) {
 				continue;
 			}
 
-			// Deregister core version.
 			gutenberg_deregister_core_block_and_assets( $metadata['name'] );
 			gutenberg_register_core_block_assets( $block_name_folder );
-			$php_file = dirname( $block_folder ) . '/' . $block_name_folder . '.php';
+
+			$php_file = $blocks_dir . $block_name_folder . '.php';
 			if ( file_exists( $php_file ) ) {
 				require_once $php_file;
 			} else {
-				register_block_type_from_metadata( $block_json_file );
+				register_block_type_from_metadata( $blocks_dir . $block_name_folder );
 			}
 		}
 	}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -18,7 +18,11 @@ function gutenberg_reregister_core_block_types() {
 
 	foreach ( $blocks_dirs as $blocks_dir ) {
 		$manifest_path = $blocks_dir . 'blocks-manifest.php';
-		$blocks        = require $manifest_path;
+
+		// Register the metadata collection for efficient lookups.
+		wp_register_block_metadata_collection( $blocks_dir, $manifest_path );
+
+		$blocks = require $manifest_path;
 
 		foreach ( $blocks as $block_name_folder => $metadata ) {
 			if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -18,11 +18,7 @@ function gutenberg_reregister_core_block_types() {
 
 	foreach ( $blocks_dirs as $blocks_dir ) {
 		$manifest_path = $blocks_dir . 'blocks-manifest.php';
-
-		// Register the metadata collection for efficient lookups.
-		wp_register_block_metadata_collection( $blocks_dir, $manifest_path );
-
-		$blocks = require $manifest_path;
+		$blocks        = require $manifest_path;
 
 		foreach ( $blocks as $block_name_folder => $metadata ) {
 			if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) ) {


### PR DESCRIPTION
## What?

Closes #74825

Enables the `build-blocks-manifest` command by default in the build process to improve performance of block registration.

## Why?

The `gutenberg_reregister_core_block_types()` function was a performance bottleneck, using `glob()` to scan directories and parse each block.json file individually on every WordPress request. Pre-generating a PHP manifest file allows the metadata to be cached by opcache, significantly improving performance.

## How?

- Added manifest generation to `bin/build.mjs` after the main package build
- Added initial manifest generation to `bin/dev.mjs` for development builds
- Updated `lib/blocks.php` to load block metadata from pre-generated manifest files instead of using `glob()` directory scanning

The generated manifest files are PHP arrays that can be `require()`d directly, eliminating the runtime overhead of directory scanning and JSON parsing.

## Testing Instructions

1. Run `npm run build` and verify manifests are generated:
   - `build/scripts/block-library/blocks-manifest.php`
   - `build/scripts/edit-widgets/blocks/blocks-manifest.php`
   - `build/scripts/widgets/blocks/blocks-manifest.php`

2. Install Gutenberg plugin in WordPress and verify blocks load normally in the editor

3. Verify no PHP errors in WordPress debug log