### PR TITLE
Navigation overlay patterns: half height overlay

### DIFF
--- a/lib/experimental/overlay-patterns.php
+++ b/lib/experimental/overlay-patterns.php
@@ -44,7 +44,7 @@ function gutenberg_register_overlay_block_patterns() {
 		array(
 			'title'       => __( 'Overlay with transparent background', 'gutenberg' ),
 			'description' => _x( 'A navigation overlay transparent background covering half the screen', 'Block pattern description', 'gutenberg' ),
-			'content'     => '<!-- wp:group {"metadata":{"name":"Navigation Overlay"},"style":{"spacing":{"padding":{"right":"0","left":"0","top":"0","bottom":"0"}},"dimensions":{"minHeight":"100vh"},"color":{"background":"#ffffff61"}},"layout":{"type":"default"}} -->
+			'content'     => '<!-- wp:group {"metadata":{"name":"' . esc_attr( __( 'Navigation Overlay', 'gutenberg' ) ) . '"},"style":{"spacing":{"padding":{"right":"0","left":"0","top":"0","bottom":"0"}},"dimensions":{"minHeight":"100vh"},"color":{"background":"#ffffff61"}},"layout":{"type":"default"}} -->
 <div class="wp-block-group has-background" style="background-color:#ffffff61;min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"full","style":{"color":{"background":"#eeeeeef2"}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull has-background" style="background-color:#eeeeeef2"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"bottom":"4rem"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 <div class="wp-block-group alignwide" style="margin-bottom:4rem"><!-- wp:navigation-overlay-close /--></div>

--- a/lib/experimental/overlay-patterns.php
+++ b/lib/experimental/overlay-patterns.php
@@ -39,6 +39,24 @@ function gutenberg_register_overlay_block_patterns() {
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
 		)
 	);
+	register_block_pattern(
+		'gutenberg/navigation-overlay-half-height',
+		array(
+			'title'       => __( 'Overlay with transparent background', 'gutenberg' ),
+			'description' => _x( 'A navigation overlay transparent background covering half the screen', 'Block pattern description', 'gutenberg' ),
+			'content'     => '<!-- wp:group {"metadata":{"name":"Navigation Overlay"},"style":{"spacing":{"padding":{"right":"0","left":"0","top":"0","bottom":"0"}},"dimensions":{"minHeight":"100vh"},"color":{"background":"#ffffff61"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group has-background" style="background-color:#ffffff61;min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"full","style":{"color":{"background":"#eeeeeef2"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-background" style="background-color:#eeeeeef2"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"bottom":"4rem"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+<div class="wp-block-group alignwide" style="margin-bottom:4rem"><!-- wp:navigation-overlay-close /--></div>
+<!-- /wp:group -->
+
+<!-- wp:navigation {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"large","layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->',
+			'categories'  => array( 'navigation' ),
+			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+		)
+	);
 }
 
 add_action( 'init', 'gutenberg_register_overlay_block_patterns', 20 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of https://github.com/WordPress/gutenberg/issues/74584

Adds a new overlay pattern so users have more options to choose from when styling their menus

## Why?

Provides users with more overlay layout options beyond the default full-width overlay.

## How?

- Registered new block patterns in `lib/experimental/overlay-patterns.php`

## Testing Instructions

1. Navigate to a Navigation block and create a new overlay template part
2. Verify that the new patterns are available as an option
3. Select the pattern and verify it displays correctly in the editor
4. View the frontend and verify it renders correctly too

These will look different depending on the theme. Let's test them widely, and also use an empty theme as a benchmark for what they would look like when default values for sizing and fonts are not changed.


Design 
<img width="1379" height="763" alt="Screenshot 2026-01-22 at 11 41 43" src="https://github.com/user-attachments/assets/b568c8e4-b5e4-4496-a801-31185058a95b" />
