### PR TITLE
Consolidate navigation submenu and link PHP rendering code

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -85,39 +85,6 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
 }
 
 /**
- * Decodes a url if it's encoded, returning the same url if not.
- *
- * @since 6.2.0
- *
- * @param string $url The url to decode.
- *
- * @return string $url Returns the decoded url.
- */
-function block_core_navigation_link_maybe_urldecode( $url ) {
-	$is_url_encoded = false;
-	$query          = parse_url( $url, PHP_URL_QUERY );
-	$query_params   = wp_parse_args( $query );
-
-	foreach ( $query_params as $query_param ) {
-		$can_query_param_be_encoded = is_string( $query_param ) && ! empty( $query_param );
-		if ( ! $can_query_param_be_encoded ) {
-			continue;
-		}
-		if ( rawurldecode( $query_param ) !== $query_param ) {
-			$is_url_encoded = true;
-			break;
-		}
-	}
-
-	if ( $is_url_encoded ) {
-		return rawurldecode( $url );
-	}
-
-	return $url;
-}
-
-
-/**
  * Renders the `core/navigation-link` block.
  *
  * @since 5.9.0
@@ -169,7 +136,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	// Start appending HTML attributes to anchor tag.
 	if ( isset( $attributes['url'] ) ) {
-		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $attributes['url'] ) ) . '"';
+		$html .= ' href="' . esc_url( block_core_shared_navigation_maybe_urldecode( $attributes['url'] ) ) . '"';
 	}
 
 	if ( $is_active ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -85,54 +85,6 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
 }
 
 /**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @since 5.9.0
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_link_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf(
-			'font-size: %s;',
-			wp_get_typography_font_size_value(
-				array(
-					'size' => $context['style']['typography']['fontSize'],
-				)
-			)
-		);
-	}
-
-	return $font_sizes;
-}
-
-/**
- * Returns the top-level submenu SVG chevron icon.
- *
- * @since 5.9.0
- *
- * @return string
- */
-function block_core_navigation_link_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
-}
-
-/**
  * Decodes a url if it's encoded, returning the same url if not.
  *
  * @since 6.2.0
@@ -189,7 +141,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
+	$font_sizes      = block_core_shared_navigation_build_css_font_sizes( $block->context );
 	$classes         = array_merge(
 		$font_sizes['css_classes']
 	);
@@ -203,15 +155,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
 	$css_classes = trim( implode( ' ', $classes ) );
-	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
-
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			$is_active = true;
-		}
-	}
+	$is_active   = block_core_shared_navigation_determine_active_state( $attributes );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
@@ -271,7 +215,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	if ( isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'] && $has_submenu ) {
 		// The submenu icon can be hidden by a CSS rule on the Navigation Block.
-		$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_link_render_submenu_icon() . '</span>';
+		$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_shared_navigation_render_submenu_icon() . '</span>';
 	}
 
 	if ( $has_submenu ) {

--- a/packages/block-library/src/navigation-link/shared/helpers.php
+++ b/packages/block-library/src/navigation-link/shared/helpers.php
@@ -112,3 +112,35 @@ function block_core_shared_navigation_determine_active_state( $attributes ) {
 
 	return $is_active;
 }
+
+/**
+ * Decodes a url if it's encoded, returning the same url if not.
+ *
+ * @since 7.0.0
+ *
+ * @param string $url The url to decode.
+ *
+ * @return string $url Returns the decoded url.
+ */
+function block_core_shared_navigation_maybe_urldecode( $url ) {
+	$is_url_encoded = false;
+	$query          = parse_url( $url, PHP_URL_QUERY );
+	$query_params   = wp_parse_args( $query );
+
+	foreach ( $query_params as $query_param ) {
+		$can_query_param_be_encoded = is_string( $query_param ) && ! empty( $query_param );
+		if ( ! $can_query_param_be_encoded ) {
+			continue;
+		}
+		if ( rawurldecode( $query_param ) !== $query_param ) {
+			$is_url_encoded = true;
+			break;
+		}
+	}
+
+	if ( $is_url_encoded ) {
+		return rawurldecode( $url );
+	}
+
+	return $url;
+}

--- a/packages/block-library/src/navigation-link/shared/helpers.php
+++ b/packages/block-library/src/navigation-link/shared/helpers.php
@@ -44,3 +44,71 @@ function block_core_shared_navigation_item_should_render( $attributes, $block ) 
 
 	return true;
 }
+
+/**
+ * Builds CSS classes and inline styles for font sizes in navigation items.
+ *
+ * @since 7.0.0
+ *
+ * @param array $context Block context containing fontSize and style settings.
+ * @return array Array containing 'css_classes' and 'inline_styles' keys.
+ */
+function block_core_shared_navigation_build_css_font_sizes( $context ) {
+	$font_sizes = array(
+		'css_classes'   => array(),
+		'inline_styles' => '',
+	);
+
+	$has_named_font_size  = array_key_exists( 'fontSize', $context );
+	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
+
+	if ( $has_named_font_size ) {
+		// Add the font size class.
+		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
+	} elseif ( $has_custom_font_size ) {
+		// Add the custom font size inline style.
+		$font_sizes['inline_styles'] = sprintf(
+			'font-size: %s;',
+			wp_get_typography_font_size_value(
+				array(
+					'size' => $context['style']['typography']['fontSize'],
+				)
+			)
+		);
+	}
+
+	return $font_sizes;
+}
+
+/**
+ * Returns the submenu SVG chevron icon.
+ *
+ * @since 7.0.0
+ *
+ * @return string SVG icon markup.
+ */
+function block_core_shared_navigation_render_submenu_icon() {
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
+}
+
+/**
+ * Determines if a navigation item is active based on current page context.
+ *
+ * @since 7.0.0
+ *
+ * @param array $attributes Block attributes containing 'kind', 'id', and 'url'.
+ * @return bool True if the navigation item is active, false otherwise.
+ */
+function block_core_shared_navigation_determine_active_state( $attributes ) {
+	$kind      = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
+	$is_active = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
+
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
+		if ( $attributes['url'] === $queried_archive_link ) {
+			$is_active = true;
+		}
+	}
+
+	return $is_active;
+}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -107,7 +107,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		// surrounded by spaces.
 		// see: https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements.
 		if ( ! empty( $item_url ) ) {
-			$html .= ' href="' . esc_url( $item_url ) . '"';
+			$html .= ' href="' . esc_url( block_core_shared_navigation_maybe_urldecode( $item_url ) ) . '"';
 		}
 
 		if ( $is_active ) {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -13,54 +13,6 @@ if ( file_exists( __DIR__ . '/../navigation-link/shared/helpers.php' ) ) {
 }
 
 /**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @since 5.9.0
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_submenu_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf(
-			'font-size: %s;',
-			wp_get_typography_font_size_value(
-				array(
-					'size' => $context['style']['typography']['fontSize'],
-				)
-			)
-		);
-	}
-
-	return $font_sizes;
-}
-
-/**
- * Returns the top-level submenu SVG chevron icon.
- *
- * @since 5.9.0
- *
- * @return string
- */
-function block_core_navigation_submenu_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
-}
-
-/**
  * Renders the `core/navigation-submenu` block.
  *
  * @since 5.9.0
@@ -84,7 +36,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
+	$font_sizes      = block_core_shared_navigation_build_css_font_sizes( $block->context );
 	$style_attribute = $font_sizes['inline_styles'];
 
 	// Render inner blocks first to check if any menu items will actually display.
@@ -94,15 +46,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$kind      = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
-
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			$is_active = true;
-		}
-	}
+	$is_active = block_core_shared_navigation_determine_active_state( $attributes );
 
 	$show_submenu_indicators = isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'];
 	$open_on_click           = isset( $block->context['openSubmenusOnClick'] ) && $block->context['openSubmenusOnClick'];
@@ -204,7 +148,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		if ( $show_submenu_indicators && $has_submenu ) {
 			// The submenu icon is rendered in a button here
 			// so that there's a clickable element to open the submenu.
-			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . block_core_navigation_submenu_render_submenu_icon() . '</button>';
+			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . block_core_shared_navigation_render_submenu_icon() . '</button>';
 		}
 	} else {
 		// If menus open on click, we render the parent as a button.
@@ -227,7 +171,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= '</button>';
 
 		if ( $has_submenu ) {
-			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_submenu_render_submenu_icon() . '</span>';
+			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_shared_navigation_render_submenu_icon() . '</span>';
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- In a few words, what is the PR actually doing? -->
Consolidates more code between the navigation link and navigation submenu blocks.

This also adds a call to block_core_shared_navigation_maybe_urldecode in the submenu block, which wasn't there before, to match the navigation link. This means that both blocks now have code to decode URLs, in case URLs are stored in the database in an encoded way.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is a lot of duplicated code between these blocks, which can lead to bugs and maintenance issues. By sharing the code we can ensure that both blocks are working in the same way.

## How?
Add more functions to the shared helpers file.

## Testing Instructions
1. Add a navigation block
2. Add submenus
3. Confirm that the blocks still render in the frontend as exected.

