### PR TITLE
Add Card Component

### DIFF
--- a/packages/ui/src/card/index.ts
+++ b/packages/ui/src/card/index.ts
@@ -1,0 +1,17 @@
+import { Card as CardRoot } from './primitives/card';
+import { CardBody } from './primitives/card-body';
+import { CardHeader } from './primitives/card-header';
+import { CardSummary } from './primitives/card-summary';
+
+/**
+ * A card component with header, body, and footer slots.
+ */
+export const Card = Object.assign( CardRoot, {
+	Header: CardHeader,
+	Body: CardBody,
+	Summary: CardSummary,
+} ) as typeof CardRoot & {
+	Header: typeof CardHeader;
+	Body: typeof CardBody;
+	Summary: typeof CardSummary;
+};

--- a/packages/ui/src/card/primitives/card-body.tsx
+++ b/packages/ui/src/card/primitives/card-body.tsx
@@ -1,0 +1,31 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { CardSectionProps } from '../types';
+import styles from '../style.module.css';
+import resetStyles from '../../utils/css/resets.module.css';
+
+/**
+ * Default render function that renders a div element with the given props.
+ */
+const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
+	<div { ...props } />
+);
+
+export const CardBody = forwardRef< HTMLDivElement, CardSectionProps >(
+	function CardBody( { className, render = DEFAULT_RENDER, ...props }, ref ) {
+		const element = useRender( {
+			render,
+			ref,
+			props: mergeProps< 'div' >( props, {
+				className: clsx(
+					resetStyles[ 'box-sizing' ],
+					styles.body,
+					className
+				),
+			} ),
+		} );
+
+		return element;
+	}
+);

--- a/packages/ui/src/card/primitives/card-header.tsx
+++ b/packages/ui/src/card/primitives/card-header.tsx
@@ -1,0 +1,31 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { CardSectionProps } from '../types';
+import styles from '../style.module.css';
+import resetStyles from '../../utils/css/resets.module.css';
+
+const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
+	<div { ...props } />
+);
+
+export const CardHeader = forwardRef< HTMLDivElement, CardSectionProps >(
+	function CardHeader(
+		{ className, render = DEFAULT_RENDER, ...props },
+		ref
+	) {
+		const element = useRender( {
+			render,
+			ref,
+			props: mergeProps< 'div' >( props, {
+				className: clsx(
+					resetStyles[ 'box-sizing' ],
+					styles.header,
+					className
+				),
+			} ),
+		} );
+
+		return element;
+	}
+);

--- a/packages/ui/src/card/primitives/card-summary.tsx
+++ b/packages/ui/src/card/primitives/card-summary.tsx
@@ -1,0 +1,31 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import styles from '../style.module.css';
+import resetStyles from '../../utils/css/resets.module.css';
+import type { CardSectionProps } from '../types';
+
+const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
+	<div { ...props } />
+);
+
+export const CardSummary = forwardRef< HTMLDivElement, CardSectionProps >(
+	function CardSummary(
+		{ className, render = DEFAULT_RENDER, ...props },
+		ref
+	) {
+		const element = useRender( {
+			render,
+			ref,
+			props: mergeProps< 'div' >( props, {
+				className: clsx(
+					resetStyles[ 'box-sizing' ],
+					styles.summary,
+					className
+				),
+			} ),
+		} );
+
+		return element;
+	}
+);

--- a/packages/ui/src/card/primitives/card.tsx
+++ b/packages/ui/src/card/primitives/card.tsx
@@ -1,0 +1,29 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { CardProps } from '../types';
+import styles from '../style.module.css';
+import resetStyles from '../../utils/css/resets.module.css';
+
+const DEFAULT_RENDER = ( props: React.ComponentPropsWithoutRef< 'div' > ) => (
+	<div { ...props } />
+);
+
+export const Card = forwardRef< HTMLDivElement, CardProps >( function Card(
+	{ className, render = DEFAULT_RENDER, ...props },
+	ref
+) {
+	const element = useRender( {
+		render,
+		ref,
+		props: mergeProps< 'div' >( props, {
+			className: clsx(
+				resetStyles[ 'box-sizing' ],
+				styles.card,
+				className
+			),
+		} ),
+	} );
+
+	return element;
+} );

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
+import { Badge } from '../../badge';
+import { Card } from '../index';
+
+const meta: Meta< typeof Card > = {
+	title: 'Design System/Components/Card',
+	component: Card,
+};
+export default meta;
+
+type Story = StoryObj< typeof Card >;
+
+const placeholderStyles: CSSProperties = {
+	height: '240px',
+	background: 'var(--wpds-color-bg-surface-neutral-weak)',
+	borderRadius: 'var(--wpds-border-radius-surface-md)',
+	display: 'grid',
+	placeItems: 'center',
+	textTransform: 'uppercase',
+	color: 'var(--wpds-color-fg-content-neutral)',
+	fontSize: 'var(--wpds-font-size-xs)',
+	fontWeight: 'var(--wpds-font-weight-medium)',
+	lineHeight: 'var(--wpds-font-line-height-xs)',
+};
+
+export const Default: Story = {
+	render: ( args ) => (
+		<Card { ...args }>
+			<Card.Header>Card title</Card.Header>
+			<Card.Body>
+				<div style={ placeholderStyles }>Content</div>
+			</Card.Body>
+		</Card>
+	),
+};
+
+export const WithSummary: Story = {
+	render: ( args ) => (
+		<Card { ...args }>
+			<Card.Header>
+				<span>Card title</span>
+				<Card.Summary>
+					<Badge intent="low">Summary</Badge>
+				</Card.Summary>
+			</Card.Header>
+			<Card.Body>
+				<div style={ placeholderStyles }>Content</div>
+			</Card.Body>
+		</Card>
+	),
+};

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -1,0 +1,43 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+	.card {
+		--wp-ui-card-gap: calc(var(--wpds-dimension-gap-md) + var(--wpds-dimension-gap-2xs));
+		--wp-ui-card-padding-inline: var(--wpds-dimension-padding-surface-md);
+		--wp-ui-card-padding-block-start:
+			calc(var(--wpds-dimension-padding-surface-sm) +
+			var(--wpds-dimension-gap-2xs));
+		--wp-ui-card-padding-block-end: var(--wpds-dimension-padding-surface-md);
+
+		display: flex;
+		flex-direction: column;
+		gap: var(--wp-ui-card-gap);
+		padding-block-start: var(--wp-ui-card-padding-block-start);
+		padding-block-end: var(--wp-ui-card-padding-block-end);
+		padding-inline: var(--wp-ui-card-padding-inline);
+		border:
+			var(--wpds-border-width-surface-xs) solid
+			var(--wpds-color-stroke-surface-neutral-weak);
+		border-radius: var(--wpds-border-radius-surface-lg);
+		background-color: var(--wpds-color-bg-surface-neutral-strong);
+	}
+
+	.header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--wpds-dimension-gap-xs);
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-lg);
+		font-weight: var(--wpds-font-weight-medium);
+		line-height: var(--wpds-font-line-height-sm);
+		color: var(--wpds-color-fg-content-neutral);
+	}
+
+	.summary {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--wpds-dimension-gap-xs);
+	}
+}

--- a/packages/ui/src/card/test/card.test.tsx
+++ b/packages/ui/src/card/test/card.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '../index';
+
+describe( 'Card', () => {
+	it( 'renders a div by default', () => {
+		render( <Card>Content</Card> );
+
+		expect( screen.getByText( 'Content' ).tagName ).toBe( 'DIV' );
+	} );
+
+	it( 'forwards ref', () => {
+		const ref = createRef< HTMLDivElement >();
+
+		render( <Card ref={ ref }>Content</Card> );
+
+		expect( ref.current ).toBeInstanceOf( HTMLDivElement );
+	} );
+
+	it( 'merges custom className with built-in classes', () => {
+		const customClass = 'my-card';
+		render( <Card className={ customClass }>Content</Card> );
+
+		expect( screen.getByText( 'Content' ) ).toHaveClass( customClass );
+	} );
+
+	it( 'renders header and body sections', () => {
+		render(
+			<Card>
+				<Card.Header>Card title</Card.Header>
+				<Card.Body>Card content</Card.Body>
+			</Card>
+		);
+
+		expect( screen.getByText( 'Card title' ).tagName ).toBe( 'DIV' );
+		expect( screen.getByText( 'Card content' ).tagName ).toBe( 'DIV' );
+	} );
+} );

--- a/packages/ui/src/card/types.ts
+++ b/packages/ui/src/card/types.ts
@@ -1,0 +1,15 @@
+import type { ComponentProps } from '../utils/types';
+
+export interface CardProps extends ComponentProps< 'div' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: React.ReactNode;
+}
+
+export interface CardSectionProps extends ComponentProps< 'div' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: React.ReactNode;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './badge';
 export * from './box';
 export * from './button';
+export * from './card';
 export * from './form/primitives';
 export * from './icon';
 export * from './stack';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Mockup


<img width="1444" height="976" alt="image" src="https://github.com/user-attachments/assets/44a55573-59bc-4e49-a6fd-edf7a51b55ab" />


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Introduce a new `Card` component in `@wordpress/ui`, including header/body primitives, styles, Storybook stories, tests, and public export.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We're building a new set of UI primitives, see https://github.com/WordPress/gutenberg/issues/71196


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add `Card`, `Card.Header`, and `Card.Body` primitives using `@base-ui/react` render/merge patterns.
- Define component styling in `style.module.css`.
- Add Storybook examples and basic unit tests.
- Export the new component from `packages/ui/src/index.ts`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Run `npm run storybook` (or the project’s Storybook command).
2. Open “Design System/Components/Card”.
3. Verify the default and with summary stories render as expected.

## Screenshots or screencast <!-- if applicable -->

<img width="1514" height="422" alt="image" src="https://github.com/user-attachments/assets/d8331077-4c4d-44b9-b77a-1e25288dc464" />
