### PR TITLE
[Experimental] Notes: Support partial text selection notes

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -48,6 +48,34 @@ function gutenberg_register_block_comment_metadata() {
 			},
 		)
 	);
+	register_meta(
+		'comment',
+		'_wp_note_selection',
+		array(
+			'type'          => 'object',
+			'description'   => __( 'Note text selection', 'gutenberg' ),
+			'single'        => true,
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'attributeKey' => array(
+							'type' => 'string',
+						),
+						'start'        => array(
+							'type' => 'integer',
+						),
+						'end'          => array(
+							'type' => 'integer',
+						),
+					),
+				),
+			),
+			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				return current_user_can( 'edit_comment', $object_id );
+			},
+		)
+	);
 }
 add_action( 'init', 'gutenberg_register_block_comment_metadata' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59611,6 +59611,7 @@
 			"dependencies": {
 				"@floating-ui/react-dom": "2.0.8",
 				"@wordpress/a11y": "file:../a11y",
+				"@wordpress/annotations": "file:../annotations",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -62,6 +62,7 @@
 	"dependencies": {
 		"@floating-ui/react-dom": "2.0.8",
 		"@wordpress/a11y": "file:../a11y",
+		"@wordpress/annotations": "file:../annotations",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -41,7 +41,7 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { focusCommentThread, getCommentExcerpt } from './utils';
-import { useFloatingThread } from './hooks';
+import { useFloatingThread, useAnnotateThreadSelections } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
 
@@ -472,6 +472,7 @@ function Thread( {
 		commentLastUpdated,
 	} );
 	const isKeyboardTabbingRef = useRef( false );
+	useAnnotateThreadSelections( thread );
 
 	const onMouseEnter = () => {
 		debouncedToggleBlockHighlight( thread.blockClientId, true );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -41,7 +41,7 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { focusCommentThread, getCommentExcerpt } from './utils';
-import { useFloatingThread, useAnnotateThreadSelections } from './hooks';
+import { useFloatingThread } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
 
@@ -472,7 +472,6 @@ function Thread( {
 		commentLastUpdated,
 	} );
 	const isKeyboardTabbingRef = useRef( false );
-	useAnnotateThreadSelections( thread );
 
 	const onMouseEnter = () => {
 		debouncedToggleBlockHighlight( thread.blockClientId, true );

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -451,31 +451,55 @@ export function useFloatingThread( {
 	};
 }
 
-export function useAnnotateThreadSelections( thread ) {
+export function useAnnotateBlocks( threads ) {
 	const {
 		__experimentalAddAnnotation,
 		__experimentalRemoveAnnotationsBySource,
 	} = useDispatch( annotationsStore );
 	const selections = useMemo( () => {
-		const meta = [];
+		const values = [];
 
-		if ( ! thread?.meta ) {
-			return meta;
+		if ( ! threads?.length ) {
+			return values;
 		}
 
-		// Empty object meta data is returned as array.
-		if ( ! Array.isArray( thread.meta._wp_note_selection ) ) {
-			meta.push( { id: thread.id, ...thread.meta._wp_note_selection } );
+		function getSelectionMeta( thread ) {
+			// Empty object meta data is returned as array.
+			if (
+				! thread?.meta?._wp_note_selection ||
+				Array.isArray( thread.meta._wp_note_selection )
+			) {
+				return null;
+			}
+
+			return {
+				id: thread.id,
+				...thread.meta._wp_note_selection,
+			};
 		}
 
-		for ( const reply of thread.reply ) {
-			if ( ! Array.isArray( reply.meta._wp_note_selection ) ) {
-				meta.push( { id: reply.id, ...reply.meta._wp_note_selection } );
+		for ( const thread of threads ) {
+			const threadSelection = getSelectionMeta( thread );
+			if ( threadSelection ) {
+				values.push( {
+					clientId: thread.blockClientId,
+					...threadSelection,
+				} );
+			}
+
+			for ( const reply of thread.reply ) {
+				const replySelection = getSelectionMeta( reply );
+				if ( replySelection ) {
+					values.push( {
+						clientId: thread.blockClientId,
+						...replySelection,
+					} );
+				}
 			}
 		}
 
-		return meta;
-	}, [ thread ] );
+		return values;
+	}, [ threads ] );
 
 	useEffect( () => {
 		if ( ! selections.length ) {
@@ -486,7 +510,7 @@ export function useAnnotateThreadSelections( thread ) {
 			__experimentalAddAnnotation( {
 				id: selection.id,
 				source: 'core-note',
-				blockClientId: thread.blockClientId,
+				blockClientId: selection.clientId,
 				richTextIdentifier: selection.attributeKey,
 				range: {
 					start: selection.start,
@@ -500,7 +524,6 @@ export function useAnnotateThreadSelections( thread ) {
 		};
 	}, [
 		selections,
-		thread.blockClientId,
 		__experimentalAddAnnotation,
 		__experimentalRemoveAnnotationsBySource,
 	] );

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -26,6 +26,7 @@ import {
 import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as annotationsStore } from '@wordpress/annotations';
 
 /**
  * Internal dependencies
@@ -174,8 +175,12 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getCurrentPostId } = useSelect( editorStore );
-	const { getBlockAttributes, getSelectedBlockClientId } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockAttributes,
+		getSelectedBlockClientId,
+		getSelectionStart,
+		getSelectionEnd,
+	} = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const onError = ( error ) => {
@@ -191,6 +196,21 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 
 	const onCreate = async ( { content, parent } ) => {
 		try {
+			const selectionStart = getSelectionStart();
+			const selectionEnd = getSelectionEnd();
+			const hasValidSelection =
+				selectionStart.clientId === selectionEnd.clientId &&
+				selectionStart.offset !== selectionEnd.offset;
+			const textSelection = hasValidSelection
+				? {
+						_wp_note_selection: {
+							attributeKey: selectionStart.attributeKey,
+							start: selectionStart.offset,
+							end: selectionEnd.offset,
+						},
+				  }
+				: undefined;
+
 			const savedRecord = await saveEntityRecord(
 				'root',
 				'comment',
@@ -200,6 +220,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 					status: 'hold',
 					type: 'note',
 					parent: parent || 0,
+					meta: textSelection,
 				},
 				{ throwOnError: true }
 			);
@@ -428,4 +449,59 @@ export function useFloatingThread( {
 		y,
 		refs,
 	};
+}
+
+export function useAnnotateThreadSelections( thread ) {
+	const {
+		__experimentalAddAnnotation,
+		__experimentalRemoveAnnotationsBySource,
+	} = useDispatch( annotationsStore );
+	const selections = useMemo( () => {
+		const meta = [];
+
+		if ( ! thread?.meta ) {
+			return meta;
+		}
+
+		// Empty object meta data is returned as array.
+		if ( ! Array.isArray( thread.meta._wp_note_selection ) ) {
+			meta.push( { id: thread.id, ...thread.meta._wp_note_selection } );
+		}
+
+		for ( const reply of thread.reply ) {
+			if ( ! Array.isArray( reply.meta._wp_note_selection ) ) {
+				meta.push( { id: reply.id, ...reply.meta._wp_note_selection } );
+			}
+		}
+
+		return meta;
+	}, [ thread ] );
+
+	useEffect( () => {
+		if ( ! selections.length ) {
+			return;
+		}
+
+		selections.forEach( ( selection ) => {
+			__experimentalAddAnnotation( {
+				id: selection.id,
+				source: 'core-note',
+				blockClientId: thread.blockClientId,
+				richTextIdentifier: selection.attributeKey,
+				range: {
+					start: selection.start,
+					end: selection.end,
+				},
+			} );
+		} );
+
+		return () => {
+			__experimentalRemoveAnnotationsBySource( 'core-note' );
+		};
+	}, [
+		selections,
+		thread.blockClientId,
+		__experimentalAddAnnotation,
+		__experimentalRemoveAnnotationsBySource,
+	] );
 }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -29,6 +29,7 @@ import {
 	useBlockComments,
 	useBlockCommentsActions,
 	useEnableFloatingSidebar,
+	useAnnotateBlocks,
 } from './hooks';
 import { focusCommentThread } from './utils';
 import PostTypeSupportCheck from '../post-type-support-check';
@@ -121,6 +122,7 @@ function NotesSidebar( { postId } ) {
 			( unresolvedSortedThreads.length > 0 ||
 				newNoteFormState !== 'closed' )
 	);
+	useAnnotateBlocks( unresolvedSortedThreads );
 
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();


### PR DESCRIPTION
## What?
Related #59445.

> [!IMPORTANT]
This is an exploration PR for the technical side of this feature and doesn't include anything from design specs.

PR tests the ability to add notes for partial selections within a block's rich text fields. This works without adding content markers to the DB (see annotations package).

## How?
* Selection data is stored as note meta.
* The first note created for a block is the parent, regardless of type (inline, block-level); all follow-up notes will be its children. This way, WP maintains a relationship for us.
* Highlighting is handled by `@wordpress/annotations` package.

## Challenges

* Without permanent content markers, it's hard to keep selection in sync. If you change the text, the editor will still try to annotate content via start/end offsets, which won't match the original.

## Testing Instructions
1. Open a post or page.
2. Add text block and test.
3. Select part of the text.
4. Open the options dropdown while text is selected and add a note.
5. The selected test should be highlighted after the note is created.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1058b66d-6a62-4fda-9037-7319903892db