### PR TITLE
fix: Allow navigation child blocks in contentOnly mode

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -4,6 +4,7 @@
 import { createSelector, createRegistrySelector } from '@wordpress/data';
 import {
 	hasBlockSupport,
+	getBlockType,
 	privateApis as blocksPrivateApis,
 } from '@wordpress/blocks';
 
@@ -23,6 +24,7 @@ import {
 	getBlockAttributes,
 } from './selectors';
 import {
+	checkAllowList,
 	checkAllowListRecursive,
 	getAllPatternsDependants,
 	getInsertBlockTypeDependants,
@@ -102,14 +104,37 @@ export function isContainerInsertableToInContentOnlyMode(
 	blockName,
 	rootClientId
 ) {
-	const isBlockContentBlock = isContentBlock( blockName );
 	const rootBlockName = getBlockName( state, rootClientId );
-	const isContainerContentBlock = isContentBlock( rootBlockName );
 	const isRootBlockMain = getSectionRootClientId( state ) === rootClientId;
+
+	// Special case: Allow all navigation child blocks in contentOnly mode
+	if ( rootBlockName === 'core/navigation' ) {
+		const blockType = getBlockType( blockName );
+		const parentBlockType = getBlockType( rootBlockName );
+
+		// Check if block has core/navigation as parent
+		const hasNavigationParent = checkAllowList(
+			blockType?.parent,
+			'core/navigation'
+		);
+
+		// Check if block is in navigation's allowedBlocks
+		const isInNavigationAllowedBlocks = checkAllowList(
+			parentBlockType?.allowedBlocks,
+			blockName
+		);
+
+		// If it's a valid navigation child, allow insertion
+		if ( hasNavigationParent || isInNavigationAllowedBlocks ) {
+			return true;
+		}
+	}
 
 	// In contentOnly mode, containers shouldn't be inserted into unless:
 	// 1. they are a section root;
 	// 2. they are a content block and the block to be inserted is also content.
+	const isBlockContentBlock = isContentBlock( blockName );
+	const isContainerContentBlock = isContentBlock( rootBlockName );
 	return (
 		isRootBlockMain || ( isContainerContentBlock && isBlockContentBlock )
 	);


### PR DESCRIPTION
## What?

Fixes #73826

Allows all navigation child blocks to be inserted in the isolated navigation editor, even when the navigation block is in `contentOnly` mode. This fixes a regression introduced in PR #72043 where custom blocks with `parent: ["core/navigation"]` and blocks in navigation's `allowedBlocks` array were incorrectly filtered out.

## Why?

When editing a navigation block in isolation (from Appearance > Editor > Navigation), the navigation block is set to `contentOnly` mode to hide non-content controls. PR #72043 introduced `contentRole` support, allowing blocks to mark themselves with `supports: { contentRole: true }` to be insertable in `contentOnly` mode. However, this approach didn't consider existing third-party blocks that were already valid navigation children but would need to be updated to add `contentRole` support.

This is a regression that broke functionality that worked in WordPress 6.8, affecting custom blocks like Polylang's navigation language switcher and core blocks like Spacer and Login/out. Requiring third-party blocks to add `contentRole` support would break backward compatibility and require plugin authors to update their blocks.

## How?

Modified `isContainerInsertableToInContentOnlyMode` in `packages/block-editor/src/store/private-selectors.js` to add a special case for navigation blocks. When inserting into a `core/navigation` block, the function now checks if the block being inserted is a valid navigation child by:

1. Checking if the block has `parent: ["core/navigation"]` in its block.json
2. Checking if the block is listed in navigation's `allowedBlocks` array

If the block is a valid navigation child, it bypasses the `contentOnly` restrictions and allows insertion. This preserves existing `contentOnly` behavior for other contexts while specifically addressing the navigation block case.

**Scope**: This change is isolated to the navigation block insertion logic and doesn't affect other `contentOnly` mode behavior, making it a safe and targeted fix that's easier to consider for merge.

## Testing Instructions

1. Create a custom block with `parent: ["core/navigation"]` in its block.json
2. Activate a block theme (e.g., TwentyTwentyFive)
3. Visit Appearance > Editor > Navigation
4. Edit the Navigation block
5. Open the inserter and verify the custom block can be inserted
6. Verify core blocks in navigation's `allowedBlocks` (like Spacer, Login/out) can also be inserted
7. Verify non-navigation-child blocks are still properly filtered in contentOnly mode
8. Test in regular template editor to ensure no regressions
