### PR TITLE
Navigation: Add a shared helper for font sizes in Navigation Link and Navigation Submenu blocks

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -70,16 +70,17 @@ function block_core_home_link_build_css_colors( $context ) {
  * @return string The li wrapper attributes.
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
-	$colors          = block_core_home_link_build_css_colors( $context );
+	$colors = block_core_home_link_build_css_colors( $context );
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $context );
 	} else {
 		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $context );
 	}
-	$classes         = array_merge(
+	$classes = array_merge(
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
+
 	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
 	$classes[]       = 'wp-block-navigation-item';
 

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -71,10 +71,9 @@ function block_core_home_link_build_css_colors( $context ) {
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
 	$colors = block_core_home_link_build_css_colors( $context );
-	// The gutenberg_ prefix is needed because Core already defines its own
-	// block_core_home_link_build_css_font_sizes, and redeclaring it would
-	// cause a fatal error. Once the shared helper is backported to Core,
-	// the else branch will call it directly.
+	// The gutenberg_ prefix is needed because Gutenberg automatically
+	// prefixes function definitions. Once the shared helper is backported to
+	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $context );
 	} else {

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -71,9 +71,10 @@ function block_core_home_link_build_css_colors( $context ) {
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
 	$colors = block_core_home_link_build_css_colors( $context );
-	// The gutenberg_ prefix is needed because Gutenberg automatically
-	// prefixes function definitions. Once the shared helper is backported to
-	// Core, the else branch will call it directly.
+	//  The build system prefixes this function with "gutenberg_" to avoid
+	// collisions with the core version. Until this function is backported to
+	// core, we need to guard it's use and only call the prefixed name in
+	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $context );
 	} else {

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -5,6 +5,8 @@
  * @package WordPress
  */
 
+require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
+
 /**
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the home link markup in the front-end.
@@ -60,36 +62,6 @@ function block_core_home_link_build_css_colors( $context ) {
 }
 
 /**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the home link markup in the front-end.
- *
- * @since 6.0.0
- *
- * @param  array $context Home link block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_home_link_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %s;', $context['style']['typography']['fontSize'] );
-	}
-
-	return $font_sizes;
-}
-
-/**
  * Builds an array with classes and style for the li wrapper
  *
  * @since 6.0.0
@@ -99,7 +71,11 @@ function block_core_home_link_build_css_font_sizes( $context ) {
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
 	$colors          = block_core_home_link_build_css_colors( $context );
-	$font_sizes      = block_core_home_link_build_css_font_sizes( $context );
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $context );
+	} else {
+		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $context );
+	}
 	$classes         = array_merge(
 		$colors['css_classes'],
 		$font_sizes['css_classes']

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -71,6 +71,10 @@ function block_core_home_link_build_css_colors( $context ) {
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
 	$colors = block_core_home_link_build_css_colors( $context );
+	// The gutenberg_ prefix is needed because Core already defines its own
+	// block_core_home_link_build_css_font_sizes, and redeclaring it would
+	// cause a fatal error. Once the shared helper is backported to Core,
+	// the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $context );
 	} else {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -138,7 +138,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	//  The build system prefixes this function with "gutenberg_" to avoid
+	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
 	// core, we need to guard it's use and only call the prefixed name in
 	//  the plugin.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -140,7 +140,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
-	// core, we need to guard it's use and only call the prefixed name in
+	// core, we need to guard its use and only call the prefixed name in
 	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -138,9 +138,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// The gutenberg_ prefix is needed because Core already defines its own
-	// block_core_navigation_link_build_css_font_sizes, and redeclaring it
-	// would cause a fatal error. Once the shared helper is backported to
+	// The gutenberg_ prefix is needed because Gutenberg automatically
+	// prefixes function definitions. Once the shared helper is backported to
 	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -138,6 +138,10 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// The gutenberg_ prefix is needed because Core already defines its own
+	// block_core_navigation_link_build_css_font_sizes, and redeclaring it
+	// would cause a fatal error. Once the shared helper is backported to
+	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -138,9 +138,10 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// The gutenberg_ prefix is needed because Gutenberg automatically
-	// prefixes function definitions. Once the shared helper is backported to
-	// Core, the else branch will call it directly.
+	//  The build system prefixes this function with "gutenberg_" to avoid
+	// collisions with the core version. Until this function is backported to
+	// core, we need to guard it's use and only call the prefixed name in
+	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -7,6 +7,7 @@
 
 require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
+require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
 
 /**
  * Build an array with CSS classes and inline styles defining the colors
@@ -81,43 +82,6 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
 }
 
 /**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @since 5.9.0
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_link_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf(
-			'font-size: %s;',
-			wp_get_typography_font_size_value(
-				array(
-					'size' => $context['style']['typography']['fontSize'],
-				)
-			)
-		);
-	}
-
-	return $font_sizes;
-}
-
-/**
  * Decodes a url if it's encoded, returning the same url if not.
  *
  * @since 6.2.0
@@ -174,7 +138,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
+	} else {
+		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $block->context );
+	}
 	$classes         = array_merge(
 		$font_sizes['css_classes']
 	);

--- a/packages/block-library/src/navigation-link/shared/build-css-font-sizes.php
+++ b/packages/block-library/src/navigation-link/shared/build-css-font-sizes.php
@@ -9,7 +9,7 @@
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
- * @since 5.9.0
+ * @since 7.1.0
  *
  * @param  array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.

--- a/packages/block-library/src/navigation-link/shared/build-css-font-sizes.php
+++ b/packages/block-library/src/navigation-link/shared/build-css-font-sizes.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Shared helper function for building CSS font sizes in navigation blocks.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Build an array with CSS classes and inline styles defining the font sizes
+ * which will be applied to the navigation markup in the front-end.
+ *
+ * @since 5.9.0
+ *
+ * @param  array $context Navigation block context.
+ * @return array Font size CSS classes and inline styles.
+ */
+function block_core_shared_navigation_build_css_font_sizes( $context ) {
+	// CSS classes.
+	$font_sizes = array(
+		'css_classes'   => array(),
+		'inline_styles' => '',
+	);
+
+	$has_named_font_size  = array_key_exists( 'fontSize', $context );
+	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
+
+	if ( $has_named_font_size ) {
+		// Add the font size class.
+		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
+	} elseif ( $has_custom_font_size ) {
+		// Add the custom font size inline style.
+		$font_sizes['inline_styles'] = sprintf(
+			'font-size: %s;',
+			wp_get_typography_font_size_value(
+				array(
+					'size' => $context['style']['typography']['fontSize'],
+				)
+			)
+		);
+	}
+
+	return $font_sizes;
+}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -76,7 +76,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
-	// core, we need to guard it's use and only call the prefixed name in
+	// core, we need to guard its use and only call the prefixed name in
 	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -74,6 +74,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// The gutenberg_ prefix is needed because Core already defines its own
+	// block_core_navigation_submenu_build_css_font_sizes, and redeclaring it
+	// would cause a fatal error. Once the shared helper is backported to
+	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -74,7 +74,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	//  The build system prefixes this function with "gutenberg_" to avoid
+	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
 	// core, we need to guard it's use and only call the prefixed name in
 	//  the plugin.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -74,9 +74,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// The gutenberg_ prefix is needed because Core already defines its own
-	// block_core_navigation_submenu_build_css_font_sizes, and redeclaring it
-	// would cause a fatal error. Once the shared helper is backported to
+	// The gutenberg_ prefix is needed because Gutenberg automatically
+	// prefixes function definitions. Once the shared helper is backported to
 	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -74,9 +74,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// The gutenberg_ prefix is needed because Gutenberg automatically
-	// prefixes function definitions. Once the shared helper is backported to
-	// Core, the else branch will call it directly.
+	//  The build system prefixes this function with "gutenberg_" to avoid
+	// collisions with the core version. Until this function is backported to
+	// core, we need to guard it's use and only call the prefixed name in
+	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -7,6 +7,7 @@
 
 require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
+require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
 
 /**
  * Returns the submenu visibility value with backward compatibility
@@ -50,43 +51,6 @@ function block_core_navigation_submenu_get_submenu_visibility( $context ) {
 }
 
 /**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @since 5.9.0
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_submenu_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf(
-			'font-size: %s;',
-			wp_get_typography_font_size_value(
-				array(
-					'size' => $context['style']['typography']['fontSize'],
-				)
-			)
-		);
-	}
-
-	return $font_sizes;
-}
-
-/**
  * Renders the `core/navigation-submenu` block.
  *
  * @since 5.9.0
@@ -110,7 +74,11 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
+	} else {
+		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $block->context );
+	}
 	$style_attribute = $font_sizes['inline_styles'];
 
 	// Render inner blocks first to check if any menu items will actually display.

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -309,7 +309,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
 	//  The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
-	// core, we need to guard it's use and only call the prefixed name in
+	// core, we need to guard its use and only call the prefixed name in
 	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -306,16 +306,17 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		}
 	}
 
-	$colors          = block_core_page_list_build_css_colors( $attributes, $block->context );
+	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {
 		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $block->context );
 	}
-	$classes         = array_merge(
+	$classes = array_merge(
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
+
 	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
 	$css_classes     = trim( implode( ' ', $classes ) );
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,7 +307,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	}
 
 	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
-	//  The build system prefixes this function with "gutenberg_" to avoid
+	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
 	// core, we need to guard its use and only call the prefixed name in
 	// the plugin.

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,9 +307,10 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	}
 
 	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
-	// The gutenberg_ prefix is needed because Gutenberg automatically
-	// prefixes function definitions. Once the shared helper is backported to
-	// Core, the else branch will call it directly.
+	//  The build system prefixes this function with "gutenberg_" to avoid
+	// collisions with the core version. Until this function is backported to
+	// core, we need to guard it's use and only call the prefixed name in
+	//  the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,6 +307,10 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	}
 
 	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
+	// The gutenberg_ prefix is needed because Core already defines its own
+	// block_core_page_list_build_css_font_sizes, and redeclaring it would
+	// cause a fatal error. Once the shared helper is backported to Core,
+	// the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -307,10 +307,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	}
 
 	$colors = block_core_page_list_build_css_colors( $attributes, $block->context );
-	// The gutenberg_ prefix is needed because Core already defines its own
-	// block_core_page_list_build_css_font_sizes, and redeclaring it would
-	// cause a fatal error. Once the shared helper is backported to Core,
-	// the else branch will call it directly.
+	// The gutenberg_ prefix is needed because Gutenberg automatically
+	// prefixes function definitions. Once the shared helper is backported to
+	// Core, the else branch will call it directly.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -5,6 +5,8 @@
  * @package WordPress
  */
 
+require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
+
 /**
  * Returns the submenu visibility value with backward compatibility
  * for the deprecated openSubmenusOnClick attribute.
@@ -123,44 +125,6 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 
 	return $colors;
 }
-
-/**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the pages markup in the front-end when it is a descendant of navigation.
- *
- * @since 5.8.0
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_page_list_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = isset( $context['style']['typography']['fontSize'] );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf(
-			'font-size: %s;',
-			wp_get_typography_font_size_value(
-				array(
-					'size' => $context['style']['typography']['fontSize'],
-				)
-			)
-		);
-	}
-
-	return $font_sizes;
-}
-
 /**
  * Outputs Page list markup from an array of pages with nested children.
  *
@@ -343,7 +307,11 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	}
 
 	$colors          = block_core_page_list_build_css_colors( $attributes, $block->context );
-	$font_sizes      = block_core_page_list_build_css_font_sizes( $block->context );
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
+	} else {
+		$font_sizes = block_core_shared_navigation_build_css_font_sizes( $block->context );
+	}
 	$classes         = array_merge(
 		$colors['css_classes'],
 		$font_sizes['css_classes']

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -310,7 +310,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	//  The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
 	// core, we need to guard its use and only call the prefixed name in
-	//  the plugin.
+	// the plugin.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$font_sizes = gutenberg_block_core_shared_navigation_build_css_font_sizes( $block->context );
 	} else {

--- a/phpunit/blocks/block-core-shared-navigation-build-css-font-sizes-test.php
+++ b/phpunit/blocks/block-core-shared-navigation-build-css-font-sizes-test.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for block_core_shared_navigation_build_css_font_sizes() function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the shared navigation font sizes helper function.
+ *
+ * @group blocks
+ */
+class Block_Core_Shared_Navigation_Build_Css_Font_Sizes_Test extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Load the shared navigation font sizes helper file.
+		require_once dirname( __DIR__, 2 ) . '/packages/block-library/src/navigation-link/shared/build-css-font-sizes.php';
+	}
+
+	/**
+	 * Test that the function exists.
+	 */
+	public function test_function_exists() {
+		$this->assertTrue(
+			function_exists( 'block_core_shared_navigation_build_css_font_sizes' ),
+			'Function block_core_shared_navigation_build_css_font_sizes should exist'
+		);
+	}
+
+	/**
+	 * Test that the function returns expected array structure.
+	 */
+	public function test_returns_array_structure() {
+		$context = array();
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertIsArray( $result, 'Function should return an array' );
+		$this->assertArrayHasKey( 'css_classes', $result, 'Result should have css_classes key' );
+		$this->assertArrayHasKey( 'inline_styles', $result, 'Result should have inline_styles key' );
+		$this->assertIsArray( $result['css_classes'], 'css_classes should be an array' );
+		$this->assertIsString( $result['inline_styles'], 'inline_styles should be a string' );
+	}
+
+	/**
+	 * Test with empty context.
+	 */
+	public function test_with_empty_context() {
+		$context = array();
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertEmpty( $result['css_classes'], 'css_classes should be empty with no font size' );
+		$this->assertSame( '', $result['inline_styles'], 'inline_styles should be empty string with no font size' );
+	}
+
+	/**
+	 * Test with named font size.
+	 */
+	public function test_with_named_font_size() {
+		$context = array(
+			'fontSize' => 'large',
+		);
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertCount( 1, $result['css_classes'], 'Should have one CSS class for named font size' );
+		$this->assertSame( 'has-large-font-size', $result['css_classes'][0], 'Should have correct font size class' );
+		$this->assertSame( '', $result['inline_styles'], 'inline_styles should be empty with named font size' );
+	}
+
+	/**
+	 * Test with custom font size.
+	 */
+	public function test_with_custom_font_size() {
+		$context = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize' => '20px',
+				),
+			),
+		);
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertEmpty( $result['css_classes'], 'css_classes should be empty with only custom font size' );
+		$this->assertStringContainsString( 'font-size:', $result['inline_styles'], 'inline_styles should contain font-size property' );
+		$this->assertStringContainsString( '20px', $result['inline_styles'], 'inline_styles should contain the custom font size value' );
+	}
+
+	/**
+	 * Test that named font size takes precedence over custom font size.
+	 */
+	public function test_named_takes_precedence() {
+		$context = array(
+			'fontSize' => 'medium',
+			'style'    => array(
+				'typography' => array(
+					'fontSize' => '18px',
+				),
+			),
+		);
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertCount( 1, $result['css_classes'], 'Should have CSS class for named font size' );
+		$this->assertSame( 'has-medium-font-size', $result['css_classes'][0], 'Should use named font size class' );
+		$this->assertSame( '', $result['inline_styles'], 'inline_styles should be empty when named font size is present' );
+	}
+
+	/**
+	 * Test with various named font size values.
+	 *
+	 * @dataProvider data_named_font_sizes
+	 */
+	public function test_with_various_named_sizes( $font_size_name ) {
+		$context = array(
+			'fontSize' => $font_size_name,
+		);
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$expected_class = sprintf( 'has-%s-font-size', $font_size_name );
+		$this->assertContains( $expected_class, $result['css_classes'], "Should have class for {$font_size_name} font size" );
+	}
+
+	/**
+	 * Data provider for named font sizes.
+	 */
+	public function data_named_font_sizes() {
+		return array(
+			'small'      => array( 'small' ),
+			'medium'     => array( 'medium' ),
+			'large'      => array( 'large' ),
+			'x-large'    => array( 'x-large' ),
+			'custom-big' => array( 'custom-big' ),
+		);
+	}
+
+	/**
+	 * Test with custom font size using different units.
+	 *
+	 * @dataProvider data_custom_font_sizes
+	 */
+	public function test_with_various_custom_sizes( $custom_size ) {
+		$context = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize' => $custom_size,
+				),
+			),
+		);
+		$result  = block_core_shared_navigation_build_css_font_sizes( $context );
+
+		$this->assertStringContainsString( 'font-size:', $result['inline_styles'], 'inline_styles should contain font-size property' );
+		$this->assertNotEmpty( $result['inline_styles'], 'inline_styles should not be empty with custom font size' );
+	}
+
+	/**
+	 * Data provider for custom font sizes.
+	 */
+	public function data_custom_font_sizes() {
+		return array(
+			'pixels'     => array( '16px' ),
+			'ems'        => array( '1.5em' ),
+			'rems'       => array( '2rem' ),
+			'percentage' => array( '120%' ),
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Consolidate the font size calculation function for navigation link and navigation submenu blocks to a shared helper.

## Why?
Reducing duplicate code avoids bugs and makes maintenance easier.

## How?
Moved the duplicate `build_css_font_sizes` functions from navigation-link and navigation-submenu to a new shared file: `packages/block-library/src/navigation-link/shared/build-css-font-sizes.php`

  ## Testing Instructions
  1. Add a Navigation block to a post/page
  2. Add some Navigation Link and Navigation Submenu blocks within it
  3. In the block settings sidebar, set a custom font size for the navigation block
     (this applies via context to child blocks)
  4. Save and view on the frontend
  5. Verify that both navigation links and submenus display with the correct font size
  6. Test with both named font sizes (e.g., "Medium") and custom pixel values
