### PR TITLE
iAPI Router: Fix initial router regions with `attachTo` being duplicated after `navigate()`

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Prevent router regions with data-wp-key from being recreated on navigation. ([#74750](https://github.com/WordPress/gutenberg/pull/74750))
+-   Fix initial router regions with `attachTo` being duplicated after `navigate()`. ([#74857](https://github.com/WordPress/gutenberg/pull/74857))
 
 ## 2.38.0 (2026-01-16)
 

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -138,6 +138,15 @@ const regionsToAttachByParent = new WeakMap< Element, string[] >();
 const rootFragmentsByParent = new WeakMap< Element, any >();
 
 /**
+ * Set of router regions using the `attachTo` property that are present in the
+ * initial page.
+ *
+ * These regions should be treated as regular regions without the `attachTo`
+ * attribute as they don't need to be appended; they are already in the HTML.
+ */
+const initialRegionsToAttach = new Set< string >();
+
+/**
  * Fetches and prepares a page from a given URL.
  *
  * @param url          The URL of the page to fetch.
@@ -201,7 +210,7 @@ const preparePage: PreparePage = async ( url, dom, { vdom } = {} ) => {
 				: toVdom( region );
 		}
 
-		if ( attachTo ) {
+		if ( attachTo && ! initialRegionsToAttach.has( id ) ) {
 			regionsToAttach[ id ] = attachTo;
 		}
 	} );
@@ -333,6 +342,16 @@ window.addEventListener( 'popstate', async () => {
 		} );
 	} else {
 		window.location.reload();
+	}
+} );
+
+// Detect router regions with `attachTo` in the initial page. This step should
+// be done before the initial page is processed with `preparePage()` so this
+// function treats them as regular router regions.
+document.querySelectorAll( regionsSelector ).forEach( ( region ) => {
+	const { id, attachTo } = parseRegionAttribute( region );
+	if ( attachTo ) {
+		initialRegionsToAttach.add( id );
 	}
 } );
 

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -41,12 +41,10 @@ export default class InteractivityUtils {
 		this.requestUtils = requestUtils;
 	}
 
-	getLink( blockName: string ) {
-		const link = this.links.get( blockName );
+	getLink( alias: string ) {
+		const link = this.links.get( alias );
 		if ( ! link ) {
-			throw new Error(
-				`No link found for post with block '${ blockName }'`
-			);
+			throw new Error( `No link found for post with alias '${ alias }'` );
 		}
 
 		/*

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -566,7 +566,7 @@ test.describe( 'Router regions', () => {
 		// The text of this element is used to check a navigation is completed.
 		const region1Ssr = page.getByTestId( 'region-1-ssr' );
 
-		await expect( region1Ssr ).toHaveText( 'content from page 1' );
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo1' );
 
 		// Navigate to "Page attachTo 1".
 		await page.getByTestId( 'next' ).click();

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -15,7 +15,7 @@ test.describe( 'Router regions', () => {
 			alias: 'router regions - page 2',
 			attributes: { page: 2 },
 		} );
-		await utils.addPostWithBlock( 'test/router-regions', {
+		const page1 = await utils.addPostWithBlock( 'test/router-regions', {
 			alias: 'router regions - page 1',
 			attributes: { page: 1, next },
 		} );
@@ -53,9 +53,10 @@ test.describe( 'Router regions', () => {
 		const pageAttachTo2 = await utils.addPostWithBlock(
 			'test/router-regions',
 			{
-				alias: 'router regions - page 2',
+				alias: 'router regions - page 2 - attachTo',
 				attributes: {
 					page: 'attachTo2',
+					next: page1,
 					regionsWithAttachTo: [
 						region3,
 						region4,
@@ -71,7 +72,7 @@ test.describe( 'Router regions', () => {
 		const pageAttachTo1 = await utils.addPostWithBlock(
 			'test/router-regions',
 			{
-				alias: 'router regions - page 2',
+				alias: 'router regions - page 1 - attachTo',
 				attributes: {
 					page: 'attachTo1',
 					next: pageAttachTo2,
@@ -80,7 +81,7 @@ test.describe( 'Router regions', () => {
 			}
 		);
 		await utils.addPostWithBlock( 'test/router-regions', {
-			alias: 'router regions - page 1 - attachTo',
+			alias: 'router regions - main - attachTo',
 			attributes: { page: 1, next: pageAttachTo1 },
 		} );
 	} );
@@ -254,9 +255,7 @@ test.describe( 'Router regions', () => {
 		page,
 		interactivityUtils: utils,
 	} ) => {
-		await page.goto(
-			utils.getLink( 'router regions - page 1 - attachTo' )
-		);
+		await page.goto( utils.getLink( 'router regions - main - attachTo' ) );
 
 		const bodyLocator = page.locator( 'body' );
 		const regionsLocator = page.locator( '#regions-with-attach-to' );
@@ -391,9 +390,7 @@ test.describe( 'Router regions', () => {
 		page,
 		interactivityUtils: utils,
 	} ) => {
-		await page.goto(
-			utils.getLink( 'router regions - page 1 - attachTo' )
-		);
+		await page.goto( utils.getLink( 'router regions - main - attachTo' ) );
 
 		const region7 = page.locator( 'body' ).getByTestId( 'region7' );
 		const region8 = page
@@ -591,6 +588,125 @@ test.describe( 'Router regions', () => {
 		for ( const regionId in regions ) {
 			const region = regions[ regionId ];
 			await expect( region ).toHaveAttribute( 'data-tag', regionId );
+		}
+	} );
+
+	test( 'should not be duplicated after `navigate()` when they use `attachTo` and appeared in the initial page', async ( {
+		page,
+		interactivityUtils: utils,
+	} ) => {
+		const bodyLocator = page.locator( 'body' );
+		const regionsLocator = page.locator( '#regions-with-attach-to' );
+
+		const regionsPage1: Record< string, Locator > = {
+			region3: bodyLocator.getByTestId( 'region3' ),
+			region4: regionsLocator.getByTestId( 'region4' ),
+			region5: bodyLocator.getByTestId( 'region5' ),
+			region6: regionsLocator.getByTestId( 'region6' ),
+		};
+
+		const regionsPage2: Record< string, Locator > = {
+			region7: bodyLocator.getByTestId( 'region7' ),
+			region8: regionsLocator.getByTestId( 'region8' ),
+		};
+
+		const allRegions: Record< string, Locator > = {
+			...regionsPage1,
+			...regionsPage2,
+		};
+
+		// The text of this element is used to check a navigation is completed.
+		const region1Ssr = page.getByTestId( 'region-1-ssr' );
+
+		// 1. Visit page 1 - attachTo using "goto".
+		await page.goto(
+			utils.getLink( 'router regions - page 1 - attachTo' )
+		);
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo1' );
+
+		// 2. Ensure regions 3 to 6 are unique and interactive.
+		for ( const regionId in regionsPage1 ) {
+			const region = regionsPage1[ regionId ];
+			await expect( region ).toBeVisible();
+			await expect( region ).toHaveCount( 1 );
+
+			const text = region.getByTestId( 'text' );
+			const clientCounter = region.getByTestId( 'client-counter' );
+
+			await expect( text ).toHaveText( regionId );
+			await expect( clientCounter ).toHaveText( '0' );
+
+			await clientCounter.click( { clickCount: 3, delay: 50 } );
+			await expect( clientCounter ).toHaveText( '3' );
+		}
+
+		// 3. Navigate to page 2 - attachTo.
+		await page.getByTestId( 'next' ).click();
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo2' );
+
+		// 4. Ensure regions 3 to 6 are unique and still interactive.
+		for ( const regionId in regionsPage1 ) {
+			const region = regionsPage1[ regionId ];
+			await expect( region ).toBeVisible();
+			await expect( region ).toHaveCount( 1 );
+
+			const text = region.getByTestId( 'text' );
+			const clientCounter = region.getByTestId( 'client-counter' );
+
+			await expect( text ).toHaveText( regionId );
+			// Counter state is preserved from step 2.
+			await expect( clientCounter ).toHaveText( '3' );
+
+			await clientCounter.click( { clickCount: 3, delay: 50 } );
+			await expect( clientCounter ).toHaveText( '6' );
+		}
+
+		// 5. Ensure regions 7 and 8 are visible, unique, and interactive.
+		for ( const regionId in regionsPage2 ) {
+			const region = regionsPage2[ regionId ];
+			await expect( region ).toBeVisible();
+			await expect( region ).toHaveCount( 1 );
+
+			const text = region.getByTestId( 'text' );
+			const clientCounter = region.getByTestId( 'client-counter' );
+
+			await expect( text ).toHaveText( regionId );
+			// Counter for page 2 regions starts at 10.
+			await expect( clientCounter ).toHaveText( '10' );
+
+			await clientCounter.click( { clickCount: 3, delay: 50 } );
+			await expect( clientCounter ).toHaveText( '13' );
+		}
+
+		// 6. Navigate to page 1 (no regions with `attachTo`).
+		await page.getByTestId( 'next' ).click();
+		await expect( region1Ssr ).toHaveText( 'content from page 1' );
+
+		// 7. Ensure all regions have been unmounted after navigation.
+		for ( const regionId in allRegions ) {
+			const region = allRegions[ regionId ];
+			await expect( region ).toBeHidden();
+		}
+
+		// 8. Navigate back to page 2 - attachTo.
+		await page.goBack();
+		await expect( region1Ssr ).toHaveText( 'content from page attachTo2' );
+
+		// 9. Ensure all regions are there again, are interactive, and there are no duplications.
+		for ( const regionId in allRegions ) {
+			const region = allRegions[ regionId ];
+			await expect( region ).toBeVisible();
+			await expect( region ).toHaveCount( 1 );
+
+			const text = region.getByTestId( 'text' );
+			const clientCounter = region.getByTestId( 'client-counter' );
+
+			await expect( text ).toHaveText( regionId );
+			// After a full page reload, all counters start at 10 (server value).
+			await expect( clientCounter ).toHaveText( '10' );
+
+			await clientCounter.click( { clickCount: 3, delay: 50 } );
+			await expect( clientCounter ).toHaveText( '13' );
 		}
 	} );
 } );


### PR DESCRIPTION
### What?

This PR fixes a bug where router regions with the `attachTo` property were duplicated in the DOM after calling `navigate()` when they were already present on the initial page.

This bug arose after the https://github.com/WordPress/gutenberg/pull/74750 bug fix. That bug was somehow hiding this issue.

### Why?

When a page containing router regions with `attachTo` is loaded directly (via full page load), those regions are already rendered in the HTML. However, when `navigate()` was called, the router treated these regions as if they needed to be appended to their target elements, resulting in duplicate elements in the DOM.

### How?

The fix introduces a new `initialRegionsToAttach` Set that tracks router regions with `attachTo` that are present in the initial page. Before the initial page is processed with `preparePage()`, the code scans the document for all router regions with `attachTo` and stores their IDs. 

When processing pages (including the initial one), the `preparePage()` function now checks if a region with `attachTo` is in this set. If it is, the region is treated as a regular router region (without `attachTo`), meaning it won't be appended to its target element since it's already in the correct place in the HTML.

### Testing Instructions

1. Create three, two of them with an image with the "enlarge on click" setting enabled, the third one without an image.
2. Modify the homepage Query block to display only one post per page, then disable "Reload full page".
3. Visit the homepage.
4. Open the dev tools, and locate the `core/image-overlay` router region element (it contains the `wp-lightbox-overlay zoom` class).
5. Navigate to the second post.
6. Ensure the image overlay router region element has not been duplicated.
7. Ensure "enlarge on click" works as usual.
8. Navigate to the third block.
9. Ensure the image overlay element disappears.
10. Navigate back to the second post.
11. Ensure the image overlay appears again, only once.