### PR TITLE
Navigation: Move submenus to that they don't overflow the sides of the viewport

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1129,6 +1129,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
 		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu", "modal": null, "previousFocus": null }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
+		$tags->set_attribute( 'data-wp-watch--submenu-position', 'callbacks.checkSubmenuPosition' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1243,6 +1243,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
 		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu", "modal": null, "previousFocus": null }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
+		$tags->set_attribute( 'data-wp-watch--submenu-position', 'callbacks.checkSubmenuPosition' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -13,6 +13,44 @@
 // Size of burger and close icons.
 $navigation-icon-size: 24px;
 
+// Mixin for positioning submenus to open leftward
+@mixin submenu-open-left {
+	left: auto;
+	right: 0;
+
+	// Nested submenus.
+	// On smaller breakpoints, nested menus open downwards.
+	.wp-block-navigation__submenu-container {
+		left: -1px; // Border width.
+		right: -1px;
+	}
+	@include break-medium {
+		.wp-block-navigation__submenu-container {
+			left: auto;
+			right: 100%;
+		}
+	}
+}
+
+// Mixin for positioning submenus to open rightward
+@mixin submenu-open-right {
+	left: 0;
+	right: auto;
+
+	// Nested submenus.
+	// On smaller breakpoints, nested menus open downwards.
+	.wp-block-navigation__submenu-container {
+		left: -1px; // Border width.
+		right: -1px;
+	}
+	@include break-medium {
+		.wp-block-navigation__submenu-container {
+			left: 100%;
+			right: auto;
+		}
+	}
+}
+
 .wp-block-navigation {
 	position: relative;
 
@@ -437,21 +475,7 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
 	// First submenu.
 	.wp-block-navigation__submenu-container {
-		left: auto;
-		right: 0;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: auto;
-				right: 100%;
-			}
-		}
+		@include submenu-open-left;
 	}
 }
 
@@ -470,21 +494,7 @@ button.wp-block-navigation-item__content {
 
 	// First submenu.
 	> .wp-block-navigation__submenu-container {
-		left: auto;
-		right: 0;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: auto;
-				right: 100%;
-			}
-		}
+		@include submenu-open-left;
 	}
 }
 
@@ -503,21 +513,7 @@ button.wp-block-navigation-item__content {
 	// First submenu - force rightward opening.
 	// Repeat class name to increase specificity and override justification rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
-		left: 0;
-		right: auto;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: 100%;
-				right: auto;
-			}
-		}
+		@include submenu-open-right;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -482,16 +482,6 @@ button.wp-block-navigation-item__content {
 // When a submenu would overflow the viewport, open it leftward.
 // This class is dynamically added by JavaScript when overflow is detected.
 .wp-block-navigation .open-on-left {
-	// Move submenu arrow to the left side
-	> .wp-block-navigation-item__content {
-		.wp-block-navigation__submenu-icon {
-			margin-left: 0;
-			margin-right: 0.25em;
-			/* stylelint-disable-next-line property-disallowed-list -- The submenu icon is decorative only. Moving it visually to indicate leftward submenu opening does not affect reading order or interaction. */
-			order: -1; // Move icon before the label text
-		}
-	}
-
 	// First submenu.
 	> .wp-block-navigation__submenu-container {
 		@include submenu-open-left;
@@ -502,14 +492,6 @@ button.wp-block-navigation-item__content {
 // This class is dynamically added by JavaScript when left overflow is detected
 // (e.g., for right-justified navigation items near the left edge).
 .wp-block-navigation .open-on-right {
-	// Keep submenu arrow on the right side (default positioning)
-	> .wp-block-navigation-item__content {
-		.wp-block-navigation__submenu-icon {
-			margin-left: 0.25em;
-			margin-right: 0;
-		}
-	}
-
 	// First submenu - force rightward opening.
 	// Repeat class name to increase specificity and override justification rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -491,7 +491,6 @@ button.wp-block-navigation-item__content {
 // When a submenu would overflow the viewport on the left, open it rightward.
 // This class is dynamically added by JavaScript when left overflow is detected
 // (e.g., for right-justified navigation items near the left edge).
-// Uses !important to override justification-based positioning rules.
 .wp-block-navigation .open-on-right {
 	// Keep submenu arrow on the right side (default positioning)
 	> .wp-block-navigation-item__content {
@@ -501,21 +500,22 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	// First submenu - force rightward opening
-	> .wp-block-navigation__submenu-container {
-		left: 0 !important;
-		right: auto !important;
+	// First submenu - force rightward opening.
+	// Repeat class name to increase specificity and override justification rules.
+	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
+		left: 0;
+		right: auto;
 
 		// Nested submenus.
 		// On smaller breakpoints, nested menus open downwards.
 		.wp-block-navigation__submenu-container {
-			left: -1px !important; // Border width.
-			right: -1px !important;
+			left: -1px; // Border width.
+			right: -1px;
 		}
 		@include break-medium {
 			.wp-block-navigation__submenu-container {
-				left: 100% !important;
-				right: auto !important;
+				left: 100%;
+				right: auto;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -455,6 +455,39 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// When a submenu would overflow the viewport, open it leftward.
+// This class is dynamically added by JavaScript when overflow is detected.
+.wp-block-navigation .open-on-left {
+	// Move submenu arrow to the left side
+	> .wp-block-navigation-item__content {
+		.wp-block-navigation__submenu-icon {
+			margin-left: 0;
+			margin-right: 0.25em;
+			/* stylelint-disable-next-line property-disallowed-list -- The submenu icon is decorative only. Moving it visually to indicate leftward submenu opening does not affect reading order or interaction. */
+			order: -1; // Move icon before the label text
+		}
+	}
+
+	// First submenu.
+	> .wp-block-navigation__submenu-container {
+		left: auto;
+		right: 0;
+
+		// Nested submenus.
+		// On smaller breakpoints, nested menus open downwards.
+		.wp-block-navigation__submenu-container {
+			left: -1px; // Border width.
+			right: -1px;
+		}
+		@include break-medium {
+			.wp-block-navigation__submenu-container {
+				left: auto;
+				right: 100%;
+			}
+		}
+	}
+}
+
 // Default background and font color.
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	// Set a background color for submenus so that they're not transparent.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -488,6 +488,39 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// When a submenu would overflow the viewport on the left, open it rightward.
+// This class is dynamically added by JavaScript when left overflow is detected
+// (e.g., for right-justified navigation items near the left edge).
+// Uses !important to override justification-based positioning rules.
+.wp-block-navigation .open-on-right {
+	// Keep submenu arrow on the right side (default positioning)
+	> .wp-block-navigation-item__content {
+		.wp-block-navigation__submenu-icon {
+			margin-left: 0.25em;
+			margin-right: 0;
+		}
+	}
+
+	// First submenu - force rightward opening
+	> .wp-block-navigation__submenu-container {
+		left: 0 !important;
+		right: auto !important;
+
+		// Nested submenus.
+		// On smaller breakpoints, nested menus open downwards.
+		.wp-block-navigation__submenu-container {
+			left: -1px !important; // Border width.
+			right: -1px !important;
+		}
+		@include break-medium {
+			.wp-block-navigation__submenu-container {
+				left: 100% !important;
+				right: auto !important;
+			}
+		}
+	}
+}
+
 // Default background and font color.
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	// Set a background color for submenus so that they're not transparent.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -13,6 +13,44 @@
 // Size of burger and close icons.
 $navigation-icon-size: 24px;
 
+// Mixin for positioning submenus to open leftward
+@mixin submenu-open-left {
+	left: auto;
+	right: 0;
+
+	// Nested submenus.
+	// On smaller breakpoints, nested menus open downwards.
+	.wp-block-navigation__submenu-container {
+		left: -1px; // Border width.
+		right: -1px;
+	}
+	@include break-medium {
+		.wp-block-navigation__submenu-container {
+			left: auto;
+			right: 100%;
+		}
+	}
+}
+
+// Mixin for positioning submenus to open rightward
+@mixin submenu-open-right {
+	left: 0;
+	right: auto;
+
+	// Nested submenus.
+	// On smaller breakpoints, nested menus open downwards.
+	.wp-block-navigation__submenu-container {
+		left: -1px; // Border width.
+		right: -1px;
+	}
+	@include break-medium {
+		.wp-block-navigation__submenu-container {
+			left: 100%;
+			right: auto;
+		}
+	}
+}
+
 .wp-block-navigation {
 	position: relative;
 
@@ -445,21 +483,7 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
 	// First submenu.
 	.wp-block-navigation__submenu-container {
-		left: auto;
-		right: 0;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: auto;
-				right: 100%;
-			}
-		}
+		@include submenu-open-left;
 	}
 }
 
@@ -478,21 +502,7 @@ button.wp-block-navigation-item__content {
 
 	// First submenu.
 	> .wp-block-navigation__submenu-container {
-		left: auto;
-		right: 0;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: auto;
-				right: 100%;
-			}
-		}
+		@include submenu-open-left;
 	}
 }
 
@@ -511,21 +521,7 @@ button.wp-block-navigation-item__content {
 	// First submenu - force rightward opening.
 	// Repeat class name to increase specificity and override justification rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
-		left: 0;
-		right: auto;
-
-		// Nested submenus.
-		// On smaller breakpoints, nested menus open downwards.
-		.wp-block-navigation__submenu-container {
-			left: -1px; // Border width.
-			right: -1px;
-		}
-		@include break-medium {
-			.wp-block-navigation__submenu-container {
-				left: 100%;
-				right: auto;
-			}
-		}
+		@include submenu-open-right;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -490,8 +490,10 @@ button.wp-block-navigation-item__content {
 // When a submenu would overflow the viewport, open it leftward.
 // This class is dynamically added by JavaScript when overflow is detected.
 .wp-block-navigation .open-on-left {
-	// First submenu.
-	> .wp-block-navigation__submenu-container {
+	// First submenu - force leftward opening.
+	// Repeat class name to increase specificity and override justification and
+	// background rules.
+	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 		@include submenu-open-left;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -499,7 +499,6 @@ button.wp-block-navigation-item__content {
 // When a submenu would overflow the viewport on the left, open it rightward.
 // This class is dynamically added by JavaScript when left overflow is detected
 // (e.g., for right-justified navigation items near the left edge).
-// Uses !important to override justification-based positioning rules.
 .wp-block-navigation .open-on-right {
 	// Keep submenu arrow on the right side (default positioning)
 	> .wp-block-navigation-item__content {
@@ -509,21 +508,22 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	// First submenu - force rightward opening
-	> .wp-block-navigation__submenu-container {
-		left: 0 !important;
-		right: auto !important;
+	// First submenu - force rightward opening.
+	// Repeat class name to increase specificity and override justification rules.
+	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
+		left: 0;
+		right: auto;
 
 		// Nested submenus.
 		// On smaller breakpoints, nested menus open downwards.
 		.wp-block-navigation__submenu-container {
-			left: -1px !important; // Border width.
-			right: -1px !important;
+			left: -1px; // Border width.
+			right: -1px;
 		}
 		@include break-medium {
 			.wp-block-navigation__submenu-container {
-				left: 100% !important;
-				right: auto !important;
+				left: 100%;
+				right: auto;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -463,6 +463,39 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// When a submenu would overflow the viewport, open it leftward.
+// This class is dynamically added by JavaScript when overflow is detected.
+.wp-block-navigation .open-on-left {
+	// Move submenu arrow to the left side
+	> .wp-block-navigation-item__content {
+		.wp-block-navigation__submenu-icon {
+			margin-left: 0;
+			margin-right: 0.25em;
+			/* stylelint-disable-next-line property-disallowed-list -- The submenu icon is decorative only. Moving it visually to indicate leftward submenu opening does not affect reading order or interaction. */
+			order: -1; // Move icon before the label text
+		}
+	}
+
+	// First submenu.
+	> .wp-block-navigation__submenu-container {
+		left: auto;
+		right: 0;
+
+		// Nested submenus.
+		// On smaller breakpoints, nested menus open downwards.
+		.wp-block-navigation__submenu-container {
+			left: -1px; // Border width.
+			right: -1px;
+		}
+		@include break-medium {
+			.wp-block-navigation__submenu-container {
+				left: auto;
+				right: 100%;
+			}
+		}
+	}
+}
+
 // Default background and font color.
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	// Set a background color for submenus so that they're not transparent.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -496,6 +496,39 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// When a submenu would overflow the viewport on the left, open it rightward.
+// This class is dynamically added by JavaScript when left overflow is detected
+// (e.g., for right-justified navigation items near the left edge).
+// Uses !important to override justification-based positioning rules.
+.wp-block-navigation .open-on-right {
+	// Keep submenu arrow on the right side (default positioning)
+	> .wp-block-navigation-item__content {
+		.wp-block-navigation__submenu-icon {
+			margin-left: 0.25em;
+			margin-right: 0;
+		}
+	}
+
+	// First submenu - force rightward opening
+	> .wp-block-navigation__submenu-container {
+		left: 0 !important;
+		right: auto !important;
+
+		// Nested submenus.
+		// On smaller breakpoints, nested menus open downwards.
+		.wp-block-navigation__submenu-container {
+			left: -1px !important; // Border width.
+			right: -1px !important;
+		}
+		@include break-medium {
+			.wp-block-navigation__submenu-container {
+				left: 100% !important;
+				right: auto !important;
+			}
+		}
+	}
+}
+
 // Default background and font color.
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	// Set a background color for submenus so that they're not transparent.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -490,16 +490,6 @@ button.wp-block-navigation-item__content {
 // When a submenu would overflow the viewport, open it leftward.
 // This class is dynamically added by JavaScript when overflow is detected.
 .wp-block-navigation .open-on-left {
-	// Move submenu arrow to the left side
-	> .wp-block-navigation-item__content {
-		.wp-block-navigation__submenu-icon {
-			margin-left: 0;
-			margin-right: 0.25em;
-			/* stylelint-disable-next-line property-disallowed-list -- The submenu icon is decorative only. Moving it visually to indicate leftward submenu opening does not affect reading order or interaction. */
-			order: -1; // Move icon before the label text
-		}
-	}
-
 	// First submenu.
 	> .wp-block-navigation__submenu-container {
 		@include submenu-open-left;
@@ -510,14 +500,6 @@ button.wp-block-navigation-item__content {
 // This class is dynamically added by JavaScript when left overflow is detected
 // (e.g., for right-justified navigation items near the left edge).
 .wp-block-navigation .open-on-right {
-	// Keep submenu arrow on the right side (default positioning)
-	> .wp-block-navigation-item__content {
-		.wp-block-navigation__submenu-icon {
-			margin-left: 0.25em;
-			margin-right: 0;
-		}
-	}
-
 	// First submenu - force rightward opening.
 	// Repeat class name to increase specificity and override justification rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -477,10 +477,14 @@ button.wp-block-navigation-item__content {
 // When justified space-between, open submenus leftward for last menu item.
 // When justified right, open all submenus leftwards.
 // This needs high specificity.
-.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
-.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
-.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
+// Skipped once JavaScript has measured a direction for the item, so that the
+// measured direction wins outright rather than by out-specifying these. The
+// test sits in :where() so it adds no specificity of its own, which would
+// otherwise let these rules outrank the direction rules for nested levels.
+.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:where(:not(.open-on-left):not(.open-on-right)):last-child,
+.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:where(:not(.open-on-left):not(.open-on-right)):last-child,
+.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child:where(:not(.open-on-left):not(.open-on-right)),
+.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child:where(:not(.open-on-left):not(.open-on-right)) {
 	// First submenu.
 	.wp-block-navigation__submenu-container {
 		@include submenu-open-left;
@@ -491,8 +495,7 @@ button.wp-block-navigation-item__content {
 // This class is dynamically added by JavaScript when overflow is detected.
 .wp-block-navigation .open-on-left {
 	// First submenu - force leftward opening.
-	// Repeat class name to increase specificity and override justification and
-	// background rules.
+	// Repeat class name to increase specificity and override background rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 		@include submenu-open-left;
 	}
@@ -503,7 +506,7 @@ button.wp-block-navigation-item__content {
 // (e.g., for right-justified navigation items near the left edge).
 .wp-block-navigation .open-on-right {
 	// First submenu - force rightward opening.
-	// Repeat class name to increase specificity and override justification rules.
+	// Repeat class name to increase specificity and override background rules.
 	> .wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 		@include submenu-open-right;
 	}

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -242,46 +242,47 @@ const { state, actions } = store(
 					return;
 				}
 
+				if ( ! state.isMenuOpen ) {
+					return;
+				}
+
 				const { ref } = getElement();
 
-				if ( state.isMenuOpen ) {
-					// Find the submenu container within this navigation item
-					const submenuContainer = ref.querySelector(
-						':scope > .wp-block-navigation__submenu-container'
-					);
+				// Find the submenu container within this navigation item
+				const submenuContainer = ref.querySelector(
+					':scope > .wp-block-navigation__submenu-container'
+				);
 
-					if ( ! submenuContainer ) {
-						return;
-					}
+				if ( ! submenuContainer ) {
+					return;
+				}
 
-					// Measure based on parent item position, not submenu position
-					// This prevents issues when the submenu is already repositioned
-					const parentRect = ref.getBoundingClientRect();
-					const viewportWidth = window.innerWidth;
+				// Measure based on parent item position, not submenu position
+				// This prevents issues when the submenu is already repositioned
+				const parentRect = ref.getBoundingClientRect();
+				const viewportWidth = window.innerWidth;
 
-					// Estimate submenu width (minimum 200px as per CSS)
-					const submenuMinWidth = 200;
+				// Estimate submenu width (minimum 200px as per CSS)
+				const submenuMinWidth = 200;
 
-					// Check if opening in either direction would overflow
-					const wouldOverflowRight =
-						parentRect.right + submenuMinWidth > viewportWidth;
-					const wouldOverflowLeft =
-						parentRect.left - submenuMinWidth < 0;
+				// Check if opening in either direction would overflow
+				const wouldOverflowRight =
+					parentRect.right + submenuMinWidth > viewportWidth;
+				const wouldOverflowLeft = parentRect.left - submenuMinWidth < 0;
 
-					// Determine optimal positioning
-					if ( wouldOverflowRight && ! wouldOverflowLeft ) {
-						// Open left to avoid right overflow
-						ref.classList.add( 'open-on-left' );
-						ref.classList.remove( 'open-on-right' );
-					} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
-						// Open right to avoid left overflow
-						ref.classList.add( 'open-on-right' );
-						ref.classList.remove( 'open-on-left' );
-					} else {
-						// No overflow or both would overflow - use default positioning
-						ref.classList.remove( 'open-on-left' );
-						ref.classList.remove( 'open-on-right' );
-					}
+				// Determine optimal positioning
+				if ( wouldOverflowRight && ! wouldOverflowLeft ) {
+					// Open left to avoid right overflow
+					ref.classList.add( 'open-on-left' );
+					ref.classList.remove( 'open-on-right' );
+				} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
+					// Open right to avoid left overflow
+					ref.classList.add( 'open-on-right' );
+					ref.classList.remove( 'open-on-left' );
+				} else {
+					// No overflow or both would overflow - use default positioning
+					ref.classList.remove( 'open-on-left' );
+					ref.classList.remove( 'open-on-right' );
 				}
 			},
 		},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -260,16 +260,27 @@ const { state, actions } = store(
 					const viewportWidth = window.innerWidth;
 
 					// Estimate submenu width (minimum 200px as per CSS)
-					// If parent is close enough to right edge that submenu would overflow, flip it
 					const submenuMinWidth = 200;
-					const wouldOverflow =
-						parentRect.right + submenuMinWidth > viewportWidth;
 
-					// Add or remove class based on overflow prediction
-					if ( wouldOverflow ) {
+					// Check if opening in either direction would overflow
+					const wouldOverflowRight =
+						parentRect.right + submenuMinWidth > viewportWidth;
+					const wouldOverflowLeft =
+						parentRect.left - submenuMinWidth < 0;
+
+					// Determine optimal positioning
+					if ( wouldOverflowRight && ! wouldOverflowLeft ) {
+						// Open left to avoid right overflow
 						ref.classList.add( 'open-on-left' );
-					} else {
+						ref.classList.remove( 'open-on-right' );
+					} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
+						// Open right to avoid left overflow
+						ref.classList.add( 'open-on-right' );
 						ref.classList.remove( 'open-on-left' );
+					} else {
+						// No overflow or both would overflow - use default positioning
+						ref.classList.remove( 'open-on-left' );
+						ref.classList.remove( 'open-on-right' );
 					}
 				}
 			},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -262,13 +262,14 @@ const { state, actions } = store(
 				const parentRect = ref.getBoundingClientRect();
 				const viewportWidth = window.innerWidth;
 
-				// Estimate submenu width (minimum 200px as per CSS)
-				const submenuMinWidth = 200;
+				// Get actual submenu width, fallback to 200px minimum if not measurable
+				const submenuRect = submenuContainer.getBoundingClientRect();
+				const submenuWidth = submenuRect.width || 200;
 
 				// Check if opening in either direction would overflow
 				const wouldOverflowRight =
-					parentRect.right + submenuMinWidth > viewportWidth;
-				const wouldOverflowLeft = parentRect.left - submenuMinWidth < 0;
+					parentRect.right + submenuWidth > viewportWidth;
+				const wouldOverflowLeft = parentRect.left - submenuWidth < 0;
 
 				// Determine optimal positioning
 				if ( wouldOverflowRight && ! wouldOverflowLeft ) {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -234,6 +234,45 @@ const { state, actions } = store(
 					focusableElements?.[ 0 ]?.focus();
 				}
 			},
+			checkSubmenuPosition() {
+				const { type } = getContext();
+
+				// Only check positioning for submenus, not overlays
+				if ( type !== 'submenu' ) {
+					return;
+				}
+
+				const { ref } = getElement();
+
+				if ( state.isMenuOpen ) {
+					// Find the submenu container within this navigation item
+					const submenuContainer = ref.querySelector(
+						':scope > .wp-block-navigation__submenu-container'
+					);
+
+					if ( ! submenuContainer ) {
+						return;
+					}
+
+					// Measure based on parent item position, not submenu position
+					// This prevents issues when the submenu is already repositioned
+					const parentRect = ref.getBoundingClientRect();
+					const viewportWidth = window.innerWidth;
+
+					// Estimate submenu width (minimum 200px as per CSS)
+					// If parent is close enough to right edge that submenu would overflow, flip it
+					const submenuMinWidth = 200;
+					const wouldOverflow =
+						parentRect.right + submenuMinWidth > viewportWidth;
+
+					// Add or remove class based on overflow prediction
+					if ( wouldOverflow ) {
+						ref.classList.add( 'open-on-left' );
+					} else {
+						ref.classList.remove( 'open-on-left' );
+					}
+				}
+			},
 		},
 	},
 	{ lock: true }

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -272,13 +272,14 @@ const { state, actions } = store(
 				const parentRect = ref.getBoundingClientRect();
 				const viewportWidth = window.innerWidth;
 
-				// Estimate submenu width (minimum 200px as per CSS)
-				const submenuMinWidth = 200;
+				// Get actual submenu width, fallback to 200px minimum if not measurable
+				const submenuRect = submenuContainer.getBoundingClientRect();
+				const submenuWidth = submenuRect.width || 200;
 
 				// Check if opening in either direction would overflow
 				const wouldOverflowRight =
-					parentRect.right + submenuMinWidth > viewportWidth;
-				const wouldOverflowLeft = parentRect.left - submenuMinWidth < 0;
+					parentRect.right + submenuWidth > viewportWidth;
+				const wouldOverflowLeft = parentRect.left - submenuWidth < 0;
 
 				// Determine optimal positioning
 				if ( wouldOverflowRight && ! wouldOverflowLeft ) {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -412,29 +412,24 @@ const { state, actions } = store(
 
 				const { ref } = getElement();
 
-				// Only the outermost item of a tree carries a direction. Nested
-				// levels inherit it, so the whole tree opens the same way.
-				let item = ref;
-				let parent = item.parentElement?.closest( 'li.has-child' );
-				while ( parent ) {
-					item = parent;
-					parent = item.parentElement?.closest( 'li.has-child' );
-				}
-
-				if ( ! state.isMenuOpen ) {
-					// A nested level closing leaves the tree itself open.
-					if ( ref === item ) {
-						openSubmenuTrees.delete( item );
-					}
+				// Only the outermost item of a tree carries a direction, and
+				// the measurement already spans every level below it, so a
+				// nested level opening cannot change the answer its tree root
+				// already picked.
+				if ( ref.parentElement?.closest( 'li.has-child' ) ) {
 					return;
 				}
 
-				openSubmenuTrees.add( item );
+				if ( ! state.isMenuOpen ) {
+					openSubmenuTrees.delete( ref );
+					return;
+				}
 
-				// Measured again whenever a level opens, rather than trusting a
-				// direction that may have been picked at a different viewport
-				// width.
-				applySubmenuDirection( item );
+				openSubmenuTrees.add( ref );
+
+				// Measured on every open, rather than trusting a direction
+				// that may have been picked at a different viewport width.
+				applySubmenuDirection( ref );
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -37,6 +37,61 @@ function getFocusableElements( ref ) {
 	} );
 }
 
+// Matches the `min-width` the stylesheet gives a submenu once it is shown.
+const SUBMENU_MIN_WIDTH = '200px';
+
+/**
+ * Measures how far a submenu tree would extend if every level were open.
+ *
+ * Closed submenus are collapsed to `width: 0`, so they cannot be measured as
+ * they are. Each level is given its open dimensions, read, and restored within
+ * the same synchronous block, so nothing is painted in between.
+ *
+ * @param {HTMLElement}   item       The `has-child` item that owns the tree.
+ * @param {HTMLElement[]} containers Every submenu container in the tree.
+ * @param {string}        direction  Direction to lay the tree out in.
+ *
+ * @return {{left: number, right: number}} Bounds of the widest chain.
+ */
+function measureSubmenuTree( item, containers, direction ) {
+	const previousStyles = containers.map( ( el ) => el.getAttribute( 'style' ) );
+	const wasOpenOnLeft = item.classList.contains( 'open-on-left' );
+	const wasOpenOnRight = item.classList.contains( 'open-on-right' );
+
+	item.classList.toggle( 'open-on-left', direction === 'left' );
+	item.classList.toggle( 'open-on-right', direction === 'right' );
+
+	containers.forEach( ( el ) => {
+		// `important` so these survive whatever the stylesheet sets while the
+		// submenu is closed.
+		el.style.setProperty( 'visibility', 'hidden', 'important' );
+		el.style.setProperty( 'width', 'auto', 'important' );
+		el.style.setProperty( 'height', 'auto', 'important' );
+		el.style.setProperty( 'overflow', 'visible', 'important' );
+		el.style.setProperty( 'min-width', SUBMENU_MIN_WIDTH, 'important' );
+	} );
+
+	let left = Infinity;
+	let right = -Infinity;
+	containers.forEach( ( el ) => {
+		const rect = el.getBoundingClientRect();
+		left = Math.min( left, rect.left );
+		right = Math.max( right, rect.right );
+	} );
+
+	containers.forEach( ( el, index ) => {
+		if ( previousStyles[ index ] === null ) {
+			el.removeAttribute( 'style' );
+		} else {
+			el.setAttribute( 'style', previousStyles[ index ] );
+		}
+	} );
+	item.classList.toggle( 'open-on-left', wasOpenOnLeft );
+	item.classList.toggle( 'open-on-right', wasOpenOnRight );
+
+	return { left, right };
+}
+
 // This is a fix for Safari in iOS/iPadOS. Without it, Safari doesn't focus out
 // when the user taps in the body. It can be removed once we add an overlay to
 // capture the clicks, instead of relying on the focusout event.
@@ -258,7 +313,12 @@ const { state, actions } = store(
 
 				const { ref } = getElement();
 
-				// Find the submenu container within this navigation item
+				// Only the outermost submenu picks a direction. Nested submenus
+				// inherit it, so the whole tree opens the same way.
+				if ( ref.closest( '.wp-block-navigation__submenu-container' ) ) {
+					return;
+				}
+
 				const submenuContainer = ref.querySelector(
 					':scope > .wp-block-navigation__submenu-container'
 				);
@@ -267,33 +327,40 @@ const { state, actions } = store(
 					return;
 				}
 
-				// Measure based on parent item position, not submenu position
-				// This prevents issues when the submenu is already repositioned
-				const parentRect = ref.getBoundingClientRect();
-				const viewportWidth = window.innerWidth;
+				// Every level in the tree, not just the one being opened. A
+				// submenu that fits on its own can still have a child that does
+				// not, and each level is offset further along than its parent.
+				const containers = [
+					submenuContainer,
+					...submenuContainer.querySelectorAll(
+						'.wp-block-navigation__submenu-container'
+					),
+				];
 
-				// Get actual submenu width, fallback to 200px minimum if not measurable
-				const submenuRect = submenuContainer.getBoundingClientRect();
-				const submenuWidth = submenuRect.width || 200;
+				// `clientWidth` rather than `innerWidth`, which counts the
+				// scrollbar as usable space.
+				const viewportWidth = document.documentElement.clientWidth;
+				const openedRight = measureSubmenuTree( ref, containers, 'right' );
+				const openedLeft = measureSubmenuTree( ref, containers, 'left' );
 
-				// Check if opening in either direction would overflow
-				const wouldOverflowRight =
-					parentRect.right + submenuWidth > viewportWidth;
-				const wouldOverflowLeft = parentRect.left - submenuWidth < 0;
+				const rightOverflow = openedRight.right - viewportWidth;
+				const leftOverflow = -openedLeft.left;
 
 				// Determine optimal positioning
-				if ( wouldOverflowRight && ! wouldOverflowLeft ) {
-					// Open left to avoid right overflow
+				if ( rightOverflow <= 0 && leftOverflow <= 0 ) {
+					// Fits either way - use default positioning
+					ref.classList.remove( 'open-on-left' );
+					ref.classList.remove( 'open-on-right' );
+				} else if ( leftOverflow < rightOverflow ) {
+					// Open left, either because opening right overflows or -
+					// when a tree is too deep to fit either way - because it
+					// spills less than opening right would.
 					ref.classList.add( 'open-on-left' );
 					ref.classList.remove( 'open-on-right' );
-				} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
-					// Open right to avoid left overflow
+				} else {
+					// Open right, on the same terms.
 					ref.classList.add( 'open-on-right' );
 					ref.classList.remove( 'open-on-left' );
-				} else {
-					// No overflow or both would overflow - use default positioning
-					ref.classList.remove( 'open-on-left' );
-					ref.classList.remove( 'open-on-right' );
 				}
 			},
 		},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -37,60 +37,163 @@ function getFocusableElements( ref ) {
 	} );
 }
 
-// Matches the `min-width` the stylesheet gives a submenu once it is shown.
-const SUBMENU_MIN_WIDTH = '200px';
-
 /**
- * Measures how far a submenu tree would extend if every level were open.
+ * Measures how far a submenu tree would extend if every level were open, once
+ * for each direction it could open in.
  *
  * Closed submenus are collapsed to `width: 0`, so they cannot be measured as
- * they are. Each level is given its open dimensions, read, and restored within
- * the same synchronous block, so nothing is painted in between.
+ * they are. Every level is given its open dimensions, measured in both
+ * directions, then restored within the same synchronous block, so nothing is
+ * painted in between.
+ *
+ * The bounds span every container in the tree rather than the chain being
+ * opened: a single direction is applied to the whole tree, so it has to suit
+ * whichever branch is opened next.
  *
  * @param {HTMLElement}   item       The `has-child` item that owns the tree.
- * @param {HTMLElement[]} containers Every submenu container in the tree.
- * @param {string}        direction  Direction to lay the tree out in.
+ * @param {HTMLElement[]} containers Every submenu container in the tree, the
+ *                                   already-open first level first.
  *
- * @return {{left: number, right: number}} Bounds of the widest chain.
+ * @return {Object} Bounds of the tree keyed by the direction applied to it.
  */
-function measureSubmenuTree( item, containers, direction ) {
-	const previousStyles = containers.map( ( el ) => el.getAttribute( 'style' ) );
+function measureSubmenuTree( item, containers ) {
+	const previousStyles = containers.map( ( el ) =>
+		el.getAttribute( 'style' )
+	);
 	const wasOpenOnLeft = item.classList.contains( 'open-on-left' );
 	const wasOpenOnRight = item.classList.contains( 'open-on-right' );
 
-	item.classList.toggle( 'open-on-left', direction === 'left' );
-	item.classList.toggle( 'open-on-right', direction === 'right' );
+	// The first level is already open, so this is the `min-width` that is
+	// really in effect, whether it comes from the stylesheet or from a theme.
+	const { minWidth } = window.getComputedStyle( containers[ 0 ] );
 
-	containers.forEach( ( el ) => {
-		// `important` so these survive whatever the stylesheet sets while the
-		// submenu is closed.
-		el.style.setProperty( 'visibility', 'hidden', 'important' );
-		el.style.setProperty( 'width', 'auto', 'important' );
-		el.style.setProperty( 'height', 'auto', 'important' );
-		el.style.setProperty( 'overflow', 'visible', 'important' );
-		el.style.setProperty( 'min-width', SUBMENU_MIN_WIDTH, 'important' );
-	} );
+	function measure( direction ) {
+		item.classList.toggle( 'open-on-left', direction === 'left' );
+		item.classList.toggle( 'open-on-right', direction === 'right' );
 
-	let left = Infinity;
-	let right = -Infinity;
-	containers.forEach( ( el ) => {
-		const rect = el.getBoundingClientRect();
-		left = Math.min( left, rect.left );
-		right = Math.max( right, rect.right );
-	} );
+		let left = Infinity;
+		let right = -Infinity;
+		containers.forEach( ( el ) => {
+			const rect = el.getBoundingClientRect();
+			left = Math.min( left, rect.left );
+			right = Math.max( right, rect.right );
+		} );
 
-	containers.forEach( ( el, index ) => {
-		if ( previousStyles[ index ] === null ) {
-			el.removeAttribute( 'style' );
-		} else {
-			el.setAttribute( 'style', previousStyles[ index ] );
-		}
-	} );
-	item.classList.toggle( 'open-on-left', wasOpenOnLeft );
-	item.classList.toggle( 'open-on-right', wasOpenOnRight );
+		return { left, right };
+	}
 
-	return { left, right };
+	let bounds;
+	try {
+		containers.forEach( ( el ) => {
+			// `important` so these survive whatever the stylesheet sets
+			// while the submenu is closed.
+			el.style.setProperty( 'visibility', 'hidden', 'important' );
+			el.style.setProperty( 'width', 'auto', 'important' );
+			el.style.setProperty( 'height', 'auto', 'important' );
+			el.style.setProperty( 'overflow', 'visible', 'important' );
+			el.style.setProperty( 'min-width', minWidth, 'important' );
+		} );
+
+		bounds = { left: measure( 'left' ), right: measure( 'right' ) };
+	} finally {
+		// A tree left at `visibility: hidden` has no way back, so restore it
+		// even if measuring threw part way through.
+		containers.forEach( ( el, index ) => {
+			if ( previousStyles[ index ] === null ) {
+				el.removeAttribute( 'style' );
+			} else {
+				el.setAttribute( 'style', previousStyles[ index ] );
+			}
+		} );
+		item.classList.toggle( 'open-on-left', wasOpenOnLeft );
+		item.classList.toggle( 'open-on-right', wasOpenOnRight );
+	}
+
+	return bounds;
 }
+
+/**
+ * Picks the direction a submenu tree opens in so that it stays inside the
+ * viewport, and applies it to the item that owns the tree.
+ *
+ * @param {HTMLElement} item The outermost `has-child` item of the tree.
+ */
+function applySubmenuDirection( item ) {
+	// Inside an open overlay every level is laid out in flow, so there is no
+	// direction to pick and nothing the classes could change.
+	const overlaySelector =
+		'.wp-block-navigation__responsive-container.is-menu-open';
+	if ( item.closest( overlaySelector ) ) {
+		return;
+	}
+
+	const submenuContainer = item.querySelector(
+		':scope > .wp-block-navigation__submenu-container'
+	);
+
+	if ( ! submenuContainer ) {
+		return;
+	}
+
+	// Every level in the tree, not just the one being opened. A submenu that
+	// fits on its own can still have a child that does not, and each level is
+	// offset further along than its parent.
+	const containers = [
+		submenuContainer,
+		...submenuContainer.querySelectorAll(
+			'.wp-block-navigation__submenu-container'
+		),
+	];
+
+	const bounds = measureSubmenuTree( item, containers );
+
+	// `clientWidth` rather than `innerWidth`, which counts the scrollbar as
+	// usable space.
+	const viewportWidth = document.documentElement.clientWidth;
+
+	// Score both edges of each layout. Which way a class opens is up to the
+	// stylesheet - `open-on-left` opens rightward once the CSS is flipped for
+	// right-to-left languages - so neither class can be assumed to overflow on
+	// one side only.
+	const spill = ( { left, right } ) =>
+		Math.max( 0, -left ) + Math.max( 0, right - viewportWidth );
+	const leftSpill = spill( bounds.left );
+	const rightSpill = spill( bounds.right );
+
+	if ( leftSpill === 0 && rightSpill === 0 ) {
+		// Fits either way, so leave the stylesheet's own positioning alone.
+		item.classList.remove( 'open-on-left' );
+		item.classList.remove( 'open-on-right' );
+	} else if ( leftSpill < rightSpill ) {
+		// Open left, either because opening right overflows or - when a tree
+		// is too deep to fit either way - because it spills less than opening
+		// right would.
+		item.classList.add( 'open-on-left' );
+		item.classList.remove( 'open-on-right' );
+	} else {
+		// Open right, on the same terms.
+		item.classList.add( 'open-on-right' );
+		item.classList.remove( 'open-on-left' );
+	}
+}
+
+// Trees that are open right now, so their direction can be measured again when
+// the viewport changes under them.
+const openSubmenuTrees = new Set();
+
+let submenuDirectionTimeout;
+window.addEventListener( 'resize', () => {
+	window.clearTimeout( submenuDirectionTimeout );
+	submenuDirectionTimeout = window.setTimeout( () => {
+		openSubmenuTrees.forEach( ( item ) => {
+			if ( item.isConnected ) {
+				applySubmenuDirection( item );
+			} else {
+				openSubmenuTrees.delete( item );
+			}
+		} );
+	}, 100 );
+} );
 
 // This is a fix for Safari in iOS/iPadOS. Without it, Safari doesn't focus out
 // when the user taps in the body. It can be removed once we add an overlay to
@@ -302,66 +405,36 @@ const { state, actions } = store(
 			checkSubmenuPosition() {
 				const { type } = getContext();
 
-				// Only check positioning for submenus, not overlays
+				// Only submenus open to one side; overlays do not.
 				if ( type !== 'submenu' ) {
-					return;
-				}
-
-				if ( ! state.isMenuOpen ) {
 					return;
 				}
 
 				const { ref } = getElement();
 
-				// Only the outermost submenu picks a direction. Nested submenus
-				// inherit it, so the whole tree opens the same way.
-				if ( ref.closest( '.wp-block-navigation__submenu-container' ) ) {
+				// Only the outermost item of a tree carries a direction. Nested
+				// levels inherit it, so the whole tree opens the same way.
+				let item = ref;
+				let parent = item.parentElement?.closest( 'li.has-child' );
+				while ( parent ) {
+					item = parent;
+					parent = item.parentElement?.closest( 'li.has-child' );
+				}
+
+				if ( ! state.isMenuOpen ) {
+					// A nested level closing leaves the tree itself open.
+					if ( ref === item ) {
+						openSubmenuTrees.delete( item );
+					}
 					return;
 				}
 
-				const submenuContainer = ref.querySelector(
-					':scope > .wp-block-navigation__submenu-container'
-				);
+				openSubmenuTrees.add( item );
 
-				if ( ! submenuContainer ) {
-					return;
-				}
-
-				// Every level in the tree, not just the one being opened. A
-				// submenu that fits on its own can still have a child that does
-				// not, and each level is offset further along than its parent.
-				const containers = [
-					submenuContainer,
-					...submenuContainer.querySelectorAll(
-						'.wp-block-navigation__submenu-container'
-					),
-				];
-
-				// `clientWidth` rather than `innerWidth`, which counts the
-				// scrollbar as usable space.
-				const viewportWidth = document.documentElement.clientWidth;
-				const openedRight = measureSubmenuTree( ref, containers, 'right' );
-				const openedLeft = measureSubmenuTree( ref, containers, 'left' );
-
-				const rightOverflow = openedRight.right - viewportWidth;
-				const leftOverflow = -openedLeft.left;
-
-				// Determine optimal positioning
-				if ( rightOverflow <= 0 && leftOverflow <= 0 ) {
-					// Fits either way - use default positioning
-					ref.classList.remove( 'open-on-left' );
-					ref.classList.remove( 'open-on-right' );
-				} else if ( leftOverflow < rightOverflow ) {
-					// Open left, either because opening right overflows or -
-					// when a tree is too deep to fit either way - because it
-					// spills less than opening right would.
-					ref.classList.add( 'open-on-left' );
-					ref.classList.remove( 'open-on-right' );
-				} else {
-					// Open right, on the same terms.
-					ref.classList.add( 'open-on-right' );
-					ref.classList.remove( 'open-on-left' );
-				}
+				// Measured again whenever a level opens, rather than trusting a
+				// direction that may have been picked at a different viewport
+				// width.
+				applySubmenuDirection( item );
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -244,6 +244,45 @@ const { state, actions } = store(
 					focusableElements?.[ 0 ]?.focus();
 				}
 			},
+			checkSubmenuPosition() {
+				const { type } = getContext();
+
+				// Only check positioning for submenus, not overlays
+				if ( type !== 'submenu' ) {
+					return;
+				}
+
+				const { ref } = getElement();
+
+				if ( state.isMenuOpen ) {
+					// Find the submenu container within this navigation item
+					const submenuContainer = ref.querySelector(
+						':scope > .wp-block-navigation__submenu-container'
+					);
+
+					if ( ! submenuContainer ) {
+						return;
+					}
+
+					// Measure based on parent item position, not submenu position
+					// This prevents issues when the submenu is already repositioned
+					const parentRect = ref.getBoundingClientRect();
+					const viewportWidth = window.innerWidth;
+
+					// Estimate submenu width (minimum 200px as per CSS)
+					// If parent is close enough to right edge that submenu would overflow, flip it
+					const submenuMinWidth = 200;
+					const wouldOverflow =
+						parentRect.right + submenuMinWidth > viewportWidth;
+
+					// Add or remove class based on overflow prediction
+					if ( wouldOverflow ) {
+						ref.classList.add( 'open-on-left' );
+					} else {
+						ref.classList.remove( 'open-on-left' );
+					}
+				}
+			},
 		},
 	},
 	{ lock: true }

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -252,46 +252,47 @@ const { state, actions } = store(
 					return;
 				}
 
+				if ( ! state.isMenuOpen ) {
+					return;
+				}
+
 				const { ref } = getElement();
 
-				if ( state.isMenuOpen ) {
-					// Find the submenu container within this navigation item
-					const submenuContainer = ref.querySelector(
-						':scope > .wp-block-navigation__submenu-container'
-					);
+				// Find the submenu container within this navigation item
+				const submenuContainer = ref.querySelector(
+					':scope > .wp-block-navigation__submenu-container'
+				);
 
-					if ( ! submenuContainer ) {
-						return;
-					}
+				if ( ! submenuContainer ) {
+					return;
+				}
 
-					// Measure based on parent item position, not submenu position
-					// This prevents issues when the submenu is already repositioned
-					const parentRect = ref.getBoundingClientRect();
-					const viewportWidth = window.innerWidth;
+				// Measure based on parent item position, not submenu position
+				// This prevents issues when the submenu is already repositioned
+				const parentRect = ref.getBoundingClientRect();
+				const viewportWidth = window.innerWidth;
 
-					// Estimate submenu width (minimum 200px as per CSS)
-					const submenuMinWidth = 200;
+				// Estimate submenu width (minimum 200px as per CSS)
+				const submenuMinWidth = 200;
 
-					// Check if opening in either direction would overflow
-					const wouldOverflowRight =
-						parentRect.right + submenuMinWidth > viewportWidth;
-					const wouldOverflowLeft =
-						parentRect.left - submenuMinWidth < 0;
+				// Check if opening in either direction would overflow
+				const wouldOverflowRight =
+					parentRect.right + submenuMinWidth > viewportWidth;
+				const wouldOverflowLeft = parentRect.left - submenuMinWidth < 0;
 
-					// Determine optimal positioning
-					if ( wouldOverflowRight && ! wouldOverflowLeft ) {
-						// Open left to avoid right overflow
-						ref.classList.add( 'open-on-left' );
-						ref.classList.remove( 'open-on-right' );
-					} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
-						// Open right to avoid left overflow
-						ref.classList.add( 'open-on-right' );
-						ref.classList.remove( 'open-on-left' );
-					} else {
-						// No overflow or both would overflow - use default positioning
-						ref.classList.remove( 'open-on-left' );
-						ref.classList.remove( 'open-on-right' );
-					}
+				// Determine optimal positioning
+				if ( wouldOverflowRight && ! wouldOverflowLeft ) {
+					// Open left to avoid right overflow
+					ref.classList.add( 'open-on-left' );
+					ref.classList.remove( 'open-on-right' );
+				} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
+					// Open right to avoid left overflow
+					ref.classList.add( 'open-on-right' );
+					ref.classList.remove( 'open-on-left' );
+				} else {
+					// No overflow or both would overflow - use default positioning
+					ref.classList.remove( 'open-on-left' );
+					ref.classList.remove( 'open-on-right' );
 				}
 			},
 		},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -270,16 +270,27 @@ const { state, actions } = store(
 					const viewportWidth = window.innerWidth;
 
 					// Estimate submenu width (minimum 200px as per CSS)
-					// If parent is close enough to right edge that submenu would overflow, flip it
 					const submenuMinWidth = 200;
-					const wouldOverflow =
-						parentRect.right + submenuMinWidth > viewportWidth;
 
-					// Add or remove class based on overflow prediction
-					if ( wouldOverflow ) {
+					// Check if opening in either direction would overflow
+					const wouldOverflowRight =
+						parentRect.right + submenuMinWidth > viewportWidth;
+					const wouldOverflowLeft =
+						parentRect.left - submenuMinWidth < 0;
+
+					// Determine optimal positioning
+					if ( wouldOverflowRight && ! wouldOverflowLeft ) {
+						// Open left to avoid right overflow
 						ref.classList.add( 'open-on-left' );
-					} else {
+						ref.classList.remove( 'open-on-right' );
+					} else if ( wouldOverflowLeft && ! wouldOverflowRight ) {
+						// Open right to avoid left overflow
+						ref.classList.add( 'open-on-right' );
 						ref.classList.remove( 'open-on-left' );
+					} else {
+						// No overflow or both would overflow - use default positioning
+						ref.classList.remove( 'open-on-left' );
+						ref.classList.remove( 'open-on-right' );
 					}
 				}
 			},

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -523,4 +523,161 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( innerElement ).toBeHidden();
 		} );
 	} );
+
+	test.describe( 'Submenu overflow positioning (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Overflow menu',
+				content: `
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 3","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 4","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-submenu {"label":"Right Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- /wp:navigation-submenu -->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: { overlayMenu: 'off', submenuVisibility: 'click' },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		test( 'submenu opens on left when it would overflow right edge', async ( {
+			page,
+		} ) => {
+			// Set a narrow viewport to force right edge overflow
+			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Right Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element (parent of the button)
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Check that the submenu container is visible
+			const submenuContainer = navigationItem.locator(
+				'.wp-block-navigation__submenu-container'
+			);
+			await expect( submenuContainer ).toBeVisible();
+
+			// Verify that the open-on-left class is applied to prevent overflow
+			await expect( navigationItem ).toHaveClass( /open-on-left/ );
+		} );
+
+		test( 'submenu does not have overflow class when it fits in viewport', async ( {
+			page,
+		} ) => {
+			// Set a wide viewport where submenu won't overflow
+			await page.setViewportSize( { width: 1920, height: 1080 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Right Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Verify that neither overflow class is applied
+			const hasOpenOnLeft = await navigationItem
+				.evaluate( ( el ) => el.classList.contains( 'open-on-left' ) )
+				.catch( () => false );
+			const hasOpenOnRight = await navigationItem
+				.evaluate( ( el ) => el.classList.contains( 'open-on-right' ) )
+				.catch( () => false );
+
+			expect( hasOpenOnLeft ).toBe( false );
+			expect( hasOpenOnRight ).toBe( false );
+		} );
+	} );
+
+	test.describe( 'Submenu overflow with right-justified navigation (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Right-justified menu',
+				content: `
+					<!-- wp:navigation-submenu {"label":"Left Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- /wp:navigation-submenu -->
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					overlayMenu: 'off',
+					submenuVisibility: 'click',
+					layout: {
+						type: 'flex',
+						justifyContent: 'right',
+					},
+				},
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		test( 'submenu opens on right when it would overflow left edge', async ( {
+			page,
+		} ) => {
+			// Set a narrow viewport to force left edge overflow
+			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Left Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Check that the submenu container is visible
+			const submenuContainer = navigationItem.locator(
+				'.wp-block-navigation__submenu-container'
+			);
+			await expect( submenuContainer ).toBeVisible();
+
+			// Verify that the open-on-right class is applied to prevent overflow
+			await expect( navigationItem ).toHaveClass( /open-on-right/ );
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -768,6 +768,38 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 	} );
 
+	// Submenu overflow scenarios are anchored to a viewport edge rather than
+	// tuned to a viewport width. A submenu is at least 200px wide, so the item
+	// at the start of a menu is always narrower than its own submenu and the
+	// item at the end of a right-justified menu always has its trailing edge on
+	// the viewport edge. Both hold whatever width the theme's font renders the
+	// labels at.
+	//
+	// The widths are also at or above the 782px breakpoint where nested
+	// submenus fly out sideways. Below it they stack vertically, so a deep tree
+	// is no wider than a single level and there is nothing to correct.
+	const FLYOUT_VIEWPORT = { width: 800, height: 800 };
+
+	/**
+	 * The horizontal extent of every level of a submenu tree.
+	 *
+	 * @param {Object} navigationItem Locator for the item that owns the tree.
+	 */
+	async function submenuTreeBounds( navigationItem ) {
+		const edges = await navigationItem
+			.locator( '.wp-block-navigation__submenu-container' )
+			.evaluateAll( ( elements ) =>
+				elements.map( ( element ) => {
+					const { left, right } = element.getBoundingClientRect();
+					return [ left, right ];
+				} )
+			);
+		return {
+			left: Math.min( ...edges.map( ( [ left ] ) => left ) ),
+			right: Math.max( ...edges.map( ( [ , right ] ) => right ) ),
+		};
+	}
+
 	test.describe( 'Submenu overflow positioning (@firefox, @webkit)', () => {
 		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 			await admin.visitSiteEditor( {
@@ -776,16 +808,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				canvas: 'edit',
 			} );
 			await requestUtils.createNavigationMenu( {
-				title: 'Overflow menu',
+				title: 'Start edge menu',
 				content: `
-					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 3","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 4","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-submenu {"label":"Right Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+					<!-- wp:navigation-submenu {"label":"Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
 						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
 						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
 					<!-- /wp:navigation-submenu -->
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
 					`,
 			} );
 			await editor.insertBlock( {
@@ -797,70 +827,35 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			} );
 		} );
 
-		test( 'submenu opens on left when it would overflow right edge', async ( {
+		test( 'submenu opens on right when it would overflow the left edge', async ( {
 			page,
 		} ) => {
-			// Set a narrow viewport to force right edge overflow
-			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.setViewportSize( FLYOUT_VIEWPORT );
 			await page.goto( '/' );
 
 			const submenuButton = page.getByRole( 'button', {
-				name: 'Right Edge Submenu',
+				name: 'Edge Submenu',
 			} );
-
-			// Open the submenu
 			await submenuButton.click();
 
-			// Get the navigation item element (parent of the button)
 			const navigationItem = page.locator(
 				'.wp-block-navigation-item.has-child',
 				{ has: submenuButton }
 			);
+			await expect(
+				navigationItem.locator(
+					'.wp-block-navigation__submenu-container'
+				)
+			).toBeVisible();
+			await expect( navigationItem ).toHaveClass( /open-on-right/ );
 
-			// Check that the submenu container is visible
-			const submenuContainer = navigationItem.locator(
-				'.wp-block-navigation__submenu-container'
-			);
-			await expect( submenuContainer ).toBeVisible();
-
-			// Verify that the open-on-left class is applied to prevent overflow
-			await expect( navigationItem ).toHaveClass( /open-on-left/ );
-		} );
-
-		test( 'submenu does not have overflow class when it fits in viewport', async ( {
-			page,
-		} ) => {
-			// Set a wide viewport where submenu won't overflow
-			await page.setViewportSize( { width: 1920, height: 1080 } );
-			await page.goto( '/' );
-
-			const submenuButton = page.getByRole( 'button', {
-				name: 'Right Edge Submenu',
-			} );
-
-			// Open the submenu
-			await submenuButton.click();
-
-			// Get the navigation item element
-			const navigationItem = page.locator(
-				'.wp-block-navigation-item.has-child',
-				{ has: submenuButton }
-			);
-
-			// Verify that neither overflow class is applied
-			const hasOpenOnLeft = await navigationItem
-				.evaluate( ( el ) => el.classList.contains( 'open-on-left' ) )
-				.catch( () => false );
-			const hasOpenOnRight = await navigationItem
-				.evaluate( ( el ) => el.classList.contains( 'open-on-right' ) )
-				.catch( () => false );
-
-			expect( hasOpenOnLeft ).toBe( false );
-			expect( hasOpenOnRight ).toBe( false );
+			// A pixel of slack for the submenu borders.
+			const bounds = await submenuTreeBounds( navigationItem );
+			expect( bounds.left ).toBeGreaterThanOrEqual( -1 );
 		} );
 	} );
 
-	test.describe( 'Submenu overflow with right-justified navigation (@firefox, @webkit)', () => {
+	test.describe( 'Submenu overflow positioning with right-justified navigation (@firefox, @webkit)', () => {
 		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 			await admin.visitSiteEditor( {
 				postId: 'emptytheme//header',
@@ -868,15 +863,15 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				canvas: 'edit',
 			} );
 			await requestUtils.createNavigationMenu( {
-				title: 'Right-justified menu',
+				title: 'End edge menu',
 				content: `
-					<!-- wp:navigation-submenu {"label":"Left Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
-						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
-						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- /wp:navigation-submenu -->
-					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
-					`,
+						<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-submenu {"label":"Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+							<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+							<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- /wp:navigation-submenu -->
+						`,
 			} );
 			await editor.insertBlock( {
 				name: 'core/navigation',
@@ -894,34 +889,86 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			} );
 		} );
 
-		test( 'submenu opens on right when it would overflow left edge', async ( {
+		test( 'submenu opens on left when it would overflow the right edge', async ( {
 			page,
 		} ) => {
-			// Set a narrow viewport to force left edge overflow
-			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.setViewportSize( FLYOUT_VIEWPORT );
 			await page.goto( '/' );
 
 			const submenuButton = page.getByRole( 'button', {
-				name: 'Left Edge Submenu',
+				name: 'Edge Submenu',
 			} );
-
-			// Open the submenu
 			await submenuButton.click();
 
-			// Get the navigation item element
 			const navigationItem = page.locator(
 				'.wp-block-navigation-item.has-child',
 				{ has: submenuButton }
 			);
+			await expect(
+				navigationItem.locator(
+					'.wp-block-navigation__submenu-container'
+				)
+			).toBeVisible();
+			await expect( navigationItem ).toHaveClass( /open-on-left/ );
 
-			// Check that the submenu container is visible
-			const submenuContainer = navigationItem.locator(
-				'.wp-block-navigation__submenu-container'
+			const bounds = await submenuTreeBounds( navigationItem );
+			expect( bounds.right ).toBeLessThanOrEqual(
+				FLYOUT_VIEWPORT.width + 1
 			);
-			await expect( submenuContainer ).toBeVisible();
+		} );
+	} );
 
-			// Verify that the open-on-right class is applied to prevent overflow
-			await expect( navigationItem ).toHaveClass( /open-on-right/ );
+	test.describe( 'Submenu with room on both sides (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Roomy menu',
+				content: `
+					<!-- wp:navigation-link {"label":"Navigation Item One","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Navigation Item Two","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Navigation Item Three","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-submenu {"label":"Roomy Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- /wp:navigation-submenu -->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: { overlayMenu: 'off', submenuVisibility: 'click' },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		test( 'submenu keeps the default positioning when it fits either way', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( { width: 1920, height: 1080 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Roomy Submenu',
+			} );
+			await submenuButton.click();
+
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+			await expect(
+				navigationItem.locator(
+					'.wp-block-navigation__submenu-container'
+				)
+			).toBeVisible();
+			await expect( navigationItem ).not.toHaveClass(
+				/open-on-left|open-on-right/
+			);
 		} );
 	} );
 
@@ -937,8 +984,6 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				content: `
 					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
 					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 3","type":"custom","url":"http://www.wordpress.org/"} /-->
-					<!-- wp:navigation-link {"label":"Item 4","type":"custom","url":"http://www.wordpress.org/"} /-->
 					<!-- wp:navigation-submenu {"label":"Top Submenu","type":"internal","url":"#heading","kind":"custom"} -->
 						<!-- wp:navigation-link {"label":"Child Link","type":"custom","url":"http://www.wordpress.org/"} /-->
 						<!-- wp:navigation-submenu {"label":"Nested Submenu","type":"internal","url":"#heading","kind":"custom"} -->
@@ -957,9 +1002,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		// The direction is picked from the whole tree, so a nested submenu
-		// should never spill out of the viewport — including at widths where
-		// the first level on its own would have fitted.
-		for ( const width of [ 800, 900, 1000, 1100, 1200 ] ) {
+		// should never spill out of the viewport - including at widths where
+		// the first level on its own would have fitted. One width just above
+		// the flyout breakpoint and one with room to spare.
+		for ( const width of [ 800, 1200 ] ) {
 			test( `nested submenu stays within a ${ width }px viewport`, async ( {
 				page,
 			} ) => {
@@ -988,7 +1034,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'the whole submenu tree opens in a single direction', async ( {
 			page,
 		} ) => {
-			await page.setViewportSize( { width: 900, height: 800 } );
+			await page.setViewportSize( FLYOUT_VIEWPORT );
 			await page.goto( '/' );
 
 			await page.getByRole( 'button', { name: 'Top Submenu' } ).click();
@@ -1005,19 +1051,17 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 	} );
 
-	test.describe(
-		'Nested submenu overflow with right-justified navigation (@firefox, @webkit)',
-		() => {
-			test.beforeEach( async ( { admin, editor, requestUtils } ) => {
-				await admin.visitSiteEditor( {
-					postId: 'emptytheme//header',
-					postType: 'wp_template_part',
-					canvas: 'edit',
-				} );
-				await requestUtils.createNavigationMenu( {
-					title: 'Nested right-justified menu',
-					content: `
-						<!-- wp:navigation-submenu {"label":"Left Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+	test.describe( 'Nested submenu overflow with right-justified navigation (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Nested right-justified menu',
+				content: `
+						<!-- wp:navigation-submenu {"label":"Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
 							<!-- wp:navigation-link {"label":"Child Link","type":"custom","url":"http://www.wordpress.org/"} /-->
 							<!-- wp:navigation-submenu {"label":"Nested Left Submenu","type":"internal","url":"#heading","kind":"custom"} -->
 								<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
@@ -1026,79 +1070,49 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 						<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
 						<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
 						`,
-				} );
-				await editor.insertBlock( {
-					name: 'core/navigation',
-					attributes: {
-						overlayMenu: 'off',
-						submenuVisibility: 'click',
-						layout: {
-							type: 'flex',
-							justifyContent: 'right',
-						},
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					overlayMenu: 'off',
+					submenuVisibility: 'click',
+					layout: {
+						type: 'flex',
+						justifyContent: 'right',
 					},
-				} );
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
+				},
 			} );
-
-			// A right-justified submenu opens leftward by default, so a nested
-			// level can run past the left edge even when the first level fits.
-			for ( const width of [ 800, 900, 1000, 1100, 1200 ] ) {
-				test( `nested submenu stays within a ${ width }px viewport`, async ( {
-					page,
-				} ) => {
-					await page.setViewportSize( { width, height: 800 } );
-					await page.goto( '/' );
-
-					await page
-						.getByRole( 'button', { name: 'Left Edge Submenu' } )
-						.click();
-					await page
-						.getByRole( 'button', { name: 'Nested Left Submenu' } )
-						.click();
-
-					const nestedContainer = page.locator(
-						'.wp-block-navigation__submenu-container .wp-block-navigation__submenu-container'
-					);
-					await expect( nestedContainer ).toBeVisible();
-
-					// A pixel of slack for the submenu borders.
-					const box = await nestedContainer.boundingBox();
-					expect( box.x ).toBeGreaterThanOrEqual( -1 );
-					expect( box.x + box.width ).toBeLessThanOrEqual(
-						width + 1
-					);
-				} );
-			}
-
-			test( 'the whole tree flips right when a nested level would overflow left', async ( {
-				page,
-			} ) => {
-				await page.setViewportSize( { width: 800, height: 800 } );
-				await page.goto( '/' );
-
-				const submenuButton = page.getByRole( 'button', {
-					name: 'Left Edge Submenu',
-				} );
-				await submenuButton.click();
-
-				const navigationItem = page.locator(
-					'.wp-block-navigation-item.has-child',
-					{ has: submenuButton }
-				);
-				await expect( navigationItem ).toHaveClass( /open-on-right/ );
-
-				// Nested items inherit the direction rather than choosing
-				// their own.
-				const nestedWithDirection = page.locator(
-					'.wp-block-navigation__submenu-container .has-child.open-on-left, .wp-block-navigation__submenu-container .has-child.open-on-right'
-				);
-				await expect( nestedWithDirection ).toHaveCount( 0 );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
 			} );
-		}
-	);
+		} );
+
+		// A right-justified submenu opens leftward by default, so a nested
+		// level can run past the left edge even when the first level fits.
+		test( 'nested submenu stays within the viewport', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( FLYOUT_VIEWPORT );
+			await page.goto( '/' );
+
+			await page.getByRole( 'button', { name: 'Edge Submenu' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Nested Left Submenu' } )
+				.click();
+
+			const nestedContainer = page.locator(
+				'.wp-block-navigation__submenu-container .wp-block-navigation__submenu-container'
+			);
+			await expect( nestedContainer ).toBeVisible();
+
+			// A pixel of slack for the submenu borders.
+			const box = await nestedContainer.boundingBox();
+			expect( box.x ).toBeGreaterThanOrEqual( -1 );
+			expect( box.x + box.width ).toBeLessThanOrEqual(
+				FLYOUT_VIEWPORT.width + 1
+			);
+		} );
+	} );
 
 	test.describe( 'Deeply nested submenu overflow (@firefox, @webkit)', () => {
 		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
@@ -1114,7 +1128,9 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 						<!-- wp:navigation-submenu {"label":"Level 2","type":"internal","url":"#heading","kind":"custom"} -->
 							<!-- wp:navigation-submenu {"label":"Level 3","type":"internal","url":"#heading","kind":"custom"} -->
 								<!-- wp:navigation-submenu {"label":"Level 4","type":"internal","url":"#heading","kind":"custom"} -->
-									<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+									<!-- wp:navigation-submenu {"label":"Level 5","type":"internal","url":"#heading","kind":"custom"} -->
+										<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+									<!-- /wp:navigation-submenu -->
 								<!-- /wp:navigation-submenu -->
 							<!-- /wp:navigation-submenu -->
 						<!-- /wp:navigation-submenu -->
@@ -1130,13 +1146,15 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			} );
 		} );
 
-		// A tree this deep is wider than a narrow viewport whichever way it
-		// opens. It should still commit to the side that spills less, rather
-		// than giving up and leaving the default in place.
+		// Five levels are at least 1000px wide, so the tree cannot fit in an
+		// 800px viewport whichever way it opens. It should still commit to the
+		// side that spills less - here rightward, since the item sits at the
+		// start of the menu and opening leftward would spill the full width of
+		// the tree - rather than giving up and leaving the default in place.
 		test( 'still picks a direction when neither side fits', async ( {
 			page,
 		} ) => {
-			await page.setViewportSize( { width: 700, height: 800 } );
+			await page.setViewportSize( FLYOUT_VIEWPORT );
 			await page.goto( '/' );
 
 			const submenuButton = page.getByRole( 'button', {
@@ -1148,9 +1166,68 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				'.wp-block-navigation-item.has-child',
 				{ has: submenuButton }
 			);
-			await expect( navigationItem ).toHaveClass(
-				/open-on-left|open-on-right/
+			await expect( navigationItem ).toHaveClass( /open-on-right/ );
+		} );
+	} );
+
+	test.describe( 'Submenu direction overrides the justification rules (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Space between menu',
+				content: `
+						<!-- wp:navigation-submenu {"label":"Only Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+							<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+							<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- /wp:navigation-submenu -->
+						`,
+			} );
+			// `never` keeps the container a direct child of the nav, which
+			// is what the space-between justification rule selects on.
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					overlayMenu: 'never',
+					submenuVisibility: 'click',
+					layout: {
+						type: 'flex',
+						justifyContent: 'space-between',
+					},
+				},
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		// The last item of a space-between menu opens leftward by default.
+		// It is also the only item here, so it sits at the start of the
+		// menu and opening leftward leaves the viewport: the measured
+		// direction has to win over the justification rule.
+		test( 'the measured direction beats the justification default', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( FLYOUT_VIEWPORT );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Only Submenu',
+			} );
+			await submenuButton.click();
+
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
 			);
+			await expect( navigationItem ).toHaveClass( /open-on-right/ );
+
+			// A pixel of slack for the submenu borders.
+			const bounds = await submenuTreeBounds( navigationItem );
+			expect( bounds.left ).toBeGreaterThanOrEqual( -1 );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -767,4 +767,161 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			} );
 		} );
 	} );
+
+	test.describe( 'Submenu overflow positioning (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Overflow menu',
+				content: `
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 3","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 4","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-submenu {"label":"Right Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- /wp:navigation-submenu -->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: { overlayMenu: 'off', submenuVisibility: 'click' },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		test( 'submenu opens on left when it would overflow right edge', async ( {
+			page,
+		} ) => {
+			// Set a narrow viewport to force right edge overflow
+			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Right Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element (parent of the button)
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Check that the submenu container is visible
+			const submenuContainer = navigationItem.locator(
+				'.wp-block-navigation__submenu-container'
+			);
+			await expect( submenuContainer ).toBeVisible();
+
+			// Verify that the open-on-left class is applied to prevent overflow
+			await expect( navigationItem ).toHaveClass( /open-on-left/ );
+		} );
+
+		test( 'submenu does not have overflow class when it fits in viewport', async ( {
+			page,
+		} ) => {
+			// Set a wide viewport where submenu won't overflow
+			await page.setViewportSize( { width: 1920, height: 1080 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Right Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Verify that neither overflow class is applied
+			const hasOpenOnLeft = await navigationItem
+				.evaluate( ( el ) => el.classList.contains( 'open-on-left' ) )
+				.catch( () => false );
+			const hasOpenOnRight = await navigationItem
+				.evaluate( ( el ) => el.classList.contains( 'open-on-right' ) )
+				.catch( () => false );
+
+			expect( hasOpenOnLeft ).toBe( false );
+			expect( hasOpenOnRight ).toBe( false );
+		} );
+	} );
+
+	test.describe( 'Submenu overflow with right-justified navigation (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Right-justified menu',
+				content: `
+					<!-- wp:navigation-submenu {"label":"Left Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Submenu Link 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Submenu Link 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- /wp:navigation-submenu -->
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					overlayMenu: 'off',
+					submenuVisibility: 'click',
+					layout: {
+						type: 'flex',
+						justifyContent: 'right',
+					},
+				},
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		test( 'submenu opens on right when it would overflow left edge', async ( {
+			page,
+		} ) => {
+			// Set a narrow viewport to force left edge overflow
+			await page.setViewportSize( { width: 600, height: 800 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Left Edge Submenu',
+			} );
+
+			// Open the submenu
+			await submenuButton.click();
+
+			// Get the navigation item element
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+
+			// Check that the submenu container is visible
+			const submenuContainer = navigationItem.locator(
+				'.wp-block-navigation__submenu-container'
+			);
+			await expect( submenuContainer ).toBeVisible();
+
+			// Verify that the open-on-right class is applied to prevent overflow
+			await expect( navigationItem ).toHaveClass( /open-on-right/ );
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -924,4 +924,233 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( navigationItem ).toHaveClass( /open-on-right/ );
 		} );
 	} );
+
+	test.describe( 'Nested submenu overflow positioning (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Nested overflow menu',
+				content: `
+					<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 3","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-link {"label":"Item 4","type":"custom","url":"http://www.wordpress.org/"} /-->
+					<!-- wp:navigation-submenu {"label":"Top Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-link {"label":"Child Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-submenu {"label":"Nested Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+							<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- /wp:navigation-submenu -->
+					<!-- /wp:navigation-submenu -->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: { overlayMenu: 'off', submenuVisibility: 'click' },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		// The direction is picked from the whole tree, so a nested submenu
+		// should never spill out of the viewport — including at widths where
+		// the first level on its own would have fitted.
+		for ( const width of [ 800, 900, 1000, 1100, 1200 ] ) {
+			test( `nested submenu stays within a ${ width }px viewport`, async ( {
+				page,
+			} ) => {
+				await page.setViewportSize( { width, height: 800 } );
+				await page.goto( '/' );
+
+				await page
+					.getByRole( 'button', { name: 'Top Submenu' } )
+					.click();
+				await page
+					.getByRole( 'button', { name: 'Nested Submenu' } )
+					.click();
+
+				const nestedContainer = page.locator(
+					'.wp-block-navigation__submenu-container .wp-block-navigation__submenu-container'
+				);
+				await expect( nestedContainer ).toBeVisible();
+
+				// A pixel of slack for the submenu borders.
+				const box = await nestedContainer.boundingBox();
+				expect( box.x ).toBeGreaterThanOrEqual( -1 );
+				expect( box.x + box.width ).toBeLessThanOrEqual( width + 1 );
+			} );
+		}
+
+		test( 'the whole submenu tree opens in a single direction', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( { width: 900, height: 800 } );
+			await page.goto( '/' );
+
+			await page.getByRole( 'button', { name: 'Top Submenu' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Nested Submenu' } )
+				.click();
+
+			// Only the outermost item carries a direction; nested items
+			// inherit it rather than choosing their own.
+			const nestedWithDirection = page.locator(
+				'.wp-block-navigation__submenu-container .has-child.open-on-left, .wp-block-navigation__submenu-container .has-child.open-on-right'
+			);
+			await expect( nestedWithDirection ).toHaveCount( 0 );
+		} );
+	} );
+
+	test.describe(
+		'Nested submenu overflow with right-justified navigation (@firefox, @webkit)',
+		() => {
+			test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+				await admin.visitSiteEditor( {
+					postId: 'emptytheme//header',
+					postType: 'wp_template_part',
+					canvas: 'edit',
+				} );
+				await requestUtils.createNavigationMenu( {
+					title: 'Nested right-justified menu',
+					content: `
+						<!-- wp:navigation-submenu {"label":"Left Edge Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+							<!-- wp:navigation-link {"label":"Child Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+							<!-- wp:navigation-submenu {"label":"Nested Left Submenu","type":"internal","url":"#heading","kind":"custom"} -->
+								<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+							<!-- /wp:navigation-submenu -->
+						<!-- /wp:navigation-submenu -->
+						<!-- wp:navigation-link {"label":"Item 1","type":"custom","url":"http://www.wordpress.org/"} /-->
+						<!-- wp:navigation-link {"label":"Item 2","type":"custom","url":"http://www.wordpress.org/"} /-->
+						`,
+				} );
+				await editor.insertBlock( {
+					name: 'core/navigation',
+					attributes: {
+						overlayMenu: 'off',
+						submenuVisibility: 'click',
+						layout: {
+							type: 'flex',
+							justifyContent: 'right',
+						},
+					},
+				} );
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
+			} );
+
+			// A right-justified submenu opens leftward by default, so a nested
+			// level can run past the left edge even when the first level fits.
+			for ( const width of [ 800, 900, 1000, 1100, 1200 ] ) {
+				test( `nested submenu stays within a ${ width }px viewport`, async ( {
+					page,
+				} ) => {
+					await page.setViewportSize( { width, height: 800 } );
+					await page.goto( '/' );
+
+					await page
+						.getByRole( 'button', { name: 'Left Edge Submenu' } )
+						.click();
+					await page
+						.getByRole( 'button', { name: 'Nested Left Submenu' } )
+						.click();
+
+					const nestedContainer = page.locator(
+						'.wp-block-navigation__submenu-container .wp-block-navigation__submenu-container'
+					);
+					await expect( nestedContainer ).toBeVisible();
+
+					// A pixel of slack for the submenu borders.
+					const box = await nestedContainer.boundingBox();
+					expect( box.x ).toBeGreaterThanOrEqual( -1 );
+					expect( box.x + box.width ).toBeLessThanOrEqual(
+						width + 1
+					);
+				} );
+			}
+
+			test( 'the whole tree flips right when a nested level would overflow left', async ( {
+				page,
+			} ) => {
+				await page.setViewportSize( { width: 800, height: 800 } );
+				await page.goto( '/' );
+
+				const submenuButton = page.getByRole( 'button', {
+					name: 'Left Edge Submenu',
+				} );
+				await submenuButton.click();
+
+				const navigationItem = page.locator(
+					'.wp-block-navigation-item.has-child',
+					{ has: submenuButton }
+				);
+				await expect( navigationItem ).toHaveClass( /open-on-right/ );
+
+				// Nested items inherit the direction rather than choosing
+				// their own.
+				const nestedWithDirection = page.locator(
+					'.wp-block-navigation__submenu-container .has-child.open-on-left, .wp-block-navigation__submenu-container .has-child.open-on-right'
+				);
+				await expect( nestedWithDirection ).toHaveCount( 0 );
+			} );
+		}
+	);
+
+	test.describe( 'Deeply nested submenu overflow (@firefox, @webkit)', () => {
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//header',
+				postType: 'wp_template_part',
+				canvas: 'edit',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Deep menu',
+				content: `
+					<!-- wp:navigation-submenu {"label":"Level 1","type":"internal","url":"#heading","kind":"custom"} -->
+						<!-- wp:navigation-submenu {"label":"Level 2","type":"internal","url":"#heading","kind":"custom"} -->
+							<!-- wp:navigation-submenu {"label":"Level 3","type":"internal","url":"#heading","kind":"custom"} -->
+								<!-- wp:navigation-submenu {"label":"Level 4","type":"internal","url":"#heading","kind":"custom"} -->
+									<!-- wp:navigation-link {"label":"Deep Link","type":"custom","url":"http://www.wordpress.org/"} /-->
+								<!-- /wp:navigation-submenu -->
+							<!-- /wp:navigation-submenu -->
+						<!-- /wp:navigation-submenu -->
+					<!-- /wp:navigation-submenu -->
+					`,
+			} );
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: { overlayMenu: 'off', submenuVisibility: 'click' },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		} );
+
+		// A tree this deep is wider than a narrow viewport whichever way it
+		// opens. It should still commit to the side that spills less, rather
+		// than giving up and leaving the default in place.
+		test( 'still picks a direction when neither side fits', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( { width: 700, height: 800 } );
+			await page.goto( '/' );
+
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Level 1',
+			} );
+			await submenuButton.click();
+
+			const navigationItem = page.locator(
+				'.wp-block-navigation-item.has-child',
+				{ has: submenuButton }
+			);
+			await expect( navigationItem ).toHaveClass(
+				/open-on-left|open-on-right/
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74823

Moves submenus to the other side when they would otherwise overlap the viewport edges.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users need to be able to see their submenus, so we shouldn't let them flow off the edge of the screen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
New approach: September 3rd 2026
Instead of moving submenus to the left/right to get them to fit in the viewport, on a case by case basis, we pre-calculate the entire submenu tree and open left/right depending on which one fits better in the viewport. This avoids the issue where the children would open over the parents.

## Testing Instructions
1. Add two navigation blocks with submenus that have long links inside.
2. Set one navigation block to be aligned to the left of the screen and have the submenus to flow left
3. Set the other navigation block to be aligned to the right of the screen and have the submenus to flow right
4. Open the site on the frontend and resize the window such that the submenus would be outside the viewport edge
5. Confirm that the submenus that would have overlapped the viewport edge now flow the other way, rather than going outside of the viewport.

## Screenshot
<img width="1122" height="326" alt="Screenshot 2026-09-03 at 17 43 08" src="https://github.com/user-attachments/assets/e1bc097b-9295-46f8-9ccf-7c8218224ee7" />
<img width="2263" height="476" alt="Screenshot 2026-09-03 at 17 42 57" src="https://github.com/user-attachments/assets/9fc389e3-bee3-4261-8a1e-9b1dea0e6b53" />
s or screencast <!-- if applicable -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Navigation submenus now automatically open in the direction that best fits within the viewport.
  - Nested submenu levels maintain consistent positioning and remain visible near screen edges.
  - Submenu positioning adapts when the browser window is resized.
  - Explicit left- or right-opening settings remain supported, with viewport-aware positioning taking precedence when needed.

- **Bug Fixes**
  - Improved submenu placement for right-aligned navigation and deeply nested menus, reducing off-screen or clipped content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->