### PR TITLE
Fix: Fit Text not working on calculated line heights.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -22,7 +22,7 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	const paddingRight = parseFloat( computedStyle.paddingRight ) || 0;
 	const range = document.createRange();
 	range.selectNodeContents( textElement );
-
+	let maxclientHeight = textElement.clientHeight;
 	while ( minSize <= maxSize ) {
 		const midSize = Math.floor( ( minSize + maxSize ) / 2 );
 		applyFontSize( midSize );
@@ -41,7 +41,17 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 		// Check if text fits within the element's height.
 		const fitsHeight =
 			alreadyHasScrollableHeight ||
-			textElement.scrollHeight <= textElement.clientHeight;
+			textElement.scrollHeight <= textElement.clientHeight ||
+			textElement.scrollHeight <= maxclientHeight;
+
+		// When there are calculated line heights, text may jump in height
+		// the available space may decrease while the font size decreases,
+		// making text not fit.
+		// We store a maximum reference height: the maximum reference element height that was observed
+		// during the loop to avoid issues with such jumps.
+		if ( textElement.clientHeight > maxclientHeight ) {
+			maxclientHeight = textElement.clientHeight;
+		}
 
 		if ( fitsWidth && fitsHeight ) {
 			bestSize = midSize;


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/73806


We have an issue where on calculated line heights fit text may not work. Basically on calculated line heights the clientHeight may decrease while the font size decreases. This PR fixes the issue by comparing the scroll heigh against the maximum observed clientHeight, in normal circumstances the clientHeight does not decreases.


cc: @iamtakashi, @t-hamano 

## Testing
Paste the following on the code editor:
```
<!-- wp:paragraph {"style":{"typography":{"lineHeight":"calc(1em + 0.5rem)"}},"fitText":true} -->
<p class="has-fit-text" style="line-height:calc(1em + 0.5rem)">Stretch</p>
<!-- /wp:paragraph -->
```
Verify text stretches (trunk it does not).