### PR TITLE
Fix: Safari "Edit as HTML" for Fit Text  deletes content

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -68,9 +68,10 @@ function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
 
-	// Monitor block attribute changes, and parent changes.
+	// Monitor block attribute changes, parent changes, and block mode.
 	// Any attribute or parent change may change the available space.
-	const { blockAttributes, parentId } = useSelect(
+	// Block mode is needed to disable fit text when in HTML editing mode.
+	const { blockAttributes, parentId, blockMode } = useSelect(
 		( select ) => {
 			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {
 				return EMPTY_OBJECT;
@@ -80,6 +81,7 @@ function useFitText( { fitText, name, clientId } ) {
 					select( blockEditorStore ).getBlockAttributes( clientId ),
 				parentId:
 					select( blockEditorStore ).getBlockRootClientId( clientId ),
+				blockMode: select( blockEditorStore ).getBlockMode( clientId ),
 			};
 		},
 		[ clientId, hasFitTextSupport, fitText ]
@@ -118,7 +120,8 @@ function useFitText( { fitText, name, clientId } ) {
 			! fitText ||
 			! blockElement ||
 			! clientId ||
-			! hasFitTextSupport
+			! hasFitTextSupport ||
+			blockMode === 'html'
 		) {
 			return;
 		}
@@ -189,11 +192,17 @@ function useFitText( { fitText, name, clientId } ) {
 		applyFitText,
 		blockElement,
 		hasFitTextSupport,
+		blockMode,
 	] );
 
 	// Trigger fit text recalculation when content changes
 	useEffect( () => {
-		if ( fitText && blockElement && hasFitTextSupport ) {
+		if (
+			fitText &&
+			blockElement &&
+			hasFitTextSupport &&
+			blockMode !== 'html'
+		) {
 			// Wait for next frame to ensure DOM has updated after content changes
 			const frameId = window.requestAnimationFrame( () => {
 				if ( blockElement ) {
@@ -209,6 +218,7 @@ function useFitText( { fitText, name, clientId } ) {
 		applyFitText,
 		blockElement,
 		hasFitTextSupport,
+		blockMode,
 	] );
 
 	return { fontSize };

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -76,12 +76,17 @@ function useFitText( { fitText, name, clientId } ) {
 			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {
 				return EMPTY_OBJECT;
 			}
+			const _blockMode =
+				select( blockEditorStore ).getBlockMode( clientId );
+			if ( _blockMode === 'html' ) {
+				return { mode: _blockMode };
+			}
 			return {
 				blockAttributes:
 					select( blockEditorStore ).getBlockAttributes( clientId ),
 				parentId:
 					select( blockEditorStore ).getBlockRootClientId( clientId ),
-				blockMode: select( blockEditorStore ).getBlockMode( clientId ),
+				blockMode: _blockMode,
 			};
 		},
 		[ clientId, hasFitTextSupport, fitText ]

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -79,7 +79,7 @@ function useFitText( { fitText, name, clientId } ) {
 			const _blockMode =
 				select( blockEditorStore ).getBlockMode( clientId );
 			if ( _blockMode === 'html' ) {
-				return { mode: _blockMode };
+				return { blockMode: _blockMode };
 			}
 			return {
 				blockAttributes:


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/73768

cc: @mrwweb, @t-hamano 

On safari we had a bug when "Edit as HTML" was pressed and the block had "Fit Text" enabled, the content of the block disappear. This PR fixes the issue by making sure useFitText doesn't run when we are on HTML block mode. It is a good change and saves some CPU cycles in all browsers as when in HTML mode running the hook has no value because the block is hidden and the dimensions are irrelevant (and change while switching modes).

## Testing

On safari:
Paste this on the code editor:
```
<!-- wp:paragraph {"fitText":true} -->
<p class="has-fit-text">Content</p>
<!-- /wp:paragraph -->
```
Switch to visual mode and then at the block level press: "Edit as HTML".
Verify the content is kept on trunk it is lost.


