### PR TITLE
Latest Posts: Parse blocks in full content display

### DIFF
--- a/backport-changelog/7.1/12421.md
+++ b/backport-changelog/7.1/12421.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12421
+
+* https://github.com/WordPress/gutenberg/pull/74866

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -407,6 +407,7 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
  * and removed after, preventing infinite loops when content references itself.
  *
  * @since 19.9.0
+ * @access private
  *
  * @param string      $content  The content to process.
  * @param string      $context  Optional. Context identifier for wp_filter_content_tags. Default empty string.
@@ -414,7 +415,7 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
  * @param string|null $id       Optional. Unique identifier for this content, used with $seen_ids. Default null.
  * @return string The processed content.
  */
-function gutenberg_apply_content_filters( $content, $context = '', &$seen_ids = null, $id = null ) {
+function _gutenberg_apply_content_filters( $content, $context = '', &$seen_ids = null, $id = null ) {
 	$content = shortcode_unautop( $content );
 	$content = do_shortcode( $content );
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -386,3 +386,54 @@ function _gutenberg_footnotes_force_filtered_html_on_import_filter( $arg ) {
 add_action( 'init', '_gutenberg_footnotes_kses_init' );
 add_action( 'set_current_user', '_gutenberg_footnotes_kses_init' );
 add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtered_html_on_import_filter', 999 );
+
+/**
+ * Applies standard content filters similar to 'the_content' filter.
+ *
+ * This function runs the typical content processing filters that WordPress
+ * applies to post content, useful for blocks that render nested content.
+ *
+ * The filters applied in order are:
+ * - shortcode_unautop()
+ * - do_shortcode()
+ * - do_blocks()
+ * - wptexturize()
+ * - convert_smilies()
+ * - wp_filter_content_tags()
+ * - $wp_embed->autoembed()
+ *
+ * Optionally supports recursion prevention by accepting a seen IDs array
+ * and an ID. When provided, the ID is added to the array before do_blocks()
+ * and removed after, preventing infinite loops when content references itself.
+ *
+ * @since 19.9.0
+ *
+ * @param string      $content  The content to process.
+ * @param string      $context  Optional. Context identifier for wp_filter_content_tags. Default empty string.
+ * @param array|null  $seen_ids Optional. Reference to array tracking seen IDs for recursion prevention. Default null.
+ * @param string|null $id       Optional. Unique identifier for this content, used with $seen_ids. Default null.
+ * @return string The processed content.
+ */
+function gutenberg_apply_content_filters( $content, $context = '', &$seen_ids = null, $id = null ) {
+	$content = shortcode_unautop( $content );
+	$content = do_shortcode( $content );
+
+	if ( null !== $seen_ids && null !== $id ) {
+		$seen_ids[ $id ] = true;
+	}
+
+	$content = do_blocks( $content );
+
+	if ( null !== $seen_ids && null !== $id ) {
+		unset( $seen_ids[ $id ] );
+	}
+
+	$content = wptexturize( $content );
+	$content = convert_smilies( $content );
+	$content = wp_filter_content_tags( $content, $context );
+
+	global $wp_embed;
+	$content = $wp_embed->autoembed( $content );
+
+	return $content;
+}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -406,7 +406,6 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
  * and an ID. When provided, the ID is added to the array before do_blocks()
  * and removed after, preventing infinite loops when content references itself.
  *
- * @since 19.9.0
  * @access private
  *
  * @param string      $content  The content to process.

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -807,7 +807,7 @@ export default function LatestPostsEdit( {
 									<div
 										className="wp-block-latest-posts__post-full-content"
 										dangerouslySetInnerHTML={ {
-											__html: post.content.raw.trim(),
+											__html: post.content.rendered.trim(),
 										} }
 									/>
 								) }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -819,7 +819,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									<div
 										className="wp-block-latest-posts__post-full-content"
 										dangerouslySetInnerHTML={ {
-											__html: post.content.raw.trim(),
+											__html: post.content.rendered.trim(),
 										} }
 									/>
 								) }

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -196,8 +196,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 					try {
 						// Run through the actions that are typically taken on the_content.
-						// phpcs:ignore Gutenberg.CodeAnalysis.ForbiddenFunctionsAndClasses.ForbiddenFunctionCall
-						$post_content = gutenberg_apply_content_filters( $post_content, 'latest-posts' );
+						$post_content = _gutenberg_apply_content_filters( $post_content, 'latest-posts' );
 					} finally {
 						array_pop( $rendering_stack );
 					}

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -35,15 +35,14 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
- * @global WP_Post $post                                      Global post object.
- * @global int     $block_core_latest_posts_excerpt_length    Excerpt length set by the Latest Posts core block.
+ * @global int $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
  *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	global $post, $block_core_latest_posts_excerpt_length;
+	global $block_core_latest_posts_excerpt_length;
 	static $rendering_stack = array();
 
 	$args = array(

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -184,11 +184,10 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
-
 			if ( post_password_required( $post ) ) {
 				$post_content = __( 'This content is password protected.' );
 			} else {
+				$post_content = $post->post_content;
 				// Check if we're already rendering this post to prevent infinite recursion.
 				if ( in_array( $post->ID, $rendering_stack, true ) ) {
 					$post_content = '';
@@ -196,8 +195,14 @@ function render_block_core_latest_posts( $attributes ) {
 					$rendering_stack[] = $post->ID;
 
 					try {
-						// Parse blocks so they are properly rendered with styles and attributes.
+						// Run through the actions that are typically taken on the_content.
 						$post_content = do_blocks( $post_content );
+						$post_content = shortcode_unautop( $post_content );
+						$post_content = do_shortcode( $post_content );
+						$post_content = wp_filter_content_tags( $post_content, 'latest-posts' );
+
+						global $wp_embed;
+						$post_content = $wp_embed->autoembed( $post_content );
 					} finally {
 						array_pop( $rendering_stack );
 					}

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -196,6 +196,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 					try {
 						// Run through the actions that are typically taken on the_content.
+						// phpcs:ignore Gutenberg.CodeAnalysis.ForbiddenFunctionsAndClasses.ForbiddenFunctionCall
 						$post_content = gutenberg_apply_content_filters( $post_content, 'latest-posts' );
 					} finally {
 						array_pop( $rendering_stack );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -203,7 +203,6 @@ function render_block_core_latest_posts( $attributes ) {
 				}
 			}
 
-			$post_content = str_replace( ']]>', ']]&gt;', $post_content );
 			$post_content       = str_replace( ']]>', ']]&gt;', $post_content );
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -187,6 +187,9 @@ function render_block_core_latest_posts( $attributes ) {
 
 			if ( post_password_required( $post ) ) {
 				$post_content = __( 'This content is password protected.' );
+			} else {
+				// Parse blocks so they are properly rendered with styles and attributes.
+				$post_content = do_blocks( $post_content );
 			}
 
 			$list_items_markup .= sprintf(

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -65,8 +65,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$args['author'] = $attributes['selectedAuthor'];
 	}
 
-	$query        = new WP_Query();
-	$recent_posts = $query->query( $args );
+	$query = new WP_Query( $args );
 
 	if ( isset( $attributes['displayFeaturedImage'] ) && $attributes['displayFeaturedImage'] ) {
 		update_post_thumbnail_cache( $query );
@@ -74,9 +73,10 @@ function render_block_core_latest_posts( $attributes ) {
 
 	$list_items_markup = '';
 
-	foreach ( $recent_posts as $post ) {
-		$post_link = esc_url( get_permalink( $post ) );
-		$title     = get_the_title( $post );
+	while ( $query->have_posts() ) {
+		$query->the_post();
+		$post_link = esc_url( get_permalink() );
+		$title     = get_the_title();
 
 		if ( ! $title ) {
 			$title = __( '(no title)' );
@@ -84,7 +84,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$list_items_markup .= '<li>';
 
-		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
+		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail() ) {
 			$image_style = '';
 			if ( isset( $attributes['featuredImageSizeWidth'] ) ) {
 				$image_style .= sprintf( 'max-width:%spx;', $attributes['featuredImageSizeWidth'] );
@@ -99,7 +99,7 @@ function render_block_core_latest_posts( $attributes ) {
 			}
 
 			$featured_image = get_the_post_thumbnail(
-				$post,
+				null,
 				$attributes['featuredImageSizeSlug'],
 				array(
 					'style' => esc_attr( $image_style ),
@@ -127,7 +127,7 @@ function render_block_core_latest_posts( $attributes ) {
 		);
 
 		if ( isset( $attributes['displayAuthor'] ) && $attributes['displayAuthor'] ) {
-			$author_display_name = get_the_author_meta( 'display_name', $post->post_author );
+			$author_display_name = get_the_author_meta( 'display_name' );
 
 			/* translators: byline. %s: author. */
 			$byline = sprintf( __( 'by %s' ), $author_display_name );
@@ -143,15 +143,15 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
 			$list_items_markup .= sprintf(
 				'<time datetime="%1$s" class="wp-block-latest-posts__post-date">%2$s</time>',
-				esc_attr( get_the_date( 'c', $post ) ),
-				get_the_date( '', $post )
+				esc_attr( get_the_date( 'c' ) ),
+				get_the_date( '' )
 			);
 		}
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
 
-			$trimmed_excerpt = get_the_excerpt( $post );
+			$trimmed_excerpt = get_the_excerpt();
 
 			/*
 			 * Adds a "Read more" link with screen reader text.
@@ -171,7 +171,7 @@ function render_block_core_latest_posts( $attributes ) {
 				}
 			}
 
-			if ( post_password_required( $post ) ) {
+			if ( post_password_required() ) {
 				$trimmed_excerpt = __( 'This content is password protected.' );
 			}
 
@@ -184,15 +184,16 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			if ( post_password_required( $post ) ) {
+			if ( post_password_required() ) {
 				$post_content = __( 'This content is password protected.' );
 			} else {
-				$post_content = $post->post_content;
+				$post_id      = get_the_ID();
+				$post_content = get_post_field( 'post_content', $post_id );
 				// Check if we're already rendering this post to prevent infinite recursion.
-				if ( in_array( $post->ID, $rendering_stack, true ) ) {
+				if ( in_array( $post_id, $rendering_stack, true ) ) {
 					$post_content = '';
 				} else {
-					$rendering_stack[] = $post->ID;
+					$rendering_stack[] = $post_id;
 
 					try {
 						// Run through the actions that are typically taken on the_content.
@@ -212,6 +213,13 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$list_items_markup .= "</li>\n";
 	}
+
+	/*
+	 * Use this function to restore the context of the template tags
+	 * from a secondary query loop back to the main query loop.
+	 * Since we use a custom loop, it's safest to always restore.
+	 */
+	wp_reset_postdata();
 
 	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -15,16 +15,6 @@ global $block_core_latest_posts_excerpt_length;
 $block_core_latest_posts_excerpt_length = 0;
 
 /**
- * Stack of post IDs currently being rendered in full content mode.
- * Used to prevent infinite recursion when a Latest Posts block appears
- * in a post that it's trying to display.
- *
- * @var array
- */
-global $block_core_latest_posts_rendering_stack;
-$block_core_latest_posts_rendering_stack = array();
-
-/**
  * Callback for the excerpt_length filter used by
  * the Latest Posts block at render time.
  *
@@ -47,14 +37,14 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @global WP_Post $post                                      Global post object.
  * @global int     $block_core_latest_posts_excerpt_length    Excerpt length set by the Latest Posts core block.
- * @global array   $block_core_latest_posts_rendering_stack   Stack of post IDs being rendered to prevent recursion.
  *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	global $post, $block_core_latest_posts_excerpt_length, $block_core_latest_posts_rendering_stack;
+	global $post, $block_core_latest_posts_excerpt_length;
+	static $rendering_stack = array();
 
 	$args = array(
 		'posts_per_page'      => $attributes['postsToShow'],
@@ -200,18 +190,25 @@ function render_block_core_latest_posts( $attributes ) {
 				$post_content = __( 'This content is password protected.' );
 			} else {
 				// Check if we're already rendering this post to prevent infinite recursion.
-				if ( in_array( $post->ID, $block_core_latest_posts_rendering_stack, true ) ) {
+				if ( in_array( $post->ID, $rendering_stack, true ) ) {
 					// Skip rendering to prevent recursion.
 					$post_content = '';
 				} else {
 					// Add this post to the rendering stack.
-					$block_core_latest_posts_rendering_stack[] = $post->ID;
+					$rendering_stack[] = $post->ID;
 
-					// Parse blocks so they are properly rendered with styles and attributes.
-					$post_content = do_blocks( $post_content );
-
-					// Remove this post from the rendering stack.
-					array_pop( $block_core_latest_posts_rendering_stack );
+					try {
+						// Parse blocks so they are properly rendered with styles and attributes.
+						// This will parse any blocks in the post content, including nested Latest Posts blocks.
+						// If a nested Latest Posts block tries to render this same post (creating recursion),
+						// the check above (in_array check) will detect it and skip rendering that post's content,
+						// preventing infinite recursion while still allowing the nested block to render other posts.
+						$post_content = do_blocks( $post_content );
+					} finally {
+						// Remove this post from the rendering stack.
+						// Using finally ensures cleanup even if do_blocks() throws an exception.
+						array_pop( $rendering_stack );
+					}
 				}
 			}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -15,6 +15,16 @@ global $block_core_latest_posts_excerpt_length;
 $block_core_latest_posts_excerpt_length = 0;
 
 /**
+ * Stack of post IDs currently being rendered in full content mode.
+ * Used to prevent infinite recursion when a Latest Posts block appears
+ * in a post that it's trying to display.
+ *
+ * @var array
+ */
+global $block_core_latest_posts_rendering_stack;
+$block_core_latest_posts_rendering_stack = array();
+
+/**
  * Callback for the excerpt_length filter used by
  * the Latest Posts block at render time.
  *
@@ -35,15 +45,16 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
- * @global WP_Post $post                                   Global post object.
- * @global int     $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
+ * @global WP_Post $post                                      Global post object.
+ * @global int     $block_core_latest_posts_excerpt_length    Excerpt length set by the Latest Posts core block.
+ * @global array   $block_core_latest_posts_rendering_stack   Stack of post IDs being rendered to prevent recursion.
  *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	global $post, $block_core_latest_posts_excerpt_length;
+	global $post, $block_core_latest_posts_excerpt_length, $block_core_latest_posts_rendering_stack;
 
 	$args = array(
 		'posts_per_page'      => $attributes['postsToShow'],
@@ -188,8 +199,20 @@ function render_block_core_latest_posts( $attributes ) {
 			if ( post_password_required( $post ) ) {
 				$post_content = __( 'This content is password protected.' );
 			} else {
-				// Parse blocks so they are properly rendered with styles and attributes.
-				$post_content = do_blocks( $post_content );
+				// Check if we're already rendering this post to prevent infinite recursion.
+				if ( in_array( $post->ID, $block_core_latest_posts_rendering_stack, true ) ) {
+					// Skip rendering to prevent recursion.
+					$post_content = '';
+				} else {
+					// Add this post to the rendering stack.
+					$block_core_latest_posts_rendering_stack[] = $post->ID;
+
+					// Parse blocks so they are properly rendered with styles and attributes.
+					$post_content = do_blocks( $post_content );
+
+					// Remove this post from the rendering stack.
+					array_pop( $block_core_latest_posts_rendering_stack );
+				}
 			}
 
 			$list_items_markup .= sprintf(

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -191,22 +191,14 @@ function render_block_core_latest_posts( $attributes ) {
 			} else {
 				// Check if we're already rendering this post to prevent infinite recursion.
 				if ( in_array( $post->ID, $rendering_stack, true ) ) {
-					// Skip rendering to prevent recursion.
 					$post_content = '';
 				} else {
-					// Add this post to the rendering stack.
 					$rendering_stack[] = $post->ID;
 
 					try {
 						// Parse blocks so they are properly rendered with styles and attributes.
-						// This will parse any blocks in the post content, including nested Latest Posts blocks.
-						// If a nested Latest Posts block tries to render this same post (creating recursion),
-						// the check above (in_array check) will detect it and skip rendering that post's content,
-						// preventing infinite recursion while still allowing the nested block to render other posts.
 						$post_content = do_blocks( $post_content );
 					} finally {
-						// Remove this post from the rendering stack.
-						// Using finally ensures cleanup even if do_blocks() throws an exception.
 						array_pop( $rendering_stack );
 					}
 				}
@@ -214,7 +206,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
-				wp_kses_post( $post_content )
+				$post_content
 			);
 		}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -203,6 +203,7 @@ function render_block_core_latest_posts( $attributes ) {
 				}
 			}
 
+			$post_content = str_replace( ']]>', ']]&gt;', $post_content );
 			$post_content       = str_replace( ']]>', ']]&gt;', $post_content );
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -203,6 +203,7 @@ function render_block_core_latest_posts( $attributes ) {
 				}
 			}
 
+			$post_content       = str_replace( ']]>', ']]&gt;', $post_content );
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
 				$post_content

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -196,13 +196,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 					try {
 						// Run through the actions that are typically taken on the_content.
-						$post_content = do_blocks( $post_content );
-						$post_content = shortcode_unautop( $post_content );
-						$post_content = do_shortcode( $post_content );
-						$post_content = wp_filter_content_tags( $post_content, 'latest-posts' );
-
-						global $wp_embed;
-						$post_content = $wp_embed->autoembed( $post_content );
+						$post_content = gutenberg_apply_content_filters( $post_content, 'latest-posts' );
 					} finally {
 						array_pop( $rendering_stack );
 					}

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -35,14 +35,15 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
- * @global int $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
+ * @global WP_Post $post                                   Global post object.
+ * @global int     $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
  *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	global $block_core_latest_posts_excerpt_length;
+	global $post, $block_core_latest_posts_excerpt_length;
 	static $rendering_stack = array();
 
 	$args = array(
@@ -71,6 +72,7 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	$list_items_markup = '';
+	$previous_post     = $post ?? null;
 
 	while ( $query->have_posts() ) {
 		$query->the_post();
@@ -213,12 +215,11 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= "</li>\n";
 	}
 
-	/*
-	 * Use this function to restore the context of the template tags
-	 * from a secondary query loop back to the main query loop.
-	 * Since we use a custom loop, it's safest to always restore.
-	 */
-	wp_reset_postdata();
+	// Restore the post context that was active before this secondary query.
+	$post = $previous_post;
+	if ( $previous_post instanceof WP_Post ) {
+		setup_postdata( $previous_post );
+	}
 
 	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -72,7 +72,11 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	$list_items_markup = '';
-	$previous_post     = $post ?? null;
+	// Snapshot the current global post so it can be restored after the loop.
+	// We use have_posts()/the_post() rather than foreach so that setup_postdata()
+	// is called for each post, establishing the correct global context for
+	// do_blocks() and other filters that run during full-content rendering.
+	$previous_post = $post ?? null;
 
 	while ( $query->have_posts() ) {
 		$query->the_post();
@@ -216,6 +220,9 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	// Restore the post context that was active before this secondary query.
+	// wp_reset_postdata() is intentionally not used here: when this block is
+	// rendered inside another post's content (e.g. via do_blocks()), it would
+	// restore to the main query post rather than the outer rendering post.
 	$post = $previous_post;
 	if ( $previous_post instanceof WP_Post ) {
 		setup_postdata( $previous_post );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -187,7 +187,7 @@ function render_block_core_latest_posts( $attributes ) {
 				$post_content = __( 'This content is password protected.' );
 			} else {
 				$post_id      = get_the_ID();
-				$post_content = get_post_field( 'post_content', $post_id );
+				$post_content = get_post_field( 'post_content', $post_id, 'raw' );
 				// Check if we're already rendering this post to prevent infinite recursion.
 				if ( in_array( $post_id, $rendering_stack, true ) ) {
 					$post_content = '';

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -150,22 +150,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	// Run through the actions that are typically taken on the_content.
-	$content                       = shortcode_unautop( $content );
-	$content                       = do_shortcode( $content );
-	$seen_ids[ $template_part_id ] = true;
-	$content                       = do_blocks( $content );
-	unset( $seen_ids[ $template_part_id ] );
-	$content = wptexturize( $content );
-	$content = convert_smilies( $content );
-	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
-
-	/**
-	 * Handle embeds for block template parts.
-	 *
-	 * @global WP_Embed $wp_embed WordPress Embed object.
-	 */
-	global $wp_embed;
-	$content = $wp_embed->autoembed( $content );
+	$content = gutenberg_apply_content_filters( $content, "template_part_{$area}", $seen_ids, $template_part_id );
 
 	if ( empty( $attributes['tagName'] ) || tag_escape( $attributes['tagName'] ) !== $attributes['tagName'] ) {
 		$area_tag = 'div';

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -150,7 +150,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	// Run through the actions that are typically taken on the_content.
-	$content = gutenberg_apply_content_filters( $content, "template_part_{$area}", $seen_ids, $template_part_id );
+	$content = _gutenberg_apply_content_filters( $content, "template_part_{$area}", $seen_ids, $template_part_id );
 
 	if ( empty( $attributes['tagName'] ) || tag_escape( $attributes['tagName'] ) !== $attributes['tagName'] ) {
 		$area_tag = 'div';

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -124,9 +124,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$gallery_output    = do_blocks( $processed_content );
 
 		// Check if gallery block is registered.
-		$registry      = WP_Block_Type_Registry::get_instance();
-		$gallery_block = $registry->get_registered( 'core/gallery' );
-		$image_block   = $registry->get_registered( 'core/image' );
+		$registry = WP_Block_Type_Registry::get_instance();
 
 		$this->assertTrue( $registry->is_registered( 'core/gallery' ), 'Gallery block should be registered' );
 		$this->assertTrue( $registry->is_registered( 'core/image' ), 'Image block should be registered' );
@@ -241,11 +239,6 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_prevents_recursion() {
-		// Create attachment IDs for gallery block (matching the test scenario).
-		$file            = DIR_TESTDATA . '/images/canola.jpg';
-		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
-		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
-
 		// Create a paragraph block for testing block parsing.
 		$paragraph_block = '<!-- wp:paragraph --><p>Test content in a paragraph block.</p><!-- /wp:paragraph -->';
 
@@ -277,9 +270,17 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		// This should not cause a fatal error or memory exhaustion.
-		// The recursion protection should prevent infinite loops.
-		$output = render_block_core_latest_posts( $attributes );
+		// Render through the block pipeline so that the Gutenberg-registered
+		// callback (gutenberg_render_block_core_latest_posts) is used.
+		$output = render_block(
+			array(
+				'blockName'    => 'core/latest-posts',
+				'attrs'        => $attributes,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			)
+		);
 
 		// Verify the output contains the wrapper for the outer Latest Posts block.
 		$this->assertStringContainsString(
@@ -365,11 +366,6 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
-		// Create attachment IDs for gallery block (used as example block type).
-		$file            = DIR_TESTDATA . '/images/canola.jpg';
-		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
-		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
-
 		// Create a post with block content that we know renders server-side.
 		// Use paragraph blocks as they have reliable server-side rendering.
 		$block_content = '<!-- wp:paragraph --><p>This is a test paragraph that should be rendered with block classes.</p><!-- /wp:paragraph -->';
@@ -394,7 +390,17 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		$output = render_block_core_latest_posts( $attributes );
+		// Render through the block pipeline so that the Gutenberg-registered
+		// callback (gutenberg_render_block_core_latest_posts) is used.
+		$output = render_block(
+			array(
+				'blockName'    => 'core/latest-posts',
+				'attrs'        => $attributes,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			)
+		);
 
 		// Verify that the post content is included in the output.
 		$this->assertStringContainsString(

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -69,6 +69,73 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that _gutenberg_apply_content_filters() works.
+	 *
+	 * @covers ::_gutenberg_apply_content_filters
+	 */
+	public function test_gutenberg_apply_content_filters_works() {
+		// Check if the function exists.
+		$this->assertTrue( function_exists( '_gutenberg_apply_content_filters' ), '_gutenberg_apply_content_filters function should exist' );
+
+		// Test with paragraph block.
+		$content = '<!-- wp:paragraph --><p>Test paragraph</p><!-- /wp:paragraph -->';
+		$output  = _gutenberg_apply_content_filters( $content, 'test-context' );
+
+		// Block comments should be removed.
+		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $output, 'Block comments should be removed' );
+		// Block should be rendered with class.
+		$this->assertStringContainsString( 'wp-block-paragraph', $output, 'Block should have wp-block class' );
+	}
+
+	/**
+	 * Test that do_blocks() works in the test environment.
+	 *
+	 * @covers ::do_blocks
+	 */
+	public function test_do_blocks_works() {
+		// Test paragraph block.
+		$block_content = '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->';
+		$output        = do_blocks( $block_content );
+
+		// Block comments should be removed.
+		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $output, 'Block comments should be removed by do_blocks()' );
+		// Paragraph should be rendered with block class.
+		$this->assertStringContainsString( 'wp-block-paragraph', $output, 'Block should be rendered with classes' );
+		$this->assertStringContainsString( 'Test', $output, 'Block content should be present' );
+
+		// Test gallery block with actual attachment IDs.
+		// Create attachments for the test.
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		$gallery_content = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<!-- wp:image {"id":%d} /-->
+<!-- wp:image {"id":%d} /-->
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		// Apply the same filters that _gutenberg_apply_content_filters does.
+		$processed_content = shortcode_unautop( $gallery_content );
+		$processed_content = do_shortcode( $processed_content );
+		$gallery_output    = do_blocks( $processed_content );
+
+		// Check if gallery block is registered.
+		$registry      = WP_Block_Type_Registry::get_instance();
+		$gallery_block = $registry->get_registered( 'core/gallery' );
+		$image_block   = $registry->get_registered( 'core/image' );
+
+		$this->assertTrue( $registry->is_registered( 'core/gallery' ), 'Gallery block should be registered' );
+		$this->assertTrue( $registry->is_registered( 'core/image' ), 'Image block should be registered' );
+
+		// Check if block comments are removed.
+		$this->assertStringNotContainsString( '<!-- wp:gallery', $gallery_output, 'Gallery block comments should be removed' );
+	}
+
+	/**
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts() {
@@ -179,31 +246,19 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
-		// Create a gallery block (as was being tested when the recursion was discovered).
-		$gallery_block = sprintf(
-			'<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
-<!-- /wp:image --></figure>
-<!-- /wp:gallery -->',
-			$attachment_id_1,
-			$attachment_id_2
-		);
+		// Create a paragraph block for testing block parsing.
+		$paragraph_block = '<!-- wp:paragraph --><p>Test content in a paragraph block.</p><!-- /wp:paragraph -->';
 
 		// Create a Latest Posts block markup (showing 5 posts with full content).
 		$latest_posts_block = '<!-- wp:latest-posts {"postsToShow":5,"displayPostContent":true,"displayPostContentRadio":"full_post"} /-->';
 
-		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
-		// This matches the exact scenario where the recursion issue was discovered.
+		// Create a post that contains BOTH a paragraph block AND a Latest Posts block.
+		// This matches the scenario where recursion prevention and block parsing should work.
 		// The post will be picked up by the Latest Posts query since it's the most recent.
 		self::factory()->post->create_and_get(
 			array(
-				'post_title'   => 'Post with gallery and Latest Posts block',
-				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,
+				'post_title'   => 'Post with paragraph and Latest Posts block',
+				'post_content' => $paragraph_block . "\n\n" . $latest_posts_block,
 				'post_status'  => 'publish',
 				'post_date'    => gmdate( 'Y-m-d H:i:s' ), // Make it the most recent post
 			)
@@ -235,16 +290,16 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Verify the post title is in the output.
 		$this->assertStringContainsString(
-			'Post with gallery and Latest Posts block',
+			'Post with paragraph and Latest Posts block',
 			$output,
 			'The post containing a Latest Posts block should be displayed'
 		);
 
-		// Verify that the gallery block was parsed correctly (from do_blocks call).
+		// Verify that the paragraph block was parsed correctly (from do_blocks call).
 		$this->assertStringContainsString(
-			'wp-block-gallery',
+			'wp-block-paragraph',
 			$output,
-			'Gallery block should be parsed and rendered'
+			'Paragraph block should be parsed and rendered'
 		);
 
 		// Verify that recursion protection works correctly.
@@ -315,27 +370,15 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
-		// Create a post with a gallery block in its content.
-		// Note: Gallery is used as an example, but this issue affects ALL blocks.
-		$gallery_block_content = sprintf(
-			'<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
-<!-- /wp:image -->
+		// Create a post with block content that we know renders server-side.
+		// Use paragraph blocks as they have reliable server-side rendering.
+		$block_content = '<!-- wp:paragraph --><p>This is a test paragraph that should be rendered with block classes.</p><!-- /wp:paragraph -->';
 
-<!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
-<!-- /wp:image --></figure>
-<!-- /wp:gallery -->',
-			$attachment_id_1,
-			$attachment_id_2
-		);
-
-		// Create a post with gallery block content for the Latest Posts block to display.
+		// Create a post with block content for the Latest Posts block to display.
 		self::factory()->post->create_and_get(
 			array(
-				'post_title'   => 'Post with gallery block',
-				'post_content' => $gallery_block_content,
+				'post_title'   => 'Post with paragraph block',
+				'post_content' => $block_content,
 				'post_status'  => 'publish',
 			)
 		);
@@ -362,28 +405,28 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Verify that blocks are parsed: block markup comments should be removed.
 		$this->assertStringNotContainsString(
-			'<!-- wp:gallery -->',
+			'<!-- wp:paragraph -->',
 			$output,
 			'Block markup comments should be removed when blocks are parsed'
 		);
 		$this->assertStringNotContainsString(
-			'<!-- /wp:gallery -->',
+			'<!-- /wp:paragraph -->',
 			$output,
 			'Block markup comments should be removed when blocks are parsed'
 		);
 
 		// Verify that parsed blocks have proper block structure and classes.
 		$this->assertStringContainsString(
-			'wp-block-gallery',
+			'wp-block-paragraph',
 			$output,
-			'Parsed gallery blocks should have proper block classes'
+			'Parsed paragraph blocks should have proper block classes'
 		);
 
-		// Verify that gallery images have proper block classes when parsed.
+		// Verify that the actual content is present.
 		$this->assertStringContainsString(
-			'wp-block-image',
+			'This is a test paragraph',
 			$output,
-			'Gallery images should have proper block classes when blocks are parsed'
+			'Block content should be rendered'
 		);
 	}
 }

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -11,7 +11,7 @@
  *
  * @group blocks
  */
-class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
+class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	/**
 	 * @var array
 	 */
@@ -157,6 +157,102 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'is-grid', $markup );
 		$this->assertStringContainsString( 'columns-5', $markup );
 		$this->assertStringNotContainsString( 'has-native-responsive-grid', $markup );
+	}
+
+	/**
+	 * Tests that recursion is prevented when a Latest Posts block displays itself.
+	 *
+	 * When a Latest Posts block is added to a post and that post is then displayed
+	 * by another Latest Posts block with "Show full post" enabled, infinite recursion
+	 * could occur. This test verifies that the recursion protection prevents memory
+	 * exhaustion by skipping the nested rendering of the same post.
+	 *
+	 * This reproduces the scenario reported in PR #74866 where adding a Latest Posts
+	 * block to a post (with gallery blocks) caused memory exhaustion when that post
+	 * was displayed by the Latest Posts block.
+	 *
+	 * @covers ::gutenberg_render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_prevents_recursion() {
+		// Create attachment IDs for gallery block (matching the test scenario).
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		// Create a gallery block (as was being tested when the recursion was discovered).
+		$gallery_block = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		// Create a Latest Posts block markup (showing 5 posts with full content).
+		$latest_posts_block = '<!-- wp:latest-posts {"postsToShow":5,"displayPostContent":true,"displayPostContentRadio":"full_post"} /-->';
+
+		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
+		// This matches the exact scenario where the recursion issue was discovered.
+		$post_with_block = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Post with gallery and Latest Posts block',
+				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,
+				'post_status'  => 'publish',
+				'post_date'    => gmdate( 'Y-m-d H:i:s' ), // Make it the most recent post
+			)
+		);
+
+		// Render a Latest Posts block that will display the post containing the Latest Posts block.
+		// This creates a potential infinite loop: Latest Posts displays a post that contains
+		// a Latest Posts block, which would try to display posts including itself.
+		$attributes = array(
+			'postsToShow'             => 5,
+			'orderBy'                 => 'date',
+			'order'                   => 'DESC',
+			'excerptLength'           => 55,
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
+			'displayPostContentRadio' => 'full_post',
+		);
+
+		// This should not cause a fatal error or memory exhaustion.
+		// The recursion protection should prevent infinite loops.
+		$output = gutenberg_render_block_core_latest_posts( $attributes );
+
+		// Verify the output contains the wrapper for the outer Latest Posts block.
+		$this->assertStringContainsString(
+			'wp-block-latest-posts__list',
+			$output,
+			'The outer Latest Posts block should render'
+		);
+
+		// Verify the post title is in the output.
+		$this->assertStringContainsString(
+			'Post with gallery and Latest Posts block',
+			$output,
+			'The post containing a Latest Posts block should be displayed'
+		);
+
+		// Verify that the gallery block was parsed correctly (from do_blocks call).
+		$this->assertStringContainsString(
+			'wp-block-gallery',
+			$output,
+			'Gallery block should be parsed and rendered'
+		);
+
+		// The most important assertion: this test completing means no infinite recursion
+		// or memory exhaustion occurred, proving the recursion protection works.
+		// The nested Latest Posts block content should be empty due to recursion protection.
+		$this->assertTrue(
+			true,
+			'Test completed without memory exhaustion, recursion protection works'
+		);
 	}
 
 	/**

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -199,7 +199,8 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
 		// This matches the exact scenario where the recursion issue was discovered.
-		$post_with_block = self::factory()->post->create_and_get(
+		// The post will be picked up by the Latest Posts query since it's the most recent.
+		self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Post with gallery and Latest Posts block',
 				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -178,7 +178,7 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
 		// Create attachment IDs for gallery block (used as example block type).
-		$file = DIR_TESTDATA . '/images/canola.jpg';
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
@@ -198,6 +198,7 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 			$attachment_id_2
 		);
 
+		// Create a post with gallery block content for the Latest Posts block to display.
 		self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Post with gallery block',
@@ -208,12 +209,12 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 
 		// Render Latest Posts block with "Show full post" enabled.
 		$attributes = array(
-			'postsToShow'            => 1,
-			'orderBy'                => 'date',
-			'order'                  => 'DESC',
-			'excerptLength'          => 55,
-			'displayFeaturedImage'   => false,
-			'displayPostContent'     => true,
+			'postsToShow'             => 1,
+			'orderBy'                 => 'date',
+			'order'                   => 'DESC',
+			'excerptLength'           => 55,
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
 			'displayPostContentRadio' => 'full_post',
 		);
 

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Last post block rendering tests.
+ * Latest Posts block rendering tests.
  *
  * @package WordPress
  * @subpackage Blocks
  */
 
 /**
- * Tests for the Last post block.
+ * Tests for the Latest Posts block.
  *
  * @group blocks
  */
@@ -157,5 +157,94 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'is-grid', $markup );
 		$this->assertStringContainsString( 'columns-5', $markup );
 		$this->assertStringNotContainsString( 'has-native-responsive-grid', $markup );
+	}
+
+	/**
+	 * Tests that blocks are parsed when "Show full post" is enabled.
+	 *
+	 * When the Latest Posts block displays full post content, blocks
+	 * within that content should be parsed and rendered properly using
+	 * do_blocks(). This ensures:
+	 * - Videos are constrained to their container width
+	 * - Gallery blocks display images side by side correctly
+	 * - Block styles are applied
+	 * - Block attributes are respected
+	 *
+	 * @covers ::gutenberg_render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
+		// Create attachment IDs for gallery block.
+		$file = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		// Create a post with a gallery block in its content.
+		$gallery_block_content = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Post with gallery block',
+				'post_content' => $gallery_block_content,
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Render Latest Posts block with "Show full post" enabled.
+		$attributes = array(
+			'postsToShow'            => 1,
+			'orderBy'                => 'date',
+			'order'                  => 'DESC',
+			'excerptLength'          => 55,
+			'displayFeaturedImage'   => false,
+			'displayPostContent'     => true,
+			'displayPostContentRadio' => 'full_post',
+		);
+
+		$output = gutenberg_render_block_core_latest_posts( $attributes );
+
+		// Verify that the post content is included in the output.
+		$this->assertStringContainsString(
+			'wp-block-latest-posts__post-full-content',
+			$output,
+			'Post full content wrapper should be present'
+		);
+
+		// Verify that blocks are parsed: block markup comments should be removed.
+		$this->assertStringNotContainsString(
+			'<!-- wp:gallery -->',
+			$output,
+			'Block markup comments should be removed when blocks are parsed'
+		);
+		$this->assertStringNotContainsString(
+			'<!-- /wp:gallery -->',
+			$output,
+			'Block markup comments should be removed when blocks are parsed'
+		);
+
+		// Verify that parsed blocks have proper block structure and classes.
+		$this->assertStringContainsString(
+			'wp-block-gallery',
+			$output,
+			'Parsed gallery blocks should have proper block classes'
+		);
+
+		// Verify that gallery images have proper block classes when parsed.
+		$this->assertStringContainsString(
+			'wp-block-image',
+			$output,
+			'Gallery images should have proper block classes when blocks are parsed'
+		);
 	}
 }

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -84,7 +84,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		gutenberg_render_block_core_latest_posts( $attributes );
+		render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertSameSets( self::$attachment_ids, $last_args[1] );
@@ -106,7 +106,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		gutenberg_render_block_core_latest_posts( $attributes );
+		render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );
@@ -171,7 +171,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * block to a post (with gallery blocks) caused memory exhaustion when that post
 	 * was displayed by the Latest Posts block.
 	 *
-	 * @covers ::gutenberg_render_block_core_latest_posts
+	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_prevents_recursion() {
 		// Create attachment IDs for gallery block (matching the test scenario).
@@ -224,7 +224,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// This should not cause a fatal error or memory exhaustion.
 		// The recursion protection should prevent infinite loops.
-		$output = gutenberg_render_block_core_latest_posts( $attributes );
+		$output = render_block_core_latest_posts( $attributes );
 
 		// Verify the output contains the wrapper for the outer Latest Posts block.
 		$this->assertStringContainsString(
@@ -307,7 +307,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * This test uses a gallery block as an example, but the issue affects
 	 * all block types. See #61477 and #69517.
 	 *
-	 * @covers ::gutenberg_render_block_core_latest_posts
+	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
 		// Create attachment IDs for gallery block (used as example block type).
@@ -351,7 +351,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		$output = gutenberg_render_block_core_latest_posts( $attributes );
+		$output = render_block_core_latest_posts( $attributes );
 
 		// Verify that the post content is included in the output.
 		$this->assertStringContainsString(

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -41,7 +41,11 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$file = DIR_TESTDATA . '/images/canola.jpg';
 
 		for ( $i = 0; $i < 5; $i++ ) {
-			self::$posts[ $i ]          = $factory->post->create_and_get();
+			self::$posts[ $i ]          = $factory->post->create_and_get(
+				array(
+					'post_date' => gmdate( 'Y-m-d H:i:s', time() - ( 5 - $i ) ),
+				)
+			);
 			self::$attachment_ids[ $i ] = $factory->attachment->create_upload_object( $file, self::$posts[ $i ]->ID );
 			set_post_thumbnail( self::$posts[ $i ], self::$attachment_ids[ $i ] );
 		}
@@ -149,7 +153,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		render_block_core_latest_posts( $attributes );
+		gutenberg_render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertSameSets( self::$attachment_ids, $last_args[1] );
@@ -171,7 +175,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		render_block_core_latest_posts( $attributes );
+		gutenberg_render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -162,23 +162,28 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 	/**
 	 * Tests that blocks are parsed when "Show full post" is enabled.
 	 *
-	 * When the Latest Posts block displays full post content, blocks
+	 * When the Latest Posts block displays full post content, ALL blocks
 	 * within that content should be parsed and rendered properly using
-	 * do_blocks(). This ensures:
+	 * do_blocks(). This applies to any block type (video, gallery, paragraph,
+	 * etc.), not just specific blocks. This ensures:
 	 * - Videos are constrained to their container width
 	 * - Gallery blocks display images side by side correctly
 	 * - Block styles are applied
 	 * - Block attributes are respected
 	 *
+	 * This test uses a gallery block as an example, but the issue affects
+	 * all block types. See #61477 and #69517.
+	 *
 	 * @covers ::gutenberg_render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
-		// Create attachment IDs for gallery block.
+		// Create attachment IDs for gallery block (used as example block type).
 		$file = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
 		// Create a post with a gallery block in its content.
+		// Note: Gallery is used as an example, but this issue affects ALL blocks.
 		$gallery_block_content = sprintf(
 			'<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -246,12 +246,48 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'Gallery block should be parsed and rendered'
 		);
 
-		// The most important assertion: this test completing means no infinite recursion
-		// or memory exhaustion occurred, proving the recursion protection works.
-		// The nested Latest Posts block content should be empty due to recursion protection.
+		// Verify that recursion protection works correctly.
+		// The nested Latest Posts block will render its wrapper, but the recursive post's content
+		// should be empty. We verify this by checking that the post content div for the recursive
+		// post is present but empty (or contains only the nested block wrapper without nested content).
+
+		// The key assertion: no infinite recursion occurred (test completes without memory exhaustion).
+		// Additionally, verify that the nested Latest Posts block was parsed (not raw markup).
+		// The block markup comment should not appear in the output since do_blocks() parses it.
+		$this->assertStringNotContainsString(
+			'<!-- wp:latest-posts',
+			$output,
+			'Nested Latest Posts block markup should be parsed by do_blocks(), not present as raw markup'
+		);
+
+		// Verify that the recursive post's full content div exists but the nested block's
+		// recursive post content is empty (prevented by recursion protection).
+		// Extract the post content for the post containing the Latest Posts block.
+		$post_content_pattern = '/<div class="wp-block-latest-posts__post-full-content">(.*?)<\/div>/s';
+		preg_match_all( $post_content_pattern, $output, $matches );
+
+		// Find the post content div that contains the nested Latest Posts block.
+		// The nested block will render its wrapper, but when it tries to render the recursive post,
+		// that post's content will be empty due to recursion protection.
+		$found_nested_block = false;
+		foreach ( $matches[1] as $content ) {
+			if ( strpos( $content, 'wp-block-latest-posts__list' ) !== false ) {
+				$found_nested_block = true;
+				// The nested block's list should exist, but verify recursion protection worked
+				// by checking that we don't have infinite nesting (more than 2 levels).
+				$nested_list_count = substr_count( $content, 'wp-block-latest-posts__list' );
+				$this->assertLessThanOrEqual(
+					1,
+					$nested_list_count,
+					'Nested Latest Posts block should not contain further nested blocks (recursion protection prevents infinite nesting)'
+				);
+				break;
+			}
+		}
+
 		$this->assertTrue(
-			true,
-			'Test completed without memory exhaustion, recursion protection works'
+			$found_nested_block,
+			'Nested Latest Posts block should be rendered (parsed by do_blocks())'
 		);
 	}
 

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -153,7 +153,8 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
 		// This matches the exact scenario where the recursion issue was discovered.
-		$post_with_block = self::factory()->post->create_and_get(
+		// The post will be picked up by the Latest Posts query since it's the most recent.
+		self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Post with gallery and Latest Posts block',
 				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -132,7 +132,7 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
 		// Create attachment IDs for gallery block (used as example block type).
-		$file = DIR_TESTDATA . '/images/canola.jpg';
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
@@ -152,7 +152,8 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 			$attachment_id_2
 		);
 
-		$post_with_gallery = self::factory()->post->create_and_get(
+		// Create a post with gallery block content for the Latest Posts block to display.
+		self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Post with gallery block',
 				'post_content' => $gallery_block_content,
@@ -162,12 +163,12 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 
 		// Render Latest Posts block with "Show full post" enabled.
 		$attributes = array(
-			'postsToShow'            => 1,
-			'orderBy'                => 'date',
-			'order'                  => 'DESC',
-			'excerptLength'          => 55,
-			'displayFeaturedImage'   => false,
-			'displayPostContent'     => true,
+			'postsToShow'             => 1,
+			'orderBy'                 => 'date',
+			'order'                   => 'DESC',
+			'excerptLength'           => 55,
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
 			'displayPostContentRadio' => 'full_post',
 		);
 

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -200,12 +200,48 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'Gallery block should be parsed and rendered'
 		);
 
-		// The most important assertion: this test completing means no infinite recursion
-		// or memory exhaustion occurred, proving the recursion protection works.
-		// The nested Latest Posts block content should be empty due to recursion protection.
+		// Verify that recursion protection works correctly.
+		// The nested Latest Posts block will render its wrapper, but the recursive post's content
+		// should be empty. We verify this by checking that the post content div for the recursive
+		// post is present but empty (or contains only the nested block wrapper without nested content).
+
+		// The key assertion: no infinite recursion occurred (test completes without memory exhaustion).
+		// Additionally, verify that the nested Latest Posts block was parsed (not raw markup).
+		// The block markup comment should not appear in the output since do_blocks() parses it.
+		$this->assertStringNotContainsString(
+			'<!-- wp:latest-posts',
+			$output,
+			'Nested Latest Posts block markup should be parsed by do_blocks(), not present as raw markup'
+		);
+
+		// Verify that the recursive post's full content div exists but the nested block's
+		// recursive post content is empty (prevented by recursion protection).
+		// Extract the post content for the post containing the Latest Posts block.
+		$post_content_pattern = '/<div class="wp-block-latest-posts__post-full-content">(.*?)<\/div>/s';
+		preg_match_all( $post_content_pattern, $output, $matches );
+
+		// Find the post content div that contains the nested Latest Posts block.
+		// The nested block will render its wrapper, but when it tries to render the recursive post,
+		// that post's content will be empty due to recursion protection.
+		$found_nested_block = false;
+		foreach ( $matches[1] as $content ) {
+			if ( strpos( $content, 'wp-block-latest-posts__list' ) !== false ) {
+				$found_nested_block = true;
+				// The nested block's list should exist, but verify recursion protection worked
+				// by checking that we don't have infinite nesting (more than 2 levels).
+				$nested_list_count = substr_count( $content, 'wp-block-latest-posts__list' );
+				$this->assertLessThanOrEqual(
+					1,
+					$nested_list_count,
+					'Nested Latest Posts block should not contain further nested blocks (recursion protection prevents infinite nesting)'
+				);
+				break;
+			}
+		}
+
 		$this->assertTrue(
-			true,
-			'Test completed without memory exhaustion, recursion protection works'
+			$found_nested_block,
+			'Nested Latest Posts block should be rendered (parsed by do_blocks())'
 		);
 	}
 

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -11,7 +11,7 @@
  *
  * @group blocks
  */
-class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
+class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	/**
 	 * @var array
 	 */
@@ -111,6 +111,102 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$last_args = end( $args );
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );
 		$this->assertNotContains( self::$sticky_post->ID, $last_args[1], 'Ensure that sticky post is not in array of post ids that are primed' );
+	}
+
+	/**
+	 * Tests that recursion is prevented when a Latest Posts block displays itself.
+	 *
+	 * When a Latest Posts block is added to a post and that post is then displayed
+	 * by another Latest Posts block with "Show full post" enabled, infinite recursion
+	 * could occur. This test verifies that the recursion protection prevents memory
+	 * exhaustion by skipping the nested rendering of the same post.
+	 *
+	 * This reproduces the scenario reported in PR #74866 where adding a Latest Posts
+	 * block to a post (with gallery blocks) caused memory exhaustion when that post
+	 * was displayed by the Latest Posts block.
+	 *
+	 * @covers ::gutenberg_render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_prevents_recursion() {
+		// Create attachment IDs for gallery block (matching the test scenario).
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		// Create a gallery block (as was being tested when the recursion was discovered).
+		$gallery_block = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		// Create a Latest Posts block markup (showing 5 posts with full content).
+		$latest_posts_block = '<!-- wp:latest-posts {"postsToShow":5,"displayPostContent":true,"displayPostContentRadio":"full_post"} /-->';
+
+		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
+		// This matches the exact scenario where the recursion issue was discovered.
+		$post_with_block = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Post with gallery and Latest Posts block',
+				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,
+				'post_status'  => 'publish',
+				'post_date'    => gmdate( 'Y-m-d H:i:s' ), // Make it the most recent post
+			)
+		);
+
+		// Render a Latest Posts block that will display the post containing the Latest Posts block.
+		// This creates a potential infinite loop: Latest Posts displays a post that contains
+		// a Latest Posts block, which would try to display posts including itself.
+		$attributes = array(
+			'postsToShow'             => 5,
+			'orderBy'                 => 'date',
+			'order'                   => 'DESC',
+			'excerptLength'           => 55,
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
+			'displayPostContentRadio' => 'full_post',
+		);
+
+		// This should not cause a fatal error or memory exhaustion.
+		// The recursion protection should prevent infinite loops.
+		$output = gutenberg_render_block_core_latest_posts( $attributes );
+
+		// Verify the output contains the wrapper for the outer Latest Posts block.
+		$this->assertStringContainsString(
+			'wp-block-latest-posts__list',
+			$output,
+			'The outer Latest Posts block should render'
+		);
+
+		// Verify the post title is in the output.
+		$this->assertStringContainsString(
+			'Post with gallery and Latest Posts block',
+			$output,
+			'The post containing a Latest Posts block should be displayed'
+		);
+
+		// Verify that the gallery block was parsed correctly (from do_blocks call).
+		$this->assertStringContainsString(
+			'wp-block-gallery',
+			$output,
+			'Gallery block should be parsed and rendered'
+		);
+
+		// The most important assertion: this test completing means no infinite recursion
+		// or memory exhaustion occurred, proving the recursion protection works.
+		// The nested Latest Posts block content should be empty due to recursion protection.
+		$this->assertTrue(
+			true,
+			'Test completed without memory exhaustion, recursion protection works'
+		);
 	}
 
 	/**

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Last post block rendering tests.
+ * Latest Posts block rendering tests.
  *
  * @package WordPress
  * @subpackage Blocks
  */
 
 /**
- * Tests for the Last post block.
+ * Tests for the Latest Posts block.
  *
  * @group blocks
  */
@@ -111,5 +111,94 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$last_args = end( $args );
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );
 		$this->assertNotContains( self::$sticky_post->ID, $last_args[1], 'Ensure that sticky post is not in array of post ids that are primed' );
+	}
+
+	/**
+	 * Tests that blocks are parsed when "Show full post" is enabled.
+	 *
+	 * When the Latest Posts block displays full post content, blocks
+	 * within that content should be parsed and rendered properly using
+	 * do_blocks(). This ensures:
+	 * - Videos are constrained to their container width
+	 * - Gallery blocks display images side by side correctly
+	 * - Block styles are applied
+	 * - Block attributes are respected
+	 *
+	 * @covers ::gutenberg_render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
+		// Create attachment IDs for gallery block.
+		$file = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		// Create a post with a gallery block in its content.
+		$gallery_block_content = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":%d} -->
+<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		$post_with_gallery = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Post with gallery block',
+				'post_content' => $gallery_block_content,
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Render Latest Posts block with "Show full post" enabled.
+		$attributes = array(
+			'postsToShow'            => 1,
+			'orderBy'                => 'date',
+			'order'                  => 'DESC',
+			'excerptLength'          => 55,
+			'displayFeaturedImage'   => false,
+			'displayPostContent'     => true,
+			'displayPostContentRadio' => 'full_post',
+		);
+
+		$output = gutenberg_render_block_core_latest_posts( $attributes );
+
+		// Verify that the post content is included in the output.
+		$this->assertStringContainsString(
+			'wp-block-latest-posts__post-full-content',
+			$output,
+			'Post full content wrapper should be present'
+		);
+
+		// Verify that blocks are parsed: block markup comments should be removed.
+		$this->assertStringNotContainsString(
+			'<!-- wp:gallery -->',
+			$output,
+			'Block markup comments should be removed when blocks are parsed'
+		);
+		$this->assertStringNotContainsString(
+			'<!-- /wp:gallery -->',
+			$output,
+			'Block markup comments should be removed when blocks are parsed'
+		);
+
+		// Verify that parsed blocks have proper block structure and classes.
+		$this->assertStringContainsString(
+			'wp-block-gallery',
+			$output,
+			'Parsed gallery blocks should have proper block classes'
+		);
+
+		// Verify that gallery images have proper block classes when parsed.
+		$this->assertStringContainsString(
+			'wp-block-image',
+			$output,
+			'Gallery images should have proper block classes when blocks are parsed'
+		);
 	}
 }

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -116,23 +116,28 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 	/**
 	 * Tests that blocks are parsed when "Show full post" is enabled.
 	 *
-	 * When the Latest Posts block displays full post content, blocks
+	 * When the Latest Posts block displays full post content, ALL blocks
 	 * within that content should be parsed and rendered properly using
-	 * do_blocks(). This ensures:
+	 * do_blocks(). This applies to any block type (video, gallery, paragraph,
+	 * etc.), not just specific blocks. This ensures:
 	 * - Videos are constrained to their container width
 	 * - Gallery blocks display images side by side correctly
 	 * - Block styles are applied
 	 * - Block attributes are respected
 	 *
+	 * This test uses a gallery block as an example, but the issue affects
+	 * all block types. See #61477 and #69517.
+	 *
 	 * @covers ::gutenberg_render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
-		// Create attachment IDs for gallery block.
+		// Create attachment IDs for gallery block (used as example block type).
 		$file = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
 		// Create a post with a gallery block in its content.
+		// Note: Gallery is used as an example, but this issue affects ALL blocks.
 		$gallery_block_content = sprintf(
 			'<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -338,6 +338,86 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that nested Latest Posts blocks restore the outer post context.
+	 *
+	 * @covers ::render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_restores_outer_context_after_nested_render() {
+		$block_name = 'test/current-post-title';
+
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( $block_name ) ) {
+			unregister_block_type( $block_name );
+		}
+
+		register_block_type(
+			$block_name,
+			array(
+				'render_callback' => static function () {
+					return sprintf(
+						'<span class="latest-posts-current-title">%s</span>',
+						esc_html( get_the_title() )
+					);
+				},
+			)
+		);
+
+		try {
+			$main_post = self::factory()->post->create_and_get(
+				array(
+					'post_title'  => 'Main query post',
+					'post_status' => 'publish',
+				)
+			);
+			$this->go_to( get_permalink( $main_post ) );
+
+			$category_id      = self::factory()->category->create();
+			$latest_posts_att = array(
+				'postsToShow'             => 1,
+				'orderBy'                 => 'date',
+				'order'                   => 'DESC',
+				'excerptLength'           => 55,
+				'displayFeaturedImage'    => false,
+				'displayPostContent'      => true,
+				'displayPostContentRadio' => 'full_post',
+				'categories'              => array(
+					array(
+						'id' => $category_id,
+					),
+				),
+			);
+
+			$nested_latest_posts_block = sprintf(
+				'<!-- wp:latest-posts %s /-->',
+				wp_json_encode( $latest_posts_att )
+			);
+
+			self::factory()->post->create_and_get(
+				array(
+					'post_title'    => 'Outer latest posts item',
+					'post_content'  => $nested_latest_posts_block . "\n\n<!-- wp:test/current-post-title /-->",
+					'post_status'   => 'publish',
+					'post_category' => array( $category_id ),
+				)
+			);
+
+			$output = gutenberg_render_block_core_latest_posts( $latest_posts_att );
+
+			$this->assertStringContainsString(
+				'<span class="latest-posts-current-title">Outer latest posts item</span>',
+				$output,
+				'Blocks rendered after a nested Latest Posts block should use the outer post context.'
+			);
+			$this->assertStringNotContainsString(
+				'<span class="latest-posts-current-title">Main query post</span>',
+				$output,
+				'Nested Latest Posts blocks should not reset later sibling blocks to the main query context.'
+			);
+		} finally {
+			unregister_block_type( $block_name );
+		}
+	}
+
+	/**
 	 * Tests that blocks are parsed when "Show full post" is enabled.
 	 *
 	 * When the Latest Posts block displays full post content, ALL blocks

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -55,6 +55,11 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		foreach ( self::$attachment_ids as $attachment_id ) {
 			wp_delete_post( $attachment_id, true );
 		}
+		foreach ( self::$posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+		unstick_post( self::$sticky_post->ID );
+		wp_delete_post( self::$sticky_post->ID, true );
 	}
 
 	public function set_up() {
@@ -307,13 +312,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'Paragraph block should be parsed and rendered'
 		);
 
-		// Verify that recursion protection works correctly.
-		// The nested Latest Posts block will render its wrapper, but the recursive post's content
-		// should be empty. We verify this by checking that the post content div for the recursive
-		// post is present but empty (or contains only the nested block wrapper without nested content).
-
-		// The key assertion: no infinite recursion occurred (test completes without memory exhaustion).
-		// Additionally, verify that the nested Latest Posts block was parsed (not raw markup).
+		// Verify that the nested Latest Posts block was parsed (not raw markup).
 		// The block markup comment should not appear in the output since do_blocks() parses it.
 		$this->assertStringNotContainsString(
 			'<!-- wp:latest-posts',
@@ -321,34 +320,20 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'Nested Latest Posts block markup should be parsed by do_blocks(), not present as raw markup'
 		);
 
-		// Verify that the recursive post's full content div exists but the nested block's
-		// recursive post content is empty (prevented by recursion protection).
-		// Extract the post content for the post containing the Latest Posts block.
-		$post_content_pattern = '/<div class="wp-block-latest-posts__post-full-content">(.*?)<\/div>/s';
-		preg_match_all( $post_content_pattern, $output, $matches );
-
-		// Find the post content div that contains the nested Latest Posts block.
-		// The nested block will render its wrapper, but when it tries to render the recursive post,
-		// that post's content will be empty due to recursion protection.
-		$found_nested_block = false;
-		foreach ( $matches[1] as $content ) {
-			if ( strpos( $content, 'wp-block-latest-posts__list' ) !== false ) {
-				$found_nested_block = true;
-				// The nested block's list should exist, but verify recursion protection worked
-				// by checking that we don't have infinite nesting (more than 2 levels).
-				$nested_list_count = substr_count( $content, 'wp-block-latest-posts__list' );
-				$this->assertLessThanOrEqual(
-					1,
-					$nested_list_count,
-					'Nested Latest Posts block should not contain further nested blocks (recursion protection prevents infinite nesting)'
-				);
-				break;
-			}
-		}
-
-		$this->assertTrue(
-			$found_nested_block,
-			'Nested Latest Posts block should be rendered (parsed by do_blocks())'
+		// Verify recursion protection: the nested block renders once (producing a second
+		// wp-block-latest-posts__list wrapper) but does not trigger further recursive rendering.
+		// Counting occurrences of the list class is robust to changes in inner HTML structure.
+		// Infinite recursion would produce far more than 3 occurrences.
+		$list_count = substr_count( $output, 'wp-block-latest-posts__list' );
+		$this->assertGreaterThanOrEqual(
+			2,
+			$list_count,
+			'Output should contain at least 2 list wrappers: the outer block and the nested block'
+		);
+		$this->assertLessThanOrEqual(
+			3,
+			$list_count,
+			'Recursion protection should prevent more than one level of nesting'
 		);
 	}
 

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -84,7 +84,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		gutenberg_render_block_core_latest_posts( $attributes );
+		render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertSameSets( self::$attachment_ids, $last_args[1] );
@@ -106,7 +106,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'addLinkToFeaturedImage' => false,
 		);
 
-		gutenberg_render_block_core_latest_posts( $attributes );
+		render_block_core_latest_posts( $attributes );
 		$args      = $action->get_args();
 		$last_args = end( $args );
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );
@@ -125,7 +125,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * block to a post (with gallery blocks) caused memory exhaustion when that post
 	 * was displayed by the Latest Posts block.
 	 *
-	 * @covers ::gutenberg_render_block_core_latest_posts
+	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_prevents_recursion() {
 		// Create attachment IDs for gallery block (matching the test scenario).
@@ -178,7 +178,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// This should not cause a fatal error or memory exhaustion.
 		// The recursion protection should prevent infinite loops.
-		$output = gutenberg_render_block_core_latest_posts( $attributes );
+		$output = render_block_core_latest_posts( $attributes );
 
 		// Verify the output contains the wrapper for the outer Latest Posts block.
 		$this->assertStringContainsString(
@@ -261,7 +261,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * This test uses a gallery block as an example, but the issue affects
 	 * all block types. See #61477 and #69517.
 	 *
-	 * @covers ::gutenberg_render_block_core_latest_posts
+	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
 		// Create attachment IDs for gallery block (used as example block type).
@@ -305,7 +305,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		$output = gutenberg_render_block_core_latest_posts( $attributes );
+		$output = render_block_core_latest_posts( $attributes );
 
 		// Verify that the post content is included in the output.
 		$this->assertStringContainsString(

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -69,6 +69,73 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that _gutenberg_apply_content_filters() works.
+	 *
+	 * @covers ::_gutenberg_apply_content_filters
+	 */
+	public function test_gutenberg_apply_content_filters_works() {
+		// Check if the function exists.
+		$this->assertTrue( function_exists( '_gutenberg_apply_content_filters' ), '_gutenberg_apply_content_filters function should exist' );
+
+		// Test with paragraph block.
+		$content = '<!-- wp:paragraph --><p>Test paragraph</p><!-- /wp:paragraph -->';
+		$output  = _gutenberg_apply_content_filters( $content, 'test-context' );
+
+		// Block comments should be removed.
+		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $output, 'Block comments should be removed' );
+		// Block should be rendered with class.
+		$this->assertStringContainsString( 'wp-block-paragraph', $output, 'Block should have wp-block class' );
+	}
+
+	/**
+	 * Test that do_blocks() works in the test environment.
+	 *
+	 * @covers ::do_blocks
+	 */
+	public function test_do_blocks_works() {
+		// Test paragraph block.
+		$block_content = '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->';
+		$output        = do_blocks( $block_content );
+
+		// Block comments should be removed.
+		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $output, 'Block comments should be removed by do_blocks()' );
+		// Paragraph should be rendered with block class.
+		$this->assertStringContainsString( 'wp-block-paragraph', $output, 'Block should be rendered with classes' );
+		$this->assertStringContainsString( 'Test', $output, 'Block content should be present' );
+
+		// Test gallery block with actual attachment IDs.
+		// Create attachments for the test.
+		$file            = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
+		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
+
+		$gallery_content = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} -->
+<!-- wp:image {"id":%d} /-->
+<!-- wp:image {"id":%d} /-->
+<!-- /wp:gallery -->',
+			$attachment_id_1,
+			$attachment_id_2
+		);
+
+		// Apply the same filters that _gutenberg_apply_content_filters does.
+		$processed_content = shortcode_unautop( $gallery_content );
+		$processed_content = do_shortcode( $processed_content );
+		$gallery_output    = do_blocks( $processed_content );
+
+		// Check if gallery block is registered.
+		$registry      = WP_Block_Type_Registry::get_instance();
+		$gallery_block = $registry->get_registered( 'core/gallery' );
+		$image_block   = $registry->get_registered( 'core/image' );
+
+		$this->assertTrue( $registry->is_registered( 'core/gallery' ), 'Gallery block should be registered' );
+		$this->assertTrue( $registry->is_registered( 'core/image' ), 'Image block should be registered' );
+
+		// Check if block comments are removed.
+		$this->assertStringNotContainsString( '<!-- wp:gallery', $gallery_output, 'Gallery block comments should be removed' );
+	}
+
+	/**
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts() {
@@ -133,31 +200,19 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
-		// Create a gallery block (as was being tested when the recursion was discovered).
-		$gallery_block = sprintf(
-			'<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
-<!-- /wp:image --></figure>
-<!-- /wp:gallery -->',
-			$attachment_id_1,
-			$attachment_id_2
-		);
+		// Create a paragraph block for testing block parsing.
+		$paragraph_block = '<!-- wp:paragraph --><p>Test content in a paragraph block.</p><!-- /wp:paragraph -->';
 
 		// Create a Latest Posts block markup (showing 5 posts with full content).
 		$latest_posts_block = '<!-- wp:latest-posts {"postsToShow":5,"displayPostContent":true,"displayPostContentRadio":"full_post"} /-->';
 
-		// Create a post that contains BOTH a gallery block AND a Latest Posts block.
-		// This matches the exact scenario where the recursion issue was discovered.
+		// Create a post that contains BOTH a paragraph block AND a Latest Posts block.
+		// This matches the scenario where recursion prevention and block parsing should work.
 		// The post will be picked up by the Latest Posts query since it's the most recent.
 		self::factory()->post->create_and_get(
 			array(
-				'post_title'   => 'Post with gallery and Latest Posts block',
-				'post_content' => $gallery_block . "\n\n" . $latest_posts_block,
+				'post_title'   => 'Post with paragraph and Latest Posts block',
+				'post_content' => $paragraph_block . "\n\n" . $latest_posts_block,
 				'post_status'  => 'publish',
 				'post_date'    => gmdate( 'Y-m-d H:i:s' ), // Make it the most recent post
 			)
@@ -189,16 +244,16 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Verify the post title is in the output.
 		$this->assertStringContainsString(
-			'Post with gallery and Latest Posts block',
+			'Post with paragraph and Latest Posts block',
 			$output,
 			'The post containing a Latest Posts block should be displayed'
 		);
 
-		// Verify that the gallery block was parsed correctly (from do_blocks call).
+		// Verify that the paragraph block was parsed correctly (from do_blocks call).
 		$this->assertStringContainsString(
-			'wp-block-gallery',
+			'wp-block-paragraph',
 			$output,
-			'Gallery block should be parsed and rendered'
+			'Paragraph block should be parsed and rendered'
 		);
 
 		// Verify that recursion protection works correctly.
@@ -269,27 +324,15 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
 		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
 
-		// Create a post with a gallery block in its content.
-		// Note: Gallery is used as an example, but this issue affects ALL blocks.
-		$gallery_block_content = sprintf(
-			'<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test1.jpg" alt=""/></figure>
-<!-- /wp:image -->
+		// Create a post with block content that we know renders server-side.
+		// Use paragraph blocks as they have reliable server-side rendering.
+		$block_content = '<!-- wp:paragraph --><p>This is a test paragraph that should be rendered with block classes.</p><!-- /wp:paragraph -->';
 
-<!-- wp:image {"id":%d} -->
-<figure class="wp-block-image"><img src="test2.jpg" alt=""/></figure>
-<!-- /wp:image --></figure>
-<!-- /wp:gallery -->',
-			$attachment_id_1,
-			$attachment_id_2
-		);
-
-		// Create a post with gallery block content for the Latest Posts block to display.
+		// Create a post with block content for the Latest Posts block to display.
 		self::factory()->post->create_and_get(
 			array(
-				'post_title'   => 'Post with gallery block',
-				'post_content' => $gallery_block_content,
+				'post_title'   => 'Post with paragraph block',
+				'post_content' => $block_content,
 				'post_status'  => 'publish',
 			)
 		);
@@ -316,28 +359,28 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 
 		// Verify that blocks are parsed: block markup comments should be removed.
 		$this->assertStringNotContainsString(
-			'<!-- wp:gallery -->',
+			'<!-- wp:paragraph -->',
 			$output,
 			'Block markup comments should be removed when blocks are parsed'
 		);
 		$this->assertStringNotContainsString(
-			'<!-- /wp:gallery -->',
+			'<!-- /wp:paragraph -->',
 			$output,
 			'Block markup comments should be removed when blocks are parsed'
 		);
 
 		// Verify that parsed blocks have proper block structure and classes.
 		$this->assertStringContainsString(
-			'wp-block-gallery',
+			'wp-block-paragraph',
 			$output,
-			'Parsed gallery blocks should have proper block classes'
+			'Parsed paragraph blocks should have proper block classes'
 		);
 
-		// Verify that gallery images have proper block classes when parsed.
+		// Verify that the actual content is present.
 		$this->assertStringContainsString(
-			'wp-block-image',
+			'This is a test paragraph',
 			$output,
-			'Gallery images should have proper block classes when blocks are parsed'
+			'Block content should be rendered'
 		);
 	}
 }

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -124,9 +124,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 		$gallery_output    = do_blocks( $processed_content );
 
 		// Check if gallery block is registered.
-		$registry      = WP_Block_Type_Registry::get_instance();
-		$gallery_block = $registry->get_registered( 'core/gallery' );
-		$image_block   = $registry->get_registered( 'core/image' );
+		$registry = WP_Block_Type_Registry::get_instance();
 
 		$this->assertTrue( $registry->is_registered( 'core/gallery' ), 'Gallery block should be registered' );
 		$this->assertTrue( $registry->is_registered( 'core/image' ), 'Image block should be registered' );
@@ -195,11 +193,6 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_prevents_recursion() {
-		// Create attachment IDs for gallery block (matching the test scenario).
-		$file            = DIR_TESTDATA . '/images/canola.jpg';
-		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
-		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
-
 		// Create a paragraph block for testing block parsing.
 		$paragraph_block = '<!-- wp:paragraph --><p>Test content in a paragraph block.</p><!-- /wp:paragraph -->';
 
@@ -231,9 +224,17 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		// This should not cause a fatal error or memory exhaustion.
-		// The recursion protection should prevent infinite loops.
-		$output = render_block_core_latest_posts( $attributes );
+		// Render through the block pipeline so that the Gutenberg-registered
+		// callback (gutenberg_render_block_core_latest_posts) is used.
+		$output = render_block(
+			array(
+				'blockName'    => 'core/latest-posts',
+				'attrs'        => $attributes,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			)
+		);
 
 		// Verify the output contains the wrapper for the outer Latest Posts block.
 		$this->assertStringContainsString(
@@ -319,11 +320,6 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	 * @covers ::render_block_core_latest_posts
 	 */
 	public function test_render_block_core_latest_posts_full_content_blocks_parsed() {
-		// Create attachment IDs for gallery block (used as example block type).
-		$file            = DIR_TESTDATA . '/images/canola.jpg';
-		$attachment_id_1 = self::factory()->attachment->create_upload_object( $file );
-		$attachment_id_2 = self::factory()->attachment->create_upload_object( $file );
-
 		// Create a post with block content that we know renders server-side.
 		// Use paragraph blocks as they have reliable server-side rendering.
 		$block_content = '<!-- wp:paragraph --><p>This is a test paragraph that should be rendered with block classes.</p><!-- /wp:paragraph -->';
@@ -348,7 +344,17 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			'displayPostContentRadio' => 'full_post',
 		);
 
-		$output = render_block_core_latest_posts( $attributes );
+		// Render through the block pipeline so that the Gutenberg-registered
+		// callback (gutenberg_render_block_core_latest_posts) is used.
+		$output = render_block(
+			array(
+				'blockName'    => 'core/latest-posts',
+				'attrs'        => $attributes,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			)
+		);
 
 		// Verify that the post content is included in the output.
 		$this->assertStringContainsString(


### PR DESCRIPTION
## What?
Fixes #61477

## Why?
When "Show full post" is enabled in the Latest Posts block, blocks within the post content were not being parsed. This caused:
- Videos not being constrained to container width
- Gallery blocks not displaying images side by side  
- Block styles not being applied
- Block attributes not being respected

The root cause was that blocks were output as raw block markup without being parsed through WordPress's block system.

## How?
Added `do_blocks()` call to parse blocks before outputting them, ensuring blocks are properly rendered with their styles and attributes. This follows the same pattern used in other blocks:
- `packages/block-library/src/template-part/index.php` (line 156)
- `packages/block-library/src/pattern/index.php` (line 63)

**Note:** This builds on the investigation and initial fix attempt in [PR #69466](https://github.com/WordPress/gutenberg/pull/69466) by @sabbir1991, which identified the root cause and proposed using `the_content` filter. This PR uses a more direct approach with `do_blocks()` to match the pattern used in similar blocks.

Also includes a test file rename: `phpunit/blocks/render-last-posts-test.php` → `phpunit/blocks/render-latest-posts-test.php`. Git history verification confirmed the original filename was a naming mistake - the test file was created to test the "Latest Posts" block (as confirmed by the original commit message "Ensure that post thumbnail is cached in latest post block"), but was incorrectly named. The rename corrects this to match the actual block name.

## Testing Instructions

### Before the fix:
1. Create a new post and add a video block (or a cover block or media & text block with a video)
2. Add the Latest Posts block (in the same post, a new post or page, or in a template)
3. Enable "Post content > Show full post" in the block settings panel of the Latest Posts block
4. Save and view the front of the site
5. **Expected (broken behavior)**: The video expands outside the list item, covers/overlaps other content, and can create a horizontal scroll bar. The video shows at its original width (e.g., 3016px) instead of being constrained to the column width.

### After the fix:
1. Follow the same steps as above
2. **Expected (fixed behavior)**: The video is properly constrained to its container width, matches the editor preview, and does not overflow or create horizontal scroll bars.

### Additional testing:
- Test with grid layout using different column counts (e.g., 5 columns as mentioned in the issue)
- Test with default list view layout
- Test with other block types (gallery, cover, media & text) to verify all blocks are parsed correctly
- Verify that block styles and attributes are properly applied