### PR TITLE
Route: Add notFound to public API and add route validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55374,7 +55374,8 @@
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
-				"@wordpress/i18n": "file:../../packages/i18n"
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/route": "file:../../packages/route"
 			}
 		},
 		"routes/post-edit/node_modules/@wordpress/html-entities": {

--- a/packages/route/src/index.ts
+++ b/packages/route/src/index.ts
@@ -4,7 +4,9 @@
 import { useRouter } from '@tanstack/react-router';
 export {
 	Link,
+	notFound,
 	redirect,
+	useLinkProps,
 	useNavigate,
 	useParams,
 	useSearch,

--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -17,6 +17,7 @@ import {
 	useLocation,
 	useMatches,
 	useRouter,
+	useRouterState,
 } from '@tanstack/react-router';
 
 /**
@@ -50,6 +51,7 @@ lock( privateApis, {
 	useLocation,
 	useMatches,
 	useRouter,
+	useRouterState,
 
 	// History utilities
 	parseHref,

--- a/routes/navigation-edit/route.ts
+++ b/routes/navigation-edit/route.ts
@@ -5,10 +5,38 @@ import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { notFound } from '@wordpress/route';
 
 const NAVIGATION_POST_TYPE = 'wp_navigation';
 
 export const route = {
+	beforeLoad: async ( {
+		params,
+	}: {
+		params: {
+			id: string;
+		};
+	} ) => {
+		const navigationId = parseInt( params.id, 10 );
+
+		if ( Number.isNaN( navigationId ) ) {
+			throw notFound();
+		}
+
+		try {
+			const navigation = await resolveSelect( coreStore ).getEntityRecord(
+				'postType',
+				NAVIGATION_POST_TYPE,
+				navigationId
+			);
+
+			if ( ! navigation ) {
+				throw notFound();
+			}
+		} catch {
+			throw notFound();
+		}
+	},
 	title: async ( {
 		params,
 	}: {

--- a/routes/post-edit/package.json
+++ b/routes/post-edit/package.json
@@ -10,6 +10,7 @@
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
-		"@wordpress/i18n": "file:../../packages/i18n"
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/route": "file:../../packages/route"
 	}
 }

--- a/routes/post-edit/route.ts
+++ b/routes/post-edit/route.ts
@@ -5,11 +5,43 @@ import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { notFound } from '@wordpress/route';
 
 /**
  * Route configuration for post edit.
  */
 export const route = {
+	beforeLoad: async ( {
+		params,
+	}: {
+		params: {
+			type: string;
+			id: string;
+		};
+	} ) => {
+		const postId = parseInt( params.id, 10 );
+
+		if ( Number.isNaN( postId ) ) {
+			throw notFound();
+		}
+
+		try {
+			const [ postType, post ] = await Promise.all( [
+				resolveSelect( coreStore ).getPostType( params.type ),
+				resolveSelect( coreStore ).getEntityRecord(
+					'postType',
+					params.type,
+					postId
+				),
+			] );
+
+			if ( ! postType || ! post ) {
+				throw notFound();
+			}
+		} catch {
+			throw notFound();
+		}
+	},
 	title: async ( {
 		params,
 	}: {

--- a/routes/post-list/route.ts
+++ b/routes/post-list/route.ts
@@ -3,6 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { notFound } from '@wordpress/route';
 
 /**
  * Internal dependencies
@@ -13,6 +14,19 @@ import { ensureView, viewToQuery } from './view-utils';
  * Route configuration for post list.
  */
 export const route = {
+	beforeLoad: async ( { params }: { params: { type: string } } ) => {
+		try {
+			const postType = await resolveSelect( coreStore ).getPostType(
+				params.type
+			);
+
+			if ( ! postType ) {
+				throw notFound();
+			}
+		} catch {
+			throw notFound();
+		}
+	},
 	title: async ( { params }: { params: { type: string } } ) => {
 		const postType = await resolveSelect( coreStore ).getPostType(
 			params.type


### PR DESCRIPTION
Related #70862 

## Summary

This PR introduces `notFound` as a public export from `@wordpress/route` and adds validation to key routes to provide a better user experience when navigating to invalid or non-existent resources.

## What's new

- **Export `notFound`** from `@wordpress/route` package for use in route files
- **Add `beforeLoad` validation** to routes that validates:
  - IDs are valid numbers (prevents NaN errors)
  - Entities exist before attempting to load them
  - Post types are registered and valid

## Routes updated

- **`post-edit`**: Validates post type and post existence before loading editor
- **`navigation-edit`**: Validates navigation menu exists before loading
- **`post-list`**: Validates post type is registered before showing list

## Benefits

- **Early validation** catches invalid routes before expensive data fetching
- **Better UX**: Users see a proper "not found" page instead of broken states or errors
- **Consistent pattern**: Establishes a clear error handling pattern across routes
- **Performance**: Fails fast on invalid parameters, avoiding unnecessary API calls

## Test plan

- [ ] Navigate to `/types/post/edit/999999` (non-existent post) - should show not found page
- [ ] Navigate to `/types/invalid_type/list/all` (invalid post type) - should show not found page
- [ ] Navigate to `/navigation/edit/abc` (invalid ID format) - should show not found page
- [ ] Navigate to valid routes - should work normally

🤖 Generated with [Claude Code](https://claude.ai/code)