### PR TITLE
Added Missing Global Documentation extensible-site-editor file

### DIFF
--- a/lib/experimental/extensible-site-editor.php
+++ b/lib/experimental/extensible-site-editor.php
@@ -8,6 +8,8 @@
 /**
  * Redirect the Appearance > Design menu to the extensible site editor
  * when the experiment is enabled.
+ *
+ * @global array $submenu WordPress admin submenu array.
  */
 function gutenberg_redirect_to_extensible_site_editor() {
 	// Only proceed if the experiment is enabled.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?
- Added Missing `@global` documentation in `extensible-site-editor.php` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open extensible-site-editor.php.
2. See Missing `@global` Documentation
