### PR TITLE
Sync: Refactor ProviderCreator signature to an object

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -180,7 +180,7 @@ export function createSyncManager(): SyncManager {
 		// Create providers for the given entity and its Yjs document.
 		const providerResults = await Promise.all(
 			providerCreators.map( ( create ) =>
-				create( objectType, objectId, ydoc, awareness )
+				create( { objectType, objectId, ydoc, awareness } )
 			)
 		);
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -137,12 +137,12 @@ describe( 'SyncManager', () => {
 			);
 
 			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
-			expect( mockProviderCreator ).toHaveBeenCalledWith(
-				'postType/post',
-				'123',
-				expect.any( Y.Doc ),
-				expect.any( Awareness )
-			);
+			expect( mockProviderCreator ).toHaveBeenCalledWith( {
+				objectType: 'postType/post',
+				objectId: '123',
+				ydoc: expect.any( Y.Doc ),
+				awareness: expect.any( Awareness ),
+			} );
 		} );
 
 		it( 'does not load entity when no providers are available', async () => {
@@ -483,16 +483,10 @@ describe( 'SyncManager', () => {
 		it( 'updates CRDT document with local changes', async () => {
 			// Capture the Y.Doc from provider creator
 			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
 
 			const manager = createSyncManager();
 
@@ -536,16 +530,10 @@ describe( 'SyncManager', () => {
 		it( 'applies changes with specified origin', async () => {
 			// Capture the Y.Doc from provider creator
 			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
 
 			const manager = createSyncManager();
 
@@ -580,16 +568,10 @@ describe( 'SyncManager', () => {
 		it( 'updates the record metadata when the update is associated with a save', async () => {
 			// Capture the Y.Doc from provider creator.
 			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
 
 			const manager = createSyncManager();
 
@@ -628,16 +610,10 @@ describe( 'SyncManager', () => {
 		it( 'edits the local entity record when remote updates arrive', async () => {
 			// Capture the Y.Doc from provider creator.
 			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
 
 			const manager = createSyncManager();
 
@@ -677,16 +653,10 @@ describe( 'SyncManager', () => {
 		it( 'does not edit the local record for local transactions', async () => {
 			// Capture the Y.Doc from provider creator.
 			let capturedDoc: Y.Doc | null = null;
-			mockProviderCreator.mockImplementation(
-				async (
-					_objectType: string,
-					_objectId: string,
-					ydoc: Y.Doc
-				) => {
-					capturedDoc = ydoc;
-					return mockProviderResult;
-				}
-			);
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
 
 			const manager = createSyncManager();
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -53,11 +53,15 @@ export interface ProviderCreatorResult {
 	destroy: () => void;
 }
 
+export interface ProviderCreatorOptions {
+	objectType: ObjectType;
+	objectId: ObjectID | null;
+	ydoc: Y.Doc;
+	awareness?: Awareness;
+}
+
 export type ProviderCreator = (
-	objectType: ObjectType,
-	objectId: ObjectID,
-	ydoc: Y.Doc,
-	awareness?: Awareness
+	options: ProviderCreatorOptions
 ) => Promise< ProviderCreatorResult >;
 
 export interface RecordHandlers {


### PR DESCRIPTION
## What?

Updates the `ProviderCreator` type signature to use an options object instead of individual parameters, matching the signature used in the `wpvip/rtc-plugin` branch.

## Why?

The `wpvip/rtc-plugin` branch updated the `ProviderCreator` signature to use an options object pattern in PR #74075. This change brings trunk in alignment with that branch to:

1. Make it easier to test with external providers like the WebSocket provider in https://github.com/Automattic/vip-real-time-collaboration
2. Improve maintainability by making it easier to add new parameters in the future

Reference: https://github.com/WordPress/gutenberg/blob/c026df2dedff03441df2c2981822bccee530711a/packages/sync/src/types.ts#L110-L119

## How?

- Created a new `ProviderCreatorOptions` interface with `objectType`, `objectId`, `ydoc`, and `awareness` fields
- Updated the `ProviderCreator` type to accept a single options parameter
- Updated `manager.ts` to pass an options object when calling provider creators
- Updated all test mocks in `test/manager.ts` to use the new signature

## Testing Instructions

This is an internal API change with no end-user functionality impact. CI checks will verify types and tests.

### Testing Instructions for Keyboard

Not applicable - this is an internal API change with no UI impact.
