### PR TITLE
POC: Query Loop slider

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -95,6 +95,12 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$classnames .= ' ' . sanitize_title( 'columns-' . $attributes['layout']['columnCount'] );
 	}
 
+	// Check if this is inside a slider query variation (detected by className on post-template).
+	$is_slider = isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-slider-track' ) !== false;
+	if ( $is_slider ) {
+		$classnames .= ' is-slider-track';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );
 
 	$content = '';
@@ -124,11 +130,16 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		remove_filter( 'render_block_context', $filter_block_context, 1 );
 
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
+		// For slider mode, use div with slide class instead.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
 
 		$inner_block_directives = $enhanced_pagination ? ' data-wp-key="post-template-item-' . $post_id . '"' : '';
 
-		$content .= '<li' . $inner_block_directives . ' class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
+		if ( $is_slider ) {
+			$content .= '<div class="wp-block-slide ' . esc_attr( $post_classes ) . '">' . $block_content . '</div>';
+		} else {
+			$content .= '<li' . $inner_block_directives . ' class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
+		}
 	}
 
 	/*
@@ -137,6 +148,18 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	 * Since we use two custom loops, it's safest to always restore.
 	*/
 	wp_reset_postdata();
+
+	// For slider mode, add track directives and use div instead of ul/li.
+	if ( $is_slider ) {
+		$slider_directives = ' data-wp-on--scroll="actions.handleScroll" data-wp-init="callbacks.initTrack" data-wp-watch="callbacks.updateTrack"';
+
+		return sprintf(
+			'<div %1$s%2$s>%3$s</div>',
+			$wrapper_attributes,
+			$slider_directives,
+			$content
+		);
+	}
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -58,3 +58,29 @@
 	margin-inline-start: auto;
 	margin-inline-end: auto;
 }
+
+// Slider track styles when post-template is inside a slider query variation.
+.wp-block-post-template.is-slider-track {
+	display: flex;
+	flex-wrap: nowrap;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	-webkit-overflow-scrolling: touch;
+
+	// Hide scrollbar but keep functionality.
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+
+	// Style each slide (post).
+	> .wp-block-slide {
+		scroll-snap-align: start;
+		flex-shrink: 0;
+		width: 100%;
+		box-sizing: border-box;
+	}
+}

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -64,3 +64,28 @@
 .wp-block-query > .block-editor-media-placeholder.is-small {
 	min-height: 60px;
 }
+
+// Slider variation styles - horizontal layout preview in editor
+.wp-block-query.is-style-slider,
+.wp-block-query:has(.is-slider-track) {
+	// Post template acts as slider track
+	.wp-block-post-template.is-slider-track {
+		display: flex;
+		flex-direction: row;
+		gap: $grid-unit-20;
+		overflow: hidden; // Hide overflow, no scrolling in editor
+
+		// Each post/slide
+		> .wp-block-post {
+			flex: 0 0 100%; // Full width slides by default
+			min-width: 0;
+		}
+	}
+
+	// Slider controls styling in editor
+	.wp-block-slider-controls {
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: $grid-unit-15;
+	}
+}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -21,8 +21,9 @@ function render_block_core_query( $attributes, $content, $block ) {
 		&& true === $attributes['enhancedPagination']
 		&& isset( $attributes['queryId'] );
 
-	// Check if this is a slider variation (detected by className).
-	$is_slider = isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-slider' ) !== false;
+	// Check if this is a slider variation (detected by className on query or is-slider-track in content).
+	$is_slider = ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-slider' ) !== false )
+		|| strpos( $content, 'is-slider-track' ) !== false;
 
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -21,6 +21,9 @@ function render_block_core_query( $attributes, $content, $block ) {
 		&& true === $attributes['enhancedPagination']
 		&& isset( $attributes['queryId'] );
 
+	// Check if this is a slider variation (detected by className).
+	$is_slider = isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-slider' ) !== false;
+
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
@@ -33,6 +36,31 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$p->set_attribute( 'data-wp-router-region', 'query-' . $attributes['queryId'] );
 			$p->set_attribute( 'data-wp-context', '{}' );
 			$p->set_attribute( 'data-wp-key', $attributes['queryId'] );
+			$content = $p->get_updated_html();
+		}
+	}
+
+	// Add slider directives if this is a slider variation.
+	if ( $is_slider ) {
+		wp_enqueue_script_module( '@wordpress/block-library/slider/view' );
+
+		// Count slides (posts) from post-template inner block.
+		$slide_count = 0;
+		$per_page    = isset( $attributes['query']['perPage'] ) ? (int) $attributes['query']['perPage'] : 10;
+		$slide_count = $per_page; // Approximate - actual count depends on query results.
+
+		$p = new WP_HTML_Tag_Processor( $content );
+		if ( $p->next_tag() ) {
+			$p->set_attribute( 'data-wp-interactive', 'core/slider' );
+			$p->set_attribute(
+				'data-wp-context',
+				wp_json_encode(
+					array(
+						'currentIndex' => 0,
+						'totalSlides'  => $slide_count,
+					)
+				)
+			);
 			$content = $p->get_updated_html();
 		}
 	}

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { gallery as sliderIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,6 +29,39 @@ const postDate = [
 ];
 
 const variations = [
+	{
+		name: 'slider',
+		title: __( 'Slider' ),
+		icon: sliderIcon,
+		attributes: {
+			className: 'is-style-slider',
+			query: {
+				perPage: 10,
+				pages: 1,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				sticky: 'exclude',
+				inherit: false,
+			},
+		},
+		innerBlocks: [
+			[ 'core/slider-controls' ],
+			[
+				'core/post-template',
+				{
+					className: 'is-slider-track',
+				},
+				[ [ 'core/post-featured-image' ], [ 'core/post-title' ] ],
+			],
+		],
+		scope: [ 'block', 'inserter' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.className?.includes( 'is-style-slider' ),
+	},
 	{
 		name: 'title-date',
 		title: __( 'Title & Date' ),

--- a/packages/block-library/src/slider-controls/block.json
+++ b/packages/block-library/src/slider-controls/block.json
@@ -8,7 +8,7 @@
 	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
-	"parent": [ "core/slider" ],
+	"parent": [ "core/slider", "core/query" ],
 	"allowedBlocks": [ "core/buttons", "core/button" ],
 	"attributes": {},
 	"usesContext": [ "core/slider-id" ],

--- a/packages/block-library/src/slider/view.js
+++ b/packages/block-library/src/slider/view.js
@@ -57,9 +57,13 @@ store( 'core/slider', {
 		nextSlide() {
 			const { ref } = getElement();
 
-			// Find the track element (go up to slider, then find track)
-			const slider = ref.closest( '.wp-block-slider' );
-			const track = slider?.querySelector( '.wp-block-slider-track' );
+			// Find the track element - support both dedicated slider and query loop slider
+			const container =
+				ref.closest( '.wp-block-slider' ) ||
+				ref.closest( '.wp-block-query' );
+			const track =
+				container?.querySelector( '.wp-block-slider-track' ) ||
+				container?.querySelector( '.is-slider-track' );
 
 			if ( ! track ) {
 				return;
@@ -85,9 +89,13 @@ store( 'core/slider', {
 		prevSlide() {
 			const { ref } = getElement();
 
-			// Find the track element
-			const slider = ref.closest( '.wp-block-slider' );
-			const track = slider?.querySelector( '.wp-block-slider-track' );
+			// Find the track element - support both dedicated slider and query loop slider
+			const container =
+				ref.closest( '.wp-block-slider' ) ||
+				ref.closest( '.wp-block-query' );
+			const track =
+				container?.querySelector( '.wp-block-slider-track' ) ||
+				container?.querySelector( '.is-slider-track' );
 
 			if ( ! track ) {
 				return;
@@ -139,20 +147,23 @@ store( 'core/slider', {
 
 			// Handle keyboard events
 			ref.addEventListener( 'keydown', ( event ) => {
+				// Support both dedicated slider and query loop slider
+				const container =
+					ref.closest( '.wp-block-slider' ) ||
+					ref.closest( '.wp-block-query' );
+
 				if ( event.key === 'ArrowLeft' ) {
 					event.preventDefault();
-					const slider = ref.closest( '.wp-block-slider' );
-					const prevButton = slider?.querySelector(
-						'.wp-block-slider-controls__previous'
+					const prevButton = container?.querySelector(
+						'.wp-block-slider-controls__previous .wp-block-button__link'
 					);
 					if ( prevButton && ! prevButton.disabled ) {
 						prevButton.click();
 					}
 				} else if ( event.key === 'ArrowRight' ) {
 					event.preventDefault();
-					const slider = ref.closest( '.wp-block-slider' );
-					const nextButton = slider?.querySelector(
-						'.wp-block-slider-controls__next'
+					const nextButton = container?.querySelector(
+						'.wp-block-slider-controls__next .wp-block-button__link'
 					);
 					if ( nextButton && ! nextButton.disabled ) {
 						nextButton.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Query Loop Slider Layout - POC

Extremely rough implementation of slider layout in Query Loop just to show the potential approach in opposition to #74769.

### Approach

Instead of a dedicated Slider block, this POC explores adding a **"Slider" variation** to the existing Query Loop block. The idea is to reuse Query Loop's querying capabilities while applying slider behavior to the post-template output.

**Structure:**
```
core/query (with data-wp-interactive="core/slider")
├── core/slider-controls (reused from #74769)
└── core/post-template.is-slider-track
├── .wp-block-slide (post 1)
├── .wp-block-slide (post 2)
└── ...
```

### What's Implemented

- **Block Variation** (`query/variations.js`) with `className: "is-style-slider"` and `isActive` matcher
- **PHP detection** in `query/index.php` - adds `data-wp-interactive="core/slider"` and context when slider variation detected
- **Modified `post-template/index.php`** - renders `<div>` instead of `<ul>/<li>`, adds `.wp-block-slide` class to each post, injects scroll directives
- **Shared Interactivity API store** (`core/slider`) - same `view.js` handles both dedicated slider block and Query Loop variation
- **Editor styles** (`query/editor.scss`) - horizontal layout preview for slider variation
- **`slider-controls` updated** to allow `core/query` as parent

### Problems & Limitations

#### 1. Disconnected UX / Control Injection Problem

If we want to control slider-specific settings (slides per view, gap, peek amount, etc.), we need to inject custom inspector controls into Query Loop **only for the slider layout**. This is problematic because:

- It creates **disconnected UX** from the dedicated Slider block (which would have its own controls)
- Either we **duplicate controls** across both implementations, or they have **different controls** entirely
- Implementation requires `if (isSliderVariation)` conditionals scattered throughout Query Loop's edit component
- This pattern doesn't scale - every "layout mode" would need similar conditional injection

#### 2. Other Unsolved Issues

- **Overlay positioning** - No native way to position controls over slides
- **Responsive slides-per-view** - No controls for "3 on desktop, 1 on mobile"
- **Content fill behavior** - How images/content fill slides
- **Pagination conflict** - Sliders don't work well with Query Loop pagination
- **Editor preview** - Shows horizontal layout but no actual sliding behavior

### Conclusion

This POC demonstrates that Query Loop *can* be extended with slider behavior, but it highlights that neither approach (dedicated block nor variation) solves the underlying conflict between deterministic slides vs iteratively rendered blocks like Post Template.

A proper solution likely requires broader Gutenberg architecture work before sliders can be implemented cleanly.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/ceaddbdd-cd3a-4af7-afc8-f44160af0c5c
