### PR TITLE
Real-time collaboration: Use relative positions in undo stack

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -253,7 +253,7 @@ export const getEntityRecord =
 									// Because Yjs initiates an undo, we need to
 									// wait until the content is restored before
 									// we can update the selection.
-									// Use queueMicrotask() to wait until content is
+									// Use setTimeout() to wait until content is
 									// finished updating, and then set the correct
 									// selection.
 									setTimeout( () => {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -26,6 +26,7 @@ import {
 	isNumericID,
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
+import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
 
 /**
  * Requests authors from the REST API.
@@ -232,6 +233,36 @@ export const getEntityRecord =
 									name,
 									key
 								);
+							},
+							addUndoMeta: ( ydoc, meta ) => {
+								const selectionHistory =
+									getSelectionHistory( ydoc );
+
+								if ( selectionHistory ) {
+									meta.set(
+										'selectionHistory',
+										selectionHistory
+									);
+								}
+							},
+							restoreUndoMeta: ( ydoc, meta ) => {
+								const selectionHistory =
+									meta.get( 'selectionHistory' );
+
+								if ( selectionHistory ) {
+									// Because Yjs initiates an undo, we need to
+									// wait until the content is restored before
+									// we can update the selection.
+									// Use queueMicrotask() to wait until content is
+									// finished updating, and then set the correct
+									// selection.
+									setTimeout( () => {
+										restoreSelection(
+											selectionHistory,
+											ydoc
+										);
+									}, 0 );
+								}
 							},
 						}
 					);

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -168,9 +168,11 @@ describe( 'getEntityRecord', () => {
 			1,
 			POST_RECORD,
 			{
+				addUndoMeta: expect.any( Function ),
 				editRecord: expect.any( Function ),
 				getEditedRecord: expect.any( Function ),
 				refetchRecord: expect.any( Function ),
+				restoreUndoMeta: expect.any( Function ),
 				saveRecord: expect.any( Function ),
 			}
 		);
@@ -221,9 +223,11 @@ describe( 'getEntityRecord', () => {
 			1,
 			{ ...POST_RECORD, foo: 'bar' },
 			{
+				addUndoMeta: expect.any( Function ),
 				editRecord: expect.any( Function ),
 				getEditedRecord: expect.any( Function ),
 				refetchRecord: expect.any( Function ),
+				restoreUndoMeta: expect.any( Function ),
 				saveRecord: expect.any( Function ),
 			}
 		);

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -2,7 +2,16 @@ export interface AnyFunction {
 	( ...args: any[] ): any;
 }
 
-// Avoid a circular dependency with @wordpress/editor
+/**
+ * Avoid a circular dependency with @wordpress/editor
+ *
+ * Additionaly, this type marks `attributeKey` and `offset` as possibly
+ * `undefined`, which can happen in two known scenarios:
+ *
+ * 1. If a user has an entire block highlighted (e.g., a `core/image` block).
+ * 2. If there's an intermediate selection state while inserting a block, those
+ *    properties will be temporarily`undefined`.
+ */
 export interface WPBlockSelection {
 	clientId: string;
 	attributeKey?: string;

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -5,8 +5,8 @@ export interface AnyFunction {
 // Avoid a circular dependency with @wordpress/editor
 export interface WPBlockSelection {
 	clientId: string;
-	attributeKey: string;
-	offset: number;
+	attributeKey?: string;
+	offset?: number;
 }
 
 export interface WPSelection {

--- a/packages/core-data/src/utils/block-selection-history.ts
+++ b/packages/core-data/src/utils/block-selection-history.ts
@@ -1,0 +1,176 @@
+/**
+ * External dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import { findBlockByClientIdInDoc } from './crdt-utils';
+import type { WPBlockSelection, WPSelection } from '../types';
+
+// Default size for selection history (not including current selection)
+const SELECTION_HISTORY_DEFAULT_SIZE = 5;
+
+export enum YSelectionType {
+	RelativeSelection = 'RelativeSelection',
+	BlockSelection = 'BlockSelection',
+}
+
+export interface YRelativeSelection {
+	type: YSelectionType.RelativeSelection;
+	attributeKey: string;
+	relativePosition: Y.RelativePosition;
+	clientId: string;
+	offset: number;
+}
+
+export interface YBlockSelection {
+	type: YSelectionType.BlockSelection;
+	clientId: string;
+}
+
+export type YSelection = YRelativeSelection | YBlockSelection;
+
+export type YFullSelection = {
+	start: YSelection;
+	end: YSelection;
+};
+
+export interface YSelectionHistory {
+	selection: YFullSelection;
+	backupSelections?: YFullSelection[];
+}
+
+export interface BlockSelectionHistory {
+	getSelectionHistory: () => YFullSelection[];
+	updateSelection: ( newSelection: WPSelection ) => void;
+}
+
+/**
+ * This function is used to track recent block selections to help in restoring
+ * a user's selection after an undo or redo operation.
+ *
+ * Maintains a history array for previous selections, which can be used for
+ * backup restoration locations.
+ * @param ydoc
+ * @param historySize
+ */
+export function createBlockSelectionHistory(
+	ydoc: Y.Doc,
+	historySize: number = SELECTION_HISTORY_DEFAULT_SIZE
+): BlockSelectionHistory {
+	let history: YFullSelection[] = [];
+
+	/**
+	 * Get the block history including current selection.
+	 */
+	const getSelectionHistory = (): YFullSelection[] => {
+		return history.slice( 0 );
+	};
+
+	/**
+	 * Update the selection history with a new selection.
+	 * @param newSelection
+	 */
+	const updateSelection = ( newSelection: WPSelection ): void => {
+		if (
+			! newSelection?.selectionStart?.clientId ||
+			! newSelection?.selectionEnd?.clientId
+		) {
+			return;
+		}
+
+		const { selectionStart, selectionEnd } = newSelection;
+		const start = convertWPBlockSelectionToSelection(
+			selectionStart,
+			ydoc
+		);
+		const end = convertWPBlockSelectionToSelection( selectionEnd, ydoc );
+
+		addToHistory( { start, end } );
+	};
+
+	/**
+	 * Add a selection to the history, maintaining only the last `historySize` unique selections.
+	 * New selections are added to the front.
+	 * Removes any existing entries with the same start and end block combination.
+	 * @param yFullSelection
+	 */
+	const addToHistory = ( yFullSelection: YFullSelection ): void => {
+		// Remove any existing entries with the same start and end block combination
+		const startClientId = yFullSelection.start.clientId;
+		const endClientId = yFullSelection.end.clientId;
+
+		history = history.filter( ( entry ) => {
+			const isSameBlockCombination =
+				entry.start.clientId === startClientId &&
+				entry.end.clientId === endClientId;
+
+			return ! isSameBlockCombination;
+		} );
+
+		// Add the new selection to the front
+		history.unshift( yFullSelection );
+
+		// Trim to max size (remove oldest entries from the back)
+		if ( history.length > historySize + 1 ) {
+			history = history.slice( 0, historySize + 1 );
+		}
+	};
+
+	return {
+		getSelectionHistory,
+		updateSelection,
+	};
+}
+
+/**
+ * Convert a WPBlockSelection to a YSelection.
+ * @param selection
+ * @param ydoc
+ * @return A YSelection object.
+ */
+function convertWPBlockSelectionToSelection(
+	selection: WPBlockSelection,
+	ydoc: Y.Doc
+): YSelection {
+	const clientId = selection.clientId;
+	const block = findBlockByClientIdInDoc( clientId, ydoc );
+	const attributes = block?.get( 'attributes' );
+	const attributeKey = selection.attributeKey;
+
+	const changedYText = attributeKey
+		? attributes?.get( attributeKey )
+		: undefined;
+
+	const isYText = changedYText instanceof Y.Text;
+	const isFullyDefinedSelection = attributeKey && clientId;
+
+	if ( ! isYText || ! isFullyDefinedSelection ) {
+		// We either don't have a valid YText (it's been deleted) or we've
+		// been passed a selection that's just a block clientId.
+		// Store as BlockSelection.
+		return {
+			type: YSelectionType.BlockSelection,
+			clientId,
+		};
+	}
+
+	const offset = selection.offset ?? 0;
+	const relativePosition = Y.createRelativePositionFromTypeIndex(
+		changedYText,
+		offset
+	);
+
+	return {
+		type: YSelectionType.RelativeSelection,
+		attributeKey,
+		relativePosition,
+		clientId,
+		offset,
+	};
+}

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -1,0 +1,172 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+// @ts-expect-error No exported types.
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { type CRDTDoc, Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createBlockSelectionHistory,
+	YSelectionType,
+	type BlockSelectionHistory,
+	type YFullSelection,
+	type YSelection,
+} from './block-selection-history';
+import { findBlockByClientIdInDoc } from './crdt-utils';
+import type { WPBlockSelection, WPSelection } from '../types';
+
+// WeakMap to store BlockSelectionHistory instances per Y.Doc
+const selectionHistoryMap = new WeakMap< CRDTDoc, BlockSelectionHistory >();
+
+/**
+ * Get or create a BlockSelectionHistory instance for a given Y.Doc.
+ *
+ * @param ydoc The Y.Doc to get the selection history for
+ * @return The BlockSelectionHistory instance
+ */
+function getBlockSelectionHistory( ydoc: CRDTDoc ): BlockSelectionHistory {
+	let history = selectionHistoryMap.get( ydoc );
+
+	if ( ! history ) {
+		history = createBlockSelectionHistory( ydoc );
+		selectionHistoryMap.set( ydoc, history );
+	}
+
+	return history;
+}
+
+export function getSelectionHistory( ydoc: CRDTDoc ): YFullSelection[] {
+	return getBlockSelectionHistory( ydoc ).getSelectionHistory();
+}
+
+export function updateSelectionHistory(
+	ydoc: CRDTDoc,
+	wpSelection: WPSelection
+): void {
+	return getBlockSelectionHistory( ydoc ).updateSelection( wpSelection );
+}
+
+/**
+ * Convert a YSelection to a WPBlockSelection.
+ * @param ySelection The YSelection (relative) to convert
+ * @param ydoc       The Y.Doc to convert the selection to a block selection for
+ * @return The converted WPBlockSelection, or null if the conversion fails
+ */
+function convertYSelectionToBlockSelection(
+	ySelection: YSelection,
+	ydoc: Y.Doc
+): WPBlockSelection | null {
+	if ( ySelection.type === YSelectionType.RelativeSelection ) {
+		const { relativePosition, attributeKey, clientId } = ySelection;
+
+		const absolutePosition = Y.createAbsolutePositionFromRelativePosition(
+			relativePosition,
+			ydoc
+		);
+
+		if ( absolutePosition ) {
+			return {
+				clientId,
+				attributeKey,
+				offset: absolutePosition.index,
+			};
+		}
+	} else if ( ySelection.type === YSelectionType.BlockSelection ) {
+		return {
+			clientId: ySelection.clientId,
+			attributeKey: undefined,
+			offset: undefined,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Given a Y.Doc and a selection history, find the most recent selection
+ * that exists in the document. Skip any selections that are not in the document.
+ * @param ydoc             The Y.Doc to find the selection in
+ * @param selectionHistory The selection history to check
+ * @return The most recent selection that exists in the document, or null if no selection exists.
+ */
+function findSelectionFromHistory(
+	ydoc: Y.Doc,
+	selectionHistory: YFullSelection[]
+): WPSelection | null {
+	// Try each position until we find one that exists in the document
+	for ( const positionToTry of selectionHistory ) {
+		const { start, end } = positionToTry;
+		const startBlock = findBlockByClientIdInDoc( start.clientId, ydoc );
+		const endBlock = findBlockByClientIdInDoc( end.clientId, ydoc );
+
+		if ( ! startBlock || ! endBlock ) {
+			// This block no longer exists, skip it.
+			continue;
+		}
+
+		const startBlockSelection = convertYSelectionToBlockSelection(
+			start,
+			ydoc
+		);
+		const endBlockSelection = convertYSelectionToBlockSelection(
+			end,
+			ydoc
+		);
+
+		if ( startBlockSelection === null || endBlockSelection === null ) {
+			continue;
+		}
+
+		return {
+			selectionStart: startBlockSelection,
+			selectionEnd: endBlockSelection,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Restore the selection to the most recent selection in history that is
+ * available in the document.
+ * @param selectionHistory The selection history to restore
+ * @param ydoc             The Y.Doc where blocks are stored
+ */
+export function restoreSelection(
+	selectionHistory: YFullSelection[],
+	ydoc: Y.Doc
+): void {
+	// Find the most recent selection in history that is available in
+	// the document.
+	const selectionToRestore = findSelectionFromHistory(
+		ydoc,
+		selectionHistory
+	);
+
+	if ( selectionToRestore === null ) {
+		// Case 1: No blocks in history are available for restoration.
+		// Do nothing.
+		return;
+	}
+
+	const { resetSelection } = dispatch( blockEditorStore );
+	const { selectionStart, selectionEnd } = selectionToRestore;
+	const isSelectionInSameBlock =
+		selectionStart.clientId === selectionEnd.clientId;
+
+	if ( isSelectionInSameBlock ) {
+		// Case 2: After content is restored, the selection is available
+		// within the same block
+		resetSelection( selectionStart, selectionEnd, null );
+	} else {
+		// Case 3: A multi-block selection was made. resetSelection() can only
+		// restore selections within the same block.
+		// When a multi-block selection is made, selectionEnd represents
+		// where the user's cursor ended.
+		resetSelection( selectionEnd, selectionEnd, null );
+	}
+}

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -189,12 +189,16 @@ function getCursorPosition(
 	blocks: YBlocks
 ): CursorPosition | null {
 	const block = findBlockByClientId( selection.clientId, blocks );
-	if ( ! block ) {
+	if (
+		! block ||
+		! selection.attributeKey ||
+		undefined === selection.offset
+	) {
 		return null;
 	}
 
-	const attributes = block.get( 'attributes' ) as Y.Map< Y.Text >;
-	const currentYText = attributes.get( selection.attributeKey ) as Y.Text;
+	const attributes = block.get( 'attributes' );
+	const currentYText = attributes?.get( selection.attributeKey ) as Y.Text;
 
 	const relativePosition = Y.createRelativePositionFromTypeIndex(
 		currentYText,

--- a/packages/core-data/src/utils/test/block-selection-history.test.ts
+++ b/packages/core-data/src/utils/test/block-selection-history.test.ts
@@ -1,0 +1,764 @@
+/**
+ * External dependencies
+ */
+import * as Y from 'yjs';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createBlockSelectionHistory,
+	YSelectionType,
+	type YRelativeSelection,
+	type BlockSelectionHistory,
+} from '../block-selection-history';
+import { CRDT_RECORD_MAP_KEY } from '../../sync';
+import type { WPSelection } from '../../types';
+
+/**
+ * Helper function to create a simple Y.Doc with blocks for testing
+ */
+function createTestDoc() {
+	const ydoc = new Y.Doc();
+	const documentMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+	const blocks = new Y.Array();
+	documentMap.set( 'blocks', blocks );
+
+	// Create block 1 with a content attribute
+	const block1 = new Y.Map();
+	block1.set( 'clientId', 'block-1' );
+	const block1Attrs = new Y.Map();
+	block1Attrs.set( 'content', new Y.Text( 'Hello world' ) );
+	block1.set( 'attributes', block1Attrs );
+	block1.set( 'innerBlocks', new Y.Array() );
+	blocks.push( [ block1 ] );
+
+	// Create block 2 with a content attribute
+	const block2 = new Y.Map();
+	block2.set( 'clientId', 'block-2' );
+	const block2Attrs = new Y.Map();
+	block2Attrs.set( 'content', new Y.Text( 'Second block' ) );
+	block2.set( 'attributes', block2Attrs );
+	block2.set( 'innerBlocks', new Y.Array() );
+	blocks.push( [ block2 ] );
+
+	// Create block 3 with a different attribute key
+	const block3 = new Y.Map();
+	block3.set( 'clientId', 'block-3' );
+	const block3Attrs = new Y.Map();
+	block3Attrs.set( 'value', new Y.Text( 'Third block with value attr' ) );
+	block3.set( 'attributes', block3Attrs );
+	block3.set( 'innerBlocks', new Y.Array() );
+	blocks.push( [ block3 ] );
+
+	return ydoc;
+}
+
+function createSelection(
+	start: { clientId: string; attributeKey?: string; offset?: number },
+	end?: { clientId: string; attributeKey?: string; offset?: number }
+): WPSelection {
+	const selectionStart = {
+		clientId: start.clientId,
+		attributeKey: start.attributeKey as string,
+		offset: start.offset ?? 0,
+	};
+
+	const selectionEnd = end
+		? {
+				clientId: end.clientId,
+				attributeKey: end.attributeKey as string,
+				offset: end.offset ?? 0,
+		  }
+		: selectionStart;
+
+	return {
+		selectionStart,
+		selectionEnd,
+	};
+}
+
+describe( 'BlockSelectionHistory', () => {
+	let history: BlockSelectionHistory;
+	let ydoc: Y.Doc;
+
+	beforeEach( () => {
+		ydoc = createTestDoc();
+		history = createBlockSelectionHistory( ydoc, 5 );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	describe( 'initialization', () => {
+		test( 'should initialize with empty history', () => {
+			expect( history.getSelectionHistory() ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'updateSelection with relative positions', () => {
+		test( 'should convert and store a selection as a relative position', () => {
+			const selection = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 5,
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			expect( fullSelection.end.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+
+			const startPosition = fullSelection.start as YRelativeSelection;
+			const endPosition = fullSelection.end as YRelativeSelection;
+
+			expect( startPosition.clientId ).toBe( 'block-1' );
+			expect( startPosition.attributeKey ).toBe( 'content' );
+			expect( startPosition.offset ).toBe( 5 );
+			expect( startPosition.relativePosition ).toBeDefined();
+
+			expect( endPosition.clientId ).toBe( 'block-1' );
+			expect( endPosition.attributeKey ).toBe( 'content' );
+			expect( endPosition.offset ).toBe( 5 );
+			expect( endPosition.relativePosition ).toBeDefined();
+		} );
+
+		test( 'should update position when selection changes within same block', () => {
+			const selection1 = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 5,
+			} );
+			history.updateSelection( selection1 );
+
+			const selection2 = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 8,
+			} );
+			history.updateSelection( selection2 );
+
+			const selectionHistory = history.getSelectionHistory();
+
+			// Should have only one selection in block history (still in same block)
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.clientId ).toBe( 'block-1' );
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+
+			const startPosition = fullSelection.start as YRelativeSelection;
+			expect( startPosition.offset ).toBe( 8 );
+		} );
+
+		test( 'should add new position when moving to different block', () => {
+			const selection1 = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 5,
+			} );
+			history.updateSelection( selection1 );
+
+			const selection2 = createSelection( {
+				clientId: 'block-2',
+				attributeKey: 'content',
+				offset: 3,
+			} );
+			history.updateSelection( selection2 );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 2 );
+
+			// Current selection at index 0
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-2' );
+			expect( selectionHistory[ 0 ].end.clientId ).toBe( 'block-2' );
+			// Previous selection at index 1
+			expect( selectionHistory[ 1 ].start.clientId ).toBe( 'block-1' );
+			expect( selectionHistory[ 1 ].end.clientId ).toBe( 'block-1' );
+		} );
+
+		test( 'should store offset 0 when offset is not provided', () => {
+			const selection = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			const startPosition = fullSelection.start as YRelativeSelection;
+			expect( startPosition.offset ).toBe( 0 );
+
+			expect( fullSelection.end.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			const endPosition = fullSelection.end as YRelativeSelection;
+			expect( endPosition.offset ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'updateSelection with block positions', () => {
+		test( 'should create block position (not relative) when clientId does not exist', () => {
+			const selection = createSelection( {
+				clientId: 'non-existent-block',
+				attributeKey: 'content',
+				offset: 5,
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.BlockSelection
+			);
+			expect( fullSelection.start.clientId ).toBe( 'non-existent-block' );
+			expect( fullSelection.end.type ).toBe(
+				YSelectionType.BlockSelection
+			);
+			expect( fullSelection.end.clientId ).toBe( 'non-existent-block' );
+		} );
+
+		test( 'should create block position (not relative) when attribute does not exist', () => {
+			const selection = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'nonexistent',
+				offset: 5,
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.BlockSelection
+			);
+			expect( fullSelection.start.clientId ).toBe( 'block-1' );
+			expect( fullSelection.end.type ).toBe(
+				YSelectionType.BlockSelection
+			);
+			expect( fullSelection.end.clientId ).toBe( 'block-1' );
+		} );
+	} );
+
+	describe( 'updateSelection edge cases', () => {
+		test( 'should ignore null selection', () => {
+			history.updateSelection( null as any );
+			expect( history.getSelectionHistory() ).toEqual( [] );
+		} );
+
+		test( 'should ignore undefined selection', () => {
+			history.updateSelection( undefined as any );
+			expect( history.getSelectionHistory() ).toEqual( [] );
+		} );
+
+		test( 'should ignore selection without clientId', () => {
+			const invalidSelection = {
+				selectionStart: {
+					clientId: '',
+					attributeKey: 'content',
+					offset: 0,
+				},
+				selectionEnd: {
+					clientId: '',
+					attributeKey: 'content',
+					offset: 0,
+				},
+			};
+			history.updateSelection( invalidSelection );
+			expect( history.getSelectionHistory() ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'history management', () => {
+		test( 'should maintain history of last N unique blocks', () => {
+			const selections = [
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 1,
+				} ),
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 2,
+				} ),
+				createSelection( {
+					clientId: 'block-3',
+					attributeKey: 'value',
+					offset: 3,
+				} ),
+			];
+
+			selections.forEach( ( sel ) => history.updateSelection( sel ) );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 3 );
+
+			// Current selection at index 0
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-3' );
+			expect( selectionHistory[ 0 ].end.clientId ).toBe( 'block-3' );
+			// Previous selections
+			expect( selectionHistory[ 1 ].start.clientId ).toBe( 'block-2' );
+			expect( selectionHistory[ 1 ].end.clientId ).toBe( 'block-2' );
+			expect( selectionHistory[ 2 ].start.clientId ).toBe( 'block-1' );
+			expect( selectionHistory[ 2 ].end.clientId ).toBe( 'block-1' );
+		} );
+
+		test( 'should respect history size limit', () => {
+			const smallHistory = createBlockSelectionHistory( ydoc, 3 );
+
+			// Add more selections than history size
+			for ( let i = 1; i <= 5; i++ ) {
+				const selection = createSelection( {
+					clientId: `block-${ i }`,
+					attributeKey: 'content',
+					offset: i,
+				} );
+				smallHistory.updateSelection( selection );
+			}
+
+			// Should only keep last 4 total (3 history + 1 current)
+			const selectionHistory = smallHistory.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 4 );
+
+			// Current selection at index 0
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-5' );
+			expect( selectionHistory[ 0 ].end.clientId ).toBe( 'block-5' );
+			// Previous 3 selections
+			expect( selectionHistory[ 1 ].start.clientId ).toBe( 'block-4' );
+			expect( selectionHistory[ 2 ].start.clientId ).toBe( 'block-3' );
+			expect( selectionHistory[ 3 ].start.clientId ).toBe( 'block-2' );
+		} );
+
+		test( 'should remove duplicate block from history when revisited', () => {
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 1,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 2,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-3',
+					attributeKey: 'value',
+					offset: 3,
+				} )
+			);
+
+			// Go back to block-1
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 5,
+				} )
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+
+			// block-1 should be current (most recent) at index 0
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-1' );
+			expect( selectionHistory[ 0 ].start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+
+			const startPosition = selectionHistory[ 0 ]
+				.start as YRelativeSelection;
+			expect( startPosition.offset ).toBe( 5 ); // Updated offset
+
+			// block-1 should not appear again in history
+			expect( selectionHistory.length ).toBe( 3 );
+			expect( selectionHistory[ 1 ].start.clientId ).toBe( 'block-3' );
+			expect( selectionHistory[ 2 ].start.clientId ).toBe( 'block-2' );
+		} );
+	} );
+
+	describe( 'getSelectionHistory', () => {
+		test( 'should return current selection when only one selection exists', () => {
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 1,
+				} )
+			);
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-1' );
+		} );
+
+		test( 'should return most recent position at index 0', () => {
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 1,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 2,
+				} )
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 2 );
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-2' );
+			expect( selectionHistory[ 0 ].end.clientId ).toBe( 'block-2' );
+		} );
+
+		test( 'should return empty array when history is empty', () => {
+			expect( history.getSelectionHistory() ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'relative position accuracy', () => {
+		test( 'should create relative position that survives text insertion before it', () => {
+			const selection = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 5,
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			const startPosition = fullSelection.start as YRelativeSelection;
+			// Get the Y.Text and insert text before the position
+			const documentMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+			const blocks = documentMap.get( 'blocks' ) as Y.Array< any >;
+			const block1 = blocks.get( 0 ) as Y.Map< any >;
+			const attrs = block1.get( 'attributes' ) as Y.Map< Y.Text >;
+			const ytext = attrs.get( 'content' );
+			if ( ! ytext ) {
+				throw new Error( 'Y.Text not found' );
+			}
+			ytext.insert( 0, 'PREFIX ' ); // Insert at beginning
+
+			// Convert relative position back to absolute
+			const absolutePosition =
+				Y.createAbsolutePositionFromRelativePosition(
+					startPosition.relativePosition,
+					ydoc
+				);
+
+			// The absolute index should have shifted by 7 (length of 'PREFIX ')
+			expect( absolutePosition?.index ).toBe( 12 ); // 5 + 7
+		} );
+
+		test( 'should create relative position that survives text deletion before it', () => {
+			const selection = createSelection( {
+				clientId: 'block-1',
+				attributeKey: 'content',
+				offset: 8,
+			} );
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const fullSelection = selectionHistory[ 0 ];
+			expect( fullSelection.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			const startPosition = fullSelection.start as YRelativeSelection;
+			// Delete text before the position
+			const documentMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+			const blocks = documentMap.get( 'blocks' ) as Y.Array< any >;
+			const block1 = blocks.get( 0 ) as Y.Map< any >;
+			const attrs = block1.get( 'attributes' ) as Y.Map< Y.Text >;
+			const ytext = attrs.get( 'content' );
+			if ( ! ytext ) {
+				throw new Error( 'Y.Text not found' );
+			}
+			ytext.delete( 0, 5 ); // Delete "Hello"
+
+			// Convert relative position back to absolute
+			const absolutePosition =
+				Y.createAbsolutePositionFromRelativePosition(
+					startPosition.relativePosition,
+					ydoc
+				);
+
+			// The absolute index should have shifted back by 5
+			expect( absolutePosition?.index ).toBe( 3 ); // 8 - 5
+		} );
+	} );
+
+	describe( 'integration scenarios', () => {
+		test( 'should handle rapid selection changes in same block', () => {
+			for ( let i = 0; i < 10; i++ ) {
+				history.updateSelection(
+					createSelection( {
+						clientId: 'block-1',
+						attributeKey: 'content',
+						offset: i,
+					} )
+				);
+			}
+
+			const selectionHistory = history.getSelectionHistory();
+
+			// Should have only one selection in block history (still in same block)
+			expect( selectionHistory.length ).toBe( 1 );
+
+			const current = selectionHistory[ 0 ];
+			expect( current.start.clientId ).toBe( 'block-1' );
+			expect( current.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			const startPosition = current.start as YRelativeSelection;
+
+			expect( startPosition.offset ).toBe( 9 );
+		} );
+
+		test( 'should handle alternating between two blocks', () => {
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 1,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 2,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 3,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 4,
+				} )
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+
+			// Current selection at index 0
+			expect( selectionHistory[ 0 ].start.clientId ).toBe( 'block-2' );
+			expect( selectionHistory[ 0 ].end.clientId ).toBe( 'block-2' );
+			// Only one previous selection (block-1)
+			expect( selectionHistory[ 1 ].start.clientId ).toBe( 'block-1' );
+
+			// Should only have 2 entries total (current + 1 previous)
+			expect( selectionHistory.length ).toBe( 2 );
+		} );
+
+		test( 'should handle mixed block and relative selections', () => {
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 5,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'non-existent',
+					attributeKey: 'content',
+					offset: 0,
+				} )
+			);
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-2',
+					attributeKey: 'content',
+					offset: 3,
+				} )
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+			const backupSelections = selectionHistory.slice( 1 );
+
+			expect( current?.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			expect( backupSelections[ 0 ]?.start.type ).toBe(
+				YSelectionType.BlockSelection
+			);
+			expect( backupSelections[ 1 ]?.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+		} );
+	} );
+
+	describe( 'cross-block selections', () => {
+		test( 'should update currentSelection when both start and end are within same block', () => {
+			const selection1 = createSelection(
+				{ clientId: 'block-1', attributeKey: 'content', offset: 2 },
+				{ clientId: 'block-1', attributeKey: 'content', offset: 8 }
+			);
+			history.updateSelection( selection1 );
+
+			const selection2 = createSelection(
+				{ clientId: 'block-1', attributeKey: 'content', offset: 2 },
+				{ clientId: 'block-1', attributeKey: 'content', offset: 10 }
+			);
+			history.updateSelection( selection2 );
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+
+			// Both selections are in same block, so should update current without adding to history
+			expect( current?.start.clientId ).toBe( 'block-1' );
+			expect( current?.end.clientId ).toBe( 'block-1' );
+			expect( ( current?.start as YRelativeSelection ).offset ).toBe( 2 );
+			expect( ( current?.end as YRelativeSelection ).offset ).toBe( 10 );
+			expect( selectionHistory.length ).toBe( 1 );
+		} );
+
+		test( 'should track cross-block selection spanning two blocks', () => {
+			const selection = createSelection(
+				{ clientId: 'block-1', attributeKey: 'content', offset: 5 },
+				{ clientId: 'block-2', attributeKey: 'content', offset: 3 }
+			);
+			history.updateSelection( selection );
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+
+			expect( current?.start.clientId ).toBe( 'block-1' );
+			expect( current?.start.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			expect( ( current?.start as YRelativeSelection ).offset ).toBe( 5 );
+
+			expect( current?.end.clientId ).toBe( 'block-2' );
+			expect( current?.end.type ).toBe(
+				YSelectionType.RelativeSelection
+			);
+			expect( ( current?.end as YRelativeSelection ).offset ).toBe( 3 );
+		} );
+
+		test( 'should differentiate between same-block and cross-block selections', () => {
+			// Single block selection
+			history.updateSelection(
+				createSelection( {
+					clientId: 'block-1',
+					attributeKey: 'content',
+					offset: 5,
+				} )
+			);
+
+			// Cross-block selection from block-1 to block-2
+			history.updateSelection(
+				createSelection(
+					{ clientId: 'block-1', attributeKey: 'content', offset: 3 },
+					{ clientId: 'block-2', attributeKey: 'content', offset: 2 }
+				)
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+			const blockHistory = selectionHistory.slice( 1 );
+
+			// Should have moved to different block combination
+			expect( current?.start.clientId ).toBe( 'block-1' );
+			expect( current?.end.clientId ).toBe( 'block-2' );
+			expect( blockHistory.length ).toBe( 1 );
+			expect( blockHistory[ 0 ].start.clientId ).toBe( 'block-1' );
+			expect( blockHistory[ 0 ].end.clientId ).toBe( 'block-1' );
+		} );
+
+		test( 'should add to history when transitioning between different cross-block selections', () => {
+			// Cross-block from block-1 to block-2
+			history.updateSelection(
+				createSelection(
+					{ clientId: 'block-1', attributeKey: 'content', offset: 5 },
+					{ clientId: 'block-2', attributeKey: 'content', offset: 3 }
+				)
+			);
+
+			// Cross-block from block-2 to block-3
+			history.updateSelection(
+				createSelection(
+					{ clientId: 'block-2', attributeKey: 'content', offset: 1 },
+					{ clientId: 'block-3', attributeKey: 'value', offset: 2 }
+				)
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+			const blockHistory = selectionHistory.slice( 1 );
+
+			expect( current?.start.clientId ).toBe( 'block-2' );
+			expect( current?.end.clientId ).toBe( 'block-3' );
+			expect( blockHistory.length ).toBe( 1 );
+			expect( blockHistory[ 0 ].start.clientId ).toBe( 'block-1' );
+			expect( blockHistory[ 0 ].end.clientId ).toBe( 'block-2' );
+		} );
+
+		test( 'should not add to history when updating same cross-block selection combination', () => {
+			// Cross-block from block-1 to block-2
+			history.updateSelection(
+				createSelection(
+					{ clientId: 'block-1', attributeKey: 'content', offset: 5 },
+					{ clientId: 'block-2', attributeKey: 'content', offset: 3 }
+				)
+			);
+
+			// Same block combination, different offsets
+			history.updateSelection(
+				createSelection(
+					{ clientId: 'block-1', attributeKey: 'content', offset: 2 },
+					{ clientId: 'block-2', attributeKey: 'content', offset: 8 }
+				)
+			);
+
+			const selectionHistory = history.getSelectionHistory();
+			const current = selectionHistory[ 0 ];
+			const blockHistory = selectionHistory.slice( 1 );
+
+			expect( current?.start.clientId ).toBe( 'block-1' );
+			expect( current?.end.clientId ).toBe( 'block-2' );
+			expect( ( current?.start as YRelativeSelection ).offset ).toBe( 2 );
+			expect( ( current?.end as YRelativeSelection ).offset ).toBe( 8 );
+			// Should not add to history - same block combination
+			expect( blockHistory.length ).toBe( 0 );
+		} );
+	} );
+} );

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -166,7 +166,12 @@ export function createSyncManager(): SyncManager {
 		if ( ! undoManager ) {
 			undoManager = createUndoManager();
 		}
-		undoManager.addToScope( recordMap );
+
+		const { addUndoMeta, restoreUndoMeta } = handlers;
+		undoManager.addToScope( recordMap, {
+			addUndoMeta,
+			restoreUndoMeta,
+		} );
 
 		const entityState: EntityState = {
 			awareness,

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -97,11 +97,13 @@ describe( 'SyncManager', () => {
 		};
 
 		mockHandlers = {
+			addUndoMeta: jest.fn(),
 			editRecord: jest.fn(),
 			getEditedRecord: jest.fn( async () =>
 				Promise.resolve( mockRecord )
 			),
 			refetchRecord: jest.fn( async () => Promise.resolve() ),
+			restoreUndoMeta: jest.fn(),
 			saveRecord: jest.fn( async () => Promise.resolve() ),
 		};
 	} );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -67,12 +67,14 @@ export type ProviderCreator = (
 ) => Promise< ProviderCreatorResult >;
 
 export interface RecordHandlers {
+	addUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 	editRecord: (
 		data: Partial< ObjectData >,
 		options?: { undoIgnore?: boolean }
 	) => void;
 	getEditedRecord: () => Promise< ObjectData >;
 	refetchRecord: () => Promise< void >;
+	restoreUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 	saveRecord: () => Promise< void >;
 }
 
@@ -121,5 +123,8 @@ export interface SyncManager {
 }
 
 export interface SyncUndoManager extends WPUndoManager< ObjectData > {
-	addToScope: ( ymap: Y.Map< any > ) => void;
+	addToScope: (
+		ymap: Y.Map< any >,
+		handlers: Pick< RecordHandlers, 'addUndoMeta' | 'restoreUndoMeta' >
+	) => void;
 }

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -13,7 +13,15 @@ import type { HistoryRecord } from '@wordpress/undo-manager';
  */
 import { LOCAL_EDITOR_ORIGIN } from './config';
 import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
-import type { ObjectData, SyncUndoManager } from './types';
+import type { ObjectData, RecordHandlers, SyncUndoManager } from './types';
+
+interface StackItemEvent {
+	stackItem: { meta: Map< any, any > };
+	origin: any;
+	type: 'undo' | 'redo';
+	changedParentTypes: Map< Y.AbstractType< any >, Y.YEvent< any >[] >;
+	ydoc: Y.Doc;
+}
 
 /**
  * Implementation of the WordPress UndoManager interface using YMultiDocUndoManager
@@ -22,9 +30,14 @@ import type { ObjectData, SyncUndoManager } from './types';
  * without conflicts.
  */
 export function createUndoManager(): SyncUndoManager {
+	// A map of Yjs document guids to their BlockSelectionHistory instances.
+	// const selectionHistoryMap = new Map< string, BlockSelectionHistory >();
+
 	const yUndoManager = new YMultiDocUndoManager( [], {
-		// Throttle undo/redo captures. (default: 500ms)
-		captureTimeout: 200,
+		// Throttle undo/redo captures after 500ms of inactivity.
+		// 500 was selected from subjective local UX testing, shorter timeouts
+		// may cause mid-word undo stack items.
+		captureTimeout: 500,
 		// Ensure that we only scope the undo/redo to the current editor.
 		// The yjs document's clientID is added once it's available.
 		trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
@@ -50,10 +63,32 @@ export function createUndoManager(): SyncUndoManager {
 		/**
 		 * Add a Yjs map to the scope of the undo manager.
 		 *
-		 * @param {Y.Map< any >} ymap The Yjs map to add to the scope.
+		 * @param {Y.Map< any >} ymap                     The Yjs map to add to the scope.
+		 * @param                handlers
+		 * @param                handlers.addUndoMeta
+		 * @param                handlers.restoreUndoMeta
 		 */
-		addToScope( ymap: Y.Map< any > ): void {
+		addToScope(
+			ymap: Y.Map< any >,
+			handlers: Pick< RecordHandlers, 'addUndoMeta' | 'restoreUndoMeta' >
+		): void {
+			if ( ymap.doc === null ) {
+				// Necessary for a type check, but this shouldn't happen.
+				return;
+			}
+
+			const ydoc = ymap.doc;
 			yUndoManager.addToScope( ymap );
+
+			const { addUndoMeta, restoreUndoMeta } = handlers;
+
+			yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
+				addUndoMeta( ydoc, event.stackItem.meta );
+			} );
+
+			yUndoManager.on( 'stack-item-popped', ( event: StackItemEvent ) => {
+				restoreUndoMeta( ydoc, event.stackItem.meta );
+			} );
 		},
 
 		/**

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -30,9 +30,6 @@ interface StackItemEvent {
  * without conflicts.
  */
 export function createUndoManager(): SyncUndoManager {
-	// A map of Yjs document guids to their BlockSelectionHistory instances.
-	// const selectionHistoryMap = new Map< string, BlockSelectionHistory >();
-
 	const yUndoManager = new YMultiDocUndoManager( [], {
 		// Throttle undo/redo captures after 500ms of inactivity.
 		// 500 was selected from subjective local UX testing, shorter timeouts


### PR DESCRIPTION
## What?

[This PR is the work of @alecgeatches as noted by the commit.]

Improve undo positioning in real-time collaborative documents.

Our current implementation of the `UndoStack` with real-time collaboration [undoes stack operations](https://github.com/WordPress/gutenberg/blob/9714d0a9bd7fcaeee3e1b80514e5854ccddb5ef3/packages/sync/src/undo-manager.ts#L68-L69) but does not manage the user's cursor position within the undo stack. This leads to a lot of unexpected jumps, selection loss, or relocation to the beginning of the line when changes are undone.

*Before*:

https://github.com/user-attachments/assets/1689bf57-b139-4dd2-a6a0-adec191cb874

The user's cursor can jump to an unexpected place or lose focus when an undo operation happens. This is caused from restoring content but not the user's cursor.

The changes in this PR use [`Y.UndoManager`](https://docs.yjs.dev/api/undo-manager#example-add-additional-information-to-the-stackitems)'s `stack-item-added` and `stack-item-popped` events to store the user's [`RelativePosition`](https://docs.yjs.dev/api/relative-positions) on the stack. This fixes regular undo behavior, and also accounts for position changes that might have been made by another user in the CRDT doc. Here are the same tests above in this branch:

*After*:

https://github.com/user-attachments/assets/b7e3d0b3-12b0-4633-970d-48696ef91b30

## Why?

Because our real-time undo stack relies on `Y.UndoManager`, we need to give it information on the user's cursor when we save items to the stack, or change the user's cursor when we pop items off. We store [`RelativePosition`](https://docs.yjs.dev/api/relative-positions) objects instead of absolute offsets which allow cursor positions to move if the underlying content has changed.

## How?

This PR relies on a couple of important pieces:

- Viewing the user's current selection, and restoring selection in the `sync`'s `UndoManager` is difficult without introducing circular dependencies. To work around this, we pass `addUndoMeta()` and `restoreUndoMeta()` record handlers to core data, which the sync manager uses to pass undo stack meta and activate it during an undo operation.
- The `BlockSelectionHistory` lives in core data class keeps a recent set of selected blocks, bucketed by start and end block clientId, which was found in practice to be a good way to store recent selections without duplicated data. For example, here's a user typing in two blocks:

    ![b1-b2](https://github.com/user-attachments/assets/e3e8df5a-5847-4e31-8f1b-326dccfb9eed)

    The de-duplicated selection updates from the block editor store give these set of selection updates:

    ```js
    { "selectionStart": {}, "selectionEnd": {} }
    {
        "selectionStart": { "clientId": "<block1>", "attributeKey": "content", "offset": 0 },
        "selectionEnd":   { "clientId": "<block1>", "attributeKey": "content", "offset": 0 }
    }
    {
        "selectionStart": { "clientId": "<block1>", "attributeKey": "content", "offset": 1 },
        "selectionEnd":   { "clientId": "<block1>", "attributeKey": "content", "offset": 1 }
    }
    {
        "selectionStart": { "clientId": "<block1>", "attributeKey": "content", "offset": 2 },
        "selectionEnd":   { "clientId": "<block1>", "attributeKey": "content", "offset": 2 }
    }
    {
        "selectionStart": { "clientId": "<block2>" },
        "selectionEnd":   { "clientId": "<block2>" }
    }
    {
        "selectionStart": { "clientId": "<block2>", "attributeKey": "content" },
        "selectionEnd":   { "clientId": "<block2>", "attributeKey": "content" }
    }
    {
        "selectionStart": { "clientId": "<block2>", "attributeKey": "content", "offset": 0 },
        "selectionEnd":   { "clientId": "<block2>", "attributeKey": "content", "offset": 0 }
    }
    {
        "selectionStart": { "clientId": "<block2>", "attributeKey": "content", "offset": 1 },
        "selectionEnd":   { "clientId": "<block2>", "attributeKey": "content", "offset": 1 }
    }
    {
        "selectionStart": { "clientId": "<block2>", "attributeKey": "content", "offset": 2 },
        "selectionEnd":   { "clientId": "<block2>", "attributeKey": "content", "offset": 2 }
    }
    ```

    `<block1>` and `<block2>` are shortened block clientIds.

    There's a lot of noise in here, especially when blocks are created like `<block2>` which send an update with just the`clientId`, then the `clientId` and `attributeKey`, and finally the location of the cursor when the block is done being created with an `offset`.  It can be tricky to determine which of these represent a valid state for the user's selection to return to.

    `BlockSelectionHistory` processes these updates to bucket them by `clientId`. At the end of the actions above, here's what `BlockSelectionHistory` has stored:

    ```js
    {
        "currentSelection": {
            "start": {
                "type": "RelativeSelection",
                "attributeKey": "content",
                "relativePosition": { /* ... */ },
                "clientId":"<block2>",
                "offset":2
            },
            "end": { /** same as start */ },
        }
        "history": [
            {
                "start": {
                    "type": "RelativeSelection",
                    "attributeKey": "content",
                    "relativePosition": { /* ... */ },
                    "clientId":"<block1>",
                    "offset":2
                },
                "end": { /** same as start */ },
            }
        ]
    }
    ```

    where the `relativePosition` property is a [`Y.RelativePosition`](https://docs.yjs.dev/api/relative-positions) type.

    Now when we process an undo stack being added, it's easy to grab the current relative position and some recent backups and push them onto the stack. The current implementation saves the current selection along with the last three unique block selections made before it.
    
    When the user undoes an item in the undo stack, we [iterate through the positions](https://github.com/WordPress/gutenberg/blob/b3d75ad10705113c75f7979e7de36ad1910e3ef4/packages/core-data/src/utils/crdt.ts#L548) on that item and move to the first valid one. In testing, especially in a multi-user environment, that was found to be a robust way to handle fallback positions when the underlying document can change.

### Selection ranges

We also store the `start` and `end` for each selection, which allows us to restore selected content made before a change:

![restore-selected-content](https://github.com/user-attachments/assets/3033d316-698e-43c4-8c8a-78c2a9ff2e99)

This is change from non-collaborative Gutenberg, which does not keep selection state in the undo stack.

## What's missing?

There are still some features we can enhance to improve the undo stack or match WordPress behavior better:

### 1. Match WordPress behavior by creating an undo stack item when a block is inserted

WordPress will create a new undo location at the beginning of each block:

![wordpress-line-undo](https://github.com/user-attachments/assets/cba1d98b-caf1-4f2f-a454-2a7c98bc4829)

When undoing, the cursor stops at each new block. However, `Y.UndoManager` instead uses a [`captureTimeout` of `500ms`](https://github.com/WordPress/gutenberg/blob/2449f9ef0ee549efbb490adee47c125bf1103f79/packages/sync/src/undo-manager.ts#L53) to decide when new stack items are added. If typed quickly enough, all 3 blocks are grouped together in one stack item instead:

![rtc-line-undo](https://github.com/user-attachments/assets/7975736f-4378-4943-81bb-095b838961ea)

This may be possible to fix, but in the current behavior `Y.UndoManager` is fully in charge of when stack items are committed and we don't have specific say other than `captureTimeout`.

### 2. Block lookup inefficiencies

In order to convert a cursor offset to a `RelativePosition`, we need access to the underlying `Y.Text` object that represents the block's RichText content. This currently relies on the [`findBlockByClientIdInDoc()` function](https://github.com/WordPress/gutenberg/blob/2449f9ef0ee549efbb490adee47c125bf1103f79/packages/sync/src/utils.ts#L95), which recursively scans a document's entire content to find the associated `Y.Text` object. This works fine for small document tests but may be a bottleneck in larger documents.

This is the same inefficient approach we use within the [vip-real-time-collaboration plugin](https://github.com/Automattic/vip-real-time-collaboration/blob/9a378d4834af6812d33d078b0b399a8701f44ae3/src/utilities/selection.ts#L226-L229), but it should be changed in both to a better system. I think a top level map of `clientId -> attributeName -> Y.Text` would be a much more efficient way to store `Y.Text` values for lookup and would solve the O(N) runtime of the current implementation, but this will require changes to attribute storage.

## Testing Instructions

1. Check out this PR.
2. As a single user, type things in the editor, create new blocks, and move the cursor around. Try undoing and redoing actions, an ensure that the cursor position returns to an intuitive position.
3. Try selecting a range within a single block, type over the selected content, and then undo. The selection should be restored. Note that this behavior doesn't work when restoring a selection across multiple blocks, which is a limitation of selection state in Gutenberg.
4. Open another tab with another user and edit the document at the same time. Ensure that undo and redo operations continue to work, even if blocks are changed. Since we store a `RelativePosition`, the user's cursor should still return to the correct logical spot in a previous paragraph even if the offset has changed.

There are also a set of tests in `block-selection-history.test.ts`:

```
npm run test:unit -- --testPathPattern=block-selection-history
```