### PR TITLE
Style Engine: Bail early when adding a declaration if not passed a string

### DIFF
--- a/backport-changelog/7.0/10779.md
+++ b/backport-changelog/7.0/10779.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10779
+
+* https://github.com/WordPress/gutenberg/pull/74881

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -50,7 +50,10 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 				return $this;
 			}
 
-			// Trims the value. If empty, bail early.
+			// Bail early if value is not a string. Prevents fatal errors from malformed block markup.
+			if ( ! is_string( $value ) ) {
+				return $this;
+			}
 			$value = trim( $value );
 			if ( '' === $value ) {
 				return $this;

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -219,6 +219,32 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that non-string values are rejected without causing fatal errors.
+	 *
+	 * @covers ::add_declaration
+	 */
+	public function test_should_reject_non_string_values() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+
+		// Add valid string value first.
+		$css_declarations->add_declaration( 'color', 'red' );
+
+		// Try to add array value - should be silently rejected.
+		$css_declarations->add_declaration( 'padding-margin', array( 'top' => '10px' ) );
+
+		// Try to add other non-string values.
+		$css_declarations->add_declaration( 'font-size', 123 );
+		$css_declarations->add_declaration( 'margin', null );
+
+		// Only the valid string value should be stored.
+		$this->assertSame(
+			array( 'color' => 'red' ),
+			$css_declarations->get_declarations(),
+			'Non-string values should be rejected without causing errors.'
+		);
+	}
+
+	/**
 	 * Tests removing a single declaration.
 	 *
 	 * @covers ::remove_declaration


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Harden the `add_declaration` method in the Style Engine so that if passed a value that isn't a string, it bails early rather than attempting to call `trim()` .

<!-- In a few words, what is the PR actually doing? -->

## Why?

If a site or post has malformed markup, then it's sometimes possible for the Style Engine to be erroneously passed an array or other value instead of a string. This change hardens it a little to make sure things safely bail, rather than throwing a fatal.

## How?

Bail early if not a string.

## Testing Instructions

Check that tests pass.

---

For more thorough testing, here is some markup that erroneously puts `margin` as a child of `spacing.padding` in a block's block attribute markup. That kind of malformed markup (prior to this PR) throws a fatal. But with this PR, gracefully bails.

<details>
<summary>Malformed markup</summary>

```html
<!-- wp:group {"metadata":{"name":"Header Container","patternCategory":"header","remotePatternId":13450},"align":"full","className":"big-sky__is-processing","style":{"spacing":{"padding":{"top":"0","bottom":"0","margin":{"top":"0","bottom":"0"},"left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}},"backgroundColor":"theme-6","textColor":"theme-5","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull big-sky__is-processing has-theme-5-color has-theme-6-background-color has-text-color has-background" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"tagName":"header","metadata":{"name":"Contents"},"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"},"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
<header class="wp-block-group alignwide" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"className":"","style":{"spacing":{"blockGap":"0","padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"width":"32","height":"32","sizeSlug":"full","linkDestination":"none","className":"is-resized","style":{"width":"120px","margin":{"bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
<figure class="wp-block-image size-full is-resized" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><img src="https://wordpress.org/files/2023/02/wmark.png" alt="A logo" style="width:32;height:32" /></figure>
<!-- /wp:image -->

<!-- wp:site-title {"className":"","style":{"typography":{"fontSize":"2em"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"textColor":"theme-5","fontSize":"small"} /--></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:navigation {"ref":10,"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"0"}},"fontSize":"small"} /-->

<!-- wp:buttons {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
<div class="wp-block-buttons" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:button {"style":{"spacing":{"padding":{"top":"0.44rem","bottom":"0.44rem","left":"0.67rem","right":"0.67rem"}}},"fontSize":"small"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-small-font-size has-custom-font-size wp-element-button" style="padding-top:0.44rem;padding-right:0.67rem;padding-bottom:0.44rem;padding-left:0.67rem"></a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group --></header>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
</details>