### PR TITLE
MediaReplaceFlow: Move Reset option to bottom of menu

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -239,6 +239,9 @@ const MediaReplaceFlow = ( {
 								{ __( 'Use featured image' ) }
 							</MenuItem>
 						) }
+						{ typeof children === 'function'
+							? children( { onClose } )
+							: children }
 						{ mediaURL && onReset && (
 							<MenuItem
 								onClick={ () => {
@@ -249,9 +252,6 @@ const MediaReplaceFlow = ( {
 								{ __( 'Reset' ) }
 							</MenuItem>
 						) }
-						{ typeof children === 'function'
-							? children( { onClose } )
-							: children }
 					</NavigableMenu>
 					{ onSelectURL && (
 						<form className="block-editor-media-flow__url-input">


### PR DESCRIPTION
## Summary

Moves the Reset menu item to appear after custom children options, placing it at the bottom of the replace media dropdown. This follows standard UI conventions where destructive/secondary actions appear last.

## Testing steps

1. Add a Cover block
2. Set an image.
3. Click "Replace" in the toolbar
4. Verify "Reset" now appears at the bottom of the dropdown menu (after "Embed video from URL")

Fixes #74880

## Screenshots

Before:

<img width="759" height="329" alt="Screenshot 2026-01-22 at 7 55 56 PM" src="https://github.com/user-attachments/assets/2c211359-5853-4908-be63-eef670f6c776" />

After:

<img width="967" height="642" alt="Screenshot 2026-01-22 at 9 54 09 PM" src="https://github.com/user-attachments/assets/7529b6e6-1745-4d12-833b-7d7124b8c493" />



🤖 Generated with [Claude Code](https://claude.ai/code)