### PR TITLE
Cover Block: Show current embed URL in dialog 

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -17,7 +17,7 @@ import { link } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { ALLOWED_MEDIA_TYPES } from '../shared';
+import { ALLOWED_MEDIA_TYPES, EMBED_VIDEO_BACKGROUND_TYPE } from '../shared';
 import { unlock } from '../../lock-unlock';
 import EmbedVideoUrlInput from './embed-video-url-input';
 
@@ -33,8 +33,14 @@ export default function CoverBlockControls( {
 	onSelectEmbedUrl,
 	blockEditingMode,
 } ) {
-	const { contentPosition, id, useFeaturedImage, minHeight, minHeightUnit } =
-		attributes;
+	const {
+		contentPosition,
+		id,
+		useFeaturedImage,
+		minHeight,
+		minHeightUnit,
+		backgroundType,
+	} = attributes;
 	const { hasInnerBlocks, url } = currentSettings;
 
 	const [ prevMinHeightValue, setPrevMinHeightValue ] = useState( minHeight );
@@ -133,6 +139,11 @@ export default function CoverBlockControls( {
 						onSelectEmbedUrl( embedUrl );
 					} }
 					onClose={ () => setIsEmbedUrlInputOpen( false ) }
+					initialUrl={
+						backgroundType === EMBED_VIDEO_BACKGROUND_TYPE
+							? url
+							: ''
+					}
 				/>
 			) }
 		</>

--- a/packages/block-library/src/cover/edit/embed-video-url-input.js
+++ b/packages/block-library/src/cover/edit/embed-video-url-input.js
@@ -15,8 +15,12 @@ import { __ } from '@wordpress/i18n';
  */
 import { isValidVideoEmbedUrl } from '../embed-video-utils';
 
-export default function EmbedVideoUrlInput( { onSubmit, onClose } ) {
-	const [ url, setUrl ] = useState( '' );
+export default function EmbedVideoUrlInput( {
+	onSubmit,
+	onClose,
+	initialUrl = '',
+} ) {
+	const [ url, setUrl ] = useState( initialUrl );
 	const [ error, setError ] = useState( '' );
 
 	const handleConfirm = () => {


### PR DESCRIPTION
## What?

Fixes #74879

This PR improves the user experience when working with embedded videos in the Cover block by displaying the current video URL when reopening the "Embed video from URL" dialog.

## Why?
Previously, when a user embedded a video from a URL (like YouTube or Vimeo) in the Cover block and later wanted to see or modify that URL, clicking "Embed video from URL" would show an empty dialog. This made it impossible to know what video was currently embedded without inspecting the block's code or removing and re-adding the video.

## How?
- Added an `initialUrl` prop to the `EmbedVideoUrlInput` component with a default value of empty string
- Modified `block-controls.js` to pass the current embed URL when `backgroundType` is `EMBED_VIDEO_BACKGROUND_TYPE`
- The TextControl input field now pre-populates with the current URL, similar to how the media library option shows the currently selected media

## Testing Instructions
1. Create or edit a Cover block
2. Click the Replace button in the toolbar
3. Select "Embed video from URL"
4. Enter a valid video URL (e.g., https://vimeo.com/347119375)
5. Click "Add video" to confirm
6. The video should now be embedded in the Cover block
7. Click the Replace button again
8. Select "Embed video from URL"
9. The dialog should now display the previously entered URL
10. You should be able to modify the URL or leave it as is

## Screenshots
Before: The dialog showed an empty input field even when a video was already embedded

https://github.com/user-attachments/assets/14a48ba3-7cf3-424a-a81f-92a4bca9dfb3



After: The dialog now shows the current embed URL, allowing users to see and modify it


https://github.com/user-attachments/assets/39658b59-36e7-4b1b-af3e-e82d5b11ee43


