### PR TITLE
Rich Text: Preserve leading whitespace in inline formatting

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -398,7 +398,10 @@ function collapseWhiteSpace( element, isRoot = true ) {
 				newNodeValue = newNodeValue.replace( / {2,}/g, ' ' );
 			}
 
-			if ( i === 0 && newNodeValue.startsWith( ' ' ) ) {
+			// Only trim leading space from first node if we're at root level
+			// Don't trim if we're inside an inline format element as this would
+			// incorrectly remove intentionally formatted whitespace
+			if ( isRoot && i === 0 && newNodeValue.startsWith( ' ' ) ) {
 				newNodeValue = newNodeValue.slice( 1 );
 			} else if (
 				isRoot &&


### PR DESCRIPTION
## What?
Fixes #74876

## Why?
When text with leading whitespace (e.g., " word") is selected and inline formatting (Bold/Link) is applied, the leading space was being removed after saving and refreshing the page. This caused formatted text like "one **two** three" to become "one**two** three".

## How?
The issue was in the `collapseWhiteSpace` function in `packages/rich-text/src/create.js`. This function was removing leading whitespace from ALL text nodes, including those inside inline format elements like `<strong>` or `<em>`.

The fix ensures that leading whitespace is only removed at the root level, not inside inline formatting elements, preserving intentionally formatted whitespace.

## Testing Instructions
1. Create a paragraph with multiple words (e.g., "one two three")
2. Select the middle word WITH its leading space (e.g., select " two")
3. Apply Bold to the selection
4. Save the post
5. Refresh the page
6. Verify the leading space is preserved (should show "one **two** three", not "one**two** three")

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/15467c8c-cda4-4ae2-9067-a23b429584a8


After:

https://github.com/user-attachments/assets/67b17106-5bee-4dec-8cc2-927d8fca636a


