### PR TITLE
Navigation Overlays: Default new blocks to "always" show overlays

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -516,35 +516,20 @@ function Navigation( {
 		[ clientId ]
 	);
 
-	// Force overlayMenu to 'never' if within an overlay template part
-	// to prevent overlays within overlays.
+	// Configure navigation blocks in overlay templates.
+	const hasSetOverlayDefault = useRef( false );
 	useEffect( () => {
-		if ( isWithinOverlay && overlayMenu !== 'never' ) {
+		if ( ! isWithinOverlay ) {
+			return;
+		}
+
+		// Prevent nested overlays.
+		if ( overlayMenu !== 'never' ) {
 			setAttributes( { overlayMenu: 'never' } );
 		}
-	}, [ isWithinOverlay, overlayMenu, setAttributes ] );
 
-	// Set submenuVisibility to 'always' by default when in navigation overlay template
-	const hasSetOverlayDefault = useRef( false );
-	const { hasInnerBlocks } = useSelect(
-		( select ) => {
-			const { getBlockCount } = select( blockEditorStore );
-			return {
-				hasInnerBlocks: getBlockCount( clientId ) > 0,
-			};
-		},
-		[ clientId ]
-	);
-
-	useEffect( () => {
-		// Set overlay-friendly defaults when block is first created in an overlay template.
-		if (
-			isWithinOverlay &&
-			! hasSetOverlayDefault.current &&
-			submenuVisibility === 'hover' &&
-			! hasInnerBlocks &&
-			! ref
-		) {
+		// Set vertical orientation and always-open submenus for new blocks.
+		if ( ! hasSetOverlayDefault.current && ! ref ) {
 			hasSetOverlayDefault.current = true;
 			setAttributes( {
 				submenuVisibility: 'always',
@@ -558,9 +543,7 @@ function Navigation( {
 	}, [
 		attributes.layout,
 		isWithinOverlay,
-		submenuVisibility,
-		orientation,
-		hasInnerBlocks,
+		overlayMenu,
 		ref,
 		setAttributes,
 	] );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -302,16 +302,6 @@ function Navigation( {
 		[ setAttributes ]
 	);
 
-	// Reset submenuVisibility to default if orientation changes to horizontal while "always" is selected
-	useEffect( () => {
-		if ( orientation === 'horizontal' && submenuVisibility === 'always' ) {
-			setAttributes( {
-				submenuVisibility: 'hover',
-				showSubmenuIcon: true,
-			} );
-		}
-	}, [ orientation, submenuVisibility, setAttributes ] );
-
 	const recursionId = `navigationMenu/${ ref }`;
 
 	// Skip recursion check when in preview mode.
@@ -523,6 +513,62 @@ function Navigation( {
 			setAttributes( { overlayMenu: 'never' } );
 		}
 	}, [ isWithinOverlay, overlayMenu, setAttributes ] );
+
+	// Set submenuVisibility to 'always' by default when in navigation overlay template
+	const hasSetOverlayDefault = useRef( false );
+	const { hasInnerBlocks } = useSelect(
+		( select ) => {
+			const { getBlockCount } = select( blockEditorStore );
+			return {
+				hasInnerBlocks: getBlockCount( clientId ) > 0,
+			};
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		// Set overlay-friendly defaults when block is first created in an overlay template.
+		if (
+			isWithinOverlay &&
+			! hasSetOverlayDefault.current &&
+			submenuVisibility === 'hover' &&
+			! hasInnerBlocks &&
+			! ref
+		) {
+			hasSetOverlayDefault.current = true;
+			setAttributes( {
+				submenuVisibility: 'always',
+				layout: {
+					...attributes.layout,
+					orientation: 'vertical',
+				},
+				showSubmenuIcon: false,
+			} );
+		}
+	}, [
+		attributes.layout,
+		isWithinOverlay,
+		submenuVisibility,
+		orientation,
+		hasInnerBlocks,
+		ref,
+		setAttributes,
+	] );
+
+	// Reset submenuVisibility to default if orientation is horizontal while "always" is selected.
+	// Skip this reset if we're in an overlay template.
+	useEffect( () => {
+		if (
+			! isWithinOverlay &&
+			orientation === 'horizontal' &&
+			submenuVisibility === 'always'
+		) {
+			setAttributes( {
+				submenuVisibility: 'hover',
+				showSubmenuIcon: true,
+			} );
+		}
+	}, [ isWithinOverlay, orientation, submenuVisibility, setAttributes ] );
 
 	const isResponsive = 'never' !== overlayMenu;
 	const blockProps = useBlockProps( {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -302,6 +302,16 @@ function Navigation( {
 		[ setAttributes ]
 	);
 
+	// Reset submenuVisibility to default if orientation changes to horizontal while "always" is selected
+	useEffect( () => {
+		if ( orientation === 'horizontal' && submenuVisibility === 'always' ) {
+			setAttributes( {
+				submenuVisibility: 'hover',
+				showSubmenuIcon: true,
+			} );
+		}
+	}, [ orientation, submenuVisibility, setAttributes ] );
+
 	const recursionId = `navigationMenu/${ ref }`;
 
 	// Skip recursion check when in preview mode.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -555,21 +555,6 @@ function Navigation( {
 		setAttributes,
 	] );
 
-	// Reset submenuVisibility to default if orientation is horizontal while "always" is selected.
-	// Skip this reset if we're in an overlay template.
-	useEffect( () => {
-		if (
-			! isWithinOverlay &&
-			orientation === 'horizontal' &&
-			submenuVisibility === 'always'
-		) {
-			setAttributes( {
-				submenuVisibility: 'hover',
-				showSubmenuIcon: true,
-			} );
-		}
-	}, [ isWithinOverlay, orientation, submenuVisibility, setAttributes ] );
-
 	const isResponsive = 'never' !== overlayMenu;
 	const blockProps = useBlockProps( {
 		ref: navRef,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
When inserting navigation blocks into a navigation overlay, we should default them to have their submenus always visible

Closes #74779

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Hover and click submenus don't work well on mobile devices so we should discourage users from making these choices.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a useEffect to make this change to the attributes when the block is inserted.

## Testing Instructions
1. Enable the navigation overlays experiment
2. Add a navigation block
3. Set the block to use a custom overlay
4. Edit the custom overlay
5. Add a new navigation block inside the overlay
6. Confirm that the new block has its submenus set to always visible.
essibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1384" height="794" alt="Screenshot 2026-01-23 at 12 16 28" src="https://github.com/user-attachments/assets/9dbdd868-25d4-45e9-b0b9-64f08edfecfe" />
