### PR TITLE
Add block drag tests for webkit (+ one firefox)

### DIFF
--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -26,7 +26,7 @@ async function dragTo( page, x, y ) {
 	}
 }
 
-test.describe( 'Draggable block', () => {
+test.describe( 'Draggable block (@webkit)', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -68,7 +68,11 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
-		await dragTo( page, firstParagraphBound.x, firstParagraphBound.y );
+		await dragTo(
+			page,
+			firstParagraphBound.x + firstParagraphBound.width * 0.5,
+			firstParagraphBound.y + 1
+		);
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -333,7 +337,12 @@ test.describe( 'Draggable block', () => {
 		page,
 		editor,
 		pageUtils,
-	} ) => {
+	}, testInfo ) => {
+		testInfo.skip(
+			testInfo.project.name !== 'chromium',
+			'pageUtils.dragFiles uses CDP which is Chromium-only'
+		);
+
 		// Insert a row.
 		await editor.insertBlock( {
 			name: 'core/group',
@@ -457,7 +466,10 @@ test.describe( 'Draggable block', () => {
 		}
 	} );
 
-	test( 'can directly drag an image', async ( { page, editor } ) => {
+	test( 'can directly drag an image (@firefox)', async ( {
+		page,
+		editor,
+	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 		await editor.insertBlock( {
 			name: 'core/group',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
