### PR TITLE
Field API: make `getValue` and `setValue` declarative

### DIFF
--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -47,14 +47,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				allowedTypes: [ 'audio' ],
 				multiple: false,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.id,
-				url: item.src,
-			} ),
-			setValue: ( { value } ) => ( {
-				id: value.id,
-				src: value.url,
-			} ),
+			getValue: { id: 'id', url: 'src' },
+			setValue: { id: 'id', src: 'url' },
 		},
 		{
 			id: 'caption',

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -63,16 +63,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link', // TODO: replace with custom component
-			getValue: ( { item } ) => ( {
-				url: item.url,
-				rel: item.rel,
-				linkTarget: item.linkTarget,
-			} ),
-			setValue: ( { value } ) => ( {
-				url: value.url,
-				rel: value.rel,
-				linkTarget: value.linkTarget,
-			} ),
+			getValue: { url: 'url', rel: 'rel', linkTarget: 'linkTarget' },
+			setValue: { url: 'url', rel: 'rel', linkTarget: 'linkTarget' },
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -74,20 +74,20 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				multiple: false,
 				useFeaturedImage: true,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.id,
-				url: item.url,
-				alt: item.alt,
-				mediaType: item.backgroundType,
-				featuredImage: item.useFeaturedImage,
-			} ),
-			setValue: ( { value } ) => ( {
-				id: value.id,
-				url: value.url,
-				alt: value.alt,
-				mediaType: value.backgroundType,
-				useFeaturedImage: value.featuredImage,
-			} ),
+			getValue: {
+				id: 'id',
+				url: 'url',
+				alt: 'alt',
+				mediaType: 'backgroundType',
+				featuredImage: 'useFeaturedImage',
+			},
+			setValue: {
+				id: 'id',
+				url: 'url',
+				alt: 'alt',
+				backgroundType: 'mediaType',
+				useFeaturedImage: 'featuredImage',
+			},
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -47,14 +47,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				allowedTypes: [],
 				multiple: false,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.id,
-				url: item.href,
-			} ),
-			setValue: ( { value } ) => ( {
-				id: value.id,
-				href: value.url,
-			} ),
+			getValue: { id: 'id', url: 'href' },
+			setValue: { id: 'id', href: 'url' },
 		},
 		{
 			id: 'fileName',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -77,34 +77,16 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				allowedTypes: [ 'image' ],
 				multiple: false,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.id,
-				url: item.url,
-				alt: item.alt,
-				caption: item.caption,
-			} ),
-			setValue: ( { value } ) => ( {
-				id: value.id,
-				url: value.url,
-				alt: value.alt,
-				caption: value.caption,
-			} ),
+			getValue: { id: 'id', url: 'url', alt: 'alt', caption: 'caption' },
+			setValue: { id: 'id', url: 'url', alt: 'alt', caption: 'caption' },
 		},
 		{
 			id: 'link',
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link', // TODO: replace with custom component
-			getValue: ( { item } ) => ( {
-				url: item.href,
-				rel: item.rel,
-				linkTarget: item.linkTarget,
-			} ),
-			setValue: ( { value } ) => ( {
-				href: value.url,
-				rel: value.rel,
-				linkTarget: value.linkTarget,
-			} ),
+			getValue: { url: 'href', rel: 'rel', linkTarget: 'linkTarget' },
+			setValue: { href: 'url', rel: 'rel', linkTarget: 'linkTarget' },
 		},
 		{
 			id: 'caption',

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -65,34 +65,26 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				allowedTypes: [ 'image', 'video' ],
 				multiple: false,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.mediaId,
-				url: item.mediaUrl,
-				mediaType: item.mediaType,
-				link: item.mediaLink,
-			} ),
-			setValue: ( { value } ) => ( {
-				mediaId: value.id,
-				mediaUrl: value.url,
-				mediaType: value.mediaType,
-				mediaLink: value.link,
-			} ),
+			getValue: {
+				id: 'mediaId',
+				url: 'mediaUrl',
+				mediaType: 'mediaType',
+				link: 'mediaLink',
+			},
+			setValue: {
+				mediaId: 'id',
+				mediaUrl: 'url',
+				mediaType: 'mediaType',
+				mediaLink: 'link',
+			},
 		},
 		{
 			id: 'link',
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link', // TODO: replace with custom component
-			getValue: ( { item } ) => ( {
-				url: item.href,
-				rel: item.rel,
-				linkTarget: item.linkTarget,
-			} ),
-			setValue: ( { value } ) => ( {
-				href: value.url,
-				rel: value.rel,
-				linkTarget: value.linkTarget,
-			} ),
+			getValue: { url: 'href', rel: 'rel', linkTarget: 'linkTarget' },
+			setValue: { href: 'url', rel: 'rel', linkTarget: 'linkTarget' },
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -106,14 +106,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link',
-			getValue: ( { item } ) => ( {
-				url: item.url,
-				rel: item.rel,
-			} ),
-			setValue: ( { value } ) => ( {
-				url: value.url,
-				rel: value.rel,
-			} ),
+			getValue: { url: 'url', rel: 'rel' },
+			setValue: { url: 'url', rel: 'rel' },
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -65,14 +65,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link', // TODO: replace with custom component
-			getValue: ( { item } ) => ( {
-				url: item.url,
-				rel: item.rel,
-			} ),
-			setValue: ( { value } ) => ( {
-				url: value.url,
-				rel: value.rel,
-			} ),
+			getValue: { url: 'url', rel: 'rel' },
+			setValue: { url: 'url', rel: 'rel' },
 		},
 	];
 	settings[ formKey ] = {

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -33,14 +33,8 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			label: __( 'Link' ),
 			type: 'url',
 			Edit: 'link', // TODO: replace with custom component
-			getValue: ( { item } ) => ( {
-				url: item.url,
-				rel: item.rel,
-			} ),
-			setValue: ( { value } ) => ( {
-				url: value.url,
-				rel: value.rel,
-			} ),
+			getValue: { url: 'url', rel: 'rel' },
+			setValue: { url: 'url', rel: 'rel' },
 		},
 		{
 			id: 'label',

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -48,18 +48,18 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				allowedTypes: [ 'video' ],
 				multiple: false,
 			},
-			getValue: ( { item } ) => ( {
-				id: item.id,
-				url: item.src,
-				caption: item.caption,
-				poster: item.poster,
-			} ),
-			setValue: ( { value } ) => ( {
-				id: value.id,
-				src: value.url,
-				caption: value.caption,
-				poster: value.poster,
-			} ),
+			getValue: {
+				id: 'id',
+				url: 'src',
+				caption: 'caption',
+				poster: 'poster',
+			},
+			setValue: {
+				id: 'id',
+				src: 'url',
+				caption: 'caption',
+				poster: 'poster',
+			},
 		},
 		{
 			id: 'caption',

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Enhancements
 
+- Field API: `getValue` and `setValue` can provide an object. [#74900](https://github.com/WordPress/gutenberg/pull/74900)
 - Add new `combobox` DataForm control. [#74891](https://github.com/WordPress/gutenberg/pull/74891)
 - Include total items count in footer. [#73491](https://github.com/WordPress/gutenberg/pull/73491)
 

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -77,19 +77,23 @@ export default function normalizeFields< Item >(
 	return fields.map( ( field ) => {
 		const fieldType = getFieldTypeByName< Item >( field.type );
 
-		const getValue =
-			typeof field.getValue === 'function'
-				? field.getValue
-				: field.getValue
-					? getValueFromMap( field.getValue )
-					: getValueFromId( field.id );
+		let getValue;
+		if ( typeof field.getValue === 'function' ) {
+			getValue = field.getValue;
+		} else if ( typeof field.getValue === 'object' ) {
+			getValue = getValueFromMap( field.getValue );
+		} else {
+			getValue = getValueFromId( field.id );
+		}
 
-		const setValue =
-			typeof field.setValue === 'function'
-				? field.setValue
-				: field.setValue
-					? setValueFromMap( field.setValue )
-					: setValueFromId( field.id );
+		let setValue;
+		if ( typeof field.setValue === 'function' ) {
+			setValue = field.setValue;
+		} else if ( typeof field.setValue === 'object' ) {
+			setValue = setValueFromMap( field.setValue );
+		} else {
+			setValue = setValueFromId( field.id );
+		}
 
 		const sort = function ( a: any, b: any, direction: SortDirection ) {
 			const aValue = getValue( { item: a } );

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -11,8 +11,10 @@ import type { FieldType } from '../types/private';
 import { getControl } from '../components/dataform-controls';
 import getFilterBy from './utils/get-filter-by';
 import getValueFromId from './utils/get-value-from-id';
+import getValueFromMap from './utils/get-value-from-map';
 import hasElements from './utils/has-elements';
 import setValueFromId from './utils/set-value-from-id';
+import setValueFromMap from './utils/set-value-from-map';
 import { default as email } from './email';
 import { default as integer } from './integer';
 import { default as number } from './number';
@@ -75,7 +77,20 @@ export default function normalizeFields< Item >(
 	return fields.map( ( field ) => {
 		const fieldType = getFieldTypeByName< Item >( field.type );
 
-		const getValue = field.getValue || getValueFromId( field.id );
+		const getValue =
+			typeof field.getValue === 'function'
+				? field.getValue
+				: field.getValue
+					? getValueFromMap( field.getValue )
+					: getValueFromId( field.id );
+
+		const setValue =
+			typeof field.setValue === 'function'
+				? field.setValue
+				: field.setValue
+					? setValueFromMap( field.setValue )
+					: setValueFromId( field.id );
+
 		const sort = function ( a: any, b: any, direction: SortDirection ) {
 			const aValue = getValue( { item: a } );
 			const bValue = getValue( { item: b } );
@@ -91,7 +106,7 @@ export default function normalizeFields< Item >(
 			description: field.description,
 			placeholder: field.placeholder,
 			getValue,
-			setValue: field.setValue || setValueFromId( field.id ),
+			setValue,
 			elements: field.elements,
 			getElements: field.getElements,
 			hasElements: hasElements( field ),

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -42,6 +42,60 @@ describe( 'normalizeFields: default getValue', () => {
 			expect( result ).toBe( 'value' );
 		} );
 	} );
+	describe( 'getValue from map', () => {
+		it( 'maps simple properties', () => {
+			const item = { id: 1, src: 'https://example.com/audio.mp3' };
+			const fields: Field< {} >[] = [
+				{
+					id: 'audio',
+					getValue: { id: 'id', url: 'src' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toEqual( { id: 1, url: 'https://example.com/audio.mp3' } );
+		} );
+
+		it( 'maps properties with same names', () => {
+			const item = { id: 1, url: 'https://example.com/image.jpg', alt: 'Description' };
+			const fields: Field< {} >[] = [
+				{
+					id: 'image',
+					getValue: { id: 'id', url: 'url', alt: 'alt' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toEqual( { id: 1, url: 'https://example.com/image.jpg', alt: 'Description' } );
+		} );
+
+		it( 'supports nested property paths', () => {
+			const item = { user: { profile: { name: 'John' } } };
+			const fields: Field< {} >[] = [
+				{
+					id: 'name',
+					getValue: { name: 'user.profile.name' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toEqual( { name: 'John' } );
+		} );
+
+		it( 'returns undefined for missing properties', () => {
+			const item = { id: 1 };
+			const fields: Field< {} >[] = [
+				{
+					id: 'audio',
+					getValue: { id: 'id', url: 'src' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toEqual( { id: 1, url: undefined } );
+		} );
+	} );
+
 	describe( 'setValue from ID', () => {
 		it( 'user', () => {
 			const item = { user: 'value', email: 'user@example.com' };
@@ -153,6 +207,72 @@ describe( 'normalizeFields: default getValue', () => {
 				value: undefined,
 			} );
 			expect( result ).toEqual( { user: undefined } );
+		} );
+	} );
+
+	describe( 'setValue from map', () => {
+		it( 'maps simple properties', () => {
+			const item = { id: 1, src: 'https://example.com/audio.mp3' };
+			const fields: Field< {} >[] = [
+				{
+					id: 'audio',
+					setValue: { id: 'id', src: 'url' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].setValue( {
+				item,
+				value: { id: 2, url: 'https://example.com/new.mp3' },
+			} );
+			expect( result ).toEqual( { id: 2, src: 'https://example.com/new.mp3' } );
+		} );
+
+		it( 'maps properties with same names', () => {
+			const item = { id: 1, url: 'https://example.com/image.jpg', alt: 'Old' };
+			const fields: Field< {} >[] = [
+				{
+					id: 'image',
+					setValue: { id: 'id', url: 'url', alt: 'alt' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].setValue( {
+				item,
+				value: { id: 2, url: 'https://example.com/new.jpg', alt: 'New' },
+			} );
+			expect( result ).toEqual( { id: 2, url: 'https://example.com/new.jpg', alt: 'New' } );
+		} );
+
+		it( 'supports nested property paths', () => {
+			const item = { user: { profile: { name: 'John' } } };
+			const fields: Field< {} >[] = [
+				{
+					id: 'name',
+					setValue: { 'user.profile.name': 'name' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].setValue( {
+				item,
+				value: { name: 'Jane' },
+			} );
+			expect( result ).toEqual( { user: { profile: { name: 'Jane' } } } );
+		} );
+
+		it( 'handles undefined values', () => {
+			const item = { id: 1, src: 'https://example.com/audio.mp3' };
+			const fields: Field< {} >[] = [
+				{
+					id: 'audio',
+					setValue: { id: 'id', src: 'url' },
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].setValue( {
+				item,
+				value: { id: 2, url: undefined },
+			} );
+			expect( result ).toEqual( { id: 2, src: undefined } );
 		} );
 	} );
 

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -53,11 +53,18 @@ describe( 'normalizeFields: default getValue', () => {
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toEqual( { id: 1, url: 'https://example.com/audio.mp3' } );
+			expect( result ).toEqual( {
+				id: 1,
+				url: 'https://example.com/audio.mp3',
+			} );
 		} );
 
 		it( 'maps properties with same names', () => {
-			const item = { id: 1, url: 'https://example.com/image.jpg', alt: 'Description' };
+			const item = {
+				id: 1,
+				url: 'https://example.com/image.jpg',
+				alt: 'Description',
+			};
 			const fields: Field< {} >[] = [
 				{
 					id: 'image',
@@ -66,10 +73,14 @@ describe( 'normalizeFields: default getValue', () => {
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toEqual( { id: 1, url: 'https://example.com/image.jpg', alt: 'Description' } );
+			expect( result ).toEqual( {
+				id: 1,
+				url: 'https://example.com/image.jpg',
+				alt: 'Description',
+			} );
 		} );
 
-		it( 'supports nested property paths', () => {
+		it( 'nested property paths', () => {
 			const item = { user: { profile: { name: 'John' } } };
 			const fields: Field< {} >[] = [
 				{
@@ -211,39 +222,53 @@ describe( 'normalizeFields: default getValue', () => {
 	} );
 
 	describe( 'setValue from map', () => {
-		it( 'maps simple properties', () => {
+		it( 'single property', () => {
 			const item = { id: 1, src: 'https://example.com/audio.mp3' };
 			const fields: Field< {} >[] = [
 				{
 					id: 'audio',
-					setValue: { id: 'id', src: 'url' },
+					setValue: { src: 'url' },
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].setValue( {
 				item,
-				value: { id: 2, url: 'https://example.com/new.mp3' },
+				value: { url: 'https://example.com/new.mp3' },
 			} );
-			expect( result ).toEqual( { id: 2, src: 'https://example.com/new.mp3' } );
+			expect( result ).toEqual( {
+				src: 'https://example.com/new.mp3',
+			} );
 		} );
 
-		it( 'maps properties with same names', () => {
-			const item = { id: 1, url: 'https://example.com/image.jpg', alt: 'Old' };
+		it( 'multiple properties', () => {
+			const item = {
+				id: 1,
+				url: 'https://example.com/image.jpg',
+				alt: 'Old',
+			};
 			const fields: Field< {} >[] = [
 				{
 					id: 'image',
-					setValue: { id: 'id', url: 'url', alt: 'alt' },
+					setValue: { id: 'id', url: 'href', alt: 'text' },
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].setValue( {
 				item,
-				value: { id: 2, url: 'https://example.com/new.jpg', alt: 'New' },
+				value: {
+					id: 2,
+					href: 'https://example.com/new.jpg',
+					text: 'New',
+				},
 			} );
-			expect( result ).toEqual( { id: 2, url: 'https://example.com/new.jpg', alt: 'New' } );
+			expect( result ).toEqual( {
+				id: 2,
+				url: 'https://example.com/new.jpg',
+				alt: 'New',
+			} );
 		} );
 
-		it( 'supports nested property paths', () => {
+		it( 'nested property paths', () => {
 			const item = { user: { profile: { name: 'John' } } };
 			const fields: Field< {} >[] = [
 				{
@@ -259,7 +284,7 @@ describe( 'normalizeFields: default getValue', () => {
 			expect( result ).toEqual( { user: { profile: { name: 'Jane' } } } );
 		} );
 
-		it( 'handles undefined values', () => {
+		it( 'returns undefined for missing properties', () => {
 			const item = { id: 1, src: 'https://example.com/audio.mp3' };
 			const fields: Field< {} >[] = [
 				{
@@ -270,7 +295,7 @@ describe( 'normalizeFields: default getValue', () => {
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].setValue( {
 				item,
-				value: { id: 2, url: undefined },
+				value: { id: 2 },
 			} );
 			expect( result ).toEqual( { id: 2, src: undefined } );
 		} );

--- a/packages/dataviews/src/field-types/utils/get-value-from-map.ts
+++ b/packages/dataviews/src/field-types/utils/get-value-from-map.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import getValueFromId from './get-value-from-id';
+import type { PropertyMap } from '../../types';
+
+/**
+ * Creates a getValue function from a property map.
+ *
+ * Map syntax: `{ outputKey: 'itemPath' }` - reads `item[itemPath]` as `outputKey`.
+ * Example: `{ id: 'id', url: 'src' }` reads `item.src` as `url`.
+ *
+ * @param map The property map defining the mapping from item paths to output keys.
+ * @return A getValue function that extracts values from an item based on the map.
+ */
+const getValueFromMap =
+	( map: PropertyMap ) =>
+	( { item }: { item: any } ) => {
+		const result: any = {};
+		for ( const [ outputKey, itemPath ] of Object.entries( map ) ) {
+			result[ outputKey ] = getValueFromId( itemPath )( { item } );
+		}
+		return result;
+	};
+
+export default getValueFromMap;

--- a/packages/dataviews/src/field-types/utils/set-value-from-map.ts
+++ b/packages/dataviews/src/field-types/utils/set-value-from-map.ts
@@ -1,0 +1,32 @@
+import type { PropertyMap } from '../../types';
+
+/**
+ * Creates a setValue function from a property map.
+ *
+ * Map syntax: `{ itemKey: 'valueKey' }` - writes `value[valueKey]` to `itemKey`.
+ * Example: `{ id: 'id', src: 'url' }` writes `value.url` to `src`.
+ *
+ * @param map The property map defining the mapping from value keys to item paths.
+ * @return A setValue function that creates a partial item update based on the map.
+ */
+const setValueFromMap =
+	( map: PropertyMap ) =>
+	( { value }: { value: any } ) => {
+		const result: any = {};
+
+		for ( const [ itemPath, valueKey ] of Object.entries( map ) ) {
+			const parts = itemPath.split( '.' );
+			let current = result;
+
+			for ( const part of parts.slice( 0, -1 ) ) {
+				current[ part ] = current[ part ] || {};
+				current = current[ part ];
+			}
+
+			current[ parts.at( -1 )! ] = value[ valueKey ];
+		}
+
+		return result;
+	};
+
+export default setValueFromMap;

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -76,6 +76,13 @@ export type FieldTypeName =
 	| 'url'
 	| 'array';
 
+/**
+ * A map of property names for declarative getValue/setValue definitions.
+ * For getValue: { outputKey: 'itemPath' } - maps item property paths to output keys.
+ * For setValue: { itemKey: 'valueKey' } - maps value keys to item property paths.
+ */
+export type PropertyMap = Record< string, string >;
+
 export type Rules< Item > = {
 	required?: boolean;
 	elements?: boolean;
@@ -271,14 +278,24 @@ export type Field< Item > = {
 	/**
 	 * Callback used to retrieve the value of the field from the item.
 	 * Defaults to `item[ field.id ]`.
+	 *
+	 * Can be a function or a PropertyMap for declarative property mapping.
+	 * Map syntax: `{ outputKey: 'itemPath' }` - reads `item[itemPath]` as `outputKey`.
+	 * Example: `{ id: 'id', url: 'src' }` reads `item.src` as `url`.
 	 */
-	getValue?: ( args: { item: Item } ) => any;
+	getValue?: ( ( args: { item: Item } ) => any ) | PropertyMap;
 
 	/**
 	 * Callback used to set the value of the field on the item.
 	 * Used for editing operations to update field values.
+	 *
+	 * Can be a function or a PropertyMap for declarative property mapping.
+	 * Map syntax: `{ itemKey: 'valueKey' }` - writes `value[valueKey]` to `itemKey`.
+	 * Example: `{ id: 'id', src: 'url' }` writes `value.url` to `src`.
 	 */
-	setValue?: ( args: { item: Item; value: any } ) => DeepPartial< Item >;
+	setValue?:
+		| ( ( args: { item: Item; value: any } ) => DeepPartial< Item > )
+		| PropertyMap;
 
 	/**
 	 * Display format configuration for fields.

--- a/packages/media-fields/src/filename/test/index.test.ts
+++ b/packages/media-fields/src/filename/test/index.test.ts
@@ -4,6 +4,11 @@
 import filenameField from '../index';
 import type { MediaItem } from '../../types';
 
+// Type assertion for getValue since it's defined as a function in this field
+const getValue = filenameField.getValue as ( args: {
+	item: MediaItem;
+} ) => string | undefined;
+
 describe( 'filenameField', () => {
 	it( 'has correct field configuration', () => {
 		expect( filenameField ).toMatchObject( {
@@ -23,7 +28,7 @@ describe( 'filenameField', () => {
 					'https://example.com/wp-content/uploads/2024/image.jpg',
 			};
 
-			const result = filenameField.getValue?.( {
+			const result = getValue?.( {
 				item: item as MediaItem,
 			} );
 
@@ -33,7 +38,7 @@ describe( 'filenameField', () => {
 		it( 'returns undefined when source_url is undefined', () => {
 			const item: Partial< MediaItem > = {};
 
-			const result = filenameField.getValue?.( {
+			const result = getValue?.( {
 				item: item as MediaItem,
 			} );
 
@@ -45,7 +50,7 @@ describe( 'filenameField', () => {
 				source_url: '',
 			};
 
-			const result = filenameField.getValue?.( {
+			const result = getValue?.( {
 				item: item as MediaItem,
 			} );
 

--- a/packages/media-fields/src/filesize/test/index.test.tsx
+++ b/packages/media-fields/src/filesize/test/index.test.tsx
@@ -4,6 +4,11 @@
 import filesizeField from '../index';
 import type { MediaItem } from '../../types';
 
+// Type assertion for getValue since it's defined as a function in this field
+const getValue = filesizeField.getValue as
+	| ( ( args: { item: MediaItem } ) => string )
+	| undefined;
+
 describe( 'filesizeField', () => {
 	it( 'has correct field configuration', () => {
 		expect( filesizeField ).toMatchObject( {
@@ -25,7 +30,7 @@ describe( 'filesizeField', () => {
 				},
 			} as MediaItem;
 
-			const result = filesizeField.getValue?.( {
+			const result = getValue?.( {
 				item,
 			} );
 
@@ -54,7 +59,7 @@ describe( 'filesizeField', () => {
 					},
 				} as MediaItem;
 
-				const result = filesizeField.getValue?.( {
+				const result = getValue?.( {
 					item,
 				} );
 
@@ -76,7 +81,7 @@ describe( 'filesizeField', () => {
 			[ { media_details: { sizes: {} } }, 'when filesize is missing' ],
 			[ {}, 'when media_details is missing' ],
 		] )( 'returns empty string %s', ( item, description ) => {
-			const result = filesizeField.getValue?.( {
+			const result = getValue?.( {
 				item: item as MediaItem,
 			} );
 

--- a/packages/media-fields/src/media_dimensions/test/index.test.ts
+++ b/packages/media-fields/src/media_dimensions/test/index.test.ts
@@ -8,6 +8,11 @@ import type { Attachment, Updatable } from '@wordpress/core-data';
  */
 import mediaDimensionsField from '../index';
 
+// Type assertion for getValue since it's defined as a function in this field
+const getValue = mediaDimensionsField.getValue as
+	| ( ( args: { item: Updatable< Attachment > } ) => string )
+	| undefined;
+
 describe( 'mediaDimensionsField', () => {
 	it( 'has correct field configuration', () => {
 		expect( mediaDimensionsField ).toMatchObject( {
@@ -26,7 +31,7 @@ describe( 'mediaDimensionsField', () => {
 				media_details: { width: 1920, height: 1080, sizes: {} },
 			} as Updatable< Attachment >;
 
-			const result = mediaDimensionsField.getValue?.( {
+			const result = getValue?.( {
 				item,
 			} );
 
@@ -60,7 +65,7 @@ describe( 'mediaDimensionsField', () => {
 				'when both width and height are 0',
 			],
 		] )( 'returns empty string %s', ( item, description ) => {
-			const result = mediaDimensionsField.getValue?.( {
+			const result = getValue?.( {
 				item: item as Updatable< Attachment >,
 			} );
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/73076
Related https://github.com/WordPress/gutenberg/issues/73261, https://github.com/WordPress/gutenberg/pull/74409

## What?

Adds support for declarative property mapping syntax in the Field API's `getValue` and `setValue` options, allowing simple 1:1 property mappings to be expressed as objects instead of functions. 

Before:

```tsx
{
  getValue: ( { item } ) => ( { id: item.id, url: item.src } ),
  setValue: ( { value } ) => ( { id: value.id, src: value.url } )
}
```

After:

_in addition to supporting functions, we also support objects_

```tsx
{
  getValue: { id: 'id', url: 'src' },
  setValue: { id: 'id', src: 'url' }
}
```

## Why?

In `@wordpress/block-library`, for the BlockFields/content-only experiment some blocks needed to define `getValue`/`setValue` functions to make that work with the custom Edit components (media, link, rich-text). This is problematic because we want this info to be sourced from `block.json`, and so we need the field definition to be serializable (can't have JavaScript functions).

By introducing a serializable version of `getValue` and `setValue` all blocks have removed the equivalent functions.

## How?

1. Make `getValue` / `setValue` type definition take a `Record<string, string>`, in addition to the existing function.
2. Updated `normalizeFields` to convert objects-based `getValue` / `setValue` to functions, via some new utilities:
    - `get-value-from-map.ts`: converts a `getValue` map to a function (syntax: `{ outputKey: 'itemPath' }`)
    - `set-value-from-map.ts`: converts a `setValue` map to a function (syntax: `{ itemKey: 'valueKey' }`)
3. Migrated all blocks to use the new declarative syntax.

The implementation supports dot-path notation for nested properties (e.g., { name: 'user.profile.name' }).

## Testing Instructions

1. Enable the block fields experiments.
2. Create a post and insert an Image block.
3. Select the block and verify the content-only inspector fields work correctly.
4. Test with other migrated blocks: Audio, Video, File, Cover, Media & Text, Button, Social Links, Navigation Link.