### PR TITLE
Remove link underline style from default theme.json

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -394,11 +394,6 @@
 				"border": {
 					"width": "0"
 				}
-			},
-			"link": {
-				"typography": {
-					"textDecoration": "underline"
-				}
 			}
 		},
 		"spacing": {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/41786#discussion_r2618493206

## What?

Remove the default `textDecoration: underline` style applied to links in theme.json.

## Why?

The default link underline style was applied to all themes since we enabled global styles in classic themes. This change allowed classic themes to access the font library. That said, that style seems unnecessary since it's the browser default, so this PR removes that link and may cause specificity issues.

## How?

Removed the `link` element definition from the `styles.elements` section in `lib/theme.json` that was setting `textDecoration: underline`.

Potentially this change could in theory impact block themes that relied on it but I'm having trouble understanding in which case it's necessary, especially since it's the browser default.

## Testing Instructions

Test this PR with multiple block and classic themes and ensure there's no regressions in how post titles and/or links render.