### PR TITLE
Real-Time Collaboration: Update sync provider event name and modal handling

### DIFF
--- a/packages/editor/src/components/sync-connection-modal/index.js
+++ b/packages/editor/src/components/sync-connection-modal/index.js
@@ -28,7 +28,7 @@ import { getSyncErrorMessages } from '../../utils';
  * Sync connection modal that displays when any entity reports a disconnection.
  * Uses BlockCanvasCover.Fill to render in the block canvas.
  *
- * @return {Element|null} The modal component or null if no error.
+ * @return {Element|null} The modal component or null if not disconnected.
  */
 export function SyncConnectionModal() {
 	const { connectionState, content } = useSelect( ( select ) => {
@@ -47,7 +47,7 @@ export function SyncConnectionModal() {
 
 	const copyButtonRef = useCopyToClipboard( content ?? '' );
 
-	if ( ! connectionState?.error ) {
+	if ( connectionState?.status !== 'disconnected' ) {
 		return null;
 	}
 

--- a/packages/editor/src/utils/sync-error-messages.js
+++ b/packages/editor/src/utils/sync-error-messages.js
@@ -39,22 +39,29 @@ const ERROR_CODE_DEFAULTS = {
  * @return {Object} Object with title and description strings.
  */
 export function getSyncErrorMessages( error ) {
+	// Default messages for generic disconnection without specific error
+	const genericDisconnectMessages = {
+		title: __( 'Disconnected' ),
+		description: __(
+			'You are currently disconnected from the collaborative editing server. ' +
+				'Editing is temporarily disabled to prevent conflicts.'
+		),
+	};
+
 	if ( ! error ) {
-		return { title: '', description: '' };
+		return genericDisconnectMessages;
 	}
 
 	// Look up defaults based on code
 	const defaults = ERROR_CODE_DEFAULTS[ error.code ];
 
-	// Use explicit message/description if provided, otherwise fall back to defaults
+	// Use explicit message/description if provided, otherwise fall back to defaults or generic messages
 	return {
-		title: error.message || defaults?.title || __( 'Disconnected' ),
+		title:
+			error.message || defaults?.title || genericDisconnectMessages.title,
 		description:
 			error.description ||
 			defaults?.description ||
-			__(
-				'You are currently disconnected from the collaborative editing server. ' +
-					'Editing is temporarily disabled to prevent conflicts.'
-			),
+			genericDisconnectMessages.description,
 	};
 }

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -206,7 +206,7 @@ export function createSyncManager(): SyncManager {
 				} );
 
 				// Attach status listener after provider creation.
-				provider.on( 'status', handlers.onStateChange );
+				provider.on( 'sync-connection-status', handlers.onStateChange );
 
 				return provider;
 			} )
@@ -301,7 +301,7 @@ export function createSyncManager(): SyncManager {
 				} );
 
 				// Attach status listener after provider creation.
-				provider.on( 'status', handlers.onStateChange );
+				provider.on( 'sync-connection-status', handlers.onStateChange );
 
 				return provider;
 			} )

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -56,7 +56,7 @@ export interface ObjectMeta extends Record< string, unknown > {
  * Add new event types here as needed.
  */
 export interface ProviderEventMap {
-	status: SyncConnectionState;
+	'sync-connection-status': SyncConnectionState;
 }
 
 /**


### PR DESCRIPTION
## What?

Improves sync connection state handling added in #74075 by fixing event name conflicts and ensuring the disconnection modal displays in all disconnect scenarios.

## Why?

Two issues were discovered when integrating with the WebSocket provider - [Automattic/real-time-collaboration#145](https://github.com/Automattic/vip-real-time-collaboration/pull/145):

1. **Event name conflicts**: The WebSocket provider has a built-in `'status'` event that conflicts with our sync connection status event. These default WebSocket events don't include custom fields like `'error'`, causing issues when our custom `SyncConnectionState` events overlap with them.

2. **Hidden disconnections**: The sync connection modal only appeared when `connectionState.error` existed. This meant users could be disconnected without seeing any indication if the disconnection didn't include a specific error object, leading to confusion about why editing was disabled.

## How?

- Renamed the provider event from `'status'` to `'sync-connection-status'` to avoid conflicts with WebSocket provider events
- Changed modal condition to check `status !== 'disconnected'` instead of checking for error presence
