### PR TITLE
Admin UI: apply 'text-wrap: pretty' to Page

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Enhancements
+
 - Apply `text-wrap: pretty` for more balanced text in Page component [#74907](https://github.com/WordPress/gutenberg/pull/74907)
 
 ## 1.7.0 (2026-01-29)

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Apply `text-wrap: pretty` for more balanced text in Page component [#74907](https://github.com/WordPress/gutenberg/pull/74907)
+
 ## 1.7.0 (2026-01-29)
 
 ## 1.6.0 (2026-01-16)

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -11,6 +11,8 @@
 	position: relative;
 	z-index: 1;
 	flex-flow: column;
+	text-wrap: balance; /* Fallback for Safari. */
+	text-wrap: pretty;
 }
 
 .admin-ui-page__header {

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -11,7 +11,6 @@
 	position: relative;
 	z-index: 1;
 	flex-flow: column;
-	text-wrap: balance; /* Fallback for Safari. */
 	text-wrap: pretty;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Apply `text-wrap: pretty` for more balanced text in the `Page` component.

Currently, in Gutenberg to get balanced text, you need to usethe  `Text` component:

https://github.com/WordPress/gutenberg/blob/5cbdbc274fb4dc0f74b23cbc248fe8056a15f37b/packages/components/src/text/styles.ts#L15-L16

Using `Text` everywhere is fairly tedious, and I believe we could achieve better UIs going forward if we applied the rule more widely. Since it can be too much to apply all-Gutenberg or all WP Admin wide, we could start from the Page component, which is mostly used to build new UIs.

This PR does _not_ include `balance` fallback, and it should be removed from the Text component as well. See discussion below.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> This is intended for body copy where good typography is favored over performance (for example, when the number of [orphans](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/orphans) should be kept to a minimum).

[via MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-wrap#pretty)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* See [pages in Gutenberg](https://github.com/WordPress/gutenberg/pull/74907#issuecomment-3798884872) using Page component; there are no practical visual differences due to Text already containing these rules.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
