### PR TITLE
Add image output formats and interlace settings to REST API client

### DIFF
--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -63,7 +63,6 @@ function gutenberg_get_default_image_output_formats() {
 		'image/gif',
 		'image/webp',
 		'image/avif',
-		'image/heic',
 	);
 
 	$output_formats = array();

--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -414,3 +414,29 @@ function gutenberg_override_media_templates(): void {
 }
 
 add_action( 'wp_enqueue_media', 'gutenberg_override_media_templates' );
+
+/**
+ * Filters the block editor preload paths to include media processing fields.
+ *
+ * Adds image_sizes and image_size_threshold to the root endpoint preload
+ * to avoid an extra API request when these fields are needed.
+ *
+ * @param array                   $paths   REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Current block editor context.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_media_processing_preload_paths( $paths, $context ) {
+	foreach ( $paths as $key => $path ) {
+		if ( is_string( $path ) && str_starts_with( $path, '/?_fields=' ) ) {
+			// Add image_sizes and image_size_threshold to the existing fields.
+			$paths[ $key ] = str_replace(
+				'/?_fields=',
+				'/?_fields=image_sizes,image_size_threshold,',
+				$path
+			);
+			break;
+		}
+	}
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_media_processing_preload_paths', 10, 2 );

--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -422,7 +422,6 @@ add_action( 'wp_enqueue_media', 'gutenberg_override_media_templates' );
  * to avoid an extra API request when these fields are needed.
  *
  * @param array                   $paths   REST API paths to preload.
- * @param WP_Block_Editor_Context $context Current block editor context.
  * @return array Filtered preload paths.
  */
 function gutenberg_media_processing_preload_paths( $paths, $context ) {

--- a/packages/block-editor/src/components/provider/use-media-upload-settings.js
+++ b/packages/block-editor/src/components/provider/use-media-upload-settings.js
@@ -19,10 +19,10 @@ function useMediaUploadSettings( settings = {} ) {
 			allowedMimeTypes: settings.allowedMimeTypes,
 			allImageSizes: settings.allImageSizes,
 			bigImageSizeThreshold: settings.bigImageSizeThreshold,
-			imageOutputFormats: settings.imageOutputFormats,
-			jpegInterlaced: settings.jpegInterlaced,
-			pngInterlaced: settings.pngInterlaced,
-			gifInterlaced: settings.gifInterlaced,
+			imageOutputFormats: settings.imageOutputFormats || {},
+			jpegInterlaced: settings.jpegInterlaced ?? false,
+			pngInterlaced: settings.pngInterlaced ?? false,
+			gifInterlaced: settings.gifInterlaced ?? false,
 		} ),
 		[ settings ]
 	);

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -1,5 +1,12 @@
 export type QueueItemId = string;
 
+export type ImageMimeType =
+	| 'image/jpeg'
+	| 'image/png'
+	| 'image/gif'
+	| 'image/webp'
+	| 'image/avif';
+
 export type QueueStatus = 'active' | 'paused';
 
 export type BatchId = string;
@@ -183,7 +190,7 @@ export interface Settings {
 	 * { 'image/png': 'image/webp', 'image/jpeg': 'image/avif' }
 	 * ```
 	 */
-	imageOutputFormats?: Record< string, string >;
+	imageOutputFormats?: Partial< Record< ImageMimeType, ImageMimeType > >;
 	/**
 	 * Whether to use interlaced/progressive encoding for JPEG images.
 	 * Progressive JPEGs load gradually, showing a low-quality preview first.

--- a/phpunit/experimental/media/media-processing-test.php
+++ b/phpunit/experimental/media/media-processing-test.php
@@ -138,6 +138,36 @@ class Media_Processing_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::gutenberg_get_default_image_output_formats
+	 */
+	public function test_get_default_image_output_formats_returns_empty_by_default() {
+		$output_formats = gutenberg_get_default_image_output_formats();
+		$this->assertEmpty( $output_formats );
+	}
+
+	/**
+	 * @covers ::gutenberg_get_default_image_output_formats
+	 */
+	public function test_get_default_image_output_formats_with_filter() {
+		// Add a filter that converts JPEG to WebP.
+		$filter_callback = function ( $formats, $filename, $mime_type ) {
+			if ( 'image/jpeg' === $mime_type ) {
+				$formats['image/jpeg'] = 'image/webp';
+			}
+			return $formats;
+		};
+
+		add_filter( 'image_editor_output_format', $filter_callback, 10, 3 );
+
+		$output_formats = gutenberg_get_default_image_output_formats();
+
+		remove_filter( 'image_editor_output_format', $filter_callback, 10 );
+
+		$this->assertArrayHasKey( 'image/jpeg', $output_formats );
+		$this->assertSame( 'image/webp', $output_formats['image/jpeg'] );
+	}
+
+	/**
 	 * @covers ::gutenberg_add_crossorigin_attributes
 	 */
 	public function test_add_crossorigin_attributes() {

--- a/phpunit/experimental/media/media-processing-test.php
+++ b/phpunit/experimental/media/media-processing-test.php
@@ -142,6 +142,7 @@ class Media_Processing_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_default_image_output_formats_returns_empty_by_default() {
 		$output_formats = gutenberg_get_default_image_output_formats();
+		$this->assertIsArray( $output_formats );
 		$this->assertEmpty( $output_formats );
 	}
 


### PR DESCRIPTION
## Summary
- Expose `image_output_formats`, `jpeg_interlaced`, `png_interlaced`, and `gif_interlaced` settings from the REST API to the client-side media processing pipeline
- Add these fields to the core-data entities REST API request
- Pass the settings through the editor and block-editor providers to the upload-media store
- Add TypeScript type definitions for the new settings
- Add PHP tests for `gutenberg_get_default_image_output_formats()` function

## Test plan
- [ ] Verify the REST API index endpoint returns `image_output_formats`, `jpeg_interlaced`, `png_interlaced`, and `gif_interlaced` when logged in as an admin
- [ ] Verify the settings flow through to the upload-media store by checking the Redux devtools or adding console logs
- [ ] Run PHP unit tests: `npm run test:unit:php -- --filter="Media_Processing_Test"`

Closes #74361

🤖 Generated with [Claude Code](https://claude.ai/code)