### PR TITLE
Add EXIF metadata tests for Client Side Media

### DIFF
--- a/backport-changelog/7.0/10868.md
+++ b/backport-changelog/7.0/10868.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10868
+
+* https://github.com/WordPress/gutenberg/pull/74909

--- a/lib/experimental/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/experimental/media/class-gutenberg-rest-attachments-controller.php
@@ -122,10 +122,15 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 
 				// Get the EXIF orientation from the image metadata.
 				// This is stored by wp_read_image_metadata() during upload.
+				// Values:
+				//   0 = undefined (no EXIF data), treat as no rotation needed
+				//   1 = normal (no rotation needed)
+				//   2-8 = various rotations/flips needed
 				$orientation = 1; // Default: no rotation needed.
 				if (
 					is_array( $metadata ) &&
-					isset( $metadata['image_meta']['orientation'] )
+					isset( $metadata['image_meta']['orientation'] ) &&
+					(int) $metadata['image_meta']['orientation'] > 0
 				) {
 					$orientation = (int) $metadata['image_meta']['orientation'];
 				}

--- a/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
@@ -562,11 +562,11 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$this->assertArrayHasKey( 'file', $medium_size );
 		$this->assertArrayHasKey( 'width', $medium_size );
 		$this->assertArrayHasKey( 'height', $medium_size );
-		$this->assertArrayHasKey( 'mime_type', $medium_size );
+		$this->assertArrayHasKey( 'mime-type', $medium_size );
 		$this->assertArrayHasKey( 'filesize', $medium_size );
 
 		$this->assertSame( 'canola-300x200.jpg', $medium_size['file'] );
-		$this->assertSame( 'image/jpeg', $medium_size['mime_type'] );
+		$this->assertSame( 'image/jpeg', $medium_size['mime-type'] );
 		$this->assertGreaterThan( 0, $medium_size['filesize'] );
 	}
 

--- a/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
@@ -562,11 +562,11 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$this->assertArrayHasKey( 'file', $medium_size );
 		$this->assertArrayHasKey( 'width', $medium_size );
 		$this->assertArrayHasKey( 'height', $medium_size );
-		$this->assertArrayHasKey( 'mime-type', $medium_size );
+		$this->assertArrayHasKey( 'mime_type', $medium_size );
 		$this->assertArrayHasKey( 'filesize', $medium_size );
 
 		$this->assertSame( 'canola-300x200.jpg', $medium_size['file'] );
-		$this->assertSame( 'image/jpeg', $medium_size['mime-type'] );
+		$this->assertSame( 'image/jpeg', $medium_size['mime_type'] );
 		$this->assertGreaterThan( 0, $medium_size['filesize'] );
 	}
 

--- a/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
@@ -523,7 +523,7 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	/**
 	 * Verifies that sideloaded sub-sizes include expected metadata fields.
 	 *
-	 * Sub-sizes should have file, width, height, mime-type, and filesize in their metadata.
+	 * Sub-sizes should have file, width, height, mime_type, and filesize in their metadata.
 	 *
 	 * @covers ::sideload_item
 	 */

--- a/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/experimental/media/class-gutenberg-rest-attachments-controller-test.php
@@ -311,4 +311,325 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$this->assertStringNotContainsString( '2017/02', $data['source_url'] );
 		$this->assertStringContainsString( $subdir, $data['source_url'] );
 	}
+
+	/**
+	 * Verifies that exif_orientation field is returned in REST API response.
+	 *
+	 * @covers ::prepare_item_for_response
+	 * @covers ::get_item_schema
+	 */
+	public function test_exif_orientation_field_returned_in_response() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertArrayHasKey( 'exif_orientation', $data );
+		// canola.jpg has no EXIF orientation, so it should default to 1.
+		$this->assertSame( 1, $data['exif_orientation'] );
+	}
+
+	/**
+	 * Verifies that exif_orientation field is returned for image with non-1 orientation.
+	 *
+	 * Uses test-image-upside-down.jpg which has EXIF orientation value 3 (180° rotation).
+	 *
+	 * @covers ::prepare_item_for_response
+	 * @covers ::create_item
+	 * @requires extension exif
+	 */
+	public function test_exif_orientation_returned_for_rotated_image() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=test-image-upside-down.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/test-image-upside-down.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertArrayHasKey( 'exif_orientation', $data );
+		// test-image-upside-down.jpg has EXIF orientation 3 (180° rotation).
+		$this->assertSame( 3, $data['exif_orientation'] );
+	}
+
+	/**
+	 * Verifies that server-side EXIF rotation is disabled when generate_sub_sizes is false.
+	 *
+	 * When client-side processing is enabled (generate_sub_sizes=false), the server should
+	 * NOT rotate the image based on EXIF orientation. The original orientation value should
+	 * be preserved in metadata so the client can handle rotation.
+	 *
+	 * @covers ::create_item
+	 * @requires extension exif
+	 */
+	public function test_server_side_exif_rotation_disabled_for_client_side_processing() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=test-image-upside-down.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/test-image-upside-down.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Get the attachment metadata directly from the database.
+		$metadata = wp_get_attachment_metadata( $data['id'], true );
+
+		// The orientation should still be 3 (not reset to 1) because server-side rotation was disabled.
+		$this->assertArrayHasKey( 'image_meta', $metadata );
+		$this->assertArrayHasKey( 'orientation', $metadata['image_meta'] );
+		$this->assertSame( '3', $metadata['image_meta']['orientation'] );
+
+		// The exif_orientation in the REST response should also be 3.
+		$this->assertSame( 3, $data['exif_orientation'] );
+	}
+
+	/**
+	 * Verifies that full EXIF metadata is extracted and stored during client-side upload flow.
+	 *
+	 * Uses 2004-07-22-DSC_0008.jpg which has rich EXIF data from a Nikon D70 camera.
+	 *
+	 * @covers ::create_item
+	 * @covers ::prepare_item_for_response
+	 * @requires extension exif
+	 */
+	public function test_full_exif_metadata_extracted_for_client_side_upload() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=2004-07-22-DSC_0008.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertArrayHasKey( 'image_meta', $data['media_details'] );
+
+		$image_meta = $data['media_details']['image_meta'];
+
+		// Verify the full EXIF data is extracted (same data as server-side upload).
+		$this->assertSame( '6.3', $image_meta['aperture'] );
+		$this->assertSame( 'NIKON D70', $image_meta['camera'] );
+		$this->assertSame( '27', $image_meta['focal_length'] );
+		$this->assertSame( '400', $image_meta['iso'] );
+		// Verify timestamp is set (Nikon D70 image has created_timestamp).
+		$this->assertNotEmpty( $image_meta['created_timestamp'] );
+	}
+
+	/**
+	 * Verifies that EXIF metadata with IPTC data is extracted correctly.
+	 *
+	 * Uses 2004-07-22-DSC_0007.jpg which has both EXIF and IPTC data.
+	 *
+	 * @covers ::create_item
+	 * @covers ::prepare_item_for_response
+	 * @requires extension exif
+	 */
+	public function test_exif_and_iptc_metadata_extracted() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=2004-07-22-DSC_0007.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0007.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$image_meta = $data['media_details']['image_meta'];
+
+		// Verify EXIF data from camera.
+		$this->assertSame( '6.3', $image_meta['aperture'] );
+		$this->assertSame( 'NIKON D70', $image_meta['camera'] );
+		$this->assertSame( '18', $image_meta['focal_length'] );
+		$this->assertSame( '200', $image_meta['iso'] );
+
+		// Verify IPTC data.
+		$this->assertSame( 'IPTC Creator', $image_meta['credit'] );
+		$this->assertSame( 'IPTC Caption', $image_meta['caption'] );
+		$this->assertSame( 'IPTC Copyright', $image_meta['copyright'] );
+		$this->assertSame( 'IPTC Headline', $image_meta['title'] );
+	}
+
+	/**
+	 * Verifies that sideloading sub-sizes preserves the original image_meta.
+	 *
+	 * @covers ::sideload_item
+	 * @requires extension exif
+	 */
+	public function test_sideload_preserves_image_meta() {
+		wp_set_current_user( self::$admin_id );
+
+		// First, upload an image with EXIF data using client-side upload flow.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=2004-07-22-DSC_0008.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$data          = $response->get_data();
+		$attachment_id = $data['id'];
+
+		// Record the original image_meta.
+		$original_image_meta = $data['media_details']['image_meta'];
+
+		// Now sideload a sub-size.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/$attachment_id/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=2004-07-22-DSC_0008-150x150.jpg' );
+		$request->set_param( 'image_size', 'thumbnail' );
+
+		// Use a smaller image for the sub-size (dimensions don't matter for this test).
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify the image_meta is preserved after sideloading.
+		$this->assertArrayHasKey( 'image_meta', $data['media_details'] );
+		$sideloaded_image_meta = $data['media_details']['image_meta'];
+
+		// The EXIF data should be unchanged.
+		$this->assertSame( $original_image_meta['aperture'], $sideloaded_image_meta['aperture'] );
+		$this->assertSame( $original_image_meta['camera'], $sideloaded_image_meta['camera'] );
+		$this->assertSame( $original_image_meta['focal_length'], $sideloaded_image_meta['focal_length'] );
+		$this->assertSame( $original_image_meta['iso'], $sideloaded_image_meta['iso'] );
+	}
+
+	/**
+	 * Verifies that sideloaded sub-sizes include expected metadata fields.
+	 *
+	 * Sub-sizes should have file, width, height, mime-type, and filesize in their metadata.
+	 *
+	 * @covers ::sideload_item
+	 */
+	public function test_sideloaded_subsize_has_complete_metadata() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			wp_generate_attachment_metadata( $attachment_id, DIR_TESTDATA . '/images/canola.jpg' )
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/$attachment_id/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-300x200.jpg' );
+		$request->set_param( 'image_size', 'medium' );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
+		$this->assertArrayHasKey( 'medium', $data['media_details']['sizes'] );
+
+		$medium_size = $data['media_details']['sizes']['medium'];
+
+		// Verify all expected metadata fields are present for the sub-size.
+		$this->assertArrayHasKey( 'file', $medium_size );
+		$this->assertArrayHasKey( 'width', $medium_size );
+		$this->assertArrayHasKey( 'height', $medium_size );
+		$this->assertArrayHasKey( 'mime_type', $medium_size );
+		$this->assertArrayHasKey( 'filesize', $medium_size );
+
+		$this->assertSame( 'canola-300x200.jpg', $medium_size['file'] );
+		$this->assertSame( 'image/jpeg', $medium_size['mime_type'] );
+		$this->assertGreaterThan( 0, $medium_size['filesize'] );
+	}
+
+	/**
+	 * Verifies that exif_orientation is in the schema for images.
+	 *
+	 * @covers ::get_item_schema
+	 */
+	public function test_exif_orientation_in_schema() {
+		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'exif_orientation', $schema['properties'] );
+		$this->assertSame( 'integer', $schema['properties']['exif_orientation']['type'] );
+		$this->assertContains( 'edit', $schema['properties']['exif_orientation']['context'] );
+		$this->assertTrue( $schema['properties']['exif_orientation']['readonly'] );
+	}
+
+	/**
+	 * Verifies metadata consistency between server-side and client-side upload flows.
+	 *
+	 * The same image uploaded with server-side processing (generate_sub_sizes=true)
+	 * should have the same image_meta as when uploaded with client-side processing
+	 * (generate_sub_sizes=false).
+	 *
+	 * @covers ::create_item
+	 * @requires extension exif
+	 */
+	public function test_metadata_consistency_between_upload_flows() {
+		wp_set_current_user( self::$admin_id );
+
+		// Upload with server-side processing (default).
+		$request_server = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request_server->set_header( 'Content-Type', 'image/jpeg' );
+		$request_server->set_header( 'Content-Disposition', 'attachment; filename=server-side-upload.jpg' );
+		$request_server->set_param( 'generate_sub_sizes', true );
+
+		$request_server->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' ) );
+		$response_server = rest_get_server()->dispatch( $request_server );
+		$data_server     = $response_server->get_data();
+
+		// Upload with client-side processing.
+		$request_client = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request_client->set_header( 'Content-Type', 'image/jpeg' );
+		$request_client->set_header( 'Content-Disposition', 'attachment; filename=client-side-upload.jpg' );
+		$request_client->set_param( 'generate_sub_sizes', false );
+
+		$request_client->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' ) );
+		$response_client = rest_get_server()->dispatch( $request_client );
+		$data_client     = $response_client->get_data();
+
+		$this->assertSame( 201, $response_server->get_status() );
+		$this->assertSame( 201, $response_client->get_status() );
+
+		$meta_server = $data_server['media_details']['image_meta'];
+		$meta_client = $data_client['media_details']['image_meta'];
+
+		// The core EXIF fields should be identical.
+		$this->assertSame( $meta_server['aperture'], $meta_client['aperture'] );
+		$this->assertSame( $meta_server['camera'], $meta_client['camera'] );
+		$this->assertSame( $meta_server['focal_length'], $meta_client['focal_length'] );
+		$this->assertSame( $meta_server['iso'], $meta_client['iso'] );
+		$this->assertSame( $meta_server['shutter_speed'], $meta_client['shutter_speed'] );
+		$this->assertSame( $meta_server['created_timestamp'], $meta_client['created_timestamp'] );
+	}
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/74356


## Summary

Expands test coverage for #74356 to ensure client-side media uploads preserve the same EXIF data as traditional server-side processing.

### New Tests 

| Test | Purpose |
|------|---------|
| `test_exif_orientation_field_returned_in_response` | Verifies `exif_orientation` field is in REST API response |
| `test_exif_orientation_returned_for_rotated_image` | Tests with `test-image-upside-down.jpg` (EXIF orientation 3) |
| `test_server_side_exif_rotation_disabled_for_client_side_processing` | Verifies server doesn't rotate when `generate_sub_sizes=false` |
| `test_full_exif_metadata_extracted_for_client_side_upload` | Tests full EXIF extraction (camera, aperture, ISO, focal length) |
| `test_exif_and_iptc_metadata_extracted` | Tests both EXIF and IPTC data extraction |
| `test_sideload_preserves_image_meta` | Verifies sideloading sub-sizes preserves original image_meta |
| `test_sideloaded_subsize_has_complete_metadata` | Verifies sub-sizes have file, width, height, mime_type, filesize |
| `test_exif_orientation_in_schema` | Verifies `exif_orientation` is properly defined in REST API schema |
| `test_metadata_consistency_between_upload_flows` | Ensures client-side and server-side uploads produce identical EXIF metadata |


### Bug Fix

Fixes a bug where EXIF orientation `0` (undefined/no EXIF data) was being returned instead of `1` (no rotation needed). The controller now treats `orientation <= 0` as "no rotation needed".

## Test plan

- [x] Run PHP unit tests: `npm run test:unit:php -- --filter="Gutenberg_REST_Attachments_Controller_Test"`
- [x] All 23 tests pass (16 actual tests + 7 skipped base class methods)

🤖 Generated with [Claude Code](https://claude.ai/code)