### PR TITLE
Real-time collaboration: Pass non-cleaned (but merged) edits to `SyncManager#update`

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -402,6 +402,16 @@ export const editEntityRecord =
 			recordId
 		);
 
+		// Some fields are merged with the existing value instead of replaced.
+		// See `mergedEdits` definition on the entity config.
+		const editsWithMerges = Object.keys( edits ).reduce( ( acc, key ) => {
+			acc[ key ] = mergedEdits[ key ]
+				? { ...editedRecord[ key ], ...edits[ key ] }
+				: edits[ key ];
+
+			return acc;
+		}, {} );
+
 		const edit = {
 			kind,
 			name,
@@ -410,10 +420,7 @@ export const editEntityRecord =
 			// so that the property is not considered dirty.
 			edits: Object.keys( edits ).reduce( ( acc, key ) => {
 				const recordValue = record[ key ];
-				const editedRecordValue = editedRecord[ key ];
-				const value = mergedEdits[ key ]
-					? { ...editedRecordValue, ...edits[ key ] }
-					: edits[ key ];
+				const value = editsWithMerges[ key ];
 				acc[ key ] = fastDeepEqual( recordValue, value )
 					? undefined
 					: value;
@@ -428,7 +435,7 @@ export const editEntityRecord =
 				getSyncManager()?.update(
 					objectType,
 					objectId,
-					edit.edits,
+					editsWithMerges,
 					LOCAL_EDITOR_ORIGIN
 				);
 			}

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -50,6 +50,207 @@ describe( 'editEntityRecord', () => {
 		);
 		expect( select.getEntityConfig ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'dispatches the correct action for non-merged edits', () => {
+		const dispatch = jest.fn();
+		const select = {
+			getEntityConfig: () => ( {
+				kind: 'postType',
+				name: 'post',
+				mergedEdits: {},
+			} ),
+			getRawEntityRecord: () => ( {
+				id: 1,
+				title: 'Original Title',
+				content: 'Original Content',
+			} ),
+			getEditedEntityRecord: () => ( {
+				id: 1,
+				title: 'Original Title',
+				content: 'Original Content',
+			} ),
+			getUndoManager: () => ( {
+				addRecord: jest.fn(),
+			} ),
+		};
+
+		editEntityRecord( 'postType', 'post', 1, { title: 'New Title' } )( {
+			select,
+			dispatch,
+		} );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: { title: 'New Title' },
+		} );
+	} );
+
+	it( 'merges edits for fields defined in mergedEdits config', () => {
+		const dispatch = jest.fn();
+		const select = {
+			getEntityConfig: () => ( {
+				kind: 'postType',
+				name: 'post',
+				mergedEdits: { meta: true },
+			} ),
+			getRawEntityRecord: () => ( {
+				id: 1,
+				meta: { existingKey: 'existingValue' },
+			} ),
+			getEditedEntityRecord: () => ( {
+				id: 1,
+				meta: {
+					existingKey: 'existingValue',
+					editedKey: 'editedValue',
+				},
+			} ),
+			getUndoManager: () => ( {
+				addRecord: jest.fn(),
+			} ),
+		};
+
+		editEntityRecord( 'postType', 'post', 1, {
+			meta: { newKey: 'newValue' },
+		} )( {
+			select,
+			dispatch,
+		} );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				meta: {
+					existingKey: 'existingValue',
+					editedKey: 'editedValue',
+					newKey: 'newValue',
+				},
+			},
+		} );
+	} );
+
+	it( 'handles both merged and non-merged edits together', () => {
+		const dispatch = jest.fn();
+		const select = {
+			getEntityConfig: () => ( {
+				kind: 'postType',
+				name: 'post',
+				mergedEdits: { meta: true },
+			} ),
+			getRawEntityRecord: () => ( {
+				id: 1,
+				title: 'Original Title',
+				meta: { existingKey: 'existingValue' },
+			} ),
+			getEditedEntityRecord: () => ( {
+				id: 1,
+				title: 'Original Title',
+				meta: { existingKey: 'existingValue' },
+			} ),
+			getUndoManager: () => ( {
+				addRecord: jest.fn(),
+			} ),
+		};
+
+		editEntityRecord( 'postType', 'post', 1, {
+			title: 'New Title',
+			meta: { newKey: 'newValue' },
+		} )( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				title: 'New Title',
+				meta: {
+					existingKey: 'existingValue',
+					newKey: 'newValue',
+				},
+			},
+		} );
+	} );
+
+	it( 'clears edit when merged value equals persisted record', () => {
+		const dispatch = jest.fn();
+		const select = {
+			getEntityConfig: () => ( {
+				kind: 'postType',
+				name: 'post',
+				mergedEdits: { meta: true },
+			} ),
+			getRawEntityRecord: () => ( {
+				id: 1,
+				meta: { key1: 'value1', key2: 'value2' },
+			} ),
+			getEditedEntityRecord: () => ( {
+				id: 1,
+				meta: { key1: 'value1' },
+			} ),
+			getUndoManager: () => ( {
+				addRecord: jest.fn(),
+			} ),
+		};
+
+		// Editing meta to add key2 back should result in a value equal to the persisted record
+		editEntityRecord( 'postType', 'post', 1, {
+			meta: { key2: 'value2' },
+		} )( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				// meta should be undefined because merged value equals persisted record
+				meta: undefined,
+			},
+		} );
+	} );
+
+	it( 'clears non-merged edit when value equals persisted record', () => {
+		const dispatch = jest.fn();
+		const select = {
+			getEntityConfig: () => ( {
+				kind: 'postType',
+				name: 'post',
+				mergedEdits: {},
+			} ),
+			getRawEntityRecord: () => ( {
+				id: 1,
+				title: 'Original Title',
+			} ),
+			getEditedEntityRecord: () => ( {
+				id: 1,
+				title: 'Edited Title',
+			} ),
+			getUndoManager: () => ( {
+				addRecord: jest.fn(),
+			} ),
+		};
+
+		// Editing title back to original should clear the edit
+		editEntityRecord( 'postType', 'post', 1, {
+			title: 'Original Title',
+		} )( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				title: undefined,
+			},
+		} );
+	} );
 } );
 
 describe( 'deleteEntityRecord', () => {

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -18,6 +18,7 @@ import {
 	receiveCurrentUser,
 	__experimentalBatch,
 } from '../actions';
+import { getSyncManager } from '../sync';
 
 jest.mock( '../batch', () => {
 	const { createBatch } = jest.requireActual( '../batch' );
@@ -27,6 +28,11 @@ jest.mock( '../batch', () => {
 		},
 	};
 } );
+
+jest.mock( '../sync', () => ( {
+	getSyncManager: jest.fn(),
+	LOCAL_EDITOR_ORIGIN: 'local-editor',
+} ) );
 
 describe( 'editEntityRecord', () => {
 	it( 'throws when the edited entity does not have a loaded config.', async () => {
@@ -249,6 +255,198 @@ describe( 'editEntityRecord', () => {
 			edits: {
 				title: undefined,
 			},
+		} );
+	} );
+
+	describe( 'with SyncManager', () => {
+		let syncManager;
+
+		beforeEach( () => {
+			// Create a mock sync manager
+			syncManager = {
+				update: jest.fn(),
+			};
+			getSyncManager.mockReturnValue( syncManager );
+		} );
+
+		afterEach( () => {
+			getSyncManager.mockReset();
+		} );
+
+		it( 'passes merged edits to SyncManager#update for merged fields', () => {
+			const dispatch = jest.fn();
+			const select = {
+				getEntityConfig: () => ( {
+					kind: 'postType',
+					name: 'post',
+					mergedEdits: { meta: true },
+					syncConfig: {},
+				} ),
+				getRawEntityRecord: () => ( {
+					id: 1,
+					meta: { existingKey: 'existingValue' },
+				} ),
+				getEditedEntityRecord: () => ( {
+					id: 1,
+					meta: {
+						existingKey: 'existingValue',
+						editedKey: 'editedValue',
+					},
+				} ),
+				getUndoManager: () => ( {
+					addRecord: jest.fn(),
+				} ),
+			};
+
+			editEntityRecord( 'postType', 'post', 1, {
+				meta: { newKey: 'newValue' },
+			} )( {
+				select,
+				dispatch,
+			} );
+
+			// Verify SyncManager#update was called with merged edits
+			expect( syncManager.update ).toHaveBeenCalledWith(
+				'postType/post',
+				1,
+				{
+					meta: {
+						existingKey: 'existingValue',
+						editedKey: 'editedValue',
+						newKey: 'newValue',
+					},
+				},
+				'local-editor'
+			);
+		} );
+
+		it( 'passes merged edits to SyncManager#update even when value equals persisted record', () => {
+			const dispatch = jest.fn();
+			const select = {
+				getEntityConfig: () => ( {
+					kind: 'postType',
+					name: 'post',
+					mergedEdits: { meta: true },
+					syncConfig: {},
+				} ),
+				getRawEntityRecord: () => ( {
+					id: 1,
+					meta: { key1: 'value1', key2: 'value2' },
+				} ),
+				getEditedEntityRecord: () => ( {
+					id: 1,
+					meta: { key1: 'value1' },
+				} ),
+				getUndoManager: () => ( {
+					addRecord: jest.fn(),
+				} ),
+			};
+
+			// Editing meta to add key2 back results in a value equal to the persisted record
+			editEntityRecord( 'postType', 'post', 1, {
+				meta: { key2: 'value2' },
+			} )( { select, dispatch } );
+
+			// Verify SyncManager#update was called with merged edits (not cleaned/undefined)
+			expect( syncManager.update ).toHaveBeenCalledWith(
+				'postType/post',
+				1,
+				{
+					meta: {
+						key1: 'value1',
+						key2: 'value2',
+					},
+				},
+				'local-editor'
+			);
+
+			// But the local store dispatch should still receive undefined for the cleaned edit
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'EDIT_ENTITY_RECORD',
+				kind: 'postType',
+				name: 'post',
+				recordId: 1,
+				edits: {
+					meta: undefined,
+				},
+			} );
+		} );
+
+		it( 'passes merged and non-merged edits correctly to SyncManager#update', () => {
+			const dispatch = jest.fn();
+			const select = {
+				getEntityConfig: () => ( {
+					kind: 'postType',
+					name: 'post',
+					mergedEdits: { meta: true },
+					syncConfig: {},
+				} ),
+				getRawEntityRecord: () => ( {
+					id: 1,
+					title: 'Original Title',
+					meta: { existingKey: 'existingValue' },
+				} ),
+				getEditedEntityRecord: () => ( {
+					id: 1,
+					title: 'Original Title',
+					meta: { existingKey: 'existingValue' },
+				} ),
+				getUndoManager: () => ( {
+					addRecord: jest.fn(),
+				} ),
+			};
+
+			editEntityRecord( 'postType', 'post', 1, {
+				title: 'New Title',
+				meta: { newKey: 'newValue' },
+			} )( { select, dispatch } );
+
+			// Verify SyncManager#update was called with merged meta but non-merged title
+			expect( syncManager.update ).toHaveBeenCalledWith(
+				'postType/post',
+				1,
+				{
+					title: 'New Title',
+					meta: {
+						existingKey: 'existingValue',
+						newKey: 'newValue',
+					},
+				},
+				'local-editor'
+			);
+		} );
+
+		it( 'does not call SyncManager#update when syncConfig is not defined', () => {
+			const dispatch = jest.fn();
+			const select = {
+				getEntityConfig: () => ( {
+					kind: 'postType',
+					name: 'post',
+					mergedEdits: { meta: true },
+					// No syncConfig
+				} ),
+				getRawEntityRecord: () => ( {
+					id: 1,
+					meta: { existingKey: 'existingValue' },
+				} ),
+				getEditedEntityRecord: () => ( {
+					id: 1,
+					meta: { existingKey: 'existingValue' },
+				} ),
+				getUndoManager: () => ( {
+					addRecord: jest.fn(),
+				} ),
+			};
+
+			editEntityRecord( 'postType', 'post', 1, {
+				meta: { newKey: 'newValue' },
+			} )( {
+				select,
+				dispatch,
+			} );
+
+			// Verify SyncManager#update was NOT called
+			expect( syncManager.update ).not.toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

When updating the CRDT doc, pass the "un-cleaned" edits (but continue to merge values as specified by the entity config).

Closes https://github.com/WordPress/gutenberg/issues/74657

## Why?

When applying edits against the local store, it makes sense to first compare them against the persisted record. This allows us to remove edits that don't result in a changed value and therefore avoid unnecessarily marking the record as "dirty."

However, the persisted record and the CRDT document often diverge. Therefore, when updating the CRDT document, we should give it the "raw" or "un-cleaned" edits. The CRDT logic has its own robust and well-tested equality testing to avoid  committing unnecessary updates.

We still want updates to be merged if specified by the entity config.

## How?

- Add tests (2e63106d610bff3b8c65e7f85a4fd1f262892c26) to cover the existing behavior. These tests pass before and after the application code changes (b5ab7b4ff399de67ba34f8367e20ae1bda038e22).
- Separate "merging" and "cleaning" logic.
- Pass "merged" changes to `SyncManager#update`.
- Dispatch "merged" and "cleaned" changes to update the local store.
- Copilot added tests to ensure `SyncManager#update` is correctly called (https://github.com/WordPress/gutenberg/pull/74912/commits/f13290ae2062d50910fbe1a080857617a4cbac15)

## Testing Instructions

Covered by unit tests.

### Testing Instructions for Keyboard
n/a