### PR TITLE
Switch to list navigation block view in content only when navigation block is selected

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import BlockQuickNavigation from '../block-quick-navigation';
 
-const ContentTab = ( { contentClientIds } ) => {
+const ContentTab = ( { contentClientIds, onBlockSelect } ) => {
 	if ( ! contentClientIds || contentClientIds.length === 0 ) {
 		return null;
 	}
@@ -21,7 +21,10 @@ const ContentTab = ( { contentClientIds } ) => {
 		<>
 			{ ! shouldShowBlockFields && (
 				<PanelBody title={ __( 'Content' ) }>
-					<BlockQuickNavigation clientIds={ contentClientIds } />
+					<BlockQuickNavigation
+						clientIds={ contentClientIds }
+						onSelect={ onBlockSelect }
+					/>
 				</PanelBody>
 			) }
 		</>

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -19,6 +19,7 @@ import StylesTab from './styles-tab';
 import ContentTab from './content-tab';
 import InspectorControls from '../inspector-controls';
 import { unlock } from '../../lock-unlock';
+import { store as blockEditorStore } from '../../store';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -32,6 +33,14 @@ export default function InspectorControlsTabs( {
 } ) {
 	const showIconLabels = useSelect( ( select ) => {
 		return select( preferencesStore ).get( 'core', 'showIconLabels' );
+	}, [] );
+
+	// Get the actual selected block name (not the rendered parent in contentOnly mode)
+	const selectedBlockName = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlockName } =
+			select( blockEditorStore );
+		const selectedClientId = getSelectedBlockClientId();
+		return selectedClientId ? getBlockName( selectedClientId ) : null;
 	}, [] );
 
 	const [ selectedTabId, setSelectedTabId ] = useState( tabs[ 0 ]?.name );
@@ -52,15 +61,39 @@ export default function InspectorControlsTabs( {
 			return;
 		}
 
+		// Special case: Navigation block should default to list view tab
+		// when available instead of content tab
+		const hasListTab = tabs.some( ( tab ) => tab.name === 'list' );
+		if ( selectedBlockName === 'core/navigation' && hasListTab ) {
+			if ( selectedTabId !== 'list' ) {
+				setSelectedTabId( 'list' );
+			}
+			return;
+		}
+
 		const firstTabName = tabs[ 0 ]?.name;
 		if ( selectedTabId !== firstTabName ) {
 			setSelectedTabId( firstTabName );
 		}
-	}, [ tabs, selectedTabId ] );
+	}, [ tabs, selectedTabId, selectedBlockName ] );
 
 	const handleTabSelect = ( tabId ) => {
 		setSelectedTabId( tabId );
 		hasUserSelectionRef.current = true;
+	};
+
+	const { getBlockName } = useSelect( blockEditorStore );
+
+	// Handle block selection from ContentTab - switch to list tab if navigation
+	const handleContentBlockSelect = ( selectedClientId ) => {
+		const clickedBlockName = getBlockName( selectedClientId );
+
+		if ( clickedBlockName === 'core/navigation' ) {
+			const hasListTab = tabs.some( ( tab ) => tab.name === 'list' );
+			if ( hasListTab ) {
+				setSelectedTabId( 'list' );
+			}
+		}
 	};
 
 	return (
@@ -102,7 +135,10 @@ export default function InspectorControlsTabs( {
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
 					<InspectorControls.Slot group="content" />
-					<ContentTab contentClientIds={ contentClientIds } />
+					<ContentTab
+						contentClientIds={ contentClientIds }
+						onBlockSelect={ handleContentBlockSelect }
+					/>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
 					<InspectorControls.Slot group="list" />


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/74894

When selecting a navigation block in a content only section, show the navigation link block list view representation in the content only sidebar.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve discoverability of navigation editing in content only.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When a navigation block is selected (Edit navigation from toolbar) or clicking the Navigation block in the content only sidebar, switch to the navigation list view tab.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- On a template with content only template that contains a navigation
- Select the template to reveal the "Edit navigation" button in the toolbar
- Click "Edit navigation"
- The navigation list view should show in the sidebar
- Select the template again
- Click the navigation block name in the content only sidebar
- The navigation list view should show in the sidebar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
