### PR TITLE
Remove legacy babel plugins

### DIFF
--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -29,10 +29,6 @@ module.exports = ( api ) => {
 	const getPresetEnv = () => {
 		const opts = {
 			bugfixes: true,
-			include: [
-				'proposal-nullish-coalescing-operator',
-				'proposal-logical-assignment-operators',
-			],
 			...( wpBuildOpts.addPolyfillComments
 				? {
 						useBuiltIns: 'usage',


### PR DESCRIPTION
## What?
Closes #74915

This just removes the forced inclusion of the old plugins.

## Why?
Babel has been able to automatically manage whether the transforms that the forcibly-included plugins apply for a while now. Removing them from the forced-includes list just allows code built with WordPress's Babel config to use some "new" operators.

## How?
I removed the forced inclusions.

## Testing Instructions
Build a file that uses the `??=` operator with WordPress's babel config. If it comes out un-transformed, then the issue has been resolved.