### PR TITLE
Fix missing onClose prop for InserterMenu

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -176,6 +176,7 @@ class Inserter extends Component {
 				onSelect={ () => {
 					onClose();
 				} }
+				onClose={ onClose }
 				rootClientId={ rootClientId }
 				clientId={ clientId }
 				isAppender={ isAppender }


### PR DESCRIPTION
## What?

While building a [custom block editor field](https://github.com/wpmetabox/meta-box/pull/1650) for [Meta Box](https://metabox.io/block-editor-field-type/), I try to use the default `Inserter` component from `@wordpress/block-editor`. It works, but when clicking the close button when the inserter popup is opened, it shows an error message in the browser console, and the popup isn't closed.

```
Uncaught TypeError: onClose is not a function
```

<img width="589" height="388" alt="Edit Post “5 Signs It’s Time to Replace Your Old Sofa With A New One” ‹ Meta Box Local Dev — WordPress 2026-01-24 15-12-33" src="https://github.com/user-attachments/assets/63271dbd-7b14-4a06-be9d-e628a437b7e5" />

## How?

Looking at the [source code](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/index.js#L175) of the `Inserter` component, we see it calls the `InserterMenu` like this:

```js
return (
	<InserterMenu
		onSelect={ () => {
			onClose();
		} }
		rootClientId={ rootClientId }
		clientId={ clientId }
		isAppender={ isAppender }
		showInserterHelpPanel={ showInserterHelpPanel }
	/>
);
```

Note that it doesn't pass the `onClose` prop to the `InserterMenu`. And in the source code of the `InserterMenu` component, we see it [expects the `onClose` prop](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/menu.js#L51), which later [is used](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/menu.js#L339) to closed the `TabbedSidebar` component (which is the content of the inserter menu).

A simple fix for this bug is just passing the missing `onClose` callback to the `InserterMenu`. This callback is created by the `Dropdown` component, and [is passed](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/index.js#L136) to the `renderContent` prop in the `Inserter` component.

## Testing Instructions

A quick test is using our new block field, by pulling [this PR](https://github.com/wpmetabox/meta-box/pull/1650) of `wpmetabox/meta-box`, and create a field like this (put in a plugin or theme's `functions.php` file):

```php
add_filter( 'rwmb_meta_boxes', function ( $meta_boxes ) {
	$meta_boxes[] = [
		'title' => 'Test',
		'fields' => [
			[
				'type' => 'block_editor2',
				'name' => 'Block Editor',
				'id' => 'block_editor2',
			]
		]
	];
	return $meta_boxes;
} );
```

Then edit a post and you'll see a custom block editor. Click the inserter button, and then click the close button in the popup.

Another way to test this bug is building a custom block editor with the `Inserter` component. It probably requires more setup.