### PR TITLE
Inserter Component: Improving Stories

### DIFF
--- a/packages/block-editor/src/components/inserter/stories/index.story.jsx
+++ b/packages/block-editor/src/components/inserter/stories/index.story.jsx
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
  * Internal dependencies
  */
 import BlockLibrary from '../library';
@@ -8,13 +13,17 @@ import Inserter from '../';
 
 export default { title: 'BlockEditor/Inserter' };
 
+// For the purpose of this story, we need to register the core blocks samples.
+registerCoreBlocks();
+
+const wrapperStyle = {
+	margin: '24px',
+	height: 400,
+	border: '1px solid #f3f3f3',
+	display: 'inline-block',
+};
+
 export const LibraryWithoutPatterns = () => {
-	const wrapperStyle = {
-		margin: '24px',
-		height: 400,
-		border: '1px solid #f3f3f3',
-		display: 'inline-block',
-	};
 	return (
 		<ExperimentalBlockEditorProvider>
 			<div style={ wrapperStyle }>
@@ -25,12 +34,6 @@ export const LibraryWithoutPatterns = () => {
 };
 
 export const LibraryWithPatterns = () => {
-	const wrapperStyle = {
-		margin: '24px',
-		height: 400,
-		border: '1px solid #f3f3f3',
-		display: 'inline-block',
-	};
 	return (
 		<ExperimentalBlockEditorProvider
 			settings={ {
@@ -46,12 +49,6 @@ export const LibraryWithPatterns = () => {
 };
 
 export const LibraryWithPatternsAndReusableBlocks = () => {
-	const wrapperStyle = {
-		margin: '24px',
-		height: 400,
-		border: '1px solid #f3f3f3',
-		display: 'inline-block',
-	};
 	return (
 		<ExperimentalBlockEditorProvider
 			settings={ {
@@ -67,13 +64,23 @@ export const LibraryWithPatternsAndReusableBlocks = () => {
 	);
 };
 
+export const FullInserter = () => {
+	return (
+		<ExperimentalBlockEditorProvider
+			settings={ {
+				__experimentalBlockPatternCategories: patternCategories,
+				__experimentalBlockPatterns: patterns,
+				__experimentalReusableBlocks: reusableBlocks,
+			} }
+		>
+			<div style={ wrapperStyle }>
+				<Inserter />
+			</div>
+		</ExperimentalBlockEditorProvider>
+	);
+};
+
 export const QuickInserter = () => {
-	const wrapperStyle = {
-		margin: '24px',
-		height: 400,
-		border: '1px solid #f3f3f3',
-		display: 'inline-block',
-	};
 	return (
 		<ExperimentalBlockEditorProvider
 			settings={ {


### PR DESCRIPTION
## Why?
1. Currently Inserter block is not full testable without sample blocks
https://wordpress.github.io/gutenberg/?path=/docs/blockeditor-inserter--docs
2. Also there is not a full behaviour with popup as we can see in the wild. 

## How?
1. Firstly, I mimic the behaviour of `block-mover` adding the `registerCoreBlocks` so we can see real content within the inserter. 
2. Secondly I add a "Full Inserter" story, similar to the QuickInserter one, which mimics the popup element that happens within the editor.

This is going to be particularly useful to showcase in tickets like: #74920

## Testing Instructions
1. Run the storybook 
2. Go to the Inserter
3. Check for the Full Inserter, it should open, close with the X, close when clicking outside.

### Testing Instructions for Keyboard
1. It should also close with ESC

## Screenshots or screencast

<img width="944" height="1032" alt="image" src="https://github.com/user-attachments/assets/de91cd5a-97cd-4047-ab01-67169e865d9f" />

