### PR TITLE
Comments Title: Copy deprecate from block.json to deprecated.js to avoid legacy attribute usage

### DIFF
--- a/packages/block-library/src/comments-title/deprecated.js
+++ b/packages/block-library/src/comments-title/deprecated.js
@@ -1,32 +1,79 @@
-/**
- * Internal dependencies
- */
-import metadata from './block.json';
-
-const { attributes, supports } = metadata;
-
-export default [
-	{
-		attributes: {
-			...attributes,
-			singleCommentLabel: {
-				type: 'string',
-			},
-			multipleCommentsLabel: {
-				type: 'string',
-			},
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
 		},
-		supports,
-		migrate: ( oldAttributes ) => {
-			const {
-				singleCommentLabel,
-				multipleCommentsLabel,
-				...newAttributes
-			} = oldAttributes;
-			return newAttributes;
+		showPostTitle: {
+			type: 'boolean',
+			default: true,
 		},
-		isEligible: ( { multipleCommentsLabel, singleCommentLabel } ) =>
-			multipleCommentsLabel || singleCommentLabel,
-		save: () => null,
+		showCommentsCount: {
+			type: 'boolean',
+			default: true,
+		},
+		level: {
+			type: 'number',
+			default: 2,
+		},
+		levelOptions: {
+			type: 'array',
+		},
+		singleCommentLabel: {
+			type: 'string',
+		},
+		multipleCommentsLabel: {
+			type: 'string',
+		},
 	},
-];
+	supports: {
+		anchor: true,
+		align: true,
+		html: false,
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+		color: {
+			gradients: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+				__experimentalFontFamily: true,
+				__experimentalFontStyle: true,
+				__experimentalFontWeight: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	migrate: ( oldAttributes ) => {
+		const { singleCommentLabel, multipleCommentsLabel, ...newAttributes } =
+			oldAttributes;
+		return newAttributes;
+	},
+	isEligible: ( { multipleCommentsLabel, singleCommentLabel } ) =>
+		multipleCommentsLabel || singleCommentLabel,
+	save: () => null,
+};
+
+export default [ v1 ];


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The deprecate function is imported from block.json.
Importing from block.json would cause attribute changes to be used in past deprecation processes. Therefore, we will copy the current contents of block.json to deprecated.js to remove block.json's dependency.


This was discovered while working on this issue #60763.
Original PR #40817

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
All tests should pass.

