### PR TITLE
Post Excerpt Block: Fix excerpt trimming logic to handle whitespace correctly

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -169,7 +169,7 @@ export default function PostExcerptEditor( {
 	let trimmedExcerpt = '';
 	if ( wordCountType === 'words' ) {
 		trimmedExcerpt = rawOrRenderedExcerpt
-			.split( ' ', excerptLength )
+			.split( /\s+/, excerptLength )
 			.join( ' ' );
 	} else if ( wordCountType === 'characters_excluding_spaces' ) {
 		/*


### PR DESCRIPTION
Related to #74140 

## Why?
When using Manual Excerpts, depending on the text used, the result will difer from the backend editor and the frontend. 

## How?
The problem is that the algorithm that handles whitespaces differs from the `wp_trim_words` from Core. 

## Testing Instructions
1. Create a Post and add this Excerpt:
```
Plura mihi bona sunt, inclinet, amari petere vellent.
Fabio vel iudice vincam, sunt in culpa qui officia. Inmensae subtilitatis, obscuris et malesuada fames. Ambitioni dedisse scripsisse iudicaretur. Nec dubitamus multa iter quae et nos invenerat. Petierunt uti sibi concilium totius Galliae in diem certam indicere.
Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae. Salutantibus vitae elit libero, a pharetra augue. Quam diu etiam furor iste tuus nos eludet? Fabio vel iudice vincam, sunt in culpa qui officia. Quam temere in vitiis, legem sancimus haerentia. Quisque ut dolor gravida, placerat libero vel, euismod.
Non equidem invideo, miror magis posuere velit aliquet. Quisque placerat facilisis egestas cillum dolore. Curabitur blandit tempus ardua ridiculus sed magna. Contra legem facit qui id facit quod lex prohibet. Petierunt uti sibi concilium totius Galliae in diem certam indicere.
Curabitur blandit tempus ardua ridiculus sed magna. Sed haec quis possit intrepidus aestimare tellus. Quisque ut dolor gravida, placerat libero vel, euismod.
```

2. Ideally use the 2023 Theme
3. Go to Appearance => Editor
4. You will see the post with the Excerpt, click on it, and increase the lenght to the max 100
5. If you count the words, there will be 103
6. Check in the front end. There will be 100
7. With the patch, both should have 100.
