### PR TITLE
Patterns: restore pattern category actions for user patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -11,6 +11,8 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useView } from '@wordpress/views';
 import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -32,9 +34,7 @@ import {
 	previewField,
 	templatePartAuthorField,
 } from './fields';
-import { addQueryArgs } from '@wordpress/url';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
-import { Button } from '@wordpress/components';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
@@ -214,7 +214,10 @@ export default function DataviewsPatterns() {
 								{ __( 'Reset view' ) }
 							</Button>
 						) }
-						<PatternsActions />
+						<PatternsActions
+							categoryId={ categoryId }
+							postType={ postType }
+						/>
 					</>
 				}
 			>


### PR DESCRIPTION
Fixes #74921

## What? Why? How?

In WP 6.9, the UI to rename/delete pattern categories in the Site Editor disappeared unintentionally.

This regression has occurred in #72106, as the `PatternsActions` component didn't have props that are required to determine whether the current category is editable or not:

https://github.com/WordPress/gutenberg/pull/72106/changes#diff-6bf3516e0ae1bb3480576679a3d438ee8d381a33ab4b521e123c348e7614750fR217

## Testing Instructions

- Go to Appearance > Editor > Patterns
- Create a new Pattern with a custom pattern category
- Move to the pattern category
- Confirm that the pattern category can be renamed or deleted.


## Screenshots or screencast <!-- if applicable -->

### Before

<img width="955" height="244" alt="image" src="https://github.com/user-attachments/assets/606bc6c4-24a1-4ba9-a211-700779708b2b" />

### After

<img width="957" height="247" alt="image" src="https://github.com/user-attachments/assets/998112fb-da33-4a67-93de-2422c1605361" />
