### PR TITLE
Post Excerpt: Disable HTML element insertion

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -213,6 +213,8 @@ export default function PostExcerptEditor( {
 			}
 			onChange={ setExcerpt }
 			tagName="p"
+			allowedFormats={ [] }
+			preserveWhiteSpace
 		/>
 	) : (
 		<p className={ excerptClassName }>


### PR DESCRIPTION
## What?

This PR prevents the insertion of HTML elements in the Post Excerpt block. I think post excerpt is generally intended to be plain text. Furthermore, allowing HTML elements in the Post Excerpt block will result in unintended display of the excerpt UI in the sidebar.

## Testing Instructions

- Insert a Post Excerpt block.
- Confirm that no inline formats are displayed in the block tolbar
- Change the excerpt content manually and add line breaks
- Open the post sidebar
- Confirm that the excerpt content is displayed correctly

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1100" height="506" alt="image" src="https://github.com/user-attachments/assets/437544a2-f606-45db-9ace-77824256afce" />

### After

<img width="1095" height="541" alt="image" src="https://github.com/user-attachments/assets/15b689b0-a84f-413e-b88e-ca0479c90f54" />

