### PR TITLE
e2e: fix flaky tests for settings sidebar

### DIFF
--- a/test/e2e/specs/site-editor/settings-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/settings-sidebar.spec.js
@@ -38,8 +38,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Template' );
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 		} );
 
 		test( `should show the currently selected template's title and description`, async ( {
@@ -87,8 +92,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Block' );
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 		} );
 	} );
 
@@ -102,8 +112,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Template' );
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 
 			// By inserting the block is also selected.
 			await editor.insertBlock( { name: 'core/heading' } );
@@ -111,8 +126,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Block' );
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 		} );
 
 		test( 'should switch to Template tab when a block was selected and we select the Template', async ( {
@@ -127,8 +147,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Block' );
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 
 			await page.evaluate( () => {
 				window.wp.data
@@ -139,8 +164,13 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tab', { selected: true } )
-			).toHaveText( 'Template' );
+					.getByRole( 'tab', { name: 'Template' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #48878

## What?

Fixes a recently flaky e2e test for the settings sidebar.

Example:

- https://github.com/WordPress/gutenberg/actions/runs/21331439489/job/61396786678
- https://github.com/WordPress/gutenberg/actions/runs/21330701868/job/61395964070
- https://github.com/WordPress/gutenberg/actions/runs/21330114048/job/61393557476
- https://github.com/WordPress/gutenberg/actions/runs/21329866238/job/61393695520
- https://github.com/WordPress/gutenberg/actions/runs/21324541684/job/61379448115


## Why?

Looking at the log, it seems that `aria-selected` is `true` for both tabs "Template" and "Block".

```
Locator: getByRole('region', { name: 'Editor settings' }).getByRole('tab', { selected: true })
Expected: "Block"
Error: strict mode violation: getByRole('region', { name: 'Editor settings' }).getByRole('tab', { selected: true }) resolved to 2 elements:
    1) <button role="tab" type="button" aria-selected="true" data-active-item="true" id="tabs-0-edit-post/block" class="css-19xrdu3 enfox0g3" data-tab-id="edit-post/block" aria-controls="tabs-0-edit-post/block-view">…</button> aka getByRole('tab', { name: 'Block' })
    2) <button role="tab" type="button" id="tabs-1-settings" aria-selected="true" aria-label="Settings" data-active-item="true" class="css-19xrdu3 enfox0g3" aria-controls="tabs-1-settings-view">…</button> aka getByRole('tab', { name: 'Settings' })
```

Perhaps the moment the Block tab is selected instead of the Template tab, aria-selected becomes true for both tabs.

## How?

Make the assertion more strict: instead of checking the selected tab text, check the selection state of each tab instead.

## Testing Instructions
All CI checks should be ✅