### PR TITLE
Block Visibility: fix flaky e2e test

### DIFF
--- a/test/e2e/specs/editor/various/block-hiding.spec.js
+++ b/test/e2e/specs/editor/various/block-hiding.spec.js
@@ -46,6 +46,7 @@ test.describe( 'Block Hiding', () => {
 		).toBeVisible();
 
 		// Verify the Options menu now shows "Show" instead of "Hide".
+		await editor.clickBlockToolbarButton( 'Options' );
 		await expect(
 			page
 				.getByRole( 'menu', { name: 'Options' } )

--- a/test/e2e/specs/editor/various/block-hiding.spec.js
+++ b/test/e2e/specs/editor/various/block-hiding.spec.js
@@ -4,8 +4,22 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Block Hiding', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, page } ) => {
 		await admin.createNewPost();
+
+		// Run the test with the sidebar closed
+		const toggleSidebarButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', {
+				name: 'Settings',
+				disabled: false,
+			} );
+		const isClosed =
+			( await toggleSidebarButton.getAttribute( 'aria-expanded' ) ) ===
+			'false';
+		if ( ! isClosed ) {
+			await toggleSidebarButton.click();
+		}
 	} );
 
 	test( 'should hide a block completely by selecting "Omit from published content"', async ( {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/74883

## What?

Fixes a flaky e2e test for the Block Visibility feature.

```
Error: expect(locator).toBeVisible() failed

Locator: getByRole('menu', { name: 'Options' }).getByRole('menuitem', { name: 'Show' })
Expected: visible
Timeout: 5000ms
Error: element(s) not found

Call log:
  - Expect "toBeVisible" with timeout 5000ms
  - waiting for getByRole('menu', { name: 'Options' }).getByRole('menuitem', { name: 'Show' })

    at /home/runner/work/gutenberg/gutenberg/test/e2e/specs/editor/various/block-hiding.spec.js:55:5
```

Below is a screenshot of the failed test:

<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/40ef5dd3-fd96-47e8-a7dc-0a037dabc6b8" />


## Why?

When the sidebar is opened, the block toolbar dropdown automatically disappears, so the "Show" button is no longer on the screen.

I'm not sure why this test sometimes passes, but the e2e test is very fast, so there may be a short delay between clicking the sidebar and the block toolbar dropdown disappearing.

## How?

Explicitly open the toolbar dropdown. This approach is already present in another test.

https://github.com/WordPress/gutenberg/blob/a6ea7d1e3965b5729d992c215eaf7788055ebd1d/test/e2e/specs/editor/various/block-hiding.spec.js#L100-L102

## Testing Instructions

All CI checks should be ✅