### PR TITLE
Build script: Increase memory limit for storybook build process

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -32,7 +32,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"storybook:build": "storybook build -c . -o ./build",
+		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build",
 		"storybook:dev": "storybook dev -c . -p 50240"
 	}
 }


### PR DESCRIPTION
## Why?
Lately I've noted that the Storybook buildis failing do to a lack of memory, at least in WSL2
I thought that was something specific to my machine, but then I noticed that @t-hamano might have this problem also because he added in his testing instructions the same command in #74835

## How?
Adding the memory increase in the build command

## Testing Instructions
1. Ideally run Windows/with WSL2, not sure if this is happening in other systems
2. Run `npm run storybook:build`
3. 🐞 Build will blow at some point during the transforming phase with:

```bash
[149235:0x10ef5000]   131200 ms: Mark-Compact 4032.5 (4133.1) -> 4018.7 (4135.9) MB, pooled: 0 MB, 756.37 / 0.00 ms  (average mu = 0.153, current mu = 0.073) allocation failure; scavenge might not succeed
[149235:0x10ef5000]   132027 ms: Mark-Compact 4036.0 (4136.1) -> 4021.3 (4137.6) MB, pooled: 0 MB, 768.85 / 0.00 ms  (average mu = 0.112, current mu = 0.070) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xe40d24 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0x1216be0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 3: 0x1216eb7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0x1444875  [node]
 5: 0x14448a3  [node]
 6: 0x145d97a  [node]
 7: 0x1460b48  [node]
 8: 0x1cc69b1  [node]
Aborted (core dumped)
npm error Lifecycle script `storybook:build` failed with error:
npm error code 134
npm error path /home/mcamargo/src/wordpress/wordpress-develop/src/wp-content/plugins/gutenberg/storybook
npm error workspace @wordpress/storybook@0.0.0
npm error location /home/mcamargo/src/wordpress/wordpress-develop/src/wp-content/plugins/gutenberg/storybook
npm error command failed
npm error command sh -c storybook build -c . -o ./build
```