### PR TITLE
core-data: Fix missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52648,8 +52648,10 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
+				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.10",
-				"deep-freeze": "0.0.1"
+				"deep-freeze": "0.0.1",
+				"yjs": "~13.6.6"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -72,8 +72,10 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
+		"@types/jest": "^29.5.14",
 		"@types/node": "^20.17.10",
-		"deep-freeze": "0.0.1"
+		"deep-freeze": "0.0.1",
+		"yjs": "~13.6.6"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/core-data/src/entity-types/test/attachment.test.ts
+++ b/packages/core-data/src/entity-types/test/attachment.test.ts
@@ -20,7 +20,7 @@ describe( 'Attachment type', () => {
 	describe( 'Image attachment', () => {
 		it( 'should validate against real image attachment from REST API', () => {
 			const attachment: Attachment< 'edit' > =
-				imageAttachmentFixture as Attachment< 'edit' >;
+				imageAttachmentFixture as unknown as Attachment< 'edit' >;
 
 			// Edit-context fields
 			expect( attachment.permalink_template ).toBeDefined();
@@ -38,7 +38,7 @@ describe( 'Attachment type', () => {
 	describe( 'Zip file attachment', () => {
 		it( 'should validate against real zip file attachment from REST API', () => {
 			const attachment: Attachment< 'edit' > =
-				zipAttachmentFixture as Attachment< 'edit' >;
+				zipAttachmentFixture as unknown as Attachment< 'edit' >;
 
 			// Edit-context fields
 			expect( attachment.permalink_template ).toBeDefined();
@@ -58,7 +58,7 @@ describe( 'Attachment type', () => {
 	describe( 'Audio file attachment', () => {
 		it( 'should validate against real audio attachment from REST API', () => {
 			const attachment: Attachment< 'edit' > =
-				audioAttachmentFixture as Attachment< 'edit' >;
+				audioAttachmentFixture as unknown as Attachment< 'edit' >;
 
 			// Edit-context fields
 			expect( attachment.permalink_template ).toBeDefined();
@@ -79,7 +79,7 @@ describe( 'Attachment type', () => {
 	describe( 'Video file attachment', () => {
 		it( 'should validate against real video attachment from REST API', () => {
 			const attachment: Attachment< 'edit' > =
-				videoAttachmentFixture as Attachment< 'edit' >;
+				videoAttachmentFixture as unknown as Attachment< 'edit' >;
 
 			// Edit-context fields
 			expect( attachment.permalink_template ).toBeDefined();

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -4,7 +4,7 @@
 	"compilerOptions": {
 		"checkJs": false,
 		"noImplicitAny": false,
-		"types": [ "node" ]
+		"types": [ "jest", "node" ]
 	},
 	"references": [
 		{ "path": "../api-fetch" },

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -22,5 +22,12 @@
 		{ "path": "../undo-manager" },
 		{ "path": "../url" },
 		{ "path": "../warning" }
+	],
+	"exclude": [
+		"src/**/*.android.js",
+		"src/**/*.ios.js",
+		"src/**/*.native.js",
+		"src/**/react-native-*",
+		"src/**/test/**/*.js" // only exclude js files, ts files should be checked
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Detected in #74689

## What?

Addresses the concerns raised in https://github.com/WordPress/gutenberg/pull/74878#discussion_r2726550998, which creates missing dependency issues that we have been trying to solve in #74689.

- `yjs` is used in the package but not declared in dependencies
- The test TS files are not type checked in the package

## Why?

Every package needs to declare the dependencies it uses.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add `@types/jest` and `yjs` to `core-data` dev dependencies
- Include test files for type-checking
- Fix TS errors in some previous tests.

## Testing Instructions

- CI should be happy
- Edit a .ts test file  in core-data, making some type error
- Run `npm run clean:package-types && npm run build`
- Confirm that the type error is now reported

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
