### PR TITLE
dataviews: Fix missing dependency - @storybook/addon-docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52822,6 +52822,7 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
+				"@storybook/addon-docs": "^10.1.11",
 				"@storybook/react-vite": "^10.1.11",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@types/jest": "^29.5.14",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -78,6 +78,7 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
+		"@storybook/addon-docs": "^10.1.11",
 		"@storybook/react-vite": "^10.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/jest": "^29.5.14",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Addresses the concern raised in https://github.com/WordPress/gutenberg/pull/74819#discussion_r2720430921.

#74819 started importing `@storybook/addon-docs` but didn't add it to the dependencies, which creates issues that we have been trying to solve in #74689.

## Why?

Every package must declare the dependencies it consumes

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add `@storybook/addon-docs` to the package dev dependencies

## Testing Instructions

- CI should be happy

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
