### PR TITLE
E2e tests: bump all test blocks to API v3

### DIFF
--- a/packages/e2e-tests/plugins/align-hook/index.js
+++ b/packages/e2e-tests/plugins/align-hook/index.js
@@ -25,6 +25,7 @@
 		'test/test-no-alignment-set',
 		Object.assign(
 			{
+				apiVersion: 3,
 				title: 'Test No Alignment Set',
 			},
 			baseBlock
@@ -35,6 +36,7 @@
 		'test/test-align-true',
 		Object.assign(
 			{
+				apiVersion: 3,
 				title: 'Test Align True',
 				supports: {
 					align: true,
@@ -48,6 +50,7 @@
 		'test/test-align-array',
 		Object.assign(
 			{
+				apiVersion: 3,
 				title: 'Test Align Array',
 				supports: {
 					align: [ 'left', 'center' ],
@@ -61,6 +64,7 @@
 		'test/test-default-align',
 		Object.assign(
 			{
+				apiVersion: 3,
 				title: 'Test Default Align',
 				attributes: {
 					align: {

--- a/packages/e2e-tests/plugins/align-hook/index.js
+++ b/packages/e2e-tests/plugins/align-hook/index.js
@@ -1,23 +1,22 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
 	const el = wp.element.createElement;
+	const { useBlockProps } = wp.blockEditor;
 
 	const baseBlock = {
 		icon: 'cart',
 		category: 'text',
-		edit() {
-			return el(
-				'div',
-				{ style: { outline: '1px solid gray', padding: 5 } },
-				'Test Align Hook'
-			);
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			return el( 'div', blockProps, 'Test Align Hook' );
 		},
 		save() {
-			return el(
-				'div',
-				{ style: { outline: '1px solid gray', padding: 5 } },
-				'Test Align Hook'
-			);
+			const blockProps = useBlockProps.save( {
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			return el( 'div', blockProps, 'Test Align Hook' );
 		},
 	};
 

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -1,7 +1,7 @@
 ( function () {
-	const { createElement: el, Fragment } = wp.element;
+	const { createElement: el } = wp.element;
 	const { registerBlockType } = wp.blocks;
-	const { InnerBlocks } = wp.blockEditor;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 
 	registerBlockType( 'gutenberg/test-context-provider', {
 		apiVersion: 3,
@@ -18,10 +18,16 @@
 
 		category: 'text',
 
-		edit( { attributes, setAttributes } ) {
+		edit: function Edit( { attributes, setAttributes } ) {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				template: [ [ 'gutenberg/test-context-consumer', {} ] ],
+				templateLock: 'all',
+				templateInsertUpdatesSelection: true,
+			} );
 			return el(
-				Fragment,
-				null,
+				'div',
+				innerBlocksProps,
 				el( 'input', {
 					value: attributes.recordId,
 					onChange( event ) {
@@ -30,11 +36,7 @@
 						} );
 					},
 				} ),
-				el( InnerBlocks, {
-					template: [ [ 'gutenberg/test-context-consumer', {} ] ],
-					templateLock: 'all',
-					templateInsertUpdatesSelection: true,
-				} )
+				innerBlocksProps.children
 			);
 		},
 
@@ -56,8 +58,13 @@
 
 		category: 'text',
 
-		edit( { context } ) {
-			return 'The record ID is: ' + context[ 'gutenberg/recordId' ];
+		edit: function Edit( { context } ) {
+			const blockProps = useBlockProps();
+			return el(
+				'div',
+				blockProps,
+				'The record ID is: ' + context[ 'gutenberg/recordId' ]
+			);
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -4,6 +4,7 @@
 	const { InnerBlocks } = wp.blockEditor;
 
 	registerBlockType( 'gutenberg/test-context-provider', {
+		apiVersion: 3,
 		title: 'Test Context Provider',
 
 		icon: 'list-view',
@@ -43,6 +44,7 @@
 	} );
 
 	registerBlockType( 'gutenberg/test-context-consumer', {
+		apiVersion: 3,
 		title: 'Test Context Consumer',
 
 		icon: 'list-view',

--- a/packages/e2e-tests/plugins/block-icons/index.js
+++ b/packages/e2e-tests/plugins/block-icons/index.js
@@ -17,6 +17,7 @@
 	);
 
 	registerBlockType( 'test/test-single-svg-icon', {
+		apiVersion: 3,
 		title: 'TestSimpleSvgIcon',
 		icon: svg,
 		category: 'text',
@@ -55,6 +56,7 @@
 	} );
 
 	registerBlockType( 'test/test-dash-icon', {
+		apiVersion: 3,
 		title: 'TestSimpleDashIcon',
 		icon: 'cart',
 		category: 'text',
@@ -93,6 +95,7 @@
 	} );
 
 	registerBlockType( 'test/test-function-icon', {
+		apiVersion: 3,
 		title: 'TestFunctionIcon',
 		icon() {
 			return svg;
@@ -133,6 +136,7 @@
 	} );
 
 	registerBlockType( 'test/test-dash-icon-colors', {
+		apiVersion: 3,
 		title: 'TestDashIconColors',
 		icon: {
 			background: '#010000',
@@ -175,6 +179,7 @@
 	} );
 
 	registerBlockType( 'test/test-svg-icon-background', {
+		apiVersion: 3,
 		title: 'TestSvgIconBackground',
 		icon: {
 			background: '#010000',

--- a/packages/e2e-tests/plugins/block-icons/index.js
+++ b/packages/e2e-tests/plugins/block-icons/index.js
@@ -1,7 +1,7 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
 	const el = wp.element.createElement;
-	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 	const circle = el( 'circle', {
 		cx: 10,
 		cy: 10,
@@ -22,25 +22,23 @@
 		icon: svg,
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{
-					className: 'test-single-svg-icon',
-					style: { outline: '1px solid gray', padding: 5 },
-				},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-					template: [
-						[
-							'core/paragraph',
-							{
-								content: 'TestSimpleSvgIcon',
-							},
-						],
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				className: 'test-single-svg-icon',
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				template: [
+					[
+						'core/paragraph',
+						{
+							content: 'TestSimpleSvgIcon',
+						},
 					],
-				} )
-			);
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -61,25 +59,23 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{
-					className: 'test-dash-icon',
-					style: { outline: '1px solid gray', padding: 5 },
-				},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-					template: [
-						[
-							'core/paragraph',
-							{
-								content: 'TestDashIcon',
-							},
-						],
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				className: 'test-dash-icon',
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				template: [
+					[
+						'core/paragraph',
+						{
+							content: 'TestDashIcon',
+						},
 					],
-				} )
-			);
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -102,25 +98,23 @@
 		},
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{
-					className: 'test-function-icon',
-					style: { outline: '1px solid gray', padding: 5 },
-				},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-					template: [
-						[
-							'core/paragraph',
-							{
-								content: 'TestFunctionIcon',
-							},
-						],
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				className: 'test-function-icon',
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				template: [
+					[
+						'core/paragraph',
+						{
+							content: 'TestFunctionIcon',
+						},
 					],
-				} )
-			);
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -145,25 +139,23 @@
 		},
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{
-					className: 'test-dash-icon-colors',
-					style: { outline: '1px solid gray', padding: 5 },
-				},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-					template: [
-						[
-							'core/paragraph',
-							{
-								content: 'TestIconColors',
-							},
-						],
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				className: 'test-dash-icon-colors',
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				template: [
+					[
+						'core/paragraph',
+						{
+							content: 'TestIconColors',
+						},
 					],
-				} )
-			);
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -187,25 +179,23 @@
 		},
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{
-					className: 'test-svg-icon-background',
-					style: { outline: '1px solid gray', padding: 5 },
-				},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-					template: [
-						[
-							'core/paragraph',
-							{
-								content: 'TestIconColors',
-							},
-						],
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				className: 'test-svg-icon-background',
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+				template: [
+					[
+						'core/paragraph',
+						{
+							content: 'TestIconColors',
+						},
 					],
-				} )
-			);
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/child-blocks/index.js
+++ b/packages/e2e-tests/plugins/child-blocks/index.js
@@ -4,6 +4,7 @@
 	const { registerBlockType } = wp.blocks;
 
 	registerBlockType( 'test/child-blocks-unrestricted-parent', {
+		apiVersion: 3,
 		title: 'Child Blocks Unrestricted Parent',
 		icon: 'carrot',
 		category: 'text',
@@ -18,6 +19,7 @@
 	} );
 
 	registerBlockType( 'test/child-blocks-restricted-parent', {
+		apiVersion: 3,
 		title: 'Child Blocks Restricted Parent',
 		icon: 'carrot',
 		category: 'text',
@@ -38,6 +40,7 @@
 	} );
 
 	registerBlockType( 'test/child-blocks-child', {
+		apiVersion: 3,
 		title: 'Child Blocks Child',
 		icon: 'carrot',
 		category: 'text',

--- a/packages/e2e-tests/plugins/child-blocks/index.js
+++ b/packages/e2e-tests/plugins/child-blocks/index.js
@@ -1,5 +1,5 @@
 ( function () {
-	const { InnerBlocks } = wp.blockEditor;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 	const { createElement: el } = wp.element;
 	const { registerBlockType } = wp.blocks;
 
@@ -9,8 +9,10 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit() {
-			return el( 'div', {}, el( InnerBlocks ) );
+		edit: function Edit() {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -24,14 +26,12 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{},
-				el( InnerBlocks, {
-					allowedBlocks: [ 'core/paragraph', 'core/image' ],
-				} )
-			);
+		edit: function Edit() {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks: [ 'core/paragraph', 'core/image' ],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -50,8 +50,9 @@
 			'test/child-blocks-restricted-parent',
 		],
 
-		edit() {
-			return el( 'div', {}, 'Child' );
+		edit: function Edit() {
+			const blockProps = useBlockProps();
+			return el( 'div', blockProps, 'Child' );
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/container-without-paragraph/index.js
+++ b/packages/e2e-tests/plugins/container-without-paragraph/index.js
@@ -1,5 +1,6 @@
 ( function () {
 	wp.blocks.registerBlockType( 'test/container-without-paragraph', {
+		apiVersion: 3,
 		title: 'Container without paragraph',
 		category: 'text',
 		icon: 'yes',

--- a/packages/e2e-tests/plugins/container-without-paragraph/index.js
+++ b/packages/e2e-tests/plugins/container-without-paragraph/index.js
@@ -1,14 +1,19 @@
 ( function () {
+	const { useBlockProps, useInnerBlocksProps } = wp.blockEditor;
+	const { createElement: el } = wp.element;
+
 	wp.blocks.registerBlockType( 'test/container-without-paragraph', {
 		apiVersion: 3,
 		title: 'Container without paragraph',
 		category: 'text',
 		icon: 'yes',
 
-		edit() {
-			return wp.element.createElement( wp.blockEditor.InnerBlocks, {
+		edit: function Edit() {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
 				allowedBlocks: [ 'core/image', 'core/gallery' ],
 			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/iframed-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-block/editor.js
@@ -5,6 +5,7 @@
 	const { useRefEffect } = compose;
 
 	registerBlockType( 'test/iframed-block', {
+		apiVersion: 3,
 		edit: function Edit() {
 			const ref = useRefEffect( ( node ) => {
 				$( node ).test();

--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
@@ -19,6 +19,7 @@
 	};
 
 	registerBlockType( 'test/test-inner-blocks-locking-all-embed', {
+		apiVersion: 3,
 		title: 'Test Inner Blocks Locking All Embed',
 		icon: 'cart',
 		category: 'text',

--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
@@ -1,7 +1,7 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
 	const el = wp.element.createElement;
-	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 	const __ = wp.i18n.__;
 	const TEMPLATE = [
 		[
@@ -24,11 +24,13 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit() {
-			return el( InnerBlocks, {
+		edit: function Edit() {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
 				template: TEMPLATE,
 				templateLock: 'all',
 			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save,

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -1,7 +1,7 @@
 ( function () {
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
-	const { InnerBlocks } = wp.blockEditor;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 
 	const divProps = {
 		className: 'product',
@@ -21,8 +21,12 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit() {
-			return el( 'div', divProps, el( InnerBlocks, { template } ) );
+		edit: function Edit() {
+			const blockProps = useBlockProps( divProps );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				template,
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save,
@@ -33,19 +37,17 @@
 		title: 'Prioritized Inserter Blocks Set',
 		icon: 'carrot',
 		category: 'text',
-		edit() {
-			return el(
-				'div',
-				divProps,
-				el( InnerBlocks, {
-					template,
-					prioritizedInserterBlocks: [
-						'core/audio',
-						'core/spacer',
-						'core/code',
-					],
-				} )
-			);
+		edit: function Edit() {
+			const blockProps = useBlockProps( divProps );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				template,
+				prioritizedInserterBlocks: [
+					'core/audio',
+					'core/spacer',
+					'core/code',
+				],
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save,
@@ -58,25 +60,23 @@
 			title: 'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks',
 			icon: 'carrot',
 			category: 'text',
-			edit() {
-				return el(
-					'div',
-					divProps,
-					el( InnerBlocks, {
-						template,
-						allowedBlocks: [
-							'core/spacer',
-							'core/code',
-							'core/paragraph',
-							'core/heading',
-						],
-						prioritizedInserterBlocks: [
-							'core/audio', // this is **not** in the allowedBlocks list
-							'core/spacer',
-							'core/code',
-						],
-					} )
-				);
+			edit: function Edit() {
+				const blockProps = useBlockProps( divProps );
+				const innerBlocksProps = useInnerBlocksProps( blockProps, {
+					template,
+					allowedBlocks: [
+						'core/spacer',
+						'core/code',
+						'core/paragraph',
+						'core/heading',
+					],
+					prioritizedInserterBlocks: [
+						'core/audio', // this is **not** in the allowedBlocks list
+						'core/spacer',
+						'core/code',
+					],
+				} );
+				return el( 'div', innerBlocksProps );
 			},
 
 			save,

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -16,6 +16,7 @@
 		return el( 'div', divProps, el( InnerBlocks.Content ) );
 	};
 	registerBlockType( 'test/prioritized-inserter-blocks-unset', {
+		apiVersion: 3,
 		title: 'Prioritized Inserter Blocks Unset',
 		icon: 'carrot',
 		category: 'text',
@@ -28,6 +29,7 @@
 	} );
 
 	registerBlockType( 'test/prioritized-inserter-blocks-set', {
+		apiVersion: 3,
 		title: 'Prioritized Inserter Blocks Set',
 		icon: 'carrot',
 		category: 'text',
@@ -52,6 +54,7 @@
 	registerBlockType(
 		'test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks',
 		{
+			apiVersion: 3,
 			title: 'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks',
 			icon: 'carrot',
 			category: 'text',

--- a/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
@@ -2,7 +2,7 @@
 	const { wp } = window;
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
-	const { InnerBlocks } = wp.blockEditor;
+	const { InnerBlocks, useBlockProps, useInnerBlocksProps } = wp.blockEditor;
 	const { useSelect } = wp.data;
 
 	const allowedBlocks = [ 'core/quote', 'core/video' ];
@@ -60,15 +60,15 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit() {
-			return el(
-				'div',
-				{ style: { outline: '1px solid gray', padding: 5 } },
-				el( InnerBlocks, {
-					allowedBlocks,
-					renderAppender: myCustomAppender,
-				} )
-			);
+		edit: function Edit() {
+			const blockProps = useBlockProps( {
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks,
+				renderAppender: myCustomAppender,
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {
@@ -86,10 +86,10 @@
 		icon: 'carrot',
 		category: 'text',
 
-		edit( props ) {
-			// Disable reason: this is a react component, but the rule of hook
-			// fails because the block's edit function has a lowercase 'e'.
-			// eslint-disable-next-line react-hooks/rules-of-hooks
+		edit: function Edit( props ) {
+			const blockProps = useBlockProps( {
+				style: { outline: '1px solid gray', padding: 5 },
+			} );
 			const numberOfChildren = useSelect(
 				( select ) => {
 					const { getBlockOrder } = select( 'core/block-editor' );
@@ -109,14 +109,11 @@
 					renderAppender = multipleBlockAppender;
 					break;
 			}
-			return el(
-				'div',
-				{ style: { outline: '1px solid gray', padding: 5 } },
-				el( InnerBlocks, {
-					allowedBlocks,
-					renderAppender,
-				} )
-			);
+			const innerBlocksProps = useInnerBlocksProps( blockProps, {
+				allowedBlocks,
+				renderAppender,
+			} );
+			return el( 'div', innerBlocksProps );
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
@@ -55,6 +55,7 @@
 	}
 
 	registerBlockType( 'test/inner-blocks-render-appender', {
+		apiVersion: 3,
 		title: 'InnerBlocks renderAppender',
 		icon: 'carrot',
 		category: 'text',
@@ -80,6 +81,7 @@
 	} );
 
 	registerBlockType( 'test/inner-blocks-render-appender-dynamic', {
+		apiVersion: 3,
 		title: 'InnerBlocks renderAppender dynamic',
 		icon: 'carrot',
 		category: 'text',

--- a/packages/e2e-tests/plugins/meta-attribute-block.php
+++ b/packages/e2e-tests/plugins/meta-attribute-block.php
@@ -33,6 +33,7 @@ function enqueue_test_meta_attribute_block() {
 		plugins_url( 'meta-attribute-block/early.js', __FILE__ ),
 		array(
 			'wp-blocks',
+			'wp-block-editor',
 			'wp-element',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'meta-attribute-block/early.js' )
@@ -43,6 +44,7 @@ function enqueue_test_meta_attribute_block() {
 		plugins_url( 'meta-attribute-block/late.js', __FILE__ ),
 		array(
 			'wp-blocks',
+			'wp-block-editor',
 			'wp-element',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'meta-attribute-block/late.js' ),

--- a/packages/e2e-tests/plugins/meta-attribute-block/early.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/early.js
@@ -3,6 +3,7 @@
 	const el = wp.element.createElement;
 
 	registerBlockType( 'test/test-meta-attribute-block-early', {
+		apiVersion: 3,
 		title: 'Test Meta Attribute Block (Early Registration)',
 		icon: 'star',
 		category: 'text',

--- a/packages/e2e-tests/plugins/meta-attribute-block/early.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/early.js
@@ -1,6 +1,7 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
 	const el = wp.element.createElement;
+	const { useBlockProps } = wp.blockEditor;
 
 	registerBlockType( 'test/test-meta-attribute-block-early', {
 		apiVersion: 3,
@@ -16,14 +17,15 @@
 			},
 		},
 
-		edit( props ) {
-			return el( 'input', {
+		edit: function Edit( props ) {
+			const blockProps = useBlockProps( {
 				className: 'my-meta-input',
 				value: props.attributes.content,
 				onChange( event ) {
 					props.setAttributes( { content: event.target.value } );
 				},
 			} );
+			return el( 'input', blockProps );
 		},
 
 		save() {

--- a/packages/e2e-tests/plugins/meta-attribute-block/late.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/late.js
@@ -3,6 +3,7 @@
 	const el = wp.element.createElement;
 
 	registerBlockType( 'test/test-meta-attribute-block-late', {
+		apiVersion: 3,
 		title: 'Test Meta Attribute Block (Late Registration)',
 		icon: 'star',
 		category: 'text',

--- a/packages/e2e-tests/plugins/meta-attribute-block/late.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/late.js
@@ -1,6 +1,7 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
 	const el = wp.element.createElement;
+	const { useBlockProps } = wp.blockEditor;
 
 	registerBlockType( 'test/test-meta-attribute-block-late', {
 		apiVersion: 3,
@@ -16,14 +17,15 @@
 			},
 		},
 
-		edit( props ) {
-			return el( 'input', {
+		edit: function Edit( props ) {
+			const blockProps = useBlockProps( {
 				className: 'my-meta-input',
 				value: props.attributes.content,
 				onChange( event ) {
 					props.setAttributes( { content: event.target.value } );
 				},
 			} );
+			return el( 'input', blockProps );
 		},
 
 		save() {

--- a/test/e2e/specs/editor/plugins/block-context.spec.js
+++ b/test/e2e/specs/editor/plugins/block-context.spec.js
@@ -16,16 +16,13 @@ test.describe( 'Block context', () => {
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-context' );
 	} );
 
-	test( 'Block context propagates to inner blocks', async ( {
-		editor,
-		page,
-	} ) => {
+	test( 'Block context propagates to inner blocks', async ( { editor } ) => {
 		await editor.insertBlock( { name: 'gutenberg/test-context-provider' } );
 
-		const providerBlock = page.getByRole( 'document', {
+		const providerBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Test Context Provider',
 		} );
-		const consumerBlock = page.getByRole( 'document', {
+		const consumerBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Test Context Consumer',
 		} );
 
@@ -56,7 +53,7 @@ test.describe( 'Block context', () => {
 
 		// Return to editor to change context value to non-default.
 		await editorPage.bringToFront();
-		await editorPage
+		await editor.canvas
 			.getByRole( 'document', {
 				name: 'Block: Test Context Provider',
 			} )

--- a/test/e2e/specs/editor/plugins/block-directory.spec.js
+++ b/test/e2e/specs/editor/plugins/block-directory.spec.js
@@ -79,14 +79,17 @@ const MOCK_BLOCK2 = {
 const block = `( function() {
 	var registerBlockType = wp.blocks.registerBlockType;
 	var el = wp.element.createElement;
+	var useBlockProps = wp.blockEditor.useBlockProps;
 
 	registerBlockType( '${ MOCK_BLOCK1.name }', {
+		apiVersion: 3,
 		title: 'Block Directory Test Block',
 		icon: 'hammer',
 		category: 'text',
 		attributes: {},
 		edit: function( props ) {
-			return el( 'p', null, 'Test Copy' );
+			var blockProps = useBlockProps();
+			return el( 'p', blockProps, 'Test Copy' );
 		},
 		save: function() {
 			return null;
@@ -150,7 +153,10 @@ test.describe( 'Block Directory', () => {
 		);
 	} );
 
-	test( 'Should be able to add (the first) block', async ( { page } ) => {
+	test( 'Should be able to add (the first) block', async ( {
+		editor,
+		page,
+	} ) => {
 		// Mock response for search with the block.
 		await page.route(
 			( url ) => matchUrl( url, SEARCH_URLS ),
@@ -240,7 +246,7 @@ test.describe( 'Block Directory', () => {
 			.waitFor();
 
 		await expect(
-			page.getByRole( 'document', {
+			editor.canvas.getByRole( 'document', {
 				name: `Block: ${ MOCK_BLOCK1.title }`,
 			} )
 		).toBeVisible();

--- a/test/e2e/specs/editor/plugins/block-icons.spec.js
+++ b/test/e2e/specs/editor/plugins/block-icons.spec.js
@@ -46,7 +46,9 @@ test.describe( 'Block Icons', () => {
 		// Can insert the block.
 		await blockOption.click();
 		await expect(
-			page.getByRole( 'document', { name: 'Block: TestSimpleSvgIcon' } )
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: TestSimpleSvgIcon',
+			} )
 		).toBeVisible();
 
 		// Renders correctly the icon on the inspector.
@@ -84,7 +86,9 @@ test.describe( 'Block Icons', () => {
 		// Can insert the block
 		await blockOption.click();
 		await expect(
-			page.getByRole( 'document', { name: 'Block: TestSimpleDashIcon' } )
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: TestSimpleDashIcon',
+			} )
 		).toBeVisible();
 
 		// Renders correctly the icon on the inspector.
@@ -120,7 +124,9 @@ test.describe( 'Block Icons', () => {
 		// Can insert the block.
 		await blockOption.click();
 		await expect(
-			page.getByRole( 'document', { name: 'Block: TestFunctionIcon' } )
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: TestFunctionIcon',
+			} )
 		).toBeVisible();
 
 		// Renders correctly the icon on the inspector.

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -36,7 +36,7 @@ test.describe( 'Child Blocks', () => {
 			name: 'test/child-blocks-unrestricted-parent',
 		} );
 
-		await page
+		await editor.canvas
 			.getByRole( 'document', {
 				name: 'Block: Child Blocks Unrestricted Parent',
 			} )
@@ -74,7 +74,7 @@ test.describe( 'Child Blocks', () => {
 			name: 'test/child-blocks-restricted-parent',
 		} );
 
-		await page
+		await editor.canvas
 			.getByRole( 'document', {
 				name: 'Block: Child Blocks Restricted Parent',
 			} )

--- a/test/e2e/specs/editor/plugins/container-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/container-blocks.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Container block without paragraph support', () => {
 			name: 'test/container-without-paragraph',
 		} );
 
-		await page
+		await editor.canvas
 			.getByRole( 'document', {
 				name: 'Block: Container without paragraph',
 			} )

--- a/test/e2e/specs/editor/plugins/inner-blocks-locking-all-embed.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-locking-all-embed.spec.js
@@ -47,13 +47,13 @@ test.describe( 'Embed block inside a locked all parent', () => {
 		await editor.insertBlock( {
 			name: 'test/test-inner-blocks-locking-all-embed',
 		} );
-		await page
+		await editor.canvas
 			.getByRole( 'textbox', { name: 'Embed URL' } )
 			.fill( 'https://twitter.com/wordpress' );
 		await page.keyboard.press( 'Enter' );
 
 		await expect(
-			page.getByRole( 'document', { name: 'Block: X' } )
+			editor.canvas.getByRole( 'document', { name: 'Block: X' } )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 				name: 'test/prioritized-inserter-blocks-unset',
 			} );
 
-			const block = page.getByRole( 'document', {
+			const block = editor.canvas.getByRole( 'document', {
 				name: 'Block: Prioritized Inserter Blocks Unset',
 			} );
 
@@ -54,7 +54,7 @@ test.describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 				name: 'test/prioritized-inserter-blocks-set',
 			} );
 
-			const block = page.getByRole( 'document', {
+			const block = editor.canvas.getByRole( 'document', {
 				name: 'Block: Prioritized Inserter Blocks Set',
 			} );
 
@@ -86,7 +86,7 @@ test.describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 				name: 'test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks',
 			} );
 
-			const block = page.getByRole( 'document', {
+			const block = editor.canvas.getByRole( 'document', {
 				name: 'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks',
 			} );
 
@@ -121,7 +121,7 @@ test.describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 				name: 'test/prioritized-inserter-blocks-set',
 			} );
 
-			const imageBlock = page
+			const imageBlock = editor.canvas
 				.getByRole( 'document', {
 					name: 'Block: Prioritized Inserter Blocks Set',
 				} )

--- a/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
@@ -28,7 +28,9 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 			name: 'test/inner-blocks-render-appender',
 		} );
 
-		const customAppender = page.locator( '.my-custom-awesome-appender' );
+		const customAppender = editor.canvas.locator(
+			'.my-custom-awesome-appender'
+		);
 
 		// Verify if the custom block appender text is the expected one.
 		await expect( customAppender ).toContainText(
@@ -71,7 +73,9 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 			name: 'test/inner-blocks-render-appender-dynamic',
 		} );
 
-		const dynamimcAppender = page.locator( '.my-dynamic-blocks-appender' );
+		const dynamimcAppender = editor.canvas.locator(
+			'.my-dynamic-blocks-appender'
+		);
 		const addBlockBtn = dynamimcAppender.getByRole( 'button', {
 			name: 'Add block',
 		} );

--- a/test/e2e/specs/editor/plugins/meta-attribute-block.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-attribute-block.spec.js
@@ -44,13 +44,11 @@ test.describe( 'Block with a meta attribute', () => {
 				await editor.saveDraft();
 				await page.reload();
 
-				const block = page.getByRole( 'document', {
+				const block = editor.canvas.getByRole( 'document', {
 					name: `Block: Test Meta Attribute Block (${ title })`,
 				} );
 				await expect( block ).toBeVisible();
-				await expect( block.locator( '.my-meta-input' ) ).toHaveValue(
-					'Meta Value'
-				);
+				await expect( block ).toHaveValue( 'Meta Value' );
 			} );
 
 			test( 'Should use the same value in all the blocks', async ( {
@@ -64,9 +62,13 @@ test.describe( 'Block with a meta attribute', () => {
 				await editor.insertBlock( { name: blockName } );
 				await page.keyboard.type( 'Meta Value' );
 
-				const inputs = await page.locator( '.my-meta-input' ).all();
-				for ( const input of inputs ) {
-					await expect( input ).toHaveValue( 'Meta Value' );
+				const blocks = await editor.canvas
+					.getByRole( 'document', {
+						name: `Block: Test Meta Attribute Block (${ title })`,
+					} )
+					.all();
+				for ( const block of blocks ) {
+					await expect( block ).toHaveValue( 'Meta Value' );
 				}
 			} );
 
@@ -91,13 +93,11 @@ test.describe( 'Block with a meta attribute', () => {
 				await editor.saveDraft();
 				await page.reload();
 
-				const block = page.getByRole( 'document', {
+				const block = editor.canvas.getByRole( 'document', {
 					name: `Block: Test Meta Attribute Block (${ title })`,
 				} );
 				await expect( block ).toBeVisible();
-				await expect( block.locator( '.my-meta-input' ) ).toHaveValue(
-					'Meta Value'
-				);
+				await expect( block ).toHaveValue( 'Meta Value' );
 			} );
 		} );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Preparatory work for https://github.com/WordPress/gutenberg/pull/74042.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

All blocks should use API version 3 and all e2e tests should run with the iframe.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Bump API version, update some blocks to use `useBlockProps`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
