### PR TITLE
DataForm: support registering 3rd party controls

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
+- DataForm: support registering 3rd party controls. [#74942](https://github.com/WordPress/gutenberg/pull/74942)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform-controls/index.tsx
+++ b/packages/dataviews/src/components/dataform-controls/index.tsx
@@ -58,9 +58,12 @@ function isEditConfig( value: any ): value is EditConfig {
 	);
 }
 
-function createConfiguredControl( config: EditConfig ) {
+function createConfiguredControl(
+	config: EditConfig,
+	customControls?: FormControls
+) {
 	const { control, ...controlConfig } = config;
-	const BaseControlType = getControlByType( control );
+	const BaseControlType = getControlByType( control, customControls );
 	if ( BaseControlType === null ) {
 		return null;
 	}
@@ -74,32 +77,41 @@ function createConfiguredControl( config: EditConfig ) {
 
 export function getControl< Item >(
 	field: Field< Item >,
-	fallback: string | null
+	fallback: string | null,
+	customControls?: FormControls
 ): ComponentType< DataFormControlProps< Item > > | null {
 	if ( typeof field.Edit === 'function' ) {
 		return field.Edit;
 	}
 
 	if ( typeof field.Edit === 'string' ) {
-		return getControlByType( field.Edit );
+		return getControlByType( field.Edit, customControls );
 	}
 
 	if ( isEditConfig( field.Edit ) ) {
-		return createConfiguredControl( field.Edit );
+		return createConfiguredControl( field.Edit, customControls );
 	}
 
 	if ( hasElements( field ) && field.type !== 'array' ) {
-		return getControlByType( 'select' );
+		return getControlByType( 'select', customControls );
 	}
 
 	if ( fallback === null ) {
 		return null;
 	}
 
-	return getControlByType( fallback );
+	return getControlByType( fallback, customControls );
 }
 
-export function getControlByType( type: string ) {
+export function getControlByType(
+	type: string,
+	customControls?: FormControls
+) {
+	// Check custom controls first (they take precedence)
+	if ( customControls && Object.keys( customControls ).includes( type ) ) {
+		return customControls[ type ];
+	}
+
 	if ( Object.keys( FORM_CONTROLS ).includes( type ) ) {
 		return FORM_CONTROLS[ type ];
 	}

--- a/packages/dataviews/src/dataform/index.tsx
+++ b/packages/dataviews/src/dataform/index.tsx
@@ -18,11 +18,12 @@ export default function DataForm< Item >( {
 	fields,
 	onChange,
 	validity,
+	settings,
 }: DataFormProps< Item > ) {
 	const normalizedForm = useMemo( () => normalizeForm( form ), [ form ] );
 	const normalizedFields = useMemo(
-		() => normalizeFields( fields ),
-		[ fields ]
+		() => normalizeFields( fields, settings?.controls ),
+		[ fields, settings?.controls ]
 	);
 
 	if ( ! form.fields ) {

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -11,6 +11,7 @@ import LayoutPanelComponent from './layout-panel';
 import DataAdapterComponent from './data-adapter';
 import ValidationComponent from './validation';
 import VisibilityComponent from './visibility';
+import RegisterControlsComponent from './register-controls';
 
 const meta = {
 	title: 'DataViews/DataForm',
@@ -151,4 +152,29 @@ export const Visibility = {
 
 export const DataAdapter = {
 	render: DataAdapterComponent,
+};
+
+export const RegisterControls = {
+	render: RegisterControlsComponent,
+	argTypes: {
+		labelPosition: {
+			control: { type: 'select' },
+			description: 'Chooses the label position.',
+			options: [ 'default', 'top', 'side', 'none' ],
+		},
+		required: {
+			control: { type: 'boolean' },
+			description: 'Whether the required validation rule is active.',
+		},
+		custom: {
+			control: { type: 'boolean' },
+			description:
+				'Whether the custom validation rule is active (rating must be > 2).',
+		},
+	},
+	args: {
+		labelPosition: 'default',
+		required: false,
+		custom: false,
+	},
 };

--- a/packages/dataviews/src/dataform/stories/register-controls.tsx
+++ b/packages/dataviews/src/dataform/stories/register-controls.tsx
@@ -1,0 +1,196 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { Icon, starFilled, starEmpty } from '@wordpress/icons';
+import { BaseControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DataForm from '../index';
+import useFormValidity from '../../hooks/use-form-validity';
+import type {
+	DataFormControlProps,
+	Field,
+	Form,
+	RegularLayout,
+	FieldValidity,
+} from '../../types';
+
+type SampleProduct = {
+	ratingDefault?: number;
+	ratingWithConfig?: number;
+};
+
+function StarRatingControl< Item >( {
+	data,
+	field,
+	onChange,
+	config,
+	hideLabelFromVision,
+	validity,
+}: DataFormControlProps< Item > & { validity?: FieldValidity } ) {
+	const value = field.getValue( { item: data } ) ?? 0;
+	const starCount = ( config?.starCount as number ) ?? 5;
+	const stars = Array.from( { length: starCount }, ( _, i ) => i + 1 );
+
+	const getValidationError = () => {
+		if ( validity?.required?.type === 'invalid' ) {
+			return validity.required.message ?? 'This field is required.';
+		}
+		if ( validity?.custom?.type === 'invalid' ) {
+			return validity.custom.message;
+		}
+		return undefined;
+	};
+	const validationError = getValidationError();
+	const helpText = validationError ?? field.description;
+
+	return (
+		<BaseControl
+			id={ field.id }
+			label={ field.label }
+			hideLabelFromVision={ hideLabelFromVision }
+			help={ helpText }
+			__nextHasNoMarginBottom
+		>
+			<div
+				style={ {
+					display: 'flex',
+					gap: '4px',
+					...( validationError && {
+						outline: '1px solid #cc1818',
+						outlineOffset: '2px',
+						borderRadius: '2px',
+					} ),
+				} }
+			>
+				{ stars.map( ( star ) => (
+					<button
+						key={ star }
+						type="button"
+						onClick={ () =>
+							onChange(
+								field.setValue( {
+									item: data,
+									value: star === value ? undefined : star,
+								} )
+							)
+						}
+						style={ {
+							background: 'none',
+							border: 'none',
+							cursor: 'pointer',
+							padding: 0,
+						} }
+						aria-label={ `Rate ${ star } stars` }
+					>
+						<Icon
+							icon={ star <= value ? starFilled : starEmpty }
+							size={ 24 }
+							style={ {
+								fill: star <= value ? '#f0b849' : '#ccc',
+							} }
+						/>
+					</button>
+				) ) }
+			</div>
+		</BaseControl>
+	);
+}
+
+const RegisterControlsComponent = ( {
+	labelPosition,
+	required,
+	custom,
+}: {
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+	required: boolean;
+	custom: boolean;
+} ) => {
+	const [ product, setProduct ] = useState< SampleProduct >( {
+		ratingDefault: 1,
+		ratingWithConfig: 2,
+	} );
+
+	const customRatingRule = useCallback( ( item: SampleProduct ) => {
+		if ( item.ratingDefault !== undefined && item.ratingDefault <= 2 ) {
+			return 'Rating must be higher than 2.';
+		}
+		return null;
+	}, [] );
+
+	const customRatingWithConfigRule = useCallback( ( item: SampleProduct ) => {
+		if (
+			item.ratingWithConfig !== undefined &&
+			item.ratingWithConfig <= 2
+		) {
+			return 'Rating must be higher than 2.';
+		}
+		return null;
+	}, [] );
+
+	const fields: Field< SampleProduct >[] = useMemo(
+		() => [
+			{
+				id: 'ratingDefault',
+				label: 'Rating',
+				type: 'integer',
+				Edit: 'starRating', // Reference custom control by name
+				isValid: {
+					required,
+					custom: custom ? customRatingRule : undefined,
+				},
+			},
+			{
+				id: 'ratingWithConfig',
+				label: 'Rating (3 stars)',
+				type: 'integer',
+				Edit: {
+					// Reference custom control by config
+					control: 'starRating',
+					starCount: 3,
+				},
+				isValid: {
+					required,
+					custom: custom ? customRatingWithConfigRule : undefined,
+				},
+			},
+		],
+		[ required, custom, customRatingRule, customRatingWithConfigRule ]
+	);
+
+	const form: Form = useMemo( () => {
+		const layout: RegularLayout = {
+			type: 'regular',
+		};
+		if ( labelPosition !== 'default' ) {
+			layout.labelPosition = labelPosition;
+		}
+		return {
+			layout,
+			fields: [ 'ratingDefault', 'ratingWithConfig' ],
+		};
+	}, [ labelPosition ] );
+
+	const { validity } = useFormValidity( product, fields, form );
+	return (
+		<DataForm< SampleProduct >
+			data={ product }
+			fields={ fields }
+			form={ form }
+			onChange={ ( edits ) =>
+				setProduct( ( prev ) => ( { ...prev, ...edits } ) )
+			}
+			validity={ validity }
+			settings={ {
+				controls: {
+					starRating: StarRatingControl,
+				},
+			} }
+		/>
+	);
+};
+
+export default RegisterControlsComponent;

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -77,6 +77,109 @@ const fieldsSelector = {
 };
 
 describe( 'DataForm component', () => {
+	describe( 'custom controls via settings', () => {
+		it( 'should render custom control from settings', () => {
+			const CustomTitleControl = () => {
+				return <span>Custom Title Control</span>;
+			};
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text' as const,
+							Edit: 'customTitle',
+						},
+					] }
+					form={ { fields: [ 'title' ] } }
+					data={ { title: 'Hello' } }
+					settings={ {
+						controls: { customTitle: CustomTitleControl },
+					} }
+				/>
+			);
+
+			expect(
+				screen.getByText( 'Custom Title Control' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should allow custom controls to override built-in controls', () => {
+			const CustomTextControl = () => {
+				return <span>Overridden Text Control</span>;
+			};
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text' as const,
+							Edit: 'text',
+						},
+					] }
+					form={ { fields: [ 'title' ] } }
+					data={ { title: 'Hello' } }
+					settings={ { controls: { text: CustomTextControl } } }
+				/>
+			);
+
+			expect(
+				screen.getByText( 'Overridden Text Control' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should use built-in controls when no custom controls provided', () => {
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text' as const,
+							Edit: 'text',
+						},
+					] }
+					form={ { fields: [ 'title' ] } }
+					data={ { title: 'Hello' } }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'textbox', { name: /title/i } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should not render field when control name is unknown', () => {
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text' as const,
+							Edit: 'unknownControl',
+						},
+					] }
+					form={ { fields: [ 'title' ] } }
+					data={ { title: 'Hello' } }
+				/>
+			);
+
+			// The field should not be rendered as no Edit component is available
+			expect(
+				screen.queryByRole( 'textbox', { name: /title/i } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'in regular mode', () => {
 		it( 'should display fields', () => {
 			render(

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
 import type {
+	DataFormControlProps,
 	Field,
 	FieldTypeName,
 	NormalizedField,
@@ -63,14 +69,20 @@ function getFieldTypeByName< Item >( type?: FieldTypeName ): FieldType< Item > {
 	return noType;
 }
 
+interface CustomControls {
+	[ key: string ]: ComponentType< DataFormControlProps< any > >;
+}
+
 /**
  * Apply default values and normalize the fields config.
  *
- * @param fields Fields config.
+ * @param fields         Fields config.
+ * @param customControls Optional custom controls to use for Edit fields.
  * @return Normalized fields config.
  */
 export default function normalizeFields< Item >(
-	fields: Field< Item >[]
+	fields: Field< Item >[],
+	customControls?: CustomControls
 ): NormalizedField< Item >[] {
 	return fields.map( ( field ) => {
 		const fieldType = getFieldTypeByName< Item >( field.type );
@@ -101,7 +113,7 @@ export default function normalizeFields< Item >(
 			// The type provides defaults for the following props
 			type: fieldType.type,
 			render: field.render ?? fieldType.render,
-			Edit: getControl( field, fieldType.Edit ),
+			Edit: getControl( field, fieldType.Edit, customControls ),
 			sort,
 			enableSorting: field.enableSorting ?? fieldType.enableSorting,
 			enableGlobalSearch:

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
-import type { Field, FieldValidity } from './field-api';
+import type { DataFormControlProps, Field, FieldValidity } from './field-api';
 
 /**
  * DataForm layouts.
@@ -150,12 +155,21 @@ export type NormalizedForm = {
 	fields: NormalizedFormField[];
 };
 
+export interface DataFormControls {
+	[ key: string ]: ComponentType< DataFormControlProps< any > >;
+}
+
+export interface DataFormSettings {
+	controls?: DataFormControls;
+}
+
 export interface DataFormProps< Item > {
 	data: Item;
 	fields: Field< Item >[];
 	form: Form;
 	onChange: ( value: Record< string, any > ) => void;
 	validity?: FormValidity;
+	settings?: DataFormSettings;
 }
 
 export type FormValidity = Record< string, FieldValidity > | undefined;

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -164,13 +164,23 @@ export type EditConfigGeneric = {
 };
 
 /**
+ * Edit configuration for custom controls.
+ * Allows any control name and additional configuration properties.
+ */
+export type EditConfigCustom = {
+	control: string;
+	[ key: string ]: unknown;
+};
+
+/**
  * Edit configuration object with type-safe control options.
  * Each control type has its own specific configuration properties.
  */
 export type EditConfig =
 	| EditConfigTextarea
 	| EditConfigText
-	| EditConfigGeneric;
+	| EditConfigGeneric
+	| EditConfigCustom;
 
 /**
  * A dataview field for a specific property of a data type.
@@ -445,6 +455,7 @@ export type DataFormControlProps< Item > = {
 		prefix?: React.ComponentType;
 		suffix?: React.ComponentType;
 		rows?: number;
+		[ key: string ]: unknown;
 	};
 };
 


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/74856

## What?                                                                                                                                                                                                                                                                  

Adds support for registering custom controls in DataForm via a new settings prop.

```tsx
  // Register custom controls via settings prop                                                                                                                                                                                                                          
  <DataForm                                                                                                                                                                                                                                                              
      data={ product }                                                                                                                                                                                                                                                   
      fields={ fields }                                                                                                                                                                                                                                                  
      form={ form }                                                                                                                                                                                                                                                      
      onChange={ setProduct }                                                                                                                                                                                                                                            
      settings={ {                                                                                                                                                                                                                                                       
          controls: {                                                                                                                                                                                                                                                    
              starRating: StarRatingControl,                                                                                                                                                                                                                             
          },                                                                                                                                                                                                                                                             
      } }                                                                                                                                                                                                                                                                
  />                                                                                                                                                                                                                                                                     
```

Custom controls can be referenced by string name:

```tsx
  {                                                                                                                                                                                                                                                                      
      id: 'rating',                                                                                                                                                                                                                                                      
      label: 'Rating',                                                                                                                                                                                                                                                   
      type: 'integer',                                                                                                                                                                                                                                                   
      Edit: 'starRating',                                                                                                                                                                                                                                                
  }                                                                                                                                                                                                                                                                      
```

Or with additional configuration via EditConfig:

```tsx
  {                                                                                                                                                                                                                                                                      
      id: 'rating',                                                                                                                                                                                                                                                      
      label: 'Rating (3 stars)',                                                                                                                                                                                                                                         
      type: 'integer',                                                                                                                                                                                                                                                   
      Edit: {                                                                                                                                                                                                                                                            
          control: 'starRating',                                                                                                                                                                                                                                         
          starCount: 3,                                                                                                                                                                                                                                                  
      },                                                                                                                                                                                                                                                                 
  }                                                                                                                                                                                                                                                                      
```

## Why?                                                                                                                                                                                                                                                                   

Field authors can already declare custom Edit controls:

```tsx
  {                                                                                                                                                                                                                                                                      
      id: 'rating',                                                                                                                                                                                                                                                      
      label: 'Rating (3 stars)',                                                                                                                                                                                                                                         
      type: 'integer',                                                                                                                                                                                                                                                   
      Edit: ( { data, field, onChange } ) => { /* custom control */ } 
  }                                                                                                                                                                                                                                                                      
```

However, this is not serializable as so cannot be used in places like JSON or PHP. By allowing 3rd parties to register their own custom controls as if they were core ones, we unlock serialization for them.

## How?                                                                                                                                                                                                                                                                   

  - Added a new `settings` prop to DataForm with a controls object that maps control names to React components.
  - Custom controls take precedence over built-in controls, allowing overrides.
  - Custom controls can be referenced by string name (Edit: 'starRating') or with config (Edit: { control: 'starRating', starCount: 3 }).
  - Added new "Register Controls" story to highlight this use case.

## Testing Instructions                                                                                                                                                                                                                                                   

  1. Run the Storybook: npm run storybook:dev
  2. Navigate to DataViews → DataForm → Register Controls
  3. Verify the star rating controls render correctly (support label and required/custom validation).
