### PR TITLE
DataViews: Fix fields async validation

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 - DataForm: Sync React-level validation to native inputs on date fields. [#74994](https://github.com/WordPress/gutenberg/pull/74994)
 - Fix primary action visibility in table layout when the action doesn't support bulk operations, and fix compact action menu not visible on mobile when there is only one action. [#74836](https://github.com/WordPress/gutenberg/pull/74836)
 - DataViews: Use regular casing for bulk selection count. [#74573](https://github.com/WordPress/gutenberg/pull/74573)
+- DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 
 ### Code Quality
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
+- DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 
 ### Enhancements
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)
@@ -21,7 +22,6 @@
 - DataForm: Sync React-level validation to native inputs on date fields. [#74994](https://github.com/WordPress/gutenberg/pull/74994)
 - Fix primary action visibility in table layout when the action doesn't support bulk operations, and fix compact action menu not visible on mobile when there is only one action. [#74836](https://github.com/WordPress/gutenberg/pull/74836)
 - DataViews: Use regular casing for bulk selection count. [#74573](https://github.com/WordPress/gutenberg/pull/74573)
-- DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 
 ### Code Quality
 

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -265,9 +265,6 @@ function ValidatedDateControl< Item >( {
 							'components-validated-control__indicator',
 							customValidity.type === 'invalid'
 								? 'is-invalid'
-								: undefined,
-							customValidity.type === 'valid'
-								? 'is-valid'
 								: undefined
 						) }
 					>

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -233,155 +233,6 @@ describe( 'useFormValidity', () => {
 				} );
 			} );
 		} );
-
-		it( 'should remove field from validity when async elements validation passes', async () => {
-			const item = { status: 'draft' };
-			const fields: Field< any >[] = [
-				{
-					id: 'status',
-					type: 'text',
-					getElements: async () =>
-						await new Promise( ( resolve ) => {
-							setTimeout( resolve, 5 );
-						} ).then( () => [
-							{ value: 'draft', label: 'Draft' },
-							{ value: 'published', label: 'Published' },
-						] ),
-					isValid: {
-						elements: true,
-					},
-				},
-			];
-			const form = { fields: [ 'status' ] };
-			const { result } = renderHook( () =>
-				useFormValidity( item, fields, form )
-			);
-
-			// Initially should be validating.
-			expect( result.current.validity?.status?.elements?.type ).toBe(
-				'validating'
-			);
-
-			// After resolution, field should be removed (validation passed)
-			await waitFor( () => {
-				expect( result.current ).toEqual( {
-					validity: undefined, // No validation errors
-					isValid: true,
-				} );
-			} );
-		} );
-
-		it( 'should run both async elements and custom validation', async () => {
-			const item = { status: 'draft' };
-			const fields: Field< any >[] = [
-				{
-					id: 'status',
-					type: 'text',
-					getElements: async () =>
-						await new Promise( ( resolve ) => {
-							setTimeout( resolve, 5 );
-						} ).then( () => [
-							{ value: 'draft', label: 'Draft' },
-							{ value: 'published', label: 'Published' },
-						] ),
-					isValid: {
-						elements: true,
-						custom: ( value ) => {
-							if ( value.status !== 'published' ) {
-								return 'Status must be published.';
-							}
-							return null;
-						},
-					},
-				},
-			];
-			const form = { fields: [ 'status' ] };
-			const { result } = renderHook( () =>
-				useFormValidity( item, fields, form )
-			);
-
-			// Initially should have both validations
-			expect( result.current.validity?.status?.elements?.type ).toBe(
-				'validating'
-			);
-			expect( result.current.validity?.status?.custom?.type ).toBe(
-				'invalid'
-			);
-			expect( result.current.validity?.status?.custom?.message ).toBe(
-				'Status must be published.'
-			);
-
-			// After resolution, elements validation passes but custom fails
-			await waitFor( () => {
-				expect( result.current ).toEqual( {
-					validity: {
-						status: {
-							custom: {
-								type: 'invalid',
-								message: 'Status must be published.',
-							},
-						},
-					},
-					isValid: false,
-				} );
-			} );
-		} );
-
-		it( 'should run both async elements and async custom validation', async () => {
-			const item = { status: 'draft' };
-			const fields: Field< any >[] = [
-				{
-					id: 'status',
-					type: 'text',
-					getElements: async () =>
-						await new Promise( ( resolve ) => {
-							setTimeout( resolve, 5 );
-						} ).then( () => [
-							{ value: 'draft', label: 'Draft' },
-							{ value: 'published', label: 'Published' },
-						] ),
-					isValid: {
-						elements: true,
-						custom: async ( value ) =>
-							await new Promise( ( resolve ) =>
-								setTimeout( resolve, 5 )
-							).then( () => {
-								if ( value.status !== 'published' ) {
-									return 'Status must be published.';
-								}
-								return null;
-							} ),
-					},
-				},
-			];
-			const form = { fields: [ 'status' ] };
-			const { result } = renderHook( () =>
-				useFormValidity( item, fields, form )
-			);
-
-			// Initially should have both validating
-			expect( result.current.validity?.status?.elements?.type ).toBe(
-				'validating'
-			);
-			expect( result.current.validity?.status?.custom?.type ).toBe(
-				'validating'
-			);
-
-			// After both async resolve, elements passes but custom fails
-			await waitFor( () => {
-				expect( result.current ).toEqual( {
-					validity: {
-						status: {
-							custom: {
-								type: 'invalid',
-								message: 'Status must be published.',
-							},
-						},
-					},
-					isValid: false,
-				} );
-			} );
-		} );
 	} );
 
 	describe( 'isValid.required', () => {
@@ -1796,207 +1647,339 @@ describe( 'useFormValidity', () => {
 			expect( isValid ).toBe( false );
 		} );
 
-		describe( 'async', () => {
-			it( 'is valid when validity object only contains type:valid messages', async () => {
-				const item = {
-					id: 1,
-					title: 'Valid Title',
-					status: 'published',
-				};
-				const fields: Field< {} >[] = [
-					{
-						id: 'title',
-						type: 'text',
-						isValid: {
-							custom: async () =>
-								await new Promise( ( resolve ) =>
-									setTimeout( resolve, 5 )
-								).then( () => null ),
+		it( 'should return early on custom sync validation failure', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+						custom: ( value ) => {
+							if ( value.status !== 'published' ) {
+								return 'Status must be published.';
+							}
+							return null;
 						},
 					},
-					{
-						id: 'status',
-						type: 'text',
-						isValid: {
-							custom: async () =>
-								await new Promise( ( resolve ) =>
-									setTimeout( resolve, 5 )
-								).then( () => null ),
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+			expect( result.current ).toEqual( {
+				validity: {
+					status: {
+						custom: {
+							type: 'invalid',
+							message: 'Status must be published.',
 						},
 					},
-				];
-				const form = { fields: [ 'title', 'status' ] };
-				const { result } = renderHook( () =>
-					useFormValidity( item, fields, form )
-				);
+				},
+				isValid: false,
+			} );
+		} );
+	} );
+	describe( 'async', () => {
+		it( 'is valid when validity object only contains type:valid messages', async () => {
+			const item = {
+				id: 1,
+				title: 'Valid Title',
+				status: 'published',
+			};
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+					isValid: {
+						custom: async () =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => null ),
+					},
+				},
+				{
+					id: 'status',
+					type: 'text',
+					isValid: {
+						custom: async () =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => null ),
+					},
+				},
+			];
+			const form = { fields: [ 'title', 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
 
-				await waitFor( () => {
-					expect( result.current ).toEqual( {
-						validity: undefined,
-						isValid: true,
-					} );
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: undefined,
+					isValid: true,
 				} );
 			} );
+		} );
 
-			it( 'is invalid and message is "Validating…" when promise is in flight', async () => {
-				const item = {
-					id: 1,
-					title: 'Invalid Title',
-					status: 'published',
-				};
-				const fields: Field< {} >[] = [
-					{
-						id: 'title',
-						type: 'text',
-						isValid: {
-							// This promise is never resolved.
-							// Serves to test in flight behavior of validation.
-							custom: async () => await new Promise( () => {} ),
-						},
+		it( 'is invalid and message is "Validating…" when promise is in flight', async () => {
+			const item = {
+				id: 1,
+				title: 'Invalid Title',
+				status: 'published',
+			};
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+					isValid: {
+						// This promise is never resolved.
+						// Serves to test in flight behavior of validation.
+						custom: async () => await new Promise( () => {} ),
 					},
-				];
-				const form = { fields: [ 'title' ] };
-				const { result } = renderHook( () =>
-					useFormValidity( item, fields, form )
-				);
+				},
+			];
+			const form = { fields: [ 'title' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
 
-				await waitFor( () => {
-					expect( result.current ).toEqual( {
-						validity: {
-							title: {
-								custom: {
-									type: 'validating',
-									message: 'Validating…',
-								},
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						title: {
+							custom: {
+								type: 'validating',
+								message: 'Validating…',
 							},
 						},
-						isValid: false,
-					} );
+					},
+					isValid: false,
 				} );
 			} );
+		} );
 
-			it( 'is invalid when validity object contains at least one type:invalid message', async () => {
-				const item = {
-					id: 1,
-					title: 'Invalid Title',
-					status: 'published',
-				};
-				const fields: Field< {} >[] = [
-					{
-						id: 'title',
-						type: 'text',
-						isValid: {
-							custom: async () =>
-								await new Promise( ( resolve ) =>
-									setTimeout( resolve, 5 )
-								).then( () => 'Title is invalid.' ),
-						},
+		it( 'is invalid when validity object contains at least one type:invalid message', async () => {
+			const item = {
+				id: 1,
+				title: 'Invalid Title',
+				status: 'published',
+			};
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+					isValid: {
+						custom: async () =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => 'Title is invalid.' ),
 					},
-				];
-				const form = { fields: [ 'title' ] };
-				const { result } = renderHook( () =>
-					useFormValidity( item, fields, form )
-				);
+				},
+			];
+			const form = { fields: [ 'title' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
 
-				await waitFor( () => {
-					expect( result.current ).toEqual( {
-						validity: {
-							title: {
-								custom: {
-									type: 'invalid',
-									message: 'Title is invalid.',
-								},
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						title: {
+							custom: {
+								type: 'invalid',
+								message: 'Title is invalid.',
 							},
 						},
-						isValid: false,
-					} );
+					},
+					isValid: false,
 				} );
 			} );
+		} );
 
-			it( 'is invalid when custom returns anything other than null or a string', async () => {
-				const item = {
-					id: 1,
-					title: 'Invalid Title',
-					status: 'published',
-				};
-				const fields: Field< {} >[] = [
-					{
-						id: 'title',
-						type: 'text',
-						isValid: {
-							// @ts-ignore returns wrong type for testing purposes
-							custom: async () =>
-								await new Promise( ( resolve ) =>
-									setTimeout( resolve, 5 )
-								).then( () => 3 ),
-						},
+		it( 'is invalid when custom returns anything other than null or a string', async () => {
+			const item = {
+				id: 1,
+				title: 'Invalid Title',
+				status: 'published',
+			};
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+					isValid: {
+						// @ts-ignore returns wrong type for testing purposes
+						custom: async () =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => 3 ),
 					},
-				];
-				const form = { fields: [ 'title' ] };
-				const { result } = renderHook( () =>
-					useFormValidity( item, fields, form )
-				);
+				},
+			];
+			const form = { fields: [ 'title' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
 
-				await waitFor( () => {
-					expect( result.current ).toEqual( {
-						validity: {
-							title: {
-								custom: {
-									type: 'invalid',
-									message:
-										'Validation could not be processed.',
-								},
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						title: {
+							custom: {
+								type: 'invalid',
+								message: 'Validation could not be processed.',
 							},
 						},
-						isValid: false,
-					} );
+					},
+					isValid: false,
 				} );
 			} );
+		} );
 
-			it( 'is invalid when promise was rejected', async () => {
-				const item = {
-					id: 1,
-					title: 'Invalid Title',
-					status: 'published',
-				};
-				const fields: Field< {} >[] = [
-					{
-						id: 'title',
-						type: 'text',
-						isValid: {
-							custom: async () =>
-								await new Promise( ( resolve, reject ) =>
-									setTimeout(
-										() =>
-											reject(
-												new Error(
-													'Validation did not complete successfully.'
-												)
-											),
-										5
-									)
-								),
-						},
+		it( 'is invalid when promise was rejected', async () => {
+			const item = {
+				id: 1,
+				title: 'Invalid Title',
+				status: 'published',
+			};
+			const fields: Field< {} >[] = [
+				{
+					id: 'title',
+					type: 'text',
+					isValid: {
+						custom: async () =>
+							await new Promise( ( resolve, reject ) =>
+								setTimeout(
+									() =>
+										reject(
+											new Error(
+												'Validation did not complete successfully.'
+											)
+										),
+									5
+								)
+							),
 					},
-				];
-				const form = { fields: [ 'title' ] };
-				const { result } = renderHook( () =>
-					useFormValidity( item, fields, form )
-				);
+				},
+			];
+			const form = { fields: [ 'title' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
 
-				await waitFor( () => {
-					expect( result.current ).toEqual( {
-						validity: {
-							title: {
-								custom: {
-									type: 'invalid',
-									message:
-										'Validation did not complete successfully.',
-								},
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						title: {
+							custom: {
+								type: 'invalid',
+								message:
+									'Validation did not complete successfully.',
 							},
 						},
-						isValid: false,
-					} );
+					},
+					isValid: false,
+				} );
+			} );
+		} );
+
+		it( 'should remove field from validity when async elements validation passes', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+					},
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+
+			// Initially should be validating.
+			expect( result.current.validity?.status?.elements?.type ).toBe(
+				'validating'
+			);
+
+			// After resolution, field should be removed (validation passed)
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: undefined, // No validation errors
+					isValid: true,
+				} );
+			} );
+		} );
+
+		it( 'should run both async elements and async custom validation', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+						custom: async ( value ) =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => {
+								if ( value.status !== 'published' ) {
+									return 'Status must be published.';
+								}
+								return null;
+							} ),
+					},
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+
+			// Initially should have both validating
+			expect( result.current.validity?.status?.elements?.type ).toBe(
+				'validating'
+			);
+			expect( result.current.validity?.status?.custom?.type ).toBe(
+				'validating'
+			);
+
+			// After both async resolve, elements passes but custom fails
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						status: {
+							custom: {
+								type: 'invalid',
+								message: 'Status must be published.',
+							},
+						},
+					},
+					isValid: false,
 				} );
 			} );
 		} );

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -233,6 +233,155 @@ describe( 'useFormValidity', () => {
 				} );
 			} );
 		} );
+
+		it( 'should remove field from validity when async elements validation passes', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+					},
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+
+			// Initially should be validating.
+			expect( result.current.validity?.status?.elements?.type ).toBe(
+				'validating'
+			);
+
+			// After resolution, field should be removed (validation passed)
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: undefined, // No validation errors
+					isValid: true,
+				} );
+			} );
+		} );
+
+		it( 'should run both async elements and custom validation', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+						custom: ( value ) => {
+							if ( value.status !== 'published' ) {
+								return 'Status must be published.';
+							}
+							return null;
+						},
+					},
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+
+			// Initially should have both validations
+			expect( result.current.validity?.status?.elements?.type ).toBe(
+				'validating'
+			);
+			expect( result.current.validity?.status?.custom?.type ).toBe(
+				'invalid'
+			);
+			expect( result.current.validity?.status?.custom?.message ).toBe(
+				'Status must be published.'
+			);
+
+			// After resolution, elements validation passes but custom fails
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						status: {
+							custom: {
+								type: 'invalid',
+								message: 'Status must be published.',
+							},
+						},
+					},
+					isValid: false,
+				} );
+			} );
+		} );
+
+		it( 'should run both async elements and async custom validation', async () => {
+			const item = { status: 'draft' };
+			const fields: Field< any >[] = [
+				{
+					id: 'status',
+					type: 'text',
+					getElements: async () =>
+						await new Promise( ( resolve ) => {
+							setTimeout( resolve, 5 );
+						} ).then( () => [
+							{ value: 'draft', label: 'Draft' },
+							{ value: 'published', label: 'Published' },
+						] ),
+					isValid: {
+						elements: true,
+						custom: async ( value ) =>
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 5 )
+							).then( () => {
+								if ( value.status !== 'published' ) {
+									return 'Status must be published.';
+								}
+								return null;
+							} ),
+					},
+				},
+			];
+			const form = { fields: [ 'status' ] };
+			const { result } = renderHook( () =>
+				useFormValidity( item, fields, form )
+			);
+
+			// Initially should have both validating
+			expect( result.current.validity?.status?.elements?.type ).toBe(
+				'validating'
+			);
+			expect( result.current.validity?.status?.custom?.type ).toBe(
+				'validating'
+			);
+
+			// After both async resolve, elements passes but custom fails
+			await waitFor( () => {
+				expect( result.current ).toEqual( {
+					validity: {
+						status: {
+							custom: {
+								type: 'invalid',
+								message: 'Status must be published.',
+							},
+						},
+					},
+					isValid: false,
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'isValid.required', () => {
@@ -1683,14 +1832,7 @@ describe( 'useFormValidity', () => {
 
 				await waitFor( () => {
 					expect( result.current ).toEqual( {
-						validity: {
-							title: {
-								custom: { type: 'valid', message: 'Valid' },
-							},
-							status: {
-								custom: { type: 'valid', message: 'Valid' },
-							},
-						},
+						validity: undefined,
 						isValid: true,
 					} );
 				} );

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -1689,7 +1689,7 @@ describe( 'useFormValidity', () => {
 		} );
 	} );
 	describe( 'async', () => {
-		it( 'is valid when validity object only contains type:valid messages', async () => {
+		it( 'is valid when async custom validations pass (return null)', async () => {
 			const item = {
 				id: 1,
 				title: 'Valid Title',

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -150,6 +150,7 @@ function setValidityAtPath(
 			current[ segment ] = {};
 		}
 
+		current[ segment ] = { ...current[ segment ] };
 		current = current[ segment ];
 	}
 

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -160,6 +160,45 @@ function setValidityAtPath(
 	return result;
 }
 
+function removeValidationProperty(
+	formValidity: FormValidity | undefined,
+	path: string[],
+	property: keyof FieldValidity
+): FormValidity | undefined {
+	if ( ! formValidity || path.length === 0 ) {
+		return formValidity;
+	}
+	const result = { ...formValidity };
+	// Navigate to parent of target.
+	let current: any = result;
+	for ( let i = 0; i < path.length - 1; i++ ) {
+		const segment = path[ i ];
+		if ( ! current[ segment ] ) {
+			return formValidity; // Path doesn't exist
+		}
+		current[ segment ] = { ...current[ segment ] };
+		current = current[ segment ];
+	}
+	const finalKey = path[ path.length - 1 ];
+	if ( ! current[ finalKey ] ) {
+		return formValidity;
+	}
+	const fieldValidity = { ...current[ finalKey ] };
+	delete fieldValidity[ property ];
+	// If field has no more validations, remove it entirely.
+	if ( Object.keys( fieldValidity ).length === 0 ) {
+		delete current[ finalKey ];
+	} else {
+		// Keep the field if it has other validations (including children).
+		current[ finalKey ] = fieldValidity;
+	}
+	// If root is empty, return undefined
+	if ( Object.keys( result ).length === 0 ) {
+		return undefined;
+	}
+	return result;
+}
+
 function handleElementsValidationAsync< Item >(
 	promise: Promise< any >,
 	formField: FormFieldToValidate< Item >,
@@ -215,6 +254,15 @@ function handleElementsValidationAsync< Item >(
 					);
 					return newFormValidity;
 				} );
+			} else {
+				// Validation passed so we need to remove `elements` from validity.
+				setFormValidity( ( prev ) => {
+					return removeValidationProperty(
+						prev,
+						[ ...path, formField.id ],
+						'elements'
+					);
+				} );
 			}
 		} )
 		.catch( ( error ) => {
@@ -265,18 +313,13 @@ function handleCustomValidationAsync< Item >(
 			}
 
 			if ( result === null ) {
+				// Validation passed so we need to remove `custom` from validity.
 				setFormValidity( ( prev ) => {
-					const newFormValidity = setValidityAtPath(
+					return removeValidationProperty(
 						prev,
-						{
-							custom: {
-								type: 'valid',
-								message: __( 'Valid' ),
-							},
-						},
-						[ ...path, formField.id ]
+						[ ...path, formField.id ],
+						'custom'
 					);
-					return newFormValidity;
 				} );
 				return;
 			}
@@ -448,6 +491,8 @@ function validateFormField< Item >(
 		};
 	}
 
+	// Aggregate async validations (`elements` and `custom`).
+	const fieldValidity: FieldValidity = {};
 	// Validate the field: isValid.elements (async)
 	if (
 		!! formField.field &&
@@ -460,12 +505,9 @@ function validateFormField< Item >(
 			formField,
 			promiseHandler
 		);
-
-		return {
-			elements: {
-				type: 'validating',
-				message: __( 'Validating…' ),
-			},
+		fieldValidity.elements = {
+			type: 'validating',
+			message: __( 'Validating…' ),
 		};
 	}
 
@@ -494,21 +536,17 @@ function validateFormField< Item >(
 					__( 'Unknown error when running custom validation.' );
 			}
 
-			return {
-				custom: {
-					type: 'invalid',
-					message: errorMessage,
-				},
+			fieldValidity.custom = {
+				type: 'invalid',
+				message: errorMessage,
 			};
 		}
 	}
 
 	if ( typeof customError === 'string' ) {
-		return {
-			custom: {
-				type: 'invalid',
-				message: customError,
-			},
+		fieldValidity.custom = {
+			type: 'invalid',
+			message: customError,
 		};
 	}
 
@@ -516,12 +554,15 @@ function validateFormField< Item >(
 	if ( customError instanceof Promise ) {
 		handleCustomValidationAsync( customError, formField, promiseHandler );
 
-		return {
-			custom: {
-				type: 'validating',
-				message: __( 'Validating…' ),
-			},
+		fieldValidity.custom = {
+			type: 'validating',
+			message: __( 'Validating…' ),
 		};
+	}
+
+	// Return aggregated validations if any exist
+	if ( Object.keys( fieldValidity ).length > 0 ) {
+		return fieldValidity;
 	}
 
 	// Validate its children.

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -491,26 +491,6 @@ function validateFormField< Item >(
 		};
 	}
 
-	// Aggregate async validations (`elements` and `custom`).
-	const fieldValidity: FieldValidity = {};
-	// Validate the field: isValid.elements (async)
-	if (
-		!! formField.field &&
-		formField.field.isValid.elements &&
-		formField.field.hasElements &&
-		typeof formField.field.getElements === 'function'
-	) {
-		handleElementsValidationAsync(
-			formField.field.getElements(),
-			formField,
-			promiseHandler
-		);
-		fieldValidity.elements = {
-			type: 'validating',
-			message: __( 'Validating…' ),
-		};
-	}
-
 	// Validate the field: isValid.custom (sync)
 	let customError;
 	if ( !! formField.field && formField.field.isValid.custom ) {
@@ -536,17 +516,41 @@ function validateFormField< Item >(
 					__( 'Unknown error when running custom validation.' );
 			}
 
-			fieldValidity.custom = {
-				type: 'invalid',
-				message: errorMessage,
+			return {
+				custom: {
+					type: 'invalid',
+					message: errorMessage,
+				},
 			};
 		}
 	}
 
 	if ( typeof customError === 'string' ) {
-		fieldValidity.custom = {
-			type: 'invalid',
-			message: customError,
+		return {
+			custom: {
+				type: 'invalid',
+				message: customError,
+			},
+		};
+	}
+
+	// Aggregate async validations (`elements` and `custom`).
+	const fieldValidity: FieldValidity = {};
+	// Validate the field: isValid.elements (async)
+	if (
+		!! formField.field &&
+		formField.field.isValid.elements &&
+		formField.field.hasElements &&
+		typeof formField.field.getElements === 'function'
+	) {
+		handleElementsValidationAsync(
+			formField.field.getElements(),
+			formField,
+			promiseHandler
+		);
+		fieldValidity.elements = {
+			type: 'validating',
+			message: __( 'Validating…' ),
 		};
 	}
 

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -40,7 +40,10 @@ function isFormValid( formValidity: FormValidity | undefined ): boolean {
 					// Recursively check children validations
 					return isFormValid( validation as FormValidity );
 				}
-				return validation.type === 'valid';
+				return (
+					validation.type !== 'invalid' &&
+					validation.type !== 'validating'
+				);
 			}
 		);
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on https://github.com/WordPress/gutenberg/pull/74937 I noticed the async validation logic doesn't work properly.

We can have async `elements` and `custom` validation and in trunk we immediately returned `type: 'invalidating'`, without updating the validity state after resolution. Additionally that early return would skip `custom` validation and just get stuck in that `invalidating` state.

This PR fixes that by aggregating the async validations and also cleans up the validity state when async validation resolves. 

Finally, it updates `handleCustomValidationAsync` to work as the rest of validation handling by not returning a `valid` message, but instead removing any validation errors if existed. 

## Testing Instructions
1. In storybook (`npm run storybook:dev`) you can go to the validation story (`?path=/story/dataviews-dataform--validation&args=elements:async`) and observe that validation messages update or appear/disappear properly by your actions. For example `combobox` control has custom validation about needing `Apple` as the required value.
2. Everything else works as before

### Before video (storybook)

https://github.com/user-attachments/assets/fc7970a5-69a4-4747-887a-7ec82be1a7dc



### Aftrer video (storybook)


https://github.com/user-attachments/assets/7e1476ba-c947-4783-be15-6d927bb460e4


