### PR TITLE
Shortcode: Fix non-string attribute values being silently dropped

### DIFF
--- a/packages/shortcode/CHANGELOG.md
+++ b/packages/shortcode/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix non-string attribute values being silently dropped ([#74949](https://github.com/WordPress/gutenberg/pull/74949)).
+
 ## 4.38.0 (2026-01-16)
 
 ## 4.36.0 (2025-11-26)

--- a/packages/shortcode/src/index.ts
+++ b/packages/shortcode/src/index.ts
@@ -298,12 +298,8 @@ class Shortcode implements ShortcodeInstance {
 			// Handle a flat object of attributes (e.g., { foo: 'bar', baz: 'qux' }).
 		} else {
 			Object.entries( attributes ).forEach( ( [ key, value ] ) => {
-				if (
-					typeof value === 'string' ||
-					typeof value === 'undefined'
-				) {
-					this.set( key, value );
-				}
+				// Coerce non-string values to strings to maintain backward compatibility.
+				this.set( key, String( value ) );
 			} );
 		}
 	}

--- a/packages/shortcode/src/index.ts
+++ b/packages/shortcode/src/index.ts
@@ -298,8 +298,10 @@ class Shortcode implements ShortcodeInstance {
 			// Handle a flat object of attributes (e.g., { foo: 'bar', baz: 'qux' }).
 		} else {
 			Object.entries( attributes ).forEach( ( [ key, value ] ) => {
-				// Coerce non-string values to strings to maintain backward compatibility.
-				this.set( key, String( value ) );
+				if ( value !== undefined ) {
+					// Coerce non-string values to strings to maintain backward compatibility.
+					this.set( key, String( value ) );
+				}
 			} );
 		}
 	}

--- a/packages/shortcode/src/test/index.ts
+++ b/packages/shortcode/src/test/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { next, replace, attrs } from '../';
+import { next, replace, attrs, string } from '../';
 
 describe( 'shortcode', () => {
 	describe( 'next', () => {
@@ -304,6 +304,25 @@ describe( 'shortcode', () => {
 			};
 
 			expect( result ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'string', () => {
+		it( 'should coerce non-string attribute values to strings', () => {
+			const result = string( {
+				tag: 'gallery',
+				attrs: {
+					// @ts-expect-error TS is not happy about unknown properties here.
+					ids: [ 1, 2, 3 ],
+					columns: 4,
+					data: { test: 'value' },
+					flip: true,
+				},
+				type: 'single',
+			} );
+			expect( result ).toBe(
+				'[gallery ids="1,2,3" columns="4" data="[object Object]" flip="true"]'
+			);
 		} );
 	} );
 } );

--- a/packages/shortcode/src/test/index.ts
+++ b/packages/shortcode/src/test/index.ts
@@ -308,15 +308,19 @@ describe( 'shortcode', () => {
 	} );
 
 	describe( 'string', () => {
-		it( 'should coerce non-string attribute values to strings', () => {
+		it( 'should coerce non-string attribute values to strings and skip undefined', () => {
 			const result = string( {
 				tag: 'gallery',
 				attrs: {
 					// @ts-expect-error TS is not happy about unknown properties here.
 					ids: [ 1, 2, 3 ],
 					columns: 4,
+					// Note: Objects are coerced to "[object Object]" which is not useful.
+					// Passing objects as attribute values should be avoided in real usage.
 					data: { test: 'value' },
 					flip: true,
+					// Undefined values should be skipped entirely.
+					missing: undefined,
 				},
 				type: 'single',
 			} );


### PR DESCRIPTION
## What?

Closes #74947

Fixes a regression in the `@wordpress/shortcode` package where non-string attribute values were being silently ignored when creating shortcodes.

## Why?

The TypeScript migration in #74522 (commit fa3e0afac18) introduced a type guard that only allowed string or undefined values when handling flat attribute objects. This caused non-string values (like numbers, arrays, booleans) to be silently dropped, breaking functionality such as the Gallery shortcode not saving images.

**Before (JavaScript):**

```javascript
Object.entries( attributes ).forEach( ( [ key, value ] ) => {
	this.set( key, value );
} );
```

**After migration (TypeScript - buggy):**

```typescript
Object.entries( attributes ).forEach( ( [ key, value ] ) => {
	if ( typeof value === 'string' || typeof value === 'undefined' ) {
		this.set( key, value );
	}
} );
```

The original JavaScript code relied on implicit type coercion when serializing. The new code skipped non-string values entirely.

## How?

The fix skips undefined values and coerces all other attribute values to strings using `String(value)`, maintaining backward compatibility with the pre-TypeScript behavior:

```typescript
Object.entries( attributes ).forEach( ( [ key, value ] ) => {
	if ( value !== undefined ) {
		// Coerce non-string values to strings to maintain backward compatibility.
		this.set( key, String( value ) );
	}
} );
```

A regression test was also added to prevent this issue from recurring.

## Testing Instructions

1. Run the shortcode package tests:

    ```bash
    npm run test:unit -- --testPathPattern=packages/shortcode
    ```

2. Verify that non-string attribute values are coerced correctly:
    - Arrays: `[1, 2, 3]` → `"1,2,3"`
    - Numbers: `4` → `"4"`
    - Booleans: `true` → `"true"`
    - Undefined values are skipped entirely
3. Follow the instructions in #74947 to verify that the issue is resolved

### Testing Instructions for Keyboard

N/A - This is a code-level fix with no UI changes.

## Screenshots or screencast

N/A - This is a code-level fix.
