### PR TITLE
Lock save button during Client Side Media processing and uploading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59647,6 +59647,7 @@
 				"@wordpress/reusable-blocks": "file:../reusable-blocks",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/server-side-render": "file:../server-side-render",
+				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -51,7 +51,7 @@ function mediaUpload(
 	}
 ) {
 	void registry.dispatch( uploadStore ).addItems( {
-		files: filesList,
+		files: Array.from( filesList ),
 		onChange: onFileChange,
 		onSuccess,
 		onBatchSuccess,

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -7,7 +7,6 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/interface',
 	'@wordpress/sync',
 	'@wordpress/undo-manager',
-	'@wordpress/upload-media',
 	'@wordpress/fields',
 	'@wordpress/views',
 	'@wordpress/ui',

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -98,6 +98,7 @@
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",
+		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -30,6 +30,7 @@ import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
 import NavigationBlockEditingMode from './navigation-block-editing-mode';
 import { useHideBlocksFromInserter } from './use-hide-blocks-from-inserter';
 import useCommands from '../commands';
+import useUploadSaveLock from './use-upload-save-lock';
 import BlockRemovalWarnings from '../block-removal-warnings';
 import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
@@ -351,6 +352,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Register the editor commands.
 		useCommands();
+
+		// Lock post saving when media uploads are in progress (experimental feature).
+		useUploadSaveLock();
 
 		if ( ! isReady || ! mode ) {
 			return null;

--- a/packages/editor/src/components/provider/use-upload-save-lock.js
+++ b/packages/editor/src/components/provider/use-upload-save-lock.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as uploadStore } from '@wordpress/upload-media';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+const LOCK_NAME = 'upload-in-progress';
+
+/**
+ * A hook that locks post saving and autosaving while media uploads are in progress.
+ * This prevents users from publishing or saving while files are still uploading.
+ *
+ * Only active when the experimental media processing feature is enabled.
+ */
+export default function useUploadSaveLock() {
+	const isExperimentEnabled = window.__experimentalMediaProcessing;
+
+	const isUploading = useSelect(
+		( select ) => {
+			if ( ! isExperimentEnabled ) {
+				return false;
+			}
+			return select( uploadStore ).isUploading();
+		},
+		[ isExperimentEnabled ]
+	);
+
+	const {
+		lockPostSaving,
+		unlockPostSaving,
+		lockPostAutosaving,
+		unlockPostAutosaving,
+	} = useDispatch( editorStore );
+
+	useEffect( () => {
+		if ( ! isExperimentEnabled ) {
+			return;
+		}
+
+		if ( isUploading ) {
+			lockPostSaving( LOCK_NAME );
+			lockPostAutosaving( LOCK_NAME );
+		} else {
+			unlockPostSaving( LOCK_NAME );
+			unlockPostAutosaving( LOCK_NAME );
+		}
+
+		return () => {
+			unlockPostSaving( LOCK_NAME );
+			unlockPostAutosaving( LOCK_NAME );
+		};
+	}, [
+		isExperimentEnabled,
+		isUploading,
+		lockPostSaving,
+		unlockPostSaving,
+		lockPostAutosaving,
+		unlockPostAutosaving,
+	] );
+}

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -62,9 +62,6 @@ export default function mediaUpload( {
 			? currentPost.id
 			: currentPost?.wp_id;
 	const setSaveLock = () => {
-		if ( window.__experimentalMediaProcessing ) {
-			return; // Skip - handled by useUploadSaveLock in editor provider
-		}
 		lockPostSaving( lockKey );
 		lockPostAutosaving( lockKey );
 		imageIsUploading = true;
@@ -72,9 +69,6 @@ export default function mediaUpload( {
 
 	const postData = currentPostId ? { post: currentPostId } : {};
 	const clearSaveLock = () => {
-		if ( window.__experimentalMediaProcessing ) {
-			return; // Skip - handled by useUploadSaveLock in editor provider
-		}
 		unlockPostSaving( lockKey );
 		unlockPostAutosaving( lockKey );
 		imageIsUploading = false;
@@ -84,10 +78,14 @@ export default function mediaUpload( {
 		allowedTypes,
 		filesList,
 		onFileChange: ( file ) => {
-			if ( ! imageIsUploading ) {
-				setSaveLock();
-			} else {
-				clearSaveLock();
+			// When client-side media processing is enabled, save locking
+			// is handled by useUploadSaveLock in the editor provider.
+			if ( ! window.__experimentalMediaProcessing ) {
+				if ( ! imageIsUploading ) {
+					setSaveLock();
+				} else {
+					clearSaveLock();
+				}
 			}
 			onFileChange?.( file );
 
@@ -113,7 +111,9 @@ export default function mediaUpload( {
 		},
 		maxUploadFileSize,
 		onError: ( { message } ) => {
-			clearSaveLock();
+			if ( ! window.__experimentalMediaProcessing ) {
+				clearSaveLock();
+			}
 			onError( message );
 		},
 		wpAllowedMimeTypes,

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -62,6 +62,9 @@ export default function mediaUpload( {
 			? currentPost.id
 			: currentPost?.wp_id;
 	const setSaveLock = () => {
+		if ( window.__experimentalMediaProcessing ) {
+			return; // Skip - handled by useUploadSaveLock in editor provider
+		}
 		lockPostSaving( lockKey );
 		lockPostAutosaving( lockKey );
 		imageIsUploading = true;
@@ -69,6 +72,9 @@ export default function mediaUpload( {
 
 	const postData = currentPostId ? { post: currentPostId } : {};
 	const clearSaveLock = () => {
+		if ( window.__experimentalMediaProcessing ) {
+			return; // Skip - handled by useUploadSaveLock in editor provider
+		}
 		unlockPostSaving( lockKey );
 		unlockPostAutosaving( lockKey );
 		imageIsUploading = false;

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -35,6 +35,7 @@
 		{ "path": "../private-apis" },
 		{ "path": "../rich-text" },
 		{ "path": "../url" },
+		{ "path": "../upload-media" },
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }
 	]

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -38,8 +38,16 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"wpScript": true,
 	"types": "build-types",
-	"sideEffects": false,
+	"sideEffects": [
+		"src/index.ts",
+		"src/store/index.ts",
+		"build/index.cjs",
+		"build/store/index.cjs",
+		"build-module/index.mjs",
+		"build-module/store/index.mjs"
+	],
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -219,7 +219,7 @@ export function processItem( id: QueueItemId ) {
 				onSuccess?.( [ attachment ] );
 			}
 
-			// dispatch.removeItem( id );
+			dispatch.removeItem( id );
 			dispatch.revokeBlobUrls( id );
 
 			if ( batchId && select.isBatchUploaded( batchId ) ) {


### PR DESCRIPTION
Replaces https://github.com/WordPress/gutenberg/pull/74712 which was merged to the feature branch causing GitHub to close the PR.

Fixes https://github.com/WordPress/gutenberg/issues/73654

## What

Update the `editor` package to use the `isUploading` state from the `upload-media` package when the client-side media experiment is active. This ensures that the post locking behaviour (applied when an upload is in progress) is managed via the actual uploading state in the store, rather than handled in the `mediaUpload` function

## How / why

When the client side media processing experiment was active, after uploading an image to the block editor, the (published) post would become locked and stay locked.

* When the experiment is not active, use the existing approach to lock the editor
* When the experiment is active, use the `upload-media` package's uploading state to determine when to lock/unlock the editor

Note that this change also partially reverts #68522 which bundled the upload-media package rather than treating as an external script. While testing, e2e tests were failing due to a notice that the `upload-media` store was being registered twice. It turns out the cause was due to the bundling as the `upload-media` package is used by _both_ the block-editor and editor packages.

The fix there is to ensure it's unbundled (add `wpScript: true` to the package.json, define sideEffects) so that only one version of that code is called. That resolves the error.

## Testing instructions

Enable the client-side media processing experiment:

<img width="1018" height="75" alt="image" src="https://github.com/user-attachments/assets/52439149-9b34-419b-80df-6aed11782e82" />

1. Open a published post or page
2. Upload a few images to an image or gallery block and note that the post will be locked while the upload is in progress
3. Once the upload has concluded the post should be unlocked
4. Switch off the experiment and test that the same happens without the experiment active
