### PR TITLE
Fix: Programmatic required error does not work as expected on the toggle control

### DIFF
--- a/packages/components/src/validated-form-controls/components/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-control.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef, useRef, useEffect } from '@wordpress/element';
+import { forwardRef, useRef, useLayoutEffect } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -27,7 +27,7 @@ const UnforwardedValidatedToggleControl = (
 
 	// TODO: Upstream limitation - The `required` attribute is not passed down to the input,
 	// so we need to set it manually.
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( validityTargetRef.current ) {
 			validityTargetRef.current.required = required ?? false;
 		}


### PR DESCRIPTION
Fixes an issue reported by @oandregal where on toggle control the programmatic errors don't work as expected.
 The cause was a timing bug where the Toggle field's validation error was not displayed after opening a previously collapsed card, even though the badge correctly showed the field count.
The solution was to change  `useEffect`  to  `useLayoutEffect`  in  `ValidatedToggleControl`  so the  `required`  attribute is set on the input before  `ControlWithError`'s effect reads  `validationMessage`


## Testing

-   Open Storybook at  `?path=/story/dataviews-dataform--validation&args=layout:card-collapsible`
-   Open the "Boolean Fields" card, then close it — badge shows "2 fields need attention"
-   Reopen the card — verify the Toggle error message now appears (on trunk it does not)
-   Verify checkbox and toggle group errors still display correctly
-   Toggle the control on/off to confirm it still functions