### PR TITLE
Real-time collaboration: Fix undo tests

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -453,8 +453,7 @@ export const editEntityRecord =
 					objectId,
 					editsWithMerges,
 					LOCAL_EDITOR_ORIGIN,
-					false, // isSave
-					isNewUndoLevel
+					{ isNewUndoLevel }
 				);
 			}
 		}
@@ -755,7 +754,7 @@ export const saveEntityRecord =
 								recordId,
 								updatedRecord,
 								LOCAL_EDITOR_ORIGIN,
-								true // isSave
+								{ isSave: true }
 							);
 						}
 					}

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -432,11 +432,29 @@ export const editEntityRecord =
 				const objectType = `${ kind }/${ name }`;
 				const objectId = recordId;
 
+				// Determine whether this edit should create a new undo level.
+				//
+				// In Gutenberg, block changes flow through two callbacks:
+				// - `onInput`: For transient/in-progress changes (e.g., typing each
+				//   character). These use `isCached: true` and get merged into
+				//   the current undo item.
+				// - `onChange`: For persistent/completed changes (e.g., formatting
+				//   transforms, block insertions). These use `isCached: false` and
+				//   should create a new undo level.
+				//
+				// Additionally, `undoIgnore: true` means the change should not
+				// affect the undo history at all (e.g., selection-only changes).
+				const isNewUndoLevel = options.undoIgnore
+					? false
+					: ! options.isCached;
+
 				getSyncManager()?.update(
 					objectType,
 					objectId,
 					editsWithMerges,
-					LOCAL_EDITOR_ORIGIN
+					LOCAL_EDITOR_ORIGIN,
+					false, // isSave
+					isNewUndoLevel
 				);
 			}
 		}

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -316,7 +316,8 @@ describe( 'editEntityRecord', () => {
 						newKey: 'newValue',
 					},
 				},
-				'local-editor'
+				'local-editor',
+				{ isNewUndoLevel: true }
 			);
 		} );
 
@@ -357,7 +358,8 @@ describe( 'editEntityRecord', () => {
 						key2: 'value2',
 					},
 				},
-				'local-editor'
+				'local-editor',
+				{ isNewUndoLevel: true }
 			);
 
 			// But the local store dispatch should still receive undefined for the cleaned edit
@@ -412,7 +414,8 @@ describe( 'editEntityRecord', () => {
 						newKey: 'newValue',
 					},
 				},
-				'local-editor'
+				'local-editor',
+				{ isNewUndoLevel: true }
 			);
 		} );
 

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { dispatch } from '@wordpress/data';
-// @ts-expect-error No exported types.
+import { dispatch, select } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { isUnmodifiedBlock } from '@wordpress/blocks';
 import { type CRDTDoc, Y } from '@wordpress/sync';
 
 /**
@@ -153,6 +153,7 @@ export function restoreSelection(
 		return;
 	}
 
+	const { getBlock } = select( blockEditorStore );
 	const { resetSelection } = dispatch( blockEditorStore );
 	const { selectionStart, selectionEnd } = selectionToRestore;
 	const isSelectionInSameBlock =
@@ -161,12 +162,42 @@ export function restoreSelection(
 	if ( isSelectionInSameBlock ) {
 		// Case 2: After content is restored, the selection is available
 		// within the same block
-		resetSelection( selectionStart, selectionEnd, null );
+
+		const block = getBlock( selectionStart.clientId );
+		const isBlockEmpty = block && isUnmodifiedBlock( block );
+		const isBeginningOfEmptyBlock =
+			0 === selectionStart.offset &&
+			0 === selectionEnd.offset &&
+			isBlockEmpty;
+
+		if ( isBeginningOfEmptyBlock ) {
+			// Case 2a: When the content in a block has been removed after an
+			// undo, WordPress will set the selection to the block's client ID
+			// with an undefined startOffset and endOffset.
+			//
+			// To match the default behavior and tests, exclude the selection
+			// offset when resetting to position 0.
+			const selectionStartWithoutOffset = {
+				clientId: selectionStart.clientId,
+			};
+			const selectionEndWithoutOffset = {
+				clientId: selectionEnd.clientId,
+			};
+
+			resetSelection(
+				selectionStartWithoutOffset,
+				selectionEndWithoutOffset,
+				0
+			);
+		} else {
+			// Case 2b: Otherwise, reset including the saved selection offset.
+			resetSelection( selectionStart, selectionEnd, 0 );
+		}
 	} else {
 		// Case 3: A multi-block selection was made. resetSelection() can only
 		// restore selections within the same block.
 		// When a multi-block selection is made, selectionEnd represents
 		// where the user's cursor ended.
-		resetSelection( selectionEnd, selectionEnd, null );
+		resetSelection( selectionEnd, selectionEnd, 0 );
 	}
 }

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
+// @ts-expect-error No exported types.
 import { store as blockEditorStore } from '@wordpress/block-editor';
+// @ts-expect-error No exported types.
 import { isUnmodifiedBlock } from '@wordpress/blocks';
 import { type CRDTDoc, Y } from '@wordpress/sync';
 

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -450,18 +450,20 @@ export function createSyncManager(): SyncManager {
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
-	 * @param {ObjectType}            objectType Object type.
-	 * @param {ObjectID}              objectId   Object ID.
-	 * @param {Partial< ObjectData >} changes    Updates to make.
-	 * @param {string}                origin     The source of change.
-	 * @param {boolean}               isSave     Whether this update is part of a save operation.
+	 * @param {ObjectType}            objectType     Object type.
+	 * @param {ObjectID}              objectId       Object ID.
+	 * @param {Partial< ObjectData >} changes        Updates to make.
+	 * @param {string}                origin         The source of change.
+	 * @param {boolean}               isSave         Whether this update is part of a save operation.
+	 * @param                         isNewUndoLevel Whether to create a new undo level for this change.
 	 */
 	function updateCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		isSave: boolean = false
+		isSave: boolean = false,
+		isNewUndoLevel: boolean = false
 	): void {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -469,6 +471,16 @@ export function createSyncManager(): SyncManager {
 
 		if ( entityState ) {
 			const { syncConfig, ydoc } = entityState;
+
+			// If this is change should create a new undo level, tell the undo
+			// manager to stop capturing and create a new undo group.
+			// We can't do this in the undo manager itself, because addRecord() is
+			// called after the CRDT changes have been applied, and we want to
+			// ensure that the undo set is created before the changes are applied.
+			if ( isNewUndoLevel && undoManager ) {
+				undoManager.stopCapturing?.();
+			}
+
 			ydoc.transact( () => {
 				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
 

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -49,6 +49,11 @@ interface EntityState {
 	ydoc: CRDTDoc;
 }
 
+export interface SyncManagerUpdateOptions {
+	isSave?: boolean;
+	isNewUndoLevel?: boolean;
+}
+
 /**
  * The sync manager orchestrates the lifecycle of syncing entity records. It
  * creates Yjs documents, connects to providers, creates awareness instances,
@@ -306,7 +311,7 @@ export function createSyncManager(): SyncManager {
 	 */
 	function unloadEntity( objectType: ObjectType, objectId: ObjectID ): void {
 		entityStates.get( getEntityId( objectType, objectId ) )?.unload();
-		updateCRDTDoc( objectType, null, {}, origin, true /* isSave */ );
+		updateCRDTDoc( objectType, null, {}, origin, { isSave: true } );
 	}
 
 	/**
@@ -450,21 +455,22 @@ export function createSyncManager(): SyncManager {
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
-	 * @param {ObjectType}            objectType     Object type.
-	 * @param {ObjectID}              objectId       Object ID.
-	 * @param {Partial< ObjectData >} changes        Updates to make.
-	 * @param {string}                origin         The source of change.
-	 * @param {boolean}               isSave         Whether this update is part of a save operation.
-	 * @param                         isNewUndoLevel Whether to create a new undo level for this change.
+	 * @param {ObjectType}               objectType             Object type.
+	 * @param {ObjectID}                 objectId               Object ID.
+	 * @param {Partial< ObjectData >}    changes                Updates to make.
+	 * @param {string}                   origin                 The source of change.
+	 * @param {SyncManagerUpdateOptions} options                Optional flags for the update.
+	 * @param {boolean}                  options.isSave         Whether this update is part of a save operation. Defaults to false.
+	 * @param {boolean}                  options.isNewUndoLevel Whether to create a new undo level for this change. Defaults to false.
 	 */
 	function updateCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		isSave: boolean = false,
-		isNewUndoLevel: boolean = false
+		options: SyncManagerUpdateOptions = {}
 	): void {
+		const { isSave = false, isNewUndoLevel = false } = options;
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
 		const collectionState = collectionStates.get( objectType );

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -601,7 +601,9 @@ describe( 'SyncManager', () => {
 			const changes = { title: 'Updated Title' };
 			const now = Date.now();
 
-			manager.update( 'post', '123', changes, 'local-editor', true );
+			manager.update( 'post', '123', changes, 'local-editor', {
+				isSave: true,
+			} );
 
 			// Verify that applyChangesToCRDTDoc was called with the changes.
 			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -127,7 +127,8 @@ export interface SyncManager {
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		isSave?: boolean
+		isSave?: boolean,
+		isNewUndoLevel?: boolean
 	) => void;
 }
 
@@ -136,4 +137,5 @@ export interface SyncUndoManager extends WPUndoManager< ObjectData > {
 		ymap: Y.Map< any >,
 		handlers: Pick< RecordHandlers, 'addUndoMeta' | 'restoreUndoMeta' >
 	) => void;
+	stopCapturing: () => void;
 }

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -14,6 +14,7 @@ import type { Awareness } from 'y-protocols/awareness';
  */
 import type { AwarenessState } from './awareness/awareness-state';
 import type { WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE } from './config';
+import type { SyncManagerUpdateOptions } from './manager';
 
 /* globalThis */
 declare global {
@@ -127,8 +128,7 @@ export interface SyncManager {
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		isSave?: boolean,
-		isNewUndoLevel?: boolean
+		options?: SyncManagerUpdateOptions
 	) => void;
 }
 

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -138,5 +138,13 @@ export function createUndoManager(): SyncUndoManager {
 		hasRedo(): boolean {
 			return yUndoManager.canRedo();
 		},
+
+		/**
+		 * Stop capturing changes into the current undo item.
+		 * The next change will create a new undo item.
+		 */
+		stopCapturing(): void {
+			yUndoManager.stopCapturing();
+		},
 	};
 }


### PR DESCRIPTION
## What?

Fixes a lot of failing undo-related e2e tests in https://github.com/WordPress/gutenberg/pull/74564 after adding a default sync provider and utilizing the Yjs undo manager. This PR is an unification of fixes that make the RTC undo manager match expected default WordPress behavior.

## Why?

Fix undo-related tests in https://github.com/WordPress/gutenberg/pull/74564 so we can merge a default real-time collaboration provider.

## How?

 Fixes in this PR fall into a couple of main categories:

1. Creating undo stack locations when Gutenberg indicates a change is not cached. For example, when a new block is created or a block transformation happens, Gutenberg uses options flags to indicate that the operation should result in a new undo stack item. 

    `editEntityRecord` has two options flags that determine if the change should be treated as a new undo stack item,  `options.undoIgnore` and `options.isCached`. When [these flags indicate](https://github.com/Automattic/gutenberg/blob/01fca72e470d3a74943420c4521d1607249c3725/packages/core-data/src/actions.js#L435-L449) there should be a new undo record, we pass that flag to `getSyncManager().update()`. The `update()` function will call Yjs' `stopCapturing()` method, which just tells it to create a new undo level.

    The timing is important. We need to ensure the undo level is created [before calling `applyChangesToCRDTDoc()`](https://github.com/Automattic/gutenberg/blob/01fca72e470d3a74943420c4521d1607249c3725/packages/sync/src/manager.ts#L486-L496), or the undo level will be created too late after the change has occurred. This is the primary reason why `getUndoManager().addRecord()` doesn't handle the `stopCapturing()` action, because it is applied after CRDT changes are made. We might be able to reorder these if desired, but I haven't tested with that.

    This change ensures that the CRDT document is creating undo levels where WordPress expects, like when creating a new block, and this change fixed the majority of failing tests.
2. There were a handful of other tests that explicitly require selection to only include a block [without a start/end offset](https://github.com/Automattic/gutenberg/blob/01fca72e470d3a74943420c4521d1607249c3725/test/e2e/specs/editor/various/undo.spec.js#L54-L56):

    ```js
    await pageUtils.pressKeys( 'primary+z' );

    await expect.poll( editor.getEditedPostContent ).toBe( '' );
    await expect.poll( undoUtils.getSelection ).toEqual( {
        blockIndex: 0,
    } );
    ```

    The `expect.poll( undoUtils.getSelection ).toEqual( { blockIndex: 0 } );` checks that the selection returned by the editor after an undo ONLY has a client ID and nothing else, like an offset or attribute key.

    In default WordPress, when an undo is made back to the beginning of a block, the editor updates the selection to:

    ```js
    { selectionStart: { clientId: 'abc...' }, selectionEnd: { clientId: 'abc...' } }
    ```

    This selection does not include `attributeKey` or `offset`. Our RTC implementation was returning this value in the same test:

    ```js
    { selectionStart: { clientId: 'abc...', attributeKey: 'content', offset: 0 }, selectionEnd: { clientId: 'abc...', attributeKey: 'content', offset: 0 } }
    ```

    I'm not exactly sure why WordPress is set up or tested to have this particular behavior, but we changed our RTC to [mimic the same behavior](https://github.com/Automattic/gutenberg/blob/01fca72e470d3a74943420c4521d1607249c3725/packages/core-data/src/utils/crdt-selection.ts#L168-L194) (removing offset and attribute) when a block is undone to a default state and it fixed the rest of the tests.

## Testing Instructions

When combined with the changes in https://github.com/WordPress/gutenberg/pull/74564, see unit and e2e tests passing.
