### PR TITLE
ToggleControl: Pass full props to the input element

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `ValidatedComboboxControl`: Expose the component under private API's. [#74891](https://github.com/WordPress/gutenberg/pull/74891)
 
+### Enhancements
+
+-   `ToggleControl` pass full props and support required validation in `ValidatedToggleControl`. [#74956](https://github.com/WordPress/gutenberg/pull/74956)
+
 ## 32.0.0 (2026-01-16)
 
 ### Code Quality

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -28,6 +28,7 @@ function UnforwardedToggleControl(
 		className,
 		onChange,
 		disabled,
+		...additionalProps
 	}: WordPressComponentProps< ToggleControlProps, 'input', false >,
 	ref: ForwardedRef< HTMLInputElement >
 ) {
@@ -74,6 +75,7 @@ function UnforwardedToggleControl(
 					aria-describedby={ describedBy }
 					disabled={ disabled }
 					ref={ ref }
+					{ ...additionalProps }
 				/>
 				<FlexBlock
 					as="label"

--- a/packages/components/src/validated-form-controls/components/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-control.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef, useRef, useEffect } from '@wordpress/element';
+import { forwardRef, useRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -25,14 +25,6 @@ const UnforwardedValidatedToggleControl = (
 	const validityTargetRef = useRef< HTMLInputElement >( null );
 	const mergedRefs = useMergeRefs( [ forwardedRef, validityTargetRef ] );
 
-	// TODO: Upstream limitation - The `required` attribute is not passed down to the input,
-	// so we need to set it manually.
-	useEffect( () => {
-		if ( validityTargetRef.current ) {
-			validityTargetRef.current.required = required ?? false;
-		}
-	}, [ required ] );
-
 	return (
 		<ControlWithError
 			required={ required }
@@ -40,7 +32,11 @@ const UnforwardedValidatedToggleControl = (
 			customValidity={ customValidity }
 			getValidityTarget={ () => validityTargetRef.current }
 		>
-			<ToggleControl ref={ mergedRefs } { ...restProps } />
+			<ToggleControl
+				ref={ mergedRefs }
+				required={ required }
+				{ ...restProps }
+			/>
 		</ControlWithError>
 	);
 };


### PR DESCRIPTION
Alternative to #74952

## Why? 
#74952 solves the problem as form validation requires sync processing. 

But ultimately the problem is that `required` is not being passed in first place. Why not passing?

Maybe I'm missing something, but this was the first thing that came to my mind when I saw this trouble

## Testing Instructions
Copied/pasted from #74952
- Open Storybook at ?path=/story/dataviews-dataform--validation&args=layout:card-collapsible
- Open the "Boolean Fields" card, then close it — badge shows "2 fields need attention"
- Reopen the card — verify the Toggle error message now appears (on trunk it does not)
- Verify checkbox and toggle group errors still display correctly
- Toggle the control on/off to confirm it still functions
