### PR TITLE
Docs: Add missing @return tags to experimental functions

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -120,6 +120,8 @@ function gutenberg_register_block_style( $block_name, $style_properties ) {
 
 /**
  * Additional data to expose to the view script module in the Form block.
+ *
+ * @return array The script module data.
  */
 function gutenberg_block_core_form_view_script_module( $data ) {
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-form-blocks' ) ) {

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -81,6 +81,7 @@ if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 	 *
 	 * @param bool   $allow_css Whether the CSS is allowed.
 	 * @param string $css_test_string The CSS to test.
+	 * @return bool Whether the CSS is allowed.
 	 */
 	function allow_filter_in_styles( $allow_css, $css_test_string ) {
 		if ( preg_match(

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -7,6 +7,7 @@
  *
  * @param array $settings Array of determined settings for registering a block type.
  * @param array $metadata Metadata provided for registering a block type.
+ * @return array The filtered block settings.
  */
 function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(


### PR DESCRIPTION
**Description**
This PR adds missing `@return` tags to several functions in the `lib/experimental` directory to ensure compliance with WordPress PHP Inline Documentation Standards.

**Changes**
*   `lib/experimental/blocks.php`: Added `@return array` to `gutenberg_block_core_form_view_script_module`.
*   `lib/experimental/kses.php`: Added `@return bool` to `allow_filter_in_styles`.
*   `lib/experimental/script-modules.php`: Added `@return array` to `gutenberg_filter_block_type_metadata_settings_register_view_module`.

**Testing Instructions**
1.  Verify that the changes are strictly limited to DocBlocks.
2.  Assess that the added types accurately reflect the return values of the functions.