### PR TITLE
Replace @see with @link for URL references in Inline Documentation

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -735,7 +735,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 			 * that would have broken out of the containing STYLE element, thus
 			 * corrupting the page and potentially introducing security issues.
 			 *
-			 * @see https://html.spec.whatwg.org/multipage/parsing.html#rawtext-end-tag-name-state
+			 * @link https://html.spec.whatwg.org/multipage/parsing.html#rawtext-end-tag-name-state
 			 */
 			$possible_style_close_tag = 0 === substr_compare(
 				$css,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -283,7 +283,7 @@ add_action( 'wp_default_styles', 'gutenberg_register_packages_styles', 15 );
  *
  * @since 6.1
  *
- * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
+ * @link https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
  *
  * @param array $options {
  *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -29,7 +29,7 @@ add_action( 'rest_api_init', 'gutenberg_register_block_editor_settings' );
  *
  * This is a temporary fix until we can patch get_sample_permalink()
  *
- * @see https://core.trac.wordpress.org/ticket/46266
+ * @link https://core.trac.wordpress.org/ticket/46266
  *
  * @param array  $permalink Array containing the sample permalink with placeholder for the post name, and the post name.
  * @param int    $id        ID of the post.


### PR DESCRIPTION
This PR standardizes the use of inline documentation tags by replacing `@see` with `@link` in instances where URLs are referenced.

**Why this change?**
To align with the [WordPress PHP Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#1-functions-class-methods), proper tag usage distinguishes between internal code references and external links:

*   **When to use `@see`:** accurately references a **function, method, class, or variable** within the codebase (e.g., `@see WP_Query::get_posts()`).
*   **When to use `@link`:** accurately references a **URL**, such as external documentation, Trac tickets, GitHub issues, or specifications (e.g., `@link https://core.trac.wordpress.org/ticket/12345`).

This PR corrects instances where `@see` was incorrectly used to point to external URLs.

**Changes**
*   lib/experimental/rest-api.php: Replaced `@see` with `@link` for a Trac ticket reference.
*   lib/class-wp-rest-global-styles-controller-gutenberg.php: Replaced `@see` with `@link` for an HTML specification URL.
*   lib/client-assets.php: Replaced `@see` with `@link` for Style Engine documentation.
