### PR TITLE
Hide grid visualiser if the grid block is hidden

### DIFF
--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -10,19 +10,22 @@ import { useSelect } from '@wordpress/data';
  */
 import { GridVisualizer, useGridLayoutSync } from '../components/grid';
 import { store as blockEditorStore } from '../store';
+import useBlockVisibility from '../components/block-visibility/use-block-visibility';
 
 function GridLayoutSync( props ) {
 	useGridLayoutSync( props );
 }
 
 function GridTools( { clientId, layout } ) {
-	const isVisible = useSelect(
+	const { isVisible, blockVisibility, deviceType } = useSelect(
 		( select ) => {
 			const {
 				isBlockSelected,
 				isDraggingBlocks,
 				getTemplateLock,
 				getBlockEditingMode,
+				getBlockAttributes,
+				getSettings,
 			} = select( blockEditorStore );
 
 			// These calls are purposely ordered from least expensive to most expensive.
@@ -32,18 +35,32 @@ function GridTools( { clientId, layout } ) {
 				getTemplateLock( clientId ) ||
 				getBlockEditingMode( clientId ) !== 'default'
 			) {
-				return false;
+				return { isVisible: false };
 			}
 
-			return true;
+			const attributes = getBlockAttributes( clientId );
+			const settings = getSettings();
+
+			return {
+				isVisible: true,
+				blockVisibility: attributes?.metadata?.blockVisibility,
+				deviceType: settings?.__experimentalSetIsInserterOpened
+					? settings.deviceType
+					: undefined,
+			};
 		},
 		[ clientId ]
 	);
 
+	const { isBlockCurrentlyHidden } = useBlockVisibility( {
+		blockVisibility,
+		deviceType,
+	} );
+
 	return (
 		<>
 			<GridLayoutSync clientId={ clientId } />
-			{ isVisible && (
+			{ isVisible && ! isBlockCurrentlyHidden && (
 				<GridVisualizer clientId={ clientId } parentLayout={ layout } />
 			) }
 		</>

--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -11,6 +11,8 @@ import { useSelect } from '@wordpress/data';
 import { GridVisualizer, useGridLayoutSync } from '../components/grid';
 import { store as blockEditorStore } from '../store';
 import useBlockVisibility from '../components/block-visibility/use-block-visibility';
+import { deviceTypeKey } from '../store/private-keys';
+import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/constants';
 
 function GridLayoutSync( props ) {
 	useGridLayoutSync( props );
@@ -44,9 +46,9 @@ function GridTools( { clientId, layout } ) {
 			return {
 				isVisible: true,
 				blockVisibility: attributes?.metadata?.blockVisibility,
-				deviceType: settings?.__experimentalSetIsInserterOpened
-					? settings.deviceType
-					: undefined,
+				deviceType:
+					settings?.[ deviceTypeKey ]?.toLowerCase() ||
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -16,6 +16,7 @@ import {
 	GridItemResizer,
 	GridItemMovers,
 } from '../components/grid';
+import useBlockVisibility from '../components/block-visibility/use-block-visibility';
 
 // Used for generating the instance ID
 const LAYOUT_CHILD_BLOCK_PROPS_REFERENCE = {};
@@ -199,12 +200,14 @@ function GridTools( {
 	isManualPlacement,
 	parentLayout,
 } ) {
-	const { rootClientId, isVisible } = useSelect(
+	const { rootClientId, isVisible, blockVisibility, deviceType } = useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
 				getBlockEditingMode,
 				getTemplateLock,
+				getBlockAttributes,
+				getSettings,
 			} = select( blockEditorStore );
 
 			const _rootClientId = getBlockRootClientId( clientId );
@@ -219,18 +222,30 @@ function GridTools( {
 				};
 			}
 
+			const attributes = getBlockAttributes( _rootClientId );
+			const settings = getSettings();
+
 			return {
 				rootClientId: _rootClientId,
 				isVisible: true,
+				blockVisibility: attributes?.metadata?.blockVisibility,
+				deviceType: settings?.__experimentalSetIsInserterOpened
+					? settings.deviceType
+					: undefined,
 			};
 		},
 		[ clientId ]
 	);
 
+	const { isBlockCurrentlyHidden } = useBlockVisibility( {
+		blockVisibility,
+		deviceType,
+	} );
+
 	// Use useState() instead of useRef() so that GridItemResizer updates when ref is set.
 	const [ resizerBounds, setResizerBounds ] = useState();
 
-	if ( ! isVisible ) {
+	if ( ! isVisible || isBlockCurrentlyHidden ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -202,7 +202,13 @@ function GridTools( {
 	isManualPlacement,
 	parentLayout,
 } ) {
-	const { rootClientId, isVisible, blockVisibility, deviceType } = useSelect(
+	const {
+		rootClientId,
+		isVisible,
+		parentBlockVisibility,
+		blockBlockVisibility,
+		deviceType,
+	} = useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
@@ -224,13 +230,17 @@ function GridTools( {
 				};
 			}
 
-			const attributes = getBlockAttributes( _rootClientId );
+			const parentAttributes = getBlockAttributes( _rootClientId );
+			const blockAttributes = getBlockAttributes( clientId );
 			const settings = getSettings();
 
 			return {
 				rootClientId: _rootClientId,
 				isVisible: true,
-				blockVisibility: attributes?.metadata?.blockVisibility,
+				parentBlockVisibility:
+					parentAttributes?.metadata?.blockVisibility,
+				blockBlockVisibility:
+					blockAttributes?.metadata?.blockVisibility,
 				deviceType:
 					settings?.[ deviceTypeKey ]?.toLowerCase() ||
 					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
@@ -239,17 +249,26 @@ function GridTools( {
 		[ clientId ]
 	);
 
-	const { isBlockCurrentlyHidden } = useBlockVisibility( {
-		blockVisibility,
-		deviceType,
-	} );
+	const { isBlockCurrentlyHidden: isParentBlockCurrentlyHidden } =
+		useBlockVisibility( {
+			blockVisibility: parentBlockVisibility,
+			deviceType,
+		} );
+
+	const { isBlockCurrentlyHidden: isBlockItselfCurrentlyHidden } =
+		useBlockVisibility( {
+			blockVisibility: blockBlockVisibility,
+			deviceType,
+		} );
 
 	// Use useState() instead of useRef() so that GridItemResizer updates when ref is set.
 	const [ resizerBounds, setResizerBounds ] = useState();
 
-	if ( ! isVisible || isBlockCurrentlyHidden ) {
+	if ( ! isVisible || isParentBlockCurrentlyHidden ) {
 		return null;
 	}
+
+	const showResizer = allowSizingOnChildren && ! isBlockItselfCurrentlyHidden;
 
 	function updateLayout( layout ) {
 		setAttributes( {
@@ -270,7 +289,7 @@ function GridTools( {
 				contentRef={ setResizerBounds }
 				parentLayout={ parentLayout }
 			/>
-			{ allowSizingOnChildren && (
+			{ showResizer && (
 				<GridItemResizer
 					clientId={ clientId }
 					// Don't allow resizing beyond the grid visualizer.

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -17,6 +17,8 @@ import {
 	GridItemMovers,
 } from '../components/grid';
 import useBlockVisibility from '../components/block-visibility/use-block-visibility';
+import { deviceTypeKey } from '../store/private-keys';
+import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/constants';
 
 // Used for generating the instance ID
 const LAYOUT_CHILD_BLOCK_PROPS_REFERENCE = {};
@@ -229,9 +231,9 @@ function GridTools( {
 				rootClientId: _rootClientId,
 				isVisible: true,
 				blockVisibility: attributes?.metadata?.blockVisibility,
-				deviceType: settings?.__experimentalSetIsInserterOpened
-					? settings.deviceType
-					: undefined,
+				deviceType:
+					settings?.[ deviceTypeKey ]?.toLowerCase() ||
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Found while working on #74839.

If a Grid block is hidden in the current viewport or removed from the document, its visualizer should not show when the block is selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block with some blocks inside it to a post.
2. Options > Hide in the Grid block, and choose whichever breakpoints you want to test. Check that when the block is hidden, selecting it in the list view doesn't make the visualizer visible.
3. If the Grid is hidden, selecting one of its children in the list view also shouldn't make the visualizer visible.



|Before|After|
|-|-|
| <img width="1074" height="455" alt="Screenshot 2026-01-27 at 4 07 06 pm" src="https://github.com/user-attachments/assets/6a60acaa-50fd-4ab7-b669-50b39eecb155" /> | <img width="1072" height="449" alt="Screenshot 2026-01-27 at 4 07 51 pm" src="https://github.com/user-attachments/assets/cac12c33-498e-4f59-822f-036fa7ebf009" /> |


