### PR TITLE
fix: Video block: video URLs pasted without "https://" show broken media

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -27,6 +27,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { video as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { prependHTTP } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -110,9 +111,10 @@ function VideoEdit( {
 
 	function onSelectURL( newSrc ) {
 		if ( newSrc !== src ) {
+			const url = prependHTTP( newSrc );
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock( {
-				attributes: { url: newSrc },
+				attributes: { url },
 			} );
 			if ( undefined !== embedBlock && onReplace ) {
 				onReplace( embedBlock );
@@ -120,7 +122,7 @@ function VideoEdit( {
 			}
 			setAttributes( {
 				blob: undefined,
-				src: newSrc,
+				src: url,
 				id: undefined,
 				poster: undefined,
 			} );

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -27,7 +27,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { video as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { prependHTTP } from '@wordpress/url';
+import { prependHTTPS } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -111,7 +111,7 @@ function VideoEdit( {
 
 	function onSelectURL( newSrc ) {
 		if ( newSrc !== src ) {
-			const url = prependHTTP( newSrc );
+			const url = prependHTTPS( newSrc );
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock( {
 				attributes: { url },


### PR DESCRIPTION
## What?
See #74738

Fixes video block to properly load videos when users enter URLs without a protocol (e.g., example.com/video.mp4).

## Why?
The block accepts the protocol-less URL as-is, causing the video player to fail to load.

## How?
`prependHTTP` is used to prepend `http://` to the video URL

## Testing Instructions
1. Insert the Core Video block
2. Select insert from URL
3. Enter an URL without https://
4. Ensure the preview loads
