### PR TITLE
Media Modal Experiment: Add a simple notices-based uploading state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54783,6 +54783,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/media-fields": "file:../media-fields",
+				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis"
 			},
 			"engines": {

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -58,6 +58,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/media-fields": "file:../media-fields",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
 	"peerDependencies": {

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -2,13 +2,19 @@
  * WordPress dependencies
  */
 import { useState, useCallback, useMemo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 import {
 	privateApis as coreDataPrivateApis,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { resolveSelect, useDispatch } from '@wordpress/data';
-import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
+import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
+import {
+	Modal,
+	DropZone,
+	FormFileUpload,
+	Button,
+	SnackbarList,
+} from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
 import type { View, Field, ActionButton } from '@wordpress/dataviews';
@@ -42,6 +48,12 @@ const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 // Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
 const LAYOUT_PICKER_TABLE = 'pickerTable';
+
+// Custom notices context for the media modal
+const NOTICES_CONTEXT = 'media-modal';
+
+// Notice ID - reused for all upload-related notices to prevent flooding
+const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
 
 interface MediaUploadModalProps {
 	/**
@@ -163,10 +175,20 @@ export function MediaUploadModal( {
 			: [ String( value ) ];
 	} );
 
-	const { createSuccessNotice, createErrorNotice, createInfoNotice } =
-		useDispatch( noticesStore );
+	const {
+		createSuccessNotice,
+		createErrorNotice,
+		createInfoNotice,
+		removeNotice,
+	} = useDispatch( noticesStore );
 	// @ts-expect-error - invalidateResolution is not in the typed actions but is available at runtime
 	const { invalidateResolution } = useDispatch( coreStore );
+
+	// Get notices for this modal context
+	const notices = useSelect(
+		( select ) => select( noticesStore ).getNotices( NOTICES_CONTEXT ),
+		[]
+	);
 
 	// DataViews configuration - allow view updates
 	const [ view, setView ] = useState< View >( () => ( {
@@ -326,25 +348,23 @@ export function MediaUploadModal( {
 				const filesArray = Array.from( files );
 
 				// Show upload start notice
-				if ( filesArray.length === 1 ) {
-					createInfoNotice(
-						sprintf(
-							// translators: %s: file name
-							__( 'Uploading %s' ),
-							filesArray[ 0 ].name
-						),
-						{ type: 'snackbar' }
-					);
-				} else {
-					createInfoNotice(
-						sprintf(
-							// translators: %d: number of files
-							__( 'Uploading %d files' ),
+				createInfoNotice(
+					sprintf(
+						// translators: %s: number of files
+						_n(
+							'Uploading %s file',
+							'Uploading %s files',
 							filesArray.length
 						),
-						{ type: 'snackbar' }
-					);
-				}
+						filesArray.length.toLocaleString()
+					),
+					{
+						type: 'snackbar',
+						context: NOTICES_CONTEXT,
+						id: NOTICE_ID_UPLOAD_PROGRESS,
+						explicitDismiss: true,
+					}
+				);
 
 				handleUpload( {
 					allowedTypes,
@@ -359,21 +379,23 @@ export function MediaUploadModal( {
 						);
 
 						if ( allComplete && attachments.length > 0 ) {
-							// Show success notice
-							if ( attachments.length === 1 ) {
-								createSuccessNotice( __( 'Upload complete' ), {
-									type: 'snackbar',
-								} );
-							} else {
-								createSuccessNotice(
-									sprintf(
-										// translators: %d: number of files
-										__( '%d files uploaded successfully' ),
+							// Show success notice (replaces progress notice via ID)
+							createSuccessNotice(
+								sprintf(
+									// translators: %s: number of files
+									_n(
+										'Uploaded %s file',
+										'Uploaded %s files',
 										attachments.length
 									),
-									{ type: 'snackbar' }
-								);
-							}
+									attachments.length.toLocaleString()
+								),
+								{
+									type: 'snackbar',
+									context: NOTICES_CONTEXT,
+									id: NOTICE_ID_UPLOAD_PROGRESS,
+								}
+							);
 
 							// Invalidate the entity records resolution to refresh the view
 							invalidateResolution( 'getEntityRecords', [
@@ -384,8 +406,11 @@ export function MediaUploadModal( {
 						}
 					},
 					onError: ( error ) => {
+						// Show error notice (replaces progress notice via ID)
 						createErrorNotice( error.message, {
 							type: 'snackbar',
+							context: NOTICES_CONTEXT,
+							id: NOTICE_ID_UPLOAD_PROGRESS,
 						} );
 					},
 				} );
@@ -487,25 +512,23 @@ export function MediaUploadModal( {
 					}
 					if ( filteredFiles.length > 0 ) {
 						// Show upload start notice
-						if ( filteredFiles.length === 1 ) {
-							createInfoNotice(
-								sprintf(
-									// translators: %s: file name
-									__( 'Uploading %s' ),
-									filteredFiles[ 0 ].name
-								),
-								{ type: 'snackbar' }
-							);
-						} else {
-							createInfoNotice(
-								sprintf(
-									// translators: %d: number of files
-									__( 'Uploading %d files' ),
+						createInfoNotice(
+							sprintf(
+								// translators: %s: number of files
+								_n(
+									'Uploading %s file',
+									'Uploading %s files',
 									filteredFiles.length
 								),
-								{ type: 'snackbar' }
-							);
-						}
+								filteredFiles.length.toLocaleString()
+							),
+							{
+								type: 'snackbar',
+								context: NOTICES_CONTEXT,
+								id: NOTICE_ID_UPLOAD_PROGRESS,
+								explicitDismiss: true,
+							}
+						);
 
 						handleUpload( {
 							allowedTypes,
@@ -520,26 +543,23 @@ export function MediaUploadModal( {
 								);
 
 								if ( allComplete && attachments.length > 0 ) {
-									// Show success notice
-									if ( attachments.length === 1 ) {
-										createSuccessNotice(
-											__( 'Upload complete' ),
-											{
-												type: 'snackbar',
-											}
-										);
-									} else {
-										createSuccessNotice(
-											sprintf(
-												// translators: %d: number of files
-												__(
-													'%d files uploaded successfully'
-												),
+									// Show success notice (replaces progress notice via ID)
+									createSuccessNotice(
+										sprintf(
+											// translators: %s: number of files
+											_n(
+												'Uploaded %s file',
+												'Uploaded %s files',
 												attachments.length
 											),
-											{ type: 'snackbar' }
-										);
-									}
+											attachments.length.toLocaleString()
+										),
+										{
+											type: 'snackbar',
+											context: NOTICES_CONTEXT,
+											id: NOTICE_ID_UPLOAD_PROGRESS,
+										}
+									);
 
 									// Invalidate the entity records resolution to refresh the view
 									invalidateResolution( 'getEntityRecords', [
@@ -550,8 +570,11 @@ export function MediaUploadModal( {
 								}
 							},
 							onError: ( error ) => {
+								// Show error notice (replaces progress notice via ID)
 								createErrorNotice( error.message, {
 									type: 'snackbar',
+									context: NOTICES_CONTEXT,
+									id: NOTICE_ID_UPLOAD_PROGRESS,
 								} );
 							},
 						} );
@@ -574,6 +597,13 @@ export function MediaUploadModal( {
 				search={ search }
 				searchLabel={ searchLabel }
 				itemListLabel={ __( 'Media items' ) }
+			/>
+			<SnackbarList
+				notices={ notices.filter(
+					( { type } ) => type === 'snackbar'
+				) }
+				className="media-upload-modal__snackbar"
+				onRemove={ ( id ) => removeNotice( id, NOTICES_CONTEXT ) }
 			/>
 		</Modal>
 	);

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { useState, useCallback, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	privateApis as coreDataPrivateApis,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { resolveSelect } from '@wordpress/data';
+import { resolveSelect, useDispatch } from '@wordpress/data';
 import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
@@ -26,6 +26,8 @@ import {
 	mediaThumbnailField,
 	mimeTypeField,
 } from '@wordpress/media-fields';
+import { store as noticesStore } from '@wordpress/notices';
+import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -160,6 +162,11 @@ export function MediaUploadModal( {
 			? value.map( String )
 			: [ String( value ) ];
 	} );
+
+	const { createSuccessNotice, createErrorNotice, createInfoNotice } =
+		useDispatch( noticesStore );
+	// @ts-expect-error - invalidateResolution is not in the typed actions but is available at runtime
+	const { invalidateResolution } = useDispatch( coreStore );
 
 	// DataViews configuration - allow view updates
 	const [ view, setView ] = useState< View >( () => ( {
@@ -317,13 +324,82 @@ export function MediaUploadModal( {
 			const files = event.target.files;
 			if ( files && files.length > 0 ) {
 				const filesArray = Array.from( files );
+
+				// Show upload start notice
+				if ( filesArray.length === 1 ) {
+					createInfoNotice(
+						sprintf(
+							// translators: %s: file name
+							__( 'Uploading %s' ),
+							filesArray[ 0 ].name
+						),
+						{ type: 'snackbar' }
+					);
+				} else {
+					createInfoNotice(
+						sprintf(
+							// translators: %d: number of files
+							__( 'Uploading %d files' ),
+							filesArray.length
+						),
+						{ type: 'snackbar' }
+					);
+				}
+
 				handleUpload( {
 					allowedTypes,
 					filesList: filesArray,
+					onFileChange: ( attachments ) => {
+						// Check if all uploads are complete (no blob URLs)
+						const allComplete = attachments.every(
+							( attachment ) =>
+								attachment.id &&
+								attachment.url &&
+								! isBlobURL( attachment.url )
+						);
+
+						if ( allComplete && attachments.length > 0 ) {
+							// Show success notice
+							if ( attachments.length === 1 ) {
+								createSuccessNotice( __( 'Upload complete' ), {
+									type: 'snackbar',
+								} );
+							} else {
+								createSuccessNotice(
+									sprintf(
+										// translators: %d: number of files
+										__( '%d files uploaded successfully' ),
+										attachments.length
+									),
+									{ type: 'snackbar' }
+								);
+							}
+
+							// Invalidate the entity records resolution to refresh the view
+							invalidateResolution( 'getEntityRecords', [
+								'postType',
+								'attachment',
+								queryArgs,
+							] );
+						}
+					},
+					onError: ( error ) => {
+						createErrorNotice( error.message, {
+							type: 'snackbar',
+						} );
+					},
 				} );
 			}
 		},
-		[ allowedTypes, handleUpload ]
+		[
+			allowedTypes,
+			handleUpload,
+			createInfoNotice,
+			createSuccessNotice,
+			createErrorNotice,
+			invalidateResolution,
+			queryArgs,
+		]
 	);
 
 	const paginationInfo = useMemo(
@@ -410,9 +486,74 @@ export function MediaUploadModal( {
 						);
 					}
 					if ( filteredFiles.length > 0 ) {
+						// Show upload start notice
+						if ( filteredFiles.length === 1 ) {
+							createInfoNotice(
+								sprintf(
+									// translators: %s: file name
+									__( 'Uploading %s' ),
+									filteredFiles[ 0 ].name
+								),
+								{ type: 'snackbar' }
+							);
+						} else {
+							createInfoNotice(
+								sprintf(
+									// translators: %d: number of files
+									__( 'Uploading %d files' ),
+									filteredFiles.length
+								),
+								{ type: 'snackbar' }
+							);
+						}
+
 						handleUpload( {
 							allowedTypes,
 							filesList: filteredFiles,
+							onFileChange: ( attachments ) => {
+								// Check if all uploads are complete (no blob URLs)
+								const allComplete = attachments.every(
+									( attachment ) =>
+										attachment.id &&
+										attachment.url &&
+										! isBlobURL( attachment.url )
+								);
+
+								if ( allComplete && attachments.length > 0 ) {
+									// Show success notice
+									if ( attachments.length === 1 ) {
+										createSuccessNotice(
+											__( 'Upload complete' ),
+											{
+												type: 'snackbar',
+											}
+										);
+									} else {
+										createSuccessNotice(
+											sprintf(
+												// translators: %d: number of files
+												__(
+													'%d files uploaded successfully'
+												),
+												attachments.length
+											),
+											{ type: 'snackbar' }
+										);
+									}
+
+									// Invalidate the entity records resolution to refresh the view
+									invalidateResolution( 'getEntityRecords', [
+										'postType',
+										'attachment',
+										queryArgs,
+									] );
+								}
+							},
+							onError: ( error ) => {
+								createErrorNotice( error.message, {
+									type: 'snackbar',
+								} );
+							},
 						} );
 					}
 				} }

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -341,6 +341,60 @@ export function MediaUploadModal( {
 	// Use onUpload if provided, otherwise fall back to uploadMedia
 	const handleUpload = onUpload || uploadMedia;
 
+	// Shared upload success handler
+	const handleUploadComplete = useCallback(
+		( attachments: Partial< Attachment >[] ) => {
+			// Check if all uploads are complete (no blob URLs)
+			const allComplete = attachments.every(
+				( attachment ) =>
+					attachment.id &&
+					attachment.url &&
+					! isBlobURL( attachment.url )
+			);
+
+			if ( allComplete && attachments.length > 0 ) {
+				// Show success notice (replaces progress notice via ID)
+				createSuccessNotice(
+					sprintf(
+						// translators: %s: number of files
+						_n(
+							'Uploaded %s file',
+							'Uploaded %s files',
+							attachments.length
+						),
+						attachments.length.toLocaleString()
+					),
+					{
+						type: 'snackbar',
+						context: NOTICES_CONTEXT,
+						id: NOTICE_ID_UPLOAD_PROGRESS,
+					}
+				);
+
+				// Invalidate the entity records resolution to refresh the view
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'attachment',
+					queryArgs,
+				] );
+			}
+		},
+		[ createSuccessNotice, invalidateResolution, queryArgs ]
+	);
+
+	// Shared upload error handler
+	const handleUploadError = useCallback(
+		( error: Error ) => {
+			// Show error notice (replaces progress notice via ID)
+			createErrorNotice( error.message, {
+				type: 'snackbar',
+				context: NOTICES_CONTEXT,
+				id: NOTICE_ID_UPLOAD_PROGRESS,
+			} );
+		},
+		[ createErrorNotice ]
+	);
+
 	const handleFileSelect = useCallback(
 		( event: React.ChangeEvent< HTMLInputElement > ) => {
 			const files = event.target.files;
@@ -369,50 +423,8 @@ export function MediaUploadModal( {
 				handleUpload( {
 					allowedTypes,
 					filesList: filesArray,
-					onFileChange: ( attachments ) => {
-						// Check if all uploads are complete (no blob URLs)
-						const allComplete = attachments.every(
-							( attachment ) =>
-								attachment.id &&
-								attachment.url &&
-								! isBlobURL( attachment.url )
-						);
-
-						if ( allComplete && attachments.length > 0 ) {
-							// Show success notice (replaces progress notice via ID)
-							createSuccessNotice(
-								sprintf(
-									// translators: %s: number of files
-									_n(
-										'Uploaded %s file',
-										'Uploaded %s files',
-										attachments.length
-									),
-									attachments.length.toLocaleString()
-								),
-								{
-									type: 'snackbar',
-									context: NOTICES_CONTEXT,
-									id: NOTICE_ID_UPLOAD_PROGRESS,
-								}
-							);
-
-							// Invalidate the entity records resolution to refresh the view
-							invalidateResolution( 'getEntityRecords', [
-								'postType',
-								'attachment',
-								queryArgs,
-							] );
-						}
-					},
-					onError: ( error ) => {
-						// Show error notice (replaces progress notice via ID)
-						createErrorNotice( error.message, {
-							type: 'snackbar',
-							context: NOTICES_CONTEXT,
-							id: NOTICE_ID_UPLOAD_PROGRESS,
-						} );
-					},
+					onFileChange: handleUploadComplete,
+					onError: handleUploadError,
 				} );
 			}
 		},
@@ -420,10 +432,8 @@ export function MediaUploadModal( {
 			allowedTypes,
 			handleUpload,
 			createInfoNotice,
-			createSuccessNotice,
-			createErrorNotice,
-			invalidateResolution,
-			queryArgs,
+			handleUploadComplete,
+			handleUploadError,
 		]
 	);
 
@@ -533,50 +543,8 @@ export function MediaUploadModal( {
 						handleUpload( {
 							allowedTypes,
 							filesList: filteredFiles,
-							onFileChange: ( attachments ) => {
-								// Check if all uploads are complete (no blob URLs)
-								const allComplete = attachments.every(
-									( attachment ) =>
-										attachment.id &&
-										attachment.url &&
-										! isBlobURL( attachment.url )
-								);
-
-								if ( allComplete && attachments.length > 0 ) {
-									// Show success notice (replaces progress notice via ID)
-									createSuccessNotice(
-										sprintf(
-											// translators: %s: number of files
-											_n(
-												'Uploaded %s file',
-												'Uploaded %s files',
-												attachments.length
-											),
-											attachments.length.toLocaleString()
-										),
-										{
-											type: 'snackbar',
-											context: NOTICES_CONTEXT,
-											id: NOTICE_ID_UPLOAD_PROGRESS,
-										}
-									);
-
-									// Invalidate the entity records resolution to refresh the view
-									invalidateResolution( 'getEntityRecords', [
-										'postType',
-										'attachment',
-										queryArgs,
-									] );
-								}
-							},
-							onError: ( error ) => {
-								// Show error notice (replaces progress notice via ID)
-								createErrorNotice( error.message, {
-									type: 'snackbar',
-									context: NOTICES_CONTEXT,
-									id: NOTICE_ID_UPLOAD_PROGRESS,
-								} );
-							},
+							onFileChange: handleUploadComplete,
+							onError: handleUploadError,
 						} );
 					}
 				} }

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -20,4 +20,12 @@
 	.dataviews-footer {
 		padding-bottom: $grid-unit-10;
 	}
+
+	.media-upload-modal__snackbar {
+		position: absolute;
+		left: 0;
+		bottom: 16px;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
 }

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -16,6 +16,7 @@
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
 		{ "path": "../media-fields" },
+		{ "path": "../notices" },
 		{ "path": "../private-apis" }
 	]
 }


### PR DESCRIPTION
## What?

Part of: #73085

Add a minimal uploading state to the experimental media upload modal, using notices.

## Why?

While #73085 shows a different visual treatment for in-progress uploads, there were a few complex issues with attempting to render transient or placeholder items within the list of the modal to indicate upload state.

This PR proposes a simpler approach as an MVP — create and display notices when an upload starts and completes. And when the upload completes, invalidate the resolution for the current query so that the results in the DataView refresh.

Showing some kind of visual feedback during an upload is essential, so I'm hoping we can land on this approach in the short-term, and continue to iterate or explore other options in follow-ups.

## How?

* Add notices to the media upload modal, using a new / separate notices context that's particular to media
* Then, add a `SnackbarList` directly to the media modal — this is necessary for two reasons:
  * Without it, the snackbar notices will render under the modal, we need the snackbar to be a child of the modal in order to get the right stacking context
  * This allows the notices to be relative to the modal instead of to the viewport, which makes them feel more _part_ of the modal itself
* Show notices when uploads start, complete, and when they error
* Invalidate the store resolution once the upload is complete so that the results refresh 

## Testing Instructions

Enable the media modal experiment:

<img width="964" height="77" alt="image" src="https://github.com/user-attachments/assets/32e07d40-4635-4f21-98b9-3c1af379d606" />

* Go to edit a post or page and select to add a featured image.
* Try dragging and dropping an image or multiple images into the modal. It should show some notices and eventually refresh the modal.
* Do the same, but using the upload button in the modal header.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/13dc60ae-01fc-4814-a46a-82f8710f97ae