### PR TITLE
Navigation overlay: remove experiment

### DIFF
--- a/backport-changelog/7.0/10844.md
+++ b/backport-changelog/7.0/10844.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10844
+
+* https://github.com/WordPress/gutenberg/pull/74968

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -548,7 +548,6 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 A customizable button to close overlays. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation-overlay-close))
 
 -	**Name:** core/navigation-overlay-close
--	**Experimental:** true
 -	**Category:** design
 -	**Supports:** color (background, text, ~~gradients~~), spacing (padding), typography (fontSize, lineHeight)
 -	**Attributes:** displayMode, text

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -49,25 +49,23 @@ function gutenberg_modify_wp_template_part_post_type_args_7_0( $args ) {
 add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_template_part_post_type_args_7_0' );
 
 /**
- * Registers the 'navigation-overlay' template part area when the experiment is enabled.
+ * Registers the 'navigation-overlay' template part area.
  *
  * @param array $areas Array of template part area definitions.
  * @return array Modified array of template part area definitions.
  */
-if ( gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
-	function gutenberg_register_overlay_template_part_area( $areas ) {
-		$areas[] = array(
-			'area'        => 'navigation-overlay',
-			'label'       => __( 'Navigation Overlay', 'gutenberg' ),
-			'description' => __( 'Custom overlay area for navigation overlays.', 'gutenberg' ),
-			'icon'        => 'overlay',
-			'area_tag'    => 'div',
-		);
+function gutenberg_register_overlay_template_part_area( $areas ) {
+	$areas[] = array(
+		'area'        => 'navigation-overlay',
+		'label'       => __( 'Navigation Overlay', 'gutenberg' ),
+		'description' => __( 'Custom overlay area for navigation overlays.', 'gutenberg' ),
+		'icon'        => 'overlay',
+		'area_tag'    => 'div',
+	);
 
-		return $areas;
-	}
-	add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_template_part_area' );
+	return $areas;
 }
+add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_template_part_area' );
 
 /**
  * Adds user global styles link relation to all theme responses.

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,7 +31,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}
-	wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
 	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalTemplateActivate = true', 'before' );
 	}

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,9 +31,7 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
-	}
+	wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavigationOverlays = true', 'before' );
 	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalTemplateActivate = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -198,18 +198,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-customizable-navigation-overlays',
-		__( 'Customizable Navigation Overlays', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enables custom mobile overlay design and content control for Navigation blocks, allowing you to create flexible, professional menu experiences.', 'gutenberg' ),
-			'id'    => 'gutenberg-customizable-navigation-overlays',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-extensible-site-editor',
 		__( 'Extensible Site Editor', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/lib/load.php
+++ b/lib/load.php
@@ -200,10 +200,8 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-full-page-client-side-navigatio
 	Gutenberg_Interactivity_API_Full_Page_Navigation::instance();
 }
 
-// Block patterns (only load when navigation overlays experiment is enabled).
-if ( gutenberg_is_experiment_enabled( 'gutenberg-customizable-navigation-overlays' ) ) {
-	require __DIR__ . '/experimental/overlay-patterns.php';
-}
+// Block patterns for navigation overlays.
+require __DIR__ . '/overlay-patterns.php';
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-svg-icon-registry' ) ) {
 	require __DIR__ . '/experimental/class-wp-icons-registry.php';

--- a/lib/overlay-patterns.php
+++ b/lib/overlay-patterns.php
@@ -41,6 +41,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+			'source'      => 'gutenberg/navigation-overlay',
 		)
 	);
 
@@ -58,6 +59,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+			'source'      => 'gutenberg/navigation-overlay',
 		)
 	);
 	register_block_pattern(
@@ -84,6 +86,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+			'source'      => 'gutenberg/navigation-overlay',
 		)
 	);
 	register_block_pattern(
@@ -126,6 +129,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+			'source'      => 'gutenberg/navigation-overlay',
 		)
 	);
 	register_block_pattern(
@@ -144,6 +148,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
+			'source'      => 'gutenberg/navigation-overlay',
 		)
 	);
 }

--- a/lib/overlay-patterns.php
+++ b/lib/overlay-patterns.php
@@ -41,7 +41,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
-			'source'      => 'gutenberg/navigation-overlay',
+			'source'      => 'core',
 		)
 	);
 
@@ -86,7 +86,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
-			'source'      => 'gutenberg/navigation-overlay',
+			'source'      => 'core',
 		)
 	);
 	register_block_pattern(
@@ -129,7 +129,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
-			'source'      => 'gutenberg/navigation-overlay',
+			'source'      => 'core',
 		)
 	);
 	register_block_pattern(
@@ -148,7 +148,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
-			'source'      => 'gutenberg/navigation-overlay',
+			'source'      => 'core',
 		)
 	);
 }

--- a/lib/overlay-patterns.php
+++ b/lib/overlay-patterns.php
@@ -59,7 +59,7 @@ function gutenberg_register_overlay_block_patterns() {
 <!-- /wp:group -->',
 			'categories'  => array( 'navigation' ),
 			'blockTypes'  => array( 'core/template-part/navigation-overlay' ),
-			'source'      => 'gutenberg/navigation-overlay',
+			'source'      => 'core',
 		)
 	);
 	register_block_pattern(

--- a/lib/overlay-patterns.php
+++ b/lib/overlay-patterns.php
@@ -15,16 +15,20 @@
  * @since 6.0.0
  */
 function gutenberg_register_overlay_block_patterns() {
-	register_block_pattern_category(
-		'navigation',
-		array(
-			'label'       => _x( 'Navigation', 'Block pattern category', 'gutenberg' ),
-			'description' => _x( 'Display your website navigation.', 'Block pattern category', 'gutenberg' ),
-		)
-	);
+	// Register category only if it doesn't exist in core.
+	$category_registry = WP_Block_Pattern_Categories_Registry::get_instance();
+	if ( ! $category_registry->is_registered( 'navigation' ) ) {
+		register_block_pattern_category(
+			'navigation',
+			array(
+				'label'       => _x( 'Navigation', 'Block pattern category', 'gutenberg' ),
+				'description' => _x( 'Display your website navigation.', 'Block pattern category', 'gutenberg' ),
+			)
+		);
+	}
 
 	register_block_pattern(
-		'gutenberg/navigation-overlay',
+		'core/navigation-overlay',
 		array(
 			'title'       => __( 'Navigation Overlay', 'gutenberg' ),
 			'description' => _x( 'A simple pattern with a navigation block and a navigation overlay close button.', 'Block pattern description', 'gutenberg' ),
@@ -41,7 +45,7 @@ function gutenberg_register_overlay_block_patterns() {
 	);
 
 	register_block_pattern(
-		'gutenberg/navigation-overlay-black-bg',
+		'core/navigation-overlay-black-bg',
 		array(
 			'title'       => __( 'Overlay with black background', 'gutenberg' ),
 			'description' => _x( 'A navigation overlay with black background and big white text', 'Block pattern description', 'gutenberg' ),
@@ -57,7 +61,7 @@ function gutenberg_register_overlay_block_patterns() {
 		)
 	);
 	register_block_pattern(
-		'gutenberg/navigation-overlay-accent-bg',
+		'core/navigation-overlay-accent-bg',
 		array(
 			'title'       => __( 'Overlay with orange background', 'gutenberg' ),
 			'description' => _x( 'A navigation overlay with orange background site title and tagline', 'Block pattern description', 'gutenberg' ),
@@ -83,7 +87,7 @@ function gutenberg_register_overlay_block_patterns() {
 		)
 	);
 	register_block_pattern(
-		'gutenberg/navigation-overlay-centered-with-extras',
+		'core/navigation-overlay-centered-with-extras',
 		array(
 			'title'       => __( 'Overlay with site info and CTA', 'gutenberg' ),
 			'description' => _x( 'A navigation overlay with vertically and horizontally centered navigation, site info, and a CTA', 'Block pattern description', 'gutenberg' ),
@@ -125,7 +129,7 @@ function gutenberg_register_overlay_block_patterns() {
 		)
 	);
 	register_block_pattern(
-		'gutenberg/navigation-overlay-centered',
+		'core/navigation-overlay-centered',
 		array(
 			'title'       => __( 'Overlay with centered navigation', 'gutenberg' ),
 			'description' => _x( 'A navigation overlay with vertically and horizontally centered navigation', 'Block pattern description', 'gutenberg' ),

--- a/lib/overlay-patterns.php
+++ b/lib/overlay-patterns.php
@@ -8,8 +8,8 @@
 /**
  * Registers block patterns for navigation overlays.
  *
- * This function adds patterns that are specific to the navigation overlays
- * experiment. It runs after core patterns are registered to ensure all patterns
+ * This function adds patterns that are specific to navigation overlays.
+ * It runs after core patterns are registered to ensure all patterns
  * are available.
  *
  * @since 6.0.0

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -291,9 +291,7 @@ const getAllBlocks = () => {
 		blocks.push( formSubmissionNotification );
 	}
 
-	if ( window?.__experimentalNavigationOverlays ) {
-		blocks.push( navigationOverlayClose );
-	}
+	blocks.push( navigationOverlayClose );
 
 	if ( window?.__experimentalEnableBlockExperiments ) {
 		blocks.push( playlist );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -266,6 +266,7 @@ const getAllBlocks = () => {
 		tableOfContents,
 		homeLink,
 		logInOut,
+		navigationOverlayClose,
 		termCount,
 		termDescription,
 		termName,
@@ -290,8 +291,6 @@ const getAllBlocks = () => {
 		blocks.push( formSubmitButton );
 		blocks.push( formSubmissionNotification );
 	}
-
-	blocks.push( navigationOverlayClose );
 
 	if ( window?.__experimentalEnableBlockExperiments ) {
 		blocks.push( playlist );

--- a/packages/block-library/src/navigation-overlay-close/block.json
+++ b/packages/block-library/src/navigation-overlay-close/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/navigation-overlay-close",
 	"title": "Navigation Overlay Close",

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -340,10 +340,6 @@ function Navigation( {
 
 	const blockEditingMode = useBlockEditingMode();
 
-	const isOverlayExperimentEnabled =
-		typeof window !== 'undefined' &&
-		window.__experimentalNavigationOverlays === true;
-
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
 	const { menus: classicMenus } = useNavigationEntities();
@@ -755,7 +751,7 @@ function Navigation( {
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
-				{ ( ! isOverlayExperimentEnabled || hasSubmenus ) && (
+				{ hasSubmenus && (
 					<ToolsPanel
 						label={ __( 'Display' ) }
 						resetAll={ () => {
@@ -769,7 +765,7 @@ function Navigation( {
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ ! isOverlayExperimentEnabled && (
+						{ false && (
 							<>
 								{ isResponsive && (
 									<OverlayMenuPreviewButton
@@ -919,7 +915,7 @@ function Navigation( {
 					</ToolsPanel>
 				) }
 			</InspectorControls>
-			{ isOverlayExperimentEnabled && ! isWithinOverlay && (
+			{ ! isWithinOverlay && (
 				<InspectorControls>
 					<OverlayPanel
 						overlayMenu={ overlayMenu }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -65,8 +65,6 @@ import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 import useNavigationNotice from './use-navigation-notice';
 import OverlayMenuPreview from './overlay-menu-preview';
 import OverlayPanel from './overlay-panel';
-import OverlayVisibilityControl from './overlay-visibility-control';
-import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_ERROR,
 	CLASSIC_MENU_CONVERSION_PENDING,
@@ -765,50 +763,6 @@ function Navigation( {
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ false && (
-							<>
-								{ isResponsive && (
-									<OverlayMenuPreviewButton
-										isResponsive={ isResponsive }
-										overlayMenuPreview={
-											overlayMenuPreview
-										}
-										setOverlayMenuPreview={
-											setOverlayMenuPreview
-										}
-										hasIcon={ hasIcon }
-										icon={ icon }
-										setAttributes={ setAttributes }
-										overlayMenuPreviewClasses={
-											overlayMenuPreviewClasses
-										}
-										overlayMenuPreviewId={
-											overlayMenuPreviewId
-										}
-										containerStyle={ {
-											gridColumn: 'span 2',
-										} }
-									/>
-								) }
-
-								<ToolsPanelItem
-									hasValue={ () => overlayMenu !== 'mobile' }
-									label={ __( 'Overlay Visibility' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											overlayMenu: 'mobile',
-										} )
-									}
-									isShownByDefault
-								>
-									<OverlayVisibilityControl
-										overlayMenu={ overlayMenu }
-										setAttributes={ setAttributes }
-									/>
-								</ToolsPanelItem>
-							</>
-						) }
-
 						{ hasSubmenus && (
 							<>
 								<h3 className="wp-block-navigation__submenu-header">

--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -83,7 +83,7 @@ describe( 'useCreateOverlayTemplatePart', () => {
 		} );
 
 		mockGetPatternBySlug.mockReturnValue( {
-			name: 'gutenberg/navigation-overlay',
+			name: 'core/navigation-overlay',
 			title: 'Navigation Overlay',
 			content:
 				'<!-- wp:group --><div class="wp-block-group"><!-- wp:navigation-overlay-close /--><!-- wp:navigation /--></div><!-- /wp:group -->',
@@ -199,7 +199,7 @@ describe( 'useCreateOverlayTemplatePart', () => {
 		} );
 
 		expect( mockGetPatternBySlug ).toHaveBeenCalledWith(
-			'gutenberg/navigation-overlay'
+			'core/navigation-overlay'
 		);
 
 		expect( parse ).toHaveBeenCalledWith( mockGetPatternBySlug().content, {

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -27,7 +27,7 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 	const pattern = useSelect(
 		( select ) =>
 			unlock( select( blockEditorStore ) ).getPatternBySlug(
-				'gutenberg/navigation-overlay'
+				'core/navigation-overlay'
 			),
 		[]
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -72,17 +72,6 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static $seen_menu_names = array();
 
-	/**
-	 * Returns whether the navigation overlay experiment is enabled.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return bool Returns whether the navigation overlay experiment is enabled.
-	 */
-	private static function is_overlay_experiment_enabled() {
-		$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-		return $gutenberg_experiments && array_key_exists( 'gutenberg-customizable-navigation-overlays', $gutenberg_experiments );
-	}
 
 	/**
 	 * Returns whether or not this is responsive navigation.
@@ -693,38 +682,34 @@ class WP_Navigation_Block_Renderer {
 
 		$is_hidden_by_default = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
 
-		// Set-up variables for the custom overlay experiment.
-		// Values are set to "off" so they don't affect the default behavior.
-		$is_overlay_experiment_enabled  = static::is_overlay_experiment_enabled();
+		// Set-up variables for custom overlays.
 		$has_custom_overlay             = false;
 		$close_button_markup            = '';
 		$has_custom_overlay_close_block = false;
 		$overlay_blocks_html            = '';
 		$custom_overlay_markup          = '';
 
-		if ( $is_overlay_experiment_enabled ) {
-			// Check if an overlay template part is selected and render it.
-			// This needs to happen before building classes so we know if overlay blocks actually exist.
-			if ( ! empty( $attributes['overlay'] ) ) {
-				// Get blocks from the overlay template part.
-				$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
-				// Check if overlay contains a navigation-overlay-close block.
-				$has_custom_overlay_close_block = block_core_navigation_block_tree_has_block_type(
-					$overlay_blocks,
-					'core/navigation-overlay-close',
-					array( 'core/navigation' ) // Skip navigation blocks, as they cannot contain an overlay close block
-				);
-				// Render template part blocks directly without navigation container wrapper.
-				$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
-				// Add Interactivity API directives to the overlay close block if present.
-				if ( $has_custom_overlay_close_block && $is_interactive ) {
-					$tags                = new WP_HTML_Tag_Processor( $overlay_blocks_html );
-					$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
-				}
+		// Check if an overlay template part is selected and render it.
+		// This needs to happen before building classes so we know if overlay blocks actually exist.
+		if ( ! empty( $attributes['overlay'] ) ) {
+			// Get blocks from the overlay template part.
+			$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
+			// Check if overlay contains a navigation-overlay-close block.
+			$has_custom_overlay_close_block = block_core_navigation_block_tree_has_block_type(
+				$overlay_blocks,
+				'core/navigation-overlay-close',
+				array( 'core/navigation' ) // Skip navigation blocks, as they cannot contain an overlay close block
+			);
+			// Render template part blocks directly without navigation container wrapper.
+			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
+			// Add Interactivity API directives to the overlay close block if present.
+			if ( $has_custom_overlay_close_block && $is_interactive ) {
+				$tags                = new WP_HTML_Tag_Processor( $overlay_blocks_html );
+				$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
 			}
-
-			$has_custom_overlay = ! empty( $overlay_blocks_html );
 		}
+
+		$has_custom_overlay = ! empty( $overlay_blocks_html );
 
 		$responsive_container_classes = static::get_responsive_container_classes( $is_hidden_by_default, $has_custom_overlay, $colors );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -641,7 +641,6 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		if ( $has_custom_overlay ) {
-			// Only add the disable-default-overlay class if experiment is enabled AND overlay blocks actually rendered.
 			$responsive_container_classes[] = 'disable-default-overlay';
 		} else {
 			// Don't apply overlay color classes if using a custom overlay template part.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -40,22 +40,7 @@ import {
 	useTemplatePartArea,
 } from './utils/hooks';
 
-const SUPPORTED_AREAS = [ 'header', 'footer' ];
-
-/**
- * Returns the list of supported template part areas for pattern replacement.
- * Includes 'overlay' only if the navigation overlays experiment is enabled.
- *
- * @return {string[]} Array of supported area names.
- */
-function getSupportedAreas() {
-	const isOverlayExperimentEnabled =
-		typeof window !== 'undefined' &&
-		window.__experimentalNavigationOverlays === true;
-	return isOverlayExperimentEnabled
-		? [ ...SUPPORTED_AREAS, 'navigation-overlay' ]
-		: SUPPORTED_AREAS;
-}
+const SUPPORTED_AREAS = [ 'header', 'footer', 'navigation-overlay' ];
 
 function ReplaceButton( {
 	isEntityAvailable,
@@ -71,9 +56,10 @@ function ReplaceButton( {
 		templatePartId
 	);
 	const hasReplacements = !! templateParts.length;
-	const supportedAreas = getSupportedAreas();
 	const canReplace =
-		isEntityAvailable && hasReplacements && supportedAreas.includes( area );
+		isEntityAvailable &&
+		hasReplacements &&
+		SUPPORTED_AREAS.includes( area );
 
 	if ( ! canReplace ) {
 		return null;
@@ -96,11 +82,10 @@ function TemplatesList( { area, clientId, isEntityAvailable, onSelect } ) {
 	// This hook fetches patterns, so don't run it unconditionally in the main
 	// edit function!
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
-	const supportedAreas = getSupportedAreas();
 	const canReplace =
 		isEntityAvailable &&
 		!! blockPatterns.length &&
-		supportedAreas.includes( area );
+		SUPPORTED_AREAS.includes( area );
 
 	if ( ! canReplace ) {
 		return null;

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -9,8 +9,6 @@ export const EXCLUDED_PATTERN_SOURCES = [
 	'core',
 	'pattern-directory/core',
 	'pattern-directory/featured',
-	// Remove once the patterns are merged into core.
-	'gutenberg/navigation-overlay',
 ];
 export const PATTERN_SYNC_TYPES = {
 	full: 'fully',

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -9,6 +9,8 @@ export const EXCLUDED_PATTERN_SOURCES = [
 	'core',
 	'pattern-directory/core',
 	'pattern-directory/featured',
+	// Remove once the patterns are merged into core.
+	'gutenberg/navigation-overlay',
 ];
 export const PATTERN_SYNC_TYPES = {
 	full: 'fully',

--- a/test/integration/fixtures/blocks/core__navigation-overlay-close.html
+++ b/test/integration/fixtures/blocks/core__navigation-overlay-close.html
@@ -1,0 +1,1 @@
+<!-- wp:navigation-overlay-close /-->

--- a/test/integration/fixtures/blocks/core__navigation-overlay-close.json
+++ b/test/integration/fixtures/blocks/core__navigation-overlay-close.json
@@ -1,0 +1,10 @@
+[
+	{
+		"name": "core/navigation-overlay-close",
+		"isValid": true,
+		"attributes": {
+			"displayMode": "icon"
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__navigation-overlay-close.parsed.json
+++ b/test/integration/fixtures/blocks/core__navigation-overlay-close.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/navigation-overlay-close",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__navigation-overlay-close.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation-overlay-close.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:navigation-overlay-close /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes the experimental flag for navigation overlays and makes the feature always available. Moves overlay patterns from the experimental folder to the main lib folder.

## Why?

Navigation overlays are ready for general use and no longer need to be behind an experimental flag.

## How?

- Moved `lib/experimental/overlay-patterns.php` to `lib/overlay-patterns.php`
- Removed experimental flag checks from PHP files
- Removed experiment checkbox from settings page
- Updated JavaScript to always enable overlay features
- Always register navigation-overlay template part area
- Created new fixtures for the overlay close block

## Testing Instructions

1. Navigate to a Navigation block and verify overlay controls are available without enabling any experiment
2. Create a new overlay template part and verify patterns are available
3. Select a pattern and verify it displays correctly in the editor
4. View the frontend and verify overlays render correctly
