### PR TITLE
Add the `has-custom-css` class name to the editor and dynamic blocks.

### DIFF
--- a/backport-changelog/7.0/10777.md
+++ b/backport-changelog/7.0/10777.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10777
 
 * https://github.com/WordPress/gutenberg/pull/73959
+* https://github.com/WordPress/gutenberg/pull/74969

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -88,7 +88,7 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 	$tags = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $tags->next_tag() ) {
-		// $tags->add_class( "has-custom-css" );
+		$tags->add_class( "has-custom-css" );
 		$tags->add_class( $matches[0] );
 	}
 

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -88,7 +88,7 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 	$tags = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $tags->next_tag() ) {
-		$tags->add_class( "has-custom-css" );
+		$tags->add_class( 'has-custom-css' );
 		$tags->add_class( $matches[0] );
 	}
 

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -88,6 +88,7 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 	$tags = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $tags->next_tag() ) {
+		// $tags->add_class( "has-custom-css" );
 		$tags->add_class( $matches[0] );
 	}
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -137,7 +137,7 @@ function useBlockProps( { style } ) {
 	}
 
 	return {
-		className: clsx( 'has-custom-css', customCSSIdentifier ),
+		className: `has-custom-css ${customCSSIdentifier}`
 	};
 }
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
@@ -132,7 +137,7 @@ function useBlockProps( { style } ) {
 	}
 
 	return {
-		className: customCSSIdentifier,
+		className: clsx( 'has-custom-css', customCSSIdentifier ),
 	};
 }
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -132,7 +132,7 @@ function useBlockProps( { style } ) {
 	}
 
 	return {
-		className: `has-custom-css ${customCSSIdentifier}`
+		className: `has-custom-css ${ customCSSIdentifier }`,
 	};
 }
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to ["Add custom CSS support for individual block instances"](https://github.com/WordPress/gutenberg/pull/73959#issuecomment-3787128956)
Add the 'has-custom-css' class name to the editor and dynamic blocks.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Enhances HTML consistency between the frontend and editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a heading and Archives block . 
3. Add custom CSS from advanced settings.
4. The 'has-custom-css' class will be added to the editor and frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| |Before|After|
|-|-|-|
| Editor | <img width="1379" height="230" alt="before-editor" src="https://github.com/user-attachments/assets/ac647e8e-6e38-43da-b123-599b08ab1619" /> | <img width="1387" height="307" alt="after-editor" src="https://github.com/user-attachments/assets/aa78ac2a-c643-4f0f-abdc-74219b0b8446" /> |
| Front | <img width="1353" height="102" alt="before" src="https://github.com/user-attachments/assets/95bae525-b7d9-46fa-b084-7096440f7d14" /> |  <img width="1363" height="103" alt="after" src="https://github.com/user-attachments/assets/b07bffa7-b830-485e-a10d-a1f6d04e11c7" /> |
