### PR TITLE
Unified view persistence: Share one persisted view across all tabs

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -103,7 +103,7 @@ export default function DataviewsPatterns() {
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: postType,
-		slug: categoryId,
+		slug: 'default',
 		defaultView: DEFAULT_VIEW,
 		queryParams: {
 			page: query.pageNumber,

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -21,7 +21,11 @@ import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import { authorField, descriptionField, previewField } from './fields';
-import { defaultLayouts, getDefaultView } from './view-utils';
+import {
+	defaultLayouts,
+	getDefaultView,
+	getActiveFiltersForTab,
+} from './view-utils';
 
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -33,13 +37,18 @@ export default function PageTemplates() {
 	const [ selection, setSelection ] = useState( [ postId ] );
 
 	const defaultView = useMemo( () => {
-		return getDefaultView( activeView );
-	}, [ activeView ] );
+		return getDefaultView();
+	}, [] );
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( activeView ),
+		[ activeView ]
+	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: TEMPLATE_POST_TYPE,
-		slug: activeView,
+		slug: 'default',
 		defaultView,
+		activeFilters,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,
@@ -116,11 +125,11 @@ export default function PageTemplates() {
 	);
 
 	const onChangeView = useEvent( ( newView ) => {
+		updateView( newView );
 		if ( newView.type !== view.type ) {
 			// Retrigger the routing areas resolution.
 			history.invalidate();
 		}
-		updateView( newView );
 	} );
 
 	return (

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -23,7 +23,7 @@ import { useEditPostAction } from '../dataviews-actions';
 import { authorField, descriptionField, previewField } from './fields';
 import {
 	defaultLayouts,
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 } from './view-utils';
 
@@ -36,9 +36,7 @@ export default function PageTemplates() {
 	const { activeView = 'active', postId } = query;
 	const [ selection, setSelection ] = useState( [ postId ] );
 
-	const defaultView = useMemo( () => {
-		return getDefaultView();
-	}, [] );
+	const defaultView = DEFAULT_VIEW;
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTab( activeView ),
 		[ activeView ]

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -39,7 +39,7 @@ import {
 } from './fields';
 import {
 	defaultLayouts,
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 } from './view-utils';
 
@@ -54,9 +54,7 @@ export default function PageTemplates() {
 	const [ selection, setSelection ] = useState( [ postId ] );
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState( false );
-	const defaultView = useMemo( () => {
-		return getDefaultView();
-	}, [] );
+	const defaultView = DEFAULT_VIEW;
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTab( activeView ),
 		[ activeView ]

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -37,7 +37,11 @@ import {
 	slugField,
 	useThemeField,
 } from './fields';
-import { defaultLayouts, getDefaultView } from './view-utils';
+import {
+	defaultLayouts,
+	getDefaultView,
+	getActiveFiltersForTab,
+} from './view-utils';
 
 const { usePostActions, usePostFields, templateTitleField } =
 	unlock( editorPrivateApis );
@@ -51,13 +55,18 @@ export default function PageTemplates() {
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState( false );
 	const defaultView = useMemo( () => {
-		return getDefaultView( activeView );
-	}, [ activeView ] );
+		return getDefaultView();
+	}, [] );
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( activeView ),
+		[ activeView ]
+	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: TEMPLATE_POST_TYPE,
-		slug: activeView,
+		slug: 'default',
 		defaultView,
+		activeFilters,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,
@@ -303,11 +312,11 @@ export default function PageTemplates() {
 	);
 
 	const onChangeView = useEvent( ( newView ) => {
+		updateView( newView );
 		if ( newView.type !== view.type ) {
 			// Retrigger the routing areas resolution.
 			history.invalidate();
 		}
-		updateView( newView );
 	} );
 
 	const duplicateAction = actions.find(

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -25,24 +25,22 @@ const DEFAULT_VIEW = {
 	...defaultLayouts.grid,
 };
 
-export function getDefaultView( activeView ) {
+export function getDefaultView() {
 	return {
 		...DEFAULT_VIEW,
-		sort:
-			activeView === 'user'
-				? {
-						field: 'date',
-						direction: 'desc',
-				  }
-				: DEFAULT_VIEW.sort,
-		filters: ! [ 'active', 'user' ].includes( activeView )
-			? [
-					{
-						field: 'author',
-						operator: 'isAny',
-						value: [ activeView ],
-					},
-			  ]
-			: [],
 	};
+}
+
+export function getActiveFiltersForTab( activeView ) {
+	if ( activeView === 'active' || activeView === 'user' ) {
+		return [];
+	}
+	// Author-based view
+	return [
+		{
+			field: 'author',
+			operator: 'isAny',
+			value: [ activeView ],
+		},
+	];
 }

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -10,7 +10,7 @@ export const defaultLayouts = {
 	},
 };
 
-const DEFAULT_VIEW = {
+export const DEFAULT_VIEW = {
 	type: 'grid',
 	perPage: 20,
 	sort: {
@@ -24,12 +24,6 @@ const DEFAULT_VIEW = {
 	filters: [],
 	...defaultLayouts.grid,
 };
-
-export function getDefaultView() {
-	return {
-		...DEFAULT_VIEW,
-	};
-}
 
 export function getActiveFiltersForTab( activeView ) {
 	if ( activeView === 'active' || activeView === 'user' ) {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -32,7 +32,11 @@ import {
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
-import { defaultLayouts, getDefaultView } from './view-utils';
+import {
+	defaultLayouts,
+	getDefaultView,
+	getActiveFiltersForTab,
+} from './view-utils';
 import useNotesCount from './use-notes-count';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
@@ -54,17 +58,17 @@ export default function PostList( { postType } ) {
 	const { path, query } = useLocation();
 	const { activeView = 'all', postId, quickEdit = false } = query;
 	const history = useHistory();
-	const postTypeObject = useSelect(
-		( select ) => {
-			const { getPostType } = select( coreStore );
-			return getPostType( postType );
-		},
-		[ postType ]
+	const defaultView = useMemo( () => getDefaultView(), [] );
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( activeView ),
+		[ activeView ]
 	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: postType,
-		slug: activeView,
+		slug: 'default',
+		defaultView,
+		activeFilters,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,
@@ -78,15 +82,14 @@ export default function PostList( { postType } ) {
 				} )
 			);
 		},
-		defaultView: getDefaultView( postTypeObject, activeView ),
 	} );
 
 	const onChangeView = useEvent( ( newView ) => {
+		updateView( newView );
 		if ( newView.type !== view.type ) {
 			// Retrigger the routing areas resolution.
 			history.invalidate();
 		}
-		updateView( newView );
 	} );
 
 	const [ selection, setSelection ] = useState( postId?.split( ',' ) ?? [] );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -34,7 +34,7 @@ import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import {
 	defaultLayouts,
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 } from './view-utils';
 import useNotesCount from './use-notes-count';
@@ -58,7 +58,7 @@ export default function PostList( { postType } ) {
 	const { path, query } = useLocation();
 	const { activeView = 'all', postId, quickEdit = false } = query;
 	const history = useHistory();
-	const defaultView = useMemo( () => getDefaultView(), [] );
+	const defaultView = DEFAULT_VIEW;
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTab( activeView ),
 		[ activeView ]

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -148,8 +148,30 @@ export function getDefaultViews( postType ) {
 	];
 }
 
-export const getDefaultView = ( postType, activeView ) => {
-	return getDefaultViews( postType ).find(
-		( { slug } ) => slug === activeView
-	)?.view;
+export const getDefaultView = () => {
+	return DEFAULT_POST_BASE;
 };
+
+const SLUG_TO_STATUS = {
+	published: 'publish',
+	future: 'future',
+	drafts: 'draft',
+	pending: 'pending',
+	private: 'private',
+	trash: 'trash',
+};
+
+export function getActiveFiltersForTab( activeView ) {
+	const status = SLUG_TO_STATUS[ activeView ];
+	if ( ! status ) {
+		return [];
+	}
+	return [
+		{
+			field: 'status',
+			operator: OPERATOR_IS_ANY,
+			value: status,
+			isLocked: true,
+		},
+	];
+}

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -24,7 +24,7 @@ export const defaultLayouts = {
 	list: {},
 };
 
-const DEFAULT_POST_BASE = {
+export const DEFAULT_VIEW = {
 	type: 'list',
 	filters: [],
 	perPage: 20,
@@ -45,14 +45,14 @@ export function getDefaultViews( postType ) {
 			title: postType?.labels?.all_items || __( 'All items' ),
 			slug: 'all',
 			icon: pages,
-			view: DEFAULT_POST_BASE,
+			view: DEFAULT_VIEW,
 		},
 		{
 			title: __( 'Published' ),
 			slug: 'published',
 			icon: published,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				filters: [
 					{
 						field: 'status',
@@ -68,7 +68,7 @@ export function getDefaultViews( postType ) {
 			slug: 'future',
 			icon: scheduled,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				filters: [
 					{
 						field: 'status',
@@ -84,7 +84,7 @@ export function getDefaultViews( postType ) {
 			slug: 'drafts',
 			icon: drafts,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				filters: [
 					{
 						field: 'status',
@@ -100,7 +100,7 @@ export function getDefaultViews( postType ) {
 			slug: 'pending',
 			icon: pending,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				filters: [
 					{
 						field: 'status',
@@ -116,7 +116,7 @@ export function getDefaultViews( postType ) {
 			slug: 'private',
 			icon: notAllowed,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				filters: [
 					{
 						field: 'status',
@@ -132,7 +132,7 @@ export function getDefaultViews( postType ) {
 			slug: 'trash',
 			icon: trash,
 			view: {
-				...DEFAULT_POST_BASE,
+				...DEFAULT_VIEW,
 				type: 'table',
 				layout: defaultLayouts.table.layout,
 				filters: [
@@ -147,10 +147,6 @@ export function getDefaultViews( postType ) {
 		},
 	];
 }
-
-export const getDefaultView = () => {
-	return DEFAULT_POST_BASE;
-};
 
 const SLUG_TO_STATUS = {
 	published: 'publish',

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -15,10 +15,7 @@ import DataViewsSidebarContent from '../sidebar-dataviews';
 import PostList from '../post-list';
 import { unlock } from '../../lock-unlock';
 import { PostEdit } from '../post-edit';
-import {
-	DEFAULT_VIEW,
-	getActiveFiltersForTab,
-} from '../post-list/view-utils';
+import { DEFAULT_VIEW, getActiveFiltersForTab } from '../post-list/view-utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -16,7 +16,7 @@ import PostList from '../post-list';
 import { unlock } from '../../lock-unlock';
 import { PostEdit } from '../post-edit';
 import {
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 } from '../post-list/view-utils';
 
@@ -28,7 +28,7 @@ async function isListView( query ) {
 		kind: 'postType',
 		name: 'page',
 		slug: 'default',
-		defaultView: getDefaultView(),
+		defaultView: DEFAULT_VIEW,
 		activeFilters: getActiveFiltersForTab( activeView ),
 	} );
 	return view.type === 'list';

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -4,8 +4,6 @@
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { __ } from '@wordpress/i18n';
 import { loadView } from '@wordpress/views';
-import { resolveSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -17,19 +15,21 @@ import DataViewsSidebarContent from '../sidebar-dataviews';
 import PostList from '../post-list';
 import { unlock } from '../../lock-unlock';
 import { PostEdit } from '../post-edit';
-import { getDefaultView } from '../post-list/view-utils';
+import {
+	getDefaultView,
+	getActiveFiltersForTab,
+} from '../post-list/view-utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
 async function isListView( query ) {
 	const { activeView = 'all' } = query;
-	const postTypeObject =
-		await resolveSelect( coreStore ).getPostType( 'page' );
 	const view = await loadView( {
 		kind: 'postType',
 		name: 'page',
-		slug: activeView,
-		defaultView: getDefaultView( postTypeObject, activeView ),
+		slug: 'default',
+		defaultView: getDefaultView(),
+		activeFilters: getActiveFiltersForTab( activeView ),
 	} );
 	return view.type === 'list';
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -11,15 +11,19 @@ import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import PageTemplates from '../page-templates';
 import PageTemplatesLegacy from '../page-templates/index-legacy';
-import { getDefaultView } from '../page-templates/view-utils';
+import {
+	getDefaultView,
+	getActiveFiltersForTab,
+} from '../page-templates/view-utils';
 
 async function isTemplateListView( query ) {
 	const { activeView = 'active' } = query;
 	const view = await loadView( {
 		kind: 'postType',
 		name: 'wp_template',
-		slug: activeView,
-		defaultView: getDefaultView( activeView ),
+		slug: 'default',
+		defaultView: getDefaultView(),
+		activeFilters: getActiveFiltersForTab( activeView ),
 	} );
 	return view.type === 'list';
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -12,7 +12,7 @@ import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-uns
 import PageTemplates from '../page-templates';
 import PageTemplatesLegacy from '../page-templates/index-legacy';
 import {
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 } from '../page-templates/view-utils';
 
@@ -22,7 +22,7 @@ async function isTemplateListView( query ) {
 		kind: 'postType',
 		name: 'wp_template',
 		slug: 'default',
-		defaultView: getDefaultView(),
+		defaultView: DEFAULT_VIEW,
 		activeFilters: getActiveFiltersForTab( activeView ),
 	} );
 	return view.type === 'list';

--- a/packages/views/README.md
+++ b/packages/views/README.md
@@ -45,6 +45,7 @@ _Parameters_
 -   _config.name_ `ViewConfig`: Specific entity name.
 -   _config.slug_ `ViewConfig`: View identifier.
 -   _config.defaultView_ `ViewConfig`: Default view configuration.
+-   _config.activeFilters_ `ViewConfig`: Filters applied on top but never persisted.
 -   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
 
 _Returns_
@@ -62,6 +63,7 @@ _Parameters_
 -   _config.name_ `ViewConfig`: Specific entity name.
 -   _config.slug_ `ViewConfig`: View identifier.
 -   _config.defaultView_ `ViewConfig`: Default view configuration.
+-   _config.activeFilters_ `ViewConfig`: Filters applied on top of the view but never persisted.
 -   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
 -   _config.onChangeQueryParams_ `ViewConfig`: Optional callback to update URL parameters.
 

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import type { View, Filter } from '@wordpress/dataviews';
+
+/**
+ * Merges activeFilters into a view's filters array.
+ * Active filters take precedence: any existing filter on the same
+ * field is removed and replaced by the active filter.
+ *
+ * @param view          The view to merge filters into.
+ * @param activeFilters The tab-specific filters to overlay.
+ * @return A new view with merged filters, or the original view if no activeFilters.
+ */
+export function mergeActiveFilters(
+	view: View,
+	activeFilters?: Filter[]
+): View {
+	if ( ! activeFilters || activeFilters.length === 0 ) {
+		return view;
+	}
+	const activeFields = new Set( activeFilters.map( ( f ) => f.field ) );
+	const preserved = ( view.filters ?? [] ).filter(
+		( f: Filter ) => ! activeFields.has( f.field )
+	);
+	return {
+		...view,
+		filters: [ ...preserved, ...activeFilters ],
+	};
+}
+
+/**
+ * Strips filters on fields managed by activeFilters.
+ * Used before persisting to ensure tab-specific filters
+ * are not stored in preferences.
+ *
+ * @param view          The view to strip filters from.
+ * @param activeFilters The tab-specific filter definitions.
+ * @return A new view with managed fields' filters removed, or the original view if no activeFilters.
+ */
+export function stripActiveFilterFields(
+	view: View,
+	activeFilters?: Filter[]
+): View {
+	if ( ! activeFilters || activeFilters.length === 0 ) {
+		return view;
+	}
+	const activeFields = new Set( activeFilters.map( ( f ) => f.field ) );
+	return {
+		...view,
+		filters: ( view.filters ?? [] ).filter(
+			( f: Filter ) => ! activeFields.has( f.field )
+		),
+	};
+}

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -10,6 +10,7 @@ import type { View } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { generatePreferenceKey } from './preference-keys';
+import { mergeActiveFilters } from './filter-utils';
 import type { ViewConfig } from './types';
 
 /**
@@ -28,17 +29,19 @@ import type { ViewConfig } from './types';
  * } );
  * ```
  *
- * @param config             Configuration object for loading the view.
- * @param config.kind        Entity kind (e.g., 'postType', 'taxonomy', 'root').
- * @param config.name        Specific entity name.
- * @param config.slug        View identifier.
- * @param config.defaultView Default view configuration.
- * @param config.queryParams Object with `page` and/or `search` from URL.
+ * @param config               Configuration object for loading the view.
+ * @param config.kind          Entity kind (e.g., 'postType', 'taxonomy', 'root').
+ * @param config.name          Specific entity name.
+ * @param config.slug          View identifier.
+ * @param config.defaultView   Default view configuration.
+ * @param config.activeFilters Filters applied on top but never persisted.
+ * @param config.queryParams   Object with `page` and/or `search` from URL.
  *
  * @return Promise resolving to the loaded view object.
  */
 export async function loadView( config: ViewConfig ) {
-	const { kind, name, slug, defaultView, queryParams } = config;
+	const { kind, name, slug, defaultView, activeFilters, queryParams } =
+		config;
 	const preferenceKey = generatePreferenceKey( kind, name, slug );
 	const persistedView: View | undefined = select( preferencesStore ).get(
 		'core/views',
@@ -49,9 +52,12 @@ export async function loadView( config: ViewConfig ) {
 	const page = queryParams?.page ?? 1;
 	const search = queryParams?.search ?? '';
 
-	return {
-		...baseView,
-		page,
-		search,
-	};
+	return mergeActiveFilters(
+		{
+			...baseView,
+			page,
+			search,
+		},
+		activeFilters
+	);
 }

--- a/packages/views/src/types.ts
+++ b/packages/views/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import type { View } from '@wordpress/dataviews';
+import type { View, Filter } from '@wordpress/dataviews';
 
 export interface ViewConfig {
 	/**
@@ -25,6 +25,13 @@ export interface ViewConfig {
 	 * Default view configuration
 	 */
 	defaultView: View;
+
+	/**
+	 * Filters applied on top of the persisted view but never persisted.
+	 * These represent tab-specific filtering that should override
+	 * any persisted filters on the same fields.
+	 */
+	activeFilters?: Filter[];
 
 	/**
 	 * Optional query parameters from URL (page, search)

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -100,8 +100,9 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				search: newView?.search,
 			};
 			// Strip activeFilters and URL params before persisting
+			// Cast is safe: omitting page/search doesn't change the discriminant (type field)
 			const preferenceView = stripActiveFilterFields(
-				omit( newView, [ 'page', 'search' ] ),
+				omit( newView, [ 'page', 'search' ] ) as View,
 				activeFilters
 			);
 

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -4,12 +4,6 @@
 import { dequal } from 'dequal';
 
 /**
- * Internal dependencies
- */
-import { generatePreferenceKey } from './preference-keys';
-import type { ViewConfig } from './types';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
@@ -17,6 +11,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import type { View } from '@wordpress/dataviews';
 // @ts-ignore - Preferences package is not typed
 import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { generatePreferenceKey } from './preference-keys';
+import { mergeActiveFilters, stripActiveFilterFields } from './filter-utils';
+import type { ViewConfig } from './types';
 
 interface UseViewReturn {
 	view: View;
@@ -44,14 +45,22 @@ function omit< T extends object, K extends keyof T >(
  * @param config.name                Specific entity name.
  * @param config.slug                View identifier.
  * @param config.defaultView         Default view configuration.
+ * @param config.activeFilters       Filters applied on top of the view but never persisted.
  * @param config.queryParams         Object with `page` and/or `search` from URL.
  * @param config.onChangeQueryParams Optional callback to update URL parameters.
  *
  * @return Object with current view, modification state, and update functions.
  */
 export function useView( config: ViewConfig ): UseViewReturn {
-	const { kind, name, slug, defaultView, queryParams, onChangeQueryParams } =
-		config;
+	const {
+		kind,
+		name,
+		slug,
+		defaultView,
+		activeFilters,
+		queryParams,
+		onChangeQueryParams,
+	} = config;
 
 	const preferenceKey = generatePreferenceKey( kind, name, slug );
 	const persistedView: View | undefined = useSelect(
@@ -69,14 +78,17 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
-	// Merge URL query parameters (page, search) into the view
+	// Merge URL query parameters (page, search) and activeFilters into the view
 	const view: View = useMemo( () => {
-		return {
-			...baseView,
-			page,
-			search,
-		};
-	}, [ baseView, page, search ] );
+		return mergeActiveFilters(
+			{
+				...baseView,
+				page,
+				search,
+			},
+			activeFilters
+		);
+	}, [ baseView, page, search, activeFilters ] );
 
 	const isModified = !! persistedView;
 
@@ -87,7 +99,11 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				page: newView?.page,
 				search: newView?.search,
 			};
-			const preferenceView = omit( newView, [ 'page', 'search' ] );
+			// Strip activeFilters and URL params before persisting
+			const preferenceView = stripActiveFilterFields(
+				omit( newView, [ 'page', 'search' ] ),
+				activeFilters
+			);
 
 			// If we have URL handling enabled, separate URL state from preference state
 			if (
@@ -97,9 +113,19 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				onChangeQueryParams( urlParams );
 			}
 
+			// Compare with baseView and defaultView after stripping activeFilters
+			const comparableBaseView = stripActiveFilterFields(
+				baseView,
+				activeFilters
+			);
+			const comparableDefaultView = stripActiveFilterFields(
+				defaultView,
+				activeFilters
+			);
+
 			// Only persist non-URL preferences if different from baseView
-			if ( ! dequal( baseView, preferenceView ) ) {
-				if ( dequal( preferenceView, defaultView ) ) {
+			if ( ! dequal( comparableBaseView, preferenceView ) ) {
+				if ( dequal( preferenceView, comparableDefaultView ) ) {
 					set( 'core/views', preferenceKey, undefined );
 				} else {
 					set( 'core/views', preferenceKey, preferenceView );
@@ -112,6 +138,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 			search,
 			baseView,
 			defaultView,
+			activeFilters,
 			set,
 			preferenceKey,
 		]

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -66,7 +66,7 @@ function NavigationList() {
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: NAVIGATION_POST_TYPE,
-		slug: 'all',
+		slug: 'default-new',
 		defaultView,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,

--- a/routes/navigation-list/view-utils.ts
+++ b/routes/navigation-list/view-utils.ts
@@ -27,7 +27,7 @@ export async function ensureView( search?: {
 	return loadView( {
 		kind: 'postType',
 		name: NAVIGATION_POST_TYPE,
-		slug: 'all',
+		slug: 'default-new',
 		defaultView,
 		queryParams: search,
 	} );

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -86,7 +86,7 @@ function PatternList() {
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
 		name: 'wp_block',
-		slug: type,
+		slug: 'default-new',
 		defaultView: DEFAULT_VIEW,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -32,6 +32,7 @@ import { __ } from '@wordpress/i18n';
 import { unlock } from '../lock-unlock';
 import {
 	getDefaultView,
+	getActiveFiltersForTab,
 	DEFAULT_VIEWS,
 	DEFAULT_LAYOUTS,
 	viewToQuery,
@@ -78,8 +79,13 @@ function PostList() {
 	);
 
 	const defaultView: View = useMemo( () => {
-		return getDefaultView( postTypeObject, slug );
-	}, [ postTypeObject, slug ] );
+		return getDefaultView( postTypeObject );
+	}, [ postTypeObject ] );
+
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( slug ),
+		[ slug ]
+	);
 
 	// Callback to handle URL query parameter changes
 	const handleQueryParamsChange = useCallback(
@@ -98,8 +104,9 @@ function PostList() {
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
 		name: postType,
-		slug,
+		slug: 'default-new',
 		defaultView,
+		activeFilters,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -5,7 +5,7 @@ import { loadView } from '@wordpress/views';
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Type } from '@wordpress/core-data';
-import type { View } from '@wordpress/dataviews';
+import type { View, Filter } from '@wordpress/dataviews';
 
 const DEFAULT_VIEW: View = {
 	type: 'table' as const,
@@ -28,99 +28,49 @@ export const DEFAULT_LAYOUTS = {
 export const DEFAULT_VIEWS: {
 	slug: string;
 	label: string;
-	view: View;
 }[] = [
 	{
 		slug: 'all',
 		label: 'All',
-		view: {
-			...DEFAULT_VIEW,
-		},
 	},
 	{
 		slug: 'publish',
 		label: 'Published',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'status',
-					operator: 'is',
-					value: 'publish',
-				},
-			],
-		},
 	},
 	{
 		slug: 'draft',
 		label: 'Draft',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'status',
-					operator: 'is',
-					value: 'draft',
-				},
-			],
-		},
 	},
 	{
 		slug: 'pending',
 		label: 'Pending',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'status',
-					operator: 'is',
-					value: 'pending',
-				},
-			],
-		},
 	},
 	{
 		slug: 'private',
 		label: 'Private',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'status',
-					operator: 'is',
-					value: 'private',
-				},
-			],
-		},
 	},
 	{
 		slug: 'trash',
 		label: 'Trash',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'status',
-					operator: 'is',
-					value: 'trash',
-				},
-			],
-		},
 	},
 ];
 
-export function getDefaultView(
-	postType: Type | undefined,
-	slug?: string
-): View {
-	// Find the view configuration by slug
-	const viewConfig = DEFAULT_VIEWS.find( ( v ) => v.slug === slug );
+export function getActiveFiltersForTab( slug: string ): Filter[] {
+	if ( slug === 'all' ) {
+		return [];
+	}
+	return [
+		{
+			field: 'status',
+			operator: 'is',
+			value: slug,
+		},
+	];
+}
 
-	// Use the view from the config if found, otherwise use default
-	const baseView = viewConfig?.view || DEFAULT_VIEW;
-
+export function getDefaultView( postType: Type | undefined ): View {
 	return {
-		...baseView,
+		...DEFAULT_VIEW,
 		showLevels: postType?.hierarchical,
 	};
 }
@@ -131,12 +81,13 @@ export async function ensureView(
 	search?: { page?: number; search?: string }
 ) {
 	const postTypeObject = await resolveSelect( coreStore ).getPostType( type );
-	const defaultView = getDefaultView( postTypeObject, slug );
+	const defaultView = getDefaultView( postTypeObject );
 	return loadView( {
 		kind: 'postType',
 		name: type,
-		slug: slug ?? 'all',
+		slug: 'default-new',
 		defaultView,
+		activeFilters: getActiveFiltersForTab( slug ?? 'all' ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -28,7 +28,7 @@ import { published, commentAuthorAvatar } from '@wordpress/icons';
  */
 import { unlock } from '../lock-unlock';
 import {
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 	DEFAULT_LAYOUTS,
 } from './view-utils';
@@ -69,9 +69,7 @@ function TemplateListActivation() {
 	);
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState< Template | null >( null );
-	const defaultView: View = useMemo( () => {
-		return getDefaultView();
-	}, [] );
+	const defaultView = DEFAULT_VIEW;
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTab( activeView ),
 		[ activeView ]

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -27,7 +27,11 @@ import { published, commentAuthorAvatar } from '@wordpress/icons';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-import { getDefaultView, DEFAULT_LAYOUTS } from './view-utils';
+import {
+	getDefaultView,
+	getActiveFiltersForTab,
+	DEFAULT_LAYOUTS,
+} from './view-utils';
 import { previewField } from './fields/preview';
 import { authorField } from './fields/author';
 import { descriptionField } from './fields/description';
@@ -66,8 +70,12 @@ function TemplateListActivation() {
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState< Template | null >( null );
 	const defaultView: View = useMemo( () => {
-		return getDefaultView( activeView );
-	}, [ activeView ] );
+		return getDefaultView();
+	}, [] );
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( activeView ),
+		[ activeView ]
+	);
 
 	// Callback to handle URL query parameter changes
 	const handleQueryParamsChange = useCallback(
@@ -86,8 +94,9 @@ function TemplateListActivation() {
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
 		name: 'wp_template',
-		slug: activeView,
+		slug: 'default-new',
 		defaultView,
+		activeFilters,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -27,7 +27,7 @@ import { layout } from '@wordpress/icons';
  */
 import { unlock } from '../lock-unlock';
 import {
-	getDefaultViewLegacy,
+	DEFAULT_VIEW_LEGACY,
 	getActiveFiltersForTabLegacy,
 	DEFAULT_LAYOUTS,
 } from './view-utils';
@@ -63,9 +63,7 @@ function TemplateListLegacy() {
 		( select ) => select( coreStore ).getPostType( 'wp_template' ),
 		[]
 	);
-	const defaultView: View = useMemo( () => {
-		return getDefaultViewLegacy();
-	}, [] );
+	const defaultView = DEFAULT_VIEW_LEGACY;
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTabLegacy( activeView ),
 		[ activeView ]

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -26,7 +26,11 @@ import { layout } from '@wordpress/icons';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-import { getDefaultViewLegacy, DEFAULT_LAYOUTS } from './view-utils';
+import {
+	getDefaultViewLegacy,
+	getActiveFiltersForTabLegacy,
+	DEFAULT_LAYOUTS,
+} from './view-utils';
 import { previewField } from './fields/preview';
 import { authorField } from './fields/author';
 import { descriptionField } from './fields/description';
@@ -60,8 +64,12 @@ function TemplateListLegacy() {
 		[]
 	);
 	const defaultView: View = useMemo( () => {
-		return getDefaultViewLegacy( activeView );
-	}, [ activeView ] );
+		return getDefaultViewLegacy();
+	}, [] );
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTabLegacy( activeView ),
+		[ activeView ]
+	);
 
 	// Callback to handle URL query parameter changes
 	const handleQueryParamsChange = useCallback(
@@ -80,8 +88,9 @@ function TemplateListLegacy() {
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
 		name: 'wp_template',
-		slug: activeView,
+		slug: 'default-new',
 		defaultView,
+		activeFilters,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-list/view-utils.ts
+++ b/routes/template-list/view-utils.ts
@@ -4,7 +4,7 @@
 import { loadView } from '@wordpress/views';
 import type { View, Filter } from '@wordpress/dataviews';
 
-const DEFAULT_VIEW: View = {
+export const DEFAULT_VIEW: View = {
 	type: 'grid' as const,
 	perPage: 20,
 	sort: {
@@ -16,6 +16,11 @@ const DEFAULT_VIEW: View = {
 	descriptionField: 'description',
 	mediaField: 'preview',
 	filters: [],
+};
+
+export const DEFAULT_VIEW_LEGACY: View = {
+	...DEFAULT_VIEW,
+	fields: [ 'author' ],
 };
 
 export const DEFAULT_LAYOUTS = {
@@ -44,22 +49,15 @@ export function getActiveFiltersForTab( activeView: string ): Filter[] {
 	];
 }
 
-export function getDefaultView(): View {
-	return {
-		...DEFAULT_VIEW,
-	};
-}
-
 export async function ensureView(
 	activeView?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const defaultView = getDefaultView();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template',
 		slug: 'default-new',
-		defaultView,
+		defaultView: DEFAULT_VIEW,
 		activeFilters: getActiveFiltersForTab( activeView ?? 'active' ),
 		queryParams: search,
 	} );
@@ -79,23 +77,15 @@ export function getActiveFiltersForTabLegacy( activeView: string ): Filter[] {
 	];
 }
 
-export function getDefaultViewLegacy(): View {
-	return {
-		...DEFAULT_VIEW,
-		fields: [ 'author' ],
-	};
-}
-
 export async function ensureViewLegacy(
 	activeView?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const defaultView = getDefaultViewLegacy();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template',
 		slug: 'default-new',
-		defaultView,
+		defaultView: DEFAULT_VIEW_LEGACY,
 		activeFilters: getActiveFiltersForTabLegacy( activeView ?? 'all' ),
 		queryParams: search,
 	} );

--- a/routes/template-list/view-utils.ts
+++ b/routes/template-list/view-utils.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { loadView } from '@wordpress/views';
-import type { View } from '@wordpress/dataviews';
+import type { View, Filter } from '@wordpress/dataviews';
 
 const DEFAULT_VIEW: View = {
 	type: 'grid' as const,
@@ -30,36 +30,23 @@ export const DEFAULT_LAYOUTS = {
 	},
 };
 
-export function getDefaultView( activeView?: string ): View {
-	// User view: sort by date, newest first, include theme field
-	if ( activeView === 'user' ) {
-		return {
-			...DEFAULT_VIEW,
-			sort: {
-				field: 'date',
-				direction: 'desc' as const,
-			},
-			fields: [ 'author', 'active', 'slug', 'theme' ],
-		};
+export function getActiveFiltersForTab( activeView: string ): Filter[] {
+	if ( activeView === 'active' || activeView === 'user' ) {
+		return [];
 	}
+	// Author-based view
+	return [
+		{
+			field: 'author',
+			operator: 'isAny',
+			value: [ activeView ],
+		},
+	];
+}
 
-	// Active view: default sorting
-	if ( activeView === 'active' || ! activeView ) {
-		return {
-			...DEFAULT_VIEW,
-		};
-	}
-
-	// Author-based view: filter by author
+export function getDefaultView(): View {
 	return {
 		...DEFAULT_VIEW,
-		filters: [
-			{
-				field: 'author',
-				operator: 'isAny',
-				value: [ activeView ],
-			},
-		],
 	};
 }
 
@@ -67,36 +54,35 @@ export async function ensureView(
 	activeView?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const defaultView = getDefaultView( activeView );
+	const defaultView = getDefaultView();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template',
-		slug: activeView ?? 'active',
+		slug: 'default-new',
 		defaultView,
+		activeFilters: getActiveFiltersForTab( activeView ?? 'active' ),
 		queryParams: search,
 	} );
 }
 
-export function getDefaultViewLegacy( activeView?: string ): View {
-	// All templates view (default) - remove 'active' and 'slug' fields
-	if ( activeView === 'all' || ! activeView ) {
-		return {
-			...DEFAULT_VIEW,
-			fields: [ 'author' ], // Remove 'active' and 'slug' fields
-		};
+export function getActiveFiltersForTabLegacy( activeView: string ): Filter[] {
+	if ( activeView === 'all' ) {
+		return [];
 	}
+	// Author-based view
+	return [
+		{
+			field: 'author',
+			operator: 'isAny',
+			value: [ activeView ],
+		},
+	];
+}
 
-	// Author-based view: filter by author
+export function getDefaultViewLegacy(): View {
 	return {
 		...DEFAULT_VIEW,
 		fields: [ 'author' ],
-		filters: [
-			{
-				field: 'author',
-				operator: 'isAny',
-				value: [ activeView ],
-			},
-		],
 	};
 }
 
@@ -104,12 +90,13 @@ export async function ensureViewLegacy(
 	activeView?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const defaultView = getDefaultViewLegacy( activeView );
+	const defaultView = getDefaultViewLegacy();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template',
-		slug: activeView ?? 'all',
+		slug: 'default-new',
 		defaultView,
+		activeFilters: getActiveFiltersForTabLegacy( activeView ?? 'all' ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -33,6 +33,7 @@ import { CreateTemplatePartModal } from '@wordpress/fields';
 import { unlock } from '../lock-unlock';
 import {
 	getDefaultView,
+	getActiveFiltersForTab,
 	DEFAULT_VIEWS,
 	DEFAULT_LAYOUTS,
 	viewToQuery,
@@ -79,8 +80,13 @@ function TemplatePartList() {
 		useState( false );
 
 	const defaultView: View = useMemo( () => {
-		return getDefaultView( postTypeObject, area );
-	}, [ postTypeObject, area ] );
+		return getDefaultView();
+	}, [] );
+
+	const activeFilters = useMemo(
+		() => getActiveFiltersForTab( area ),
+		[ area ]
+	);
 
 	// Callback to handle URL query parameter changes
 	const handleQueryParamsChange = useCallback(
@@ -99,8 +105,9 @@ function TemplatePartList() {
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
 		name: 'wp_template_part',
-		slug: area,
+		slug: 'default-new',
 		defaultView,
+		activeFilters,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -32,7 +32,7 @@ import { CreateTemplatePartModal } from '@wordpress/fields';
  */
 import { unlock } from '../lock-unlock';
 import {
-	getDefaultView,
+	DEFAULT_VIEW,
 	getActiveFiltersForTab,
 	DEFAULT_VIEWS,
 	DEFAULT_LAYOUTS,
@@ -79,9 +79,7 @@ function TemplatePartList() {
 	const [ showTemplatePartModal, setShowTemplatePartModal ] =
 		useState( false );
 
-	const defaultView: View = useMemo( () => {
-		return getDefaultView();
-	}, [] );
+	const defaultView = DEFAULT_VIEW;
 
 	const activeFilters = useMemo(
 		() => getActiveFiltersForTab( area ),

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { loadView } from '@wordpress/views';
-import { resolveSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import type { Type } from '@wordpress/core-data';
-import type { View } from '@wordpress/dataviews';
+import type { View, Filter } from '@wordpress/dataviews';
 
 /**
  * Navigation overlay template part area constant.
@@ -34,110 +31,61 @@ export const DEFAULT_LAYOUTS = {
 export const DEFAULT_VIEWS: {
 	slug: string;
 	label: string;
-	view: View;
 }[] = [
 	{
 		slug: 'all',
 		label: 'All Template Parts',
-		view: {
-			...DEFAULT_VIEW,
-		},
 	},
 	{
 		slug: 'header',
 		label: 'Headers',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'area',
-					operator: 'is',
-					value: 'header',
-				},
-			],
-		},
 	},
 	{
 		slug: 'footer',
 		label: 'Footers',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'area',
-					operator: 'is',
-					value: 'footer',
-				},
-			],
-		},
 	},
 	{
 		slug: 'sidebar',
 		label: 'Sidebars',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'area',
-					operator: 'is',
-					value: 'sidebar',
-				},
-			],
-		},
 	},
 	{
 		slug: NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
 		label: 'Overlays',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'area',
-					operator: 'is',
-					value: NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
-				},
-			],
-		},
 	},
 	{
 		slug: 'uncategorized',
 		label: 'General',
-		view: {
-			...DEFAULT_VIEW,
-			filters: [
-				{
-					field: 'area',
-					operator: 'is',
-					value: 'uncategorized',
-				},
-			],
-		},
 	},
 ];
 
-export function getDefaultView(
-	postType: Type | undefined,
-	area?: string
-): View {
-	// Find the view configuration by area
-	const viewConfig = DEFAULT_VIEWS.find( ( v ) => v.slug === area );
+export function getActiveFiltersForTab( area: string ): Filter[] {
+	if ( area === 'all' ) {
+		return [];
+	}
+	return [
+		{
+			field: 'area',
+			operator: 'is',
+			value: area,
+		},
+	];
+}
 
-	// Use the view from the config if found, otherwise use default
-	return viewConfig?.view || DEFAULT_VIEW;
+export function getDefaultView(): View {
+	return DEFAULT_VIEW;
 }
 
 export async function ensureView(
 	area?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const postTypeObject =
-		await resolveSelect( coreStore ).getPostType( 'wp_template_part' );
-	const defaultView = getDefaultView( postTypeObject, area );
+	const defaultView = getDefaultView();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template_part',
-		slug: area ?? 'all',
+		slug: 'default-new',
 		defaultView,
+		activeFilters: getActiveFiltersForTab( area ?? 'all' ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -11,7 +11,7 @@ import type { View, Filter } from '@wordpress/dataviews';
  */
 const NAVIGATION_OVERLAY_TEMPLATE_PART_AREA = 'navigation-overlay';
 
-const DEFAULT_VIEW: View = {
+export const DEFAULT_VIEW: View = {
 	type: 'grid' as const,
 	sort: {
 		field: 'date',
@@ -71,20 +71,15 @@ export function getActiveFiltersForTab( area: string ): Filter[] {
 	];
 }
 
-export function getDefaultView(): View {
-	return DEFAULT_VIEW;
-}
-
 export async function ensureView(
 	area?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const defaultView = getDefaultView();
 	return loadView( {
 		kind: 'postType',
 		name: 'wp_template_part',
 		slug: 'default-new',
-		defaultView,
+		defaultView: DEFAULT_VIEW,
 		activeFilters: getActiveFiltersForTab( area ?? 'all' ),
 		queryParams: search,
 	} );

--- a/test/e2e/specs/site-editor/pages-view-persistence.spec.js
+++ b/test/e2e/specs/site-editor/pages-view-persistence.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Pages View Persistence', () => {
 		}
 	} );
 
-	test( 'persists table layout and shows reset button across navigation', async ( {
+	test( 'persists table layout across all tabs with unified view persistence', async ( {
 		page,
 	} ) => {
 		// Change layout to table view
@@ -56,14 +56,13 @@ test.describe( 'Pages View Persistence', () => {
 			} )
 			.click();
 
-		// On Drafts view, we should be back to default view (list)
-		// and Reset button should not be visible/enabled for modifications
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
-		await expect( resetButton ).toBeHidden();
-		// Verify canvas (preview) is visible in list layout
-		await expect(
-			page.getByRole( 'region', { name: 'Editor content' } )
-		).toBeVisible();
+		// With unified persistence, Drafts tab should also show table layout
+		// since all tabs share the same persisted view
+		await expect( page.getByRole( 'table' ) ).toBeVisible();
+
+		// Reset button should still be visible on Drafts tab
+		await expect( resetButton ).toBeVisible();
+		await expect( resetButton ).toBeEnabled();
 
 		// Navigate back to All Pages
 		await page


### PR DESCRIPTION
## What

A lot of folks mentioned to me that the layout not persisting between tabs on dataviews based pages is confusing. This PR changes the behavior to share the persistence between the tabs and apply the tab as a filter on top of it.
 
## Summary
- All tabs of a given page now share a single persisted view preference. Tab-specific behavior (status/area/author filtering) becomes transient "active filters" applied on top of the persisted view but never stored.
- New `activeFilters` property in `ViewConfig` allows tab-controlled filters to be merged on read and stripped before persistence, using new `mergeActiveFilters` / `stripActiveFilterFields` utilities in `filter-utils.ts`.
- All call sites use a unified preference slug (`'default'` for edit-site, `'default-new'` for routes) instead of per-tab slugs, so changing layout/sort/fields on one tab persists when switching tabs.
- Fixes layout switching in edit-site by ensuring route area resolvers (`isListView`, `isTemplateListView`) read the same preference key as the list components, and by correcting the `updateView`/`history.invalidate()` call order.

## Test plan
- [ ] Navigate to Pages in edit-site → switch layout from list to table → verify canvas disappears and table renders full-width
- [ ] Switch between sidebar tabs (Published, Drafts, etc.) → verify table layout persists across tabs
- [ ] Click "Reset view" → verify it resets to default list layout with canvas
- [ ] Navigate to Templates in edit-site → verify layout switching works the same way
- [ ] Navigate to Pages in the new site editor (routes) → switch between tabs → verify layout persists
- [ ] On any list, add a user filter (e.g., author) → switch tabs → verify the user filter persists
- [ ] Verify "Reset view" button clears the shared persisted view in both editors
