### PR TITLE
Navigation Overlay: Add Create Overlay button

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -28,7 +28,11 @@ import {
 	useBlockEditingMode,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import {
+	EntityProvider,
+	store as coreStore,
+	useEntityRecords,
+} from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
@@ -79,7 +83,10 @@ import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
-import { DEFAULT_BLOCK } from '../constants';
+import {
+	DEFAULT_BLOCK,
+	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
+} from '../constants';
 import { getSubmenuVisibility } from '../utils/get-submenu-visibility';
 
 /**
@@ -382,6 +389,20 @@ function Navigation( {
 	const hasSubmenus = !! innerBlocks.find(
 		( block ) => block.name === 'core/navigation-submenu'
 	);
+
+	// Check if any overlay template parts exist
+	const { records: overlayTemplateParts } = useEntityRecords(
+		'postType',
+		'wp_template_part',
+		{
+			per_page: -1,
+		}
+	);
+	const hasOverlays =
+		overlayTemplateParts?.some(
+			( templatePart ) =>
+				templatePart.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA
+		) ?? false;
 
 	const {
 		replaceInnerBlocks,
@@ -914,6 +935,7 @@ function Navigation( {
 						overlayMenuPreviewId={ overlayMenuPreviewId }
 						isResponsive={ isResponsive }
 						currentTheme={ currentTheme }
+						hasOverlays={ hasOverlays }
 					/>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -31,6 +31,7 @@ import OverlayPreview from './overlay-preview';
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
  * @param {string}   props.currentTheme              Current theme stylesheet name.
+ * @param {boolean}  props.hasOverlays               Whether any overlay template parts exist.
  * @return {JSX.Element|null}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -46,6 +47,7 @@ export default function OverlayPanel( {
 	overlayMenuPreviewId,
 	isResponsive,
 	currentTheme,
+	hasOverlays,
 } ) {
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
@@ -76,7 +78,7 @@ export default function OverlayPanel( {
 					/>
 				) }
 
-				{ overlayMenu !== 'never' && overlay && (
+				{ overlayMenu !== 'never' && overlay && hasOverlays && (
 					<OverlayPreview
 						overlay={ overlay }
 						currentTheme={ currentTheme }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -6,6 +6,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,6 +50,8 @@ export default function OverlayPanel( {
 	currentTheme,
 	hasOverlays,
 } ) {
+	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
+
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
 			<VStack spacing={ 4 }>
@@ -75,15 +78,20 @@ export default function OverlayPanel( {
 						overlay={ overlay }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+						isCreatingOverlay={ isCreatingOverlay }
+						setIsCreatingOverlay={ setIsCreatingOverlay }
 					/>
 				) }
 
-				{ overlayMenu !== 'never' && overlay && hasOverlays && (
-					<OverlayPreview
-						overlay={ overlay }
-						currentTheme={ currentTheme }
-					/>
-				) }
+				{ overlayMenu !== 'never' &&
+					overlay &&
+					hasOverlays &&
+					! isCreatingOverlay && (
+						<OverlayPreview
+							overlay={ overlay }
+							currentTheme={ currentTheme }
+						/>
+					) }
 			</VStack>
 		</PanelBody>
 	);

--- a/packages/block-library/src/navigation/edit/overlay-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-preview.js
@@ -30,14 +30,13 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 		return createTemplatePartId( currentTheme, overlay );
 	}, [ currentTheme, overlay ] );
 
-	const { content, editedBlocks, hasResolved, recordExists } = useSelect(
+	const { content, editedBlocks, hasResolved } = useSelect(
 		( select ) => {
 			if ( ! templatePartId ) {
 				return {
 					content: null,
 					editedBlocks: null,
 					hasResolved: true,
-					recordExists: false,
 				};
 			}
 
@@ -60,7 +59,6 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 					templatePartId,
 					{ context: 'view' },
 				] ),
-				recordExists: !! editedRecord,
 			};
 		},
 		[ templatePartId ]
@@ -90,23 +88,6 @@ export default function OverlayPreview( { overlay, currentTheme } ) {
 		return (
 			<div className="wp-block-navigation__overlay-preview-loading">
 				<Spinner />
-			</div>
-		);
-	}
-
-	// Show message if the overlay template part has been deleted.
-	if ( hasResolved && ! recordExists ) {
-		return (
-			<div className="wp-block-navigation__overlay-preview-empty">
-				{ __( 'This overlay template part no longer exists.' ) }
-			</div>
-		);
-	}
-
-	if ( ! blocks || blocks.length === 0 ) {
-		return (
-			<div className="wp-block-navigation__overlay-preview-empty">
-				{ __( 'This overlay is empty.' ) }
 			</div>
 		);
 	}

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -261,7 +261,7 @@ export default function OverlayTemplatePartSelector( {
 				id={ headingId }
 				className="wp-block-navigation__overlay-selector-header"
 			>
-				{ __( 'Overlay Template' ) }
+				{ __( 'Overlay template' ) }
 			</h3>
 			{ hasResolved &&
 			( overlayTemplateParts.length === 0 ||

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -10,6 +11,7 @@ import {
 	FlexBlock,
 	FlexItem,
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -38,6 +40,11 @@ export default function OverlayTemplatePartSelector( {
 	setAttributes,
 	onNavigateToEntityRecord,
 } ) {
+	const headingId = useInstanceId(
+		OverlayTemplatePartSelector,
+		'wp-block-navigation__overlay-selector-heading'
+	);
+
 	const {
 		records: templateParts,
 		isResolving,
@@ -238,7 +245,10 @@ export default function OverlayTemplatePartSelector( {
 
 	return (
 		<div className="wp-block-navigation__overlay-selector">
-			<h3 className="wp-block-navigation__overlay-selector-header">
+			<h3
+				id={ headingId }
+				className="wp-block-navigation__overlay-selector-header"
+			>
 				{ __( 'Overlay Template' ) }
 			</h3>
 			{ hasResolved && overlayTemplateParts.length === 0 ? (
@@ -274,6 +284,8 @@ export default function OverlayTemplatePartSelector( {
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 								label={ __( 'Overlay template' ) }
+								hideLabelFromVision
+								aria-labelledby={ headingId }
 								value={ overlay || '' }
 								options={ options }
 								onChange={ handleSelectChange }
@@ -312,11 +324,15 @@ export default function OverlayTemplatePartSelector( {
 				alignment="flex-start"
 				className="wp-block-navigation__overlay-help-text-wrapper"
 			>
-				<p className="wp-block-navigation__overlay-help-text">
+				<Text
+					variant="muted"
+					isBlock
+					className="wp-block-navigation__overlay-help-text"
+				>
 					{ __(
 						'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
 					) }
-				</p>
+				</Text>
 			</HStack>
 		</div>
 	);

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -278,7 +278,10 @@ export default function OverlayTemplatePartSelector( {
 						showTooltip
 						className="wp-block-navigation__overlay-create-button"
 					/>
-					<HStack alignment="flex-start">
+					<HStack
+						alignment="flex-start"
+						className="wp-block-navigation__overlay-selector-controls"
+					>
 						<FlexBlock>
 							<SelectControl
 								__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -85,7 +85,7 @@ export default function OverlayTemplatePartSelector( {
 	const options = useMemo( () => {
 		const baseOptions = [
 			{
-				label: __( 'None (default)' ),
+				label: __( 'Default' ),
 				value: '',
 			},
 		];
@@ -238,54 +238,79 @@ export default function OverlayTemplatePartSelector( {
 
 	return (
 		<div className="wp-block-navigation__overlay-selector">
-			<Button
-				size="small"
-				icon={ plus }
-				onClick={ handleCreateOverlay }
-				disabled={ isCreateButtonDisabled }
-				accessibleWhenDisabled
-				isBusy={ isCreating }
-				label={ __( 'Create new overlay template' ) }
-				showTooltip
-				className="wp-block-navigation__overlay-create-button"
-			/>
-			<HStack alignment="flex-start">
-				<FlexBlock>
-					<SelectControl
+			<h3 className="wp-block-navigation__overlay-selector-header">
+				{ __( 'Overlay Template' ) }
+			</h3>
+			{ hasResolved && overlayTemplateParts.length === 0 ? (
+				<>
+					<Button
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Overlay template' ) }
-						value={ overlay || '' }
-						options={ options }
-						onChange={ handleSelectChange }
-						disabled={ isResolving }
+						variant="secondary"
+						onClick={ handleCreateOverlay }
+						disabled={ isCreateButtonDisabled }
 						accessibleWhenDisabled
-						help={ helpText }
+						isBusy={ isCreating }
+						className="wp-block-navigation__overlay-create-button-prominent"
+					>
+						{ __( 'Create overlay' ) }
+					</Button>
+					<p className="wp-block-navigation__overlay-help-text">
+						{ __(
+							'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
+						) }
+					</p>
+				</>
+			) : (
+				<>
+					<Button
+						size="small"
+						icon={ plus }
+						onClick={ handleCreateOverlay }
+						disabled={ isCreateButtonDisabled }
+						accessibleWhenDisabled
+						isBusy={ isCreating }
+						label={ __( 'Create new overlay template' ) }
+						showTooltip
+						className="wp-block-navigation__overlay-create-button"
 					/>
-				</FlexBlock>
-				{ overlay && hasResolved && selectedTemplatePart && (
-					<FlexItem>
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							onClick={ handleEditClick }
-							disabled={ ! onNavigateToEntityRecord }
-							accessibleWhenDisabled
-							label={ editButtonLabel }
-							showTooltip
-							className="wp-block-navigation__overlay-edit-button"
-						>
-							{ __( 'Edit' ) }
-						</Button>
-					</FlexItem>
-				) }
-			</HStack>
-			{ isOverlayMissing && (
-				<DeletedOverlayWarning
-					onClear={ handleClearOverlay }
-					onCreate={ handleCreateOverlay }
-					isCreating={ isCreating }
-				/>
+					<HStack alignment="flex-start">
+						<FlexBlock>
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								value={ overlay || '' }
+								options={ options }
+								onChange={ handleSelectChange }
+								disabled={ isResolving }
+								accessibleWhenDisabled
+								help={ helpText }
+							/>
+						</FlexBlock>
+						{ overlay && hasResolved && selectedTemplatePart && (
+							<FlexItem>
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+									onClick={ handleEditClick }
+									disabled={ ! onNavigateToEntityRecord }
+									accessibleWhenDisabled
+									label={ editButtonLabel }
+									showTooltip
+									className="wp-block-navigation__overlay-edit-button"
+								>
+									{ __( 'Edit' ) }
+								</Button>
+							</FlexItem>
+						) }
+					</HStack>
+					{ isOverlayMissing && (
+						<DeletedOverlayWarning
+							onClear={ handleClearOverlay }
+							onCreate={ handleCreateOverlay }
+							isCreating={ isCreating }
+						/>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -254,11 +254,6 @@ export default function OverlayTemplatePartSelector( {
 					>
 						{ __( 'Create overlay' ) }
 					</Button>
-					<p className="wp-block-navigation__overlay-help-text">
-						{ __(
-							'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
-						) }
-					</p>
 				</>
 			) : (
 				<>
@@ -312,6 +307,16 @@ export default function OverlayTemplatePartSelector( {
 					) }
 				</>
 			) }
+			<HStack
+				alignment="flex-start"
+				className="wp-block-navigation__overlay-help-text-wrapper"
+			>
+				<p className="wp-block-navigation__overlay-help-text">
+					{ __(
+						'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
+					) }
+				</p>
+			</HStack>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -33,12 +33,16 @@ import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
  * @param {string}   props.overlay                  Currently selected overlay template part ID.
  * @param {Function} props.setAttributes            Function to update block attributes.
  * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
+ * @param {boolean}  props.isCreatingOverlay        Whether an overlay is being created (lifted state).
+ * @param {Function} props.setIsCreatingOverlay     Function to set creating overlay state (lifted state).
  * @return {JSX.Element} The overlay template part selector component.
  */
 export default function OverlayTemplatePartSelector( {
 	overlay,
 	setAttributes,
 	onNavigateToEntityRecord,
+	isCreatingOverlay,
+	setIsCreatingOverlay,
 } ) {
 	const headingId = useInstanceId(
 		OverlayTemplatePartSelector,
@@ -60,8 +64,14 @@ export default function OverlayTemplatePartSelector( {
 		[]
 	);
 
-	// Track if we're currently creating a new overlay
-	const [ isCreating, setIsCreating ] = useState( false );
+	// Check state for creating status if provided, otherwise use local state
+	const [ localIsCreating, setLocalIsCreating ] = useState( false );
+	const isCreating =
+		isCreatingOverlay !== undefined ? isCreatingOverlay : localIsCreating;
+	const setIsCreating =
+		setIsCreatingOverlay !== undefined
+			? setIsCreatingOverlay
+			: setLocalIsCreating;
 
 	// Filter template parts by overlay area
 	const overlayTemplateParts = useMemo( () => {
@@ -183,6 +193,8 @@ export default function OverlayTemplatePartSelector( {
 					postId: templatePartId,
 					postType: 'wp_template_part',
 				} );
+			} else {
+				setIsCreating( false );
 			}
 		} catch ( error ) {
 			// Error handling pattern matches CreateTemplatePartModalContents.
@@ -198,7 +210,6 @@ export default function OverlayTemplatePartSelector( {
 					: __( 'An error occurred while creating the overlay.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
-		} finally {
 			setIsCreating( false );
 		}
 	}, [
@@ -207,6 +218,7 @@ export default function OverlayTemplatePartSelector( {
 		onNavigateToEntityRecord,
 		createErrorNotice,
 		currentTheme,
+		setIsCreating,
 	] );
 
 	const handleClearOverlay = useCallback( () => {
@@ -251,7 +263,9 @@ export default function OverlayTemplatePartSelector( {
 			>
 				{ __( 'Overlay Template' ) }
 			</h3>
-			{ hasResolved && overlayTemplateParts.length === 0 ? (
+			{ hasResolved &&
+			( overlayTemplateParts.length === 0 ||
+				( isCreating && overlayTemplateParts.length === 1 ) ) ? (
 				<>
 					<Button
 						__next40pxDefaultSize

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -273,6 +273,7 @@ export default function OverlayTemplatePartSelector( {
 							<SelectControl
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
+								label={ __( 'Overlay template' ) }
 								value={ overlay || '' }
 								options={ options }
 								onChange={ handleSelectChange }

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -119,7 +119,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 			expect( select ).toBeDisabled();
 		} );
@@ -165,7 +165,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			expect(
-				screen.getByRole( 'combobox', { name: 'Overlay Template' } )
+				screen.getByRole( 'combobox', { name: 'Overlay template' } )
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole( 'button', {
@@ -188,7 +188,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 			expect( select ).toBeInTheDocument();
 
@@ -243,7 +243,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 
 			await user.selectOptions( select, 'my-overlay' );
@@ -270,7 +270,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 
 			await user.selectOptions( select, '' );
@@ -295,7 +295,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 
 			expect( select ).toHaveValue( 'my-overlay' );
@@ -335,7 +335,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			// Component shows disabled select and disabled button when loading
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay Template',
+				name: 'Overlay template',
 			} );
 			expect( select ).toBeDisabled();
 
@@ -493,7 +493,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			// Should show dropdown selector
 			expect(
-				screen.getByRole( 'combobox', { name: 'Overlay Template' } )
+				screen.getByRole( 'combobox', { name: 'Overlay template' } )
 			).toBeInTheDocument();
 
 			// Should show default help text

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.js
@@ -119,7 +119,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 			expect( select ).toBeDisabled();
 		} );
@@ -165,7 +165,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			expect(
-				screen.getByRole( 'combobox', { name: 'Overlay template' } )
+				screen.getByRole( 'combobox', { name: 'Overlay Template' } )
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole( 'button', {
@@ -188,7 +188,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 			expect( select ).toBeInTheDocument();
 
@@ -243,7 +243,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			render( <OverlayTemplatePartSelector { ...defaultProps } /> );
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 
 			await user.selectOptions( select, 'my-overlay' );
@@ -270,7 +270,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 
 			await user.selectOptions( select, '' );
@@ -295,7 +295,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 			);
 
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 
 			expect( select ).toHaveValue( 'my-overlay' );
@@ -335,7 +335,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			// Component shows disabled select and disabled button when loading
 			const select = screen.getByRole( 'combobox', {
-				name: 'Overlay template',
+				name: 'Overlay Template',
 			} );
 			expect( select ).toBeDisabled();
 
@@ -493,7 +493,7 @@ describe( 'OverlayTemplatePartSelector', () => {
 
 			// Should show dropdown selector
 			expect(
-				screen.getByRole( 'combobox', { name: 'Overlay template' } )
+				screen.getByRole( 'combobox', { name: 'Overlay Template' } )
 			).toBeInTheDocument();
 
 			// Should show default help text

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -650,13 +650,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	grid-column: span 2;
 }
 
-// Nudge the edit button down to align with the select control input field.
-// The SelectControl has a label above it, so we need to offset the button
-// to align it with the input rather than the top of the control.
-.wp-block-navigation__overlay-edit-button {
-	margin-top: $grid-unit-30;
-}
-
 .wp-block-navigation__overlay-selector {
 	position: relative;
 }
@@ -672,7 +665,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 // Overlay Preview styles
 .wp-block-navigation__overlay-preview {
-	margin-top: $grid-unit-20;
 	border: 1px solid $gray-300;
 	border-radius: 2px;
 	overflow-y: auto;
@@ -719,4 +711,17 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 .wp-block-navigation__deleted-overlay-warning {
 	margin-top: $grid-unit-15;
+}
+
+// Create Overlay button
+.wp-block-navigation__overlay-create-button-prominent {
+	width: 100%;
+	justify-content: center;
+	margin-bottom: $grid-unit-10;
+}
+
+.wp-block-navigation__overlay-help-text {
+	margin-bottom: 0;
+	color: $gray-700;
+	font-size: 13px;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -720,7 +720,11 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-bottom: $grid-unit-10;
 }
 
-.wp-block-navigation__overlay-help-text {
+.wp-block-navigation__overlay-selector .wp-block-navigation__overlay-help-text-wrapper {
+	margin-top: $grid-unit-10;
+}
+
+.wp-block-navigation__overlay-selector .wp-block-navigation__overlay-help-text {
 	margin-bottom: 0;
 	color: $gray-700;
 	font-size: 13px;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -656,10 +656,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 .wp-block-navigation__overlay-selector-controls {
 	margin-bottom: $grid-unit-10;
-
-	.components-base-control__help {
-		margin-top: $grid-unit-20;
-	}
 }
 
 .wp-block-navigation__overlay-create-button {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -720,12 +720,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-bottom: $grid-unit-10;
 }
 
-.wp-block-navigation__overlay-selector .wp-block-navigation__overlay-help-text-wrapper {
+.wp-block-navigation__overlay-help-text-wrapper {
 	margin-top: $grid-unit-10;
-}
-
-.wp-block-navigation__overlay-selector .wp-block-navigation__overlay-help-text {
-	margin-bottom: 0;
-	color: $gray-700;
-	font-size: 13px;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -654,6 +654,14 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	position: relative;
 }
 
+.wp-block-navigation__overlay-selector-controls {
+	margin-bottom: $grid-unit-10;
+
+	.components-base-control__help {
+		margin-top: $grid-unit-20;
+	}
+}
+
 .wp-block-navigation__overlay-create-button {
 	position: absolute;
 	// Align with SelectControl label by offsetting by button padding


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
  https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

  ## What?
  Closes https://github.com/WordPress/gutenberg/issues/74773

  Adds a "Create overlay" button to the Navigation block's overlay settings when no overlay templates exist, replacing the less obvious small "+" icon button in the empty state.

  ## Why?
  The current UI for creating custom navigation overlays is unclear when none exist. The small "+" icon button above the dropdown isn't discoverable, making it difficult for users to understand how to create their first custom overlay template. This PR improves the empty state UX by providing a clear CTA.

  ## How?
  - Modified `overlay-template-part-selector.js` to conditionally render based on overlay template availability:
    - **Empty state (no overlays)**: Shows a "Create overlay" button with a heading and help text explaining what overlay templates do
    - **Overlays exist**: Shows the existing dropdown selector interface with the small "+" icon button
  - Changed the "None (default)" dropdown option to "Default"
  - Added CSS styling for the new button and help text
  - Updated the unit tests to reflect the new behaviour

  ## Testing Instructions

  ### Test empty state (no overlays)
  1. Ensure you have no existing overlay template parts (check Site Editor > Patterns > Template Parts, filter by "Navigation Overlay" area)
  2. Create a new post/page
  3. Insert a Navigation block
  4. Open Block Settings sidebar > Overlay panel
  5. Set "Overlay menu" to "Mobile" or "Always"
  6. You should see a "Create overlay" button with the heading "Overlay Template" and help text below it
  7. The dropdown selector should NOT be visible
  8. Click "Create overlay" button
  9. It should create a new overlay template and navigate to the template part editor

  ### Test with existing overlays
  1. After creating an overlay (or if overlays already exist)
  2. Return to the Navigation block settings > Overlay panel
  3. You should now see the dropdown selector with "Default" as the first option
  4. The small "+" icon button appears above the dropdown
  5. The button is no longer visible

  ### Test with a theme that includes overlays
  1. Use a theme that provides navigation overlay template parts
  2. Insert a Navigation block
  3. Open Block Settings > Overlay panel > Set overlay visibility
  4. The dropdown selector appears (NOT the prominent button)
  5. Theme overlay appears in the dropdown options

  ### Testing Instructions for Keyboard
  1. Navigate to the Navigation block using Tab
  2. Press Tab to enter Block Settings
  3. Use Arrow keys to navigate to the Overlay panel
  4. When the prominent "Create overlay" button is visible:
     - Press Tab to focus the button
     - Press Enter or Space to activate
     - Verify overlay creation and navigation occurs
  5. When dropdown is visible:
     - Press Tab to focus the dropdown
     - Use Arrow keys to select options
     - Press Tab to focus the small "+" icon button
     - Press Enter to create a new overlay

  ## Screenshots or screencast

| Before | After |
| ----- | ----- |
| <img width="589" height="607" alt="image" src="https://github.com/user-attachments/assets/f5c308c1-2039-4fb5-897a-5677054af227" /> | <img width="589" height="607" alt="image" src="https://github.com/user-attachments/assets/a1e4f61c-5fc9-4d75-aa41-a767e717aa5f" /> |