### PR TITLE
Added Missing Global Documentation class-wp-rest-block-editor-settings-controller file

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -437,6 +437,9 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 		 *
 		 * @since Gutenberg 5.8.0
 		 *
+		 * @global WP_Scripts $wp_scripts WordPress scripts objects.
+		 * @global WP_Styles  $wp_styles  WordPress styles objects.
+		 *
 		 * @param array $html_templates Optional. Array of HTML template strings.
 		 * @return array Structured asset data.
 		 */


### PR DESCRIPTION
### What? Why? How?

Improved code documentation by adding the missing @global annotation to the process_assets method in class-wp-rest-block-editor-settings-controller.php, ensuring better clarity and maintainability.

### Testing Instructions

1. Open lib/experimental/class-wp-rest-block-editor-settings-controller.php.
2. Confirm that the process_assets method now includes the required @global documentation.