### PR TITLE
Docs: Rename Interactivity API's 'API Reference' to 'Directives and Store'

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -546,9 +546,9 @@
 		"parent": "interactivity-api"
 	},
 	{
-		"title": "API Reference",
-		"slug": "api-reference",
-		"markdown_source": "../docs/reference-guides/interactivity-api/api-reference.md",
+		"title": "Directives and Store",
+		"slug": "directives-and-store",
+		"markdown_source": "../docs/reference-guides/interactivity-api/directives-and-store.md",
 		"parent": "interactivity-api"
 	},
 	{

--- a/docs/reference-guides/interactivity-api/README.md
+++ b/docs/reference-guides/interactivity-api/README.md
@@ -20,7 +20,7 @@ Use the following links to locate the topic you're interested in. If you have ne
 -   **[Quick Start Guide](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/iapi-quick-start-guide/):** Get a custom block using the Interactivity API up and running in less than one minute.
 -   **[Tutorial: A first look at the Interactivity API](https://developer.wordpress.org/news/2024/04/11/a-first-look-at-the-interactivity-api/)** This article from the [WordPress Developer Blog](https://developer.wordpress.org/news/) is a great way to get introduced to the Interactivity API.
 -   **[Core Concepts](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/)** Gain a better understanding of concepts and mental models related to Interactivity API development from this section.
--   **[API Reference](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/):** To take a deep dive into how the API works internally, the list of Directives, and how the Store works.
+-   **[Directives and Store](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/):** To take a deep dive into how the API works internally, the list of Directives, and how the Store works.
 -   **[Docs and Examples](#docs-examples):** Additional resources to learn/read more about the Interactivity API.
 
 To get a deeper understanding of what the Interactivity API is or find answers to questions you may have about this standard, check the following resources:
@@ -50,7 +50,7 @@ Install the Interactivity API to your project with the following command:
 npm install @wordpress/interactivity --save
 ```
 
-Import the store into your `view.js`. Refer to the [store documentation](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#the-store) for more information.
+Import the store into your `view.js`. Refer to the [store documentation](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#the-store) for more information.
 
 ```js
 import { store } from '@wordpress/interactivity';
@@ -103,7 +103,7 @@ To "activate" the Interactivity API in a DOM element (and its children), add the
 </div>
 ```
 
-Refer to the [`wp-interactive` documentation](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-interactive) for a more detailed description of this directive.
+Refer to the [`wp-interactive` documentation](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#wp-interactive) for a more detailed description of this directive.
 
 ## Docs & Examples
 

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -739,13 +739,13 @@ By using derived state, you create a more maintainable and less error-prone code
 
 Interactivity API offers a region-based navigation feature that dynamically replaces a part of the page without a full page reload. The [Query block](/docs/reference-guides/core-blocks.md#query-loop) natively supports this feature when the `Force page reload` toggle is disabled. Developers can use the same functionality in custom blocks by calling [`actions.navigate()`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity-router/#actions) from the [`@wordpress/interactivity-router`](https://github.com/WordPress/gutenberg/tree/trunk/packages/interactivity-router) script module.
 
-When using region-based navigation, it's crucial to ensure that your interactive blocks stay in sync with the server-provided global state and local context. By default, the Interactivity API will never overwrite the global state or local context with the server-provided values. The Interactivity API provides two functions to help manage this synchronization: [`getServerState()`](/docs/reference-guides/interactivity-api/api-reference.md#getserverstate) and [`getServerContext()`](/docs/reference-guides/interactivity-api/api-reference.md#getservercontext).
+When using region-based navigation, it's crucial to ensure that your interactive blocks stay in sync with the server-provided global state and local context. By default, the Interactivity API will never overwrite the global state or local context with the server-provided values. The Interactivity API provides two functions to help manage this synchronization: [`getServerState()`](/docs/reference-guides/interactivity-api/directives-and-store.md#getserverstate) and [`getServerContext()`](/docs/reference-guides/interactivity-api/directives-and-store.md#getservercontext).
 
 ### `getServerState()`
 
 `getServerState()` allows you to subscribe to changes in the **global state** that occur during client-side navigation. This function is analogous to `getServerContext()`, but it works with the global state instead of the local context.
 
-The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
+The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/directives-and-store.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
@@ -785,13 +785,13 @@ const { state } = store( 'myPlugin', {
 } );
 ```
 
-_Note: Actions that need to call synchronous event methods like `event.preventDefault()` must wrap the handler with `withSyncEvent()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/api-reference.md#withsyncevent) for details._
+_Note: Actions that need to call synchronous event methods like `event.preventDefault()` must wrap the handler with `withSyncEvent()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
 
 ### `getServerContext()`
 
 `getServerContext()` allows you to subscribe to changes in the **local context** that occur during client-side navigation. This function is analogous to `getServerState()`, but it works with the local context instead of the global state.
 
-The `getServerContext()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
+The `getServerContext()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/directives-and-store.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 
 Consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
@@ -837,7 +837,7 @@ Whenever you have interactive blocks that rely on global state or local context 
 ### Best Practices for using `getServerState()` and `getServerContext()`
 
 -   **Read-Only References:** Both `getServerState()` and `getServerContext()` return read-only objects. You can use those objects to update the global state or local context.
--   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) to react to state and context changes. Both `getServerState()` and `getServerContext()` return reactive objects. This means that their watch callbacks will only trigger when the value of a property changes. If the value remains the same, the callback will not re-trigger.
+-   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/directives-and-store.md#accessing-data-in-callbacks) to react to state and context changes. Both `getServerState()` and `getServerContext()` return reactive objects. This means that their watch callbacks will only trigger when the value of a property changes. If the value remains the same, the callback will not re-trigger.
 
 ## Config
 

--- a/docs/reference-guides/interactivity-api/directives-and-store.md
+++ b/docs/reference-guides/interactivity-api/directives-and-store.md
@@ -1,4 +1,4 @@
-# API Reference
+# Directives and Store
 
 <div class="callout callout-alert">
 Interactivity API is only available for WordPress 6.5 and above.

--- a/docs/reference-guides/interactivity-api/iapi-about.md
+++ b/docs/reference-guides/interactivity-api/iapi-about.md
@@ -56,7 +56,7 @@ _Dynamic block example_
 </div>
 ```
 
-As you can see, directives like [`data-wp-on--click`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-on) or [`data-wp-bind--hidden`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-bind) are added as custom HTML attributes. WordPress can process this HTML on the server, handling the directives’ logic and creating the appropriate markup.
+As you can see, directives like [`data-wp-on--click`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#wp-on) or [`data-wp-bind--hidden`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#wp-bind) are added as custom HTML attributes. WordPress can process this HTML on the server, handling the directives' logic and creating the appropriate markup.
 
 ### Backward compatible
 

--- a/docs/reference-guides/interactivity-api/iapi-faq.md
+++ b/docs/reference-guides/interactivity-api/iapi-faq.md
@@ -108,7 +108,7 @@ The API has been designed with performance in mind, so it shouldn’t be a probl
 
 ## Does it work with the Core Translation API?
 
-As the Interactivity API works perfectly with server-side rendering, you can use all the WordPress APIs including [`__()`](https://developer.wordpress.org/reference/functions/__/) and [`_e()`](https://developer.wordpress.org/reference/functions/_e/). You can use it to translate the text in the HTML (as you normally would) and even use it inside the store when [using `wp_interactivity_state()` on the server side](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#setting-the-store). It might look something like this:
+As the Interactivity API works perfectly with server-side rendering, you can use all the WordPress APIs including [`__()`](https://developer.wordpress.org/reference/functions/__/) and [`_e()`](https://developer.wordpress.org/reference/functions/_e/). You can use it to translate the text in the HTML (as you normally would) and even use it inside the store when [using `wp_interactivity_state()` on the server side](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#setting-the-store). It might look something like this:
 
 ```php
 // render.php
@@ -124,7 +124,7 @@ A translation API compatible with script modules (needed for the Interactivity A
 
 ## I’m concerned about XSS; can JavaScript be injected into directives?
 
-No. The Interactivity API only allows for [References](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#values-of-directives-are-references-to-store-properties) to be passed as values to the directives. This way, there is no need to eval() full JavaScript expressions, so it’s not possible to perform XSS attacks.
+No. The Interactivity API only allows for [References](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#values-of-directives-are-references-to-store-properties) to be passed as values to the directives. This way, there is no need to eval() full JavaScript expressions, so it's not possible to perform XSS attacks.
 
 ## Does this work with Custom Security Policies?
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -231,7 +231,7 @@
 						"docs/reference-guides/interactivity-api/iapi-quick-start-guide.md": []
 					},
 					{
-						"docs/reference-guides/interactivity-api/api-reference.md": []
+						"docs/reference-guides/interactivity-api/directives-and-store.md": []
 					},
 					{
 						"docs/reference-guides/interactivity-api/iapi-about.md": []

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -177,7 +177,7 @@
 
 ### Enhancements
 
--   Export `splitTask` function from `@wordpress/interactivity` package to facilitate yielding to the main thread. See example in [async actions](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/interactivity-api/api-reference.md#async-actions) documentation. ([#62665](https://github.com/WordPress/gutenberg/pull/62665))
+-   Export `splitTask` function from `@wordpress/interactivity` package to facilitate yielding to the main thread. See example in [async actions](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/interactivity-api/directives-and-store.md#async-actions) documentation. ([#62665](https://github.com/WordPress/gutenberg/pull/62665))
 
 ## 6.1.0 (2024-06-15)
 


### PR DESCRIPTION
## What?

This PR renames the "API Reference" page within the Interactivity API documentation to "Directives and   
Store" and updates all internal references.

Fixes #61207.

Supersedes #68540 and #71067, which can be closed in favor of this PR.
Props to  @PoloSpark and @krishnak2c for those. 🙂

## Why?
Having "Interactivity API Reference" as the parent section and "API Reference" as a child page is redundant and could be confusing. The new name "Directives and Store":

- Is shorter (18 characters vs 36 for the alternative "Directives and Store API Reference").
- Follows the convention of other child pages in Reference Guides (none include "Reference" in their title).
- Aligns with #60782's goal of removing "Reference" from subsection names.
- Accurately describes the document's main content.


## How?

1. Renamed `api-reference.md` to `directives-and-store.md`
2. Updated the title from "# API Reference" to "# Directives and Store"
3. Updated all references across the codebase:
   - `docs/toc.json`
   - `docs/manifest.json`
   - `docs/reference-guides/interactivity-api/README.md`
   - `docs/reference-guides/interactivity-api/iapi-about.md`
   - `docs/reference-guides/interactivity-api/iapi-faq.md`
   - `docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md`
   - `packages/interactivity/CHANGELOG.md`