### PR TITLE
Refactor DataFormLayout: Introduce getWrapper function for improved l…

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Enhancements
 
 - DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
+- DataForm: Refactor wrapper selection logic with improved fallback behavior. [#74978](https://github.com/WordPress/gutenberg/pull/74978)
+
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/data-form-layout.tsx
@@ -12,6 +12,7 @@ import type {
 	FormValidity,
 	NormalizedForm,
 	NormalizedFormField,
+	NormalizedLayout,
 } from '../../types';
 import { getFormFieldLayout } from './index';
 import DataFormContext from '../dataform-context';
@@ -21,6 +22,29 @@ const DEFAULT_WRAPPER = ( { children }: { children: React.ReactNode } ) => (
 		{ children }
 	</Stack>
 );
+
+const getWrapper = (
+	layout: NormalizedLayout,
+	form: NormalizedForm,
+	as?: React.ComponentType< { children: React.ReactNode } >
+) => {
+	if ( as !== undefined ) {
+		return as;
+	}
+
+	if ( layout.type !== undefined ) {
+		return getFormFieldLayout( layout.type )?.wrapper ?? DEFAULT_WRAPPER;
+	}
+
+	const firstField = form.fields[ 0 ];
+	if ( ! firstField ) {
+		return DEFAULT_WRAPPER;
+	}
+
+	return (
+		getFormFieldLayout( firstField.layout.type )?.wrapper ?? DEFAULT_WRAPPER
+	);
+};
 
 export function DataFormLayout< Item >( {
 	data,
@@ -55,10 +79,7 @@ export function DataFormLayout< Item >( {
 		);
 	}
 
-	const Wrapper =
-		as ??
-		getFormFieldLayout( form.layout.type )?.wrapper ??
-		DEFAULT_WRAPPER;
+	const Wrapper = getWrapper( form.layout, form, as );
 
 	return (
 		<Wrapper layout={ form.layout }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #74999

Refactor wrapper selection in `DataFormLayout` by extracting it into a `getWrapper` helper and clarifying fallback behavior when `form.layout.type` is missing or not resolvable.

## Why?

The wrapper selection logic had become harder to follow and reason about. This change centralizes the decision in one place.

## How?

Wrapper resolution now follows this order:

1. Use `as` when provided.
2. If `form.layout.type` is defined, use its registered wrapper, falling back to `DEFAULT_WRAPPER`.
3. If `form.layout.type` is not picked (for example, it is undefined), use the first field’s layout wrapper, falling back to `DEFAULT_WRAPPER`.

This mirrors the existing layout defaulting during normalization: fields without an explicit layout inherit the form layout, and when the form layout is not picked, the first field effectively drives the layout. The wrapper fallback now follows the same approach.

Field layout components are unchanged and still selected per-field via `getFormFieldLayout( formField.layout.type )?.component`.

## Testing Instructions

1. Check the Card Layout Storybook.
2. Ensure that the gap across the cards is 24px.
3. Remove the `layout: "card"` from form object (https://github.com/WordPress/gutenberg/blob/18573f29732d94f76c6e59c907828b18e79015e0/packages/dataviews/src/dataform/stories/layout-card.tsx#L176-L177)
4. Ensure that the gap across the cards is 24px.

