### PR TITLE
Docs: Standardize use of @link tag for URL references in lib directory

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -111,7 +111,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 	 * `render_block_data` filter in 6.6.0 to avoid filtered attributes
 	 * breaking the application of the elements CSS class.
 	 *
-	 * @see https://github.com/WordPress/gutenberg/pull/59535.
+	 * @link https://github.com/WordPress/gutenberg/pull/59535
 	 *
 	 * The change in filter means, the argument types for this function
 	 * have changed and require deprecating.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -198,7 +198,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
  * This shim is INTENTIONALLY left out of core, as Social Links have never
  * landed there.
  *
- * @see https://github.com/WordPress/gutenberg/pull/19887
+ * @link https://github.com/WordPress/gutenberg/pull/19887
  */
 function gutenberg_register_legacy_social_link_blocks() {
 	$services = array(

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -132,7 +132,7 @@ class WP_Duotone_Gutenberg {
 	 * Direct port of colord's clamp function. Using min/max instead of
 	 * nested ternaries.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L23
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L23
 	 *
 	 * @param float $number The number to clamp.
 	 * @param float $min   The minimum value.
@@ -146,7 +146,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's clampHue function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L32
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L32
 	 *
 	 * @param float $degrees The hue to clamp.
 	 * @return float The clamped hue.
@@ -159,7 +159,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's parseHue function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L40
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L40
 	 *
 	 * @param float  $value The hue value to parse.
 	 * @param string $unit  The unit of the hue value.
@@ -183,7 +183,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's parseHex function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hex.ts#L8
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hex.ts#L8
 	 *
 	 * @param string $hex The hex string to parse.
 	 * @return array|null An array of RGBA values or null if the hex string is invalid.
@@ -225,7 +225,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's clampRgba function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/rgb.ts#L5
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/rgb.ts#L5
 	 *
 	 * @param array $rgba The RGBA array to clamp.
 	 * @return array The clamped RGBA array.
@@ -242,7 +242,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's parseRgbaString function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/rgbString.ts#L18
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/rgbString.ts#L18
 	 *
 	 * @param string $input The RGBA string to parse.
 	 * @return array|null An array of RGBA values or null if the RGB string is invalid.
@@ -293,7 +293,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's clampHsla function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L6
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L6
 	 *
 	 * @param array $hsla The HSLA array to clamp.
 	 * @return array The clamped HSLA array.
@@ -310,7 +310,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's hsvaToRgba function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsv.ts#L52
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsv.ts#L52
 	 *
 	 * @param array $hsva The HSVA array to convert.
 	 * @return array The RGBA array.
@@ -338,7 +338,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's hslaToHsva function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L33
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L33
 	 *
 	 * @param array $hsla The HSLA array to convert.
 	 * @return array The HSVA array.
@@ -362,7 +362,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's hslaToRgba function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L55
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hsl.ts#L55
 	 *
 	 * @param array $hsla The HSLA array to convert.
 	 * @return array The RGBA array.
@@ -374,7 +374,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Direct port of colord's parseHslaString function.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hslString.ts#L17
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/colorModels/hslString.ts#L17
 	 *
 	 * @param string $input The HSLA string to parse.
 	 * @return array|null An array of RGBA values or null if the RGB string is invalid.
@@ -424,7 +424,7 @@ class WP_Duotone_Gutenberg {
 	 * Direct port of colord's parse function simplified for our use case. This
 	 * version only supports string parsing and only returns RGBA values.
 	 *
-	 * @see https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/parse.ts#L37
+	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/parse.ts#L37
 	 *
 	 * @param string $input The string to parse.
 	 * @return array|null An array of RGBA values or null if the string is invalid.

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -13,7 +13,7 @@
  * to ensure that the conditional registration happens after Core and correctly determine whether
  * the filter should be added.
  *
- * @see https://github.com/WordPress/wordpress-develop/pull/7304
+ * @link https://github.com/WordPress/wordpress-develop/pull/7304
  */
 function gutenberg_register_interactivity_script_module_data_hooks() {
 	if ( ! has_filter( 'script_module_data_@wordpress/interactivity-router', array( wp_interactivity(), 'filter_script_module_interactivity_router_data' ) ) ) {


### PR DESCRIPTION

**Description**
This PR standardizes the use of inline documentation tags in the `lib` directory by replacing `@see` with `@link` for instances where URLs are referenced.

**Why this change?**
To align with the WordPress PHP Inline Documentation Standards, proper tag usage distinguishes between internal code references and external links:
*   **@see**: Used to reference a function, method, class, or variable within the codebase.
*   **@link**: Used to reference a URL, such as external documentation, Trac tickets, GitHub issues, or specifications.

This PR corrects instances in the following files where `@see` was incorrectly used to point to external URLs:
*   lib/block-supports/elements.php
*   lib/class-wp-duotone-gutenberg.php
*   lib/interactivity-api.php
*   lib/blocks.php
