### PR TITLE
Fix overlay menu preview button shrinking

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -64,19 +64,20 @@ export default function OverlayMenuPreviewButton( {
 					</>
 				) }
 			</Button>
-			{ overlayMenuPreview && (
-				<VStack
-					id={ overlayMenuPreviewId }
-					spacing={ 4 }
-					style={ containerStyle }
-				>
-					<OverlayMenuPreviewControls
-						hasIcon={ hasIcon }
-						icon={ icon }
-						setAttributes={ setAttributes }
-					/>
-				</VStack>
-			) }
+			<VStack
+				id={ overlayMenuPreviewId }
+				spacing={ 4 }
+				style={ {
+					...containerStyle,
+					display: overlayMenuPreview ? 'flex' : 'none',
+				} }
+			>
+				<OverlayMenuPreviewControls
+					hasIcon={ hasIcon }
+					icon={ icon }
+					setAttributes={ setAttributes }
+				/>
+			</VStack>
 		</>
 	);
 }


### PR DESCRIPTION
# What?
Closes #74982

Fixes an issue where the overlay menu settings panel shrinks and expands unexpectedly when interacting with the Menu button in the Navigation block.

## Why?
The shrinking behavior causes noticeable layout shifts in the editor UI, which negatively affects usability and visual consistency.  
This PR ensures a stable panel layout while toggling the overlay menu settings.

## How?
Instead of conditionally removing DOM elements, this PR switches to using a CSS `display` toggle.  
This prevents unnecessary layout recalculations and avoids the shrinking/expanding behavior.

## Testing Instructions
1. Open the WordPress editor.
2. Add a **Navigation** block.
3. Open the **Block Inspector**.
4. Go to **Settings → Overlay**.
5. Click the **Menu** button.
6. Verify that the settings panel does **not shrink or expand** unexpectedly.

### Testing Instructions for Keyboard
1. Open the WordPress editor.
2. Add a **Navigation** block using the keyboard.
3. Press `Tab` to move focus to the **Block Inspector**.
4. Navigate to **Settings → Overlay** using `Tab` / arrow keys.
5. Press `Enter` on the **Menu** button.
6. Confirm that the panel remains stable and no layout shift occurs.


