### PR TITLE
eslint-plugin: Add "never" option for dependency-group rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -512,5 +512,11 @@ module.exports = {
 				'react/react-in-jsx-scope': 'error',
 			},
 		},
+		{
+			files: [ 'packages/ui/src/**' ],
+			rules: {
+				'@wordpress/dependency-group': [ 'error', 'never' ],
+			},
+		},
 	],
 };

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The `dependency-group` rule now accepts an optional `"never"` mode to forbid dependency group comments.
+
 ## 24.0.0 (2026-01-16)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -6,7 +6,36 @@ Specifically, this ensures that:
 
 -   An import is preceded by "External dependencies", "WordPress dependencies", or "Internal dependencies" as appropriate by the import source.
 
+## Options
+
+This rule accepts a single option, which can be one of the following:
+
+-   `"always"` (default): Enforce that dependency group comments are present.
+-   `"never"`: Forbid dependency group comments.
+
+Example configuration:
+
+```json
+{
+	"rules": {
+		"@wordpress/dependency-group": [ "error", "always" ]
+	}
+}
+```
+
+Or to forbid dependency group comments:
+
+```json
+{
+	"rules": {
+		"@wordpress/dependency-group": [ "error", "never" ]
+	}
+}
+```
+
 ## Rule details
+
+### `"always"` (default)
 
 Examples of **incorrect** code for this rule:
 
@@ -32,5 +61,29 @@ import { Component } from 'react';
 /*
  * Internal dependencies
  */
+import edit from './edit';
+```
+
+### `"never"`
+
+Examples of **incorrect** code for this rule with `"never"` option:
+
+```js
+/*
+ * External dependencies
+ */
+import { camelCase } from 'change-case';
+
+/*
+ * Internal dependencies
+ */
+import edit from './edit';
+```
+
+Examples of **correct** code for this rule with `"never"` option:
+
+```js
+import { camelCase } from 'change-case';
+import { Component } from 'react';
 import edit from './edit';
 ```

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -53,6 +53,14 @@ const { Component } = require( '@wordpress/element' );
  */
 const edit = require( './edit' );`,
 		},
+		{
+			code: `
+import { camelCase } from 'change-case';
+import clsx from 'clsx';
+import { Component } from '@wordpress/element';
+import edit from './edit';`,
+			options: [ 'never' ],
+		},
 	],
 	invalid: [
 		{
@@ -130,6 +138,31 @@ const { Component } = require( '@wordpress/element' );
  * Internal dependencies
  */
 const edit = require( './edit' );`,
+		},
+		{
+			code: `
+/**
+ * External dependencies
+ */
+import { camelCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+
+import { Component } from '@wordpress/element';`,
+			options: [ 'never' ],
+			errors: [
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+			],
+			output: `
+import { camelCase } from 'change-case';
+import { Component } from '@wordpress/element';`,
 		},
 	],
 } );

--- a/packages/ui/src/box/test/box.test.tsx
+++ b/packages/ui/src/box/test/box.test.tsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
 import { render, screen } from '@testing-library/react';
-
-/**
- * WordPress dependencies
- */
 import { createRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { Box } from '../box';
 
 describe( 'Box', () => {

--- a/packages/ui/src/utils/types.ts
+++ b/packages/ui/src/utils/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import {
 	type ElementType,
 	type ComponentPropsWithoutRef,


### PR DESCRIPTION
## What?

Updates the `dependency-group` custom ESLint rule to support a new `'never'` option: Now, in addition to its default behavior to check for the presence of these "WordPress dependencies"-style DocBlock comment, it can now be used to forbid their usage.

As an example, the rule is enabled for files under the new `@wordpress/ui` package, which we've conventionally tried avoiding the use of these comments.

## Why?

This follows from #73616 / #73396 , which disabled the rule enforcing the presence of the comment, but did not act on existing instances. Since the convention has existed for a long time, the habit is hard to break, and many people continue to add the comments in their pull requests despite no longer being desirable.

In turn, this creates overhead for pull request authors and reviewers, who spend cycles going back and forth about the inclusion of the comments ([example](https://github.com/WordPress/gutenberg/pull/74625#discussion_r2693656484)).

The inclusion of a rule with an automated fixer can also help facilitate future automated removals.

## Testing Instructions

Verify that lint passes: `npm run lint:js`

You can also introduce an example failure in `packages/ui` and verify that it's flagged through `npm run lint:js` and fixed automatically via `npm run lint:js:fix`.