### PR TITLE
DataForm: Sync React-level validation to native inputs on date fields.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- DataForm: Sync React-level validation to native inputs on date fields. [#74994](https://github.com/WordPress/gutenberg/pull/74994)
 - Fix primary action visibility in table layout when the action doesn't support bulk operations, and fix compact action menu not visible on mobile when there is only one action. [#74836](https://github.com/WordPress/gutenberg/pull/74836)
 - DataViews: Use regular casing for bulk selection count. [#74573](https://github.com/WordPress/gutenberg/pull/74573)
 

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -191,36 +191,27 @@ function ValidatedDateControl< Item >( {
 		setCustomValidity( undefined );
 	}, [ inputRefs ] );
 
-	// Sync React-level validation to native inputs so that
-	// reportValidity() (for example called by the card on re-expand) correctly
-	// fires the 'invalid' event for custom validation errors.
+	// Sync React-level validation to native inputs and listen for
+	// 'invalid' events (e.g., from reportValidity() on card re-expand).
 	useEffect( () => {
 		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
 		const result = validity
 			? getCustomValidity( isValid, validity )
 			: undefined;
-		for ( const ref of refs ) {
-			const input = ref.current;
-			if ( input ) {
-				if ( result?.type === 'invalid' && result.message ) {
-					input.setCustomValidity( result.message );
-				} else {
-					input.setCustomValidity( '' );
-				}
-			}
-		}
-	}, [ inputRefs, isValid, validity ] );
-
-	// Listen for 'invalid' events on input refs (e.g., triggered by
-	// reportValidity() when the card re-expands after being collapsed).
-	useEffect( () => {
-		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
 		const handleInvalid = ( event: Event ) => {
 			event.preventDefault();
 			setIsTouched( true );
 		};
 		for ( const ref of refs ) {
-			ref.current?.addEventListener( 'invalid', handleInvalid );
+			const input = ref.current;
+			if ( input ) {
+				input.setCustomValidity(
+					result?.type === 'invalid' && result.message
+						? result.message
+						: ''
+				);
+				input.addEventListener( 'invalid', handleInvalid );
+			}
 		}
 		return () => {
 			for ( const ref of refs ) {
@@ -230,21 +221,16 @@ function ValidatedDateControl< Item >( {
 				);
 			}
 		};
-	}, [ inputRefs, setIsTouched ] );
+	}, [ inputRefs, isValid, validity, setIsTouched ] );
 
 	useEffect( () => {
 		if ( isTouched ) {
 			const timeoutId = setTimeout( () => {
-				if ( validity ) {
-					const result = getCustomValidity( isValid, validity );
-					if ( result ) {
-						setCustomValidity( result );
-					} else {
-						// Fall back to native validation for rules without
-						// custom messages (e.g., required without a custom
-						// error message).
-						validateRefs();
-					}
+				const result = validity
+					? getCustomValidity( isValid, validity )
+					: undefined;
+				if ( result ) {
+					setCustomValidity( result );
 				} else {
 					validateRefs();
 				}

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -191,6 +191,26 @@ function ValidatedDateControl< Item >( {
 		setCustomValidity( undefined );
 	}, [ inputRefs ] );
 
+	// Sync React-level validation to native inputs so that
+	// reportValidity() (for example called by the card on re-expand) correctly
+	// fires the 'invalid' event for custom validation errors.
+	useEffect( () => {
+		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
+		const result = validity
+			? getCustomValidity( isValid, validity )
+			: undefined;
+		for ( const ref of refs ) {
+			const input = ref.current;
+			if ( input ) {
+				if ( result?.type === 'invalid' && result.message ) {
+					input.setCustomValidity( result.message );
+				} else {
+					input.setCustomValidity( '' );
+				}
+			}
+		}
+	}, [ inputRefs, isValid, validity ] );
+
 	// Listen for 'invalid' events on input refs (e.g., triggered by
 	// reportValidity() when the card re-expands after being collapsed).
 	useEffect( () => {

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -191,17 +191,12 @@ function ValidatedDateControl< Item >( {
 		setCustomValidity( undefined );
 	}, [ inputRefs ] );
 
-	// Sync React-level validation to native inputs and listen for
-	// 'invalid' events (e.g., from reportValidity() on card re-expand).
+	// Sync React-level validation to native inputs.
 	useEffect( () => {
 		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
 		const result = validity
 			? getCustomValidity( isValid, validity )
 			: undefined;
-		const handleInvalid = ( event: Event ) => {
-			event.preventDefault();
-			setIsTouched( true );
-		};
 		for ( const ref of refs ) {
 			const input = ref.current;
 			if ( input ) {
@@ -210,18 +205,26 @@ function ValidatedDateControl< Item >( {
 						? result.message
 						: ''
 				);
-				input.addEventListener( 'invalid', handleInvalid );
 			}
+		}
+	}, [ inputRefs, isValid, validity ] );
+
+	// Listen for 'invalid' events (e.g., from reportValidity() on card re-expand).
+	useEffect( () => {
+		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
+		const handleInvalid = ( event: Event ) => {
+			event.preventDefault();
+			setIsTouched( true );
+		};
+		for ( const ref of refs ) {
+			ref.current?.addEventListener( 'invalid', handleInvalid );
 		}
 		return () => {
 			for ( const ref of refs ) {
-				ref.current?.removeEventListener(
-					'invalid',
-					handleInvalid
-				);
+				ref.current?.removeEventListener( 'invalid', handleInvalid );
 			}
 		};
-	}, [ inputRefs, isValid, validity, setIsTouched ] );
+	}, [ inputRefs, setIsTouched ] );
 
 	useEffect( () => {
 		if ( isTouched ) {

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -228,19 +228,15 @@ function ValidatedDateControl< Item >( {
 
 	useEffect( () => {
 		if ( isTouched ) {
-			const timeoutId = setTimeout( () => {
-				const result = validity
-					? getCustomValidity( isValid, validity )
-					: undefined;
-				if ( result ) {
-					setCustomValidity( result );
-				} else {
-					validateRefs();
-				}
-			}, 0 );
-			return () => clearTimeout( timeoutId );
+			const result = validity
+				? getCustomValidity( isValid, validity )
+				: undefined;
+			if ( result ) {
+				setCustomValidity( result );
+			} else {
+				validateRefs();
+			}
 		}
-		return undefined;
 	}, [ isTouched, isValid, validity, validateRefs ] );
 
 	const onBlur = ( event: React.FocusEvent< HTMLDivElement > ) => {

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -191,11 +191,40 @@ function ValidatedDateControl< Item >( {
 		setCustomValidity( undefined );
 	}, [ inputRefs ] );
 
+	// Listen for 'invalid' events on input refs (e.g., triggered by
+	// reportValidity() when the card re-expands after being collapsed).
+	useEffect( () => {
+		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
+		const handleInvalid = ( event: Event ) => {
+			event.preventDefault();
+			setIsTouched( true );
+		};
+		for ( const ref of refs ) {
+			ref.current?.addEventListener( 'invalid', handleInvalid );
+		}
+		return () => {
+			for ( const ref of refs ) {
+				ref.current?.removeEventListener(
+					'invalid',
+					handleInvalid
+				);
+			}
+		};
+	}, [ inputRefs, setIsTouched ] );
+
 	useEffect( () => {
 		if ( isTouched ) {
 			const timeoutId = setTimeout( () => {
 				if ( validity ) {
-					setCustomValidity( getCustomValidity( isValid, validity ) );
+					const result = getCustomValidity( isValid, validity );
+					if ( result ) {
+						setCustomValidity( result );
+					} else {
+						// Fall back to native validation for rules without
+						// custom messages (e.g., required without a custom
+						// error message).
+						validateRefs();
+					}
 				} else {
 					validateRefs();
 				}

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -227,15 +227,16 @@ function ValidatedDateControl< Item >( {
 	}, [ inputRefs, setIsTouched ] );
 
 	useEffect( () => {
-		if ( isTouched ) {
-			const result = validity
-				? getCustomValidity( isValid, validity )
-				: undefined;
-			if ( result ) {
-				setCustomValidity( result );
-			} else {
-				validateRefs();
-			}
+		if ( ! isTouched ) {
+			return;
+		}
+		const result = validity
+			? getCustomValidity( isValid, validity )
+			: undefined;
+		if ( result ) {
+			setCustomValidity( result );
+		} else {
+			validateRefs();
 		}
 	}, [ isTouched, isValid, validity, validateRefs ] );
 


### PR DESCRIPTION
This PR fixes a bug discovered by @oandregal at https://github.com/WordPress/gutenberg/pull/74547, where Date and DateRange fields were not displaying validation errors when a card-collapsible panel is collapsed and re-expanded, even though the panel header correctly shows the error count badge.

## Test plan

- Open Storybook validation story with `layout: card-collapsible` http://localhost:50240/?path=/story/dataviews-dataform--validation&args=layout:card-collapsible
- Expand "Date Fields" panel, collapse without filling fields, re-expand and verify all three fields show validation errors
- Set a past date, collapse and re-expand, verify "Date must not be in the past." error persists.
- Set a date range bigger than 30 days, see the validation message appears collapse and expand the panel verify the message shows.
- Verify normal blur-based validation in "regular" layout still works (no regression)
