### PR TITLE
DataViews: Show validation errors when a panel open

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 - DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
-- DataViews: Show validation errors when a panel opens. [#74995](https://github.com/WordPress/gutenberg/pull/74995)
+- DataViews: Show validation errors when a panel closes. [#74995](https://github.com/WordPress/gutenberg/pull/74995)
 
 ### Bug Fixes
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - DataViews: Add card form layout validation. [#74547](https://github.com/WordPress/gutenberg/pull/74547)
+- DataViews: Show validation errors when a panel opens. [#74995](https://github.com/WordPress/gutenberg/pull/74995)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -35,6 +35,7 @@ import type {
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import { getSummaryFields } from '../get-summary-fields';
+import useReportValidity from '../../../hooks/use-report-validity';
 
 function countInvalidFields( validity: FieldValidity | undefined ): number {
 	if ( ! validity ) {
@@ -235,18 +236,7 @@ export default function FormCardField< Item >( {
 
 	// When the card is expanded after being touched (collapsed with errors),
 	// trigger reportValidity to show field-level errors.
-	useEffect( () => {
-		if ( isOpen && touched && cardBodyRef.current ) {
-			// Trigger reportValidity on each input within the card to fire the
-			// 'invalid' event, which makes validated controls show errors.
-			const inputs = cardBodyRef.current.querySelectorAll(
-				'input, textarea, select, fieldset'
-			);
-			inputs.forEach( ( input ) => {
-				( input as HTMLInputElement ).reportValidity();
-			} );
-		}
-	}, [ isOpen, touched ] );
+	useReportValidity( cardBodyRef, isOpen && touched );
 
 	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -140,11 +140,6 @@ function PanelDropdown< Item >( {
 			contentClassName="dataforms-layouts-panel__field-dropdown"
 			popoverProps={ popoverProps }
 			focusOnMount={ false }
-			onToggle={ ( willOpen ) => {
-				if ( ! willOpen ) {
-					onCloseCallback?.();
-				}
-			} }
 			toggleProps={ {
 				size: 'compact',
 				variant: 'tertiary',
@@ -157,7 +152,12 @@ function PanelDropdown< Item >( {
 					labelPosition={ labelPosition }
 					fieldLabel={ fieldLabel }
 					disabled={ fieldDefinition.readOnly === true }
-					onClick={ onToggle }
+					onClick={ () => {
+						if ( isOpen ) {
+							onCloseCallback?.();
+						}
+						onToggle();
+					} }
 					aria-expanded={ isOpen }
 				/>
 			) }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -60,6 +60,29 @@ function DropdownHeader( {
 	);
 }
 
+function DropdownContentWithValidation( {
+	touched,
+	children,
+}: {
+	touched: boolean;
+	children: React.ReactNode;
+} ) {
+	const ref = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		if ( touched && ref.current ) {
+			const inputs = ref.current.querySelectorAll(
+				'input, textarea, select, fieldset'
+			);
+			inputs.forEach( ( input ) => {
+				( input as HTMLInputElement ).reportValidity();
+			} );
+		}
+	}, [ touched ] );
+
+	return <div ref={ ref }>{ children }</div>;
+}
+
 function PanelDropdown< Item >( {
 	data,
 	field,
@@ -69,7 +92,8 @@ function PanelDropdown< Item >( {
 	summaryFields,
 	fieldDefinition,
 	popoverAnchor,
-	onOpen,
+	onClose: onCloseCallback,
+	touched,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -79,7 +103,8 @@ function PanelDropdown< Item >( {
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	popoverAnchor: HTMLElement | null;
-	onOpen?: () => void;
+	onClose?: () => void;
+	touched: boolean;
 } ) {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
@@ -125,6 +150,11 @@ function PanelDropdown< Item >( {
 			contentClassName="dataforms-layouts-panel__field-dropdown"
 			popoverProps={ popoverProps }
 			focusOnMount={ false }
+			onToggle={ ( willOpen ) => {
+				if ( ! willOpen ) {
+					onCloseCallback?.();
+				}
+			} }
 			toggleProps={ {
 				size: 'compact',
 				variant: 'tertiary',
@@ -137,17 +167,12 @@ function PanelDropdown< Item >( {
 					labelPosition={ labelPosition }
 					fieldLabel={ fieldLabel }
 					disabled={ fieldDefinition.readOnly === true }
-					onClick={ () => {
-						if ( ! isOpen && onOpen ) {
-							onOpen();
-						}
-						onToggle();
-					} }
+					onClick={ onToggle }
 					aria-expanded={ isOpen }
 				/>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<>
+				<DropdownContentWithValidation touched={ touched }>
 					<DropdownHeader title={ fieldLabel } onClose={ onClose } />
 					<div ref={ focusOnMountRef }>
 						<DataFormLayout
@@ -174,7 +199,7 @@ function PanelDropdown< Item >( {
 							) }
 						</DataFormLayout>
 					</div>
-				</>
+				</DropdownContentWithValidation>
 			) }
 		/>
 	);

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -140,6 +140,11 @@ function PanelDropdown< Item >( {
 			contentClassName="dataforms-layouts-panel__field-dropdown"
 			popoverProps={ popoverProps }
 			focusOnMount={ false }
+			onToggle={ ( willOpen ) => {
+				if ( ! willOpen ) {
+					onCloseCallback?.();
+				}
+			} }
 			toggleProps={ {
 				size: 'compact',
 				variant: 'tertiary',
@@ -152,12 +157,7 @@ function PanelDropdown< Item >( {
 					labelPosition={ labelPosition }
 					fieldLabel={ fieldLabel }
 					disabled={ fieldDefinition.readOnly === true }
-					onClick={ () => {
-						if ( isOpen ) {
-							onCloseCallback?.();
-						}
-						onToggle();
-					} }
+					onClick={ onToggle }
 					aria-expanded={ isOpen }
 				/>
 			) }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -26,6 +26,7 @@ import type {
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
+import useReportValidity from '../../../hooks/use-report-validity';
 
 function DropdownHeader( {
 	title,
@@ -68,18 +69,7 @@ function DropdownContentWithValidation( {
 	children: React.ReactNode;
 } ) {
 	const ref = useRef< HTMLDivElement >( null );
-
-	useEffect( () => {
-		if ( touched && ref.current ) {
-			const inputs = ref.current.querySelectorAll(
-				'input, textarea, select, fieldset'
-			);
-			inputs.forEach( ( input ) => {
-				( input as HTMLInputElement ).reportValidity();
-			} );
-		}
-	}, [ touched ] );
-
+	useReportValidity( ref, touched );
 	return <div ref={ ref }>{ children }</div>;
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -147,9 +147,9 @@ export default function FormPanelField< Item >( {
 		null
 	);
 
-	// Track if the panel has been opened (touched) to only show errors after interaction.
+	// Track if the panel has been closed (touched) to only show errors after interaction.
 	const [ touched, setTouched ] = useState( false );
-	const handleOpen = () => setTouched( true );
+	const handleClose = () => setTouched( true );
 
 	const { fieldDefinition, summaryFields } =
 		getFieldDefinitionAndSummaryFields( layout, field, fields );
@@ -193,7 +193,8 @@ export default function FormPanelField< Item >( {
 				labelPosition={ labelPosition }
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
-				onOpen={ handleOpen }
+				onClose={ handleClose }
+				touched={ touched }
 			/>
 		) : (
 			<PanelDropdown
@@ -205,7 +206,8 @@ export default function FormPanelField< Item >( {
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				popoverAnchor={ popoverAnchor }
-				onOpen={ handleOpen }
+				onClose={ handleClose }
+				touched={ touched }
 			/>
 		);
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -12,8 +12,14 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext, useState, useMemo } from '@wordpress/element';
-import { useFocusOnMount } from '@wordpress/compose';
+import {
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -37,12 +43,14 @@ function ModalContent< Item >( {
 	onChange,
 	fieldLabel,
 	onClose,
+	touched,
 }: {
 	data: Item;
 	field: NormalizedFormField;
 	onChange: ( data: Partial< Item > ) => void;
 	onClose: () => void;
 	fieldLabel: string;
+	touched: boolean;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
@@ -92,6 +100,21 @@ function ModalContent< Item >( {
 	};
 
 	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
+	const contentRef = useRef< HTMLDivElement >( null );
+	const mergedRef = useMergeRefs( [ focusOnMountRef, contentRef ] );
+
+	// When the modal is opened after being previously closed (touched),
+	// trigger reportValidity to show field-level errors.
+	useEffect( () => {
+		if ( touched && contentRef.current ) {
+			const inputs = contentRef.current.querySelectorAll(
+				'input, textarea, select, fieldset'
+			);
+			inputs.forEach( ( input ) => {
+				( input as HTMLInputElement ).reportValidity();
+			} );
+		}
+	}, [ touched ] );
 
 	return (
 		<Modal
@@ -101,7 +124,7 @@ function ModalContent< Item >( {
 			title={ fieldLabel }
 			size="medium"
 		>
-			<div ref={ focusOnMountRef }>
+			<div ref={ mergedRef }>
 				<DataFormLayout
 					data={ modalData }
 					form={ form }
@@ -152,7 +175,8 @@ function PanelModal< Item >( {
 	labelPosition,
 	summaryFields,
 	fieldDefinition,
-	onOpen,
+	onClose: onCloseCallback,
+	touched,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -160,11 +184,17 @@ function PanelModal< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
-	onOpen?: () => void;
+	onClose?: () => void;
+	touched: boolean;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
+
+	const handleClose = () => {
+		setIsOpen( false );
+		onCloseCallback?.();
+	};
 
 	return (
 		<>
@@ -174,12 +204,7 @@ function PanelModal< Item >( {
 				labelPosition={ labelPosition }
 				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
-				onClick={ () => {
-					if ( onOpen ) {
-						onOpen();
-					}
-					setIsOpen( true );
-				} }
+				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
 			/>
 			{ isOpen && (
@@ -188,7 +213,8 @@ function PanelModal< Item >( {
 					field={ field }
 					onChange={ onChange }
 					fieldLabel={ fieldLabel ?? '' }
-					onClose={ () => setIsOpen( false ) }
+					onClose={ handleClose }
+					touched={ touched }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -12,13 +12,7 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useContext, useMemo, useRef, useState } from '@wordpress/element';
 import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
@@ -35,6 +29,7 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useFormValidity from '../../../hooks/use-form-validity';
+import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
 
 function ModalContent< Item >( {
@@ -105,16 +100,7 @@ function ModalContent< Item >( {
 
 	// When the modal is opened after being previously closed (touched),
 	// trigger reportValidity to show field-level errors.
-	useEffect( () => {
-		if ( touched && contentRef.current ) {
-			const inputs = contentRef.current.querySelectorAll(
-				'input, textarea, select, fieldset'
-			);
-			inputs.forEach( ( input ) => {
-				( input as HTMLInputElement ).reportValidity();
-			} );
-		}
-	}, [ touched ] );
+	useReportValidity( contentRef, touched );
 
 	return (
 		<Modal

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -102,7 +102,8 @@ export const Validation = {
 			description: 'Choose the form layout type.',
 			options: [
 				'regular',
-				'panel',
+				'panel-dropdown',
+				'panel-modal',
 				'card-collapsible',
 				'card-not-collapsible',
 				'details',

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -88,7 +88,8 @@ const ValidationComponent = ( {
 	minMax: boolean;
 	layout:
 		| 'regular'
-		| 'panel'
+		| 'panel-dropdown'
+		| 'panel-modal'
 		| 'card-collapsible'
 		| 'card-not-collapsible'
 		| 'details';
@@ -978,9 +979,16 @@ const ValidationComponent = ( {
 			},
 		];
 
-		if ( layout === 'panel' ) {
+		if ( layout === 'panel-dropdown' ) {
 			return {
-				layout: { type: 'panel' as const },
+				layout: { type: 'panel' as const, openAs: 'dropdown' as const },
+				fields: groupedFields,
+			};
+		}
+
+		if ( layout === 'panel-modal' ) {
+			return {
+				layout: { type: 'panel' as const, openAs: 'modal' as const },
 				fields: groupedFields,
 			};
 		}

--- a/packages/dataviews/src/hooks/use-report-validity.ts
+++ b/packages/dataviews/src/hooks/use-report-validity.ts
@@ -22,7 +22,7 @@ export default function useReportValidity(
 	useEffect( () => {
 		if ( shouldReport && ref.current ) {
 			const inputs = ref.current.querySelectorAll(
-				'input, textarea, select, fieldset'
+				'input, textarea, select'
 			);
 			inputs.forEach( ( input ) => {
 				( input as HTMLInputElement ).reportValidity();

--- a/packages/dataviews/src/hooks/use-report-validity.ts
+++ b/packages/dataviews/src/hooks/use-report-validity.ts
@@ -8,12 +8,12 @@ import { useEffect } from '@wordpress/element';
  * This fires the browser's `invalid` event on each input, which validated
  * controls listen to in order to display their error states.
  *
- * Used by card, dropdown, and modal layouts to show validation errors
+ * Used by panel and card layouts to show validation errors
  * immediately when their content becomes visible after prior interaction.
  *
- * @param ref             A ref to the container element.
- * @param shouldReport    Whether to trigger reportValidity. Typically
- *                        derived from `touched` state and open/visible state.
+ * @param ref          A ref to the container element.
+ * @param shouldReport Whether to trigger reportValidity. Typically
+ *                     derived from `touched` state and open/visible state.
  */
 export default function useReportValidity(
 	ref: React.RefObject< HTMLElement | null >,

--- a/packages/dataviews/src/hooks/use-report-validity.ts
+++ b/packages/dataviews/src/hooks/use-report-validity.ts
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Triggers `reportValidity()` on all form inputs within a container element.
+ * This fires the browser's `invalid` event on each input, which validated
+ * controls listen to in order to display their error states.
+ *
+ * Used by card, dropdown, and modal layouts to show validation errors
+ * immediately when their content becomes visible after prior interaction.
+ *
+ * @param ref             A ref to the container element.
+ * @param shouldReport    Whether to trigger reportValidity. Typically
+ *                        derived from `touched` state and open/visible state.
+ */
+export default function useReportValidity(
+	ref: React.RefObject< HTMLElement | null >,
+	shouldReport: boolean
+) {
+	useEffect( () => {
+		if ( shouldReport && ref.current ) {
+			const inputs = ref.current.querySelectorAll(
+				'input, textarea, select, fieldset'
+			);
+			inputs.forEach( ( input ) => {
+				( input as HTMLInputElement ).reportValidity();
+			} );
+		}
+	}, [ shouldReport, ref ] );
+}


### PR DESCRIPTION
This PR shows validation errors immediately when a panel (dropdown or modal) is re-opened, matching the existing card behavior from #74547.
This was a request by @oandregal at https://github.com/WordPress/gutenberg/issues/72321#issuecomment-3800370628.

## Why?

Cards already show field-level validation errors when expanded after prior interaction. Panels lacked this behavior — users had to interact with each field individually to see errors. This aligns panels with cards for a consistent validation experience.

## How?

- Extracted the `reportValidity()` logic shared by card, dropdown, and modal into a reusable `useReportValidity` hook.
- Changed the panel's `touched` state to be set on **close** (instead of open), matching how cards track interaction.
- When a panel is re-opened and `touched` is true, `reportValidity()` is called on all form inputs to trigger their error states.

## Testing Instructions

1. Open Storybook > DataViews > DataForm > Validation stories.
2. Select layout: **panel** or got to http://localhost:50240/?path=/story/dataviews-dataform--validation&args=layout:panel
3. Open a panel dropdown, clear a required field, close the dropdown.
4. Re-open the panel — validation errors should appear immediately on the form inputs.
5. Verify card validation still works as before.
