### PR TITLE
Post Content Block: Improve removal confirmation modal

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -48,21 +48,17 @@ export function BlockRemovalWarningModal( { rules } ) {
 		return;
 	}
 
-	// Support both string messages (backward compatibility) and structured message objects.
-	const isStructuredMessage = typeof message === 'object' && message !== null;
-	const title = isStructuredMessage ? message.title : __( 'Be careful!' );
-	const description = isStructuredMessage ? message.description : message;
-	const warning = isStructuredMessage ? message.warning : null;
-	const subtext = isStructuredMessage ? message.subtext : null;
-	const requireConfirmation = isStructuredMessage
-		? message.requireConfirmation
-		: false;
-	const confirmLabel = isStructuredMessage
-		? message.confirmLabel
-		: __( 'I understand the consequences' );
-	const removeLabel = isStructuredMessage
-		? message.removeLabel
-		: __( 'Delete' );
+	// Normalize message to a structured object. String messages (backward
+	// compatibility) are converted to the structured format with defaults.
+	const {
+		title = __( 'Confirm deletion' ),
+		description = message,
+		warning,
+		subtext,
+		requireConfirmation = false,
+		confirmLabel = __( 'I understand the consequences' ),
+		removeLabel = __( 'Delete' ),
+	} = typeof message === 'object' && message !== null ? message : {};
 
 	const isRemoveDisabled = requireConfirmation && ! confirmed;
 

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -83,7 +83,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 					{ ( warning || subtext ) && (
 						<p>
 							{ warning && <strong>{ warning }</strong> }
-							{ warning && subtext && <br /> }
+							{ warning && subtext && ' ' }
 							{ subtext }
 						</p>
 					) }

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -48,18 +48,9 @@ export function BlockRemovalWarningModal( { rules } ) {
 		return;
 	}
 
-	// Normalize message to a structured object. String messages (backward
-	// compatibility) are converted to the structured format with defaults.
-	const {
-		title = __( 'Confirm deletion' ),
-		description = message,
-		warning,
-		subtext,
-		requireConfirmation = false,
-		confirmLabel = __( 'I understand the consequences' ),
-		removeLabel = __( 'Delete' ),
-	} = typeof message === 'object' && message !== null ? message : {};
-
+	const isStructured = typeof message === 'object' && message !== null;
+	const description = isStructured ? message.description : message;
+	const requireConfirmation = isStructured && message.requireConfirmation;
 	const isRemoveDisabled = requireConfirmation && ! confirmed;
 
 	const onConfirmRemoval = () => {
@@ -69,25 +60,28 @@ export function BlockRemovalWarningModal( { rules } ) {
 
 	return (
 		<Modal
-			title={ title }
+			title={ __( 'Confirm deletion' ) }
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
 			<VStack spacing={ 4 }>
 				<div>
 					<p>{ description }</p>
-					{ ( warning || subtext ) && (
-						<p>
-							{ warning && <strong>{ warning }</strong> }
-							{ warning && subtext && ' ' }
-							{ subtext }
-						</p>
-					) }
+					{ isStructured &&
+						( message.warning || message.subtext ) && (
+							<p>
+								{ message.warning && (
+									<strong>{ message.warning }</strong>
+								) }
+								{ message.warning && message.subtext && ' ' }
+								{ message.subtext }
+							</p>
+						) }
 				</div>
 				{ requireConfirmation && (
 					<CheckboxControl
 						__nextHasNoMarginBottom
-						label={ confirmLabel }
+						label={ __( 'I understand the consequences' ) }
 						checked={ confirmed }
 						onChange={ setConfirmed }
 					/>
@@ -107,7 +101,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 						accessibleWhenDisabled
 						__next40pxDefaultSize
 					>
-						{ removeLabel }
+						{ __( 'Delete' ) }
 					</Button>
 				</HStack>
 			</VStack>

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Modal,
 	Button,
+	CheckboxControl,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -17,6 +19,7 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export function BlockRemovalWarningModal( { rules } ) {
+	const [ confirmed, setConfirmed ] = useState( false );
 	const { clientIds, selectPrevious, message } = useSelect( ( select ) =>
 		unlock( select( blockEditorStore ) ).getRemovalPromptData()
 	);
@@ -36,9 +39,32 @@ export function BlockRemovalWarningModal( { rules } ) {
 		};
 	}, [ rules, setBlockRemovalRules ] );
 
+	// Reset confirmed state when modal opens with new content.
+	useEffect( () => {
+		setConfirmed( false );
+	}, [ clientIds ] );
+
 	if ( ! message ) {
 		return;
 	}
+
+	// Support both string messages (backward compatibility) and structured message objects.
+	const isStructuredMessage = typeof message === 'object' && message !== null;
+	const title = isStructuredMessage ? message.title : __( 'Be careful!' );
+	const description = isStructuredMessage ? message.description : message;
+	const warning = isStructuredMessage ? message.warning : null;
+	const subtext = isStructuredMessage ? message.subtext : null;
+	const requireConfirmation = isStructuredMessage
+		? message.requireConfirmation
+		: false;
+	const confirmLabel = isStructuredMessage
+		? message.confirmLabel
+		: __( 'I understand the consequences' );
+	const removeLabel = isStructuredMessage
+		? message.removeLabel
+		: __( 'Delete' );
+
+	const isRemoveDisabled = requireConfirmation && ! confirmed;
 
 	const onConfirmRemoval = () => {
 		privateRemoveBlocks( clientIds, selectPrevious, /* force */ true );
@@ -47,27 +73,48 @@ export function BlockRemovalWarningModal( { rules } ) {
 
 	return (
 		<Modal
-			title={ __( 'Be careful!' ) }
+			title={ title }
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
-			<p>{ message }</p>
-			<HStack justify="right">
-				<Button
-					variant="tertiary"
-					onClick={ clearBlockRemovalPrompt }
-					__next40pxDefaultSize
-				>
-					{ __( 'Cancel' ) }
-				</Button>
-				<Button
-					variant="primary"
-					onClick={ onConfirmRemoval }
-					__next40pxDefaultSize
-				>
-					{ __( 'Delete' ) }
-				</Button>
-			</HStack>
+			<VStack spacing={ 4 }>
+				<div>
+					<p>{ description }</p>
+					{ ( warning || subtext ) && (
+						<p>
+							{ warning && <strong>{ warning }</strong> }
+							{ warning && subtext && <br /> }
+							{ subtext }
+						</p>
+					) }
+				</div>
+				{ requireConfirmation && (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ confirmLabel }
+						checked={ confirmed }
+						onChange={ setConfirmed }
+					/>
+				) }
+				<HStack justify="right">
+					<Button
+						variant="tertiary"
+						onClick={ clearBlockRemovalPrompt }
+						__next40pxDefaultSize
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ onConfirmRemoval }
+						disabled={ isRemoveDisabled }
+						accessibleWhenDisabled
+						__next40pxDefaultSize
+					>
+						{ removeLabel }
+					</Button>
+				</HStack>
+			</VStack>
 		</Modal>
 	);
 }

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 
-import { _n } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -27,6 +27,27 @@ const BLOCK_REMOVAL_RULES = [
 		// The warning is only shown when a user manipulates templates or template parts.
 		postTypes: [ 'wp_template', 'wp_template_part' ],
 		callback( removedBlocks ) {
+			// Check specifically for post-content block first.
+			const removedPostContentBlocks = removedBlocks.filter(
+				( { name } ) => name === 'core/post-content'
+			);
+			if ( removedPostContentBlocks.length ) {
+				return {
+					title: __( 'Remove content block?' ),
+					description: __(
+						'This block displays the content of posts and pages using this template.'
+					),
+					warning: __(
+						'If you delete it, content using this template will not display.'
+					),
+					subtext: __( 'Visitors will see blank pages.' ),
+					requireConfirmation: true,
+					confirmLabel: __( 'I understand the consequences' ),
+					removeLabel: __( 'Remove' ),
+				};
+			}
+
+			// Other template blocks (post-template, query) - keep existing string message.
 			const removedTemplateBlocks = removedBlocks.filter( ( { name } ) =>
 				TEMPLATE_BLOCKS.includes( name )
 			);

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -33,7 +33,6 @@ const BLOCK_REMOVAL_RULES = [
 			);
 			if ( removedPostContentBlocks.length ) {
 				return {
-					title: __( 'Be careful!' ),
 					description: __(
 						'This block displays the content of posts and pages using this template.'
 					),
@@ -42,8 +41,6 @@ const BLOCK_REMOVAL_RULES = [
 					),
 					subtext: __( 'Visitors will see blank pages.' ),
 					requireConfirmation: true,
-					confirmLabel: __( 'I understand the consequences' ),
-					removeLabel: __( 'Delete' ),
 				};
 			}
 

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -33,17 +33,17 @@ const BLOCK_REMOVAL_RULES = [
 			);
 			if ( removedPostContentBlocks.length ) {
 				return {
-					title: __( 'Remove content block?' ),
+					title: __( 'Be careful!' ),
 					description: __(
 						'This block displays the content of posts and pages using this template.'
 					),
 					warning: __(
-						'If you delete it, content using this template will not display.'
+						'If you delete it, posts or pages using this template will not display any content.'
 					),
 					subtext: __( 'Visitors will see blank pages.' ),
 					requireConfirmation: true,
 					confirmLabel: __( 'I understand the consequences' ),
-					removeLabel: __( 'Remove' ),
+					removeLabel: __( 'Delete' ),
 				};
 			}
 

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -72,6 +72,52 @@ test.describe( 'Site editor block removal prompt', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should show confirmation checkbox and disabled Delete button when removing Post Content block', async ( {
+		admin,
+		page,
+	} ) => {
+		// Navigate to the singular template which contains a Post Content block.
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//singular',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		// Open and focus List View.
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Document Overview' } )
+			.click();
+
+		// The singular template has Post Content at the top level.
+		const listView = page.getByRole( 'region', {
+			name: 'Document Overview',
+		} );
+		await listView.getByRole( 'link', { name: 'Content' } ).click();
+		await page.keyboard.press( 'Backspace' );
+
+		// Verify the modal appears with the confirmation checkbox.
+		const dialog = page.getByRole( 'dialog' );
+		await expect( dialog ).toBeVisible();
+
+		const checkbox = dialog.getByRole( 'checkbox', {
+			name: 'I understand the consequences',
+		} );
+		await expect( checkbox ).toBeVisible();
+
+		// The Delete button should be disabled before the checkbox is checked.
+		const deleteButton = dialog.getByRole( 'button', {
+			name: 'Delete',
+		} );
+		await expect( deleteButton ).toBeDisabled();
+
+		// Check the confirmation checkbox.
+		await checkbox.click();
+
+		// The Delete button should now be enabled.
+		await expect( deleteButton ).toBeEnabled();
+	} );
+
 	test( 'should not appear when attempting to remove something else', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Enhances the block removal warning modal specifically for the Post Content block with a clearer, more informative design that requires explicit user confirmation before removal.

## Why?

Addresses #58136 - Users frequently accidentally remove the Post Content block from templates, causing their content to not display. The existing warning modal was not effective at preventing this.

## How?

**BlockRemovalWarningModal** (`packages/block-editor/src/components/block-removal-warning-modal/index.js`):
- Added support for structured message objects (in addition to simple strings for backward compatibility)
- Added confirmation checkbox that must be checked before the Remove button is enabled
- Support for custom title, description, warning text, and button labels

**BlockRemovalWarnings** (`packages/editor/src/components/block-removal-warnings/index.js`):
- Post Content block now returns a structured message object with:
  - Title: "Remove content block?"
  - Clear description of what the block does
  - Bold warning about consequences
  - Subtext about visitor impact
  - Required confirmation checkbox
- Other template blocks (Query, Post Template) continue using the existing string-based warning

## Design

Based on design from @jasmussen in #58136:

![Modal design](https://github.com/user-attachments/assets/0cfb863b-001f-48e7-b792-f9ed79e0f365)

## Testing Instructions

1. Open Site Editor > Templates > Pages
2. Select the Post Content block
3. Delete it (press Delete or use block toolbar)
4. Verify the new modal appears with:
   - Title: "Remove content block?"
   - Description, bold warning, and subtext
   - Checkbox: "I understand the consequences"
   - "Remove" button disabled until checkbox is checked
5. Verify Cancel closes modal without removing block
6. Verify Remove (after checkbox) removes the block
7. Test backward compatibility: remove a Query block - should show old-style "Be careful!" modal

**Video**

Here's what the new experience looks like:

https://github.com/user-attachments/assets/89685237-0c9f-4e7d-99e9-7a40e1fb4626

🤖 Generated with [Claude Code](https://claude.ai/code)