### PR TITLE
Fix flaky 'Revisions' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -33,6 +33,7 @@ test.describe( 'Revisions', () => {
 		await editor.saveDraft();
 
 		// Open the post settings sidebar and click the Revisions button.
+		await editor.openDocumentSettingsSidebar();
 		const settingsSidebar = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );


### PR DESCRIPTION
## What?
This is a follow-up to #74771.

PR fixes flaky 'Revisions' e2e test. It is recommended to open the sidebar before performing actions on it.

## Why?
The sidebar state can be persisted between test runs on the same shard, as it's a user preference.

## Failed runs

* https://github.com/WordPress/gutenberg/actions/runs/21420518611/job/61678780502
* https://github.com/WordPress/gutenberg/actions/runs/21417887254/job/61670673198?pr=74985

## Testing Instructions
CI checks are green.

## Screenshots or screencast <!-- if applicable -->

<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/8fbff6d4-b9da-4800-a748-156870bb55a3" />
