### PR TITLE
Remove comment about non-existing property

### DIFF
--- a/backport-changelog/7.0/10767.md
+++ b/backport-changelog/7.0/10767.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10767
 
 * https://github.com/WordPress/gutenberg/pull/74529
+* https://github.com/WordPress/gutenberg/pull/75003

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -242,7 +242,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.3.0 Added `writing-mode` property.
 	 * @since 6.6.0 Added `background-[image|position|repeat|size]` properties.
 	 * @since 7.0.0 Added `dimensions.width` and `dimensions.height`.
-	 * @since 7.0.0 Added `gap` property.
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?


In #74529 I merged a comment referring to an earlier iteration of that PR, which should have been removed. Removing it now so it doesn't cause confusion!


