### PR TITLE
Docs: Add missing @global documentation in block library

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -133,7 +133,6 @@ add_filter( 'comments_list_table_query_args', 'gutenberg_hide_note_from_comment_
 /**
  * Override comment_count to exclude notes from the comment count.
  *
- * @global wpdb $wpdb WordPress database abstraction object.
  * @param int|null $new     The new comment count. Default null.
  * @param int      $old     The old comment count.
  * @param int      $post_id Post ID.

--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -133,6 +133,7 @@ add_filter( 'comments_list_table_query_args', 'gutenberg_hide_note_from_comment_
 /**
  * Override comment_count to exclude notes from the comment count.
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
  * @param int|null $new     The new comment count. Default null.
  * @param int      $old     The old comment count.
  * @param int      $post_id Post ID.

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -20,6 +20,8 @@ $block_core_latest_posts_excerpt_length = 0;
  *
  * @since 5.4.0
  *
+ * @global int $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
+ *
  * @return int Returns the global $block_core_latest_posts_excerpt_length variable
  *             to allow the excerpt_length filter respect the Latest Block setting.
  */

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -160,6 +160,9 @@ function render_block_core_template_part( $attributes ) {
 	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
 
 	// Handle embeds for block template parts.
+	/**
+	 * @global WP_Embed $wp_embed WordPress Embed object.
+	 */
 	global $wp_embed;
 	$content = $wp_embed->autoembed( $content );
 

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -159,8 +159,9 @@ function render_block_core_template_part( $attributes ) {
 	$content = convert_smilies( $content );
 	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
 
-	// Handle embeds for block template parts.
 	/**
+	 * Handle embeds for block template parts.
+	 *
 	 * @global WP_Embed $wp_embed WordPress Embed object.
 	 */
 	global $wp_embed;


### PR DESCRIPTION
### What? Why? How?

Improved code documentation by adding the missing @global annotations to
packages/block-library/src/template-part/index.php and packages/block-library/src/latest-posts/index.php, ensuring better clarity and maintainability.

### Testing Instructions
1. Open packages/block-library/src/template-part/index.php and packages/block-library/src/latest-posts/index.php.
2. Confirm that the methods now include the required @global documentation.