### PR TITLE
Blocks: Try prepending 'https' to URLs without protocol

### DIFF
--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getProtocol, prependHTTP } from '@wordpress/url';
+import { getProtocol, prependHTTPS } from '@wordpress/url';
 import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -41,7 +41,7 @@ export const handleDirectEntry = ( val ) => {
 		{
 			id: val,
 			title: val,
-			url: type === 'URL' ? prependHTTP( val ) : val,
+			url: type === 'URL' ? prependHTTPS( val ) : val,
 			type,
 		},
 	] );

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -27,7 +27,7 @@ import {
 	fullscreen,
 	linkOff,
 } from '@wordpress/icons';
-import { prependHTTP } from '@wordpress/url';
+import { prependHTTPS } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -156,7 +156,7 @@ const ImageURLInputUI = ( {
 					)?.linkDestination || LINK_DESTINATION_CUSTOM;
 
 				onChangeUrl( {
-					href: prependHTTP( urlInput ),
+					href: prependHTTPS( urlInput ),
 					linkDestination: selectedDestination,
 					lightbox: { enabled: false },
 				} );

--- a/packages/block-library/src/button/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/get-updated-link-attributes.js
@@ -1,12 +1,12 @@
 /**
+ * WordPress dependencies
+ */
+import { prependHTTPS } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
 import { NEW_TAB_REL, NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
-
-/**
- * WordPress dependencies
- */
-import { prependHTTP } from '@wordpress/url';
 
 /**
  * Updates the link attributes.
@@ -47,7 +47,7 @@ export function getUpdatedLinkAttributes( {
 	}
 
 	return {
-		url: prependHTTP( url ),
+		url: prependHTTPS( url ),
 		linkTarget: newLinkTarget,
 		rel: updatedRel || undefined,
 	};

--- a/packages/block-library/src/button/test/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/test/get-updated-link-attributes.js
@@ -13,7 +13,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( '_blank' );
 		expect( result.rel ).toEqual( 'noreferrer noopener' );
 	} );
@@ -27,7 +27,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( undefined );
 		expect( result.rel ).toEqual( undefined );
 	} );
@@ -42,7 +42,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( '_blank' );
 		expect( result.rel ).toEqual(
 			'rel_value noreferrer noopener nofollow'
@@ -59,7 +59,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( '_blank' );
 		expect( result.rel ).toEqual( 'rel_value noreferrer noopener' );
 	} );
@@ -74,7 +74,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( undefined );
 		expect( result.rel ).toEqual( 'rel_value nofollow' );
 	} );
@@ -89,7 +89,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( undefined );
 		expect( result.rel ).toEqual( 'nofollow' );
 	} );
@@ -104,7 +104,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( '_blank' );
 		expect( result.rel ).toEqual(
 			'rel_value nofollow noreferrer noopener'
@@ -121,7 +121,7 @@ describe( 'getUpdatedLinkAttributes method', () => {
 
 		const result = getUpdatedLinkAttributes( options );
 
-		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.url ).toEqual( 'https://example.com' );
 		expect( result.linkTarget ).toEqual( '_blank' );
 		expect( result.rel ).toEqual( 'rel_value noreferrer noopener' );
 	} );

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -22,7 +22,7 @@ import {
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { grid, list, pencil, rss } from '@wordpress/icons';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { prependHTTP } from '@wordpress/url';
+import { prependHTTPS } from '@wordpress/url';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { useDisabled } from '@wordpress/compose';
 
@@ -65,7 +65,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 		event.preventDefault();
 
 		if ( feedURL ) {
-			setAttributes( { feedURL: prependHTTP( feedURL ) } );
+			setAttributes( { feedURL: prependHTTPS( feedURL ) } );
 			setIsEditing( false );
 		}
 	}

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Buttons', () => {
 		).toBeVisible();
 	} );
 
-	test( 'appends http protocol to links added which are missing a protocol', async ( {
+	test( 'appends https protocol to links added which are missing a protocol', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -138,8 +138,8 @@ test.describe( 'Buttons', () => {
 		await pageUtils.pressKeys( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
-		// Check the value of the URL input has had http:// prepended.
-		await expect( urlInput ).toHaveValue( 'http://example.com' );
+		// Check the value of the URL input has had https:// prepended.
+		await expect( urlInput ).toHaveValue( 'https://example.com' );
 	} );
 
 	test( 'can jump to the link editor using the keyboard shortcut', async ( {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -634,7 +634,7 @@ test.describe( 'Image', () => {
 		await expect( linkDom ).toHaveAttribute( 'href', url );
 	} );
 
-	test( 'appends http protocol to links added which are missing a protocol', async ( {
+	test( 'appends https protocol to links added which are missing a protocol', async ( {
 		editor,
 		page,
 		imageBlockUtils,
@@ -663,8 +663,8 @@ test.describe( 'Image', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
-		// Check the value of the URL input has had http:// prepended.
-		await expect( urlInput ).toHaveValue( 'http://example.com' );
+		// Check the value of the URL input has had https:// prepended.
+		await expect( urlInput ).toHaveValue( 'https://example.com' );
 	} );
 
 	test( 'should upload external image to media library', async ( {


### PR DESCRIPTION
## What?
Closes #46244.

PR replaces `prependHTTP` calls with `prependHTTPS`. URLs without a protocol now will use `https`.

P.S. I know Nav blocks are still using `prependHTTP`, but it's only for internal check and not for storing modified attribute.

## Why?
It's 2026, and most external services should be using `https`.

## Testing Instructions
The changes have e2e test coverage.