### PR TITLE
Feature : Inserter Priority for Custom Blocks

### DIFF
--- a/lib/compat/wordpress-6.9/block-inserter-priority.php
+++ b/lib/compat/wordpress-6.9/block-inserter-priority.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Block Inserter Priority support.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Captures inserterPriority from block.json metadata.
+ *
+ * @param array $settings Block settings.
+ * @param array $metadata Block metadata from block.json.
+ * @return array Modified settings.
+ */
+function gutenberg_block_type_metadata_inserter_priority( $settings, $metadata ) {
+	if ( isset( $metadata['inserterPriority'] ) ) {
+		$settings['inserter_priority'] = (int) $metadata['inserterPriority'];
+	}
+	return $settings;
+}
+
+add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_inserter_priority', 10, 2 );
+
+/**
+ * Sends inserterPriority data to JavaScript.
+ */
+function gutenberg_enqueue_inserter_priority_data() {
+	$registry = WP_Block_Type_Registry::get_instance();
+	$data     = array();
+
+	foreach ( $registry->get_all_registered() as $name => $block_type ) {
+		if ( isset( $block_type->inserter_priority ) ) {
+			$data[ $name ] = array( 'inserterPriority' => $block_type->inserter_priority );
+		}
+	}
+
+	if ( ! empty( $data ) ) {
+		// Inject inserterPriority data into the block editor by merging server-side metadata with client-side block definitions.
+		wp_add_inline_script(
+			'wp-blocks',
+			'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( $data ) . ');',
+			'after'
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_inserter_priority_data' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -95,6 +95,7 @@ require __DIR__ . '/compat/plugin/fonts.php';
 require __DIR__ . '/compat/wordpress-6.9/customizer-preview-custom-css.php';
 require __DIR__ . '/compat/wordpress-6.9/command-palette.php';
 require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
+require __DIR__ . '/compat/wordpress-6.9/block-inserter-priority.php';
 
 // WordPress 7.0 compat.
 require __DIR__ . '/compat/wordpress-7.0/preload.php';

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2178,6 +2178,7 @@ const buildBlockTypeItem =
 			description: blockType.description,
 			category: blockType.category,
 			keywords: blockType.keywords,
+			inserterPriority: blockType.inserterPriority ?? 0,
 			parent: blockType.parent,
 			ancestor: blockType.ancestor,
 			variations: allVariations,
@@ -2338,10 +2339,23 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 				type.push( block );
 				return blocks;
 			};
+
+			// Sort by inserterPriority (lower values first).
+			const sortByInserterPriority = ( a, b ) => {
+				const priorityA = a.inserterPriority ?? 0;
+				const priorityB = b.inserterPriority ?? 0;
+				return priorityA - priorityB;
+			};
+
 			const { core: coreItems, noncore: nonCoreItems } = items.reduce(
 				groupByType,
 				{ core: [], noncore: [] }
 			);
+
+			// Sort each group by inserterPriority.
+			coreItems.sort( sortByInserterPriority );
+			nonCoreItems.sort( sortByInserterPriority );
+
 			const sortedBlockTypes = [ ...coreItems, ...nonCoreItems ];
 			return [ ...sortedBlockTypes, ...patternInserterItems ];
 		},

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3404,6 +3404,7 @@ describe( 'selectors', () => {
 				icon: { src: 'test' },
 				id: 'core/test-block-a',
 				initialAttributes: {},
+				inserterPriority: 0,
 				isDisabled: false,
 				keywords: [ 'testing' ],
 				name: 'core/test-block-a',
@@ -4342,6 +4343,88 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			'plugin/block-c-with-variations/variation-b',
 		];
 		expect( items.map( ( { id } ) => id ) ).toEqual( expectedResult );
+	} );
+} );
+
+describe( 'getInserterItems with inserterPriority', () => {
+	beforeEach( () => {
+		registerBlockType( 'plugin/high-priority', {
+			apiVersion: 3,
+			save() {},
+			category: 'text',
+			title: 'High Priority Block',
+			icon: 'test',
+			inserterPriority: 100,
+		} );
+		registerBlockType( 'plugin/medium-priority', {
+			apiVersion: 3,
+			save() {},
+			category: 'text',
+			title: 'Medium Priority Block',
+			icon: 'test',
+			inserterPriority: 50,
+		} );
+		registerBlockType( 'plugin/low-priority', {
+			apiVersion: 3,
+			save() {},
+			category: 'text',
+			title: 'Low Priority Block',
+			icon: 'test',
+			inserterPriority: 0,
+		} );
+		registerBlockType( 'plugin/negative-priority', {
+			apiVersion: 3,
+			save() {},
+			category: 'text',
+			title: 'Negative Priority Block',
+			icon: 'test',
+			inserterPriority: -10,
+		} );
+		registerBlockType( 'plugin/no-priority', {
+			apiVersion: 3,
+			save() {},
+			category: 'text',
+			title: 'No Priority Block',
+			icon: 'test',
+		} );
+	} );
+
+	afterEach( () => {
+		[
+			'plugin/high-priority',
+			'plugin/medium-priority',
+			'plugin/low-priority',
+			'plugin/negative-priority',
+			'plugin/no-priority',
+		].forEach( unregisterBlockType );
+	} );
+
+	it( 'should sort blocks by inserterPriority (lower values first)', () => {
+		const items = select( store ).getInserterItems();
+		const pluginItems = items
+			.filter( ( { id } ) => id.startsWith( 'plugin/' ) )
+			.map( ( { id } ) => id );
+
+		expect( pluginItems ).toEqual( [
+			'plugin/negative-priority',
+			'plugin/low-priority',
+			'plugin/no-priority',
+			'plugin/medium-priority',
+			'plugin/high-priority',
+		] );
+	} );
+
+	it( 'should include inserterPriority in the returned item', () => {
+		const items = select( store ).getInserterItems();
+		const highPriorityItem = items.find(
+			( item ) => item.id === 'plugin/high-priority'
+		);
+		const noPriorityItem = items.find(
+			( item ) => item.id === 'plugin/no-priority'
+		);
+
+		expect( highPriorityItem.inserterPriority ).toBe( 100 );
+		expect( noPriorityItem.inserterPriority ).toBe( 0 );
 	} );
 } );
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -176,6 +176,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 		'icon',
 		'description',
 		'keywords',
+		'inserterPriority',
 		'attributes',
 		'providesContext',
 		'usesContext',

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -62,11 +62,6 @@ function bootstrappedBlockTypes( state = {}, action ) {
 		case 'ADD_BOOTSTRAPPED_BLOCK_TYPE':
 			const { name, blockType } = action;
 			const serverDefinition = state[ name ];
-			// Don't overwrite if already set. It covers the case when metadata
-			// was initialized from the server.
-			if ( serverDefinition ) {
-				return state;
-			}
 			const newDefinition = Object.fromEntries(
 				Object.entries( blockType )
 					.filter(
@@ -75,6 +70,13 @@ function bootstrappedBlockTypes( state = {}, action ) {
 					.map( ( [ key, value ] ) => [ camelCase( key ), value ] )
 			);
 			newDefinition.name = name;
+			// Merge with existing definition if already set.
+			if ( serverDefinition ) {
+				return {
+					...state,
+					[ name ]: { ...serverDefinition, ...newDefinition },
+				};
+			}
 			return {
 				...state,
 				[ name ]: newDefinition,

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -95,6 +95,11 @@
 				"type": "string"
 			}
 		},
+		"inserterPriority": {
+			"description": "A numerical value that influences the display order of the block in the inserter. Lower values are displayed first. The default priority is 0.",
+			"type": "integer",
+			"default": 0
+		},
 		"version": {
 			"description": "The current version number of the block, such as 1.0 or 1.0.3. It’s similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the installed version of WordPress is used instead.",
 			"type": "string"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

- Closes https://github.com/WordPress/gutenberg/issues/73915
- Adds support for `inserterPriority` property in `block.json`, allowing custom blocks to influence their display order in the Block Inserter.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, block developers have no way to control where their blocks appear in the inserter relative to other blocks in the same category. This makes it difficult to surface important custom blocks prominently. The `inserterPriority` property gives developers control over block ordering within the inserter.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Added `inserterPriority` property to the block.json schema (`schemas/json/block.json`)
2. Added `inserterPriority` to allowed fields in JS block registration (`packages/blocks/src/api/registration.js`)
3. Modified the store reducer to merge bootstrapped data (`packages/blocks/src/store/reducer.js`)
4. Added sorting logic in `getInserterItems` selector (`packages/block-editor/src/store/selectors.js`)
5. Created PHP compat file to pass `inserterPriority` from server to client (`lib/compat/wordpress-6.9/block-inserter-priority.php`)

Blocks with lower `inserterPriority` values appear first. Default is `0`.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->

1. Create a plugin with a custom block that includes `inserterPriority` in its `block.json`:
   ```json
   {
     "name": "my-plugin/priority-block",
     "title": "Priority Block",
     "category": "widgets",
     "inserterPriority": -10
   }
   ```
2. Activate the plugin and open the block editor.
3. Open the Block Inserter and navigate to the "Widgets" category.
4. Verify the block with `inserterPriority: -10` appears before other blocks in the category.
5. In the browser console, verify:
   ```javascript
   wp.data.select('core/block-editor').getInserterItems()
     .filter(i => i.name.startsWith('my-plugin/'))
     .map(i => `${i.name}: ${i.inserterPriority}`)
   ```

### Testing Instructions for Keyboard

1. Open the block editor and press `/` to open the slash inserter.
2. Type a block name to filter results.
3. Use arrow keys to navigate the list.
4. Verify blocks are ordered by their `inserterPriority` value (lower values first).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before: Blocks ordered by registration | After: Blocks ordered by `inserterPriority` (lower values first)|
| ------------------------------- | ------------------------------ |
| <img width="313" height="212" alt="Screenshot 2026-01-28 at 11 41 23 AM" src="https://github.com/user-attachments/assets/42595cb8-25f5-4ef1-8a08-a6bc4f0031d4" /> | <img width="313" height="216" alt="Screenshot 2026-01-28 at 11 41 02 AM" src="https://github.com/user-attachments/assets/dca5fc49-2bc3-480e-9780-54212ee98e2e" /> |
