### PR TITLE
Pattern Editing: Hide List View child blocks in Content panel

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
+	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { __unstableMotion as motion } from '@wordpress/components';
@@ -145,32 +146,30 @@ function BlockInspector() {
 				renderedBlockClientId
 			);
 
-			// Temporary workaround for issue #71991
-			// Exclude Navigation block children from Content sidebar until proper
-			// drill-down experience is implemented (see #65699)
-			// This prevents a poor UX where all Nav block sub-items are shown
-			// when the parent block is in contentOnly mode.
-			// Build a Set of all navigation block descendants for efficient lookup
-			const navigationDescendants = new Set();
+			// Exclude items from the content tab that are already present in the
+			// List View tab.
+			const listViewDescendants = new Set();
 			descendants.forEach( ( clientId ) => {
-				if ( getBlockName( clientId ) === 'core/navigation' ) {
-					const navChildren = getClientIdsOfDescendants( clientId );
-					navChildren.forEach( ( childId ) =>
-						navigationDescendants.add( childId )
+				const blockName = getBlockName( clientId );
+				if (
+					blockName === 'core/navigation' ||
+					hasBlockSupport( blockName, 'listView' )
+				) {
+					const listViewChildren =
+						getClientIdsOfDescendants( clientId );
+					listViewChildren.forEach( ( childId ) =>
+						listViewDescendants.add( childId )
 					);
 				}
 			} );
 
 			return descendants.filter( ( current ) => {
 				// Exclude navigation block children
-				if ( navigationDescendants.has( current ) ) {
+				if ( listViewDescendants.has( current ) ) {
 					return false;
 				}
 
-				return (
-					getBlockName( current ) !== 'core/list-item' &&
-					getBlockEditingMode( current ) === 'contentOnly'
-				);
+				return getBlockEditingMode( current ) === 'contentOnly';
 			} );
 		},
 		[ isSectionBlock, renderedBlockClientId ]

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -151,6 +151,9 @@ function BlockInspector() {
 			const listViewDescendants = new Set();
 			descendants.forEach( ( clientId ) => {
 				const blockName = getBlockName( clientId );
+				// Navigation block doesn't have List View block support, but
+				// it does have a custom implementation that is shown within
+				// patterns, so it's included in this condition.
 				if (
 					blockName === 'core/navigation' ||
 					hasBlockSupport( blockName, 'listView' )
@@ -164,12 +167,10 @@ function BlockInspector() {
 			} );
 
 			return descendants.filter( ( current ) => {
-				// Exclude navigation block children
-				if ( listViewDescendants.has( current ) ) {
-					return false;
-				}
-
-				return getBlockEditingMode( current ) === 'contentOnly';
+				return (
+					! listViewDescendants.has( current ) &&
+					getBlockEditingMode( current ) === 'contentOnly'
+				);
 			} );
 		},
 		[ isSectionBlock, renderedBlockClientId ]

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -23,14 +23,14 @@ function SectionBlockColorControls( {
 	const settings = useBlockSettings( blockName );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	const { hasButton, hasHeading } = useSelect(
+	const { hasButtons, hasHeading } = useSelect(
 		( select ) => {
 			const blockNames =
 				select( blockEditorStore ).getBlockNamesByClientId(
 					contentClientIds
 				);
 			return {
-				hasButton: blockNames.includes( 'core/button' ),
+				hasButtons: blockNames.includes( 'core/buttons' ),
 				hasHeading: blockNames.includes( 'core/heading' ),
 			};
 		},
@@ -52,7 +52,7 @@ function SectionBlockColorControls( {
 			defaultControls={ {
 				text: true,
 				background: true,
-				button: hasButton,
+				button: hasButtons,
 				heading: hasHeading,
 			} }
 		/>


### PR DESCRIPTION
## What?
Addresses some feedback from @andrewserong - https://github.com/WordPress/gutenberg/pull/74843#pullrequestreview-3714043781.

> Now that we have the list view tab, I'm wondering if individual button blocks should be hidden in the content tab, similar to how list item blocks get hidden (i.e. we just show List). We expose the individual button blocks on the list view, so if we hide in the content tab, that might help a bit with reducing the overall length of the list in the content tab.

The code currently has some hard-coded rules for List and Navigation blocks to exclude their children from the Content Panel:
https://github.com/WordPress/gutenberg/blob/67266127a3775662c0698bac720ab8bdf47d8972/packages/block-editor/src/components/block-inspector/index.js#L166-L168
https://github.com/WordPress/gutenberg/blob/67266127a3775662c0698bac720ab8bdf47d8972/packages/block-editor/src/components/block-inspector/index.js#L171

In this PR I'm formalizing the logic to specifically check for blocks that have List View support. Those that do have support will have child blocks not visible in the Content Panel.

Navigation block still ends up being an exception since it uses a custom implementation of List View and doesn't technically have List View support.

## Why?
It shortens the content list to only those necessary. It also solves an issue where it looks like there are two selected blocks:
<img width="266" height="369" alt="Screenshot 2026-01-28 at 4 39 39 pm" src="https://github.com/user-attachments/assets/0c7ae071-6de1-4b9d-9069-d207561ca37d" />

Now only Buttons is shown:
<img width="267" height="334" alt="Screenshot 2026-01-28 at 4 41 49 pm" src="https://github.com/user-attachments/assets/fc1771c1-9d2c-4aba-9031-2e162662d310" />

## Testing Instructions
1. Insert a pattern or template part that contains Navigation, Social, Buttons, or List and where those blocks have inner blocks
2. Open the block inspector to the Content tab
3. Check through the list of blocks, none of the inner blocks of Navigation, Social, Buttons, or List should be present, only those blocks themselves.
4. Open the List View tab in the block inspector
5. See all the inner blocks are there.
