### PR TITLE
Notes: Don't trigger reflow for pinned sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -194,8 +194,6 @@ function NotesSidebar( { postId } ) {
 						newNoteFormState={ newNoteFormState }
 						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
-						reflowComments={ reflowComments }
-						commentLastUpdated={ commentLastUpdated }
 					/>
 				</PluginSidebar>
 			) }


### PR DESCRIPTION
## What?
A minor performance optimization. Avoid triggering comment reflow calculations for pinned notes sidebar; this is only needed for floating notes and causes the whole tree to re-render.

## Testing Instructions
1. Open a post or page.
2. Smoke test the floating notes.
3. They should work as before.

### Testing Instructions for Keyboard
Same.
