### PR TITLE
Provide path instead of just directory name to block.json if not unde…

### DIFF
--- a/packages/scripts/scripts/build-blocks-manifest.js
+++ b/packages/scripts/scripts/build-blocks-manifest.js
@@ -37,8 +37,8 @@ const blocks = {};
 
 blockJsonFiles.forEach( ( file ) => {
 	const blockJson = JSON.parse( fs.readFileSync( file, 'utf8' ) );
-	const directoryName = path.basename( path.dirname( file ) );
-	blocks[ directoryName ] = blockJson;
+	const directoryNameOrPath = path.dirname(file.replace(resolvedInputDir, '')).substring(1);
+	blocks[ directoryNameOrPath ] = blockJson;
 } );
 
 if ( Object.keys( blocks ).length === 0 ) {


### PR DESCRIPTION
…r the resolvedInputDir

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to [<!-- #ISSUE-NUMBER or URL -->](https://github.com/WordPress/gutenberg/issues/71036)

Use the path instead of just the foldername for a block when generating the blocks-manifest.

## Why?
When developing a plugin with multiple blocks that should resemble a parent/child structure it is useful to also reflect that relation within the folder structure. Foe example:

- build
- - block-a
- - - block-b

Currently this structure is flattened in the blocks-manifest and when using it, wordpress does not recognize the nested blocks because the block.json is not being found.

## How?
The value that indexes the array of blocks currently is just he foldername of the block. Instead use the full path form the determined input directory.

## Testing Instructions
1. create a plugin with a nested block structure
2. generate the blocks-manifest and register the blocks via wp_register_block_types_from_metadata_collection
3. check that all blocks are registered correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
