### PR TITLE
DataViews: always include filter container styles with free composition

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Add new `combobox` DataForm control. [#74891](https://github.com/WordPress/gutenberg/pull/74891)
 - Include total items count in footer. [#73491](https://github.com/WordPress/gutenberg/pull/73491)
 
+### Breaking changes
+
+- Always include filter container styles via `dataviews-filters__container` selector when using free composition with `DataViews.Filters` and `DataViews.FiltersToggled` components.
+
 ## 11.2.0 (2026-01-16)
 
 ### Code Quality

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Breaking changes
 
-- Always include filter container styles via `dataviews-filters__container` selector when using free composition with `DataViews.Filters` and `DataViews.FiltersToggled` components.
+- Always include filter container styles via `dataviews-filters__container` selector when using free composition with `DataViews.Filters` and `DataViews.FiltersToggled` components. [#75021](https://github.com/WordPress/gutenberg/pull/75021)
 
 ## 11.2.0 (2026-01-16)
 

--- a/packages/dataviews/src/components/dataviews-filters/filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filters.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { memo, useContext, useRef } from '@wordpress/element';
@@ -65,7 +70,7 @@ function Filters( { className }: { className?: string } ) {
 			gap="xs"
 			style={ { width: 'fit-content' } }
 			wrap="wrap"
-			className={ className }
+			className={ clsx( 'dataviews-filters__container', className ) }
 		>
 			{ filterComponents }
 		</Stack>

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -101,7 +101,7 @@ function DefaultUI( {
 					<DataViewsViewConfig />
 				</Stack>
 			</Stack>
-			<FiltersToggled className="dataviews-filters__container" />
+			<FiltersToggled />
 			<DataViewsLayout />
 			<DataViewsPickerFooter />
 		</>

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -111,7 +111,7 @@ function DefaultUI( {
 					{ header }
 				</Stack>
 			</Stack>
-			<FiltersToggled className="dataviews-filters__container" />
+			<FiltersToggled />
 			<DataViewsLayout />
 			<DataViewsFooter />
 		</>


### PR DESCRIPTION
Always include filter container styles via `dataviews-filters__container` selector when using free composition with `DataViews.Filters` and `DataViews.FiltersToggled` components.

FYI, FiltersToggled was added in https://github.com/WordPress/gutenberg/pull/71907

Currently, to get [these styles ](https://github.com/WordPress/gutenberg/blob/fe47a06b6f652ecb632e296d733896e3893cb961/packages/dataviews/src/dataviews/style.scss#L20-L32) applied to the filter row, the consumer has to apply the class manually (syntax simplified):
```jsx
<DataViews>
	<DataViews.FiltersToggle />
	<DataViews.FiltersToggled className="dataviews-filters__container" />
	<DataViews.Layout />
	<DataViews.Footer />
</DataViews>
```

This is fragile since CSS selectors like these shouldn't be considered as a stable API.

I'd expect simply this being enough to have a full set of DataViews styles applying to all components, which I can then override if needed:
```jsx
<DataViews>
	<DataViews.FiltersToggle />
	<DataViews.FiltersToggled />
	<DataViews.Layout />
	<DataViews.Footer />
</DataViews>
```

This came up [when using DataViews in a plugin](https://github.com/Automattic/jetpack/pull/46797/changes#r2736714047) and was likely picked from Gutenberg codebase examples by an AI.

Since there were only two usages of `<DataViews.FiltersToggled />` in the package, and both were already including `dataviews-filters__container`, it seemed fairly safe to simply move the selector to the component itself. DataViews also aren't externalised, so consumers fully control updating the package.

That said, consumers might already be using the FiltersToggled with their own styles, so this is a breaking change.

Note also how FiltersToggle comes up with its container CSS selector:

https://github.com/WordPress/gutenberg/blob/fe47a06b6f652ecb632e296d733896e3893cb961/packages/dataviews/src/components/dataviews-filters/toggle.tsx#L69

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
Adds `dataviews-filters__contain` always come with `<DataViews.FiltersToggled />` and `<DataViews.Filters />` components.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For easier consumption of free composition components in DataViews.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test different usages of DataViews around Gutenberg and in the storybook.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
