### PR TITLE
Fix admin menu triangle border with wp-build pages

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -488,6 +488,11 @@
 
 	ul#adminmenu a.wp-has-current-submenu::after,
 	ul#adminmenu > li.current > a.current::after {
+		margin-right: -1px;
+
+		border: solid 9px transparent;
+		margin-top: -9px;
+
 		border-right-color: colors.$white;
 	}
 


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74975

This PR fixes a visual gap next to the admin menu navigation triangle when pages are built using wp-build.

Specifically, it ensures the white navigation triangle overlaps the content border correctly, preventing a visible 1px gap.

## Why?
When pages in WP Admin (for example Appearance → Fonts) are built with the new wp-build package, a small border appears next to the navigation triangle.

This causes a noticeable visual inconsistency where the triangle does not blend seamlessly with the page content, making the UI look misaligned.

## How?
The fix adjusts the CSS for the admin menu navigation triangle so that it properly overlaps the content border.

This approach is based on the CSS behavior discussed in the issue and refined to align with existing admin menu styles, avoiding layout or sizing regressions.

## Testing Instructions

1. Open the WordPress admin dashboard.
2. Navigate to Appearance → Fonts.
3. Observe the admin menu navigation triangle.
4. Verify that the triangle blends seamlessly with the page content and that no visible border or gap appears.

Note: I was unable to run wp-env locally due to a known wp-env network issue on Windows. 
The fix was validated via isolated CSS testing and by following the issue reproduction steps.

### Testing Instructions for Keyboard

1. Open the WordPress admin dashboard.
2. Use the keyboard to navigate to Appearance → Fonts.
3. Ensure focus navigation works as expected.
4. Confirm that the navigation triangle remains visually aligned with the content and no layout shift or gap is visible.


