### PR TITLE
In-editor revisions: preserve client IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54128,6 +54128,7 @@
 				"client-zip": "^2.4.5",
 				"clsx": "^2.1.1",
 				"date-fns": "^3.6.0",
+				"diff": "^4.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -105,6 +105,7 @@
 		"client-zip": "^2.4.5",
 		"clsx": "^2.1.1",
 		"date-fns": "^3.6.0",
+		"diff": "^4.0.2",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",

--- a/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
@@ -1,0 +1,57 @@
+/**
+ * Preserves clientIds from previously rendered blocks to prevent flashing.
+ * Matches blocks by name between renders to maintain React key stability.
+ *
+ * @param {Array} newBlocks  Newly parsed blocks with fresh clientIds.
+ * @param {Array} prevBlocks Previously rendered blocks with stable clientIds.
+ * @return {Array} Blocks with preserved clientIds where possible.
+ */
+export function preserveClientIds( newBlocks, prevBlocks ) {
+	if ( ! prevBlocks?.length || ! newBlocks?.length ) {
+		return newBlocks;
+	}
+
+	// Track which prevBlocks have been used.
+	const usedPrevIndices = new Set();
+
+	return newBlocks.map( ( newBlock, newIndex ) => {
+		// Try to find a matching block in prevBlocks by name.
+		// First, try the same index position.
+		if (
+			prevBlocks[ newIndex ] &&
+			prevBlocks[ newIndex ].name === newBlock.name &&
+			! usedPrevIndices.has( newIndex )
+		) {
+			usedPrevIndices.add( newIndex );
+			return {
+				...newBlock,
+				clientId: prevBlocks[ newIndex ].clientId,
+				innerBlocks: preserveClientIds(
+					newBlock.innerBlocks,
+					prevBlocks[ newIndex ].innerBlocks
+				),
+			};
+		}
+
+		// Otherwise, find the first unused block with matching name.
+		for ( let i = 0; i < prevBlocks.length; i++ ) {
+			if (
+				! usedPrevIndices.has( i ) &&
+				prevBlocks[ i ].name === newBlock.name
+			) {
+				usedPrevIndices.add( i );
+				return {
+					...newBlock,
+					clientId: prevBlocks[ i ].clientId,
+					innerBlocks: preserveClientIds(
+						newBlock.innerBlocks,
+						prevBlocks[ i ].innerBlocks
+					),
+				};
+			}
+		}
+
+		// No match found, keep new clientId.
+		return newBlock;
+	} );
+}

--- a/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
@@ -5,7 +5,7 @@ import { diffArrays } from 'diff/lib/diff/array';
 
 /**
  * Preserves clientIds from previously rendered blocks to prevent flashing.
- * Uses LCS algorithm to match blocks by name, attributes, and originalContent.
+ * Uses LCS algorithm to match blocks by name.
  *
  * This compares the newly parsed blocks against the last rendered blocks
  * to maintain React key stability.
@@ -19,19 +19,9 @@ export function preserveClientIds( newBlocks, prevBlocks ) {
 		return newBlocks;
 	}
 
-	// Create signatures for LCS matching using name, attributes, and
-	// originalContent. Note that the original content does not include the
-	// inner blocks (which is what we want because inner blocks are processed
-	// separately). In revisions, the blocks also don't change some it's fine to
-	// use the original content.
-	const createSignature = ( block ) =>
-		JSON.stringify( {
-			name: block.name,
-			attributes: block.attributes,
-			originalContent: block.originalContent,
-		} );
-	const newSigs = newBlocks.map( createSignature );
-	const prevSigs = prevBlocks.map( createSignature );
+	// Create signatures for LCS matching using block name.
+	const newSigs = newBlocks.map( ( block ) => block.name );
+	const prevSigs = prevBlocks.map( ( block ) => block.name );
 
 	const diffResult = diffArrays( prevSigs, newSigs );
 

--- a/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
@@ -1,6 +1,15 @@
 /**
+ * External dependencies
+ */
+import { diffArrays } from 'diff/lib/diff/array';
+
+/**
  * Preserves clientIds from previously rendered blocks to prevent flashing.
- * Matches blocks by name between renders to maintain React key stability.
+ * Uses LCS algorithm to match blocks by name, attributes, and originalContent.
+ *
+ * This is separate from the visual diff (which compares revision content).
+ * This compares the newly parsed blocks against the last rendered blocks
+ * to maintain React key stability.
  *
  * @param {Array} newBlocks  Newly parsed blocks with fresh clientIds.
  * @param {Array} prevBlocks Previously rendered blocks with stable clientIds.
@@ -11,47 +20,47 @@ export function preserveClientIds( newBlocks, prevBlocks ) {
 		return newBlocks;
 	}
 
-	// Track which prevBlocks have been used.
-	const usedPrevIndices = new Set();
+	// Create signatures for LCS matching using name, attributes, and originalContent.
+	const createSignature = ( block ) =>
+		JSON.stringify( {
+			name: block.name,
+			attributes: block.attributes,
+			originalContent: block.originalContent,
+		} );
+	const newSigs = newBlocks.map( createSignature );
+	const prevSigs = prevBlocks.map( createSignature );
 
-	return newBlocks.map( ( newBlock, newIndex ) => {
-		// Try to find a matching block in prevBlocks by name.
-		// First, try the same index position.
-		if (
-			prevBlocks[ newIndex ] &&
-			prevBlocks[ newIndex ].name === newBlock.name &&
-			! usedPrevIndices.has( newIndex )
-		) {
-			usedPrevIndices.add( newIndex );
-			return {
-				...newBlock,
-				clientId: prevBlocks[ newIndex ].clientId,
-				innerBlocks: preserveClientIds(
-					newBlock.innerBlocks,
-					prevBlocks[ newIndex ].innerBlocks
-				),
-			};
-		}
+	const diffResult = diffArrays( prevSigs, newSigs );
 
-		// Otherwise, find the first unused block with matching name.
-		for ( let i = 0; i < prevBlocks.length; i++ ) {
-			if (
-				! usedPrevIndices.has( i ) &&
-				prevBlocks[ i ].name === newBlock.name
-			) {
-				usedPrevIndices.add( i );
-				return {
+	let newIndex = 0;
+	let prevIndex = 0;
+	const result = [];
+
+	for ( const chunk of diffResult ) {
+		if ( chunk.removed ) {
+			// Blocks only in prev render - skip them.
+			prevIndex += chunk.count;
+		} else if ( chunk.added ) {
+			// Blocks only in new render - keep new clientIds.
+			for ( let i = 0; i < chunk.count; i++ ) {
+				result.push( newBlocks[ newIndex++ ] );
+			}
+		} else {
+			// Matched blocks - preserve clientIds from prev render.
+			for ( let i = 0; i < chunk.count; i++ ) {
+				const newBlock = newBlocks[ newIndex++ ];
+				const prevBlock = prevBlocks[ prevIndex++ ];
+				result.push( {
 					...newBlock,
-					clientId: prevBlocks[ i ].clientId,
+					clientId: prevBlock.clientId,
 					innerBlocks: preserveClientIds(
 						newBlock.innerBlocks,
-						prevBlocks[ i ].innerBlocks
+						prevBlock.innerBlocks
 					),
-				};
+				} );
 			}
 		}
+	}
 
-		// No match found, keep new clientId.
-		return newBlock;
-	} );
+	return result;
 }

--- a/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/preserve-client-ids.js
@@ -7,7 +7,6 @@ import { diffArrays } from 'diff/lib/diff/array';
  * Preserves clientIds from previously rendered blocks to prevent flashing.
  * Uses LCS algorithm to match blocks by name, attributes, and originalContent.
  *
- * This is separate from the visual diff (which compares revision content).
  * This compares the newly parsed blocks against the last rendered blocks
  * to maintain React key stability.
  *
@@ -20,7 +19,11 @@ export function preserveClientIds( newBlocks, prevBlocks ) {
 		return newBlocks;
 	}
 
-	// Create signatures for LCS matching using name, attributes, and originalContent.
+	// Create signatures for LCS matching using name, attributes, and
+	// originalContent. Note that the original content does not include the
+	// inner blocks (which is what we want because inner blocks are processed
+	// separately). In revisions, the blocks also don't change some it's fine to
+	// use the original content.
 	const createSignature = ( block ) =>
 		JSON.stringify( {
 			name: block.name,

--- a/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
@@ -125,7 +125,8 @@ describe( 'preserveClientIds', () => {
 		const result = preserveClientIds( newBlocks, prevBlocks );
 
 		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].clientId ).toBe( 'prev-2' );
+		// Matches by name only, so first paragraph matches first paragraph.
+		expect( result[ 0 ].clientId ).toBe( 'prev-1' );
 	} );
 
 	it( 'should preserve clientIds for inner blocks recursively', () => {
@@ -170,7 +171,7 @@ describe( 'preserveClientIds', () => {
 		expect( result[ 0 ].innerBlocks[ 0 ].clientId ).toBe( 'prev-inner-1' );
 	} );
 
-	it( 'should not preserve clientId when attributes differ', () => {
+	it( 'should preserve clientId even when attributes differ (matches by name only)', () => {
 		const prevBlocks = [
 			{
 				name: 'core/paragraph',
@@ -192,7 +193,7 @@ describe( 'preserveClientIds', () => {
 
 		const result = preserveClientIds( newBlocks, prevBlocks );
 
-		expect( result[ 0 ].clientId ).toBe( 'new-1' );
+		expect( result[ 0 ].clientId ).toBe( 'prev-1' );
 	} );
 
 	it( 'should handle blocks with same name but different content using LCS', () => {
@@ -238,7 +239,8 @@ describe( 'preserveClientIds', () => {
 
 		const result = preserveClientIds( newBlocks, prevBlocks );
 
+		// Matches by name only, so matches in order (first to first, second to second).
 		expect( result[ 0 ].clientId ).toBe( 'prev-a' );
-		expect( result[ 1 ].clientId ).toBe( 'prev-c' );
+		expect( result[ 1 ].clientId ).toBe( 'prev-b' );
 	} );
 } );

--- a/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
@@ -1,0 +1,244 @@
+/**
+ * Internal dependencies
+ */
+import { preserveClientIds } from '../preserve-client-ids';
+
+describe( 'preserveClientIds', () => {
+	it( 'should return newBlocks when prevBlocks is empty', () => {
+		const newBlocks = [
+			{ name: 'core/paragraph', clientId: 'new-1', attributes: {} },
+		];
+		expect( preserveClientIds( newBlocks, [] ) ).toBe( newBlocks );
+		expect( preserveClientIds( newBlocks, null ) ).toBe( newBlocks );
+		expect( preserveClientIds( newBlocks, undefined ) ).toBe( newBlocks );
+	} );
+
+	it( 'should return newBlocks when newBlocks is empty', () => {
+		const prevBlocks = [
+			{ name: 'core/paragraph', clientId: 'prev-1', attributes: {} },
+		];
+		expect( preserveClientIds( [], prevBlocks ) ).toEqual( [] );
+		expect( preserveClientIds( null, prevBlocks ) ).toBe( null );
+		expect( preserveClientIds( undefined, prevBlocks ) ).toBe( undefined );
+	} );
+
+	it( 'should preserve clientIds for identical blocks', () => {
+		const prevBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-1',
+				attributes: { content: 'Hello' },
+				originalContent: 'Hello',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/heading',
+				clientId: 'prev-2',
+				attributes: { level: 2 },
+				originalContent: 'Title',
+				innerBlocks: [],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'new-1',
+				attributes: { content: 'Hello' },
+				originalContent: 'Hello',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/heading',
+				clientId: 'new-2',
+				attributes: { level: 2 },
+				originalContent: 'Title',
+				innerBlocks: [],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result[ 0 ].clientId ).toBe( 'prev-1' );
+		expect( result[ 1 ].clientId ).toBe( 'prev-2' );
+	} );
+
+	it( 'should keep new clientIds for added blocks', () => {
+		const prevBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-1',
+				attributes: { content: 'First' },
+				originalContent: 'First',
+				innerBlocks: [],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'new-1',
+				attributes: { content: 'First' },
+				originalContent: 'First',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				clientId: 'new-2',
+				attributes: { content: 'Second' },
+				originalContent: 'Second',
+				innerBlocks: [],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result[ 0 ].clientId ).toBe( 'prev-1' );
+		expect( result[ 1 ].clientId ).toBe( 'new-2' );
+	} );
+
+	it( 'should handle removed blocks', () => {
+		const prevBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-1',
+				attributes: { content: 'First' },
+				originalContent: 'First',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-2',
+				attributes: { content: 'Second' },
+				originalContent: 'Second',
+				innerBlocks: [],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'new-2',
+				attributes: { content: 'Second' },
+				originalContent: 'Second',
+				innerBlocks: [],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].clientId ).toBe( 'prev-2' );
+	} );
+
+	it( 'should preserve clientIds for inner blocks recursively', () => {
+		const prevBlocks = [
+			{
+				name: 'core/group',
+				clientId: 'prev-group',
+				attributes: {},
+				originalContent: '',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						clientId: 'prev-inner-1',
+						attributes: { content: 'Inner' },
+						originalContent: 'Inner',
+						innerBlocks: [],
+					},
+				],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/group',
+				clientId: 'new-group',
+				attributes: {},
+				originalContent: '',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-inner-1',
+						attributes: { content: 'Inner' },
+						originalContent: 'Inner',
+						innerBlocks: [],
+					},
+				],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result[ 0 ].clientId ).toBe( 'prev-group' );
+		expect( result[ 0 ].innerBlocks[ 0 ].clientId ).toBe( 'prev-inner-1' );
+	} );
+
+	it( 'should not preserve clientId when attributes differ', () => {
+		const prevBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-1',
+				attributes: { content: 'Old content' },
+				originalContent: 'Old content',
+				innerBlocks: [],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'new-1',
+				attributes: { content: 'New content' },
+				originalContent: 'New content',
+				innerBlocks: [],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result[ 0 ].clientId ).toBe( 'new-1' );
+	} );
+
+	it( 'should handle blocks with same name but different content using LCS', () => {
+		const prevBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-a',
+				attributes: { content: 'A' },
+				originalContent: 'A',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-b',
+				attributes: { content: 'B' },
+				originalContent: 'B',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				clientId: 'prev-c',
+				attributes: { content: 'C' },
+				originalContent: 'C',
+				innerBlocks: [],
+			},
+		];
+		const newBlocks = [
+			{
+				name: 'core/paragraph',
+				clientId: 'new-a',
+				attributes: { content: 'A' },
+				originalContent: 'A',
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				clientId: 'new-c',
+				attributes: { content: 'C' },
+				originalContent: 'C',
+				innerBlocks: [],
+			},
+		];
+
+		const result = preserveClientIds( newBlocks, prevBlocks );
+
+		expect( result[ 0 ].clientId ).toBe( 'prev-a' );
+		expect( result[ 1 ].clientId ).toBe( 'prev-c' );
+	} );
+} );

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -81,4 +81,73 @@ test.describe( 'Revisions', () => {
 			},
 		] );
 	} );
+
+	test( 'should preserve block clientId when sliding between revisions', async ( {
+		editor,
+		page,
+	} ) => {
+		// Add a heading.
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'Test Heading' },
+		} );
+
+		// Save draft to create first revision.
+		await editor.saveDraft();
+
+		// Add a paragraph at the start (before the heading).
+		await page.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'New paragraph',
+			} );
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.insertBlock( block, 0 );
+		} );
+
+		// Verify blocks are correctly configured.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'New paragraph' },
+			},
+			{
+				name: 'core/heading',
+				attributes: { content: 'Test Heading' },
+			},
+		] );
+
+		// Save draft again to create second revision.
+		await editor.saveDraft();
+
+		// Open the post settings sidebar and click the Revisions button.
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+
+		// Wait for the revisions mode to be active.
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Get the heading block's clientId before sliding.
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		const clientIdBefore = await headingBlock.getAttribute( 'data-block' );
+
+		// Use the slider to navigate to the oldest revision.
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await slider.focus();
+		await page.keyboard.press( 'Home' );
+
+		// Verify the heading's clientId is preserved (prevents flashing).
+		const clientIdAfter = await headingBlock.getAttribute( 'data-block' );
+		expect( clientIdAfter ).toBe( clientIdBefore );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Previously: #74771
Extracted from: #74443

When sliding through revisions, preserve the client IDs of blocks with the same name.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A change in client ID causes blocks to remount, so some blocks may flicker because images are videos are reloaded. It probably also benefits performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the array diffing function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the GB demo content and create some revisions. Then slide through them. Before this PR you will see that the cover block flickers. After this PR it won't.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
