### PR TITLE
Cover Block: Add filter to disable automatic overlay color selection

### DIFF
--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -209,6 +209,26 @@ addFilter(
 );
 ```
 
+### `blocks.cover.autoSetOverlayColor`
+
+The Cover block automatically selects an overlay color based on the selected image's average color. This filter allows you to disable this automatic color selection behavior. By default, the filter returns `true`, enabling automatic color selection. Set it to `false` to prevent the Cover block from automatically changing the overlay color when an image is selected.
+
+This is particularly useful when you want to:
+- Enforce a strict color palette that users cannot bypass
+- Maintain consistent overlay colors (like black or white) regardless of the selected image
+- Give users full control over overlay color selection
+
+```js
+import { addFilter } from '@wordpress/hooks';
+
+// Disable automatic overlay color selection
+addFilter(
+	'blocks.cover.autoSetOverlayColor',
+	'my-plugin/disable-cover-auto-color',
+	() => false
+);
+```
+
 ## Editor REST API preload paths
 
 You can use [`block_editor_rest_api_preload_paths`](https://developer.wordpress.org/reference/hooks/block_editor_rest_api_preload_paths/) to filter the array of REST API paths that will be used to preload common data to use with the block editor. Here's an example:

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -155,8 +156,14 @@ function CoverEdit( {
 
 			const averageBackgroundColor = await getMediaColor( mediaUrl );
 
+			// Allow disabling automatic overlay color selection via filter.
+			const shouldSetOverlayColor = applyFilters(
+				'blocks.cover.autoSetOverlayColor',
+				true
+			);
+
 			let newOverlayColor = overlayColor.color;
-			if ( ! isUserOverlayColor ) {
+			if ( ! isUserOverlayColor && shouldSetOverlayColor ) {
 				newOverlayColor = averageBackgroundColor;
 				__unstableMarkNextChangeAsNotPersistent();
 				setOverlayColor( newOverlayColor );
@@ -201,8 +208,14 @@ function CoverEdit( {
 			isImage ? newMedia?.url : undefined
 		);
 
+		// Allow disabling automatic overlay color selection via filter.
+		const shouldSetOverlayColor = applyFilters(
+			'blocks.cover.autoSetOverlayColor',
+			true
+		);
+
 		let newOverlayColor = overlayColor.color;
-		if ( ! isUserOverlayColor ) {
+		if ( ! isUserOverlayColor && shouldSetOverlayColor ) {
 			newOverlayColor = averageBackgroundColor;
 			setOverlayColor( newOverlayColor );
 
@@ -477,11 +490,18 @@ function CoverEdit( {
 			? await getMediaColor( mediaUrl )
 			: DEFAULT_BACKGROUND_COLOR;
 
-		const newOverlayColor = ! isUserOverlayColor
-			? averageBackgroundColor
-			: overlayColor.color;
+		// Allow disabling automatic overlay color selection via filter.
+		const shouldSetOverlayColor = applyFilters(
+			'blocks.cover.autoSetOverlayColor',
+			true
+		);
 
-		if ( ! isUserOverlayColor ) {
+		const newOverlayColor =
+			! isUserOverlayColor && shouldSetOverlayColor
+				? averageBackgroundColor
+				: overlayColor.color;
+
+		if ( ! isUserOverlayColor && shouldSetOverlayColor ) {
 			if ( newUseFeaturedImage ) {
 				setOverlayColor( newOverlayColor );
 			} else {


### PR DESCRIPTION
## What?

Adds a new JavaScript filter `blocks.cover.autoSetOverlayColor` to allow disabling the automatic overlay color selection in the Cover block.

## Why?

Fixes #60644

When an image is selected for the Cover Block, the overlay color automatically changes to a representative color from the image. This poses issues for users who:

1. Need to enforce strict color palettes - the automatic selection bypasses approved color restrictions
2. Prefer consistent overlay colors (like black or white) regardless of the selected image
3. Want full control over overlay color selection without automatic changes

## How?

- Added a new JavaScript filter `blocks.cover.autoSetOverlayColor` (defaults to `true` for backward compatibility)
- Applied the filter check in three locations where automatic color selection occurs:
  - `useEffect` for featured image changes  
  - `onSelectMedia` when media is selected
  - `toggleUseFeaturedImage` when toggling featured image
- Added comprehensive documentation in `/docs/reference-guides/filters/editor-filters.md`

## Usage Example

```js
import { addFilter } from '@wordpress/hooks';

// Disable automatic overlay color selection
addFilter(
    'blocks.cover.autoSetOverlayColor',
    'my-plugin/disable-cover-auto-color',
    () => false
);
```

## Testing Instructions

### Test automatic color selection still works (default behavior)

1. Create a new post
2. Add a Cover block
3. Select an image with distinct colors (e.g., a blue sky image)
4. Verify the overlay color automatically changes to match the image's average color
5. Try with different images and verify the overlay color updates each time

### Test disabling automatic color selection

1. Add this code to a plugin or your theme's `functions.php`:
```php
add_action( 'enqueue_block_editor_assets', function() {
    wp_add_inline_script( 'wp-blocks', "
        wp.hooks.addFilter(
            'blocks.cover.autoSetOverlayColor',
            'test/disable-auto-color',
            function() { return false; }
        );
    " );
} );
```
2. Create a new post  
3. Add a Cover block with a background color (e.g., black)
4. Select an image
5. Verify the overlay color remains unchanged (stays black)
6. Try changing images - the overlay should not change automatically
7. Manually change the overlay color - verify it works as expected


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Default Behaviour: (i.e: when 'blocks.cover.autoSetOverlayColor' is set to true)

https://github.com/user-attachments/assets/6b97f2b2-b7eb-48e1-bfe6-89e1a1dc80af



No Overlay Behaviour  (i.e: when 'blocks.cover.autoSetOverlayColor' is set to False)


https://github.com/user-attachments/assets/58aef060-1f3b-4a6c-b9a7-793232a3e89b


