### PR TITLE
Routing Boot Package: Remove left border from stage and inspector surfaces

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -83,9 +83,6 @@
 	overflow-y: auto;
 	background: var(--wpds-color-bg-surface-neutral, #fff);
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
-	border-left: none;
 	position: relative;
 
 	// Mobile-first: surfaces take full screen with fixed positioning

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -85,6 +85,7 @@
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	border-left: none;
 	position: relative;
 
 	// Mobile-first: surfaces take full screen with fixed positioning


### PR DESCRIPTION
Closes #74975

## Why?
There was noticed a very little glitch being caused by the boot layout inspector surface, that has a border colliding with the side menu in the admin interface. This admin interface is slated to be deprecated at some point, but for now, all integrations of this routing will cause this minor colliding border. It's very difficult to see, but it appears that some privileged people have eagle eyes. 

## How?
There are two options:
1. Removing the border all around
2. Just removing the left colliding border.

Also, we could target exclusively the inspector surface and leave the stage surface or target both. Currently only the inspector surface is colliding.

## Testing Instructions
1. Go to Appearance > Fonts
2. Get a magnifier.
3. Check for the right border located near the little white triangle (check magnified screenshots).

## Screenshots

### Before
<img width="701" height="598" alt="image" src="https://github.com/user-attachments/assets/f8173fa4-8f8f-4f4a-8670-f9ea05cbb118" />

### After
<img width="785" height="614" alt="image" src="https://github.com/user-attachments/assets/2223bb13-52e2-4767-8d4b-6103cca2eeec" />

