### PR TITLE
Fix: Rewrite the license check scripts to use Node's native module resolution

### DIFF
--- a/bin/check-licenses.mjs
+++ b/bin/check-licenses.mjs
@@ -3,36 +3,117 @@
 /**
  * External dependencies
  */
-import spawn from 'cross-spawn';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 /**
  * Internal dependencies
  */
-import { checkDeps, getLicenses } from '../packages/scripts/utils/license.js';
+import {
+	checkDeps,
+	getLicenses,
+	resolvePackagePath,
+	readPackageJson,
+} from '../packages/scripts/utils/license.js';
+
+const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
+const ROOT_DIR = path.resolve( __dirname, '..' );
 
 const ignored = [
-	'@ampproject/remapping',
-	// Jest internals with Apache-2.0 license - only used for testing, not distributed.
-	'bser',
-	'fb-watchman',
-	'walker',
+	// Nothing ignored for now
 ];
 
 /*
- * `wp-scripts check-licenses` uses prod and dev dependencies of the package to scan for dependencies. With npm workspaces, workspace packages (the @wordpress/* packages) are not listed in the main package json and this approach does not work.
+ * This script checks licenses for production dependencies of packages that are
+ * shipped with WordPress (those with wpScript or wpScriptModuleExports in package.json).
  *
- * Instead, work from an npm query that uses some custom information in package.json files to declare packages that are shipped with WordPress (and must be GPLv2 compatible) or other files that may use more permissive licenses.
+ * It works independently of the package manager (npm, pnpm, etc.) by:
+ * 1. Reading package.json files to find wpScript packages
+ * 2. Reading their production dependencies
+ * 3. Resolving each dependency using Node's module resolution
+ * 4. Reading the license from each resolved package
  */
 
-const licenses = getLicenses( true );
-const query = `.workspace:attr([wpScript],[wpScriptModuleExports]) :is(.prod):not(${ licenses
-	.map( ( license ) => `[license=${ JSON.stringify( license ) }]` )
-	.join( ',' ) })`;
+/**
+ * Get all production dependencies for packages with wpScript or wpScriptModuleExports.
+ *
+ * @return {Array} Array of dependency objects with name, version, path, and license
+ */
+function getDependenciesToProcess() {
+	const packagesDir = path.join( ROOT_DIR, 'packages' );
+	const licenses = getLicenses( true );
+	const depsMap = new Map();
+	const visited = new Set();
 
-// Use `npm query` to grab a list of all the packages for workspaces.
-const child = spawn.sync( 'npm', [ 'query', query ] );
+	/**
+	 * Recursively collect production dependencies.
+	 *
+	 * @param {Object} deps    - Dependencies object from package.json
+	 * @param {string} fromDir - Directory to resolve from
+	 */
+	function collectDeps( deps, fromDir ) {
+		if ( ! deps ) {
+			return;
+		}
 
-const dependenciesToProcess = JSON.parse( child.stdout.toString() );
+		for ( const depName of Object.keys( deps ) ) {
+			// Skip workspace packages (they start with @wordpress/)
+			if ( depName.startsWith( '@wordpress/' ) ) {
+				continue;
+			}
+
+			const depPath = resolvePackagePath( depName, fromDir );
+			if ( ! depPath ) {
+				continue;
+			}
+
+			// Avoid infinite loops
+			if ( visited.has( depPath ) ) {
+				continue;
+			}
+			visited.add( depPath );
+
+			const depPkgJson = readPackageJson( depPath );
+			if ( ! depPkgJson ) {
+				continue;
+			}
+
+			const key = `${ depName }@${ depPkgJson.version }`;
+			if ( ! depsMap.has( key ) ) {
+				const license = depPkgJson.license;
+
+				// Skip if license is in the allowed list
+				if ( ! license || ! licenses.includes( license ) ) {
+					depsMap.set( key, {
+						name: depName,
+						version: depPkgJson.version,
+						path: depPath,
+						license,
+					} );
+				}
+			}
+
+			// Recursively check this package's dependencies
+			collectDeps( depPkgJson.dependencies, depPath );
+		}
+	}
+
+	// Find all workspace packages with wpScript or wpScriptModuleExports
+	for ( const dir of fs.readdirSync( packagesDir ) ) {
+		const pkgDir = path.join( packagesDir, dir );
+		const pkgJson = readPackageJson( pkgDir );
+
+		if ( pkgJson?.wpScript || pkgJson?.wpScriptModuleExports ) {
+			// Collect production dependencies for this package
+			collectDeps( pkgJson.dependencies, pkgDir );
+		}
+	}
+
+	return Array.from( depsMap.values() );
+}
+
+const dependenciesToProcess = getDependenciesToProcess();
 
 checkDeps( dependenciesToProcess, {
 	ignored,

--- a/bin/check-licenses.mjs
+++ b/bin/check-licenses.mjs
@@ -12,8 +12,7 @@ import { fileURLToPath } from 'url';
  */
 import {
 	checkDeps,
-	getLicenses,
-	resolvePackagePath,
+	collectDeps,
 	readPackageJson,
 } from '../packages/scripts/utils/license.js';
 
@@ -31,86 +30,25 @@ const ROOT_DIR = path.resolve( __dirname, '..' );
  * 4. Reading the license from each resolved package
  */
 
-/**
- * Get all production dependencies for packages with wpScript or wpScriptModuleExports.
- *
- * @return {Array} Array of dependency objects with name, version, path, and license
- */
-function getDependenciesToProcess() {
-	const packagesDir = path.join( ROOT_DIR, 'packages' );
-	const licenses = getLicenses( true );
-	const depsMap = new Map();
-	const visited = new Set();
+const packagesDir = path.join( ROOT_DIR, 'packages' );
+const depsMap = new Map();
+const visited = new Set();
 
-	/**
-	 * Recursively collect production dependencies.
-	 *
-	 * @param {Object} deps    - Dependencies object from package.json
-	 * @param {string} fromDir - Directory to resolve from
-	 */
-	function collectDeps( deps, fromDir ) {
-		if ( ! deps ) {
-			return;
-		}
+// Find all workspace packages with wpScript or wpScriptModuleExports
+for ( const dir of fs.readdirSync( packagesDir ) ) {
+	const pkgDir = path.join( packagesDir, dir );
+	const pkgJson = readPackageJson( pkgDir );
 
-		for ( const depName of Object.keys( deps ) ) {
-			// Skip workspace packages (they start with @wordpress/)
-			if ( depName.startsWith( '@wordpress/' ) ) {
-				continue;
-			}
-
-			const depPath = resolvePackagePath( depName, fromDir );
-			if ( ! depPath ) {
-				continue;
-			}
-
-			// Avoid infinite loops
-			if ( visited.has( depPath ) ) {
-				continue;
-			}
-			visited.add( depPath );
-
-			const depPkgJson = readPackageJson( depPath );
-			if ( ! depPkgJson ) {
-				continue;
-			}
-
-			const key = `${ depName }@${ depPkgJson.version }`;
-			if ( ! depsMap.has( key ) ) {
-				const license = depPkgJson.license;
-
-				// Skip if license is in the allowed list
-				if ( ! license || ! licenses.includes( license ) ) {
-					depsMap.set( key, {
-						name: depName,
-						version: depPkgJson.version,
-						path: depPath,
-						license,
-					} );
-				}
-			}
-
-			// Recursively check this package's dependencies
-			collectDeps( depPkgJson.dependencies, depPath );
-		}
+	if ( pkgJson?.wpScript || pkgJson?.wpScriptModuleExports ) {
+		collectDeps( pkgJson.dependencies, pkgDir, {
+			gpl2: true,
+			depsMap,
+			visited,
+			shouldSkip: ( depName ) => depName.startsWith( '@wordpress/' ),
+		} );
 	}
-
-	// Find all workspace packages with wpScript or wpScriptModuleExports
-	for ( const dir of fs.readdirSync( packagesDir ) ) {
-		const pkgDir = path.join( packagesDir, dir );
-		const pkgJson = readPackageJson( pkgDir );
-
-		if ( pkgJson?.wpScript || pkgJson?.wpScriptModuleExports ) {
-			// Collect production dependencies for this package
-			collectDeps( pkgJson.dependencies, pkgDir );
-		}
-	}
-
-	return Array.from( depsMap.values() );
 }
 
-const dependenciesToProcess = getDependenciesToProcess();
-
-checkDeps( dependenciesToProcess, {
+checkDeps( Array.from( depsMap.values() ), {
 	gpl2: true,
 } );

--- a/bin/check-licenses.mjs
+++ b/bin/check-licenses.mjs
@@ -20,10 +20,6 @@ import {
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const ROOT_DIR = path.resolve( __dirname, '..' );
 
-const ignored = [
-	// Nothing ignored for now
-];
-
 /*
  * This script checks licenses for production dependencies of packages that are
  * shipped with WordPress (those with wpScript or wpScriptModuleExports in package.json).
@@ -116,6 +112,5 @@ function getDependenciesToProcess() {
 const dependenciesToProcess = getDependenciesToProcess();
 
 checkDeps( dependenciesToProcess, {
-	ignored,
 	gpl2: true,
 } );

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -1,13 +1,13 @@
 /**
- * External dependencies
- */
-const spawn = require( 'cross-spawn' );
-
-/**
  * Internal dependencies
  */
 const { getArgFromCLI, hasArgInCLI } = require( '../utils' );
-const { checkDeps, getLicenses } = require( '../utils/license' );
+const {
+	checkDeps,
+	getLicenses,
+	resolvePackagePath,
+	readPackageJson,
+} = require( '../utils/license' );
 
 /*
  * WARNING: Changes to this file may inadvertently cause us to distribute code that
@@ -29,22 +29,92 @@ const ignored = hasArgInCLI( '--ignore' )
 			.map( ( moduleName ) => moduleName.trim() )
 	: [];
 
-let query = '';
-if ( prod ) {
-	query += '.prod';
-} else if ( dev ) {
-	query += '.dev';
-} else {
-	query += '*';
+/**
+ * Get dependencies to check based on the current package.json.
+ * Uses Node's module resolution which works with any package manager.
+ *
+ * @return {Array} Array of dependency objects with name, version, path, and license
+ */
+function getDependenciesToCheck() {
+	const cwd = process.cwd();
+	const pkgJson = readPackageJson( cwd );
+
+	if ( ! pkgJson ) {
+		process.stdout.write(
+			'Unable to find package.json in current directory.\n'
+		);
+		process.exit( 1 );
+	}
+
+	let depsToCheck = {};
+	if ( prod ) {
+		depsToCheck = pkgJson.dependencies || {};
+	} else if ( dev ) {
+		depsToCheck = pkgJson.devDependencies || {};
+	} else {
+		depsToCheck = {
+			...( pkgJson.dependencies || {} ),
+			...( pkgJson.devDependencies || {} ),
+		};
+	}
+
+	const licenses = getLicenses( gpl2 );
+	const depsMap = new Map();
+	const visited = new Set();
+
+	/**
+	 * Recursively collect dependencies.
+	 *
+	 * @param {Object} deps    - Dependencies object from package.json
+	 * @param {string} fromDir - Directory to resolve from
+	 */
+	function collectDeps( deps, fromDir ) {
+		if ( ! deps ) {
+			return;
+		}
+
+		for ( const depName of Object.keys( deps ) ) {
+			const depPath = resolvePackagePath( depName, fromDir );
+			if ( ! depPath ) {
+				continue;
+			}
+
+			// Avoid infinite loops
+			if ( visited.has( depPath ) ) {
+				continue;
+			}
+			visited.add( depPath );
+
+			const depPkgJson = readPackageJson( depPath );
+			if ( ! depPkgJson ) {
+				continue;
+			}
+
+			const key = `${ depName }@${ depPkgJson.version }`;
+			if ( ! depsMap.has( key ) ) {
+				const license = depPkgJson.license;
+
+				// Skip if license is in the allowed list
+				if ( ! license || ! licenses.includes( license ) ) {
+					depsMap.set( key, {
+						name: depName,
+						version: depPkgJson.version,
+						path: depPath,
+						license,
+					} );
+				}
+			}
+
+			// Recursively check this package's dependencies
+			collectDeps( depPkgJson.dependencies, depPath );
+		}
+	}
+
+	collectDeps( depsToCheck, cwd );
+
+	return Array.from( depsMap.values() );
 }
 
-query += `:not(${ getLicenses( gpl2 )
-	.map( ( license ) => `[license=${ JSON.stringify( license ) }]` )
-	.join( ',' ) })`;
-
-// Use `npm query` to grab a list of all the packages.
-const child = spawn.sync( 'npm', [ 'query', query ] );
-
-const packages = JSON.parse( child.stdout.toString() );
+const packages = getDependenciesToCheck();
 
 checkDeps( packages, { ignored, gpl2 } );

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -4,8 +4,7 @@
 const { getArgFromCLI, hasArgInCLI } = require( '../utils' );
 const {
 	checkDeps,
-	getLicenses,
-	resolvePackagePath,
+	collectDeps,
 	readPackageJson,
 } = require( '../utils/license' );
 
@@ -29,92 +28,33 @@ const ignored = hasArgInCLI( '--ignore' )
 			.map( ( moduleName ) => moduleName.trim() )
 	: [];
 
-/**
- * Get dependencies to check based on the current package.json.
- * Uses Node's module resolution which works with any package manager.
- *
- * @return {Array} Array of dependency objects with name, version, path, and license
- */
-function getDependenciesToCheck() {
-	const cwd = process.cwd();
-	const pkgJson = readPackageJson( cwd );
+const cwd = process.cwd();
+const pkgJson = readPackageJson( cwd );
 
-	if ( ! pkgJson ) {
-		process.stdout.write(
-			'Unable to find package.json in current directory.\n'
-		);
-		process.exit( 1 );
-	}
-
-	let depsToCheck = {};
-	if ( prod ) {
-		depsToCheck = pkgJson.dependencies || {};
-	} else if ( dev ) {
-		depsToCheck = pkgJson.devDependencies || {};
-	} else {
-		depsToCheck = {
-			...( pkgJson.dependencies || {} ),
-			...( pkgJson.devDependencies || {} ),
-		};
-	}
-
-	const licenses = getLicenses( gpl2 );
-	const depsMap = new Map();
-	const visited = new Set();
-
-	/**
-	 * Recursively collect dependencies.
-	 *
-	 * @param {Object} deps    - Dependencies object from package.json
-	 * @param {string} fromDir - Directory to resolve from
-	 */
-	function collectDeps( deps, fromDir ) {
-		if ( ! deps ) {
-			return;
-		}
-
-		for ( const depName of Object.keys( deps ) ) {
-			const depPath = resolvePackagePath( depName, fromDir );
-			if ( ! depPath ) {
-				continue;
-			}
-
-			// Avoid infinite loops
-			if ( visited.has( depPath ) ) {
-				continue;
-			}
-			visited.add( depPath );
-
-			const depPkgJson = readPackageJson( depPath );
-			if ( ! depPkgJson ) {
-				continue;
-			}
-
-			const key = `${ depName }@${ depPkgJson.version }`;
-			if ( ! depsMap.has( key ) ) {
-				const license = depPkgJson.license;
-
-				// Skip if license is in the allowed list
-				if ( ! license || ! licenses.includes( license ) ) {
-					depsMap.set( key, {
-						name: depName,
-						version: depPkgJson.version,
-						path: depPath,
-						license,
-					} );
-				}
-			}
-
-			// Recursively check this package's dependencies
-			collectDeps( depPkgJson.dependencies, depPath );
-		}
-	}
-
-	collectDeps( depsToCheck, cwd );
-
-	return Array.from( depsMap.values() );
+if ( ! pkgJson ) {
+	process.stdout.write(
+		'Unable to find package.json in current directory.\n'
+	);
+	process.exit( 1 );
 }
 
-const packages = getDependenciesToCheck();
+let depsToCheck = {};
+if ( prod ) {
+	depsToCheck = pkgJson.dependencies || {};
+} else if ( dev ) {
+	depsToCheck = pkgJson.devDependencies || {};
+} else {
+	depsToCheck = {
+		...( pkgJson.dependencies || {} ),
+		...( pkgJson.devDependencies || {} ),
+	};
+}
 
-checkDeps( packages, { ignored, gpl2 } );
+const depsMap = new Map();
+collectDeps( depsToCheck, cwd, {
+	gpl2,
+	depsMap,
+	visited: new Set(),
+} );
+
+checkDeps( Array.from( depsMap.values() ), { ignored, gpl2 } );

--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -411,10 +411,17 @@ function resolvePackagePath( packageName, fromDir ) {
 		);
 		return realpathSync( path.dirname( resolved ) );
 	} catch {
+		// Some packages use `exports` in package.json without exporting
+		// `./package.json`. In that case, resolving `pkg/package.json` fails
+		// but resolving the main entry still works. Walk up from the resolved
+		// main entry to find the nearest package.json.
 		try {
 			const mainResolved = localRequire.resolve( packageName );
 			let dir = path.dirname( mainResolved );
 			while ( dir !== path.parse( dir ).root ) {
+				if ( path.basename( dir ) === 'node_modules' ) {
+					break;
+				}
 				if ( existsSync( path.join( dir, 'package.json' ) ) ) {
 					return realpathSync( dir );
 				}
@@ -434,21 +441,80 @@ function resolvePackagePath( packageName, fromDir ) {
  * @return {Object|null} Parsed package.json or null if not found
  */
 function readPackageJson( dir ) {
-	const pkgJsonPath = path.join( dir, 'package.json' );
-	if ( existsSync( pkgJsonPath ) ) {
-		try {
-			return JSON.parse( readFileSync( pkgJsonPath, 'utf8' ) );
-		} catch {
-			return null;
-		}
+	try {
+		return JSON.parse(
+			readFileSync( path.join( dir, 'package.json' ), 'utf8' )
+		);
+	} catch {
+		return null;
 	}
-	return null;
+}
+
+/**
+ * Recursively collect production dependencies using Node's module resolution.
+ *
+ * @param {Object}   deps                 - Dependencies object from package.json
+ * @param {string}   fromDir              - Directory to resolve from
+ * @param {Object}   options
+ * @param {boolean}  options.gpl2         - Only allow GPL2 compatible licenses
+ * @param {Map}      options.depsMap      - Map to accumulate discovered dependencies
+ * @param {Set}      options.visited      - Set of already-visited paths (prevents cycles)
+ * @param {Function} [options.shouldSkip] - Optional callback; return true to skip a dep by name
+ */
+function collectDeps( deps, fromDir, options ) {
+	if ( ! deps ) {
+		return;
+	}
+
+	const { gpl2, depsMap, visited, shouldSkip } = options;
+	const licenses = getLicenses( gpl2 );
+
+	for ( const depName of Object.keys( deps ) ) {
+		if ( shouldSkip && shouldSkip( depName ) ) {
+			continue;
+		}
+
+		const depPath = resolvePackagePath( depName, fromDir );
+		if ( ! depPath ) {
+			continue;
+		}
+
+		// Avoid infinite loops
+		if ( visited.has( depPath ) ) {
+			continue;
+		}
+		visited.add( depPath );
+
+		const depPkgJson = readPackageJson( depPath );
+		if ( ! depPkgJson ) {
+			continue;
+		}
+
+		const key = `${ depName }@${ depPkgJson.version }`;
+		if ( ! depsMap.has( key ) ) {
+			const license = depPkgJson.license;
+
+			// Skip if license is in the allowed list
+			if ( ! license || ! licenses.includes( license ) ) {
+				depsMap.set( key, {
+					name: depName,
+					version: depPkgJson.version,
+					path: depPath,
+					license,
+				} );
+			}
+		}
+
+		// Recursively check this package's dependencies
+		collectDeps( depPkgJson.dependencies, depPath, options );
+	}
 }
 
 module.exports = {
 	detectTypeFromLicenseText,
 	checkAllCompatible,
 	checkDeps,
+	collectDeps,
 	getLicenses,
 	resolvePackagePath,
 	readPackageJson,

--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -1,8 +1,8 @@
-/**
- * External dependencies
- */
+const { existsSync, readFileSync, realpathSync } = require( 'node:fs' );
+const path = require( 'node:path' );
+const { createRequire, findPackageJSON } = require( 'node:module' );
+const { pathToFileURL } = require( 'node:url' );
 const chalk = require( 'chalk' );
-const { existsSync, readFileSync } = require( 'node:fs' );
 
 const ERROR_TEXT = chalk.reset.inverse.bold.red( ' ERROR ' );
 const WARNING_TEXT = chalk.reset.inverse.bold.yellow( ' WARNING ' );
@@ -208,18 +208,20 @@ function detectTypeFromLicenseText( licenseText ) {
 const reportedPackages = new Set();
 
 /**
- * @param {string}   path
+ * @param {string}   depPath
  * @param {Licenses} licenses
  * @return {void}
  */
-function checkDepLicense( path, licenses ) {
-	if ( ! path ) {
+function checkDepLicense( depPath, licenses ) {
+	if ( ! depPath ) {
 		return;
 	}
 
-	const filename = path + '/package.json';
+	const filename = depPath + '/package.json';
 	if ( ! existsSync( filename ) ) {
-		process.stdout.write( `Unable to locate package.json in ${ path }.` );
+		process.stdout.write(
+			`Unable to locate package.json in ${ depPath }.`
+		);
 		process.exit( 1 );
 	}
 
@@ -349,17 +351,17 @@ function checkDeps( deps, options ) {
 }
 
 /**
- * @param {string} path The path to the package.
+ * @param {string} depPath The path to the package.
  * @return {boolean} true if the package has a license, false if it
  */
-function detectTypeFromLicenseFiles( path ) {
+function detectTypeFromLicenseFiles( depPath ) {
 	return licenseFiles.reduce( ( detectedType, licenseFile ) => {
 		// If another LICENSE file already had licenses in it, use those.
 		if ( detectedType ) {
 			return detectedType;
 		}
 
-		const licensePath = path + '/' + licenseFile;
+		const licensePath = depPath + '/' + licenseFile;
 
 		if ( existsSync( licensePath ) ) {
 			const licenseText = readFileSync( licensePath ).toString();
@@ -370,9 +372,83 @@ function detectTypeFromLicenseFiles( path ) {
 	}, false );
 }
 
+/**
+ * Resolve a package's path using Node's resolution algorithm.
+ * Works regardless of package manager (npm, pnpm, yarn, etc.).
+ *
+ * Uses `findPackageJSON` from node:module (Node.js 22.14.0+) when available,
+ * with a fallback for older versions.
+ *
+ * @param {string} packageName - Name of the package to resolve
+ * @param {string} fromDir     - Directory to resolve from
+ * @return {string|null} Path to the package directory, or null if not found
+ */
+function resolvePackagePath( packageName, fromDir ) {
+	// Use findPackageJSON when available (Node.js 22.14.0+)
+	if ( findPackageJSON ) {
+		try {
+			const parentURL = pathToFileURL(
+				path.join( fromDir, 'package.json' )
+			);
+			const pkgJsonPath = findPackageJSON( packageName, parentURL );
+			if ( pkgJsonPath ) {
+				// Use realpathSync to resolve symlinks. Without this, transitive dep resolution fails
+				// because Node resolves from the symlink path, not the real store path where sibling deps are located.
+				return realpathSync( path.dirname( pkgJsonPath ) );
+			}
+		} catch {
+			// Package not found
+		}
+		return null;
+	}
+
+	// Fallback for older Node.js versions
+	const localRequire = createRequire( path.join( fromDir, 'package.json' ) );
+	try {
+		const resolved = localRequire.resolve(
+			`${ packageName }/package.json`
+		);
+		return realpathSync( path.dirname( resolved ) );
+	} catch {
+		try {
+			const mainResolved = localRequire.resolve( packageName );
+			let dir = path.dirname( mainResolved );
+			while ( dir !== path.parse( dir ).root ) {
+				if ( existsSync( path.join( dir, 'package.json' ) ) ) {
+					return realpathSync( dir );
+				}
+				dir = path.dirname( dir );
+			}
+		} catch {
+			// Package not found
+		}
+		return null;
+	}
+}
+
+/**
+ * Read package.json from a directory.
+ *
+ * @param {string} dir - Directory containing package.json
+ * @return {Object|null} Parsed package.json or null if not found
+ */
+function readPackageJson( dir ) {
+	const pkgJsonPath = path.join( dir, 'package.json' );
+	if ( existsSync( pkgJsonPath ) ) {
+		try {
+			return JSON.parse( readFileSync( pkgJsonPath, 'utf8' ) );
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
 module.exports = {
 	detectTypeFromLicenseText,
 	checkAllCompatible,
 	checkDeps,
 	getLicenses,
+	resolvePackagePath,
+	readPackageJson,
 };

--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -71,6 +71,7 @@ const gpl2CompatibleLicenses = [
 	'ISC',
 	'LGPL-2.1',
 	'MIT',
+	'MIT-0',
 	'MIT/X11',
 	'MPL-2.0',
 	'ODC-By-1.0',


### PR DESCRIPTION
Closes #74429, inspired by #74309

## What?

Alternative to #74694, fixing the issue in the `scripts` package itself.

Rewrite the license check scripts to use Node's native module resolution, with support for `findPackageJSON` (Node.js 22.14.0+).

## Why?

The current implementation uses `npm query` to find production dependencies, but the query logic has issues:

1. **Incorrect transitive dependency inclusion**: The query captures all transitive dependencies, including those from dev-tool packages like Jest (via `@wordpress/scripts`). This causes packages like `@ampproject/remapping`, `bser`, `fb-watchman`, and `walker` to be incorrectly flagged, requiring manual maintenance of an `ignored` list.

2. **Package manager dependency**: The `npm query` approach only works with npm, not with pnpm or yarn.

The new implementation:
- Uses Node's native module resolution (`findPackageJSON` when available, with fallback)
- Works with npm, pnpm, and yarn classic (not yarn PnP which doesn't use `node_modules`)
- Consolidates the resolution logic in `packages/scripts/utils/license.js` for reuse
- Eliminates the need for the `ignored` list

## How?

1. **Added shared utilities to `packages/scripts/utils/license.js`**:
   - `resolvePackagePath()` - resolves a package using `findPackageJSON` (Node 22.14+) or `createRequire` fallback
   - `readPackageJson()` - reads and parses package.json from a directory

2. **Updated `bin/check-licenses.mjs`** (Gutenberg CI):
   - Uses the shared utilities instead of `npm query`
   - Iterates over workspace packages with `wpScript`/`wpScriptModuleExports`
   - Recursively resolves production dependencies

3. **Updated `packages/scripts/scripts/check-licenses.js`** (`wp-scripts check-licenses`):
   - Now also uses the shared utilities instead of `npm query`
   - Makes it package-manager agnostic for external users

4. **Added `MIT-0` to GPL2-compatible licenses**:
   - MIT-0 (MIT No Attribution) is more permissive than MIT, so it's GPL2 compatible

## Testing Instructions

1. Run the license check to verify it passes:
   ```bash
   node bin/check-licenses.mjs
   ```

**Test 1: Direct dependency with incompatible license**

2. Add `typescript` (Apache-2.0, not GPL-compatible) as a prod dependency:
   ```bash
   npm install --workspace=@wordpress/a11y typescript@5.9.3
   ```

3. Run the license check - it should fail:
   ```bash
   node bin/check-licenses.mjs
   # Should output an error about typescript having Apache-2.0 license
   ```

4. Move typescript to devDependencies (which are not checked):
   ```bash
   npm install --workspace=@wordpress/a11y --save-dev typescript@5.9.3
   ```

5. Run the license check again - it should pass:
   ```bash
   node bin/check-licenses.mjs
   # Should pass since devDependencies are not checked
   ```

6. Restore:
   ```bash
   git checkout packages/a11y/package.json
   npm install
   ```

**Test 2: Transitive dependency with incompatible license**

7. Add `jest` (MIT license, but has transitive deps with Apache-2.0) as a prod dependency:
   ```bash
   npm install --workspace=@wordpress/a11y jest@29.6.2
   ```

8. Run the license check - it should fail due to transitive dependencies like `@ampproject/remapping` (Apache-2.0):
   ```bash
   node bin/check-licenses.mjs
   # Should output an error about Apache-2.0 license
   ```

9. Move jest to devDependencies (which are not checked):
   ```bash
   npm install --workspace=@wordpress/a11y --save-dev jest@29.6.2
   ```

10. Run the license check again - it should pass:
    ```bash
    node bin/check-licenses.mjs
    # Should pass since devDependencies are not checked
    ```

11. Restore the original state:
    ```bash
    git checkout packages/a11y/package.json
    npm install
    ```

12. Repeat the above steps for a package without `wpScript` or `wpScriptModuleExports`. For example, `@wordpress/env` and confirm that the license check doesn't fail in any case.

**Test 3: wp-scripts check-licenses**

13. Test that `wp-scripts check-licenses` also works:
    ```bash
    cd packages/a11y
    node ../../packages/scripts/scripts/check-licenses.js --prod --gpl2
    ```
