### PR TITLE
Pattern Editing: Display link controls for nav links and submenus in the Inspector Content Tab

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -6,15 +6,28 @@ import {
 	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockQuickNavigation from '../block-quick-navigation';
 import groups from '../inspector-controls/groups';
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const ContentTab = ( { contentClientIds } ) => {
 	const contentFills = useSlotFills( groups.content?.name );
+
+	const getBlockName = useSelect(
+		( select ) => select( blockEditorStore ).getBlockName,
+		[]
+	);
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { showBlockAttributeGroup } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	if ( ! contentClientIds || contentClientIds.length === 0 ) {
 		return null;
@@ -30,6 +43,19 @@ const ContentTab = ( { contentClientIds } ) => {
 	// Collapse the Content panel when there are fills in the content group.
 	const initialOpen = ! hasContentFills;
 
+	const handleSelect = ( clientId ) => {
+		const blockName = getBlockName( clientId );
+		// Navigation block doesn't have List View block support, but
+		// it does have a custom implementation that is shown within
+		// patterns, so it's included in this condition.
+		if (
+			blockName === 'core/navigation' ||
+			hasBlockSupport( blockName, 'listView' )
+		) {
+			showBlockAttributeGroup( 'list' );
+		}
+	};
+
 	return (
 		<>
 			{ ! shouldShowBlockFields && (
@@ -37,7 +63,10 @@ const ContentTab = ( { contentClientIds } ) => {
 					title={ __( 'Content' ) }
 					initialOpen={ initialOpen }
 				>
-					<BlockQuickNavigation clientIds={ contentClientIds } />
+					<BlockQuickNavigation
+						clientIds={ contentClientIds }
+						onSelect={ handleSelect }
+					/>
 				</PanelBody>
 			) }
 		</>

--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -1,26 +1,42 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody } from '@wordpress/components';
+import {
+	PanelBody,
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockQuickNavigation from '../block-quick-navigation';
+import groups from '../inspector-controls/groups';
 
 const ContentTab = ( { contentClientIds } ) => {
+	const contentFills = useSlotFills( groups.content?.name );
+
 	if ( ! contentClientIds || contentClientIds.length === 0 ) {
 		return null;
 	}
 
+	// If there are other panels rendering in the content tab using fills,
+	// collapse the content panel to make space.
+	const hasContentFills = Boolean( contentFills && contentFills.length );
+
 	const shouldShowBlockFields =
 		window?.__experimentalContentOnlyInspectorFields;
+
+	// Collapse the Content panel when there are fills in the content group.
+	const initialOpen = ! hasContentFills;
 
 	return (
 		<>
 			{ ! shouldShowBlockFields && (
-				<PanelBody title={ __( 'Content' ) }>
+				<PanelBody
+					title={ __( 'Content' ) }
+					initialOpen={ initialOpen }
+				>
 					<BlockQuickNavigation clientIds={ contentClientIds } />
 				</PanelBody>
 			) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -6,7 +6,6 @@ import {
 	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useEffect, useState, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -46,50 +45,15 @@ export default function InspectorControlsTabs( {
 		useDispatch( blockEditorStore )
 	);
 
-	const [ selectedTabId, setSelectedTabId ] = useState( tabs[ 0 ]?.name );
-	const hasUserSelectionRef = useRef( false );
-
-	// Reset when switching blocks
-	useEffect( () => {
-		hasUserSelectionRef.current = false;
-		// Clear any programmatic tab selection when switching blocks.
-		showBlockAttributeGroup( null );
-	}, [ clientId, showBlockAttributeGroup ] );
-
-	// Handle programmatic tab selection from the store.
-	useEffect( () => {
-		if (
-			blockAttributeGroup &&
-			tabs.some( ( tab ) => tab.name === blockAttributeGroup )
-		) {
-			setSelectedTabId( blockAttributeGroup );
-			// Clear the store value after applying it.
-			showBlockAttributeGroup( null );
-			// Consider this a user selection, seeing as it
-			// is usually triggered by another user action.
-			hasUserSelectionRef.current = true;
-		}
-	}, [ blockAttributeGroup, tabs, showBlockAttributeGroup ] );
-
-	// Auto-select first available tab unless user has made a selection
-	useEffect( () => {
-		if (
-			! tabs?.length ||
-			( hasUserSelectionRef.current &&
-				tabs.some( ( tab ) => tab.name === selectedTabId ) )
-		) {
-			return;
-		}
-
-		const firstTabName = tabs[ 0 ]?.name;
-		if ( selectedTabId !== firstTabName ) {
-			setSelectedTabId( firstTabName );
-		}
-	}, [ tabs, selectedTabId ] );
+	// Determine the selected tab from store state, or fall back to the first available tab.
+	const selectedTabId =
+		blockAttributeGroup &&
+		tabs.some( ( tab ) => tab.name === blockAttributeGroup )
+			? blockAttributeGroup
+			: tabs[ 0 ]?.name;
 
 	const handleTabSelect = ( tabId ) => {
-		setSelectedTabId( tabId );
-		hasUserSelectionRef.current = true;
+		showBlockAttributeGroup( tabId );
 	};
 
 	return (

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -65,6 +65,9 @@ export default function InspectorControlsTabs( {
 			setSelectedTabId( blockAttributeGroup );
 			// Clear the store value after applying it.
 			showBlockAttributeGroup( null );
+			// Consider this a user selection, seeing as it
+			// is usually triggered by another user action.
+			hasUserSelectionRef.current = true;
 		}
 	}, [ blockAttributeGroup, tabs, showBlockAttributeGroup ] );
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import StylesTab from './styles-tab';
 import ContentTab from './content-tab';
 import InspectorControls from '../inspector-controls';
 import { unlock } from '../../lock-unlock';
+import { store as blockEditorStore } from '../../store';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -30,9 +31,20 @@ export default function InspectorControlsTabs( {
 	isSectionBlock,
 	contentClientIds,
 } ) {
-	const showIconLabels = useSelect( ( select ) => {
-		return select( preferencesStore ).get( 'core', 'showIconLabels' );
+	const { showIconLabels, blockAttributeGroup } = useSelect( ( select ) => {
+		const { getBlockAttributeGroup } = unlock( select( blockEditorStore ) );
+		return {
+			showIconLabels: select( preferencesStore ).get(
+				'core',
+				'showIconLabels'
+			),
+			blockAttributeGroup: getBlockAttributeGroup(),
+		};
 	}, [] );
+
+	const { showBlockAttributeGroup } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const [ selectedTabId, setSelectedTabId ] = useState( tabs[ 0 ]?.name );
 	const hasUserSelectionRef = useRef( false );
@@ -40,7 +52,21 @@ export default function InspectorControlsTabs( {
 	// Reset when switching blocks
 	useEffect( () => {
 		hasUserSelectionRef.current = false;
-	}, [ clientId ] );
+		// Clear any programmatic tab selection when switching blocks.
+		showBlockAttributeGroup( null );
+	}, [ clientId, showBlockAttributeGroup ] );
+
+	// Handle programmatic tab selection from the store.
+	useEffect( () => {
+		if (
+			blockAttributeGroup &&
+			tabs.some( ( tab ) => tab.name === blockAttributeGroup )
+		) {
+			setSelectedTabId( blockAttributeGroup );
+			// Clear the store value after applying it.
+			showBlockAttributeGroup( null );
+		}
+	}, [ blockAttributeGroup, tabs, showBlockAttributeGroup ] );
 
 	// Auto-select first available tab unless user has made a selection
 	useEffect( () => {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -266,7 +266,7 @@
 			content: "";
 			position: absolute;
 			top: 0;
-			right: -(24px + 5px); // Icon size + padding.
+			right: -(24px + 4px); // Icon size + padding.
 			bottom: 0;
 			left: 0;
 			border-radius: inherit;

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -453,3 +453,19 @@ export function toggleBlockSpotlight( clientId, hasBlockSpotlight ) {
 		hasBlockSpotlight,
 	};
 }
+
+/**
+ * Action that sets the active block attribute group in the inspector controls tabs.
+ *
+ * This can be used to programmatically switch between tabs in the block inspector.
+ * The value is cleared after it is applied or when the selected block changes.
+ *
+ * @param {string|null} group The group to show. One of 'settings', 'styles', 'content', or 'list'. Pass null to reset.
+ * @return {Object} Action object.
+ */
+export function showBlockAttributeGroup( group ) {
+	return {
+		type: 'SHOW_BLOCK_ATTRIBUTE_GROUP',
+		group,
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -950,3 +950,14 @@ export function isLockedBlock( state, clientId ) {
 		isRemoveLockedBlock( state, clientId )
 	);
 }
+
+/**
+ * Returns the currently active block attribute group in the inspector controls.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string|null} The active group ('settings', 'styles', 'content', 'list') or null.
+ */
+export function getBlockAttributeGroup( state ) {
+	return state.blockAttributeGroup;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2084,6 +2084,23 @@ export function zoomLevel( state = 100, action ) {
 }
 
 /**
+ * Reducer for the block attribute group visibility in the inspector.
+ *
+ * @param {string|null} state  Current state.
+ * @param {Object}      action Dispatched action.
+ *
+ * @return {string|null} Updated state.
+ */
+export function blockAttributeGroup( state = null, action ) {
+	switch ( action.type ) {
+		case 'SHOW_BLOCK_ATTRIBUTE_GROUP':
+			return action.group;
+	}
+
+	return state;
+}
+
+/**
  * Reducer setting the insertion point
  *
  * @param {boolean} state  Current state.
@@ -2123,6 +2140,7 @@ const combinedReducers = combineReducers( {
 	lastFocus,
 	expandedBlock,
 	highlightedBlock,
+	blockAttributeGroup,
 	lastBlockInserted,
 	editedContentOnlySection,
 	blockVisibility,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -366,6 +366,8 @@ export default function NavigationLinkEdit( {
 	} );
 
 	const missingText = getMissingText( type );
+	const hasDataFormBlockFields =
+		window?.__experimentalContentOnlyInspectorFields;
 
 	return (
 		<>
@@ -390,13 +392,15 @@ export default function NavigationLinkEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
-				<Controls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-				/>
-			</InspectorControls>
+			{ ! hasDataFormBlockFields && isSelected && (
+				<InspectorControls group="content">
+					<Controls
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						clientId={ clientId }
+					/>
+				</InspectorControls>
+			) }
 			<div { ...blockProps }>
 				{ hasMissingEntity && (
 					<VisuallyHidden id={ missingEntityDescriptionId }>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -306,6 +306,8 @@ export default function NavigationSubmenuEdit( {
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;
+	const hasDataFormBlockFields =
+		window?.__experimentalContentOnlyInspectorFields;
 
 	return (
 		<>
@@ -333,13 +335,15 @@ export default function NavigationSubmenuEdit( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
-				<Controls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-				/>
-			</InspectorControls>
+			{ ! hasDataFormBlockFields && isSelected && (
+				<InspectorControls group="content">
+					<Controls
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						clientId={ clientId }
+					/>
+				</InspectorControls>
+			) }
 			<div { ...blockProps }>
 				<ParentElement className="wp-block-navigation-item__content">
 					{ ! isInvalid && ! isDraft && (

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -147,6 +147,10 @@ const MainContent = ( {
 		[ clientId ]
 	);
 
+	const { showBlockAttributeGroup } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
@@ -183,6 +187,16 @@ const MainContent = ( {
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
 				additionalBlockContent={ AdditionalBlockContent }
+				onSelect={ ( block ) => {
+					if (
+						[
+							'core/navigation-link',
+							'core/navigation-submenu',
+						].includes( block.name )
+					) {
+						showBlockAttributeGroup( 'content' );
+					}
+				} }
 			/>
 		</div>
 	);

--- a/packages/editor/src/hooks/template-part-navigation-edit-button.js
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button.js
@@ -13,6 +13,11 @@ import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
 // Block name constants
 const NAVIGATION_BLOCK_NAME = 'core/navigation';
 const TEMPLATE_PART_BLOCK_NAME = 'core/template-part';
@@ -30,6 +35,9 @@ const BLOCK_INSPECTOR_AREA = 'edit-post/block';
  */
 function TemplatePartNavigationEditButton( { clientId } ) {
 	const { selectBlock, flashBlock } = useDispatch( blockEditorStore );
+	const { showBlockAttributeGroup } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const {
@@ -78,12 +86,16 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 
 			// Enable the complementary area (inspector)
 			enableComplementaryArea( 'core', BLOCK_INSPECTOR_AREA );
+
+			// Show the list view tab in the inspector
+			showBlockAttributeGroup( 'list' );
 		}
 	}, [
 		firstNavigationBlockId,
 		selectBlock,
 		flashBlock,
 		enableComplementaryArea,
+		showBlockAttributeGroup,
 	] );
 
 	// Only show if template part contains navigation blocks and they are editable


### PR DESCRIPTION
Related #74895

## What?
Moves the navigation link and submenu inspector controls to the 'Content' group/tab, so that they are displayed for patterns.

## Why?
See the issue for more context.

This PR presents a potential avenue, but currently an imperfect one. I'm curious about feedback so sharing early.

While it is possible to display the controls in the inspector for nav links and submenus, I don't think the interactions are quite right. For example the Controls are shown in a panel that just says 'Settings', and perhaps the block icon/title should be shown in this context (similar to the block fields experiment). The video below is also of a Template Part with only two blocks in the 'Content' panel. When the 'Content' panel is longer, the nav link/submenu settings will be further off-screen.

There's also the missing interplay between the List tab and the Content tab that was present before. Some changes to the tab selection are being proposed in [Navigation: select list view tab on contentOnly](https://github.com/WordPress/gutenberg/pull/75024#top), so that might help move things closer .

If we go this route and resolve the interactions, then it might be worth also showing similar controls for List Item, Button, Social Link which have a similar List View feature to the navigation block.

## How?
Switches the `InspectorControls` group to `content`. Also adds some conditions:
- `isSelected` - for patterns, multiple child blocks can display their controls at once, for simplicity this only shows the selected nav link's controls.
- `! hasDataFormBlockFields` - prevents duplicate controls from the block fields experiment when that's active.

## Testing Instructions
1. Open a template
2. Click on a navigation link or submenu
3. Observe the block's controls are shown in the Content tab.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9e0ea26e-a634-4bcd-9773-c432f8b2c6fc

