### PR TITLE
Fix emdashes in HTML anchor description

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -64,7 +64,7 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 				help={
 					<>
 						{ __(
-							'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor”. Then, you’ll be able to link directly to this section of your page.'
+							'Enter a word or two—without spaces—to make a unique web address just for this block, called an “anchor”. Then, you’ll be able to link directly to this section of your page.'
 						) }
 						{ isWeb && (
 							<>


### PR DESCRIPTION
I noticed that we're using the wrong convention for emdashes when describing a block's HTML anchor. There should be no spaces, the "Chicago" convention it's called if I'm not mistaken.

The difference is particularly conspicous when you see two conventions used in a single block sidebar:

<img width="284" height="517" alt="Screenshot 2026-01-26 at 16 06 08" src="https://github.com/user-attachments/assets/229fded8-21ff-4e47-9006-c1bc9f362c6c" />

The HTML anchor uses the wrong one, the "Reload full page" UI uses the right one.