### PR TITLE
Private APIs: remove duplicate `@wordpress/ui` entry

### DIFF
--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -36,7 +36,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/routes',
 	'@wordpress/sync',
 	'@wordpress/theme',
-	'@wordpress/ui',
 	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Clean up duplicate entry from the list of packages using private APIs

See https://github.com/WordPress/gutenberg/pull/74625#discussion_r2701210097

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The duplicate entry is not necessary

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed the duplicate entry

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure private API imports work as expected in the `@wordpress/ui` package: for example, load a `Tooltip` or `Select` storybook example and ensure the `ThemeProvider` private import loads without errors.
