### PR TITLE
Custom CSS support: Add attributes for dynamic blocks.

### DIFF
--- a/backport-changelog/7.0/10777.md
+++ b/backport-changelog/7.0/10777.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/10777
 
 * https://github.com/WordPress/gutenberg/pull/73959
 * https://github.com/WordPress/gutenberg/pull/74969
+* https://github.com/WordPress/gutenberg/pull/75052

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -98,3 +98,36 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 add_filter( 'render_block', 'gutenberg_render_custom_css_class_name', 10, 2 );
 add_filter( 'render_block_data', 'gutenberg_render_custom_css_support_styles', 10, 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_block_custom_css', 1 );
+
+/**
+ * Registers the style block attribute for block types that support it.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_custom_css_support( $block_type ) {
+	// Setup attributes and styles within that if needed.
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	// Check for existing style attribute definition e.g. from block.json.
+	if ( array_key_exists( 'style', $block_type->attributes ) ) {
+		return;
+	}
+
+	$has_custom_css_support = block_has_support( $block_type, array( 'customCSS' ), true );
+
+	if ( $has_custom_css_support ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'custom-css',
+	array(
+		'register_attribute' => 'gutenberg_register_custom_css_support',
+	)
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Custom CSS support: Add attributes for dynamic blocks.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Cannot save custom CSS when style attributes are not added to dynamic blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Place an archive block or similar and set the `supports` in `block.json` to `"supports": {}`.
3. Verify that custom CSS can be added and saved from the Advanced settings.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/5bc8e4a0-4a2f-490f-b26a-859ca5b542f2

The archive block's block support is set to `"supports": {}`.


