### PR TITLE
Routing Boot Package: Remove margin and border-radius from layout components

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -68,8 +68,6 @@
 	gap: variables.$grid-unit-10;
 
 	@include mixins.break-medium {
-		margin: variables.$grid-unit-10;
-
 		.boot-layout--single-page & {
 			margin-top: 0;
 			margin-left: 0;
@@ -101,7 +99,6 @@
 		position: static;
 		width: auto;
 		height: auto;
-		border-radius: 8px;
 		margin: 0;
 	}
 }

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -8,7 +8,7 @@
 	flex-direction: row;
 	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	isolation: isolate;
-	background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+	background: var(--wp-admin-color-menu-background, #1d2327);
 }
 
 .boot-layout__sidebar-backdrop {
@@ -68,6 +68,8 @@
 	gap: variables.$grid-unit-10;
 
 	@include mixins.break-medium {
+		margin: variables.$grid-unit-10;
+
 		.boot-layout--single-page & {
 			margin-top: 0;
 			margin-left: 0;
@@ -99,6 +101,7 @@
 		position: static;
 		width: auto;
 		height: auto;
+		border-radius: 8px;
 		margin: 0;
 	}
 }


### PR DESCRIPTION
## What?
Continues #75036

## Why?
@youknowriad commented that when adding Styles in profile, the background was popping for the new layout components

## How?
Instead of removing the background, which may make sense in the future with a future admin redesign, simply fully expanding the margins to cover the whole scene and removing the rounded corners fixes the thing while maintaining all backgrounds.

## Testing Instructions
1. Go to Users > Profile 
2. Switch your Administration Color Scheme to "Blue" for example
3. Go to Appearance > Fonts
4. You will see those black margins right and bottom

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1268" height="1262" alt="image" src="https://github.com/user-attachments/assets/9a6430b5-d0dd-476a-b209-25747e5aa5c5" />|<img width="1268" height="1262" alt="image" src="https://github.com/user-attachments/assets/6527be3c-9fa9-4624-8017-9647703ddfc9" />|
