### PR TITLE
DataViews: Consistent rendering of selection checkbox and actions in `grid` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)
+- DataViews: Consistent rendering of selection checkbox and actions in grid layout. [#75056](https://github.com/WordPress/gutenberg/pull/75056)
 
 ## 11.3.0 (2026-01-29)
 

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -104,16 +104,16 @@ const GridItem = forwardRef( function GridItem< Item >(
 	const mediaPlaceholder = (
 		<span className="dataviews-view-grid__media-placeholder" />
 	);
-	const renderedMediaField =
-		showMedia && mediaField?.render ? (
-			<mediaField.render
-				item={ item }
-				field={ mediaField }
-				config={ config }
-			/>
-		) : (
-			mediaPlaceholder
-		);
+	const rendersMediaField = showMedia && mediaField?.render;
+	const renderedMediaField = rendersMediaField ? (
+		<mediaField.render
+			item={ item }
+			field={ mediaField }
+			config={ config }
+		/>
+	) : (
+		mediaPlaceholder
+	);
 	const renderedTitleField =
 		showTitle && titleField?.render ? (
 			<titleField.render item={ item } field={ titleField } />
@@ -168,7 +168,10 @@ const GridItem = forwardRef( function GridItem< Item >(
 				isItemClickable={ isItemClickable }
 				onClickItem={ onClickItem }
 				renderItemLink={ renderItemLink }
-				className="dataviews-view-grid__media"
+				className={ clsx( 'dataviews-view-grid__media', {
+					'dataviews-view-grid__media--placeholder':
+						! rendersMediaField,
+				} ) }
 				{ ...mediaA11yProps }
 			>
 				{ renderedMediaField }

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -101,19 +101,23 @@ const GridItem = forwardRef( function GridItem< Item >(
 	const id = getItemId( item );
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
-	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render
-			item={ item }
-			field={ mediaField }
-			config={ config }
-		/>
-	) : null;
+	const mediaPlaceholder = (
+		<span className="dataviews-view-grid__media-placeholder" />
+	);
+	const renderedMediaField =
+		showMedia && mediaField?.render ? (
+			<mediaField.render
+				item={ item }
+				field={ mediaField }
+				config={ config }
+			/>
+		) : (
+			mediaPlaceholder
+		);
 	const renderedTitleField =
 		showTitle && titleField?.render ? (
 			<titleField.render item={ item } field={ titleField } />
 		) : null;
-	const shouldRenderMedia = showMedia && renderedMediaField;
-
 	let mediaA11yProps;
 	let titleA11yProps;
 	if ( isItemClickable( item ) && onClickItem ) {
@@ -159,19 +163,17 @@ const GridItem = forwardRef( function GridItem< Item >(
 				}
 			} }
 		>
-			{ shouldRenderMedia && (
-				<ItemClickWrapper
-					item={ item }
-					isItemClickable={ isItemClickable }
-					onClickItem={ onClickItem }
-					renderItemLink={ renderItemLink }
-					className="dataviews-view-grid__media"
-					{ ...mediaA11yProps }
-				>
-					{ renderedMediaField }
-				</ItemClickWrapper>
-			) }
-			{ hasBulkActions && shouldRenderMedia && (
+			<ItemClickWrapper
+				item={ item }
+				isItemClickable={ isItemClickable }
+				onClickItem={ onClickItem }
+				renderItemLink={ renderItemLink }
+				className="dataviews-view-grid__media"
+				{ ...mediaA11yProps }
+			>
+				{ renderedMediaField }
+			</ItemClickWrapper>
+			{ hasBulkActions && (
 				<DataViewsSelectionCheckbox
 					item={ item }
 					selection={ selection }
@@ -181,17 +183,13 @@ const GridItem = forwardRef( function GridItem< Item >(
 					disabled={ ! hasBulkAction }
 				/>
 			) }
-			{ ! showTitle && shouldRenderMedia && !! actions?.length && (
+			{ !! actions?.length && (
 				<div className="dataviews-view-grid__media-actions">
 					<ItemActions item={ item } actions={ actions } isCompact />
 				</div>
 			) }
 			{ showTitle && (
-				<Stack
-					direction="row"
-					gap="xs"
-					className="dataviews-view-grid__title-actions"
-				>
+				<div className="dataviews-view-grid__title">
 					<ItemClickWrapper
 						item={ item }
 						isItemClickable={ isItemClickable }
@@ -208,14 +206,7 @@ const GridItem = forwardRef( function GridItem< Item >(
 					>
 						{ renderedTitleField }
 					</ItemClickWrapper>
-					{ !! actions?.length && (
-						<ItemActions
-							item={ item }
-							actions={ actions }
-							isCompact
-						/>
-					) }
-				</Stack>
+				</div>
 			) }
 			<Stack direction="column" gap="2xs">
 				{ showDescription && descriptionField?.render && (

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -87,6 +87,10 @@
 		overflow: hidden;
 		position: relative;
 
+		&.dataviews-view-grid__media--placeholder {
+			aspect-ratio: 3/1;
+		}
+
 		img {
 			object-fit: cover;
 			width: 100%;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -46,7 +46,7 @@
 		justify-content: flex-start;
 		position: relative;
 
-		.dataviews-view-grid__title-actions {
+		.dataviews-view-grid__title {
 			padding: $grid-unit-10 0 $grid-unit-05;
 		}
 
@@ -103,6 +103,15 @@
 			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
 			border-radius: $grid-unit-05;
 			pointer-events: none;
+		}
+
+		.dataviews-view-grid__media-placeholder {
+			width: 100%;
+			height: 100%;
+			display: block;
+			border-radius: $radius-medium;
+			box-shadow: none;
+			background: $gray-100;
 		}
 	}
 
@@ -185,6 +194,7 @@
 
 .dataviews-view-grid__card .dataviews-view-grid__media-actions {
 	position: absolute;
+	z-index: 1;
 	top: $grid-unit-05;
 	opacity: 0;
 	right: $grid-unit-05;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/74046

Alternative of: https://github.com/WordPress/gutenberg/pull/71231

In `grid` layout we have actions and selection checkbox tied to `titleField` and `mediaField`. This has three issues:
1. If there is no `mediaField` or it's hidden, there is no way to render the selection checkbox
2. If there are both `titleField` and `mediaField` and we can hide one of them, actions are repositioned making it a bit inconsistent
3. If both `titleField` and `mediaField`, even if they exist, are hidden, there are no actions and no selection checkbox available. You can see this in storybook [here](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataviews--layout-grid) by hiding the `title and image` fields

This PR follows parts of this [suggestion](https://github.com/WordPress/gutenberg/issues/74046#issuecomment-3810648168). 

> Uses the media field as the element we anchor the actions menu and checkbox

> A mediaField is not required for `grid` layout, but if no mediaField is provided or it is, but is hidden, show a grey placeholder similar to Notion.

For that placeholder I copied the styles we have for featured image field's placeholder




## Testing Instructions
1. In site editor in any page (templates, patterns, etc..) observe that the actions are now always rendered in the media field position.
2. In site editor go to `pages` and hide the `featured image`. Observe that a placeholder is still rendered with the actions and selection checkbox
3. In storybook locally with this PR (`npm run storybook:dev`) test the `grid` layout story (`?path=/story/dataviews-dataviews--layout-grid`) and hide  the `title and image` fields


### Before `pages`

https://github.com/user-attachments/assets/fbceeca9-9caa-4db4-8832-9811644d3972



### After `pages`


https://github.com/user-attachments/assets/d1d8e559-7ca2-4f1c-aeee-aefb9d275050





### After `grid` story

https://github.com/user-attachments/assets/e6e9eee7-4a8e-4e43-a13d-2b33b4baf886






