### PR TITLE
wp-env: Fix mixed runtime detection issues

### DIFF
--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -18,6 +18,7 @@ const {
 	getAvailableRuntimes,
 	getRuntime,
 	UnsupportedCommandError,
+	EnvironmentNotInitializedError,
 } = require( './runtime' );
 
 // Colors.
@@ -45,8 +46,11 @@ const withSpinner =
 				process.exit( 0 );
 			},
 			( error ) => {
-				if ( error instanceof UnsupportedCommandError ) {
-					// Error is an unsupported command in the current runtime.
+				if (
+					error instanceof UnsupportedCommandError ||
+					error instanceof EnvironmentNotInitializedError
+				) {
+					// Error is a known user-facing error.
 					spinner.fail( error.message );
 					process.exit( 1 );
 				} else if (

--- a/packages/env/lib/commands/clean.js
+++ b/packages/env/lib/commands/clean.js
@@ -32,7 +32,9 @@ module.exports = async function clean( {
 	debug,
 } ) {
 	const config = await loadConfig( path.resolve( '.' ) );
-	const runtime = getRuntime( detectRuntime( config.workDirectoryPath ) );
+	const runtime = getRuntime(
+		await detectRuntime( config.workDirectoryPath )
+	);
 
 	await runtime.clean( config, { environment, spinner, debug } );
 

--- a/packages/env/lib/commands/destroy.js
+++ b/packages/env/lib/commands/destroy.js
@@ -31,7 +31,9 @@ module.exports = async function destroy( { spinner, scripts, debug } ) {
 		return;
 	}
 
-	const runtime = getRuntime( detectRuntime( config.workDirectoryPath ) );
+	const runtime = getRuntime(
+		await detectRuntime( config.workDirectoryPath )
+	);
 
 	spinner.info( runtime.getDestroyWarningMessage() );
 

--- a/packages/env/lib/commands/logs.js
+++ b/packages/env/lib/commands/logs.js
@@ -21,6 +21,8 @@ const { getRuntime, detectRuntime } = require( '../runtime' );
  */
 module.exports = async function logs( { environment, watch, spinner, debug } ) {
 	const config = await loadConfig( path.resolve( '.' ) );
-	const runtime = getRuntime( detectRuntime( config.workDirectoryPath ) );
+	const runtime = getRuntime(
+		await detectRuntime( config.workDirectoryPath )
+	);
 	await runtime.logs( config, { environment, watch, spinner, debug } );
 };

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -30,7 +30,9 @@ module.exports = async function run( {
 	debug,
 } ) {
 	const config = await loadConfig( path.resolve( '.' ) );
-	const runtime = getRuntime( detectRuntime( config.workDirectoryPath ) );
+	const runtime = getRuntime(
+		await detectRuntime( config.workDirectoryPath )
+	);
 
 	// Include any double dashed arguments in the command so that we can pass them to Docker.
 	// This lets users pass options that the command defines without them being parsed.

--- a/packages/env/lib/commands/stop.js
+++ b/packages/env/lib/commands/stop.js
@@ -19,6 +19,8 @@ const { getRuntime, detectRuntime } = require( '../runtime' );
  */
 module.exports = async function stop( { spinner, debug } ) {
 	const config = await loadConfig( path.resolve( '.' ) );
-	const runtime = getRuntime( detectRuntime( config.workDirectoryPath ) );
+	const runtime = getRuntime(
+		await detectRuntime( config.workDirectoryPath )
+	);
 	await runtime.stop( config, { spinner, debug } );
 };

--- a/packages/env/lib/runtime/errors.js
+++ b/packages/env/lib/runtime/errors.js
@@ -12,6 +12,17 @@ class UnsupportedCommandError extends Error {
 	}
 }
 
+/**
+ * Error thrown when the environment has not been initialized.
+ */
+class EnvironmentNotInitializedError extends Error {
+	constructor() {
+		super( 'Environment not initialized. Run `wp-env start` first.' );
+		this.name = 'EnvironmentNotInitializedError';
+	}
+}
+
 module.exports = {
 	UnsupportedCommandError,
+	EnvironmentNotInitializedError,
 };


### PR DESCRIPTION
## Summary

Fixes issues with mixed runtime detection when switching between Docker and Playground runtimes.

**Changes:**
- Store runtime type in cache (`wp-env-cache.json`) instead of file-based detection
- Add interactive prompt when switching runtimes (e.g., Docker to Playground) - asks user to destroy old environment first
- `detectRuntime()` now throws `EnvironmentNotInitializedError` if environment not initialized
- Centralized error handling in `cli.js` for cleaner code

## Test plan

1. **Fresh start with Docker:**
   ```bash
   npx wp-env start
   cat ~/.wp-env/*/wp-env-cache.json  # Should show "runtime" key with value "docker"
   ```

2. **Switch runtime (interactive prompt):**
   ```bash
   npx wp-env start --runtime=playground
   # Expected: Prompt "Environment was previously started with 'docker'. Destroy it and start with 'playground'? (Y/n)"
   # Answer Y -> destroys Docker, starts Playground
   # Answer n -> aborts with message
   ```

3. **Commands on uninitialized env:**
   ```bash
   rm -rf ~/.wp-env/*
   npx wp-env stop
   # Expected: "Environment not initialized. Run `wp-env start` first." error
   ```

4. **Run existing tests:**
   ```bash
   npm run test:unit -- packages/env
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)