### PR TITLE
DataViews: Fix title truncation in `list` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
+
 ### Enhancements
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)
 

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -315,7 +315,7 @@ function ListItem< Item >( {
 					gap="sm"
 					justify="start"
 					align="flex-start"
-					style={ { flex: 1 } }
+					style={ { flex: 1, minWidth: 0 } }
 				>
 					{ renderedMediaField }
 					<Stack
@@ -325,9 +325,8 @@ function ListItem< Item >( {
 					>
 						<Stack direction="row" align="center">
 							<div
-								className="dataviews-title-field"
+								className="dataviews-title-field dataviews-view-list__title-field"
 								id={ labelId }
-								style={ { flex: 1 } }
 							>
 								{ renderedTitleField }
 							</div>

--- a/packages/dataviews/src/components/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/list/style.scss
@@ -171,6 +171,7 @@ div.dataviews-view-list {
 	.dataviews-view-list__field-wrapper {
 		min-height: $grid-unit-05 * 13; // Ensures title is centrally aligned when all fields are hidden
 		flex-grow: 1;
+		min-width: 0;
 	}
 
 	.dataviews-view-list__field {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed that in `list` layout we don't truncate the titles when they are big. I couldn't pinpoint where this regressed since https://github.com/WordPress/gutenberg/pull/65376, but this PR fixes that.



## Testing Instructions
1. Add one page or template with a quite long title and switch to `list` layout.
2. Observe that the titles are properly truncated now.
3. Ensure no other visual regression is introduced.








|Before|After|
|-|-|
|<img width="1028" height="738" alt="Screenshot 2026-01-29 at 6 13 15 PM" src="https://github.com/user-attachments/assets/39a4cc8c-cb94-4c96-af6c-9535c1010618" />|<img width="1028" height="738" alt="Screenshot 2026-01-29 at 6 13 22 PM" src="https://github.com/user-attachments/assets/47d8ba79-0940-4a7c-88dd-ddfc83c944ec" />|
