### PR TITLE
Real-time Collaboration: Add collaborators presence UI

### DIFF
--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -96,7 +96,7 @@ function usePostEditorAwarenessState(
  * @param  postType - The type of the post.
  * @return {ActiveUser[]} The active users.
  */
-export function useActiveUsers(
+export function useActiveCollaborators(
 	postId: number | null,
 	postType: string | null
 ): ActiveUser[] {

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -3,10 +3,12 @@
  */
 import { useEntityRecordsWithPermissions } from './hooks/use-entity-records';
 import { RECEIVE_INTERMEDIATE_RESULTS } from './utils';
+import { useActiveUsers } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 
 export const privateApis = {};
 lock( privateApis, {
 	useEntityRecordsWithPermissions,
 	RECEIVE_INTERMEDIATE_RESULTS,
+	useActiveUsers,
 } );

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -3,12 +3,12 @@
  */
 import { useEntityRecordsWithPermissions } from './hooks/use-entity-records';
 import { RECEIVE_INTERMEDIATE_RESULTS } from './utils';
-import { useActiveUsers } from './hooks/use-post-editor-awareness-state';
+import { useActiveCollaborators } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 
 export const privateApis = {};
 lock( privateApis, {
 	useEntityRecordsWithPermissions,
 	RECEIVE_INTERMEDIATE_RESULTS,
-	useActiveUsers,
+	useActiveCollaborators,
 } );

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -1,3 +1,4 @@
+import { clsx } from 'clsx';
 import { type PostEditorAwarenessState } from '../../../../core-data/src/awareness/types';
 import './styles/avatar.scss';
 
@@ -22,25 +23,22 @@ export const Avatar: React.FC< AvatarProps > = ( {
 	showUserColorBorder,
 	size = 'small',
 } ) => {
-	const className = [
+	const className = clsx(
 		'editor-collaborators-presence__avatar',
 		`editor-collaborators-presence__avatar--${ size }`,
 		showUserColorBorder &&
-			'editor-collaborators-presence__avatar--with-color-border',
-	]
-		.filter( Boolean )
-		.join( ' ' );
+			'editor-collaborators-presence__avatar--with-color-border'
+	);
 
 	const avatarUrl =
 		userInfo.avatar_urls?.[ 48 ] ||
 		userInfo.avatar_urls?.[ 96 ] ||
 		userInfo.avatar_urls?.[ 24 ];
 
-	const avatarStyles: React.CSSProperties &
-		Record< `--${ string }`, string > = {
+	const avatarStyles = {
 		'--avatar-url': `url(${ avatarUrl })`,
 		'--user-color': userInfo.color,
-	};
+	} as React.CSSProperties;
 
 	return (
 		<div

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -1,3 +1,4 @@
+import { type PostEditorAwarenessState } from '../../../../core-data/src/awareness/types';
 import './styles/avatar.scss';
 
 type AvatarSize = 'small' | 'medium';
@@ -6,9 +7,6 @@ type AvatarSize = 'small' | 'medium';
  * Renders a circular avatar bubble for a user with an optional border.
  * @param root0
  * @param root0.userInfo
- * @param root0.userInfo.name
- * @param root0.userInfo.color
- * @param root0.userInfo.avatar_urls
  * @param root0.showUserColorBorder
  * @param root0.size
  */
@@ -17,11 +15,7 @@ export function Avatar( {
 	showUserColorBorder,
 	size = 'small',
 }: {
-	userInfo: {
-		name: string;
-		color: string;
-		avatar_urls?: Record< string, string >;
-	};
+	userInfo: PostEditorAwarenessState[ 'userInfo' ];
 	showUserColorBorder?: boolean;
 	size?: AvatarSize;
 } ) {

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -26,10 +26,10 @@ export function Avatar( {
 	size?: AvatarSize;
 } ) {
 	const className = [
-		'vip-real-time-collaboration-avatar',
-		`vip-real-time-collaboration-avatar--${ size }`,
+		'editor-collaborators-presence__avatar',
+		`editor-collaborators-presence__avatar--${ size }`,
 		showUserColorBorder &&
-			'vip-real-time-collaboration-avatar--with-color-border',
+			'editor-collaborators-presence__avatar--with-color-border',
 	]
 		.filter( Boolean )
 		.join( ' ' );

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -18,11 +18,11 @@ interface AvatarProps {
  * @param {boolean} props.showUserColorBorder Whether to show the user color border.
  * @param {string}  props.size                Size of the avatar.
  */
-export const Avatar: React.FC< AvatarProps > = ( {
+export function Avatar( {
 	userInfo,
 	showUserColorBorder,
 	size = 'small',
-} ) => {
+}: AvatarProps ) {
 	const className = clsx(
 		'editor-collaborators-presence__avatar',
 		`editor-collaborators-presence__avatar--${ size }`,
@@ -47,4 +47,4 @@ export const Avatar: React.FC< AvatarProps > = ( {
 			aria-hidden="true"
 		/>
 	);
-};
+}

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -3,22 +3,25 @@ import './styles/avatar.scss';
 
 type AvatarSize = 'small' | 'medium';
 
-/**
- * Renders a circular avatar bubble for a user with an optional border.
- * @param root0
- * @param root0.userInfo
- * @param root0.showUserColorBorder
- * @param root0.size
- */
-export function Avatar( {
-	userInfo,
-	showUserColorBorder,
-	size = 'small',
-}: {
+interface AvatarProps {
 	userInfo: PostEditorAwarenessState[ 'userInfo' ];
 	showUserColorBorder?: boolean;
 	size?: AvatarSize;
-} ) {
+}
+
+/**
+ * Renders a circular avatar bubble for a user with an optional border.
+ *
+ * @param {Object}  props                     Component props.
+ * @param {Object}  props.userInfo            User information.
+ * @param {boolean} props.showUserColorBorder Whether to show the user color border.
+ * @param {string}  props.size                Size of the avatar.
+ */
+export const Avatar: React.FC< AvatarProps > = ( {
+	userInfo,
+	showUserColorBorder,
+	size = 'small',
+} ) => {
 	const className = [
 		'editor-collaborators-presence__avatar',
 		`editor-collaborators-presence__avatar--${ size }`,
@@ -46,4 +49,4 @@ export function Avatar( {
 			aria-hidden="true"
 		/>
 	);
-}
+};

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -1,0 +1,55 @@
+import './styles/avatar.scss';
+
+type AvatarSize = 'small' | 'medium';
+
+/**
+ * Renders a circular avatar bubble for a user with an optional border.
+ * @param root0
+ * @param root0.userInfo
+ * @param root0.userInfo.name
+ * @param root0.userInfo.color
+ * @param root0.userInfo.avatar_urls
+ * @param root0.showUserColorBorder
+ * @param root0.size
+ */
+export function Avatar( {
+	userInfo,
+	showUserColorBorder,
+	size = 'small',
+}: {
+	userInfo: {
+		name: string;
+		color: string;
+		avatar_urls?: Record< string, string >;
+	};
+	showUserColorBorder?: boolean;
+	size?: AvatarSize;
+} ) {
+	const className = [
+		'vip-real-time-collaboration-avatar',
+		`vip-real-time-collaboration-avatar--${ size }`,
+		showUserColorBorder &&
+			'vip-real-time-collaboration-avatar--with-color-border',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
+	const avatarUrl =
+		userInfo.avatar_urls?.[ 48 ] ||
+		userInfo.avatar_urls?.[ 96 ] ||
+		userInfo.avatar_urls?.[ 24 ];
+
+	const avatarStyles: React.CSSProperties &
+		Record< `--${ string }`, string > = {
+		'--avatar-url': `url(${ avatarUrl })`,
+		'--user-color': userInfo.color,
+	};
+
+	return (
+		<div
+			className={ className }
+			style={ avatarStyles }
+			aria-hidden="true"
+		/>
+	);
+}

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -9,7 +9,7 @@ import { type PostEditorAwarenessState } from '../../../../core-data/src/awarene
 
 import './styles/collaborators-presence.scss';
 
-const { useActiveUsers } = unlock( privateApis );
+const { useActiveCollaborators } = unlock( privateApis );
 
 interface CollaboratorsPresenceProps {
 	postId: number | null;
@@ -28,7 +28,7 @@ export function CollaboratorsPresence( {
 	postId,
 	postType,
 }: CollaboratorsPresenceProps ) {
-	const activeUsers = useActiveUsers(
+	const activeUsers = useActiveCollaborators(
 		postId,
 		postType
 	) as PostEditorAwarenessState[];

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -45,8 +45,10 @@ export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
 		null
 	);
 
+	// When there are no other collaborators, this component should not render
+	// at all. This will always be the case when collaboration is not enabled, but
+	// also when the current user is the only editor with the post open.
 	if ( otherActiveUsers.length === 0 ) {
-		// Hide avatars when there are no other users
 		return null;
 	}
 

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -63,10 +63,10 @@ export function CollaboratorsPresence( {
 		.join( ', ' );
 
 	return visibleUsers.length > 0 ? (
-		<>
+		<div className="editor-collaborators-presence">
 			<Button
 				__next40pxDefaultSize
-				className="vip-real-time-collaboration-avatars-container"
+				className="editor-collaborators-presence__button"
 				onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
 				isPressed={ isPopoverVisible }
 				ref={ setPopoverAnchor }
@@ -83,7 +83,7 @@ export function CollaboratorsPresence( {
 
 				{ remainingUsers.length > 0 && (
 					<div
-						className="vip-real-time-collaboration-avatar-remaining"
+						className="editor-collaborators-presence__remaining"
 						title={ remainingUsersText }
 					>
 						+{ remainingUsers.length }
@@ -102,6 +102,6 @@ export function CollaboratorsPresence( {
 					setIsPopoverVisible={ setIsPopoverVisible }
 				/>
 			) }
-		</>
+		</div>
 	) : null;
 }

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -80,11 +80,7 @@ export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
 			</Button>
 			{ isPopoverVisible && (
 				<CollaboratorsList
-					activeUsers={ otherActiveUsers.map( ( user ) => ( {
-						clientId: user.clientId,
-						isConnected: true,
-						userInfo: user.userInfo,
-					} ) ) }
+					activeUsers={ otherActiveUsers }
 					popoverAnchor={ popoverAnchor }
 					setIsPopoverVisible={ setIsPopoverVisible }
 				/>

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -5,7 +5,6 @@ import { privateApis } from '@wordpress/core-data';
 import { Avatar } from './avatar';
 import { CollaboratorsList } from './list';
 import { unlock } from '../../lock-unlock';
-// import { type CursorRegistry } from '@/utilities/cursor-registry';
 
 import './styles/collaborators-presence.scss';
 
@@ -24,7 +23,6 @@ interface UserState {
 }
 
 interface AvatarsProps {
-	// cursorRegistry: CursorRegistry;
 	postId: number | null;
 	postType: string | null;
 }
@@ -36,11 +34,7 @@ interface AvatarsProps {
  * @param root0.postId
  * @param root0.postType
  */
-export function CollaboratorsPresence( {
-	// cursorRegistry,
-	postId,
-	postType,
-}: AvatarsProps ) {
+export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
 	const activeUsers = useActiveUsers( postId, postType ) as UserState[];
 
 	// Filter out current user - we never show ourselves in the list
@@ -97,7 +91,6 @@ export function CollaboratorsPresence( {
 						isConnected: true,
 						userInfo: user.userInfo,
 					} ) ) }
-					// cursorRegistry={ cursorRegistry }
 					popoverAnchor={ popoverAnchor }
 					setIsPopoverVisible={ setIsPopoverVisible }
 				/>

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -24,10 +24,10 @@ interface CollaboratorsPresenceProps {
  * @param {number} props.postId   ID of the post
  * @param {string} props.postType Type of the post
  */
-export const CollaboratorsPresence: React.FC< CollaboratorsPresenceProps > = ( {
+export function CollaboratorsPresence( {
 	postId,
 	postType,
-} ) => {
+}: CollaboratorsPresenceProps ) {
 	const activeUsers = useActiveUsers(
 		postId,
 		postType
@@ -91,4 +91,4 @@ export const CollaboratorsPresence: React.FC< CollaboratorsPresenceProps > = ( {
 			) }
 		</div>
 	) : null;
-};
+}

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -1,0 +1,107 @@
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { privateApis } from '@wordpress/core-data';
+
+import { Avatar } from './avatar';
+import { CollaboratorsList } from './list';
+import { unlock } from '../../lock-unlock';
+// import { type CursorRegistry } from '@/utilities/cursor-registry';
+
+import './styles/collaborators-presence.scss';
+
+const { useActiveUsers } = unlock( privateApis );
+
+interface UserInfo {
+	name: string;
+	color: string;
+	avatar_urls?: Record< string, string >;
+}
+
+interface UserState {
+	clientId: string;
+	isMe: boolean;
+	userInfo: UserInfo;
+}
+
+interface AvatarsProps {
+	// cursorRegistry: CursorRegistry;
+	postId: number | null;
+	postType: string | null;
+}
+
+/**
+ * Renders a list of avatars for the active users, with a maximum of 3 visible avatars.
+ * Shows a popover with all users on hover.
+ * @param root0
+ * @param root0.postId
+ * @param root0.postType
+ */
+export function CollaboratorsPresence( {
+	// cursorRegistry,
+	postId,
+	postType,
+}: AvatarsProps ) {
+	const activeUsers = useActiveUsers( postId, postType ) as UserState[];
+
+	// Filter out current user - we never show ourselves in the list
+	const otherActiveUsers = activeUsers.filter( ( user ) => ! user.isMe );
+
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
+		null
+	);
+
+	if ( otherActiveUsers.length === 0 ) {
+		// Hide avatars when there are no other users
+		return null;
+	}
+
+	const visibleUsers = otherActiveUsers.slice( 0, 3 );
+	const remainingUsers = otherActiveUsers.slice( 3 );
+	const remainingUsersText = remainingUsers
+		.map( ( { userInfo } ) => userInfo.name )
+		.join( ', ' );
+
+	return visibleUsers.length > 0 ? (
+		<>
+			<Button
+				__next40pxDefaultSize
+				className="vip-real-time-collaboration-avatars-container"
+				onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
+				isPressed={ isPopoverVisible }
+				ref={ setPopoverAnchor }
+				aria-label={ `Collaborators list, ${ otherActiveUsers.length } online` }
+			>
+				{ visibleUsers.map( ( userState ) => (
+					<Avatar
+						key={ userState.clientId }
+						userInfo={ userState.userInfo }
+						showUserColorBorder={ false }
+						size="small"
+					/>
+				) ) }
+
+				{ remainingUsers.length > 0 && (
+					<div
+						className="vip-real-time-collaboration-avatar-remaining"
+						title={ remainingUsersText }
+					>
+						+{ remainingUsers.length }
+					</div>
+				) }
+			</Button>
+			{ isPopoverVisible && (
+				<CollaboratorsList
+					activeUsers={ otherActiveUsers.map( ( user ) => ( {
+						clientId: user.clientId,
+						isConnected: true,
+						userInfo: user.userInfo,
+					} ) ) }
+					// cursorRegistry={ cursorRegistry }
+					popoverAnchor={ popoverAnchor }
+					setIsPopoverVisible={ setIsPopoverVisible }
+				/>
+			) }
+		</>
+	) : null;
+}

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -11,7 +11,7 @@ import './styles/collaborators-presence.scss';
 
 const { useActiveUsers } = unlock( privateApis );
 
-interface AvatarsProps {
+interface CollaboratorsPresenceProps {
 	postId: number | null;
 	postType: string | null;
 }
@@ -19,11 +19,15 @@ interface AvatarsProps {
 /**
  * Renders a list of avatars for the active users, with a maximum of 3 visible avatars.
  * Shows a popover with all users on hover.
- * @param root0          Component props
- * @param root0.postId   The ID of the post
- * @param root0.postType The type of the post
+ *
+ * @param {Object} props          CollaboratorsPresence component props
+ * @param {number} props.postId   ID of the post
+ * @param {string} props.postType Type of the post
  */
-export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
+export const CollaboratorsPresence: React.FC< CollaboratorsPresenceProps > = ( {
+	postId,
+	postType,
+} ) => {
 	const activeUsers = useActiveUsers(
 		postId,
 		postType
@@ -87,4 +91,4 @@ export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
 			) }
 		</div>
 	) : null;
-}
+};

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -5,22 +5,11 @@ import { privateApis } from '@wordpress/core-data';
 import { Avatar } from './avatar';
 import { CollaboratorsList } from './list';
 import { unlock } from '../../lock-unlock';
+import { type PostEditorAwarenessState } from '../../../../core-data/src/awareness/types';
 
 import './styles/collaborators-presence.scss';
 
 const { useActiveUsers } = unlock( privateApis );
-
-interface UserInfo {
-	name: string;
-	color: string;
-	avatar_urls?: Record< string, string >;
-}
-
-interface UserState {
-	clientId: string;
-	isMe: boolean;
-	userInfo: UserInfo;
-}
 
 interface AvatarsProps {
 	postId: number | null;
@@ -30,12 +19,15 @@ interface AvatarsProps {
 /**
  * Renders a list of avatars for the active users, with a maximum of 3 visible avatars.
  * Shows a popover with all users on hover.
- * @param root0
- * @param root0.postId
- * @param root0.postType
+ * @param root0          Component props
+ * @param root0.postId   The ID of the post
+ * @param root0.postType The type of the post
  */
 export function CollaboratorsPresence( { postId, postType }: AvatarsProps ) {
-	const activeUsers = useActiveUsers( postId, postType ) as UserState[];
+	const activeUsers = useActiveUsers(
+		postId,
+		postType
+	) as PostEditorAwarenessState[];
 
 	// Filter out current user - we never show ourselves in the list
 	const otherActiveUsers = activeUsers.filter( ( user ) => ! user.isMe );

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -61,6 +61,7 @@ export function CollaboratorsList( {
 			placement="bottom"
 			offset={ 8 }
 			className="editor-collaborators-presence__list"
+			onClose={ () => setIsPopoverVisible( false ) }
 		>
 			<div className="editor-collaborators-presence__list-content">
 				<div className="editor-collaborators-presence__list-header">

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -21,55 +21,59 @@ interface CollaboratorsListProps {
  * @param props.popoverAnchor       Anchor element for the popover
  * @param props.setIsPopoverVisible Callback to set the visibility of the popover
  */
-export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
+export function CollaboratorsList( {
 	activeUsers,
 	popoverAnchor,
 	setIsPopoverVisible,
-} ) => (
-	<Popover
-		anchor={ popoverAnchor }
-		placement="bottom"
-		offset={ 8 }
-		className="editor-collaborators-presence__list"
-		onClose={ () => setIsPopoverVisible( false ) }
-	>
-		<div className="editor-collaborators-presence__list-content">
-			<div className="editor-collaborators-presence__list-header">
-				<div className="editor-collaborators-presence__list-header-title">
-					{ __( 'Collaborators' ) }
-					<span> { activeUsers.length } </span>
-				</div>
-				<div className="editor-collaborators-presence__list-header-action">
-					<Button
-						__next40pxDefaultSize
-						icon={ close }
-						iconSize={ 16 }
-						label={ __( 'Close Collaborators List' ) }
-						onClick={ () => setIsPopoverVisible( false ) }
-					/>
-				</div>
-			</div>
-			<div className="editor-collaborators-presence__list-items">
-				{ activeUsers.map( ( userState ) => (
-					<button
-						key={ userState.clientId }
-						className="editor-collaborators-presence__list-item"
-						disabled
-						style={ { opacity: userState.isConnected ? 1 : 0.5 } }
-					>
-						<Avatar
-							userInfo={ userState.userInfo }
-							showUserColorBorder
-							size="medium"
+}: CollaboratorsListProps ) {
+	return (
+		<Popover
+			anchor={ popoverAnchor }
+			placement="bottom"
+			offset={ 8 }
+			className="editor-collaborators-presence__list"
+			onClose={ () => setIsPopoverVisible( false ) }
+		>
+			<div className="editor-collaborators-presence__list-content">
+				<div className="editor-collaborators-presence__list-header">
+					<div className="editor-collaborators-presence__list-header-title">
+						{ __( 'Collaborators' ) }
+						<span> { activeUsers.length } </span>
+					</div>
+					<div className="editor-collaborators-presence__list-header-action">
+						<Button
+							__next40pxDefaultSize
+							icon={ close }
+							iconSize={ 16 }
+							label={ __( 'Close Collaborators List' ) }
+							onClick={ () => setIsPopoverVisible( false ) }
 						/>
-						<div className="editor-collaborators-presence__list-item-info">
-							<div className="editor-collaborators-presence__list-item-name">
-								{ userState.userInfo.name }
+					</div>
+				</div>
+				<div className="editor-collaborators-presence__list-items">
+					{ activeUsers.map( ( userState ) => (
+						<button
+							key={ userState.clientId }
+							className="editor-collaborators-presence__list-item"
+							disabled
+							style={ {
+								opacity: userState.isConnected ? 1 : 0.5,
+							} }
+						>
+							<Avatar
+								userInfo={ userState.userInfo }
+								showUserColorBorder
+								size="medium"
+							/>
+							<div className="editor-collaborators-presence__list-item-info">
+								<div className="editor-collaborators-presence__list-item-name">
+									{ userState.userInfo.name }
+								</div>
 							</div>
-						</div>
-					</button>
-				) ) }
+						</button>
+					) ) }
+				</div>
 			</div>
-		</div>
-	</Popover>
-);
+		</Popover>
+	);
+}

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -1,0 +1,109 @@
+// import { speak } from '@wordpress/a11y';
+import { Popover, Button } from '@wordpress/components';
+import { close } from '@wordpress/icons';
+
+import { Avatar } from './avatar';
+
+import './styles/collaborators-list.scss';
+
+interface CollaboratorsListProps {
+	activeUsers: {
+		clientId: string;
+		isConnected: boolean;
+		userInfo: {
+			name: string;
+			color: string;
+			avatar_urls?: Record< string, string >;
+		};
+	}[];
+	popoverAnchor?: HTMLElement | null;
+	setIsPopoverVisible: ( isVisible: boolean ) => void;
+}
+
+/**
+ * Renders a list showing all active collaborators with their details.
+ * Note: activeUsers should already exclude the current user (filtered by parent component).
+ * @param root0
+ * @param root0.activeUsers
+ * @param root0.popoverAnchor
+ * @param root0.setIsPopoverVisible
+ */
+export function CollaboratorsList( {
+	activeUsers,
+	popoverAnchor,
+	setIsPopoverVisible,
+}: CollaboratorsListProps ) {
+	// const handleCollaboratorClick = ( clientId: number ) => {
+	// const userName = activeUsers.find(
+	// 	( user ) => user.clientId === clientId
+	// )?.userInfo.name;
+
+	// const success = cursorRegistry.scrollToCursor( clientId, {
+	// 	behavior: 'smooth',
+	// 	block: 'center',
+	// 	highlightDuration: 2000,
+	// } );
+
+	// Announce the action to screen readers
+	// if ( success && userName ) {
+	// 	speak( `Scrolled to ${ userName }'s cursor`, 'polite' );
+	// }
+
+	// // Close the popover after successful scroll
+	// if ( success ) {
+	// 	setIsPopoverVisible( false );
+	// }
+	// };
+
+	return (
+		<Popover
+			anchor={ popoverAnchor }
+			placement="bottom"
+			offset={ 8 }
+			className="vip-real-time-collaboration-collaborators-list"
+		>
+			<div className="vip-real-time-collaboration-collaborators-list-content">
+				<div className="vip-real-time-collaboration-collaborators-list-header">
+					<div className="vip-real-time-collaboration-collaborators-list-header-title">
+						Collaborators
+						<span> { activeUsers.length } </span>
+					</div>
+					<div className="vip-real-time-collaboration-collaborators-list-header-action">
+						<Button
+							__next40pxDefaultSize
+							icon={ close }
+							iconSize={ 16 }
+							label="Close Collaborators List"
+							onClick={ () => setIsPopoverVisible( false ) }
+						/>
+					</div>
+				</div>
+				<div className="vip-real-time-collaboration-collaborators-list-items">
+					{ activeUsers.map( ( userState ) => (
+						<button
+							key={ userState.clientId }
+							className="vip-real-time-collaboration-collaborators-list-item"
+							onClick={ () => {} }
+							disabled={ ! userState.isConnected }
+							aria-label="Clicking scrolls to cursor position in the editor"
+							style={ {
+								opacity: userState.isConnected ? 1 : 0.5,
+							} }
+						>
+							<Avatar
+								userInfo={ userState.userInfo }
+								showUserColorBorder
+								size="medium"
+							/>
+							<div className="vip-real-time-collaboration-collaborators-list-item-info">
+								<div className="vip-real-time-collaboration-collaborators-list-item-name">
+									{ userState.userInfo.name }
+								</div>
+							</div>
+						</button>
+					) ) }
+				</div>
+			</div>
+		</Popover>
+	);
+}

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -4,14 +4,10 @@ import { close } from '@wordpress/icons';
 import { Avatar } from './avatar';
 
 import './styles/collaborators-list.scss';
-import { type UserInfo } from '../../../../core-data/src/awareness/types';
+import { type PostEditorAwarenessState } from '../../../../core-data/src/awareness/types';
 
 interface CollaboratorsListProps {
-	activeUsers: {
-		clientId: string;
-		isConnected: boolean;
-		userInfo: UserInfo;
-	}[];
+	activeUsers: PostEditorAwarenessState[];
 	popoverAnchor?: HTMLElement | null;
 	setIsPopoverVisible: ( isVisible: boolean ) => void;
 }
@@ -57,12 +53,8 @@ export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
 					<button
 						key={ userState.clientId }
 						className="editor-collaborators-presence__list-item"
-						onClick={ () => {} }
-						disabled={ ! userState.isConnected }
-						aria-label="Clicking scrolls to cursor position in the editor"
-						style={ {
-							opacity: userState.isConnected ? 1 : 0.5,
-						} }
+						disabled
+						style={ { opacity: userState.isConnected ? 1 : 0.5 } }
 					>
 						<Avatar
 							userInfo={ userState.userInfo }

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -33,28 +33,6 @@ export function CollaboratorsList( {
 	popoverAnchor,
 	setIsPopoverVisible,
 }: CollaboratorsListProps ) {
-	// const handleCollaboratorClick = ( clientId: number ) => {
-	// const userName = activeUsers.find(
-	// 	( user ) => user.clientId === clientId
-	// )?.userInfo.name;
-
-	// const success = cursorRegistry.scrollToCursor( clientId, {
-	// 	behavior: 'smooth',
-	// 	block: 'center',
-	// 	highlightDuration: 2000,
-	// } );
-
-	// Announce the action to screen readers
-	// if ( success && userName ) {
-	// 	speak( `Scrolled to ${ userName }'s cursor`, 'polite' );
-	// }
-
-	// // Close the popover after successful scroll
-	// if ( success ) {
-	// 	setIsPopoverVisible( false );
-	// }
-	// };
-
 	return (
 		<Popover
 			anchor={ popoverAnchor }

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -60,15 +60,15 @@ export function CollaboratorsList( {
 			anchor={ popoverAnchor }
 			placement="bottom"
 			offset={ 8 }
-			className="vip-real-time-collaboration-collaborators-list"
+			className="editor-collaborators-presence__list"
 		>
-			<div className="vip-real-time-collaboration-collaborators-list-content">
-				<div className="vip-real-time-collaboration-collaborators-list-header">
-					<div className="vip-real-time-collaboration-collaborators-list-header-title">
+			<div className="editor-collaborators-presence__list-content">
+				<div className="editor-collaborators-presence__list-header">
+					<div className="editor-collaborators-presence__list-header-title">
 						Collaborators
 						<span> { activeUsers.length } </span>
 					</div>
-					<div className="vip-real-time-collaboration-collaborators-list-header-action">
+					<div className="editor-collaborators-presence__list-header-action">
 						<Button
 							__next40pxDefaultSize
 							icon={ close }
@@ -78,11 +78,11 @@ export function CollaboratorsList( {
 						/>
 					</div>
 				</div>
-				<div className="vip-real-time-collaboration-collaborators-list-items">
+				<div className="editor-collaborators-presence__list-items">
 					{ activeUsers.map( ( userState ) => (
 						<button
 							key={ userState.clientId }
-							className="vip-real-time-collaboration-collaborators-list-item"
+							className="editor-collaborators-presence__list-item"
 							onClick={ () => {} }
 							disabled={ ! userState.isConnected }
 							aria-label="Clicking scrolls to cursor position in the editor"
@@ -95,8 +95,8 @@ export function CollaboratorsList( {
 								showUserColorBorder
 								size="medium"
 							/>
-							<div className="vip-real-time-collaboration-collaborators-list-item-info">
-								<div className="vip-real-time-collaboration-collaborators-list-item-name">
+							<div className="editor-collaborators-presence__list-item-info">
+								<div className="editor-collaborators-presence__list-item-name">
 									{ userState.userInfo.name }
 								</div>
 							</div>

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -1,20 +1,16 @@
-// import { speak } from '@wordpress/a11y';
 import { Popover, Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 
 import { Avatar } from './avatar';
 
 import './styles/collaborators-list.scss';
+import { type UserInfo } from '../../../../core-data/src/awareness/types';
 
 interface CollaboratorsListProps {
 	activeUsers: {
 		clientId: string;
 		isConnected: boolean;
-		userInfo: {
-			name: string;
-			color: string;
-			avatar_urls?: Record< string, string >;
-		};
+		userInfo: UserInfo;
 	}[];
 	popoverAnchor?: HTMLElement | null;
 	setIsPopoverVisible: ( isVisible: boolean ) => void;
@@ -23,66 +19,64 @@ interface CollaboratorsListProps {
 /**
  * Renders a list showing all active collaborators with their details.
  * Note: activeUsers should already exclude the current user (filtered by parent component).
- * @param root0
- * @param root0.activeUsers
- * @param root0.popoverAnchor
- * @param root0.setIsPopoverVisible
+ * @param root0                     Component props
+ * @param root0.activeUsers         List of active users
+ * @param root0.popoverAnchor       Anchor element for the popover
+ * @param root0.setIsPopoverVisible Callback to set the visibility of the popover
  */
-export function CollaboratorsList( {
+export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
 	activeUsers,
 	popoverAnchor,
 	setIsPopoverVisible,
-}: CollaboratorsListProps ) {
-	return (
-		<Popover
-			anchor={ popoverAnchor }
-			placement="bottom"
-			offset={ 8 }
-			className="editor-collaborators-presence__list"
-			onClose={ () => setIsPopoverVisible( false ) }
-		>
-			<div className="editor-collaborators-presence__list-content">
-				<div className="editor-collaborators-presence__list-header">
-					<div className="editor-collaborators-presence__list-header-title">
-						Collaborators
-						<span> { activeUsers.length } </span>
-					</div>
-					<div className="editor-collaborators-presence__list-header-action">
-						<Button
-							__next40pxDefaultSize
-							icon={ close }
-							iconSize={ 16 }
-							label="Close Collaborators List"
-							onClick={ () => setIsPopoverVisible( false ) }
-						/>
-					</div>
+} ) => (
+	<Popover
+		anchor={ popoverAnchor }
+		placement="bottom"
+		offset={ 8 }
+		className="editor-collaborators-presence__list"
+		onClose={ () => setIsPopoverVisible( false ) }
+	>
+		<div className="editor-collaborators-presence__list-content">
+			<div className="editor-collaborators-presence__list-header">
+				<div className="editor-collaborators-presence__list-header-title">
+					Collaborators
+					<span> { activeUsers.length } </span>
 				</div>
-				<div className="editor-collaborators-presence__list-items">
-					{ activeUsers.map( ( userState ) => (
-						<button
-							key={ userState.clientId }
-							className="editor-collaborators-presence__list-item"
-							onClick={ () => {} }
-							disabled={ ! userState.isConnected }
-							aria-label="Clicking scrolls to cursor position in the editor"
-							style={ {
-								opacity: userState.isConnected ? 1 : 0.5,
-							} }
-						>
-							<Avatar
-								userInfo={ userState.userInfo }
-								showUserColorBorder
-								size="medium"
-							/>
-							<div className="editor-collaborators-presence__list-item-info">
-								<div className="editor-collaborators-presence__list-item-name">
-									{ userState.userInfo.name }
-								</div>
-							</div>
-						</button>
-					) ) }
+				<div className="editor-collaborators-presence__list-header-action">
+					<Button
+						__next40pxDefaultSize
+						icon={ close }
+						iconSize={ 16 }
+						label="Close Collaborators List"
+						onClick={ () => setIsPopoverVisible( false ) }
+					/>
 				</div>
 			</div>
-		</Popover>
-	);
-}
+			<div className="editor-collaborators-presence__list-items">
+				{ activeUsers.map( ( userState ) => (
+					<button
+						key={ userState.clientId }
+						className="editor-collaborators-presence__list-item"
+						onClick={ () => {} }
+						disabled={ ! userState.isConnected }
+						aria-label="Clicking scrolls to cursor position in the editor"
+						style={ {
+							opacity: userState.isConnected ? 1 : 0.5,
+						} }
+					>
+						<Avatar
+							userInfo={ userState.userInfo }
+							showUserColorBorder
+							size="medium"
+						/>
+						<div className="editor-collaborators-presence__list-item-info">
+							<div className="editor-collaborators-presence__list-item-name">
+								{ userState.userInfo.name }
+							</div>
+						</div>
+					</button>
+				) ) }
+			</div>
+		</div>
+	</Popover>
+);

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { Popover, Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 
@@ -15,10 +16,10 @@ interface CollaboratorsListProps {
 /**
  * Renders a list showing all active collaborators with their details.
  * Note: activeUsers should already exclude the current user (filtered by parent component).
- * @param root0                     Component props
- * @param root0.activeUsers         List of active users
- * @param root0.popoverAnchor       Anchor element for the popover
- * @param root0.setIsPopoverVisible Callback to set the visibility of the popover
+ * @param props                     Component props
+ * @param props.activeUsers         List of active users
+ * @param props.popoverAnchor       Anchor element for the popover
+ * @param props.setIsPopoverVisible Callback to set the visibility of the popover
  */
 export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
 	activeUsers,
@@ -35,7 +36,7 @@ export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
 		<div className="editor-collaborators-presence__list-content">
 			<div className="editor-collaborators-presence__list-header">
 				<div className="editor-collaborators-presence__list-header-title">
-					Collaborators
+					{ __( 'Collaborators' ) }
 					<span> { activeUsers.length } </span>
 				</div>
 				<div className="editor-collaborators-presence__list-header-action">
@@ -43,7 +44,7 @@ export const CollaboratorsList: React.FC< CollaboratorsListProps > = ( {
 						__next40pxDefaultSize
 						icon={ close }
 						iconSize={ 16 }
-						label="Close Collaborators List"
+						label={ __( 'Close Collaborators List' ) }
 						onClick={ () => setIsPopoverVisible( false ) }
 					/>
 				</div>

--- a/packages/editor/src/components/collaborators-presence/styles/avatar.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/avatar.scss
@@ -1,28 +1,31 @@
-.vip-real-time-collaboration-avatar {
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.editor-collaborators-presence__avatar {
 	background-image: var(--avatar-url);
 	background-size: cover;
 	background-position: center;
-	border-radius: 6px;
+	border-radius: $grid-unit-05 + 2;
 	border-width: 1.5px;
 	border-style: solid;
-	border-color: #ddd;
+	border-color: $gray-300;
 	font-size: 0;
 
 	&--small {
-		width: 24px;
-		height: 24px;
-		border-radius: 6px;
+		width: $button-size-small;
+		height: $button-size-small;
+		border-radius: $grid-unit-05 + 2;
 	}
 
 	&--medium {
-		width: 32px;
-		height: 32px;
-		border-radius: 8px;
+		width: $button-size-compact;
+		height: $button-size-compact;
+		border-radius: $grid-unit-10;
 	}
 
 	&--with-color-border {
 		border-color: var(--user-color);
-		box-shadow: inset 0 0 0 1px #ffffffb2;
+		box-shadow: inset 0 0 0 1px rgba($white, 0.7);
 		background-clip: padding-box;
 	}
 }

--- a/packages/editor/src/components/collaborators-presence/styles/avatar.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/avatar.scss
@@ -1,0 +1,28 @@
+.vip-real-time-collaboration-avatar {
+	background-image: var(--avatar-url);
+	background-size: cover;
+	background-position: center;
+	border-radius: 6px;
+	border-width: 1.5px;
+	border-style: solid;
+	border-color: #ddd;
+	font-size: 0;
+
+	&--small {
+		width: 24px;
+		height: 24px;
+		border-radius: 6px;
+	}
+
+	&--medium {
+		width: 32px;
+		height: 32px;
+		border-radius: 8px;
+	}
+
+	&--with-color-border {
+		border-color: var(--user-color);
+		box-shadow: inset 0 0 0 1px #ffffffb2;
+		background-clip: padding-box;
+	}
+}

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
@@ -1,0 +1,97 @@
+.vip-real-time-collaboration-collaborators-list.components-popover {
+	// Popover wrapper styles
+	.components-popover__content {
+		border: 1px solid #ddd;
+		border-width: 1px 0 0 1px;
+		border-radius: 8px;
+		background: #fff;
+		box-shadow:
+			0 1px 2px rgba(0, 0, 0, 0.05),
+			0 1px 2px rgba(0, 0, 0, 0.05),
+			0 1px 2px rgba(0, 0, 0, 0.05),
+			0 8px 8px rgba(0, 0, 0, 0.02);
+	}
+
+	.vip-real-time-collaboration-collaborators-list-content {
+		min-width: 280px;
+	}
+
+	// Header with title and action button
+	.vip-real-time-collaboration-collaborators-list-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0 16px;
+
+		&-title {
+			font-size: 13px;
+			font-weight: 500;
+			text-transform: uppercase;
+			line-height: 20px;
+			padding: 14px 0;
+
+			span {
+				color: var(--Gutenberg-Gray-700, #757575);
+			}
+		}
+
+		&-action {
+			padding: 8px 0;
+
+			button {
+				color: #1e1e1e;
+				height: 24px;
+				width: 24px;
+				padding: 0;
+			}
+		}
+	}
+
+	// List of collaborators
+	.vip-real-time-collaboration-collaborators-list-items {
+		display: flex;
+		flex-direction: column;
+		padding: 0 10px 16px;
+	}
+
+	.vip-real-time-collaboration-collaborators-list-item {
+		// Reset button styles
+		all: unset;
+		box-sizing: border-box;
+
+		// Layout styles
+		display: flex;
+		align-items: center;
+		padding: 6px;
+		gap: 8px;
+		border-radius: 12px;
+		width: 100%;
+		cursor: pointer;
+		transition: background-color 0.2s ease;
+
+		&:hover:not(:disabled) {
+			background-color: rgba(0, 0, 0, 0.05);
+		}
+
+		&:active:not(:disabled) {
+			background-color: rgba(0, 0, 0, 0.08);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: -2px;
+		}
+
+		&:disabled {
+			cursor: default;
+		}
+
+		&-info {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+			line-height: 16px;
+			font-size: 12px;
+		}
+	}
+}

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
@@ -1,60 +1,59 @@
-.vip-real-time-collaboration-collaborators-list.components-popover {
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.editor-collaborators-presence__list.components-popover {
 	// Popover wrapper styles
 	.components-popover__content {
-		border: 1px solid #ddd;
+		border: 1px solid $gray-300;
 		border-width: 1px 0 0 1px;
-		border-radius: 8px;
-		background: #fff;
-		box-shadow:
-			0 1px 2px rgba(0, 0, 0, 0.05),
-			0 1px 2px rgba(0, 0, 0, 0.05),
-			0 1px 2px rgba(0, 0, 0, 0.05),
-			0 8px 8px rgba(0, 0, 0, 0.02);
+		border-radius: $radius-large;
+		background: $white;
+		box-shadow: $elevation-small;
 	}
 
-	.vip-real-time-collaboration-collaborators-list-content {
+	.editor-collaborators-presence__list-content {
 		min-width: 280px;
 	}
 
 	// Header with title and action button
-	.vip-real-time-collaboration-collaborators-list-header {
+	.editor-collaborators-presence__list-header {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		padding: 0 16px;
+		padding: 0 $grid-unit-20;
 
 		&-title {
-			font-size: 13px;
-			font-weight: 500;
+			font-size: $font-size-medium;
+			font-weight: $font-weight-medium;
 			text-transform: uppercase;
-			line-height: 20px;
+			line-height: $font-line-height-small;
 			padding: 14px 0;
 
 			span {
-				color: var(--Gutenberg-Gray-700, #757575);
+				color: $gray-700;
 			}
 		}
 
 		&-action {
-			padding: 8px 0;
+			padding: $grid-unit-10 0;
 
 			button {
-				color: #1e1e1e;
-				height: 24px;
-				width: 24px;
+				color: $gray-900;
+				height: $button-size-small;
+				width: $button-size-small;
 				padding: 0;
 			}
 		}
 	}
 
 	// List of collaborators
-	.vip-real-time-collaboration-collaborators-list-items {
+	.editor-collaborators-presence__list-items {
 		display: flex;
 		flex-direction: column;
-		padding: 0 10px 16px;
+		padding: 0 10px $grid-unit-20;
 	}
 
-	.vip-real-time-collaboration-collaborators-list-item {
+	.editor-collaborators-presence__list-item {
 		// Reset button styles
 		all: unset;
 		box-sizing: border-box;
@@ -62,19 +61,19 @@
 		// Layout styles
 		display: flex;
 		align-items: center;
-		padding: 6px;
-		gap: 8px;
-		border-radius: 12px;
+		padding: $grid-unit-05 + 2;
+		gap: $grid-unit-10;
+		border-radius: $radius-large + $grid-unit-05;
 		width: 100%;
 		cursor: pointer;
 		transition: background-color 0.2s ease;
 
 		&:hover:not(:disabled) {
-			background-color: rgba(0, 0, 0, 0.05);
+			background-color: rgba($black, 0.05);
 		}
 
 		&:active:not(:disabled) {
-			background-color: rgba(0, 0, 0, 0.08);
+			background-color: rgba($black, 0.08);
 		}
 
 		&:focus-visible {
@@ -90,8 +89,8 @@
 			display: flex;
 			flex-direction: column;
 			flex: 1;
-			line-height: 16px;
-			font-size: 12px;
+			line-height: $font-line-height-x-small;
+			font-size: $font-size-small;
 		}
 	}
 }

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
@@ -1,0 +1,59 @@
+.vip-real-time-collaboration-avatars-container {
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	position: relative;
+	padding: 4px;
+	border-radius: inherit;
+	height: fit-content;
+	color: #2f2f2f;
+	background-color: #f0f0f0;
+
+	&:hover {
+		background-color: #e0e0e0;
+	}
+
+	// Avatar remaining count
+	.vip-real-time-collaboration-avatar-remaining {
+		margin-right: 6px;
+	}
+
+	// Override WordPress Button color on hover
+	&.components-button:hover .vip-real-time-collaboration-avatar-remaining {
+		color: #2f2f2f;
+	}
+
+	&.components-button.is-pressed:hover .vip-real-time-collaboration-avatar-remaining {
+		color: #fff;
+	}
+
+	// Avatar styles
+	.vip-real-time-collaboration-avatar {
+		margin-left: -16px;
+		flex-shrink: 0;
+		border-color: #f0f0f0;
+
+		&:nth-child(1) {
+			margin-left: 0;
+			z-index: 3;
+		}
+
+		&:nth-child(2) {
+			z-index: 2;
+		}
+
+		&:nth-child(3) {
+			z-index: 1;
+		}
+	}
+
+	// Avatar hover state
+	&:hover .vip-real-time-collaboration-avatar {
+		border-color: #ddd;
+	}
+
+	// Avatar pressed state
+	&.is-pressed .vip-real-time-collaboration-avatar {
+		border-color: #1e1e1e;
+	}
+}

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
@@ -1,37 +1,61 @@
-.vip-real-time-collaboration-avatars-container {
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.editor-collaborators-presence {
+	display: flex;
+	align-items: center;
+	height: $button-size-compact;
+	min-width: 0;
+	background: $gray-100;
+	border-radius: $grid-unit-05;
+	margin-right: $grid-unit-10;
+
+	&:hover {
+		background-color: $gray-200;
+	}
+}
+
+.editor-collaborators-presence__button.editor-collaborators-presence__button.components-button {
 	display: flex;
 	align-items: center;
 	cursor: pointer;
 	position: relative;
-	padding: 4px;
-	border-radius: inherit;
-	height: fit-content;
-	color: #2f2f2f;
-	background-color: #f0f0f0;
+	padding: $grid-unit-05;
+	border-radius: $grid-unit-05;
+	height: 100%;
+	box-sizing: border-box;
+	color: $gray-800;
+	background: transparent;
 
+	// Override default button hover
 	&:hover {
-		background-color: #e0e0e0;
+		background: transparent;
+		color: $gray-800;
+	}
+
+	// Override pressed state - keep it like document bar style
+	&.is-pressed,
+	&.is-pressed:hover {
+		background: $gray-300;
+		color: $gray-800;
+	}
+
+	// Fix focus ring to be contained within the button
+	&:focus:not(:active) {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 2px) var(--wp-admin-theme-color, #007cba);
+		outline: none;
 	}
 
 	// Avatar remaining count
-	.vip-real-time-collaboration-avatar-remaining {
-		margin-right: 6px;
-	}
-
-	// Override WordPress Button color on hover
-	&.components-button:hover .vip-real-time-collaboration-avatar-remaining {
-		color: #2f2f2f;
-	}
-
-	&.components-button.is-pressed:hover .vip-real-time-collaboration-avatar-remaining {
-		color: #fff;
+	.editor-collaborators-presence__remaining {
+		margin-right: $grid-unit-05 + 2;
 	}
 
 	// Avatar styles
-	.vip-real-time-collaboration-avatar {
+	.editor-collaborators-presence__avatar {
 		margin-left: -16px;
 		flex-shrink: 0;
-		border-color: #f0f0f0;
+		border-color: $gray-100;
 
 		&:nth-child(1) {
 			margin-left: 0;
@@ -48,12 +72,12 @@
 	}
 
 	// Avatar hover state
-	&:hover .vip-real-time-collaboration-avatar {
-		border-color: #ddd;
+	.editor-collaborators-presence:hover & .editor-collaborators-presence__avatar {
+		border-color: $gray-300;
 	}
 
 	// Avatar pressed state
-	&.is-pressed .vip-real-time-collaboration-avatar {
-		border-color: #1e1e1e;
+	&.is-pressed .editor-collaborators-presence__avatar {
+		border-color: $gray-300;
 	}
 }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -29,6 +29,7 @@ import {
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
+import { CollaboratorsPresence } from '../collaborators-presence/index';
 import { unlock } from '../../lock-unlock';
 
 function Header( {
@@ -40,6 +41,7 @@ function Header( {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
+		postId,
 		postType,
 		isTextEditor,
 		isPublishSidebarOpened,
@@ -54,6 +56,7 @@ function Header( {
 		const {
 			getEditorMode,
 			getCurrentPostType,
+			getCurrentPostId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -64,6 +67,7 @@ function Header( {
 		);
 
 		return {
+			postId: getCurrentPostId(),
 			postType: getCurrentPostType(),
 			isTextEditor: getEditorMode() === 'text',
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
@@ -120,7 +124,17 @@ function Header( {
 					) }
 				</>
 			}
-			center={ hasCenter ? <DocumentBar /> : undefined }
+			center={
+				hasCenter ? (
+					<>
+						<CollaboratorsPresence
+							postType={ postType }
+							postId={ postId }
+						/>
+						<DocumentBar />
+					</>
+				) : undefined
+			}
 			settings={
 				<>
 					{ ! customSaveButton && ! isPublishSidebarOpened && (

--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -46,7 +46,8 @@ export function getProviderCreators(): ProviderCreator[] {
 	 */
 	const filteredProviderCreators: unknown = applyFilters(
 		'sync.providers',
-		[] // Replace with `getDefaultProviderCreators()` to enable sync
+		getDefaultProviderCreators()
+		// [] // Replace with `getDefaultProviderCreators()` to enable sync
 	);
 
 	// If the returned value is not an array, ignore and set to empty array.

--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -46,8 +46,7 @@ export function getProviderCreators(): ProviderCreator[] {
 	 */
 	const filteredProviderCreators: unknown = applyFilters(
 		'sync.providers',
-		getDefaultProviderCreators()
-		// [] // Replace with `getDefaultProviderCreators()` to enable sync
+		[] // Replace with `getDefaultProviderCreators()` to enable sync
 	);
 
 	// If the returned value is not an array, ignore and set to empty array.


### PR DESCRIPTION
## What?
Adds the collaborators presence UI in the header. Closes https://github.com/WordPress/gutenberg/issues/74708

## Why?
When there are other connected collaborators in a real-time collaboration session, the current user needs to be able to know who else is in the post.

## How?
Uses the `useActiveUsers` hook added in https://github.com/WordPress/gutenberg/pull/75009 to populate data in a new `<CollaboratorsPresence>` component.

## Testing Instructions
1. Check out the PR
2. Open an existing post or create a post and save
3. Copy the URL and open in another tab
4. See the collaborators list populated in the header

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. When a collaborator is connected to a session you are in, click the collaborators button in the header
2. The menu should open
3. Press the escape key
4. The menu should close

## Screenshots or screencast <!-- if applicable -->

<img width="1566" height="688" alt="CleanShot 2026-01-29 at 14 30 30@2x" src="https://github.com/user-attachments/assets/66c6d0ae-e46b-4c30-890a-3edae997b255" />

