### PR TITLE
Adds frontmatter support for customizing sidebar labels independently from page H1 titles in the documentation generation process.

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -504,7 +504,7 @@
 		"parent": "filters"
 	},
 	{
-		"title": "Interactivity API Reference",
+		"title": "Interactivity API",
 		"slug": "interactivity-api",
 		"markdown_source": "../docs/reference-guides/interactivity-api/README.md",
 		"parent": "reference-guides"

--- a/docs/reference-guides/interactivity-api/README.md
+++ b/docs/reference-guides/interactivity-api/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Interactivity API
+---
+
 # Interactivity API Reference
 
 The Interactivity API, [introduced in WordPress 6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/), provides a standard way for developers to add interactions to the front end of their blocks. The API is also used in many Core WordPress blocks, including Search, Query, Navigation, and File.

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-const { pascalCase } = require( 'change-case' );
 const fs = require( 'fs' );
-const glob = require( 'glob' ).sync;
 const { join } = require( 'path' );
+const { pascalCase } = require( 'change-case' );
+const glob = require( 'glob' ).sync;
 
 const baseRepoUrl = '..';
 const componentPaths = glob( 'packages/components/src/*/**/README.md', {
@@ -113,13 +113,30 @@ function generateRootManifestFromTOCItems( items, parent = null ) {
 		}
 		let title = pascalCase( slug );
 		const markdownSource = fs.readFileSync( fileName, 'utf8' );
+
+		// Check for frontmatter and extract sidebar_label if present
+		let sidebarLabel = null;
+		const frontmatterMatch = markdownSource.match(
+			/^---\n([\s\S]*?)\n---/
+		);
+		if ( frontmatterMatch ) {
+			const sidebarLabelMatch = frontmatterMatch[ 1 ].match(
+				/^sidebar_label:\s*(.+)$/m
+			);
+			if ( sidebarLabelMatch ) {
+				sidebarLabel = sidebarLabelMatch[ 1 ].trim();
+			}
+		}
+
+		// Extract H1 for title
 		const titleMarkdown = markdownSource.match( /^#\s(.+)$/m );
 		if ( titleMarkdown ) {
 			title = titleMarkdown[ 1 ];
 		}
 
+		// Use sidebar_label if available, otherwise use title
 		pageItems.push( {
-			title,
+			title: sidebarLabel || title,
 			slug,
 			markdown_source: `${ baseRepoUrl }\/${ fileName }`,
 			parent,


### PR DESCRIPTION
## What?

Closes #60782

Adds support for customizing sidebar/table of contents labels in the documentation generation process using frontmatter, while keeping the original H1 titles on pages.

## Why?

Currently, the documentation generation process extracts the H1 heading from markdown files and uses it for both the page title AND the sidebar/breadcrumb navigation.
This creates a dilemma when we want to:
  - Keep descriptive page titles for SEO and clarity (e.g., "Interactivity API Reference")
  - Display shorter, cleaner labels in the sidebar navigation (e.g., "Interactivity API")

As noted in #60782, simply removing words like "reference" from the H1 would negatively impact SEO and make page titles confusing. This PR provides a solution that addresses both concerns.
  
## How?

This PR modifies docs/tool/manifest.js to:

  1. Parse frontmatter from markdown files using a regex pattern
  2. Extract the sidebar_label field if present
  3. Use the sidebar_label for the manifest title (which populates the sidebar/TOC) if available, otherwise fall back to the H1 heading
  
## Testing Instructions

1. Run npm run docs:build to regenerate the manifest
1. Verify that docs/manifest.json shows the Interactivity API entry with "title": "Interactivity API" (not "Interactivity API Reference")