### PR TITLE
72718 add new note keyboard shortcut

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -240,6 +240,22 @@ export default function BlockTools( {
 				stopEditingContentOnlySection();
 			}
 		}
+
+		// Handle add-note shortcut. Call the global callback registered by NotesSidebar.
+		// Use window.top to access the parent window's global scope if we're in an iframe.
+		if ( isMatch( 'core/editor/add-note', event ) ) {
+			const clientIds = getSelectedBlockClientIds();
+			if ( clientIds.length ) {
+				event.preventDefault();
+				const targetWindow = window.top || window;
+				if (
+					typeof targetWindow.__gutenbergOpenNotesSidebar ===
+					'function'
+				) {
+					targetWindow.__gutenbergOpenNotesSidebar();
+				}
+			}
+		}
 	}
 	const blockToolbarRef = usePopoverScroll( __unstableContentRef );
 	const blockToolbarAfterRef = usePopoverScroll( __unstableContentRef );

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -217,6 +217,18 @@ function KeyboardShortcutsRegister() {
 				character: 'h',
 			},
 		} );
+
+		// Register the add-note shortcut here so it's available in the block-editor context.
+		// This shortcut is also registered in the editor package for the keyboard shortcuts modal.
+		registerShortcut( {
+			name: 'core/editor/add-note',
+			category: 'block',
+			description: __( 'Add a note to the selected block.' ),
+			keyCombination: {
+				modifier: 'primaryAlt',
+				character: 'm',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -4,12 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useState, useRef } from '@wordpress/element';
-import { useViewportMatch, useKeyboardShortcut } from '@wordpress/compose';
+import { useState, useRef, useEffect } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
-import { rawShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -92,31 +91,24 @@ function NotesSidebar( { postId } ) {
 
 	const showFloatingSidebar = isLargeViewport;
 
-	const {
-		clientId,
-		blockCommentId,
-		isDistractionFree,
-		blockName,
-		isValidBlock,
-	} = useSelect( ( select ) => {
-		const {
-			getBlock,
-			getBlockAttributes,
-			getSelectedBlockClientId,
-			getSettings,
-		} = select( blockEditorStore );
-		const _clientId = getSelectedBlockClientId();
-		const block = _clientId ? getBlock( _clientId ) : null;
-		return {
-			clientId: _clientId,
-			blockCommentId: _clientId
-				? getBlockAttributes( _clientId )?.metadata?.noteId
-				: null,
-			isDistractionFree: getSettings().isDistractionFree,
-			blockName: block?.name,
-			isValidBlock: block?.isValid,
-		};
-	}, [] );
+	const { clientId, blockCommentId, isDistractionFree } = useSelect(
+		( select ) => {
+			const {
+				getBlockAttributes,
+				getSelectedBlockClientId,
+				getSettings,
+			} = select( blockEditorStore );
+			const _clientId = getSelectedBlockClientId();
+			return {
+				clientId: _clientId,
+				blockCommentId: _clientId
+					? getBlockAttributes( _clientId )?.metadata?.noteId
+					: null,
+				isDistractionFree: getSettings().isDistractionFree,
+			};
+		},
+		[]
+	);
 
 	const {
 		resultComments,
@@ -139,24 +131,6 @@ function NotesSidebar( { postId } ) {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 	const showAllNotesSidebar = resultComments.length > 0;
-
-	// Handle keyboard shortcut for adding a note (Cmd+Option+M on Mac, Ctrl+Alt+M on Windows).
-	useKeyboardShortcut(
-		rawShortcut.primaryAlt( 'm' ),
-		( event ) => {
-			event.preventDefault();
-			// Only trigger if we have a valid, non-freeform block selected.
-			if (
-				clientId &&
-				isValidBlock &&
-				blockName !== 'core/freeform' &&
-				! isDistractionFree
-			) {
-				openTheSidebar();
-			}
-		},
-		{ bindGlobal: true }
-	);
 
 	async function openTheSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );
@@ -188,6 +162,16 @@ function NotesSidebar( { postId } ) {
 		);
 		toggleBlockSpotlight( clientId, true );
 	}
+
+	// Register global callback for keyboard shortcut.
+	// This allows BlockTools (in iframe) and EditorKeyboardShortcuts to trigger the sidebar.
+	useEffect( () => {
+		// Use a function on globalThis that can be called from anywhere.
+		globalThis.__gutenbergOpenNotesSidebar = openTheSidebar;
+		return () => {
+			delete globalThis.__gutenbergOpenNotesSidebar;
+		};
+	} );
 
 	if ( isDistractionFree ) {
 		return <AddCommentMenuItem isDistractionFree />;

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -5,10 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useKeyboardShortcut } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
+import { rawShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -91,24 +92,31 @@ function NotesSidebar( { postId } ) {
 
 	const showFloatingSidebar = isLargeViewport;
 
-	const { clientId, blockCommentId, isDistractionFree } = useSelect(
-		( select ) => {
-			const {
-				getBlockAttributes,
-				getSelectedBlockClientId,
-				getSettings,
-			} = select( blockEditorStore );
-			const _clientId = getSelectedBlockClientId();
-			return {
-				clientId: _clientId,
-				blockCommentId: _clientId
-					? getBlockAttributes( _clientId )?.metadata?.noteId
-					: null,
-				isDistractionFree: getSettings().isDistractionFree,
-			};
-		},
-		[]
-	);
+	const {
+		clientId,
+		blockCommentId,
+		isDistractionFree,
+		blockName,
+		isValidBlock,
+	} = useSelect( ( select ) => {
+		const {
+			getBlock,
+			getBlockAttributes,
+			getSelectedBlockClientId,
+			getSettings,
+		} = select( blockEditorStore );
+		const _clientId = getSelectedBlockClientId();
+		const block = _clientId ? getBlock( _clientId ) : null;
+		return {
+			clientId: _clientId,
+			blockCommentId: _clientId
+				? getBlockAttributes( _clientId )?.metadata?.noteId
+				: null,
+			isDistractionFree: getSettings().isDistractionFree,
+			blockName: block?.name,
+			isValidBlock: block?.isValid,
+		};
+	}, [] );
 
 	const {
 		resultComments,
@@ -131,6 +139,24 @@ function NotesSidebar( { postId } ) {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 	const showAllNotesSidebar = resultComments.length > 0;
+
+	// Handle keyboard shortcut for adding a note (Cmd+Option+M on Mac, Ctrl+Alt+M on Windows).
+	useKeyboardShortcut(
+		rawShortcut.primaryAlt( 'm' ),
+		( event ) => {
+			event.preventDefault();
+			// Only trigger if we have a valid, non-freeform block selected.
+			if (
+				clientId &&
+				isValidBlock &&
+				blockName !== 'core/freeform' &&
+				! isDistractionFree
+			) {
+				openTheSidebar();
+			}
+		},
+		{ bindGlobal: true }
+	);
 
 	async function openTheSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -118,5 +118,15 @@ export default function EditorKeyboardShortcuts() {
 		}
 	} );
 
+	// Handle add-note shortcut: Call the global callback for NotesSidebar.
+	// This is a backup for when focus is outside the editor canvas (iframe).
+	// The primary handler is in BlockTools which captures events from within the iframe.
+	useShortcut( 'core/editor/add-note', ( event ) => {
+		event.preventDefault();
+		if ( typeof globalThis.__gutenbergOpenNotesSidebar === 'function' ) {
+			globalThis.__gutenbergOpenNotesSidebar();
+		}
+	} );
+
 	return null;
 }

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -144,6 +144,16 @@ function EditorKeyboardShortcutsRegister() {
 				},
 			],
 		} );
+
+		registerShortcut( {
+			name: 'core/editor/add-note',
+			category: 'block',
+			description: __( 'Add a note to the selected block.' ),
+			keyCombination: {
+				modifier: 'primaryAlt',
+				character: 'm',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return <BlockEditorKeyboardShortcuts.Register />;

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -147,7 +147,7 @@ function EditorKeyboardShortcutsRegister() {
 
 		registerShortcut( {
 			name: 'core/editor/add-note',
-			category: 'block',
+			category: 'global',
 			description: __( 'Add a note to the selected block.' ),
 			keyCombination: {
 				modifier: 'primaryAlt',

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -795,6 +795,84 @@ test.describe( 'Block Comments', () => {
 			).toBeFocused();
 		} );
 
+		test( 'can open add note form using keyboard shortcut', async ( {
+			editor,
+			page,
+			pageUtils,
+			blockCommentUtils,
+		} ) => {
+			// First add a block with a comment so the notes sidebar is available.
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Howdy!' },
+				comment: 'Test comment',
+			} );
+			// Add a second block without a comment.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Testing keyboard shortcut for notes' },
+			} );
+			const form = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+
+			// Press the keyboard shortcut to open the add note form.
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect( form ).toBeFocused();
+		} );
+
+		test( 'keyboard shortcut does nothing when no block is selected', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Testing keyboard shortcut for notes' },
+			} );
+
+			// Deselect block by clicking on the title.
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.focus();
+
+			const form = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+
+			// Press the keyboard shortcut.
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+
+			// The form should not be visible/focused since no block is selected.
+			await expect( form ).not.toBeVisible();
+		} );
+
+		test( 'keyboard shortcut focuses existing note when block has one', async ( {
+			page,
+			pageUtils,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing block with existing note' },
+				comment: 'Existing note',
+			} );
+
+			const thread = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', {
+					name: 'Note: Existing note',
+				} );
+
+			// Press the keyboard shortcut.
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+
+			// The existing thread should be expanded and focused.
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+		} );
+
 		test( 'can add a note using form shortcut', async ( {
 			editor,
 			page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72718

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
