### PR TITLE
Allow specific block selection when initializing isolated editor

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -413,6 +413,7 @@ function Layout( {
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,
 		previousSelectedBlockPath,
+		initialBlockSelection,
 	} = useNavigateToEntityRecord(
 		initialPostId,
 		initialPostType,
@@ -628,7 +629,9 @@ function Layout( {
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus={ ! isWelcomeGuideVisible }
 						onActionPerformed={ onActionPerformed }
-						initialSelection={ previousSelectedBlockPath }
+						initialSelection={
+							initialBlockSelection || previousSelectedBlockPath
+						}
 						extraSidebarPanels={
 							showMetaBoxes && <MetaBoxes location="side" />
 						}

--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -36,7 +36,13 @@ export default function useNavigateToEntityRecord(
 	const [ postHistory, dispatch ] = useReducer(
 		(
 			historyState,
-			{ type, post, previousRenderingMode, selectedBlockPath }
+			{
+				type,
+				post,
+				previousRenderingMode,
+				selectedBlockPath,
+				destinationBlockPath,
+			}
 		) => {
 			if ( type === 'push' ) {
 				// Update the current item with the selected block path before pushing new item
@@ -46,7 +52,10 @@ export default function useNavigateToEntityRecord(
 					...updatedHistory[ currentIndex ],
 					selectedBlockPath,
 				};
-				return [ ...updatedHistory, { post, previousRenderingMode } ];
+				return [
+					...updatedHistory,
+					{ post, previousRenderingMode, destinationBlockPath },
+				];
 			}
 			if ( type === 'pop' ) {
 				// Remove the current item from history
@@ -62,8 +71,12 @@ export default function useNavigateToEntityRecord(
 			},
 		]
 	);
-	const { post, previousRenderingMode, selectedBlockPath } =
-		postHistory[ postHistory.length - 1 ];
+	const {
+		post,
+		previousRenderingMode,
+		selectedBlockPath,
+		destinationBlockPath,
+	} = postHistory[ postHistory.length - 1 ];
 
 	const { getRenderingMode } = useSelect( editorStore );
 	const { setRenderingMode } = useDispatch( editorStore );
@@ -81,6 +94,8 @@ export default function useNavigateToEntityRecord(
 				// Save the current rendering mode so we can restore it when navigating back.
 				previousRenderingMode: getRenderingMode(),
 				selectedBlockPath: blockPath,
+				// Pass through destination block path if provided (for selecting a specific block at destination)
+				destinationBlockPath: params.destinationBlockPath,
 			} );
 			setRenderingMode( defaultRenderingMode );
 		},
@@ -108,7 +123,9 @@ export default function useNavigateToEntityRecord(
 			postHistory.length > 1
 				? onNavigateToPreviousEntityRecord
 				: undefined,
-		// Return the selected block path from the current history item
+		// Return the selected block path from the current history item (for back button)
 		previousSelectedBlockPath: selectedBlockPath,
+		// Return the destination block path to select at the current entity
+		initialBlockSelection: destinationBlockPath,
 	};
 }

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -58,13 +58,23 @@ export default function useNavigateToEntityRecord() {
 				}
 			}
 
+			// Build query args for destination URL
+			const queryArgs = {
+				canvas: 'edit',
+				focusMode: true,
+			};
+
+			// Add selectedBlock to destination if provided (for deep linking to a specific block)
+			if ( params.destinationBlockPath ) {
+				queryArgs.selectedBlock = encodeURIComponent(
+					JSON.stringify( params.destinationBlockPath )
+				);
+			}
+
 			// Then navigate to the new entity record
 			const url = addQueryArgs(
 				`/${ params.postType }/${ params.postId }`,
-				{
-					canvas: 'edit',
-					focusMode: true,
-				}
+				queryArgs
 			);
 
 			history.navigate( url );

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -101,23 +101,45 @@ function Editor( {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const restoreBlockFromPath = useRestoreBlockFromPath();
 
-	// Try to resolve the initial selection path to a clientId
-	// This will return null if the blocks aren't loaded yet or path can't be resolved
-	const restoredClientId = useSelect( () => {
-		if ( ! initialSelection || ! hasLoadedPost || ! post ) {
-			return null;
-		}
-		// Attempt to restore the block from the path
-		// This will only succeed once the blocks are actually loaded
-		return restoreBlockFromPath( initialSelection );
-	}, [ initialSelection, hasLoadedPost, post, restoreBlockFromPath ] );
+	// Check if the first step of the path is available (indicates blocks are loaded)
+	const canRestorePath = useSelect(
+		( select ) => {
+			if (
+				! initialSelection ||
+				! hasLoadedPost ||
+				! post ||
+				! Array.isArray( initialSelection ) ||
+				initialSelection.length === 0
+			) {
+				return false;
+			}
 
-	// Select the restored block once we have a valid clientId
+			const { getBlockOrder } = select( blockEditorStore );
+			const rootBlocks = getBlockOrder( '' );
+			const firstStep = initialSelection[ 0 ];
+
+			// Check if the first block in the path exists
+			return firstStep.index < rootBlocks.length;
+		},
+		[ initialSelection, hasLoadedPost, post ]
+	);
+
+	// Restore initial block selection once the path can be resolved
 	useEffect( () => {
-		if ( restoredClientId ) {
-			selectBlock( restoredClientId );
+		if ( ! canRestorePath ) {
+			return;
 		}
-	}, [ restoredClientId, selectBlock ] );
+
+		const clientId = restoreBlockFromPath( initialSelection );
+		if ( clientId ) {
+			selectBlock( clientId );
+		}
+	}, [
+		canRestorePath,
+		initialSelection,
+		restoreBlockFromPath,
+		selectBlock,
+	] );
 
 	return (
 		<>

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -101,15 +101,24 @@ function Editor( {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const restoreBlockFromPath = useRestoreBlockFromPath();
 
+	// Track if we've already restored to prevent continuous subscription
+	const hasRestoredRef = useRef( false );
+
+	// Reset when initialSelection changes (new navigation)
+	useEffect( () => {
+		hasRestoredRef.current = false;
+	}, [ initialSelection ] );
+
 	// Check if the first step of the path is available (indicates blocks are loaded)
 	const canRestorePath = useSelect(
 		( select ) => {
+			// Don't create a subscription if we don't have an initialSelection value
 			if (
+				hasRestoredRef.current ||
 				! initialSelection ||
-				! hasLoadedPost ||
-				! post ||
 				! Array.isArray( initialSelection ) ||
-				initialSelection.length === 0
+				initialSelection.length === 0 ||
+				! hasLoadedPost
 			) {
 				return false;
 			}
@@ -121,7 +130,7 @@ function Editor( {
 			// Check if the first block in the path exists
 			return firstStep.index < rootBlocks.length;
 		},
-		[ initialSelection, hasLoadedPost, post ]
+		[ initialSelection, hasLoadedPost ]
 	);
 
 	// Restore initial block selection once the path can be resolved
@@ -133,6 +142,7 @@ function Editor( {
 		const clientId = restoreBlockFromPath( initialSelection );
 		if ( clientId ) {
 			selectBlock( clientId );
+			hasRestoredRef.current = true;
 		}
 	}, [
 		canRestorePath,

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -101,28 +101,23 @@ function Editor( {
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const restoreBlockFromPath = useRestoreBlockFromPath();
 
-	// Restore initial block selection if provided (e.g., from navigation)
-	useEffect( () => {
+	// Try to resolve the initial selection path to a clientId
+	// This will return null if the blocks aren't loaded yet or path can't be resolved
+	const restoredClientId = useSelect( () => {
 		if ( ! initialSelection || ! hasLoadedPost || ! post ) {
-			return;
+			return null;
 		}
+		// Attempt to restore the block from the path
+		// This will only succeed once the blocks are actually loaded
+		return restoreBlockFromPath( initialSelection );
+	}, [ initialSelection, hasLoadedPost, post, restoreBlockFromPath ] );
 
-		// Use setTimeout to ensure blocks are fully rendered before selecting
-		const timeoutId = setTimeout( () => {
-			const clientId = restoreBlockFromPath( initialSelection );
-			if ( clientId ) {
-				selectBlock( clientId );
-			}
-		}, 0 );
-
-		return () => clearTimeout( timeoutId );
-	}, [
-		initialSelection,
-		hasLoadedPost,
-		post,
-		selectBlock,
-		restoreBlockFromPath,
-	] );
+	// Select the restored block once we have a valid clientId
+	useEffect( () => {
+		if ( restoredClientId ) {
+			selectBlock( restoredClientId );
+		}
+	}, [ restoredClientId, selectBlock ] );
 
 	return (
 		<>

--- a/packages/editor/src/hooks/template-part-navigation-edit-button.js
+++ b/packages/editor/src/hooks/template-part-navigation-edit-button.js
@@ -13,6 +13,11 @@ import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
+/**
+ * Internal dependencies
+ */
+import { useGenerateBlockPath } from '../utils/block-selection-path';
+
 // Block name constants
 const NAVIGATION_BLOCK_NAME = 'core/navigation';
 const TEMPLATE_PART_BLOCK_NAME = 'core/template-part';
@@ -31,17 +36,23 @@ const BLOCK_INSPECTOR_AREA = 'edit-post/block';
 function TemplatePartNavigationEditButton( { clientId } ) {
 	const { selectBlock, flashBlock } = useDispatch( blockEditorStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const generateBlockPath = useGenerateBlockPath();
 
 	const {
 		hasNavigationBlocks,
 		firstNavigationBlockId,
 		isNavigationEditable,
+		templatePartSlug,
+		templatePartTheme,
+		onNavigateToEntityRecord,
 	} = useSelect(
 		( select ) => {
 			const {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
+				getBlockAttributes,
+				getSettings,
 			} = select( blockEditorStore );
 
 			const descendants = getClientIdsOfDescendants( clientId );
@@ -55,6 +66,9 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 				? navigationBlocksInTemplatePart[ 0 ]
 				: null;
 
+			// Get template part attributes (slug and theme) for building the site editor URL
+			const templatePartAttributes = getBlockAttributes( clientId );
+
 			return {
 				hasNavigationBlocks: _hasNavigationBlocks,
 				firstNavigationBlockId: _firstNavigationBlockId,
@@ -63,13 +77,61 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 				isNavigationEditable:
 					getBlockEditingMode( _firstNavigationBlockId ) !==
 					'disabled',
+				templatePartSlug: templatePartAttributes?.slug,
+				templatePartTheme: templatePartAttributes?.theme,
+				onNavigateToEntityRecord:
+					getSettings().onNavigateToEntityRecord,
 			};
 		},
 		[ clientId ]
 	);
 
 	const onEditNavigation = useCallback( () => {
-		if ( firstNavigationBlockId ) {
+		if ( ! firstNavigationBlockId ) {
+			return;
+		}
+		if ( ! isNavigationEditable ) {
+			// Transfer the user to the isolated section editor and select the first Navigation block
+			if (
+				! templatePartSlug ||
+				! templatePartTheme ||
+				! onNavigateToEntityRecord
+			) {
+				return;
+			}
+
+			// Generate the block path to the first navigation block
+			const fullPath = generateBlockPath( firstNavigationBlockId );
+			if ( ! fullPath ) {
+				return;
+			}
+
+			// The path needs to be relative to the template part's content, not the page root
+			// Find the template part in the path and remove everything up to and including it
+			const templatePartIndex = fullPath.findIndex(
+				( step ) => step.blockName === TEMPLATE_PART_BLOCK_NAME
+			);
+
+			// Get the path starting from inside the template part
+			const destinationBlockPath =
+				templatePartIndex !== -1
+					? fullPath.slice( templatePartIndex + 1 )
+					: fullPath;
+
+			// Don't navigate if we don't have a valid relative path
+			if ( ! destinationBlockPath || destinationBlockPath.length === 0 ) {
+				return;
+			}
+
+			// Navigate to the site editor with the template part and select the navigation block
+			const templatePartId = `${ templatePartTheme }//${ templatePartSlug }`;
+			onNavigateToEntityRecord( {
+				postId: templatePartId,
+				postType: 'wp_template_part',
+				selectedBlockClientId: clientId, // Save current template part block for back button
+				destinationBlockPath, // Select the navigation block at destination
+			} );
+		} else {
 			// Select the first Navigation block
 			selectBlock( firstNavigationBlockId );
 
@@ -81,13 +143,19 @@ function TemplatePartNavigationEditButton( { clientId } ) {
 		}
 	}, [
 		firstNavigationBlockId,
+		isNavigationEditable,
+		templatePartSlug,
+		templatePartTheme,
+		onNavigateToEntityRecord,
+		generateBlockPath,
+		clientId,
 		selectBlock,
 		flashBlock,
 		enableComplementaryArea,
 	] );
 
 	// Only show if template part contains navigation blocks and they are editable
-	if ( ! hasNavigationBlocks || ! isNavigationEditable ) {
+	if ( ! hasNavigationBlocks ) {
 		return null;
 	}
 

--- a/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
+++ b/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Template Part Navigation Edit Button', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyfive' );
+		// Create some pages so the header template part has a page list
+		await requestUtils.createPage( {
+			title: 'Test Page 1',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( {
+			title: 'Test Page 2',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		// Delete all the pages we created
+		await requestUtils.deleteAllPages();
+	} );
+
+	test( 'should select navigation block in isolated editor when clicking Edit navigation button on a page ', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Create and visit a page (not a template)
+		await admin.createNewPost( { postType: 'page' } );
+
+		// Close pattern chooser dialog
+		const patternDialog = page.getByRole( 'dialog', {
+			name: 'Choose a pattern',
+		} );
+		await expect( patternDialog ).toBeVisible();
+		await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
+
+		// TODO: Turn on the "Show template parts" switch in the
+
+		const viewButton = page.getByRole( 'button', {
+			name: 'View',
+			exact: true,
+		} );
+		await expect( viewButton ).toBeVisible();
+		await viewButton.click();
+
+		const showTemplateOption = page.getByRole( 'menuitemcheckbox', {
+			name: 'Show template',
+		} );
+		await expect( showTemplateOption ).toBeVisible();
+		await showTemplateOption.click();
+
+		const editNavigationButton = page.locator(
+			'role=button[name="Edit navigation"]'
+		);
+
+		await test.step( 'should show Edit navigation button when template part has navigation block', async () => {
+			// Find the header template part block
+			const headerTemplatePart = editor.canvas.getByRole( 'document', {
+				name: 'Block: Header',
+			} );
+
+			// Wait for it to be visible
+			await expect( headerTemplatePart ).toBeVisible();
+
+			// Click to select it
+			await headerTemplatePart.click();
+
+			// Verify the button is visible
+			await expect( editNavigationButton ).toBeVisible();
+		} );
+
+		await test.step( 'clicking Edit navigation button should go to isolated editor', async () => {
+			// Get the current URL before navigation
+			await editNavigationButton.click();
+
+			// Verify we navigated to the template part editor
+			// If we went to the isolated editor, we should see the command palette button for the template part
+			const commandPaletteButton = page.getByRole( 'button', {
+				name: 'Header · Template Part ⌘K',
+			} );
+			await expect( commandPaletteButton ).toBeVisible();
+		} );
+
+		await test.step( 'The navigation block should be selected in the isolated editor', async () => {
+			const navigationBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Navigation',
+			} );
+
+			await expect( navigationBlock ).toBeVisible();
+
+			await expect( navigationBlock ).toHaveClass( /is-selected/ );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
+++ b/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
@@ -4,6 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Template Part Navigation Edit Button', () => {
+	let testPostId;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyfive' );
 		// Create some pages so the header template part has a page list
@@ -15,12 +17,20 @@ test.describe( 'Template Part Navigation Edit Button', () => {
 			title: 'Test Page 2',
 			status: 'publish',
 		} );
+		// Create a test post with content (posts don't have the pattern chooser modal)
+		const testPost = await requestUtils.createPost( {
+			title: 'Template Part Navigation Test Post',
+			content:
+				'<!-- wp:paragraph --><p>Test content</p><!-- /wp:paragraph -->',
+			status: 'publish',
+		} );
+		testPostId = testPost.id;
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
-		// Delete all the pages we created
 		await requestUtils.deleteAllPages();
+		await requestUtils.deleteAllPosts();
 	} );
 
 	test( 'should select navigation block in isolated editor when clicking Edit navigation button on a page ', async ( {
@@ -36,20 +46,8 @@ test.describe( 'Template Part Navigation Edit Button', () => {
 		);
 
 		await test.step( 'test setup', async () => {
-			// Create and visit a page (not a template)
-			await admin.createNewPost( { postType: 'page' } );
-
-			// Close pattern chooser dialog
-			const patternDialog = page.getByRole( 'dialog', {
-				name: 'Choose a pattern',
-			} );
-			await expect( patternDialog ).toBeVisible();
-			await patternDialog
-				.getByRole( 'button', { name: 'Close' } )
-				.click();
-
-			// Enter some content into the page to avoid the new page dialog
-			await page.keyboard.type( 'Test content' );
+			// Visit the existing post
+			await admin.editPost( testPostId );
 
 			// Turn on the "Show template parts" to view the header template part
 			const viewButton = page.getByRole( 'button', {

--- a/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
+++ b/test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js
@@ -28,42 +28,46 @@ test.describe( 'Template Part Navigation Edit Button', () => {
 		editor,
 		page,
 	} ) => {
-		// Create and visit a page (not a template)
-		await admin.createNewPost( { postType: 'page' } );
-
-		// Close pattern chooser dialog
-		const patternDialog = page.getByRole( 'dialog', {
-			name: 'Choose a pattern',
+		const headerTemplatePart = editor.canvas.getByRole( 'document', {
+			name: 'Block: Header',
 		} );
-		await expect( patternDialog ).toBeVisible();
-		await patternDialog.getByRole( 'button', { name: 'Close' } ).click();
-
-		// TODO: Turn on the "Show template parts" switch in the
-
-		const viewButton = page.getByRole( 'button', {
-			name: 'View',
-			exact: true,
-		} );
-		await expect( viewButton ).toBeVisible();
-		await viewButton.click();
-
-		const showTemplateOption = page.getByRole( 'menuitemcheckbox', {
-			name: 'Show template',
-		} );
-		await expect( showTemplateOption ).toBeVisible();
-		await showTemplateOption.click();
-
 		const editNavigationButton = page.locator(
 			'role=button[name="Edit navigation"]'
 		);
 
-		await test.step( 'should show Edit navigation button when template part has navigation block', async () => {
-			// Find the header template part block
-			const headerTemplatePart = editor.canvas.getByRole( 'document', {
-				name: 'Block: Header',
-			} );
+		await test.step( 'test setup', async () => {
+			// Create and visit a page (not a template)
+			await admin.createNewPost( { postType: 'page' } );
 
-			// Wait for it to be visible
+			// Close pattern chooser dialog
+			const patternDialog = page.getByRole( 'dialog', {
+				name: 'Choose a pattern',
+			} );
+			await expect( patternDialog ).toBeVisible();
+			await patternDialog
+				.getByRole( 'button', { name: 'Close' } )
+				.click();
+
+			// Enter some content into the page to avoid the new page dialog
+			await page.keyboard.type( 'Test content' );
+
+			// Turn on the "Show template parts" to view the header template part
+			const viewButton = page.getByRole( 'button', {
+				name: 'View',
+				exact: true,
+			} );
+			await expect( viewButton ).toBeVisible();
+			await viewButton.click();
+
+			const showTemplateOption = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show template',
+			} );
+			await expect( showTemplateOption ).toBeVisible();
+			await showTemplateOption.click();
+		} );
+
+		await test.step( 'should show Edit navigation button when template part has navigation block', async () => {
+			// Wait for header template part to be visible
 			await expect( headerTemplatePart ).toBeVisible();
 
 			// Click to select it
@@ -73,16 +77,17 @@ test.describe( 'Template Part Navigation Edit Button', () => {
 			await expect( editNavigationButton ).toBeVisible();
 		} );
 
+		const backButton = page.getByRole( 'button', {
+			name: 'Back',
+		} );
+
 		await test.step( 'clicking Edit navigation button should go to isolated editor', async () => {
 			// Get the current URL before navigation
 			await editNavigationButton.click();
 
 			// Verify we navigated to the template part editor
-			// If we went to the isolated editor, we should see the command palette button for the template part
-			const commandPaletteButton = page.getByRole( 'button', {
-				name: 'Header · Template Part ⌘K',
-			} );
-			await expect( commandPaletteButton ).toBeVisible();
+			// If we went to the isolated editor, we should see the back button in the header
+			await expect( backButton ).toBeVisible();
 		} );
 
 		await test.step( 'The navigation block should be selected in the isolated editor', async () => {
@@ -93,6 +98,19 @@ test.describe( 'Template Part Navigation Edit Button', () => {
 			await expect( navigationBlock ).toBeVisible();
 
 			await expect( navigationBlock ).toHaveClass( /is-selected/ );
+		} );
+
+		await test.step( 'clicking Back button should go to the page editor with the template part selected', async () => {
+			await backButton.click();
+
+			// Verify we navigated to the page editor
+			await expect( headerTemplatePart ).toBeVisible();
+
+			// Verify the header template part is selected
+			await expect( headerTemplatePart ).toHaveClass( /is-selected/ );
+
+			// Verify the edit navigation button is visible (header template part is selected)
+			await expect( editNavigationButton ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73383

<!-- In a few words, what is the PR actually doing? -->

Adds an "Edit navigation" button to template parts containing navigation blocks. When clicked from the page editor, it navigates to the isolated template
   part editor and automatically selects the first navigation block.                                                                                       
                                                                                                                                                           
  ## Why?                                                                                                                                                  
  When editing a page with a header template that contains a navigation block, users need a quick way to access and edit that navigation, as identified in user testing. 
                                                                                                                                                           
  ## How?                                                                                                                                                  
  1. **Added "Edit navigation" button** (`packages/editor/src/hooks/template-part-navigation-edit-button.js`):                                             
     - Filters the BlockEdit component for template parts                                                                                                  
     - Shows button when template part contains navigation blocks                                                                                          
     - Generates a block path from the page editor context to the navigation block                                                                         
     - Converts the path to be relative to the template part content (removes template part and ancestor blocks from the path)                             
     - Calls `onNavigateToEntityRecord` with the destination block path                                                                                    
                                                                                                                                                           
  2. **Enhanced block selection restoration** (`packages/editor/src/components/editor/index.js`):                                                          
     - Added logic to restore block selection from `initialSelection` prop when editor loads                                                               
     - Uses `useSelect` to check if the first step of the path is available (indicates blocks are loaded)                                                  
     - Calls `restoreBlockFromPath` to resolve the path to a clientId                                                                                      
     - Selects the block once restoration succeeds                                                                                                         
                                                                                                                                                           
  3. **Updated navigation hooks** to pass `destinationBlockPath`:                                                                                          
     - `packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js` - encodes destination path in URL parameter                       
     - `packages/edit-post/src/hooks/use-navigate-to-entity-record.js` - stores destination path in history state                                          
     - Both pass through to Editor as `initialBlockSelection`                                                                                              
                                                                                                                                                           
  4. **Added e2e test** (`test/e2e/specs/editor/various/template-part-navigation-edit-button.spec.js`):                                                    
     - Verifies button appears when template part has navigation block                                                                                     
     - Verifies navigation to isolated editor                                                                                                              
     - Verifies navigation block is selected after navigation                                                                                              
                                                                                                                                                           
  ## Testing Instructions                                                                                                                                  
1. Go to a page in the site editor                                                                                              
  4. In the View menu (top right), enable "Show template"                                                                                                  
  5. Click on the Header template part block in the canvas                                                                                                 
  6. Verify the "Edit navigation" button appears in the block toolbar                                                                                      
  7. Click the "Edit navigation" button                                                                                                                    
  8. Verify you navigate to the isolated template part editor (check the page title shows "Header · Template Part")                                        
  9. Verify the navigation block is automatically selected (has the blue selection outline and selection controls)                                         
  10. Verify the block inspector shows the navigation block settings                                                                                       
                                                                                                                                                           
  ### Testing Instructions for Keyboard                                                                                                                    
Press Enter instead of Click using the steps above.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/bf85fb50-2998-44e1-82a6-3a7f4519f2e7

