### PR TITLE
Try hiding parent grid cells when child grid is selected.

### DIFF
--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -15,13 +15,18 @@ import { __experimentalUseDropZone as useDropZone } from '@wordpress/compose';
  */
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import BlockPopoverCover from '../block-popover/cover';
-import { range, GridRect, getGridInfo } from './utils';
+import { range, GridRect, getGridInfo, getGridItemRect } from './utils';
 import { store as blockEditorStore } from '../../store';
 import { useGetNumberOfBlocksBeforeCell } from './use-get-number-of-blocks-before-cell';
 import ButtonBlockAppender from '../button-block-appender';
 import { unlock } from '../../lock-unlock';
 
-export function GridVisualizer( { clientId, contentRef, parentLayout } ) {
+export function GridVisualizer( {
+	clientId,
+	contentRef,
+	parentLayout,
+	childGridClientId,
+} ) {
 	const isDistractionFree = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings().isDistractionFree,
@@ -42,16 +47,30 @@ export function GridVisualizer( { clientId, contentRef, parentLayout } ) {
 			gridElement={ gridElement }
 			isManualGrid={ isManualGrid }
 			ref={ contentRef }
+			childGridClientId={ childGridClientId }
 		/>
 	);
 }
 
 const GridVisualizerGrid = forwardRef(
-	( { gridClientId, gridElement, isManualGrid }, ref ) => {
+	( { gridClientId, gridElement, isManualGrid, childGridClientId }, ref ) => {
 		const [ gridInfo, setGridInfo ] = useState( () =>
 			getGridInfo( gridElement )
 		);
 		const [ isDroppingAllowed, setIsDroppingAllowed ] = useState( false );
+
+		// Get the element for the child grid block so we can
+		// compute its position and hide overlapping visualizer cells.
+		const childGridElement = useBlockElement( childGridClientId );
+
+		// Compute the child grid block's rect from its position in the grid.
+		// This works for both manual and non-manual grids.
+		const childGridRect = useMemo( () => {
+			if ( ! childGridElement ) {
+				return null;
+			}
+			return getGridItemRect( childGridElement );
+		}, [ childGridElement ] );
 
 		useEffect( () => {
 			const resizeCallback = () =>
@@ -101,14 +120,13 @@ const GridVisualizerGrid = forwardRef(
 						<ManualGridVisualizer
 							gridClientId={ gridClientId }
 							gridInfo={ gridInfo }
+							childGridRect={ childGridRect }
 						/>
 					) : (
-						Array.from( { length: gridInfo.numItems }, ( _, i ) => (
-							<GridVisualizerCell
-								key={ i }
-								color={ gridInfo.currentColor }
-							/>
-						) )
+						<NonManualGridVisualizer
+							gridInfo={ gridInfo }
+							childGridRect={ childGridRect }
+						/>
 					) }
 				</div>
 			</BlockPopoverCover>
@@ -116,7 +134,27 @@ const GridVisualizerGrid = forwardRef(
 	}
 );
 
-function ManualGridVisualizer( { gridClientId, gridInfo } ) {
+function NonManualGridVisualizer( { gridInfo, childGridRect } ) {
+	return range( 1, gridInfo.numRows ).map( ( row ) =>
+		range( 1, gridInfo.numColumns ).map( ( column ) => {
+			// Don't render visualizer cells for a selected child block
+			// that is itself a grid, so that only the child's grid
+			// visualizer is visible.
+			let color = gridInfo.currentColor;
+			if ( childGridRect?.contains( column, row ) ) {
+				color = 'transparent';
+			}
+			return (
+				<GridVisualizerCell
+					key={ `${ row }-${ column }` }
+					color={ color }
+				/>
+			);
+		} )
+	);
+}
+
+function ManualGridVisualizer( { gridClientId, gridInfo, childGridRect } ) {
 	const [ highlightedRect, setHighlightedRect ] = useState( null );
 
 	const gridItemStyles = useSelect(
@@ -155,6 +193,14 @@ function ManualGridVisualizer( { gridClientId, gridInfo } ) {
 
 	return range( 1, gridInfo.numRows ).map( ( row ) =>
 		range( 1, gridInfo.numColumns ).map( ( column ) => {
+			// Don't render visualizer cells for a selected child block
+			// that is itself a grid, so that only the child's grid
+			// visualizer is visible.
+			const isChildGridCell = childGridRect?.contains( column, row );
+			let color = gridInfo.currentColor;
+			if ( isChildGridCell ) {
+				color = 'transparent';
+			}
 			const isCellOccupied = occupiedRects.some( ( rect ) =>
 				rect.contains( column, row )
 			);
@@ -163,10 +209,10 @@ function ManualGridVisualizer( { gridClientId, gridInfo } ) {
 			return (
 				<GridVisualizerCell
 					key={ `${ row }-${ column }` }
-					color={ gridInfo.currentColor }
+					color={ color }
 					className={ isHighlighted && 'is-highlighted' }
 				>
-					{ isCellOccupied ? (
+					{ isCellOccupied && ! isChildGridCell ? (
 						<GridVisualizerDropZone
 							column={ column }
 							row={ row }

--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -123,7 +123,7 @@ const GridVisualizerGrid = forwardRef(
 							childGridRect={ childGridRect }
 						/>
 					) : (
-						<NonManualGridVisualizer
+						<AutoGridVisualizer
 							gridInfo={ gridInfo }
 							childGridRect={ childGridRect }
 						/>
@@ -134,7 +134,7 @@ const GridVisualizerGrid = forwardRef(
 	}
 );
 
-function NonManualGridVisualizer( { gridInfo, childGridRect } ) {
+function AutoGridVisualizer( { gridInfo, childGridRect } ) {
 	return range( 1, gridInfo.numRows ).map( ( row ) =>
 		range( 1, gridInfo.numColumns ).map( ( column ) => {
 			// Don't render visualizer cells for a selected child block

--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { GridVisualizer, useGridLayoutSync } from '../components/grid';
 import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
 import useBlockVisibility from '../components/block-visibility/use-block-visibility';
 import { deviceTypeKey } from '../store/private-keys';
 import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/constants';
@@ -19,40 +20,54 @@ function GridLayoutSync( props ) {
 }
 
 function GridTools( { clientId, layout } ) {
-	const { isVisible, blockVisibility, deviceType } = useSelect(
-		( select ) => {
-			const {
-				isBlockSelected,
-				isDraggingBlocks,
-				getTemplateLock,
-				getBlockEditingMode,
-				getBlockAttributes,
-				getSettings,
-			} = select( blockEditorStore );
+	const { isVisible, blockVisibility, deviceType, isAnyAncestorHidden } =
+		useSelect(
+			( select ) => {
+				const {
+					isBlockSelected,
+					hasSelectedInnerBlock,
+					isDraggingBlocks,
+					getTemplateLock,
+					getBlockEditingMode,
+					getBlockAttributes,
+					getSettings,
+				} = select( blockEditorStore );
 
-			// These calls are purposely ordered from least expensive to most expensive.
-			// Hides the visualizer in cases where the user is not or cannot interact with it.
-			if (
-				( ! isDraggingBlocks() && ! isBlockSelected( clientId ) ) ||
-				getTemplateLock( clientId ) ||
-				getBlockEditingMode( clientId ) !== 'default'
-			) {
-				return { isVisible: false };
-			}
+				// These calls are purposely ordered from least expensive to most expensive.
+				// Hides the visualizer in cases where the user is not or cannot interact with it.
+				// Also hide if a child block is selected, because layout-child.js will render
+				// the visualizer in that case (with proper childGridClientId handling).
+				if (
+					( ! isDraggingBlocks() && ! isBlockSelected( clientId ) ) ||
+					getTemplateLock( clientId ) ||
+					getBlockEditingMode( clientId ) !== 'default' ||
+					hasSelectedInnerBlock( clientId )
+				) {
+					return { isVisible: false };
+				}
 
-			const attributes = getBlockAttributes( clientId );
-			const settings = getSettings();
+				const { isBlockParentHiddenAtViewport } = unlock(
+					select( blockEditorStore )
+				);
 
-			return {
-				isVisible: true,
-				blockVisibility: attributes?.metadata?.blockVisibility,
-				deviceType:
+				const attributes = getBlockAttributes( clientId );
+				const settings = getSettings();
+				const currentDeviceType =
 					settings?.[ deviceTypeKey ]?.toLowerCase() ||
-					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
-			};
-		},
-		[ clientId ]
-	);
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.value;
+
+				return {
+					isVisible: true,
+					blockVisibility: attributes?.metadata?.blockVisibility,
+					deviceType: currentDeviceType,
+					isAnyAncestorHidden: isBlockParentHiddenAtViewport(
+						clientId,
+						currentDeviceType
+					),
+				};
+			},
+			[ clientId ]
+		);
 
 	const { isBlockCurrentlyHidden } = useBlockVisibility( {
 		blockVisibility,
@@ -62,9 +77,14 @@ function GridTools( { clientId, layout } ) {
 	return (
 		<>
 			<GridLayoutSync clientId={ clientId } />
-			{ isVisible && ! isBlockCurrentlyHidden && (
-				<GridVisualizer clientId={ clientId } parentLayout={ layout } />
-			) }
+			{ isVisible &&
+				! isBlockCurrentlyHidden &&
+				! isAnyAncestorHidden && (
+					<GridVisualizer
+						clientId={ clientId }
+						parentLayout={ layout }
+					/>
+				) }
 		</>
 	);
 }

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -208,6 +208,7 @@ function GridTools( {
 		parentBlockVisibility,
 		blockBlockVisibility,
 		deviceType,
+		isChildBlockAGrid,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -244,6 +245,8 @@ function GridTools( {
 				deviceType:
 					settings?.[ deviceTypeKey ]?.toLowerCase() ||
 					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
+				// Check if the selected child block is itself a grid.
+				isChildBlockAGrid: blockAttributes?.layout?.type === 'grid',
 			};
 		},
 		[ clientId ]
@@ -263,6 +266,8 @@ function GridTools( {
 
 	// Use useState() instead of useRef() so that GridItemResizer updates when ref is set.
 	const [ resizerBounds, setResizerBounds ] = useState();
+
+	const childGridClientId = isChildBlockAGrid ? clientId : undefined;
 
 	if ( ! isVisible || isParentBlockCurrentlyHidden ) {
 		return null;
@@ -288,6 +293,7 @@ function GridTools( {
 				clientId={ rootClientId }
 				contentRef={ setResizerBounds }
 				parentLayout={ parentLayout }
+				childGridClientId={ childGridClientId }
 			/>
 			{ showResizer && (
 				<GridItemResizer


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #64383

* Prevents rendering of the visualizer by the parent grid block (in `packages/block-editor/src/hooks/grid-visualizer.js`) if a child is selected (because the child is already rendering the parent grid in `packages/block-editor/src/hooks/layout-child.js`).
* If the visualizer is being rendered by a selected child, and that child block is a grid, we pass a `childGridClientId` prop to it from which we calculate its position in the grid and make the corresponding cells transparent.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block to a post and add some child blocks to it, including another Grid. Resize the child Grid so it takes up multiple of the parent's cells (this makes it easier to check whether the parent cells are visible)
2. Select the child Grid and verify that the parent Grid cells it occupies aren't visible:

<img width="1001" height="398" alt="Screenshot 2026-01-30 at 11 39 33 am" src="https://github.com/user-attachments/assets/511a8895-3b86-4fc9-b7ff-b1746850afc9" />

<img width="1029" height="398" alt="Screenshot 2026-01-30 at 11 39 43 am" src="https://github.com/user-attachments/assets/4b2e511b-5bed-4cbb-b535-ebb36a190a5c" />

In testing this I realised that in #74963 I omitted to check whether any of the Grid's parents were hidden before showing the visualizer, so I also added a fix for that. Now, if a Grid is within a hidden parent, selecting it with the list view won't show the visualizer:

<img width="1124" height="238" alt="Screenshot 2026-01-30 at 11 43 37 am" src="https://github.com/user-attachments/assets/cc299675-c01f-42d7-beb5-02976d10c16c" />

