### PR TITLE
Add AVIF, WebP and MozJPEG output encoding support 

### DIFF
--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -1,0 +1,254 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlobURL, revokeBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { getTranscodeImageOperation } from '../private-actions';
+import { OperationType } from '../types';
+import { vipsHasTransparency } from '../utils';
+
+// Mock @wordpress/blob
+jest.mock( '@wordpress/blob', () => ( {
+	createBlobURL: jest.fn( () => 'blob:mock-url' ),
+	revokeBlobURL: jest.fn(),
+} ) );
+
+// Mock vips utilities
+jest.mock( '../utils', () => ( {
+	vipsHasTransparency: jest.fn(),
+} ) );
+
+describe( 'private actions', () => {
+	describe( 'getTranscodeImageOperation', () => {
+		const mockSettings = {
+			jpegInterlaced: false,
+			pngInterlaced: false,
+			gifInterlaced: false,
+		};
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should return transcode operation for valid format conversion', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/webp',
+				mockSettings
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'webp',
+					outputQuality: 0.82,
+					interlaced: false,
+				},
+			] );
+		} );
+
+		it( 'should return null for invalid output format', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/unknown',
+				mockSettings
+			);
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should return null when PNG has transparency for PNG to JPEG conversion', async () => {
+			vipsHasTransparency.mockResolvedValue( true );
+
+			const file = new File( [ 'test' ], 'test.png', {
+				type: 'image/png',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/jpeg',
+				mockSettings
+			);
+
+			expect( result ).toBeNull();
+			expect( createBlobURL ).toHaveBeenCalledWith( file );
+			expect( revokeBlobURL ).toHaveBeenCalledWith( 'blob:mock-url' );
+		} );
+
+		it( 'should return transcode operation when PNG has no transparency for PNG to JPEG conversion', async () => {
+			vipsHasTransparency.mockResolvedValue( false );
+
+			const file = new File( [ 'test' ], 'test.png', {
+				type: 'image/png',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/jpeg',
+				mockSettings
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'jpeg',
+					outputQuality: 0.82,
+					interlaced: false,
+				},
+			] );
+			expect( createBlobURL ).toHaveBeenCalledWith( file );
+			expect( revokeBlobURL ).toHaveBeenCalledWith( 'blob:mock-url' );
+		} );
+
+		it( 'should return null when transparency check fails', async () => {
+			vipsHasTransparency.mockRejectedValue(
+				new Error( 'WASM load failed' )
+			);
+
+			const file = new File( [ 'test' ], 'test.png', {
+				type: 'image/png',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/jpeg',
+				mockSettings
+			);
+
+			expect( result ).toBeNull();
+			expect( revokeBlobURL ).toHaveBeenCalledWith( 'blob:mock-url' );
+		} );
+
+		it( 'should skip transparency check for non-PNG to JPEG conversions', async () => {
+			const file = new File( [ 'test' ], 'test.png', {
+				type: 'image/png',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/webp',
+				mockSettings
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'webp',
+					outputQuality: 0.82,
+					interlaced: false,
+				},
+			] );
+			expect( vipsHasTransparency ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should respect interlaced setting for JPEG output', async () => {
+			const file = new File( [ 'test' ], 'test.png', {
+				type: 'image/png',
+			} );
+			vipsHasTransparency.mockResolvedValue( false );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/jpeg',
+				{ ...mockSettings, jpegInterlaced: true }
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'jpeg',
+					outputQuality: 0.82,
+					interlaced: true,
+				},
+			] );
+		} );
+
+		it( 'should respect interlaced setting for PNG output', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/png',
+				{ ...mockSettings, pngInterlaced: true }
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'png',
+					outputQuality: 0.82,
+					interlaced: true,
+				},
+			] );
+		} );
+
+		it( 'should respect interlaced setting for GIF output', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/gif',
+				{ ...mockSettings, gifInterlaced: true }
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'gif',
+					outputQuality: 0.82,
+					interlaced: true,
+				},
+			] );
+		} );
+
+		it( 'should return transcode operation for AVIF output', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/avif',
+				mockSettings
+			);
+
+			expect( result ).toEqual( [
+				OperationType.TranscodeImage,
+				{
+					outputFormat: 'avif',
+					outputQuality: 0.82,
+					interlaced: false,
+				},
+			] );
+		} );
+
+		it( 'should return null for malformed MIME type', async () => {
+			const file = new File( [ 'test' ], 'test.jpg', {
+				type: 'image/jpeg',
+			} );
+
+			const result = await getTranscodeImageOperation(
+				file,
+				'image/',
+				mockSettings
+			);
+
+			expect( result ).toBeNull();
+		} );
+	} );
+} );

--- a/packages/upload-media/src/store/test/vips.ts
+++ b/packages/upload-media/src/store/test/vips.ts
@@ -165,6 +165,27 @@ describe( 'vips utilities', () => {
 
 			expect( result ).toBe( false );
 		} );
+
+		it( 'throws when fetch fails', async () => {
+			mockFetch.mockResolvedValue( {
+				ok: false,
+				status: 404,
+			} as Response );
+
+			await expect(
+				vipsHasTransparency( 'blob:test-url' )
+			).rejects.toThrow( 'Failed to fetch image: 404' );
+		} );
+
+		it( 'throws when vips check fails', async () => {
+			mockHasTransparency.mockRejectedValue(
+				new Error( 'WASM load failed' )
+			);
+
+			await expect(
+				vipsHasTransparency( 'blob:test-url' )
+			).rejects.toThrow( 'WASM load failed' );
+		} );
 	} );
 
 	describe( 'vipsResizeImage', () => {

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -170,6 +170,14 @@ export interface Settings {
 	// Images larger than this will be scaled down.
 	// Default is 2560 (matching WordPress core).
 	bigImageSizeThreshold?: number;
+	// Map of source MIME types to output MIME types for transcoding.
+	imageOutputFormats?: Record< string, string >;
+	// Whether to use progressive/interlaced encoding for JPEG.
+	jpegInterlaced?: boolean;
+	// Whether to use interlaced encoding for PNG.
+	pngInterlaced?: boolean;
+	// Whether to use interlaced encoding for GIF.
+	gifInterlaced?: boolean;
 }
 
 // Matches the Attachment type from the media-utils package.
@@ -223,6 +231,7 @@ export enum OperationType {
 	Upload = 'UPLOAD',
 	ResizeCrop = 'RESIZE_CROP',
 	Rotate = 'ROTATE',
+	TranscodeImage = 'TRANSCODE_IMAGE',
 	ThumbnailGeneration = 'THUMBNAIL_GENERATION',
 }
 
@@ -262,6 +271,14 @@ export interface OperationArgs {
 		 * Used to apply the correct rotation/flip transformation.
 		 */
 		orientation: number;
+	};
+	[ OperationType.TranscodeImage ]: {
+		/** Target output format. */
+		outputFormat: ImageFormat;
+		/** Quality setting (0-1). */
+		outputQuality: number;
+		/** Whether to use interlaced encoding. */
+		interlaced: boolean;
 	};
 }
 

--- a/packages/upload-media/src/store/utils/vips.ts
+++ b/packages/upload-media/src/store/utils/vips.ts
@@ -117,18 +117,12 @@ export async function vipsCompressImage(
  * @return Whether the image has transparency.
  */
 export async function vipsHasTransparency( url: string ) {
-	try {
-		const { vipsHasTransparency: hasTransparency } = await loadVipsModule();
-		const response = await fetch( url );
-		if ( ! response.ok ) {
-			throw new Error( `Failed to fetch image: ${ response.status }` );
-		}
-		return hasTransparency( await response.arrayBuffer() );
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Error checking transparency:', error );
-		return false; // Safe fallback
+	const { vipsHasTransparency: hasTransparency } = await loadVipsModule();
+	const response = await fetch( url );
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch image: ${ response.status }` );
 	}
+	return hasTransparency( await response.arrayBuffer() );
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/74364

Depends on https://github.com/WordPress/gutenberg/pull/74566

## Summary

This PR adds output format conversion support for client-side media processing, enabling generation of modern image formats during upload:

- **AVIF** - Modern format with excellent compression
- **WebP** - Widely supported modern format  
- **MozJPEG** - Optimized JPEG encoder providing ~10-15% smaller file sizes

### Key changes:

- Add `TranscodeImage` operation type for format conversion
- Add settings (`imageOutputFormats`, `jpegInterlaced`, `pngInterlaced`, `gifInterlaced`) that flow from PHP REST API
- Implement `transcodeImageItem` action using vipsConvertImageFormat
- Update `prepareItem` to check format mapping and add TranscodeImage operations
- Add transparency check for PNG→JPEG to preserve alpha channels
- Apply format conversion to generated thumbnails
- Add MozJPEG optimizations (`optimize_coding`, `quant_table`) for JPEG output

The implementation respects WordPress's `image_editor_output_format` filter for format mapping configuration.

## Test plan

- [ ] Upload a JPEG and verify MozJPEG optimizations produce smaller files
- [ ] Configure `image_editor_output_format` filter to convert JPEG→WebP and verify conversion
- [ ] Configure filter for PNG→JPEG and verify transparent PNGs are not converted
- [ ] Verify thumbnails are also transcoded to the configured output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)