### PR TITLE
Docs: Add missing @global documentation in rtl.php and meta-box.php

### DIFF
--- a/packages/e2e-tests/plugins/meta-box.php
+++ b/packages/e2e-tests/plugins/meta-box.php
@@ -31,6 +31,7 @@ add_action( 'add_meta_boxes', 'gutenberg_test_meta_box_add_meta_box' );
 
 /**
  * Print excerpt in <meta> tag in wp_head
+ * @global WP_Post $post Global post object.
  */
 function gutenberg_test_meta_box_render_head() {
 	global $post;

--- a/packages/e2e-tests/plugins/rtl.php
+++ b/packages/e2e-tests/plugins/rtl.php
@@ -11,6 +11,8 @@
 
 /**
  * Set the locale's and styles' text direction to RTL.
+ * @global WP_Locale $wp_locale WordPress Locale object.
+ * @global WP_Styles $wp_styles WordPress Styles object.
  */
 function gutenberg_test_plugin_activate_rtl_set_direction() {
 	global $wp_locale, $wp_styles;


### PR DESCRIPTION
**Summary of Changes**

Improved code documentation by adding the missing @global annotations to
packages/e2e-tests/plugins/rtl.php and packages/e2e-tests/plugins/meta-box.php, ensuring better clarity and maintainability.

**Testing Instructions**

1. Open packages/e2e-tests/plugins/rtl.php and packages/e2e-tests/plugins/meta-box.php.
2. Confirm that the methods now include the required @global documentation.