### PR TITLE
Docs: Replace @see with @link for URLs in block-library package.

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -153,8 +153,8 @@ function enqueue_legacy_post_comments_block_styles( $block_name ) {
  *
  * @since 6.1.0
  *
- * @see https://github.com/WordPress/gutenberg/pull/41807
- * @see https://github.com/WordPress/gutenberg/pull/32514
+ * @link https://github.com/WordPress/gutenberg/pull/41807
+ * @link https://github.com/WordPress/gutenberg/pull/32514
  */
 function register_legacy_post_comments_block() {
 	$registry = WP_Block_Type_Registry::get_instance();

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -134,7 +134,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	 * @todo In the future, if this hook supports updating innerBlocks in
 	 * nested blocks, it should be refactored.
 	 *
-	 * @see: https://github.com/WordPress/gutenberg/pull/58733
+	 * @link https://github.com/WordPress/gutenberg/pull/58733
 	 */
 	if ( empty( $attributes['randomOrder'] ) ) {
 		return $updated_content;

--- a/packages/block-library/src/list/index.php
+++ b/packages/block-library/src/list/index.php
@@ -12,7 +12,7 @@
  *
  * @since 6.6.0
  *
- * @see https://github.com/WordPress/gutenberg/issues/12420
+ * @link https://github.com/WordPress/gutenberg/issues/12420
  *
  * @param array  $attributes Attributes of the block being rendered.
  * @param string $content Content of the block being rendered.

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -19,7 +19,7 @@ function render_block_core_loginout( $attributes ) {
 	/*
 	 * Build the redirect URL. This current url fetching logic matches with the core.
 	 *
-	 * @see https://github.com/WordPress/wordpress-develop/blob/6bf62e58d21739938f3bb3f9e16ba702baf9c2cc/src/wp-includes/general-template.php#L528.
+	 * @link https://github.com/WordPress/wordpress-develop/blob/6bf62e58d21739938f3bb3f9e16ba702baf9c2cc/src/wp-includes/general-template.php#L528.
 	 */
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -105,8 +105,8 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	 * The dynamic portion of the function name, `$navigation_type`,
 	 * Refers to the type of adjacency, 'next' or 'previous'.
 	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_previous_post_link/
-	 * @see https://developer.wordpress.org/reference/functions/get_next_post_link/
+	 * @link https://developer.wordpress.org/reference/functions/get_previous_post_link/
+	 * @link https://developer.wordpress.org/reference/functions/get_next_post_link/
 	 */
 	$get_link_function = "get_{$navigation_type}_post_link";
 

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -69,10 +69,10 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 			 * is the same for all custom queries. This way the link is not empty and
 			 * preserves all the other existent query args.
 			 *
-			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
+			 * @link https://developer.wordpress.org/reference/functions/paginate_links/
 			 *
 			 * The proper fix of this should be in core. Track Ticket:
-			 * @see https://core.trac.wordpress.org/ticket/53868
+			 * @link https://core.trac.wordpress.org/ticket/53868
 			 *
 			 * TODO: After two WP versions (starting from the WP version the core patch landed),
 			 * we should remove this and call `paginate_links` with the proper new arg.


### PR DESCRIPTION
## Why this change?
To align with the WordPress PHP Inline Documentation Standards, proper tag usage distinguishes between internal code references and external links:

*   **When to use `@see`**: accurately references a function, method, class, or variable within the codebase (e.g., `@see WP_Query::get_posts()`).
*   **When to use `@link`**: accurately references a URL, such as external documentation, Trac tickets, GitHub issues, or specifications.

This PR corrects instances in `packages/block-library` where `@see` was incorrectly used to point to external URLs.

## Description
Replaced incorrect `@see` tags with `@link` tags in the following files:
*   `packages/block-library/src/comments/index.php`
*   `packages/block-library/src/gallery/index.php`
*   `packages/block-library/src/list/index.php`
*   `packages/block-library/src/loginout/index.php`
*   `packages/block-library/src/post-navigation-link/index.php`
*   `packages/block-library/src/query-pagination-numbers/index.php`