### PR TITLE
DataViews: Add `title` attribute in `grid` item title field

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 
 ### Enhancements

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -199,6 +199,12 @@ const GridItem = forwardRef( function GridItem< Item >(
 						renderItemLink={ renderItemLink }
 						className="dataviews-view-grid__title-field dataviews-title-field"
 						{ ...titleA11yProps }
+						title={
+							titleField?.getValueFormatted( {
+								item,
+								field: titleField,
+							} ) || undefined
+						}
 					>
 						{ renderedTitleField }
 					</ItemClickWrapper>

--- a/packages/dataviews/src/components/dataviews-layouts/utils/item-click-wrapper.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/item-click-wrapper.tsx
@@ -66,6 +66,7 @@ export function ItemClickWrapper< Item >( {
 		} & ComponentProps< 'a' >
 	) => ReactElement;
 	className?: string;
+	title?: string;
 	children: ReactNode;
 } ) {
 	// Always render a wrapper element so layout and styling relying on the wrapper


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/65134

Alternative of: https://github.com/WordPress/gutenberg/pull/65200

From the [issue](https://github.com/WordPress/gutenberg/issues/65134#issuecomment-3816359840): 

>Added visibility of the titles can be important because one might use a naming scheme to understand what each item is without clicking into it.

This PR implements [this](https://github.com/WordPress/gutenberg/issues/65134#issuecomment-3818698361): 

>Maybe a middle-ground solution would be to add a title attribute that includes the full title?

## Testing Instructions
1. In site editor go to on of `pages/templates/patterns` page and switch to `grid` layout.
3. Observe that when you hover the titles, the native tooltip is shown
4. Add one page or template with a quite long title and observe that in the UI the title is truncated but the native tooltip shows the whole title

### After


<img width="1028" height="738" alt="Screenshot 2026-01-30 at 12 34 06 PM" src="https://github.com/user-attachments/assets/fb5a7f8b-9ccc-44dd-a8cf-76bcdfeebacb" />
