### PR TITLE
Navigation block: remove horizontal scroll from list view

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -631,12 +631,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	opacity: 1;
 }
 
-.wp-block-navigation__menu-inspector-controls {
-	overflow-x: auto;
-
-	@include custom-scrollbars-on-hover(transparent, $gray-600);
-}
-
 .wp-block-navigation__menu-inspector-controls__empty-message {
 	margin-left: 24px;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->#74897

<!-- In a few words, what is the PR actually doing? -->

This PR removes the horizontal scroll for the navigation block in the inspector

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This overflow was causing the issues in #74897 This was introduced way back in https://github.com/WordPress/gutenberg/pull/49417 and since we have changed the way we display the nav block and we don't need it to scroll any more. 

We cap the level of nesting that we can do in https://github.com/WordPress/gutenberg/blob/18f67602d0874311c2194a0e311ef248e7df4ceb/packages/block-library/src/navigation/block.json#L84 and then we added `Truncate` in https://github.com/WordPress/gutenberg/pull/41855 to avoid having to do the scroll. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We just remove the css that allows the horizontal scroll to happen

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
The original issue seems to be hard to reproduce. I've been able to reproduce it by adding multiple leveled menus that would cause the overflow to happen and selecting one of the submenus like the screenshots show. I can see this happening on firefox.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="268" height="376" alt="Screenshot 2026-01-30 at 12 16 32" src="https://github.com/user-attachments/assets/23af15f2-d503-411e-94fb-7dd380821129" /><!-- Before screenshot here -->|<img width="283" height="440" alt="Screenshot 2026-01-30 at 12 16 52" src="https://github.com/user-attachments/assets/931bb069-5c36-48b4-8d96-6b6a6ee28c74" /><!-- After screenshot here -->|


