### PR TITLE
Components: remove "text-wrap: balance" fallback from Text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used.
+
 ### Internal
 
 -   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking Changes
+### Bug Fixes
 
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used.
 

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -5,7 +5,6 @@ exports[`props should render correctly 1`] = `
   color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
-  text-wrap: balance;
   text-wrap: pretty;
   color: var(--wp-components-color-foreground, #1e1e1e);
   font-size: calc(1.95 * 13px);

--- a/packages/components/src/text/styles.ts
+++ b/packages/components/src/text/styles.ts
@@ -12,7 +12,6 @@ export const Text = css`
 	color: ${ COLORS.theme.foreground };
 	line-height: ${ CONFIG.fontLineHeightBase };
 	margin: 0;
-	text-wrap: balance; /* Fallback for Safari. */
 	text-wrap: pretty;
 `;
 

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -22,7 +22,6 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
   color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
-  text-wrap: balance;
   text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
@@ -55,7 +54,6 @@ exports[`Text snapshot tests should render correctly 1`] = `
   color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
-  text-wrap: balance;
   text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Spin off from #74907 

Removes the `text-wrap: balance` fallback from the `Text` component. The component now uses only `text-wrap: pretty` without the ~Safari~ Firefox fallback.

The code says it was Safari fallback, but actually it's Firefox which doesn't [support](https://caniuse.com/?search=css-text-wrap-pretty) `pretty`:

<img width="1269" height="226" alt="image" src="https://github.com/user-attachments/assets/13bd1114-db90-4e28-a699-17bc7a0bf406" />


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

During discussion in PR #74907 about removing `text-wrap: balance` fallbacks, it was noted that the `Text` component also includes this fallback pattern. The `text-wrap: balance` fallback was originally added for Safari compatibility.

`balance` creates visually more opinionated layout compared to `pretty`, which pretty much only handles typographic orphans. Balance is [causing issues](https://github.com/WordPress/gutenberg/pull/74907#issuecomment-3816619622) with non-Latin languages like Japanese:

| Actual (with `text-wrap: balance`) | Expected (without `text-wrap: balance`) |
|--------|--------|
| <img width="726" height="508" alt="actual" src="https://github.com/user-attachments/assets/fb352700-0117-4607-b53c-813aaf4a6bed" /> | <img width="727" height="504" alt="expected" src="https://github.com/user-attachments/assets/dfaf774b-2d5c-47da-9c5d-59a3930bb128" /> |


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `Text` component now only includes `text-wrap: pretty`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Check that text in components using `Text` (like labels, descriptions, etc.) still renders correctly without any visual regressions. You can browse Site editor pages to see it in action.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
None.

## Screenshots or screencast <!-- if applicable -->
None.