### PR TITLE
Navigation: Use :where on the :not(.disable-default-overlay) selector so that the scope doesn't change.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -835,6 +835,18 @@ button.wp-block-navigation-item__content {
 	position: relative;
 }
 
+// Adjust open dialog top margin when admin-bar is visible.
+// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
+// Don't apply margin when custom overlay is present.
+.has-modal-open .admin-bar .is-menu-open:where(:not(.disable-default-overlay)) .wp-block-navigation__responsive-dialog {
+	margin-top: $admin-bar-height-big;
+
+	// Handle smaller admin-bar.
+	@include break-medium() {
+		margin-top: $admin-bar-height;
+	}
+}
+
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -835,18 +835,6 @@ button.wp-block-navigation-item__content {
 	position: relative;
 }
 
-// Adjust open dialog top margin when admin-bar is visible.
-// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
-// Don't apply margin when custom overlay is present.
-.has-modal-open .admin-bar .is-menu-open:not(.disable-default-overlay) .wp-block-navigation__responsive-dialog {
-	margin-top: $admin-bar-height-big;
-
-	// Handle smaller admin-bar.
-	@include break-medium() {
-		margin-top: $admin-bar-height;
-	}
-}
-
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/wporg-mu-plugins/issues/725

<!-- In a few words, what is the PR actually doing? -->
By adding :not(.disable-default-overlay) to this selector we increased the specificity, so it started overriding other styles. Wrapping it in :where reduces the specificity to what it was before.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To fix the bug in https://github.com/WordPress/wporg-mu-plugins/issues/725

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add :where around the selector.

## Screenshots or screencast <!-- if applicable -->
<img width="522" height="444" alt="Screenshot 2026-01-30 at 12 40 53" src="https://github.com/user-attachments/assets/e5406c9f-8f5f-4cc5-88f5-6fdb6b215d70" />

