### PR TITLE
Media Fields: Fix filename field truncation

### DIFF
--- a/packages/media-fields/src/filename/test/view.test.tsx
+++ b/packages/media-fields/src/filename/test/view.test.tsx
@@ -49,7 +49,9 @@ describe( 'FileNameView', () => {
 
 			// Verify the full filename text is accessible to users
 			// (the component handles truncation via Truncate/Tooltip, but the text is still present)
-			expect( screen.getByText( longFilename ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( longFilename.slice( 0, 15 ) + '…' )
+			).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/media-fields/src/filename/view.tsx
+++ b/packages/media-fields/src/filename/view.tsx
@@ -31,7 +31,9 @@ export default function FileNameView( {
 
 	return fileName.length > TRUNCATE_LENGTH ? (
 		<Tooltip text={ fileName }>
-			<Truncate>{ fileName }</Truncate>
+			<Truncate limit={ TRUNCATE_LENGTH } ellipsizeMode="tail">
+				{ fileName }
+			</Truncate>
 		</Tooltip>
 	) : (
 		<>{ fileName }</>


### PR DESCRIPTION
## What?
Fixing the filename field truncation in the media editor.

## Why?
Just fixing a bug.

## How?
Truncation was already there, but using the default settings instead of the correct ones; we're now passing the right ones.

## Testing Instructions
* Make sure the "Media Editor" experiment is enabled.
* Insert an image with a long filename in a post and focus it.
* Click the "Edit media" button in the block toolbar.
* Make sure the settings sidebar is open.
* Verify the file name now truncates correctly.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/c6473b04-3ea3-4055-97ea-3a7a235675b2

After:
<img width="286" height="372" alt="Screenshot 2026-01-30 at 14 56 25" src="https://github.com/user-attachments/assets/facf47cc-d97c-4888-a719-0fd4e4cb0b4d" />
