### PR TITLE
DataViews: Add onReset prop for view persistence reset

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Enhancements
 
+- DataViews: Add `onReset` prop to control view reset functionality from the view config dropdown. [#75093](https://github.com/WordPress/gutenberg/pull/75093)
 - DataForm: Add automatic field labeling - forms now automatically mark the minority of fields (required or optional) to reduce visual noise. [#74430](https://github.com/WordPress/gutenberg/pull/74430)
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)
 - Add new `adaptiveSelect` DataForm control. [#74937](https://github.com/WordPress/gutenberg/pull/74937)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -478,6 +478,33 @@ Optional. Pass an object with a list of `perPageSizes` to control the available 
 
 An element to display when the `data` prop is empty. Defaults to `<p>No results</p>`.
 
+#### `onReset`: `( () => void ) | false`
+
+Callback function to reset the view to its default state, or `false` to indicate the view is not modified.
+
+-   Type: `function` or `false`
+-   Optional
+
+This prop controls the "Reset view" button in the view configuration dropdown:
+
+-   When `undefined` (not provided): No reset functionality is shown. Use this when view persistence is not supported.
+-   When `false`: The "Reset view" button is shown but disabled. Use this when view persistence is supported but the current view matches the default (not modified).
+-   When a function: The "Reset view" button is shown and enabled. A blue dot indicator appears on the view options button to signal that the view has been modified. The function is called when the user clicks the reset button.
+
+Example:
+
+```jsx
+const { view, setView, isModified, resetToDefault } = useView( 'my-view-key' );
+
+<DataViews
+	data={ data }
+	view={ view }
+	onChangeView={ setView }
+	onReset={ isModified ? resetToDefault : false }
+	// ...other props
+/>
+```
+
 ### Styling
 
 These are the CSS Custom Properties that can be used to tweak the appearance of the component:

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -58,6 +58,7 @@ type DataViewsContextType< Item > = {
 	empty?: ReactNode;
 	hasInfiniteScrollHandler: boolean;
 	itemListLabel?: string;
+	onReset?: ( () => void ) | false;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -268,7 +268,7 @@ function ResetViewButton() {
 				}
 			} }
 		>
-			{ __( 'Reset' ) }
+			{ __( 'Reset view' ) }
 		</Button>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -334,7 +334,7 @@ export function DataviewsViewConfigDropdown() {
 							</Heading>
 							<ResetViewButton />
 						</Stack>
-						<Stack direction="column" gap={ 4 }>
+						<Stack direction="column" gap="lg">
 							<Stack
 								direction="row"
 								gap="sm"

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -335,11 +335,7 @@ export function DataviewsViewConfigDropdown() {
 							<ResetViewButton />
 						</Stack>
 						<Stack direction="column" gap="lg">
-							<Stack
-								direction="row"
-								gap="sm"
-								className="is-divided-in-two"
-							>
+							<Stack direction="row" gap="sm">
 								<SortFieldControl />
 								<SortDirectionControl />
 							</Stack>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -335,7 +335,11 @@ export function DataviewsViewConfigDropdown() {
 							<ResetViewButton />
 						</Stack>
 						<Stack direction="column" gap="lg">
-							<Stack direction="row" gap="sm">
+							<Stack
+								direction="row"
+								gap="sm"
+								className="dataviews-view-config__sort-controls"
+							>
 								<SortFieldControl />
 								<SortDirectionControl />
 							</Stack>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -14,9 +14,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	SelectControl,
-	__experimentalGrid as Grid,
 	__experimentalHeading as Heading,
-	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
@@ -247,46 +245,36 @@ function ItemsPerPageControl() {
 	);
 }
 
-function SettingsSection( {
-	title,
-	description,
-	children,
-}: {
-	title: string;
-	description?: string;
-	children: React.ReactNode;
-} ) {
+function ResetViewButton() {
+	const { onReset } = useContext( DataViewsContext );
+
+	// Don't render if no persistence support (onReset is undefined)
+	if ( onReset === undefined ) {
+		return null;
+	}
+
+	const isDisabled = onReset === false;
+
 	return (
-		<Grid columns={ 12 } className="dataviews-settings-section" gap={ 4 }>
-			<div className="dataviews-settings-section__sidebar">
-				<Heading
-					level={ 2 }
-					className="dataviews-settings-section__title"
-				>
-					{ title }
-				</Heading>
-				{ description && (
-					<Text
-						variant="muted"
-						className="dataviews-settings-section__description"
-					>
-						{ description }
-					</Text>
-				) }
-			</div>
-			<Grid
-				columns={ 8 }
-				gap={ 4 }
-				className="dataviews-settings-section__content"
-			>
-				{ children }
-			</Grid>
-		</Grid>
+		<Button
+			variant="tertiary"
+			size="compact"
+			disabled={ isDisabled }
+			accessibleWhenDisabled
+			className="dataviews-view-config__reset-button"
+			onClick={ () => {
+				if ( typeof onReset === 'function' ) {
+					onReset();
+				}
+			} }
+		>
+			{ __( 'Reset' ) }
+		</Button>
 	);
 }
 
 export function DataviewsViewConfigDropdown() {
-	const { view } = useContext( DataViewsContext );
+	const { view, onReset } = useContext( DataViewsContext );
 	const popoverId = useInstanceId(
 		_DataViewsViewConfig,
 		'dataviews-view-config-dropdown'
@@ -294,6 +282,7 @@ export function DataviewsViewConfigDropdown() {
 	const activeLayout = VIEW_LAYOUTS.find(
 		( layout ) => layout.type === view.type
 	);
+	const isModified = typeof onReset === 'function';
 	return (
 		<Dropdown
 			expandOnMobile
@@ -303,14 +292,22 @@ export function DataviewsViewConfigDropdown() {
 			} }
 			renderToggle={ ( { onToggle, isOpen } ) => {
 				return (
-					<Button
-						size="compact"
-						icon={ cog }
-						label={ _x( 'View options', 'View is used as a noun' ) }
-						onClick={ onToggle }
-						aria-expanded={ isOpen ? 'true' : 'false' }
-						aria-controls={ popoverId }
-					/>
+					<div className="dataviews-view-config__toggle-wrapper">
+						<Button
+							size="compact"
+							icon={ cog }
+							label={ _x(
+								'View options',
+								'View is used as a noun'
+							) }
+							onClick={ onToggle }
+							aria-expanded={ isOpen ? 'true' : 'false' }
+							aria-controls={ popoverId }
+						/>
+						{ isModified && (
+							<span className="dataviews-view-config__modified-indicator" />
+						) }
+					</div>
 				);
 			} }
 			renderContent={ () => (
@@ -323,7 +320,21 @@ export function DataviewsViewConfigDropdown() {
 						className="dataviews-view-config"
 						gap="xl"
 					>
-						<SettingsSection title={ __( 'Appearance' ) }>
+						<Stack
+							direction="row"
+							justify="space-between"
+							align="center"
+							className="dataviews-view-config__header"
+						>
+							<Heading
+								level={ 2 }
+								className="dataviews-settings-section__title"
+							>
+								{ __( 'Appearance' ) }
+							</Heading>
+							<ResetViewButton />
+						</Stack>
+						<Stack direction="column" gap={ 4 }>
 							<Stack
 								direction="row"
 								gap="sm"
@@ -338,7 +349,7 @@ export function DataviewsViewConfigDropdown() {
 							<InfiniteScrollToggle />
 							<ItemsPerPageControl />
 							<PropertiesSection />
-						</SettingsSection>
+						</Stack>
 					</Stack>
 				</DropdownContentWrapper>
 			) }

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -70,14 +70,12 @@
 
 .dataviews-view-config__modified-indicator {
 	position: absolute;
-	top: 0;
-	right: 0;
-	transform: translate(25%, -25%);
-	width: $grid-unit-10;
-	height: $grid-unit-10;
+	top: $grid-unit-05;
+	right: $grid-unit-05;
+	width: $grid-unit-05;
+	height: $grid-unit-05;
 	background: var(--wp-admin-theme-color, #3858e9);
 	border-radius: 50%;
-	outline: var(--wp-admin-border-width-focus) solid $white;
 	pointer-events: none;
 }
 

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -62,3 +62,22 @@
 .dataviews-view-config__label {
 	text-wrap: nowrap;
 }
+
+.dataviews-view-config__toggle-wrapper {
+	position: relative;
+	display: inline-flex;
+}
+
+.dataviews-view-config__modified-indicator {
+	position: absolute;
+	top: 0;
+	right: 0;
+	transform: translate(25%, -25%);
+	width: $grid-unit-10;
+	height: $grid-unit-10;
+	background: var(--wp-admin-theme-color, #3858e9);
+	border-radius: 50%;
+	outline: var(--wp-admin-border-width-focus) solid $white;
+	pointer-events: none;
+}
+

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -59,6 +59,10 @@
 	}
 }
 
+.dataviews-view-config__sort-controls > * {
+	flex: 1;
+}
+
 .dataviews-view-config__label {
 	text-wrap: nowrap;
 }

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -66,6 +66,7 @@ type DataViewsProps< Item > = {
 		perPageSizes: number[];
 	};
 	empty?: ReactNode;
+	onReset?: ( () => void ) | false;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -140,6 +141,7 @@ function DataViews< Item >( {
 	children,
 	config = { perPageSizes: [ 10, 20, 50, 100 ] },
 	empty,
+	onReset,
 }: DataViewsProps< Item > ) {
 	const { infiniteScrollHandler } = paginationInfo;
 	const containerRef = useRef< HTMLDivElement | null >( null );
@@ -267,6 +269,7 @@ function DataViews< Item >( {
 				config,
 				empty,
 				hasInfiniteScrollHandler: !! infiniteScrollHandler,
+				onReset,
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -12,7 +12,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useView } from '@wordpress/views';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -205,20 +204,10 @@ export default function DataviewsPatterns() {
 				title={ title }
 				subTitle={ description }
 				actions={
-					<>
-						{ isModified && (
-							<Button
-								__next40pxDefaultSize
-								onClick={ resetToDefault }
-							>
-								{ __( 'Reset view' ) }
-							</Button>
-						) }
-						<PatternsActions
-							categoryId={ categoryId }
-							postType={ postType }
-						/>
-					</>
+					<PatternsActions
+						categoryId={ categoryId }
+						postType={ postType }
+					/>
 				}
 			>
 				<DataViews
@@ -247,6 +236,7 @@ export default function DataviewsPatterns() {
 					view={ view }
 					onChangeView={ updateView }
 					defaultLayouts={ defaultLayouts }
+					onReset={ isModified ? resetToDefault : false }
 				/>
 			</Page>
 		</ExperimentalBlockEditorProvider>

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -11,7 +11,6 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
 import { useEvent } from '@wordpress/compose';
 import { useView } from '@wordpress/views';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -134,22 +133,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
-			actions={
-				<>
-					{ isModified && (
-						<Button
-							__next40pxDefaultSize
-							onClick={ () => {
-								resetToDefault();
-								history.invalidate();
-							} }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					<AddNewTemplate />
-				</>
-			}
+			actions={ <AddNewTemplate /> }
 		>
 			<DataViews
 				key={ activeView }
@@ -167,6 +151,14 @@ export default function PageTemplates() {
 				} }
 				selection={ selection }
 				defaultLayouts={ defaultLayouts }
+				onReset={
+					isModified
+						? () => {
+								resetToDefault();
+								history.invalidate();
+						  }
+						: false
+				}
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -16,7 +16,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEvent } from '@wordpress/compose';
 import { useView } from '@wordpress/views';
-import { Button, Modal } from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -325,22 +325,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
-			actions={
-				<>
-					{ isModified && (
-						<Button
-							__next40pxDefaultSize
-							onClick={ () => {
-								resetToDefault();
-								history.invalidate();
-							} }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					<AddNewTemplate />
-				</>
-			}
+			actions={ <AddNewTemplate /> }
 		>
 			<DataViews
 				key={ activeView }
@@ -364,6 +349,14 @@ export default function PageTemplates() {
 				} }
 				selection={ selection }
 				defaultLayouts={ defaultLayouts }
+				onReset={
+					isModified
+						? () => {
+								resetToDefault();
+								history.invalidate();
+						  }
+						: false
+				}
 			/>
 			{ selectedRegisteredTemplate && duplicateAction && (
 				<Modal

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -281,17 +281,6 @@ export default function PostList( { postType } ) {
 			title={ labels?.name }
 			actions={
 				<>
-					{ isModified && (
-						<Button
-							__next40pxDefaultSize
-							onClick={ () => {
-								resetToDefault();
-								history.invalidate();
-							} }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
 					{ labels?.add_new_item && canCreateRecord && (
 						<>
 							<Button
@@ -331,6 +320,14 @@ export default function PostList( { postType } ) {
 				getItemId={ getItemId }
 				getItemLevel={ getItemLevel }
 				defaultLayouts={ defaultLayouts }
+				onReset={
+					isModified
+						? () => {
+								resetToDefault();
+								history.invalidate();
+						  }
+						: false
+				}
 			/>
 			{ quickEdit &&
 				! isLoadingData &&

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -12,7 +12,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
 import { useEvent, usePrevious } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { useView } from '@wordpress/views';

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -134,24 +134,13 @@ function NavigationList() {
 				className="navigation-page"
 				hasPadding={ false }
 				actions={
-					<>
-						{ isModified && (
-							<Button
-								variant="tertiary"
-								size="compact"
-								onClick={ resetToDefault }
-							>
-								{ __( 'Reset view' ) }
-							</Button>
-						) }
-						<Button
-							variant="primary"
-							size="compact"
-							onClick={ () => setShowAddModal( true ) }
-						>
-							{ __( 'Add New' ) }
-						</Button>
-					</>
+					<Button
+						variant="primary"
+						size="compact"
+						onClick={ () => setShowAddModal( true ) }
+					>
+						{ __( 'Add New' ) }
+					</Button>
 				}
 			>
 				<DataViews
@@ -170,6 +159,7 @@ function NavigationList() {
 					} }
 					getItemId={ getItemId }
 					selection={ selection }
+					onReset={ isModified ? resetToDefault : false }
 					onChangeSelection={ ( items: string[] ) => {
 						navigate( {
 							search: {

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -263,26 +263,16 @@ function PatternList() {
 			) }
 			className="pattern-page"
 			actions={
-				<>
-					{ isModified && (
-						<Button
-							variant="tertiary"
-							size="compact"
-							onClick={ onReset }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					{ labels?.add_new_item && canCreateRecord && (
-						<Button
-							variant="primary"
-							onClick={ () => setShowPatternModal( true ) }
-							size="compact"
-						>
-							{ labels.add_new_item }
-						</Button>
-					) }
-				</>
+				labels?.add_new_item &&
+				canCreateRecord && (
+					<Button
+						variant="primary"
+						onClick={ () => setShowPatternModal( true ) }
+						size="compact"
+					>
+						{ labels.add_new_item }
+					</Button>
+				)
 			}
 			hasPadding={ false }
 		>
@@ -320,6 +310,7 @@ function PatternList() {
 				} }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				selection={ selection }
+				onReset={ isModified ? onReset : false }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -24,7 +24,6 @@ import { useSelect } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import type { Post } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -277,32 +276,21 @@ function PostList() {
 			subTitle={ postTypeObject.labels?.description }
 			className={ `${ postTypeObject.name.toLowerCase() }-page` }
 			actions={
-				<>
-					{ isModified && (
-						<Button
-							variant="tertiary"
-							size="compact"
-							onClick={ onReset }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					{ labels?.add_new_item &&
-						canCreateRecord &&
-						postType !== 'attachment' && (
-							<Button
-								variant="primary"
-								onClick={ () => {
-									navigate( {
-										to: `/types/${ postType }/new`,
-									} );
-								} }
-								size="compact"
-							>
-								{ labels.add_new_item }
-							</Button>
-						) }
-				</>
+				labels?.add_new_item &&
+				canCreateRecord &&
+				postType !== 'attachment' && (
+					<Button
+						variant="primary"
+						onClick={ () => {
+							navigate( {
+								to: `/types/${ postType }/new`,
+							} );
+						} }
+						size="compact"
+					>
+						{ labels.add_new_item }
+					</Button>
+				)
 			}
 			hasPadding={ false }
 		>
@@ -342,6 +330,7 @@ function PostList() {
 				getItemId={ getItemId }
 				getItemLevel={ getItemLevel }
 				selection={ selection }
+				onReset={ isModified ? onReset : false }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -13,7 +13,6 @@ import { Page } from '@wordpress/admin-ui';
 import type { View, Action } from '@wordpress/dataviews';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	Button,
 	Modal,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -302,20 +301,7 @@ function TemplateListActivation() {
 		<Page
 			title={ __( 'Templates' ) }
 			className="template-page"
-			actions={
-				<>
-					{ isModified && (
-						<Button
-							variant="tertiary"
-							size="compact"
-							onClick={ onReset }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					<AddNewTemplate />
-				</>
-			}
+			actions={ <AddNewTemplate /> }
 			hasPadding={ false }
 		>
 			{ tabs.length > 1 && (
@@ -345,6 +331,7 @@ function TemplateListActivation() {
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				getItemId={ getItemId }
 				selection={ selection }
+				onReset={ isModified ? onReset : false }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -12,10 +12,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
 import type { View, Action } from '@wordpress/dataviews';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	Button,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -276,20 +273,7 @@ function TemplateListLegacy() {
 		<Page
 			title={ __( 'Templates' ) }
 			className="template-page"
-			actions={
-				<>
-					{ isModified && (
-						<Button
-							variant="tertiary"
-							size="compact"
-							onClick={ onReset }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					<AddNewTemplate />
-				</>
-			}
+			actions={ <AddNewTemplate /> }
 			hasPadding={ false }
 		>
 			{ tabs.length > 1 && (
@@ -319,6 +303,7 @@ function TemplateListLegacy() {
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				getItemId={ getItemId }
 				selection={ selection }
+				onReset={ isModified ? onReset : false }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -24,7 +24,6 @@ import { useSelect } from '@wordpress/data';
 import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import type { WpTemplatePart } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
 import { CreateTemplatePartModal } from '@wordpress/fields';
 
 /**
@@ -254,26 +253,16 @@ function TemplatePartList() {
 			subTitle={ postTypeObject.labels?.description }
 			className="template-part-page"
 			actions={
-				<>
-					{ isModified && (
-						<Button
-							variant="tertiary"
-							size="compact"
-							onClick={ onReset }
-						>
-							{ __( 'Reset view' ) }
-						</Button>
-					) }
-					{ labels?.add_new_item && canCreateRecord && (
-						<Button
-							variant="primary"
-							onClick={ () => setShowTemplatePartModal( true ) }
-							size="compact"
-						>
-							{ labels.add_new_item }
-						</Button>
-					) }
-				</>
+				labels?.add_new_item &&
+				canCreateRecord && (
+					<Button
+						variant="primary"
+						onClick={ () => setShowTemplatePartModal( true ) }
+						size="compact"
+					>
+						{ labels.add_new_item }
+					</Button>
+				)
 			}
 			hasPadding={ false }
 		>
@@ -312,6 +301,7 @@ function TemplatePartList() {
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				getItemId={ getItemId }
 				selection={ selection }
+				onReset={ isModified ? onReset : false }
 				onChangeSelection={ ( items: string[] ) => {
 					navigate( {
 						search: {

--- a/test/e2e/specs/site-editor/pages-view-persistence.spec.js
+++ b/test/e2e/specs/site-editor/pages-view-persistence.spec.js
@@ -26,10 +26,15 @@ test.describe( 'Pages View Persistence', () => {
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
 
-		const resetButton = page.getByRole( 'button', { name: 'Reset view' } );
-		if ( await resetButton.isVisible() ) {
-			await resetButton.click();
-			await expect( resetButton ).toBeHidden();
+		// Check if view is modified by looking for the blue dot indicator
+		const modifiedIndicator = page.locator(
+			'.dataviews-view-config__modified-indicator'
+		);
+		if ( await modifiedIndicator.isVisible() ) {
+			// Open dropdown and reset
+			await page.getByRole( 'button', { name: 'View options' } ).click();
+			await page.getByRole( 'button', { name: 'Reset view' } ).click();
+			await expect( modifiedIndicator ).toBeHidden();
 		}
 	} );
 
@@ -43,10 +48,11 @@ test.describe( 'Pages View Persistence', () => {
 		// Verify table is visible
 		await expect( page.getByRole( 'table' ) ).toBeVisible();
 
-		// Verify the Reset button appears when view is modified
-		const resetButton = page.getByRole( 'button', { name: 'Reset view' } );
-		await expect( resetButton ).toBeVisible();
-		await expect( resetButton ).toBeEnabled();
+		// Verify the modified indicator (blue dot) appears when view is modified
+		const modifiedIndicator = page.locator(
+			'.dataviews-view-config__modified-indicator'
+		);
+		await expect( modifiedIndicator ).toBeVisible();
 
 		// Navigate to Drafts view
 		await page
@@ -60,9 +66,8 @@ test.describe( 'Pages View Persistence', () => {
 		// since all tabs share the same persisted view
 		await expect( page.getByRole( 'table' ) ).toBeVisible();
 
-		// Reset button should still be visible on Drafts tab
-		await expect( resetButton ).toBeVisible();
-		await expect( resetButton ).toBeEnabled();
+		// Modified indicator should still be visible on Drafts tab
+		await expect( modifiedIndicator ).toBeVisible();
 
 		// Navigate back to All Pages
 		await page
@@ -74,15 +79,17 @@ test.describe( 'Pages View Persistence', () => {
 		// Verify table layout persisted
 		await expect( page.getByRole( 'table' ) ).toBeVisible();
 
-		// Verify Reset button is still visible
-		await expect( resetButton ).toBeVisible();
-		await expect( resetButton ).toBeEnabled();
+		// Verify modified indicator is still visible
+		await expect( modifiedIndicator ).toBeVisible();
 
-		// Click the Reset button
+		// Open dropdown and click the Reset button
+		await page.getByRole( 'button', { name: 'View options' } ).click();
+		const resetButton = page.getByRole( 'button', { name: 'Reset view' } );
+		await expect( resetButton ).toBeEnabled();
 		await resetButton.click();
 
-		// wait for the reset button to be hidden
-		await expect( resetButton ).toBeHidden();
+		// Verify the modified indicator is hidden after reset
+		await expect( modifiedIndicator ).toBeHidden();
 
 		// Verify view returns to list layout
 		await expect( page.getByRole( 'grid' ) ).toBeVisible();


### PR DESCRIPTION
## What?

Adds a new `onReset` prop to the DataViews component that enables a centralized Reset button in the view config dropdown. This replaces the ad-hoc reset buttons previously scattered across consumer pages.

## Why?

Previously, each page that used `useView` had to implement its own "Reset view" button in the Page actions area. This led to:
- Duplicated code across multiple components
- Inconsistent placement and behavior
- The reset functionality not being discoverable within the DataViews UI

## How?

The new `onReset` prop accepts three values:

| Value | Meaning | UI Behavior |
|-------|---------|-------------|
| `undefined` | No persistence support | No reset button rendered |
| `false` | Persistence supported but view not dirty | Disabled "Reset" button |
| `() => void` | Callback to reset the view | Active "Reset" button + blue dot on cog icon |

### Screenshot

<img width="570" height="448" alt="Screenshot 2026-01-30 at 3 18 43 PM" src="https://github.com/user-attachments/assets/63d1b0ad-7e21-4381-a15e-089ad3ac8f0f" />

The screenshot shows:
- Blue dot indicator on the cog icon when the view is modified
- Reset button in the dropdown header (next to "Appearance" title)

## Testing Instructions

1. Go to Pages, Posts, Templates, or Patterns in the Site Editor
2. Modify the view (change sort, items per page, etc.)
3. Observe the blue dot appears on the cog icon
4. Open the view config dropdown
5. Click "Reset" to restore the default view
6. Verify the blue dot disappears after reset

## Files Changed

- `packages/dataviews/src/components/dataviews-context/index.ts` - Add `onReset` to context type
- `packages/dataviews/src/dataviews/index.tsx` - Add `onReset` prop
- `packages/dataviews/src/components/dataviews-view-config/index.tsx` - Add Reset button and blue dot indicator
- `packages/dataviews/src/components/dataviews-view-config/style.scss` - Add styles
- `packages/edit-site/src/components/post-list/index.js` - Use new prop, remove old button
- `packages/edit-site/src/components/page-templates/index.js` - Use new prop, remove old button
- `packages/edit-site/src/components/page-patterns/index.js` - Use new prop, remove old button
- `packages/edit-site/src/components/page-templates/index-legacy.js` - Use new prop, remove old button

🤖 Generated with [Claude Code](https://claude.ai/code)