### PR TITLE
Refactor activeFilters to activeViewOverrides with date sort for User tab

### DIFF
--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -24,7 +24,7 @@ import { authorField, descriptionField, previewField } from './fields';
 import {
 	defaultLayouts,
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 } from './view-utils';
 
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
@@ -37,8 +37,8 @@ export default function PageTemplates() {
 	const [ selection, setSelection ] = useState( [ postId ] );
 
 	const defaultView = DEFAULT_VIEW;
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( activeView ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( activeView ),
 		[ activeView ]
 	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
@@ -46,7 +46,7 @@ export default function PageTemplates() {
 		name: TEMPLATE_POST_TYPE,
 		slug: 'default',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -40,7 +40,7 @@ import {
 import {
 	defaultLayouts,
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 } from './view-utils';
 
 const { usePostActions, usePostFields, templateTitleField } =
@@ -55,8 +55,8 @@ export default function PageTemplates() {
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState( false );
 	const defaultView = DEFAULT_VIEW;
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( activeView ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( activeView ),
 		[ activeView ]
 	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
@@ -64,7 +64,7 @@ export default function PageTemplates() {
 		name: TEMPLATE_POST_TYPE,
 		slug: 'default',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -25,16 +25,25 @@ export const DEFAULT_VIEW = {
 	...defaultLayouts.grid,
 };
 
-export function getActiveFiltersForTab( activeView ) {
-	if ( activeView === 'active' || activeView === 'user' ) {
-		return [];
+export function getActiveViewOverridesForTab( activeView ) {
+	// User view: sort by date, newest first
+	if ( activeView === 'user' ) {
+		return {
+			sort: { field: 'date', direction: 'desc' },
+		};
 	}
-	// Author-based view
-	return [
-		{
-			field: 'author',
-			operator: 'isAny',
-			value: [ activeView ],
-		},
-	];
+	// Active view: no overrides
+	if ( activeView === 'active' ) {
+		return {};
+	}
+	// Author-based view: filter by author
+	return {
+		filters: [
+			{
+				field: 'author',
+				operator: 'isAny',
+				value: [ activeView ],
+			},
+		],
+	};
 }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -35,7 +35,7 @@ import { useEditPostAction } from '../dataviews-actions';
 import {
 	defaultLayouts,
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 } from './view-utils';
 import useNotesCount from './use-notes-count';
 
@@ -59,8 +59,8 @@ export default function PostList( { postType } ) {
 	const { activeView = 'all', postId, quickEdit = false } = query;
 	const history = useHistory();
 	const defaultView = DEFAULT_VIEW;
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( activeView ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( activeView ),
 		[ activeView ]
 	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
@@ -68,7 +68,7 @@ export default function PostList( { postType } ) {
 		name: postType,
 		slug: 'default',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -157,17 +157,19 @@ const SLUG_TO_STATUS = {
 	trash: 'trash',
 };
 
-export function getActiveFiltersForTab( activeView ) {
+export function getActiveViewOverridesForTab( activeView ) {
 	const status = SLUG_TO_STATUS[ activeView ];
 	if ( ! status ) {
-		return [];
+		return {};
 	}
-	return [
-		{
-			field: 'status',
-			operator: OPERATOR_IS_ANY,
-			value: status,
-			isLocked: true,
-		},
-	];
+	return {
+		filters: [
+			{
+				field: 'status',
+				operator: OPERATOR_IS_ANY,
+				value: status,
+				isLocked: true,
+			},
+		],
+	};
 }

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -15,7 +15,10 @@ import DataViewsSidebarContent from '../sidebar-dataviews';
 import PostList from '../post-list';
 import { unlock } from '../../lock-unlock';
 import { PostEdit } from '../post-edit';
-import { DEFAULT_VIEW, getActiveFiltersForTab } from '../post-list/view-utils';
+import {
+	DEFAULT_VIEW,
+	getActiveViewOverridesForTab,
+} from '../post-list/view-utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -26,7 +29,7 @@ async function isListView( query ) {
 		name: 'page',
 		slug: 'default',
 		defaultView: DEFAULT_VIEW,
-		activeFilters: getActiveFiltersForTab( activeView ),
+		activeViewOverrides: getActiveViewOverridesForTab( activeView ),
 	} );
 	return view.type === 'list';
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -13,7 +13,7 @@ import PageTemplates from '../page-templates';
 import PageTemplatesLegacy from '../page-templates/index-legacy';
 import {
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 } from '../page-templates/view-utils';
 
 async function isTemplateListView( query ) {
@@ -23,7 +23,7 @@ async function isTemplateListView( query ) {
 		name: 'wp_template',
 		slug: 'default',
 		defaultView: DEFAULT_VIEW,
-		activeFilters: getActiveFiltersForTab( activeView ),
+		activeViewOverrides: getActiveViewOverridesForTab( activeView ),
 	} );
 	return view.type === 'list';
 }

--- a/packages/views/README.md
+++ b/packages/views/README.md
@@ -45,7 +45,7 @@ _Parameters_
 -   _config.name_ `ViewConfig`: Specific entity name.
 -   _config.slug_ `ViewConfig`: View identifier.
 -   _config.defaultView_ `ViewConfig`: Default view configuration.
--   _config.activeFilters_ `ViewConfig`: Filters applied on top but never persisted.
+-   _config.activeViewOverrides_ `ViewConfig`: View overrides (filters, sort) applied on top but never persisted.
 -   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
 
 _Returns_
@@ -63,7 +63,7 @@ _Parameters_
 -   _config.name_ `ViewConfig`: Specific entity name.
 -   _config.slug_ `ViewConfig`: View identifier.
 -   _config.defaultView_ `ViewConfig`: Default view configuration.
--   _config.activeFilters_ `ViewConfig`: Filters applied on top of the view but never persisted.
+-   _config.activeViewOverrides_ `ViewConfig`: View overrides (filters, sort) applied on top but never persisted.
 -   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
 -   _config.onChangeQueryParams_ `ViewConfig`: Optional callback to update URL parameters.
 

--- a/packages/views/README.md
+++ b/packages/views/README.md
@@ -23,20 +23,7 @@ npm install @wordpress/views --save
 
 ### loadView
 
-Async function for loading view state in route loaders with optional URL parameters.
-
-_Usage_
-
-```typescript
-// In route loader
-const view = await loadView( {
-	kind: 'taxonomy',
-	name: 'category',
-	slug: 'all',
-	defaultView,
-	queryParams: { page: search.page, search: search.search },
-} );
-```
+Async function for loading view state in route loaders.
 
 _Parameters_
 
@@ -45,7 +32,7 @@ _Parameters_
 -   _config.name_ `ViewConfig`: Specific entity name.
 -   _config.slug_ `ViewConfig`: View identifier.
 -   _config.defaultView_ `ViewConfig`: Default view configuration.
--   _config.activeViewOverrides_ `ViewConfig`: View overrides (filters, sort) applied on top but never persisted.
+-   _config.activeViewOverrides_ `ViewConfig`: View overrides applied on top but never persisted.
 -   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
 
 _Returns_
@@ -59,13 +46,6 @@ Hook for managing DataViews view state with local persistence.
 _Parameters_
 
 -   _config_ `ViewConfig`: Configuration object for loading the view.
--   _config.kind_ `ViewConfig`: Entity kind (e.g., 'postType', 'taxonomy', 'root').
--   _config.name_ `ViewConfig`: Specific entity name.
--   _config.slug_ `ViewConfig`: View identifier.
--   _config.defaultView_ `ViewConfig`: Default view configuration.
--   _config.activeViewOverrides_ `ViewConfig`: View overrides (filters, sort) applied on top but never persisted.
--   _config.queryParams_ `ViewConfig`: Object with `page` and/or `search` from URL.
--   _config.onChangeQueryParams_ `ViewConfig`: Optional callback to update URL parameters.
 
 _Returns_
 

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -10,14 +10,12 @@ type ActiveViewOverrides = {
 
 /**
  * Merges activeViewOverrides into a view.
- * - Filters: Active filters take precedence; any existing filter on the same
- *   field is removed and replaced by the active filter.
- * - Sort: Active sort is applied only if no persisted sort exists (i.e., the
- *   view uses the default sort).
+ * Filters: Active filters take precedence; same-field filters are replaced.
+ * Sort: Active sort is applied only if current sort matches the default.
  *
- * @param view                 The view to merge overrides into.
- * @param activeViewOverrides  The tab-specific overrides to apply.
- * @param defaultView          The default view configuration (used to detect if sort is customized).
+ * @param view                The view to merge overrides into.
+ * @param activeViewOverrides The tab-specific overrides to apply.
+ * @param defaultView         The default view configuration.
  * @return A new view with merged overrides, or the original view if no overrides.
  */
 export function mergeActiveViewOverrides(
@@ -32,7 +30,10 @@ export function mergeActiveViewOverrides(
 	let result = view;
 
 	// Merge filters
-	if ( activeViewOverrides.filters && activeViewOverrides.filters.length > 0 ) {
+	if (
+		activeViewOverrides.filters &&
+		activeViewOverrides.filters.length > 0
+	) {
 		const activeFields = new Set(
 			activeViewOverrides.filters.map( ( f ) => f.field )
 		);
@@ -65,12 +66,12 @@ export function mergeActiveViewOverrides(
 
 /**
  * Strips overrides before persisting.
- * - Filters: Removes filters on fields managed by activeViewOverrides.
- * - Sort: If the sort matches the activeViewOverrides sort, restores the default sort.
+ * Filters: Removes filters on fields managed by activeViewOverrides.
+ * Sort: If sort matches the override, restores the default sort.
  *
- * @param view                 The view to strip overrides from.
- * @param activeViewOverrides  The tab-specific override definitions.
- * @param defaultView          The default view configuration.
+ * @param view                The view to strip overrides from.
+ * @param activeViewOverrides The tab-specific override definitions.
+ * @param defaultView         The default view configuration.
  * @return A new view with overrides stripped, or the original view if no overrides.
  */
 export function stripActiveViewOverrides(
@@ -85,7 +86,10 @@ export function stripActiveViewOverrides(
 	let result = view;
 
 	// Strip managed filters
-	if ( activeViewOverrides.filters && activeViewOverrides.filters.length > 0 ) {
+	if (
+		activeViewOverrides.filters &&
+		activeViewOverrides.filters.length > 0
+	) {
 		const activeFields = new Set(
 			activeViewOverrides.filters.map( ( f ) => f.field )
 		);

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -3,53 +3,111 @@
  */
 import type { View, Filter } from '@wordpress/dataviews';
 
+type ActiveViewOverrides = {
+	filters?: Filter[];
+	sort?: View[ 'sort' ];
+};
+
 /**
- * Merges activeFilters into a view's filters array.
- * Active filters take precedence: any existing filter on the same
- * field is removed and replaced by the active filter.
+ * Merges activeViewOverrides into a view.
+ * - Filters: Active filters take precedence; any existing filter on the same
+ *   field is removed and replaced by the active filter.
+ * - Sort: Active sort is applied only if no persisted sort exists (i.e., the
+ *   view uses the default sort).
  *
- * @param view          The view to merge filters into.
- * @param activeFilters The tab-specific filters to overlay.
- * @return A new view with merged filters, or the original view if no activeFilters.
+ * @param view                 The view to merge overrides into.
+ * @param activeViewOverrides  The tab-specific overrides to apply.
+ * @param defaultView          The default view configuration (used to detect if sort is customized).
+ * @return A new view with merged overrides, or the original view if no overrides.
  */
-export function mergeActiveFilters(
+export function mergeActiveViewOverrides(
 	view: View,
-	activeFilters?: Filter[]
+	activeViewOverrides?: ActiveViewOverrides,
+	defaultView?: View
 ): View {
-	if ( ! activeFilters || activeFilters.length === 0 ) {
+	if ( ! activeViewOverrides ) {
 		return view;
 	}
-	const activeFields = new Set( activeFilters.map( ( f ) => f.field ) );
-	const preserved = ( view.filters ?? [] ).filter(
-		( f: Filter ) => ! activeFields.has( f.field )
-	);
-	return {
-		...view,
-		filters: [ ...preserved, ...activeFilters ],
-	};
+
+	let result = view;
+
+	// Merge filters
+	if ( activeViewOverrides.filters && activeViewOverrides.filters.length > 0 ) {
+		const activeFields = new Set(
+			activeViewOverrides.filters.map( ( f ) => f.field )
+		);
+		const preserved = ( view.filters ?? [] ).filter(
+			( f: Filter ) => ! activeFields.has( f.field )
+		);
+		result = {
+			...result,
+			filters: [ ...preserved, ...activeViewOverrides.filters ],
+		};
+	}
+
+	// Merge sort - only apply if the current sort matches the default
+	if ( activeViewOverrides.sort ) {
+		const isDefaultSort =
+			defaultView &&
+			view.sort?.field === defaultView.sort?.field &&
+			view.sort?.direction === defaultView.sort?.direction;
+
+		if ( isDefaultSort ) {
+			result = {
+				...result,
+				sort: activeViewOverrides.sort,
+			};
+		}
+	}
+
+	return result;
 }
 
 /**
- * Strips filters on fields managed by activeFilters.
- * Used before persisting to ensure tab-specific filters
- * are not stored in preferences.
+ * Strips overrides before persisting.
+ * - Filters: Removes filters on fields managed by activeViewOverrides.
+ * - Sort: If the sort matches the activeViewOverrides sort, restores the default sort.
  *
- * @param view          The view to strip filters from.
- * @param activeFilters The tab-specific filter definitions.
- * @return A new view with managed fields' filters removed, or the original view if no activeFilters.
+ * @param view                 The view to strip overrides from.
+ * @param activeViewOverrides  The tab-specific override definitions.
+ * @param defaultView          The default view configuration.
+ * @return A new view with overrides stripped, or the original view if no overrides.
  */
-export function stripActiveFilterFields(
+export function stripActiveViewOverrides(
 	view: View,
-	activeFilters?: Filter[]
+	activeViewOverrides?: ActiveViewOverrides,
+	defaultView?: View
 ): View {
-	if ( ! activeFilters || activeFilters.length === 0 ) {
+	if ( ! activeViewOverrides ) {
 		return view;
 	}
-	const activeFields = new Set( activeFilters.map( ( f ) => f.field ) );
-	return {
-		...view,
-		filters: ( view.filters ?? [] ).filter(
-			( f: Filter ) => ! activeFields.has( f.field )
-		),
-	};
+
+	let result = view;
+
+	// Strip managed filters
+	if ( activeViewOverrides.filters && activeViewOverrides.filters.length > 0 ) {
+		const activeFields = new Set(
+			activeViewOverrides.filters.map( ( f ) => f.field )
+		);
+		result = {
+			...result,
+			filters: ( view.filters ?? [] ).filter(
+				( f: Filter ) => ! activeFields.has( f.field )
+			),
+		};
+	}
+
+	// Strip sort if it matches the override (restore to default)
+	if (
+		activeViewOverrides.sort &&
+		view.sort?.field === activeViewOverrides.sort.field &&
+		view.sort?.direction === activeViewOverrides.sort.direction
+	) {
+		result = {
+			...result,
+			sort: defaultView?.sort,
+		};
+	}
+
+	return result;
 }

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -14,29 +14,15 @@ import { mergeActiveViewOverrides } from './filter-utils';
 import type { ViewConfig } from './types';
 
 /**
- * Async function for loading view state in route loaders with optional URL parameters.
+ * Async function for loading view state in route loaders.
  *
- * @example
- *
- * ```typescript
- * // In route loader
- * const view = await loadView( {
- * 	kind: 'taxonomy',
- * 	name: 'category',
- * 	slug: 'all',
- * 	defaultView,
- * 	queryParams: { page: search.page, search: search.search },
- * } );
- * ```
- *
- * @param config                      Configuration object for loading the view.
- * @param config.kind                 Entity kind (e.g., 'postType', 'taxonomy', 'root').
- * @param config.name                 Specific entity name.
- * @param config.slug                 View identifier.
- * @param config.defaultView          Default view configuration.
- * @param config.activeViewOverrides  View overrides applied on top but never persisted.
- * @param config.queryParams          Object with `page` and/or `search` from URL.
- *
+ * @param config                     Configuration object for loading the view.
+ * @param config.kind                Entity kind (e.g., 'postType', 'taxonomy', 'root').
+ * @param config.name                Specific entity name.
+ * @param config.slug                View identifier.
+ * @param config.defaultView         Default view configuration.
+ * @param config.activeViewOverrides View overrides applied on top but never persisted.
+ * @param config.queryParams         Object with `page` and/or `search` from URL.
  * @return Promise resolving to the loaded view object.
  */
 export async function loadView( config: ViewConfig ) {

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -10,7 +10,7 @@ import type { View } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { generatePreferenceKey } from './preference-keys';
-import { mergeActiveFilters } from './filter-utils';
+import { mergeActiveViewOverrides } from './filter-utils';
 import type { ViewConfig } from './types';
 
 /**
@@ -29,18 +29,18 @@ import type { ViewConfig } from './types';
  * } );
  * ```
  *
- * @param config               Configuration object for loading the view.
- * @param config.kind          Entity kind (e.g., 'postType', 'taxonomy', 'root').
- * @param config.name          Specific entity name.
- * @param config.slug          View identifier.
- * @param config.defaultView   Default view configuration.
- * @param config.activeFilters Filters applied on top but never persisted.
- * @param config.queryParams   Object with `page` and/or `search` from URL.
+ * @param config                      Configuration object for loading the view.
+ * @param config.kind                 Entity kind (e.g., 'postType', 'taxonomy', 'root').
+ * @param config.name                 Specific entity name.
+ * @param config.slug                 View identifier.
+ * @param config.defaultView          Default view configuration.
+ * @param config.activeViewOverrides  View overrides applied on top but never persisted.
+ * @param config.queryParams          Object with `page` and/or `search` from URL.
  *
  * @return Promise resolving to the loaded view object.
  */
 export async function loadView( config: ViewConfig ) {
-	const { kind, name, slug, defaultView, activeFilters, queryParams } =
+	const { kind, name, slug, defaultView, activeViewOverrides, queryParams } =
 		config;
 	const preferenceKey = generatePreferenceKey( kind, name, slug );
 	const persistedView: View | undefined = select( preferencesStore ).get(
@@ -52,12 +52,13 @@ export async function loadView( config: ViewConfig ) {
 	const page = queryParams?.page ?? 1;
 	const search = queryParams?.search ?? '';
 
-	return mergeActiveFilters(
+	return mergeActiveViewOverrides(
 		{
 			...baseView,
 			page,
 			search,
 		},
-		activeFilters
+		activeViewOverrides,
+		defaultView
 	);
 }

--- a/packages/views/src/types.ts
+++ b/packages/views/src/types.ts
@@ -27,11 +27,14 @@ export interface ViewConfig {
 	defaultView: View;
 
 	/**
-	 * Filters applied on top of the persisted view but never persisted.
-	 * These represent tab-specific filtering that should override
-	 * any persisted filters on the same fields.
+	 * View overrides applied on top of the persisted view but never persisted.
+	 * These represent tab-specific configuration (filters, sort) that should
+	 * override the persisted view settings.
 	 */
-	activeFilters?: Filter[];
+	activeViewOverrides?: {
+		filters?: Filter[];
+		sort?: View[ 'sort' ];
+	};
 
 	/**
 	 * Optional query parameters from URL (page, search)

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -16,7 +16,10 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import { generatePreferenceKey } from './preference-keys';
-import { mergeActiveFilters, stripActiveFilterFields } from './filter-utils';
+import {
+	mergeActiveViewOverrides,
+	stripActiveViewOverrides,
+} from './filter-utils';
 import type { ViewConfig } from './types';
 
 interface UseViewReturn {
@@ -40,14 +43,14 @@ function omit< T extends object, K extends keyof T >(
 /**
  * Hook for managing DataViews view state with local persistence.
  *
- * @param config                     Configuration object for loading the view.
- * @param config.kind                Entity kind (e.g., 'postType', 'taxonomy', 'root').
- * @param config.name                Specific entity name.
- * @param config.slug                View identifier.
- * @param config.defaultView         Default view configuration.
- * @param config.activeFilters       Filters applied on top of the view but never persisted.
- * @param config.queryParams         Object with `page` and/or `search` from URL.
- * @param config.onChangeQueryParams Optional callback to update URL parameters.
+ * @param config                      Configuration object for loading the view.
+ * @param config.kind                 Entity kind (e.g., 'postType', 'taxonomy', 'root').
+ * @param config.name                 Specific entity name.
+ * @param config.slug                 View identifier.
+ * @param config.defaultView          Default view configuration.
+ * @param config.activeViewOverrides  View overrides applied on top but never persisted.
+ * @param config.queryParams          Object with `page` and/or `search` from URL.
+ * @param config.onChangeQueryParams  Optional callback to update URL parameters.
  *
  * @return Object with current view, modification state, and update functions.
  */
@@ -57,7 +60,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 		name,
 		slug,
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams,
 		onChangeQueryParams,
 	} = config;
@@ -78,17 +81,18 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
-	// Merge URL query parameters (page, search) and activeFilters into the view
+	// Merge URL query parameters (page, search) and activeViewOverrides into the view
 	const view: View = useMemo( () => {
-		return mergeActiveFilters(
+		return mergeActiveViewOverrides(
 			{
 				...baseView,
 				page,
 				search,
 			},
-			activeFilters
+			activeViewOverrides,
+			defaultView
 		);
-	}, [ baseView, page, search, activeFilters ] );
+	}, [ baseView, page, search, activeViewOverrides, defaultView ] );
 
 	const isModified = !! persistedView;
 
@@ -99,11 +103,12 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				page: newView?.page,
 				search: newView?.search,
 			};
-			// Strip activeFilters and URL params before persisting
+			// Strip activeViewOverrides and URL params before persisting
 			// Cast is safe: omitting page/search doesn't change the discriminant (type field)
-			const preferenceView = stripActiveFilterFields(
+			const preferenceView = stripActiveViewOverrides(
 				omit( newView, [ 'page', 'search' ] ) as View,
-				activeFilters
+				activeViewOverrides,
+				defaultView
 			);
 
 			// If we have URL handling enabled, separate URL state from preference state
@@ -114,14 +119,16 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				onChangeQueryParams( urlParams );
 			}
 
-			// Compare with baseView and defaultView after stripping activeFilters
-			const comparableBaseView = stripActiveFilterFields(
+			// Compare with baseView and defaultView after stripping activeViewOverrides
+			const comparableBaseView = stripActiveViewOverrides(
 				baseView,
-				activeFilters
+				activeViewOverrides,
+				defaultView
 			);
-			const comparableDefaultView = stripActiveFilterFields(
+			const comparableDefaultView = stripActiveViewOverrides(
 				defaultView,
-				activeFilters
+				activeViewOverrides,
+				defaultView
 			);
 
 			// Only persist non-URL preferences if different from baseView
@@ -139,7 +146,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 			search,
 			baseView,
 			defaultView,
-			activeFilters,
+			activeViewOverrides,
 			set,
 			preferenceKey,
 		]

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -43,14 +43,7 @@ function omit< T extends object, K extends keyof T >(
 /**
  * Hook for managing DataViews view state with local persistence.
  *
- * @param config                      Configuration object for loading the view.
- * @param config.kind                 Entity kind (e.g., 'postType', 'taxonomy', 'root').
- * @param config.name                 Specific entity name.
- * @param config.slug                 View identifier.
- * @param config.defaultView          Default view configuration.
- * @param config.activeViewOverrides  View overrides applied on top but never persisted.
- * @param config.queryParams          Object with `page` and/or `search` from URL.
- * @param config.onChangeQueryParams  Optional callback to update URL parameters.
+ * @param config Configuration object for loading the view.
  *
  * @return Object with current view, modification state, and update functions.
  */

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -32,7 +32,7 @@ import { __ } from '@wordpress/i18n';
 import { unlock } from '../lock-unlock';
 import {
 	getDefaultView,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 	DEFAULT_VIEWS,
 	DEFAULT_LAYOUTS,
 	viewToQuery,
@@ -82,8 +82,8 @@ function PostList() {
 		return getDefaultView( postTypeObject );
 	}, [ postTypeObject ] );
 
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( slug ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( slug ),
 		[ slug ]
 	);
 
@@ -106,7 +106,7 @@ function PostList() {
 		name: postType,
 		slug: 'default-new',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -55,17 +55,26 @@ export const DEFAULT_VIEWS: {
 	},
 ];
 
-export function getActiveFiltersForTab( slug: string ): Filter[] {
+type ActiveViewOverrides = {
+	filters?: Filter[];
+	sort?: View[ 'sort' ];
+};
+
+export function getActiveViewOverridesForTab(
+	slug: string
+): ActiveViewOverrides {
 	if ( slug === 'all' ) {
-		return [];
+		return {};
 	}
-	return [
-		{
-			field: 'status',
-			operator: 'is',
-			value: slug,
-		},
-	];
+	return {
+		filters: [
+			{
+				field: 'status',
+				operator: 'is',
+				value: slug,
+			},
+		],
+	};
 }
 
 export function getDefaultView( postType: Type | undefined ): View {
@@ -87,7 +96,7 @@ export async function ensureView(
 		name: type,
 		slug: 'default-new',
 		defaultView,
-		activeFilters: getActiveFiltersForTab( slug ?? 'all' ),
+		activeViewOverrides: getActiveViewOverridesForTab( slug ?? 'all' ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -29,7 +29,7 @@ import { published, commentAuthorAvatar } from '@wordpress/icons';
 import { unlock } from '../lock-unlock';
 import {
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 	DEFAULT_LAYOUTS,
 } from './view-utils';
 import { previewField } from './fields/preview';
@@ -70,8 +70,8 @@ function TemplateListActivation() {
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState< Template | null >( null );
 	const defaultView = DEFAULT_VIEW;
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( activeView ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( activeView ),
 		[ activeView ]
 	);
 
@@ -94,7 +94,7 @@ function TemplateListActivation() {
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -28,7 +28,7 @@ import { layout } from '@wordpress/icons';
 import { unlock } from '../lock-unlock';
 import {
 	DEFAULT_VIEW_LEGACY,
-	getActiveFiltersForTabLegacy,
+	getActiveViewOverridesForTabLegacy,
 	DEFAULT_LAYOUTS,
 } from './view-utils';
 import { previewField } from './fields/preview';
@@ -64,8 +64,8 @@ function TemplateListLegacy() {
 		[]
 	);
 	const defaultView = DEFAULT_VIEW_LEGACY;
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTabLegacy( activeView ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTabLegacy( activeView ),
 		[ activeView ]
 	);
 
@@ -88,7 +88,7 @@ function TemplateListLegacy() {
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-list/view-utils.ts
+++ b/routes/template-list/view-utils.ts
@@ -74,7 +74,9 @@ export async function ensureView(
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView: DEFAULT_VIEW,
-		activeViewOverrides: getActiveViewOverridesForTab( activeView ?? 'active' ),
+		activeViewOverrides: getActiveViewOverridesForTab(
+			activeView ?? 'active'
+		),
 		queryParams: search,
 	} );
 }
@@ -106,7 +108,9 @@ export async function ensureViewLegacy(
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView: DEFAULT_VIEW_LEGACY,
-		activeViewOverrides: getActiveViewOverridesForTabLegacy( activeView ?? 'all' ),
+		activeViewOverrides: getActiveViewOverridesForTabLegacy(
+			activeView ?? 'all'
+		),
 		queryParams: search,
 	} );
 }

--- a/routes/template-list/view-utils.ts
+++ b/routes/template-list/view-utils.ts
@@ -35,18 +35,34 @@ export const DEFAULT_LAYOUTS = {
 	},
 };
 
-export function getActiveFiltersForTab( activeView: string ): Filter[] {
-	if ( activeView === 'active' || activeView === 'user' ) {
-		return [];
+type ActiveViewOverrides = {
+	filters?: Filter[];
+	sort?: View[ 'sort' ];
+};
+
+export function getActiveViewOverridesForTab(
+	activeView: string
+): ActiveViewOverrides {
+	// User view: sort by date, newest first
+	if ( activeView === 'user' ) {
+		return {
+			sort: { field: 'date', direction: 'desc' as const },
+		};
 	}
-	// Author-based view
-	return [
-		{
-			field: 'author',
-			operator: 'isAny',
-			value: [ activeView ],
-		},
-	];
+	// Active view: no overrides
+	if ( activeView === 'active' ) {
+		return {};
+	}
+	// Author-based view: filter by author
+	return {
+		filters: [
+			{
+				field: 'author',
+				operator: 'isAny',
+				value: [ activeView ],
+			},
+		],
+	};
 }
 
 export async function ensureView(
@@ -58,23 +74,27 @@ export async function ensureView(
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView: DEFAULT_VIEW,
-		activeFilters: getActiveFiltersForTab( activeView ?? 'active' ),
+		activeViewOverrides: getActiveViewOverridesForTab( activeView ?? 'active' ),
 		queryParams: search,
 	} );
 }
 
-export function getActiveFiltersForTabLegacy( activeView: string ): Filter[] {
+export function getActiveViewOverridesForTabLegacy(
+	activeView: string
+): ActiveViewOverrides {
 	if ( activeView === 'all' ) {
-		return [];
+		return {};
 	}
 	// Author-based view
-	return [
-		{
-			field: 'author',
-			operator: 'isAny',
-			value: [ activeView ],
-		},
-	];
+	return {
+		filters: [
+			{
+				field: 'author',
+				operator: 'isAny',
+				value: [ activeView ],
+			},
+		],
+	};
 }
 
 export async function ensureViewLegacy(
@@ -86,7 +106,7 @@ export async function ensureViewLegacy(
 		name: 'wp_template',
 		slug: 'default-new',
 		defaultView: DEFAULT_VIEW_LEGACY,
-		activeFilters: getActiveFiltersForTabLegacy( activeView ?? 'all' ),
+		activeViewOverrides: getActiveViewOverridesForTabLegacy( activeView ?? 'all' ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -33,7 +33,7 @@ import { CreateTemplatePartModal } from '@wordpress/fields';
 import { unlock } from '../lock-unlock';
 import {
 	DEFAULT_VIEW,
-	getActiveFiltersForTab,
+	getActiveViewOverridesForTab,
 	DEFAULT_VIEWS,
 	DEFAULT_LAYOUTS,
 	viewToQuery,
@@ -81,8 +81,8 @@ function TemplatePartList() {
 
 	const defaultView = DEFAULT_VIEW;
 
-	const activeFilters = useMemo(
-		() => getActiveFiltersForTab( area ),
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( area ),
 		[ area ]
 	);
 
@@ -105,7 +105,7 @@ function TemplatePartList() {
 		name: 'wp_template_part',
 		slug: 'default-new',
 		defaultView,
-		activeFilters,
+		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
 	} );

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -58,17 +58,26 @@ export const DEFAULT_VIEWS: {
 	},
 ];
 
-export function getActiveFiltersForTab( area: string ): Filter[] {
+type ActiveViewOverrides = {
+	filters?: Filter[];
+	sort?: View[ 'sort' ];
+};
+
+export function getActiveViewOverridesForTab(
+	area: string
+): ActiveViewOverrides {
 	if ( area === 'all' ) {
-		return [];
+		return {};
 	}
-	return [
-		{
-			field: 'area',
-			operator: 'is',
-			value: area,
-		},
-	];
+	return {
+		filters: [
+			{
+				field: 'area',
+				operator: 'is',
+				value: area,
+			},
+		],
+	};
 }
 
 export async function ensureView(
@@ -80,7 +89,7 @@ export async function ensureView(
 		name: 'wp_template_part',
 		slug: 'default-new',
 		defaultView: DEFAULT_VIEW,
-		activeFilters: getActiveFiltersForTab( area ?? 'all' ),
+		activeViewOverrides: getActiveViewOverridesForTab( area ?? 'all' ),
 		queryParams: search,
 	} );
 }


### PR DESCRIPTION
## What?

Refactor the `@wordpress/views` API to replace `activeFilters` with `activeViewOverrides`, enabling tab-specific sorting alongside filters. Restores date sorting (newest first) for the "User" templates tab, addressing feedback from PR #74970.

## Why?

PR #74970 unified view persistence across tabs but inadvertently removed the date sorting for user-created templates, which was a useful UX default. The `activeViewOverrides` API is more extensible, allowing any view properties to be overridden per-tab.

## How?

- Updated `ViewConfig` type to accept `activeViewOverrides?: Pick<View, 'filters' | 'sort'>`
- Renamed merge/strip utilities to handle both filters and sort
- Modified sort merge logic: applies only when current sort matches default (respects user customization)
- Modified sort strip logic: removes override sort before persistence (doesn't pollute preferences)
- Updated all call sites in edit-site and routes packages

## Testing Instructions

1. Navigate to Templates in edit-site, switch to "User" tab → verify templates are sorted by date (newest first)
2. Switch to another tab → verify sorting returns to default (title asc)
3. Switch to an author tab → verify author filter is applied correctly
4. Manually change sort on User tab, persist, switch away and back → verify custom sort persists
5. Click "Reset view" → verify it resets to default list layout

## Screenshots or screencast

N/A