### PR TITLE
ValidatedToggleControl: Fix validation timing with callback ref

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).
+-   ValidatedToggleControl: Fix validation timing with callback ref. ([#75095](https://github.com/WordPress/gutenberg/pull/75095)).
 
 ## 32.1.0 (2026-01-29)
 

--- a/packages/components/src/validated-form-controls/components/test/index.tsx
+++ b/packages/components/src/validated-form-controls/components/test/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useLayoutEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ValidatedToggleControl } from '../';
+
+describe( 'ValidatedToggleControl', () => {
+	it( 'should validate correctly when checkValidity is called before useEffect runs', () => {
+		// `useLayoutEffect` runs AFTER render but BEFORE `useEffect`.
+		// This simulates code that runs before useEffect, such as validation
+		// triggered immediately when a form card expands.
+		let validityResult: boolean | null = null;
+		function TestComponent() {
+			const ref = useRef< HTMLInputElement >( null );
+			useLayoutEffect( () => {
+				// This runs BEFORE useEffect would run
+				if ( ref.current ) {
+					validityResult = ref.current.checkValidity();
+				}
+			}, [] );
+			return (
+				<ValidatedToggleControl
+					ref={ ref }
+					label="Required toggle"
+					required
+					checked={ false }
+					onChange={ () => {} }
+				/>
+			);
+		}
+		render( <TestComponent /> );
+		// `required` is set synchronously, so unchecked box fails validation.
+		expect( validityResult ).toBe( false );
+	} );
+} );

--- a/packages/components/src/validated-form-controls/components/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-control.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef, useRef, useEffect } from '@wordpress/element';
+import { forwardRef, useRef, useCallback } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -22,16 +22,21 @@ const UnforwardedValidatedToggleControl = (
 	}: React.ComponentProps< typeof ToggleControl > & ValidatedControlProps,
 	forwardedRef: React.ForwardedRef< HTMLInputElement >
 ) => {
-	const validityTargetRef = useRef< HTMLInputElement >( null );
-	const mergedRefs = useMergeRefs( [ forwardedRef, validityTargetRef ] );
-
+	const validityTargetRef = useRef< HTMLInputElement | null >( null );
 	// TODO: Upstream limitation - The `required` attribute is not passed down to the input,
-	// so we need to set it manually.
-	useEffect( () => {
-		if ( validityTargetRef.current ) {
-			validityTargetRef.current.required = required ?? false;
-		}
-	}, [ required ] );
+	// so we need to set it manually. Using a callback ref ensures `required` is set
+	// synchronously when the element mounts, before any validation effects run.
+	const setRequiredRef = useCallback(
+		( element: HTMLInputElement | null ) => {
+			validityTargetRef.current = element;
+			if ( element ) {
+				element.required = required ?? false;
+			}
+		},
+		[ required ]
+	);
+
+	const mergedRefs = useMergeRefs( [ forwardedRef, setRequiredRef ] );
 
 	return (
 		<ControlWithError

--- a/packages/components/src/validated-form-controls/components/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-control.tsx
@@ -28,10 +28,11 @@ const UnforwardedValidatedToggleControl = (
 	// synchronously when the element mounts, before any validation effects run.
 	const setRequiredRef = useCallback(
 		( element: HTMLInputElement | null ) => {
-			validityTargetRef.current = element;
-			if ( element ) {
-				element.required = required ?? false;
+			if ( ! element ) {
+				return;
 			}
+			validityTargetRef.current = element;
+			element.required = required ?? false;
 		},
 		[ required ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: https://github.com/WordPress/gutenberg/issues/72321

This PR implements the last item of the linked issue around DataForms layout validation.

>Toggle control does not report validity after opening the card or in panel layout

## Why?
`ValidatedToggleControl` was setting the required attribute on the underlying input via a useEffect. When `reportValidity()` was called (e.g., when a card form expands), the effect hadn't run yet, so the input didn't have the `required` attribute. Without `required`, an unchecked checkbox is considered valid by the browser, so no invalid event fired and no error indicator/message appeared.

## How?

Replace the useEffect with a callback ref. The callback ref sets required synchronously when the element mounts, ensuring it's in place before any validation effects run.


### Possible alternative approach

We could make `ToggleControl` pass rest props down to `FormToggle` (similar to `TextControl` etc..). This would allow `required` to flow through naturally via [ControlWithError's cloneElement](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/validated-form-controls/control-with-error.tsx#L263). Should we implement that? --cc @WordPress/gutenberg-components 



## Testing Instructions
1. In validation story (`?path=/story/dataviews-dataform--validation&args=layout:card-collapsible`) compare trunk and this PR (`npm run storybook:dev`) by going to `Boolean fields` and collapse the card
2. You should see in both cases the `2 validation issues` badge, but when opening the card again you can see both validation messages at the inputs, only in this PR (see the videos below).

### Before

https://github.com/user-attachments/assets/6f4c65a6-de20-4b56-974b-05b2485834d7



### After 


https://github.com/user-attachments/assets/d60ac270-0012-4fb1-a169-2ab3b0d8c5d6




