### PR TITLE
iAPI Router: Update cached styles for re-fetched pages

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
@@ -74,6 +74,15 @@ $wrapper_attributes = get_block_wrapper_attributes();
 				<?php echo $label; ?>
 			</a>
 		<?php endforeach; ?>
+		<?php foreach ( $attributes['links'] as $label => $link ) : ?>
+			<a
+				data-testid="force link <?php echo $label; ?>"
+				data-wp-on--click="actions.navigateForce"
+				href="<?php echo $link; ?>"
+			>
+				<?php echo $label; ?> (force)
+			</a>
+		<?php endforeach; ?>
 	</nav>
 
 	<!-- HTML updated on navigation. -->

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
@@ -19,6 +19,15 @@ const { state } = store( 'test/router-styles', {
 			yield actions.navigate( e.target.href );
 			state.clientSideNavigation = true;
 		} ),
+		navigateForce: withSyncEvent( function* ( e ) {
+			e.preventDefault();
+			state.clientSideNavigation = false;
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( e.target.href, { force: true } );
+			state.clientSideNavigation = true;
+		} ),
 		*prefetch() {
 			state.prefetching = true;
 			const { ref } = getElement();

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Update cached styles for re-fetched pages. ([#75097](https://github.com/WordPress/gutenberg/pull/75097))
+
 ## 2.39.0 (2026-01-29)
 
 ### Bug Fixes

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -196,16 +196,6 @@ const prepareStylePromise = (
 };
 
 /**
- * Cache of style promise lists per URL.
- *
- * It contains the list of style elements associated to the page with the
- * passed URL. The original order is preserved to respect the CSS cascade.
- *
- * Each included promise resolves when the associated style element is ready.
- */
-const styleSheetCache = new Map< string, Promise< StyleElement >[] >();
-
-/**
  * Prepares all style elements contained in the passed document.
  *
  * This function calls {@link updateStylesWithSCS|`updateStylesWithSCS`}
@@ -218,32 +208,20 @@ const styleSheetCache = new Map< string, Promise< StyleElement >[] >();
  * {@link applyStyles|`applyStyles`} function.
  *
  * @param doc Document instance.
- * @param url URL for the passed document.
  * @return A list of promises for each style element in the passed document.
  */
-export const preloadStyles = (
-	doc: Document,
-	url: string
-): Promise< StyleElement >[] => {
-	if ( ! styleSheetCache.has( url ) ) {
-		const currentStyleElements = Array.from(
-			window.document.querySelectorAll< StyleElement >(
-				'style,link[rel=stylesheet]'
-			)
-		);
-		const newStyleElements = Array.from(
-			doc.querySelectorAll< StyleElement >( 'style,link[rel=stylesheet]' )
-		);
+export const preloadStyles = ( doc: Document ): Promise< StyleElement >[] => {
+	const currentStyleElements = Array.from(
+		window.document.querySelectorAll< StyleElement >(
+			'style,link[rel=stylesheet]'
+		)
+	);
+	const newStyleElements = Array.from(
+		doc.querySelectorAll< StyleElement >( 'style,link[rel=stylesheet]' )
+	);
 
-		// Set styles in order.
-		const stylePromises = updateStylesWithSCS(
-			currentStyleElements,
-			newStyleElements
-		);
-
-		styleSheetCache.set( url, stylePromises );
-	}
-	return styleSheetCache.get( url );
+	// Set styles in order.
+	return updateStylesWithSCS( currentStyleElements, newStyleElements );
 };
 
 /**

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -207,6 +207,9 @@ const prepareStylePromise = (
  * make them effectively disabled until they are applied with the
  * {@link applyStyles|`applyStyles`} function.
  *
+ * Note that this function alters the passed document, as it can transfer
+ * nodes from it to the global document.
+ *
  * @param doc Document instance.
  * @return A list of promises for each style element in the passed document.
  */

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -78,7 +78,7 @@ describe( 'Router styles management', () => {
 
 	describe( 'updateStylesWithSCS', () => {
 		it( 'should append all elements when X is empty in the correct order', () => {
-			const X = [];
+			const X: HTMLStyleElement[] = [];
 			const Y = [
 				createStyleElement( 'style1' ),
 				createLinkElement( 'link1' ),
@@ -514,25 +514,22 @@ describe( 'Router styles management', () => {
 
 	// Tests for preloadStyles function.
 	describe( 'preloadStyles', () => {
-		it( 'should use cached promises for the same URL', () => {
+		it( 'should return cached promises for the same HTML', () => {
 			// Create a test document.
 			const doc = document.implementation.createHTMLDocument();
 			const style = doc.createElement( 'style' );
 			doc.head.appendChild( style );
 
+			// NOTE: preloadStyles() modifies the passed document. That's why
+			// the document is cloned beforehand.
+
 			// First call should update the DOM.
-			const firstResult = preloadStyles(
-				doc,
-				'https://example.com/test'
-			);
+			const firstResult = preloadStyles( doc.cloneNode() as Document );
 			expect( firstResult ).toBeTruthy();
 
 			// Second call should return the same promises.
-			const secondResult = preloadStyles(
-				doc,
-				'https://example.com/test'
-			);
-			expect( secondResult ).toBe( firstResult );
+			const secondResult = preloadStyles( doc.cloneNode() as Document );
+			expect( secondResult ).toEqual( firstResult );
 		} );
 
 		it( 'should extract style elements from the provided document', () => {
@@ -546,7 +543,7 @@ describe( 'Router styles management', () => {
 			doc.head.appendChild( style1 );
 			doc.head.appendChild( style2 );
 
-			preloadStyles( doc, 'https://example.com/another-test-page' );
+			preloadStyles( doc );
 
 			// Check that styles were extracted and added to the document.
 			const addedStyle1 = document.querySelector( '#test-style-1' );

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -220,7 +220,7 @@ const preparePage: PreparePage = async ( url, dom, { vdom } = {} ) => {
 
 	// Wait for styles and modules to be ready.
 	const [ styles, scriptModules ] = await Promise.all( [
-		Promise.all( preloadStyles( dom, url ) ),
+		Promise.all( preloadStyles( dom ) ),
 		Promise.all( preloadScriptModules( dom ) ),
 	] );
 

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -481,18 +481,13 @@ test.describe( 'Router styles', () => {
 		} );
 
 		// Force-navigate to "red". The response now contains all
-		// three color blocks with their styles, but the internal
-		// style cache still holds the old "red" entry, so the new
-		// green and blue styles are never processed.
+		// three color blocks with their styles.
 		await page.getByTestId( 'force link red' ).click();
 		await expect( csn ).toBeHidden();
 		await expect( csn ).toBeVisible();
 
-		// Red styles should be present (already in the style cache).
+		// Red and green styles should be present.
 		await expect( red ).toHaveCSS( 'color', COLOR_RED );
-		// Green styles from the new response should also be applied.
-		// This fails because the style cache is not invalidated on
-		// force navigations, so the fresh green styles are ignored.
 		await expect( green ).toHaveCSS( 'color', COLOR_GREEN );
 
 		// Unroute previous route handler for "red".

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -446,6 +446,59 @@ test.describe( 'Router styles', () => {
 		await expect( hideOnPrint ).toBeVisible();
 	} );
 
+	test( 'should update styles when navigating to a cached page with force', async ( {
+		page,
+		request,
+		interactivityUtils: utils,
+	} ) => {
+		const csn = page.getByTestId( 'client-side navigation' );
+		const red = page.getByTestId( 'red' );
+		const green = page.getByTestId( 'green' );
+
+		// Navigate to "red" to cache the page and populate the
+		// internal style cache for the red page URL.
+		await page.getByTestId( 'link red' ).click();
+		await expect( csn ).toBeHidden();
+		await expect( csn ).toBeVisible();
+		await expect( red ).toHaveCSS( 'color', COLOR_RED );
+		await expect( green ).toHaveCSS( 'color', COLOR_WRAPPER );
+
+		// Navigate to "green" so red styles are removed.
+		await page.getByTestId( 'link green' ).click();
+		await expect( csn ).toBeHidden();
+		await expect( csn ).toBeVisible();
+
+		// Intercept the next fetch to the red page URL and respond
+		// with the "all" page HTML instead.
+		const redLink = utils.getLink( 'red' );
+		const allLink = utils.getLink( 'all' );
+		await page.route( redLink, async ( route ) => {
+			// Fetch the "all" page HTML to simulate server-side content
+			// changes (e.g., new blocks appearing on the page).
+			const allPage = await request.fetch( allLink );
+			const body = await allPage.body();
+			return route.fulfill( { body, contentType: 'text/html' } );
+		} );
+
+		// Force-navigate to "red". The response now contains all
+		// three color blocks with their styles, but the internal
+		// style cache still holds the old "red" entry, so the new
+		// green and blue styles are never processed.
+		await page.getByTestId( 'force link red' ).click();
+		await expect( csn ).toBeHidden();
+		await expect( csn ).toBeVisible();
+
+		// Red styles should be present (already in the style cache).
+		await expect( red ).toHaveCSS( 'color', COLOR_RED );
+		// Green styles from the new response should also be applied.
+		// This fails because the style cache is not invalidated on
+		// force navigations, so the fresh green styles are ignored.
+		await expect( green ).toHaveCSS( 'color', COLOR_GREEN );
+
+		// Unroute previous route handler for "red".
+		await page.unroute( redLink );
+	} );
+
 	test( 'should ignore styles inside noscript elements during navigation', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## What?

Fixes the Interactivity API Router not updating styles when a cached page is re-fetched with `force: true`.

## Why?

When `navigate( url, { force: true } )` is called, the `pages` cache is correctly bypassed, and a fresh HTML fetch is triggered. However, the internal `preloadStyles()` function maintained its own `styleSheetCache`, keyed by URL, which was never invalidated. The freshly fetched DOM's styles were completely ignored, and stale cached style references were returned instead.

This meant that force-navigating to a previously visited page would not load any new styles, even if the HTML response included new blocks or new stylesheets. The page regions would update with the new content, but the corresponding styles would be missing. 

## How?

The PR removes `styleSheetCache` from `preloadStyles()` entirely. This cache level is redundant, as pages are already cached with their corresponding Style elements. The `preloadStyles()` function would only be called for the same URL if that URL is being re-fetched with `force: true`, in which case styles always need to be recomputed.

## Testing Instructions

1. Create a new page.
2. Add a Query block, with "Reload full page" disabled. This creates a router region and will make the `@wordpress/interactivity-router` module available in the console.
3. Replace the Query block's content with a paragraph.
4. Visit that page.
5. Import the `@wordpress/interactivity-router` module in the console.
   ```js
   const { actions } = await import('@wordpress/interactivity-router');
   ```
6. Stay there, and edit the page in a new tab.
7. Add an Image block **inside the Query block**, with "Expand on click" enabled.
8. Go back to the tab where the page is.
9. In the console, navigate manually with the following command:
   ```js
   actions.navigate(document.location.href, { force: true });
   ```
10. Ensure the Image block appears, is correctly styled, and is interactive.
