### PR TITLE
Components Style: Clean up admin-scheme usage

### DIFF
--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/mixins" as *;
+@use "@wordpress/base-styles/default-custom-properties";
 @use "./animate/style.scss" as *;
 @use "./autocomplete/style.scss" as *;
 @use "./badge/styles.scss" as *;
@@ -47,9 +48,3 @@
 @use "./toolbar/toolbar-group/style.scss" as *;
 @use "./tooltip/style.scss" as *;
 @use "./validated-form-controls/style.scss" as *;
-
-// Include the default WP Components color variables.
-// TODO: Remove this once all admin-scheme variables are accounted for in the wp-components fallback values.
-:root {
-	@include admin-scheme( #3858e9 );
-}


### PR DESCRIPTION
## Why?
Minor fix, during chore code analysis in the works of #75096 I noted that this was being duplicated unnecessarily, 

## How?
Simply importing the default styles and removing duplication.