### PR TITLE
Site Editor: Prevent welcome guide from appearing during loading

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -213,7 +213,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }
 			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
-			{ isEditMode && (
+			{ isEditMode && isReady && (
 				<WelcomeGuide
 					postType={ postWithTemplate ? context.postType : postType }
 				/>


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/50862

Fixes the welcome guide appearing over the loading screen in the site editor.

## Why?

The welcome guide was rendering immediately when entering edit mode, even while the editor was still loading. This created a poor user experience where the welcome guide would appear on top of the loading screen.

## How?

Added the `isReady` condition to the WelcomeGuide component rendering logic in the site editor. This ensures the welcome guide only appears after the editor has finished loading, consistent with how the main Editor component is rendered.

The change is minimal - a single condition added to line 216 in `packages/edit-site/src/components/editor/index.js`:

```diff
-{ isEditMode && (
+{ isEditMode && isReady && (
```

## Testing Instructions

### Before
1. Open the site editor
2. From the editor options menu (three dots), click 'Welcome Guide' to enable it
3. Refresh the page (while keeping the page in focus - don't click elsewhere)
4. Observe that the welcome guide appears over the loading screen 

### After
1. Follow the same steps above
2. Observe that the welcome guide only appears after the loading screen is complete 

Alternatively, you can test by simulating slow network conditions:
1. Open DevTools → Network tab
2. Set throttling to "Slow 3G" or "Fast 3G"
3. Enable the welcome guide and refresh
4. The loading screen should complete before the welcome guide appears

