### PR TITLE
Run generate-worker-placeholders script in dev

### DIFF
--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -134,6 +134,13 @@ async function dev() {
 			{ silent: true }
 		);
 
+		// Step 2.5: Generate worker placeholders
+		// This must happen before TypeScript compilation because some packages
+		// (like vips) have source files that import from generated worker-code.ts
+		await exec( 'node', [
+			'./bin/packages/generate-worker-placeholders.mjs',
+		] );
+
 		// Step 3: Validate TypeScript version
 		console.log( '\n🔍 Validating TypeScript version...' );
 		await exec( 'node', [


### PR DESCRIPTION
Fixes the build issue identified by @stokesman in this comment: https://github.com/WordPress/gutenberg/pull/74785#discussion_r2747760567 since aec311f5909c93158fbd9c704900189b27f978e3