### PR TITLE
Fix dev build for fresh checkouts (or with  build/scripts/block-library missing)

### DIFF
--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -218,7 +218,6 @@ async function dev() {
 				isReady = true;
 
 				// Build blocks manifests after initial build completes
-				console.log( '\n📦 Building blocks manifests...' );
 				const blocksDirs = [
 					{
 						input: 'build/scripts/block-library',

--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -166,34 +166,6 @@ async function dev() {
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [ './bin/packages/build-vendors.mjs' ] );
 
-		// Step 6.5: Build blocks manifests (initial)
-		console.log( '\n📦 Building blocks manifests...' );
-		const blocksDirs = [
-			{
-				input: 'build/scripts/block-library',
-				output: 'build/scripts/block-library/blocks-manifest.php',
-			},
-			{
-				input: 'build/scripts/edit-widgets/blocks',
-				output: 'build/scripts/edit-widgets/blocks/blocks-manifest.php',
-			},
-			{
-				input: 'build/scripts/widgets/blocks',
-				output: 'build/scripts/widgets/blocks/blocks-manifest.php',
-			},
-		];
-		for ( const { input, output } of blocksDirs ) {
-			await exec(
-				'wp-scripts',
-				[
-					'build-blocks-manifest',
-					`--input=${ input }`,
-					`--output=${ output }`,
-				],
-				{ silent: true }
-			);
-		}
-
 		const setupTime = Date.now() - startTime;
 		console.log(
 			`\n✅ Initial build completed! (${ Math.round(
@@ -239,11 +211,40 @@ async function dev() {
 		// Using .then() ensures cleanup handlers are registered before awaiting,
 		// so early termination still triggers cleanup.
 		let isReady = false;
-		buildWatch.stdout.on( 'data', ( data ) => {
+		buildWatch.stdout.on( 'data', async ( data ) => {
 			const output = data.toString();
 			process.stdout.write( output );
 			if ( ! isReady && output.includes( 'Watching for changes' ) ) {
 				isReady = true;
+
+				// Build blocks manifests after initial build completes
+				console.log( '\n📦 Building blocks manifests...' );
+				const blocksDirs = [
+					{
+						input: 'build/scripts/block-library',
+						output: 'build/scripts/block-library/blocks-manifest.php',
+					},
+					{
+						input: 'build/scripts/edit-widgets/blocks',
+						output: 'build/scripts/edit-widgets/blocks/blocks-manifest.php',
+					},
+					{
+						input: 'build/scripts/widgets/blocks',
+						output: 'build/scripts/widgets/blocks/blocks-manifest.php',
+					},
+				];
+				for ( const { input, output: outputPath } of blocksDirs ) {
+					await exec(
+						'wp-scripts',
+						[
+							'build-blocks-manifest',
+							`--input=${ input }`,
+							`--output=${ outputPath }`,
+						],
+						{ silent: true }
+					);
+				}
+
 				readyMarkerFile.create();
 			}
 		} );


### PR DESCRIPTION
## What?
Fix a dev build issue with fresh checkouts.

Closes https://github.com/WordPress/gutenberg/issues/75107


## How?
Claude suggested running the failing step later, which worked in my testing. I'm uncertain if this the right spot or best approach, but I did verify this fixes the issue.


## Testing Instructions
1. remove previous build artifacts: `rm -R build`
2. run a dev build: `npm run dev`

Build should complete and wait for changes.
