### PR TITLE
Docs: Add missing @global documentation in server-timing.php

### DIFF
--- a/packages/e2e-tests/mu-plugins/server-timing.php
+++ b/packages/e2e-tests/mu-plugins/server-timing.php
@@ -14,6 +14,15 @@
 
 add_filter(
 	'template_include',
+	/**
+	 * Adds server timing headers for front-end requests.
+	 *
+	 * @global float $timestart
+	 * @global wpdb  $wpdb
+	 *
+	 * @param string $template The path of the template to include.
+	 * @return string The path of the template to include.
+	 */
 	static function ( $template ) {
 
 		global $timestart, $wpdb;
@@ -57,6 +66,12 @@ add_filter(
 
 add_action(
 	'admin_init',
+	/**
+	 * Adds server timing headers for admin requests.
+	 *
+	 * @global float $timestart
+	 * @global wpdb  $wpdb
+	 */
 	static function () {
 		global $timestart, $wpdb;
 


### PR DESCRIPTION
**Summary of Changes** 
Improved code documentation by adding the missing @global annotations to packages/e2e-tests/mu-plugins/server-timing.php
, ensuring better clarity and maintainability.

**Testing Instructions**
1. Open packages/e2e-tests/mu-plugins/server-timing.php
2. Confirm that the hook callbacks now include the required @global documentation for $timestart and $wpdb.