### PR TITLE
Add story for inserter component in csf3

### DIFF
--- a/packages/block-editor/src/components/inserter/stories/index.story.jsx
+++ b/packages/block-editor/src/components/inserter/stories/index.story.jsx
@@ -11,8 +11,6 @@ import { ExperimentalBlockEditorProvider } from '../../provider';
 import { patternCategories, patterns, reusableBlocks } from './utils/fixtures';
 import Inserter from '../';
 
-export default { title: 'BlockEditor/Inserter' };
-
 // For the purpose of this story, we need to register the core blocks samples.
 registerCoreBlocks();
 
@@ -23,75 +21,134 @@ const wrapperStyle = {
 	display: 'inline-block',
 };
 
-export const LibraryWithoutPatterns = () => {
-	return (
-		<ExperimentalBlockEditorProvider>
-			<div style={ wrapperStyle }>
-				<BlockLibrary showInserterHelpPanel />
-			</div>
-		</ExperimentalBlockEditorProvider>
-	);
+export default {
+	title: 'BlockEditor/Inserter',
+	component: Inserter,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The Inserter is the primary interface for adding blocks, patterns, and media to the content.',
+			},
+		},
+	},
 };
 
-export const LibraryWithPatterns = () => {
-	return (
-		<ExperimentalBlockEditorProvider
-			settings={ {
-				__experimentalBlockPatternCategories: patternCategories,
-				__experimentalBlockPatterns: patterns,
-			} }
-		>
-			<div style={ wrapperStyle }>
-				<BlockLibrary showInserterHelpPanel />
-			</div>
-		</ExperimentalBlockEditorProvider>
-	);
+export const LibraryWithoutPatterns = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Displays the standard block library panel without any patterns registered.',
+			},
+		},
+	},
+	render: () => {
+		return (
+			<ExperimentalBlockEditorProvider>
+				<div style={ wrapperStyle }>
+					<BlockLibrary showInserterHelpPanel />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		);
+	},
 };
 
-export const LibraryWithPatternsAndReusableBlocks = () => {
-	return (
-		<ExperimentalBlockEditorProvider
-			settings={ {
-				__experimentalBlockPatternCategories: patternCategories,
-				__experimentalBlockPatterns: patterns,
-				__experimentalReusableBlocks: reusableBlocks,
-			} }
-		>
-			<div style={ wrapperStyle }>
-				<BlockLibrary showInserterHelpPanel />
-			</div>
-		</ExperimentalBlockEditorProvider>
-	);
+export const LibraryWithPatterns = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Displays the block library panel including the "Patterns" tab.',
+			},
+		},
+	},
+	render: () => {
+		return (
+			<ExperimentalBlockEditorProvider
+				settings={ {
+					__experimentalBlockPatternCategories: patternCategories,
+					__experimentalBlockPatterns: patterns,
+				} }
+			>
+				<div style={ wrapperStyle }>
+					<BlockLibrary showInserterHelpPanel />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		);
+	},
 };
 
-export const FullInserter = () => {
-	return (
-		<ExperimentalBlockEditorProvider
-			settings={ {
-				__experimentalBlockPatternCategories: patternCategories,
-				__experimentalBlockPatterns: patterns,
-				__experimentalReusableBlocks: reusableBlocks,
-			} }
-		>
-			<div style={ wrapperStyle }>
-				<Inserter />
-			</div>
-		</ExperimentalBlockEditorProvider>
-	);
+export const LibraryWithPatternsAndReusableBlocks = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Displays the block library including both Patterns and Reusable Blocks tab.',
+			},
+		},
+	},
+	render: () => {
+		return (
+			<ExperimentalBlockEditorProvider
+				settings={ {
+					__experimentalBlockPatternCategories: patternCategories,
+					__experimentalBlockPatterns: patterns,
+					__experimentalReusableBlocks: reusableBlocks,
+				} }
+			>
+				<div style={ wrapperStyle }>
+					<BlockLibrary showInserterHelpPanel />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		);
+	},
 };
 
-export const QuickInserter = () => {
-	return (
-		<ExperimentalBlockEditorProvider
-			settings={ {
-				__experimentalBlockPatternCategories: patternCategories,
-				__experimentalBlockPatterns: patterns,
-				__experimentalReusableBlocks: reusableBlocks,
-			} }
-		>
-			<div style={ wrapperStyle }>
-				<Inserter __experimentalIsQuick />
-			</div>
-		</ExperimentalBlockEditorProvider>
-	);
+export const FullInserter = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Shows the full `<Inserter />` component, which includes the toggle button that opens the library panel.',
+			},
+		},
+	},
+	render: () => {
+		return (
+			<ExperimentalBlockEditorProvider
+				settings={ {
+					__experimentalBlockPatternCategories: patternCategories,
+					__experimentalBlockPatterns: patterns,
+					__experimentalReusableBlocks: reusableBlocks,
+				} }
+			>
+				<div style={ wrapperStyle }>
+					<Inserter />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		);
+	},
+};
+
+export const QuickInserter = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Shows the "Quick Inserter" (slash inserter) variant.',
+			},
+		},
+	},
+	render: () => {
+		return (
+			<ExperimentalBlockEditorProvider
+				settings={ {
+					__experimentalBlockPatternCategories: patternCategories,
+					__experimentalBlockPatterns: patterns,
+					__experimentalReusableBlocks: reusableBlocks,
+				} }
+			>
+				<div style={ wrapperStyle }>
+					<Inserter __experimentalIsQuick />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		);
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #67165 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR adds storybook for Inserter component of Block Editor in CSF3 Format


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the Inserter storybook

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<img width="400" height="810" alt="image" src="https://github.com/user-attachments/assets/7d41d8f6-f33e-4f70-95e5-a200426537c6" />