### PR TITLE
useBlockVisibility: consolidate useMemo calls to the output object

### DIFF
--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -15,7 +15,7 @@ import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
  * @param {Object}         options                 Parameters to avoid extra store subscriptions.
  * @param {Object|boolean} options.blockVisibility Block visibility metadata.
  * @param {string}         options.deviceType      Current device type ('desktop', 'tablet', 'mobile').
- * @return {Object} Object with `isBlockCurrentlyHidden` and `currentViewport` boolean properties.
+ * @return {Object} Object with `isBlockCurrentlyHidden` (boolean) and `currentViewport` (string) properties.
  */
 export default function useBlockVisibility( options = {} ) {
 	const {
@@ -31,37 +31,29 @@ export default function useBlockVisibility( options = {} ) {
 	 * 1. Device type override (Mobile/Tablet) - uses device type to determine viewport
 	 * 2. Actual window size (Desktop mode) - uses viewport detection
 	 */
-	const currentViewport = useMemo( () => {
-		if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.key ) {
-			return BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
-		}
-		if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.tablet.key ) {
-			return BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
-		}
-		if ( ! isLargerThanMobile ) {
-			return BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
-		}
-		if ( isLargerThanMobile && ! isLargerThanTablet ) {
-			return BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
-		}
-		return BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
-	}, [ deviceType, isLargerThanMobile, isLargerThanTablet ] );
+	let currentViewport;
+	if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.key ) {
+		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
+	} else if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.tablet.key ) {
+		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
+	} else if ( ! isLargerThanMobile ) {
+		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
+	} else if ( isLargerThanMobile && ! isLargerThanTablet ) {
+		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
+	} else {
+		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
+	}
 
 	// Determine if block is currently hidden.
-	const isBlockCurrentlyHidden = useMemo( () => {
-		if ( blockVisibility === false ) {
-			return true;
-		}
+	const isBlockCurrentlyHidden =
+		blockVisibility === false ||
+		blockVisibility?.viewport?.[ currentViewport ] === false;
 
-		if ( blockVisibility?.viewport?.[ currentViewport ] === false ) {
-			return true;
-		}
-
-		return false;
-	}, [ blockVisibility, currentViewport ] );
-
-	return {
-		isBlockCurrentlyHidden,
-		currentViewport,
-	};
+	return useMemo(
+		() => ( {
+			isBlockCurrentlyHidden,
+			currentViewport,
+		} ),
+		[ isBlockCurrentlyHidden, currentViewport ]
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Addresses some of the feedback from @mcsf in https://github.com/WordPress/gutenberg/pull/74379#issuecomment-3828631176

In the `useBlockVisibility` hook, only call a `useMemo` for the output object, to ensure a stable object when the props haven't changed.

Note: this PR doesn't address the feedback about types as I think that stuff would involve doing a bit more JS -> TS conversion, and I mostly just wanted to get a quick PR up for the useMemo feedback.

## Why?

The internal variables `currentViewport` and `isBlockCurrentlyHidden` are primitive values and don't require expensive computation to determine their values, so don't need a `useMemo`.

On the other hand, the output of the hook should use a `useMemo` to ensure the object is a stable reference unless any of its values change.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove two unnecessary `useMemo`s
* And a `useMemo` back in for the return object, as it looks like it mightn't have been intended to have been removed in the recent refactor

## Testing Instructions

* Check that tests pass
* Smoke test setting some blocks to be hidden in mobile, tablet, and or desktop screen sizes
  * Try resizing the viewport and make sure the blocks are hidden when expected
  * Try using the device preview dropdown and again, check that the blocks are hidden when expected

For reference, this is the UI to hide blocks:

<img width="1011" height="671" alt="image" src="https://github.com/user-attachments/assets/a8bdccb6-cb37-49a1-926a-6989c735fc94" />
