### PR TITLE
Restore deprecated Pullquote Block

### DIFF
--- a/docs/contributors/documentation/copy-guide.md
+++ b/docs/contributors/documentation/copy-guide.md
@@ -105,7 +105,7 @@ In a simple list that’s meant to be purely instructional (e.g., in UI copy whe
 > To continue, choose an action:
 >
 > -   Add a simple text block.
-> -   Add a quote block.
+> -   Add a pullquote block.
 > -   Add an image block.
 
 If your list is more persuasive (e.g., trying to convince someone to use a feature by listing its benefits) or includes multi-step instructions, you’ll want to vary your verbs to keep the reader engaged with more interesting language, as in the example above:

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -786,13 +786,13 @@ Add text that respects your spacing and tabs, and also allows styling. ([Source]
 -	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content
 
-## Pullquote (deprecated)
+## Pullquote
 
-This block is deprecated. Please use the Quote block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pullquote))
+Give special visual emphasis to a quote from your text. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pullquote))
 
 -	**Name:** core/pullquote
 -	**Category:** text
--	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~inserter~~
+-	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** citation, textAlign, value
 
 ## Query Loop

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
@@ -33,6 +33,7 @@ const BlockTransformationsMenu = ( {
 		const blocksThatSplitWhenTransformed = {
 			'core/list': [ 'core/paragraph', 'core/heading' ],
 			'core/quote': [ 'core/paragraph' ],
+			'core/pullquote': [ 'core/paragraph' ],
 		};
 
 		return possibleTransformations.map( ( item ) => {

--- a/packages/block-editor/src/components/block-toolbar/test/__snapshots__/block-toolbar-menu.native.js.snap
+++ b/packages/block-editor/src/components/block-toolbar/test/__snapshots__/block-toolbar-menu.native.js.snap
@@ -68,12 +68,10 @@ exports[`Block Actions Menu block options duplicates a block 1`] = `
 <!-- /wp:heading -->"
 `;
 
-exports[`Block Actions Menu block options transforms a Paragraph block into a Quote block 1`] = `
-"<!-- wp:quote -->
-<blockquote class="wp-block-quote"><!-- wp:paragraph -->
-<p>Hello!</p>
-<!-- /wp:paragraph --></blockquote>
-<!-- /wp:quote -->
+exports[`Block Actions Menu block options transforms a Paragraph block into a Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>Hello!</p></blockquote></figure>
+<!-- /wp:pullquote -->
 
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-menu.native.js
@@ -357,7 +357,7 @@ describe( 'Block Actions Menu', () => {
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
 
-		it( 'transforms a Paragraph block into a Quote block', async () => {
+		it( 'transforms a Paragraph block into a Pullquote block', async () => {
 			const screen = await initializeEditor();
 			const { getByLabelText, getByRole } = screen;
 
@@ -397,7 +397,7 @@ describe( 'Block Actions Menu', () => {
 			expect( headerTitle ).toBeVisible();
 
 			// Tap on the Transform block button
-			fireEvent.press( getByLabelText( /Quote/ ) );
+			fireEvent.press( getByLabelText( /Pullquote/ ) );
 
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );

--- a/packages/block-library/src/heading/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/transforms.native.js.snap
@@ -32,6 +32,12 @@ exports[`Heading block transforms to Paragraph block 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Heading block transforms to Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>Example text</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
 exports[`Heading block transforms to Quote block 1`] = `
 "<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:heading -->

--- a/packages/block-library/src/heading/test/transforms.native.js
+++ b/packages/block-library/src/heading/test/transforms.native.js
@@ -16,7 +16,11 @@ const initialHtml = `
 <!-- /wp:heading -->`;
 
 const transformsWithInnerBlocks = [ 'List', 'Quote', 'Columns', 'Group' ];
-const blockTransforms = [ 'Paragraph', ...transformsWithInnerBlocks ];
+const blockTransforms = [
+	'Paragraph',
+	'Pullquote',
+	...transformsWithInnerBlocks,
+];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/paragraph/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/transforms.native.js.snap
@@ -44,6 +44,12 @@ exports[`Paragraph block transforms to Preformatted block 1`] = `
 <!-- /wp:preformatted -->"
 `;
 
+exports[`Paragraph block transforms to Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>Example text</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
 exports[`Paragraph block transforms to Quote block 1`] = `
 "<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:paragraph -->

--- a/packages/block-library/src/paragraph/test/transforms.native.js
+++ b/packages/block-library/src/paragraph/test/transforms.native.js
@@ -21,6 +21,7 @@ const transformsWithInnerBlocks = [ 'List', 'Quote', 'Columns', 'Group' ];
 const blockTransforms = [
 	'Heading',
 	'Preformatted',
+	'Pullquote',
 	'Verse',
 	'Code',
 	...transformsWithInnerBlocks,

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -2,9 +2,9 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/pullquote",
-	"title": "Pullquote (deprecated)",
+	"title": "Pullquote",
 	"category": "text",
-	"description": "This block is deprecated. Please use the Quote block instead.",
+	"description": "Give special visual emphasis to a quote from your text.",
 	"textdomain": "default",
 	"attributes": {
 		"value": {
@@ -48,7 +48,6 @@
 				"minHeight": false
 			}
 		},
-		"inserter": false,
 		"spacing": {
 			"margin": true,
 			"padding": true

--- a/packages/block-library/src/pullquote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/pullquote/test/__snapshots__/transforms.native.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pullquote \\(deprecated\\) block transforms to Columns block 1`] = `
+exports[`Pullquote block transforms to Columns block 1`] = `
 "<!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
 <div class="wp-block-column" style="flex-basis:100%"><!-- wp:pullquote -->
@@ -10,7 +10,7 @@ exports[`Pullquote \\(deprecated\\) block transforms to Columns block 1`] = `
 <!-- /wp:columns -->"
 `;
 
-exports[`Pullquote \\(deprecated\\) block transforms to Group block 1`] = `
+exports[`Pullquote block transforms to Group block 1`] = `
 "<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:pullquote -->
 <figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><cite>Matt Mullenweg</cite></blockquote></figure>
@@ -18,7 +18,7 @@ exports[`Pullquote \\(deprecated\\) block transforms to Group block 1`] = `
 <!-- /wp:group -->"
 `;
 
-exports[`Pullquote \\(deprecated\\) block transforms to Heading block 1`] = `
+exports[`Pullquote block transforms to Heading block 1`] = `
 "<!-- wp:heading -->
 <h2 class="wp-block-heading">One of the hardest things to do in technology is disrupt yourself.</h2>
 <!-- /wp:heading -->
@@ -28,7 +28,7 @@ exports[`Pullquote \\(deprecated\\) block transforms to Heading block 1`] = `
 <!-- /wp:heading -->"
 `;
 
-exports[`Pullquote \\(deprecated\\) block transforms to Paragraph block 1`] = `
+exports[`Pullquote block transforms to Paragraph block 1`] = `
 "<!-- wp:paragraph -->
 <p>One of the hardest things to do in technology is disrupt yourself.</p>
 <!-- /wp:paragraph -->
@@ -38,7 +38,7 @@ exports[`Pullquote \\(deprecated\\) block transforms to Paragraph block 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Pullquote \\(deprecated\\) block transforms to Quote block 1`] = `
+exports[`Pullquote block transforms to Quote block 1`] = `
 "<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:paragraph -->
 <p>One of the hardest things to do in technology is disrupt yourself.</p>

--- a/packages/block-library/src/pullquote/test/edit.native.js
+++ b/packages/block-library/src/pullquote/test/edit.native.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import {
+	addBlock,
+	getBlock,
+	initializeEditor,
+	selectRangeInRichText,
+	setupCoreBlocks,
+	getEditorHtml,
+	fireEvent,
+	within,
+	waitFor,
+	typeInRichText,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { ENTER } from '@wordpress/keycodes';
+
+setupCoreBlocks();
+
+describe( 'Pullquote', () => {
+	it( 'should produce expected markup for multiline text', async () => {
+		// Arrange
+		const screen = await initializeEditor();
+		await addBlock( screen, 'Pullquote' );
+		// Await inner blocks to be rendered
+		const citationBlock = await waitFor( () =>
+			screen.getByPlaceholderText( 'Add citation' )
+		);
+
+		// Act
+		const pullquoteBlock = getBlock( screen, 'Pullquote' );
+		fireEvent.press( pullquoteBlock );
+		const pullquoteTextInput =
+			within( pullquoteBlock ).getByPlaceholderText( 'Add quote' );
+		typeInRichText( pullquoteTextInput, 'A great statement.' );
+		fireEvent( pullquoteTextInput, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
+		} );
+		typeInRichText( pullquoteTextInput, 'Again' );
+
+		const citationTextInput =
+			within( citationBlock ).getByPlaceholderText( 'Add citation' );
+		typeInRichText( citationTextInput, 'A person' );
+		fireEvent( citationTextInput, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
+		} );
+		selectRangeInRichText( citationTextInput, 2 );
+		fireEvent( citationTextInput, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
+		} );
+
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:pullquote -->
+		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br>Again</p><cite>A <br>person</cite></blockquote></figure>
+		<!-- /wp:pullquote -->
+
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
+} );

--- a/packages/block-library/src/pullquote/test/transforms.native.js
+++ b/packages/block-library/src/pullquote/test/transforms.native.js
@@ -9,7 +9,7 @@ import {
 	getBlockTransformOptions,
 } from 'test/helpers';
 
-const block = 'Pullquote \\(deprecated\\)';
+const block = 'Pullquote';
 const initialHtml = `
 <!-- wp:pullquote -->
 <figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><cite>Matt Mullenweg</cite></blockquote></figure>

--- a/packages/block-library/src/pullquote/transforms.js
+++ b/packages/block-library/src/pullquote/transforms.js
@@ -2,8 +2,39 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import { create, join, toHTMLString } from '@wordpress/rich-text';
 
 const transforms = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) => {
+				return createBlock( 'core/pullquote', {
+					value: toHTMLString( {
+						value: join(
+							attributes.map( ( { content } ) =>
+								create( { html: content } )
+							),
+							'\n'
+						),
+					} ),
+					anchor: attributes.anchor,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { content, anchor } ) => {
+				return createBlock( 'core/pullquote', {
+					value: content,
+					anchor,
+				} );
+			},
+		},
+	],
 	to: [
 		{
 			type: 'block',

--- a/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
@@ -32,6 +32,12 @@ exports[`Quote block transforms to Paragraph block 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Quote block transforms to Pullquote block 1`] = `
+"<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>"This will make running your own blog a viable alternative again."</p><cite>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></cite></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
 exports[`Quote block transforms ungroups block 1`] = `
 "<!-- wp:paragraph -->
 <p>"This will make running your own blog a viable alternative again."</p>

--- a/packages/block-library/src/quote/test/transforms.native.js
+++ b/packages/block-library/src/quote/test/transforms.native.js
@@ -21,7 +21,11 @@ const initialHtml = `
 <!-- /wp:quote -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];
-const blockTransforms = [ 'Paragraph', ...transformsWithInnerBlocks ];
+const blockTransforms = [
+	'Pullquote',
+	'Paragraph',
+	...transformsWithInnerBlocks,
+];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -105,6 +105,31 @@ const transforms = {
 	to: [
 		{
 			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			isMatch: ( {}, block ) => {
+				return block.innerBlocks.every(
+					( { name } ) => name === 'core/paragraph'
+				);
+			},
+			transform: (
+				{ align, citation, anchor, fontSize, style },
+				innerBlocks
+			) => {
+				const value = innerBlocks
+					.map( ( { attributes } ) => `${ attributes.content }` )
+					.join( '<br>' );
+				return createBlock( 'core/pullquote', {
+					value,
+					align,
+					citation,
+					anchor,
+					fontSize,
+					style,
+				} );
+			},
+		},
+		{
+			type: 'block',
 			blocks: [ 'core/verse' ],
 			isMatch: ( {}, block ) => {
 				return block.innerBlocks.every( ( innerBlock ) => {

--- a/packages/block-library/src/utils/transformation-categories.native.js
+++ b/packages/block-library/src/utils/transformation-categories.native.js
@@ -5,6 +5,7 @@ const transformationCategories = {
 		'core/list',
 		'core/list-item',
 		'core/quote',
+		'core/pullquote',
 		'core/preformatted',
 		'core/verse',
 		'core/shortcode',

--- a/packages/editor/src/components/style-book/examples.tsx
+++ b/packages/editor/src/components/style-book/examples.tsx
@@ -172,7 +172,7 @@ function getOverviewBlockExamples(
 		'core/image',
 		'core/separator',
 		'core/buttons',
-		'core/quote',
+		'core/pullquote',
 		'core/search',
 	];
 

--- a/platform-docs/docs/basic-concepts/block-library.md
+++ b/platform-docs/docs/basic-concepts/block-library.md
@@ -94,6 +94,7 @@ In addition to these two default blocks, here's a non-exhaustive list of blocks 
  - **File block**: `file`
  - **Code block**: `code`
  - **Preformatted block**: `preformatted`
+ - **Pullquote block**: `pullquote`
  - **Table block**: `table`
  - **Verse block**: `verse`
  - **Separator block**: `separator`

--- a/post-content.php
+++ b/post-content.php
@@ -170,16 +170,12 @@ https://vimeo.com/22439234
 <!-- /wp:embed -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'You can build any block you like, static or dynamic, decorative or plain. Here&#8217;s a quote block:', 'gutenberg' ); ?></p>
+<p><?php _e( 'You can build any block you like, static or dynamic, decorative or plain. Here&#8217;s a pullquote block:', 'gutenberg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:quote -->
-<blockquote class="wp-block-quote">
-<!-- wp:paragraph -->
-<p><?php _e( 'Code is Poetry', 'gutenberg' ); ?></p>
-<!-- /wp:paragraph -->
-<cite><?php _e( 'The WordPress community', 'gutenberg' ); ?></cite></blockquote>
-<!-- /wp:quote -->
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p><?php _e( 'Code is Poetry', 'gutenberg' ); ?></p><cite><?php _e( 'The WordPress community', 'gutenberg' ); ?></cite></blockquote></figure>
+<!-- /wp:pullquote -->
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">

--- a/test/e2e/specs/editor/blocks/__snapshots__/Pullquote-can-be-converted-to-a-Quote-block-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Pullquote-can-be-converted-to-a-Quote-block-1-chromium.txt
@@ -1,5 +1,0 @@
-<!-- wp:quote -->
-<blockquote class="wp-block-quote"><!-- wp:paragraph -->
-<p>First line.<br>Second line.</p>
-<!-- /wp:paragraph --><cite>Awesome Citation</cite></blockquote>
-<!-- /wp:quote -->

--- a/test/e2e/specs/editor/blocks/pullquote.spec.js
+++ b/test/e2e/specs/editor/blocks/pullquote.spec.js
@@ -3,26 +3,57 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Pullquote', () => {
+test.describe( 'Quote', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'can be converted to a Quote block', async ( { editor, page } ) => {
-		// Insert a Pullquote block.
-		await editor.insertBlock( { name: 'core/pullquote' } );
+	test( 'can be created by converting a quote and converted back to quote', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
 
-		// Add multiple lines of text.
-		await page.keyboard.type( 'First line.' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second line.' );
-
-		// Add a citation.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.type( 'Awesome Citation' );
-
+		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/quote' );
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/quote',
+				attributes: { value: '' },
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'test' },
+					},
+				],
+			},
+		] );
+
+		await editor.transformBlockTo( 'core/pullquote' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/pullquote',
+				attributes: { value: 'test' },
+				innerBlocks: [],
+			},
+		] );
+		await editor.transformBlockTo( 'core/quote' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/quote',
+				attributes: { value: '' },
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'test' },
+					},
+				],
+			},
+		] );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -265,6 +265,22 @@ test.describe( 'Quote', () => {
 		);
 	} );
 
+	test( 'can be converted to a pullquote', async ( { editor, page } ) => {
+		await editor.insertBlock( { name: 'core/quote' } );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await editor.clickBlockToolbarButton( 'Select parent block: Quote' );
+		await editor.clickBlockToolbarButton( 'Add citation' );
+		await page.keyboard.type( 'cite' );
+		await editor.transformBlockTo( 'core/pullquote' );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>one<br>two</p><cite>cite</cite></blockquote></figure>
+<!-- /wp:pullquote -->`
+		);
+	} );
+
 	test( 'can be split at the end', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '1' );

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -361,6 +361,7 @@ test.describe( 'Post-type locking', () => {
 				'Details',
 				'Group',
 				'Preformatted',
+				'Pullquote',
 				'Verse',
 			] );
 		} );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -544,7 +544,10 @@ test.describe( 'List View', () => {
 		await editor.insertBlock( { name: 'core/file' } );
 		await editor.insertBlock( {
 			name: 'core/group',
-			innerBlocks: [ { name: 'core/paragraph' }, { name: 'core/code' } ],
+			innerBlocks: [
+				{ name: 'core/paragraph' },
+				{ name: 'core/pullquote' },
+			],
 		} );
 
 		// Open List View.
@@ -558,13 +561,12 @@ test.describe( 'List View', () => {
 			} )
 			.click();
 
-		// Expand group block, then move to code block, and copy.
+		// Move down to group block, expand, and then move to the paragraph block.
+		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 		await pageUtils.pressKeys( 'primary+c' );
-
-		// Move up to paragraph block and paste.
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeys( 'primary+v' );
 
@@ -581,12 +583,12 @@ test.describe( 'List View', () => {
 					selected: true,
 					innerBlocks: [
 						{
-							name: 'core/code',
+							name: 'core/pullquote',
 							selected: false,
 							focused: true,
 						},
 						{
-							name: 'core/code',
+							name: 'core/pullquote',
 							selected: false,
 							focused: false,
 						},
@@ -686,7 +688,10 @@ test.describe( 'List View', () => {
 		await editor.insertBlock( { name: 'core/file' } );
 		await editor.insertBlock( {
 			name: 'core/group',
-			innerBlocks: [ { name: 'core/code' }, { name: 'core/code' } ],
+			innerBlocks: [
+				{ name: 'core/pullquote' },
+				{ name: 'core/pullquote' },
+			],
 		} );
 
 		// Open List View.
@@ -728,12 +733,12 @@ test.describe( 'List View', () => {
 					focused: true,
 					innerBlocks: [
 						{
-							name: 'core/code',
+							name: 'core/pullquote',
 							selected: false,
 							focused: false,
 						},
 						{
-							name: 'core/code',
+							name: 'core/pullquote',
 							selected: false,
 							focused: false,
 						},
@@ -751,7 +756,7 @@ test.describe( 'List View', () => {
 		// Insert some blocks of different types.
 		await editor.insertBlock( {
 			name: 'core/group',
-			innerBlocks: [ { name: 'core/quote' } ],
+			innerBlocks: [ { name: 'core/pullquote' } ],
 		} );
 		await editor.insertBlock( {
 			name: 'core/columns',
@@ -879,7 +884,7 @@ test.describe( 'List View', () => {
 		// Insert some blocks of different types.
 		await editor.insertBlock( {
 			name: 'core/group',
-			innerBlocks: [ { name: 'core/quote' } ],
+			innerBlocks: [ { name: 'core/pullquote' } ],
 		} );
 		await editor.insertBlock( {
 			name: 'core/columns',

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -96,7 +96,7 @@ test.describe( 'Style Book', () => {
 		await page
 			.frameLocator( '[name="style-book-canvas"]' )
 			.getByRole( 'button', {
-				name: 'Open Buttons styles in Styles panel',
+				name: 'Open Pullquote styles in Styles panel',
 			} )
 			.click();
 


### PR DESCRIPTION
Related to #11610

## What?

This PR reverts #73228.

## Why?

We initially considered Pullquote and Quote to be almost identical in purpose, with the only difference being design tools, and deprecated the Pullquote block. However, based on subsequent feedback, I realized that Pullquote and Qupte blocks are semantically distinct. Perhaps it would be ideal to change the Pullquote block to a more meaningful markup rather than deprecating it. See https://github.com/WordPress/gutenberg/issues/20606

## How?

Simply reverts #73228.

## Testing Instructions

- Confirm that the Pullquote block can be inserted correctly.
- Confirm that Pullquote and Quote can be transformed into each other.