### PR TITLE
PHP-only blocks: Refactor controls to use ToolsPanel

### DIFF
--- a/packages/block-editor/src/hooks/auto-inspector-controls.js
+++ b/packages/block-editor/src/hooks/auto-inspector-controls.js
@@ -110,7 +110,7 @@ function AutoRegisterControls( { name, clientId, setAttributes } ) {
 					>
 						<DataForm
 							data={ attributes }
-							fields={ [ field ] }
+							fields={ fields }
 							form={ { fields: [ field.id ] } }
 							onChange={ setAttributes }
 						/>

--- a/packages/block-editor/src/hooks/auto-inspector-controls.js
+++ b/packages/block-editor/src/hooks/auto-inspector-controls.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
-import { PanelBody } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { useMemo } from '@wordpress/element';
@@ -15,6 +18,7 @@ import InspectorControls from '../components/inspector-controls';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { store as blockEditorStore } from '../store';
 import { generateFieldsFromAttributes } from './generate-fields-from-attributes';
+import { useToolsPanelDropdownMenuProps } from '../components/global-styles/utils';
 
 /**
  * Checks if a block has any attributes marked for auto-generated inspector controls.
@@ -44,6 +48,7 @@ function hasAutoInspectorControlAttributes( blockTypeAttributes ) {
  */
 function AutoRegisterControls( { name, clientId, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const attributes = useSelect(
 		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
@@ -56,11 +61,11 @@ function AutoRegisterControls( { name, clientId, setAttributes } ) {
 	// The __experimentalAutoInspectorControl marker excludes block support attributes
 	// (which have their own UI) and internal state (role: 'local').
 	// Memoized since blockType.attributes don't change after registration.
-	const { fields, form } = useMemo( () => {
+	const fields = useMemo( () => {
 		if ( ! blockType?.attributes ) {
-			return { fields: [], form: { fields: [] } };
+			return [];
 		}
-		return generateFieldsFromAttributes( blockType.attributes );
+		return generateFieldsFromAttributes( blockType.attributes ).fields;
 	}, [ blockType?.attributes ] );
 
 	if ( blockEditingMode !== 'default' ) {
@@ -73,14 +78,45 @@ function AutoRegisterControls( { name, clientId, setAttributes } ) {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings' ) }>
-				<DataForm
-					data={ attributes }
-					fields={ fields }
-					form={ form }
-					onChange={ setAttributes }
-				/>
-			</PanelBody>
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () => {
+					setAttributes(
+						Object.fromEntries(
+							Object.entries( blockType?.attributes ).map(
+								( [ key, value ] ) => [ key, value.default ]
+							)
+						)
+					);
+				} }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				{ fields.map( ( field ) => (
+					<ToolsPanelItem
+						key={ field.id }
+						label={ field.label }
+						hasValue={ () =>
+							attributes[ field.id ] !==
+							blockType?.attributes?.[ field.id ]?.default
+						}
+						isShownByDefault
+						onDeselect={ () =>
+							setAttributes( {
+								[ field.id ]:
+									blockType?.attributes?.[ field.id ]
+										?.default,
+							} )
+						}
+					>
+						<DataForm
+							data={ attributes }
+							fields={ [ field ] }
+							form={ { fields: [ field.id ] } }
+							onChange={ setAttributes }
+						/>
+					</ToolsPanelItem>
+				) ) }
+			</ToolsPanel>
 		</InspectorControls>
 	);
 }

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -247,20 +247,92 @@ test.describe( 'PHP-only auto-register blocks', () => {
 
 		// Verify auto-generated controls are present
 		// String attribute → text input
-		await expect( page.getByLabel( 'Title' ) ).toBeVisible();
+		const titleInput = page.getByRole( 'textbox', { name: 'Title' } );
+		await expect( titleInput ).toBeVisible();
+		await expect( titleInput ).toHaveValue( 'My Emoji Collection' );
 
 		// Integer attribute → number input
-		await expect( page.getByLabel( 'Count' ) ).toBeVisible();
+		const countInput = page.getByRole( 'spinbutton', { name: 'Count' } );
+		await expect( countInput ).toBeVisible();
+		await expect( countInput ).toHaveValue( '5' );
 
 		// Number attribute → number control
-		await expect( page.getByLabel( 'Spacing' ) ).toBeVisible();
+		const spacingInput = page.getByRole( 'spinbutton', {
+			name: 'Spacing',
+		} );
+		await expect( spacingInput ).toBeVisible();
+		await expect( spacingInput ).toHaveValue( '0.1' );
 
 		// Boolean attribute → toggle/checkbox
-		await expect( page.getByLabel( 'Show Emojis' ) ).toBeVisible();
+		const showEmojisInput = page.getByRole( 'checkbox', {
+			name: 'Show Emojis',
+		} );
+		await expect( showEmojisInput ).toBeVisible();
+		await expect( showEmojisInput ).toBeChecked();
+
+		// Enum attribute → select control
+		const emojiInput = page.getByRole( 'combobox', {
+			name: 'Emoji',
+			exact: true,
+		} );
+		await expect( emojiInput ).toBeVisible();
+		await expect( emojiInput ).toHaveValue( '⭐' );
 
 		// Enum attribute → select control
 		await expect(
 			page.getByLabel( 'Emoji', { exact: true } )
 		).toBeVisible();
+	} );
+
+	test( 'should reset block attributes to their default values', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert the block with auto-generated controls
+		await editor.insertBlock( {
+			name: 'test/auto-register-with-controls',
+		} );
+
+		// Open the document settings sidebar
+		await editor.openDocumentSettingsSidebar();
+
+		// Verify auto-generated controls are present
+		// String attribute → text input
+		const titleInput = page.getByRole( 'textbox', { name: 'Title' } );
+		await titleInput.fill( 'My New Emoji Collection' );
+
+		// Integer attribute → number input
+		const countInput = page.getByRole( 'spinbutton', { name: 'Count' } );
+		await countInput.fill( '10' );
+
+		// Number attribute → number control
+		const spacingInput = page.getByRole( 'spinbutton', {
+			name: 'Spacing',
+		} );
+		await spacingInput.fill( '0.2' );
+
+		// Boolean attribute → toggle/checkbox
+		const showEmojisInput = page.getByRole( 'checkbox', {
+			name: 'Show Emojis',
+		} );
+		await showEmojisInput.uncheck();
+
+		// Enum attribute → select control
+		const emojiInput = page.getByRole( 'combobox', {
+			name: 'Emoji',
+			exact: true,
+		} );
+		await emojiInput.selectOption( '❤️' );
+
+		// Click the Reset All button
+		await page.getByRole( 'button', { name: 'Settings options' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Reset all' } ).click();
+
+		// Verify the block attributes are reset to their default values
+		await expect( titleInput ).toHaveValue( 'My Emoji Collection' );
+		await expect( countInput ).toHaveValue( '5' );
+		await expect( spacingInput ).toHaveValue( '0.1' );
+		await expect( showEmojisInput ).toBeChecked();
+		await expect( emojiInput ).toHaveValue( '⭐' );
 	} );
 } );


### PR DESCRIPTION
Related to:

- #71792
- #74102
- #67813

## What? Why?

Currently, the settings panels for all core blocks have been refactored to use `ToolsPanel`. Following this, I personally recommend using `ToolsPanel` for the PHP-only block as well.

This also has the advantage of making it easy to restore the default values ​​assigned to the block.

## How?

Since the `DataForm` component renders all fields, it is not possible to wrap each field in a `ToolsPanelItem`. Therefore, I assigned a `DataForm` to each field individually.

## Testing Instructions

Use the following code to register a sample PHP-only block:

```php
function gutenberg_register_php_only_blocks() {
	register_block_type(
		'my-plugin/example',
		array(
			'title'           => 'My Example Block',
			'attributes'      => array(
				'title'   => array(
					'type'    => 'string',
					'default' => 'Hello World',
				),
				'count'   => array(
					'type'    => 'integer',
					'default' => 5,
				),
				'enabled' => array(
					'type'    => 'boolean',
					'default' => true,
				),
				'size'    => array(
					'type'    => 'string',
					'enum'    => array( 'small', 'medium', 'large' ),
					'default' => 'medium',
				),
			),
			'render_callback' => function ( $attributes ) {
				return sprintf(
					'<div>%s: %d items (%s)</div>',
					esc_html( $attributes['title'] ),
					$attributes['count'],
					$attributes['size']
				);
			},
			'supports'        => array(
				'auto_register' => true,
			),
		)
	);
}

add_action( 'init', 'gutenberg_register_php_only_blocks' );
```

- Insert a block. Change the settings.
- Verify that you can reset settings to their default values ​​individually or all at once.

## Screenshots or screencast <!-- if applicable -->

| Before | Afterr |
|--------|--------|
| <img width="282" height="522" alt="before" src="https://github.com/user-attachments/assets/ac93f9bd-c4dd-4775-8b2c-8e27c5b71070" /> | <img width="282" height="470" alt="after" src="https://github.com/user-attachments/assets/92ffc23d-f8fe-403b-8f38-7b4891d931b9" /> |