### PR TITLE
useBlockVisibility: Remove the last 'useMemo' call

### DIFF
--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,11 +48,5 @@ export default function useBlockVisibility( options = {} ) {
 		blockVisibility === false ||
 		blockVisibility?.viewport?.[ currentViewport ] === false;
 
-	return useMemo(
-		() => ( {
-			isBlockCurrentlyHidden,
-			currentViewport,
-		} ),
-		[ isBlockCurrentlyHidden, currentViewport ]
-	);
+	return { isBlockCurrentlyHidden, currentViewport };
 }


### PR DESCRIPTION
## What?
A follow-up to https://github.com/WordPress/gutenberg/pull/75120#discussion_r2752595025.

PR removes the remaining `useMemo` call from the `useBlockVisibility` hook. It just wraps dependencies into a memoized object, which is always destructured later. Seems like a wasted operation.

## Testing Instructions
* Check that tests pass
* Smoke test setting some blocks to be hidden in mobile, tablet, and or desktop screen sizes
  * Try resizing the viewport and make sure the blocks are hidden when expected
  * Try using the device preview dropdown and again, check that the blocks are hidden when expected
