### PR TITLE
ui/`Button`: add min width

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `Tabs` primitive ([#74652](https://github.com/WordPress/gutenberg/pull/74652)).
 
+### Enhancements
+
+-   `Button`: Add minimum content width (`6ch` + padding) to prevent overly narrow buttons with short labels ([#75133](https://github.com/WordPress/gutenberg/pull/75133)).
+
 ## 0.6.0 (2026-01-29)
 
 ### New Features

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -21,6 +21,7 @@
 		--wp-ui-button-height: 40px;
 		--wp-ui-button-aspect-ratio: auto; /* Useful for overrides such as icon buttons */
 		--wp-ui-button-font-size: var(--wpds-font-size-md);
+		--wp-ui-button-min-width: calc(4ch + 2 * var(--wp-ui-button-padding-inline));
 
 		/* by default, borders have the same color as the background */
 		--wp-ui-button-border-color: var(--wp-ui-button-background-color);
@@ -34,6 +35,7 @@
 		align-items: center;
 		gap: calc(2 * var(--wpds-dimension-base)); /* TODO: Consider new interactive/control gap tokens */
 		aspect-ratio: var(--wp-ui-button-aspect-ratio);
+		min-width: var(--wp-ui-button-min-width);
 		height: var(--wp-ui-button-height);
 		padding-inline: var(--wp-ui-button-padding-inline);
 		border-style: solid;
@@ -188,6 +190,7 @@
 	}
 
 	.is-unstyled {
+		min-width: unset;
 		border: none;
 		background: none;
 	}

--- a/packages/ui/src/icon-button/style.module.css
+++ b/packages/ui/src/icon-button/style.module.css
@@ -4,5 +4,6 @@
 	.icon-button {
 		--wp-ui-button-aspect-ratio: 1;
 		--wp-ui-button-padding-inline: 0;
+		--wp-ui-button-min-width: unset;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up to https://github.com/WordPress/gutenberg/pull/74415

<!-- In a few words, what is the PR actually doing? -->

Add a minimum switch to the `Button` component in the `@wordpress/ui` package

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For better UI balance, especially when buttons with very short labels are paired with button with longer labels

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a `min-width` CSS property:

- it is calculated in `ch` unit, ie. it is explicitely related to the amount of characters
- it is also calculated keeping in mind the actual padding applied to the button
- it is not applied to `unstyled` variants
- it is not applied to the `IconButton` component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Play around in Storybook, changing the label text

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/e31044b3-ecba-4d59-8fe4-3ad39cf1b1dd

