### PR TITLE
Image Block: Handle image URLs without protocol

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -24,6 +24,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { image as icon, plugins as pluginsIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useResizeObserver } from '@wordpress/compose';
+import { getProtocol, prependHTTPS } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -319,10 +320,14 @@ export function ImageEdit( {
 	}
 
 	function onSelectURL( newURL ) {
-		if ( newURL !== url ) {
+		// Handle URLs without protocol.
+		const normalizedNewURL = getProtocol( newURL )
+			? newURL
+			: prependHTTPS( newURL );
+		if ( normalizedNewURL !== url ) {
 			setAttributes( {
 				blob: undefined,
-				url: newURL,
+				url: normalizedNewURL,
 				id: undefined,
 				sizeSlug: getSettings().imageDefaultSize,
 			} );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -596,6 +596,48 @@ test.describe( 'Image', () => {
 		await expect( imageDom ).toHaveAttribute( 'src', imgUrl );
 	} );
 
+	test( 'Insert from URL prepends https when URL has no protocol', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlock ).toBeVisible();
+
+		await imageBlock
+			.getByRole( 'button' )
+			.filter( { hasText: 'Insert from URL' } )
+			.click();
+
+		const form = page.locator(
+			'form.block-editor-media-placeholder__url-input-form'
+		);
+
+		const imgUrlWithoutProtocol =
+			'wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
+		const imgUrlWithHttps =
+			'https://wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
+
+		await form.getByLabel( 'URL' ).fill( imgUrlWithoutProtocol );
+		await form.getByRole( 'button', { name: 'Apply' } ).click();
+
+		const imageInEditor = imageBlock.locator( 'role=img' );
+		await expect( imageInEditor ).toBeVisible();
+		await expect( imageInEditor ).toHaveAttribute( 'src', imgUrlWithHttps );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const figureDom = page.getByRole( 'figure' );
+		await expect( figureDom ).toBeVisible();
+
+		const imageDom = figureDom.locator( 'img' );
+		await expect( imageDom ).toBeVisible();
+		await expect( imageDom ).toHaveAttribute( 'src', imgUrlWithHttps );
+	} );
+
 	test( 'adding a link should reflect configuration in published post content', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Handle image URLs without protocol when inserting from URL in the Image block.

The last part of #74738. 

## Why?
Currently, if the user inputs a URL without a protocol, it won't load. 

See #74738.

Originally #74738 reported the bug for both blocks, and #74964 only fixed it for the Video block, so this one fixes it for the Image block.

## How?
We're prepending HTTPS to the URL when necessary.

Also adding a simple e2e test for this behavior.

## Testing Instructions
Test instructions:
- Insert image block
- Click Insert from URL
- Input cdn.woocoloring.com/wp-content/uploads/Mario-And-Sonic-Birthday-Cake-With-Candles-Coloring-Sheet-For-Preschoolers-pdf-791x1024.jpg
- Verify it loads correctly and https:// was prepended
- Verify URLs with another protocol it keeps that protocol
- Verify the new e2e test passes

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Nothing was visibly changed. 