### PR TITLE
Block Fields: Try integrating Block Bindings

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/connected-button.js
+++ b/packages/block-editor/src/hooks/block-fields/connected-button.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+} from '@wordpress/components';
+import { connection, linkOff } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export default function ConnectedButton( { isConnected, ...props } ) {
+	const label = isConnected ? __( 'Disconnect' ) : __( 'Connect' );
+
+	return (
+		<InputControlSuffixWrapper variant="control">
+			<Button
+				{ ...props }
+				size="small"
+				icon={ isConnected ? connection : linkOff }
+				iconSize={ 24 }
+				label={ label }
+			/>
+		</InputControlSuffixWrapper>
+	);
+}

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -28,6 +28,7 @@ const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
 import { PrivateBlockContext } from '../../components/block-list/private-block-context';
 import InspectorControls from '../../components/inspector-controls/fill';
+import ConnectedButton from './connected-button';
 
 // controls
 import RichText from './rich-text';
@@ -153,6 +154,11 @@ function BlockFields( {
 				field.Edit = createConfiguredControl( Media, {
 					...fieldDef.Edit,
 				} );
+			} else if ( ! fieldDef.Edit ) {
+				field.Edit = {
+					control: fieldDef.type,
+					suffix: ConnectedButton,
+				};
 			}
 
 			return field;

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -93,6 +98,8 @@ export default function Media( { data, field, onChange, config = {} } ) {
 	const id = value?.id;
 	const url = value?.url;
 
+	const isBound = 'id' in ( data?.metadata?.bindings || {} );
+
 	const attachment = useSelect(
 		( select ) => {
 			if ( ! id ) {
@@ -181,7 +188,10 @@ export default function Media( { data, field, onChange, config = {} } ) {
 				renderToggle={ ( buttonProps ) => (
 					<Button
 						__next40pxDefaultSize
-						className="block-editor-content-only-controls__media"
+						className={ clsx(
+							'block-editor-content-only-controls__media',
+							{ 'is-connected': isBound }
+						) }
 						{ ...buttonProps }
 					>
 						<Grid

--- a/packages/block-editor/src/hooks/block-fields/media/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/media/styles.scss
@@ -6,6 +6,10 @@
 	box-shadow: inset 0 0 0 $border-width $gray-400;
 	padding: $grid-unit-10;
 
+	&.is-connected {
+		box-shadow: inset 0 0 0 $border-width var(--wp-block-synced-color);
+	}
+
 	&:focus:not(:disabled) {
 		// Allow smooth transition between focused and unfocused box-shadow states.
 		box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);

--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { BaseControl, useBaseControlProps } from '@wordpress/components';
@@ -30,6 +35,7 @@ export default function RichTextControl( {
 	config = {},
 } ) {
 	const registry = useRegistry();
+	const isBound = field.id in ( data?.metadata?.bindings || {} );
 	const attrValue = field.getValue( { item: data } );
 	const fieldConfig = field.config || {};
 	const { clientId } = config;
@@ -146,7 +152,10 @@ export default function RichTextControl( {
 			) }
 			<BaseControl { ...baseControlProps }>
 				<div
-					className="block-editor-content-only-controls__rich-text"
+					className={ clsx(
+						'block-editor-content-only-controls__rich-text',
+						{ 'is-connected': isBound }
+					) }
 					role="textbox"
 					aria-multiline={ ! fieldConfig?.disableLineBreaks }
 					ref={ useMergeRefs( [

--- a/packages/block-editor/src/hooks/block-fields/rich-text/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/styles.scss
@@ -21,4 +21,8 @@
 	// on newer components like InputControl, SelectControl, etc.
 	// These values should be shared with the `controlPaddingX` in ./utils/config-values.js
 	padding: $grid-unit-15;
+
+	&.is-connected {
+		border-color: var(--wp-block-synced-color);
+	}
 }

--- a/packages/dataviews/src/components/dataform-controls/style.scss
+++ b/packages/dataviews/src/components/dataform-controls/style.scss
@@ -30,3 +30,8 @@
 		background-color: $black;
 	}
 }
+
+// TODO: Make selector/classes consistent with this file/directory!
+.components-validated-control .components-input-control.is-connected .components-input-control__backdrop {
+	border-color: var(--wp-block-synced-color);
+}

--- a/packages/dataviews/src/components/dataform-controls/text.tsx
+++ b/packages/dataviews/src/components/dataform-controls/text.tsx
@@ -19,6 +19,7 @@ export default function Text< Item >( {
 	validity,
 }: DataFormControlProps< Item > ) {
 	const { prefix, suffix } = config || {};
+	const isConnected = field.id in ( data?.metadata?.bindings || {} );
 
 	return (
 		<ValidatedText
@@ -29,8 +30,12 @@ export default function Text< Item >( {
 				hideLabelFromVision,
 				markWhenOptional,
 				validity,
-				prefix: prefix ? createElement( prefix ) : undefined,
-				suffix: suffix ? createElement( suffix ) : undefined,
+				prefix: prefix
+					? createElement( prefix, { isConnected } )
+					: undefined,
+				suffix: suffix
+					? createElement( suffix, { isConnected } )
+					: undefined,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -42,6 +42,7 @@ export default function ValidatedText< Item >( {
 }: DataFormValidatedTextControlProps< Item > ) {
 	const { label, placeholder, description, getValue, setValue, isValid } =
 		field;
+	const isBound = field.id in ( data?.metadata?.bindings || {} );
 	const value = getValue( { item: data } );
 
 	const onChangeControl = useCallback(
@@ -57,6 +58,7 @@ export default function ValidatedText< Item >( {
 
 	return (
 		<ValidatedInputControl
+			className={ isBound ? 'is-connected' : undefined }
 			required={ !! isValid.required }
 			markWhenOptional={ markWhenOptional }
 			customValidity={ getCustomValidity( isValid, validity ) }


### PR DESCRIPTION
## What?
WIP. More details to come.

Closes https://github.com/WordPress/gutenberg/issues/75022. Alternative approach to https://github.com/WordPress/gutenberg/pull/75064.

## Why?
TBD

## How?
TBD

## Testing Instructions
TBD

_E2E coverage available in https://github.com/WordPress/gutenberg/pull/72096._

## TODO

- [ ] ~Massage code: Try implementing a `getValue()` Fields API compat wrapper around Block Bindings' `getValues()` (plural!) rather than overriding attribute values.~
  - Tried this in https://github.com/WordPress/gutenberg/pull/75137/changes/925f6cb27a6b77bb5815cc7e30f66c97be7f9c96 but decided to revert, as Block Fields no longer sync'd instantly with the bound attribute value in the editor canvas. 
- [ ] Add visual indicator to Block Fields to signal that an attribute is connected to a Block Bindings source:
  - [ ] Purple ("synced"/"controled") border around input field
  - [ ] Button with `connection` icon next to it (to indicate connections status and select block bindings source).
- [ ] Copy `featuredMedia.*` fields from `core/post-data` source in https://github.com/WordPress/gutenberg/pull/74610 to experiment with bindings multi-attribute fields (images).

## Screenshots or screencast

|Before|After|
|-|-|
| ![block-fields-bindings-before](https://github.com/user-attachments/assets/eff0ad89-40d1-4ed9-a871-20ae42f5d64f) | ![block-fields-bindings](https://github.com/user-attachments/assets/40384399-caa3-48ce-b0cd-e195f4ea4071) |
