### PR TITLE
ToggleGroupControl: add visual emphasis to selected item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used.
 
+### Enhancements
+
+-   Improve visual emphasis of the selected item in the ToggleGroupControl component ([#75138](https://github.com/WordPress/gutenberg/pull/75138)).
+
 ### Internal
 
 -   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -69,7 +69,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   content: '';
   position: absolute;
   pointer-events: none;
-  background: var(--wp-components-color-foreground-inverted, #fff);
+  background: var(--wp-components-color-gray-100, #f0f0f0);
   border: 1px solid var(--wp-components-color-gray-700, #757575);
   outline: 2px solid transparent;
   outline-offset: -3px;
@@ -410,7 +410,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   content: '';
   position: absolute;
   pointer-events: none;
-  background: var(--wp-components-color-foreground-inverted, #fff);
+  background: var(--wp-components-color-gray-100, #f0f0f0);
   border: 1px solid var(--wp-components-color-gray-700, #757575);
   outline: 2px solid transparent;
   outline-offset: -3px;
@@ -658,7 +658,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   content: '';
   position: absolute;
   pointer-events: none;
-  background: var(--wp-components-color-foreground-inverted, #fff);
+  background: var(--wp-components-color-gray-100, #f0f0f0);
   border: 1px solid var(--wp-components-color-gray-700, #757575);
   outline: 2px solid transparent;
   outline-offset: -3px;
@@ -993,7 +993,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
   content: '';
   position: absolute;
   pointer-events: none;
-  background: var(--wp-components-color-foreground-inverted, #fff);
+  background: var(--wp-components-color-gray-100, #f0f0f0);
   border: 1px solid var(--wp-components-color-gray-700, #757575);
   outline: 2px solid transparent;
   outline-offset: -3px;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -39,7 +39,7 @@ export const toggleGroupControl = ( {
 		content: '';
 		position: absolute;
 		pointer-events: none;
-		background: ${ COLORS.theme.foregroundInverted };
+		background: ${ COLORS.theme.gray[ 100 ] };
 		border: 1px solid ${ COLORS.theme.gray[ 700 ] };
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Tweak the background color of the selected item in the `ToggleGroupControl` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Add visual emphasis to the selected item

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changed the background color from white to `gray-100`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load the component in storybook or in the editor (select a paragraph and change typography settings such as font size)
- Verify the background color of the selected item

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|
| ![Screenshot 2026-02-02 at 17 32 30](https://github.com/user-attachments/assets/0f174302-c009-4fa7-98c2-8a2d2b4647eb) | ![Screenshot 2026-02-02 at 15 46 44](https://github.com/user-attachments/assets/95bde18d-4947-4b20-b06a-07a1ec248721) |
| ![Screenshot 2026-02-02 at 17 32 44](https://github.com/user-attachments/assets/9f4df375-beaa-451e-b1dd-9dd6bf0ec556) | ![Screenshot 2026-02-02 at 15 46 53](https://github.com/user-attachments/assets/778e99b4-9ae3-4054-9e6f-6b6cd83e3402) |
| ![Screenshot 2026-02-02 at 17 29 34](https://github.com/user-attachments/assets/de04e1cd-a678-4887-94d1-1b1a7d1399a6) | ![Screenshot 2026-02-02 at 17 27 39](https://github.com/user-attachments/assets/41ed7594-e442-4e45-895a-b2d7c2a23f38) |




