### PR TITLE
Code Quality: Remove deprecated __nextHasNoMarginBottom prop

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -80,7 +80,6 @@ export function BlockRemovalWarningModal( { rules } ) {
 				</div>
 				{ requireConfirmation && (
 					<CheckboxControl
-						__nextHasNoMarginBottom
 						label={ __( 'I understand the consequences' ) }
 						checked={ confirmed }
 						onChange={ setConfirmed }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -613,7 +613,6 @@ export default function TypographyPanel( {
 					/>
 					{ isGlobalStyles && (
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label={ __( 'Indent all paragraphs' ) }
 							checked={ isTextIndentAll }
 							onChange={ onToggleTextIndentAll }

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -106,7 +106,6 @@ export default function TextIndentControl( {
 					<FlexItem isBlock>
 						<Spacer marginX={ 2 } marginBottom={ 0 }>
 							<RangeControl
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize={ __next40pxDefaultSize }
 								__shouldNotWarnDeprecated36pxSize
 								label={ __( 'Line indent' ) }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -493,7 +493,7 @@ class URLInput extends Component {
 		}
 
 		return (
-			<BaseControl __nextHasNoMarginBottom { ...controlProps }>
+			<BaseControl { ...controlProps }>
 				<ValidatedInputControl
 					{ ...inputProps }
 					{ ...validationProps }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -831,7 +831,6 @@ function Navigation( {
 									isShownByDefault
 								>
 									<ToggleGroupControl
-										__nextHasNoMarginBottom
 										__next40pxDefaultSize
 										label={ __( 'Submenu Visibility' ) }
 										value={ submenuVisibility }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -299,7 +299,6 @@ export default function OverlayTemplatePartSelector( {
 						<FlexBlock>
 							<SelectControl
 								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 								label={ __( 'Overlay template' ) }
 								hideLabelFromVision
 								aria-labelledby={ headingId }

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -161,7 +161,6 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Artist' ) }
 						value={ artist ? stripHTML( artist ) : '' }
@@ -170,7 +169,6 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 						} }
 					/>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Album' ) }
 						value={ album ? stripHTML( album ) : '' }
@@ -179,7 +177,6 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 						} }
 					/>
 					<TextControl
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Title' ) }
 						value={ title ? stripHTML( title ) : '' }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -421,7 +421,6 @@ const PlaylistEdit = ( {
 						}
 					>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label={ __( 'Show Tracklist' ) }
 							onChange={ toggleAttribute( 'showTracklist' ) }
 							checked={ showTracklist }
@@ -438,7 +437,6 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									__nextHasNoMarginBottom
 									label={ __(
 										'Show artist name in Tracklist'
 									) }
@@ -457,7 +455,6 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									__nextHasNoMarginBottom
 									label={ __( 'Show number in Tracklist' ) }
 									onChange={ toggleAttribute(
 										'showNumbers'
@@ -476,7 +473,6 @@ const PlaylistEdit = ( {
 						}
 					>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label={ __( 'Show images' ) }
 							onChange={ toggleAttribute( 'showImages' ) }
 							checked={ showImages }
@@ -490,7 +486,6 @@ const PlaylistEdit = ( {
 					>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label={ __( 'Order' ) }
 							value={ order }
 							options={ [

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -104,7 +104,6 @@ function RevisionsSlider() {
 
 	return (
 		<RangeControl
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			className="editor-revisions-header__slider"
 			hideLabelFromVision


### PR DESCRIPTION
## What?

I noticed that some recently merged PRs have included the `__nextHasNoMarginBottom` prop. My understanding is that all components are already margin-free by default, and the `__nextHasNoMarginBottom` prop has been completely deprecated. This prop should no longer be needed going forward.

## Testing Instructions

All CI checks should be ✅. No visual changes.
