### PR TITLE
Writing flow: skip non-empty blocks on arrow key nav

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -17,7 +17,7 @@ import { useRefEffect } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { getBlockClientId, isInSameBlock } from '../../utils/dom';
+import { getBlockClientId } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -114,14 +114,13 @@ export function getClosestTabbable(
 	}
 
 	function isTabCandidate( node ) {
-		// Skip if there's only one child that is content editable (and thus a
-		// better candidate).
+		// If it's a block and there are nested focusable nodes, skip because
+		// there are better candidates.
 		if (
-			node.children.length === 1 &&
-			isInSameBlock( node, node.firstElementChild ) &&
-			node.firstElementChild.getAttribute( 'contenteditable' ) === 'true'
+			getBlockClientId( node ) &&
+			focus.focusable.find( node ).length !== 0
 		) {
-			return;
+			return false;
 		}
 
 		// Not a candidate if the node is not tabbable.

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -9,6 +9,7 @@ import {
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
 	isRTL,
+	isFormElement,
 } from '@wordpress/dom';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -118,7 +119,12 @@ export function getClosestTabbable(
 		// there are better candidates.
 		if (
 			getBlockClientId( node ) &&
-			focus.focusable.find( node ).length !== 0
+			focus.focusable
+				.find( node )
+				// Exclude form elements for now because primary+a cannot be
+				// used to select the parent element.
+				.filter( ( element ) => ! isFormElement( element ) ).length !==
+				0
 		) {
 			return false;
 		}

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -37,9 +37,14 @@ export default function useSelectAll() {
 
 			const { ownerDocument } = event.target;
 			const [ firstSelectedClientId ] = selectedClientIds;
+			const activeClientId = getBlockClientId(
+				ownerDocument.activeElement
+			);
 
 			// Handle the case when an appender is selected.
 			if (
+				activeClientId &&
+				activeClientId !== firstSelectedClientId &&
 				! isInsideRootBlock(
 					ownerDocument.getElementById(
 						'block-' + firstSelectedClientId
@@ -47,7 +52,7 @@ export default function useSelectAll() {
 					ownerDocument.activeElement
 				)
 			) {
-				selectBlock( getBlockClientId( ownerDocument.activeElement ) );
+				selectBlock( activeClientId );
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -10,6 +10,7 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { isInsideRootBlock, getBlockClientId } from '../../utils/dom';
 
 export default function useSelectAll() {
 	const { getBlockOrder, getSelectedBlockClientIds, getBlockRootClientId } =
@@ -34,7 +35,22 @@ export default function useSelectAll() {
 
 			event.preventDefault();
 
+			const { ownerDocument } = event.target;
 			const [ firstSelectedClientId ] = selectedClientIds;
+
+			// Handle the case when an appender is selected.
+			if (
+				! isInsideRootBlock(
+					ownerDocument.getElementById(
+						'block-' + firstSelectedClientId
+					),
+					ownerDocument.activeElement
+				)
+			) {
+				selectBlock( getBlockClientId( ownerDocument.activeElement ) );
+				return;
+			}
+
 			const rootClientId = getBlockRootClientId( firstSelectedClientId );
 			const blockClientIds = getBlockOrder( rootClientId );
 

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -379,7 +379,11 @@ test.describe( 'Columns', () => {
 		} );
 	} );
 
-	test( 'should arrow up into empty columns', async ( { editor, page } ) => {
+	test( 'should arrow up into empty columns', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
 		await editor.insertBlock( {
 			name: 'core/columns',
 			innerBlocks: [ { name: 'core/column' }, { name: 'core/column' } ],
@@ -389,7 +393,7 @@ test.describe( 'Columns', () => {
 		} );
 
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a' );
 		await page.keyboard.press( 'Delete' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1673,7 +1673,6 @@ test.describe( 'List (@firefox)', () => {
 		} );
 
 		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Backspace' );
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -407,7 +407,9 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.press( 'Enter' );
 		await editor.clickBlockToolbarButton( 'Indent' );
 		await page.keyboard.type( 'two' );
-		await pageUtils.pressKeys( 'ArrowUp', { times: 4 } );
+		// Select all escalates: text → block → siblings → parent, repeat
+		// until the top-level list block is selected.
+		await pageUtils.pressKeys( 'primary+a', { times: 5 } );
 		await editor.transformBlockTo( 'core/paragraph' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -591,7 +593,6 @@ test.describe( 'List (@firefox)', () => {
 		}
 
 		// Move the caret in front of "1" in the first list item.
-		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Backspace' );
 
@@ -865,11 +866,7 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
-	test( 'should outdent with children', async ( {
-		editor,
-		page,
-		pageUtils,
-	} ) => {
+	test( 'should outdent with children', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'a' );
 		await page.keyboard.press( 'Enter' );
@@ -895,7 +892,7 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->`
 		);
 
-		await pageUtils.pressKeys( 'ArrowUp', { times: 3 } );
+		await page.keyboard.press( 'ArrowUp' );
 		await editor.clickBlockToolbarButton( 'Outdent' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -1082,7 +1079,6 @@ test.describe( 'List (@firefox)', () => {
 	test( 'should place the caret in the right place with nested list', async ( {
 		editor,
 		page,
-		pageUtils,
 	} ) => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
@@ -1090,7 +1086,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( ' a' );
-		await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Enter' );
 		// The caret should land in the second item.
 		await page.keyboard.type( '2' );
@@ -1516,10 +1512,7 @@ test.describe( 'List (@firefox)', () => {
 		test( 'Backspace', async ( { editor, page } ) => {
 			await editor.insertBlock( start );
 
-			// Navigate to the start of the third item.
-			await page.keyboard.press( 'ArrowDown' );
-			await page.keyboard.press( 'ArrowDown' );
-			await page.keyboard.press( 'ArrowDown' );
+			// Navigate to the start of item "2".
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowDown' );
@@ -1535,9 +1528,6 @@ test.describe( 'List (@firefox)', () => {
 		test( 'Delete (forward)', async ( { editor, page } ) => {
 			await editor.insertBlock( start );
 
-			// Navigate to the end of the second item.
-			await page.keyboard.press( 'ArrowDown' );
-			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowRight' );
@@ -1581,7 +1571,6 @@ test.describe( 'List (@firefox)', () => {
 			],
 		} );
 
-		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );
@@ -1640,7 +1629,6 @@ test.describe( 'List (@firefox)', () => {
 			],
 		} );
 
-		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -233,9 +233,8 @@ test.describe( 'List (@firefox)', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
-			.click();
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '* ' );
 		await expect(
 			editor.canvas.locator( '[data-type="core/list"]' )

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -426,8 +426,9 @@ test.describe( 'Navigation block', () => {
 				await navigation.useLinkShortcut();
 
 				await navigation.addSubmenuPage( 'Dog' );
-				await pageUtils.pressKeys( 'ArrowUp' );
-				await pageUtils.pressKeys( 'ArrowRight' );
+				// Navigate to the Dog link content using ArrowLeft (ArrowUp skips
+				// blocks with nested focusables).
+				await pageUtils.pressKeys( 'ArrowLeft', { times: 2 } );
 			} );
 
 			await test.step( 'can use the shortcut to open the preview with the keyboard and escape keypress sends focus back to the navigation link block in the submenu', async () => {
@@ -512,8 +513,9 @@ test.describe( 'Navigation block', () => {
 			 */
 			// Exit the toolbar
 			await page.keyboard.press( 'Escape' );
-			// Move to the submenu item
-			await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
+			// Move to the submenu item (only one ArrowUp needed - skips the
+			// submenu wrapper directly to Cat's content)
+			await page.keyboard.press( 'ArrowUp' );
 			await page.keyboard.press( 'Home' );
 
 			// Check we're on our submenu link
@@ -575,9 +577,12 @@ test.describe( 'Navigation block', () => {
 			await navigation.addCustomURL( 'https://wordpress.org' );
 			await navigation.expectToHaveTextSelected( 'wordpress.org' );
 
-			await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
+			// One ArrowUp to get to Dog (skips wrapper)
+			await page.keyboard.press( 'ArrowUp' );
 			await navigation.checkLabelFocus( 'Dog' );
-			await pageUtils.pressKeys( 'ArrowUp', { times: 1 } );
+			// Use Cmd+A twice to select the block (since ArrowUp no longer goes to wrapper)
+			await pageUtils.pressKeys( 'primary+a' );
+			await pageUtils.pressKeys( 'primary+a' );
 			await pageUtils.pressKeys( 'access+z' );
 			await pageUtils.pressKeys( 'ArrowDown' );
 			await navigation.checkLabelFocus( 'example.com' );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -580,9 +580,6 @@ test.describe( 'Navigation block', () => {
 			// One ArrowUp to get to Dog (skips wrapper)
 			await page.keyboard.press( 'ArrowUp' );
 			await navigation.checkLabelFocus( 'Dog' );
-			// Use Cmd+A twice to select the block (since ArrowUp no longer goes to wrapper)
-			await pageUtils.pressKeys( 'primary+a' );
-			await pageUtils.pressKeys( 'primary+a' );
 			await pageUtils.pressKeys( 'access+z' );
 			await pageUtils.pressKeys( 'ArrowDown' );
 			await navigation.checkLabelFocus( 'example.com' );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -196,9 +196,10 @@ test.describe( 'Quote', () => {
 		test( 'and renders only one paragraph for the cite, if the quote is void', async ( {
 			editor,
 			page,
+			pageUtils,
 		} ) => {
 			await editor.insertBlock( { name: 'core/quote' } );
-			await page.keyboard.press( 'ArrowUp' );
+			await pageUtils.pressKeys( 'primary+a' );
 			await editor.clickBlockToolbarButton( 'Add citation' );
 			await page.keyboard.type( 'cite' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
@@ -215,11 +216,11 @@ test.describe( 'Quote', () => {
 
 		test( 'and renders a void paragraph if both the cite and quote are void', async ( {
 			editor,
-			page,
+			pageUtils,
 		} ) => {
 			await editor.insertBlock( { name: 'core/quote' } );
 			// Select the quote
-			await page.keyboard.press( 'ArrowUp' );
+			await pageUtils.pressKeys( 'primary+a' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe( '' );
 		} );
@@ -334,7 +335,7 @@ test.describe( 'Quote', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
 		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( '2' );
 		expect( await editor.getEditedPostContent() ).toBe(
@@ -365,7 +366,7 @@ test.describe( 'Quote', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
 		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'Shift+ArrowUp' );

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -137,7 +137,7 @@ test.describe( 'Block variations', () => {
 		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
 
 		// Select the quote block.
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a' );
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -114,6 +114,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 	test( 'correctly applies dynamic allowed blocks restrictions', async ( {
 		editor,
 		page,
+		pageUtils,
 	} ) => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
@@ -139,8 +140,8 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		// Insert list block.
 		await blockListBox.getByRole( 'option', { name: 'List' } ).click();
-		// Select the list wrapper and then parent block.
-		await page.keyboard.press( 'ArrowUp' );
+		// Use primary+a to select up to list, then click parent selector.
+		await pageUtils.pressKeys( 'primary+a' );
 		await editor.clickBlockToolbarButton(
 			'Select parent block: Allowed Blocks Dynamic'
 		);

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -17,7 +17,7 @@ test.describe( 'Block Switcher', () => {
 			.getByRole( 'button', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
 		await pageUtils.pressKeys( 'alt+F10' );
 
 		const blockSwitcher = page
@@ -64,7 +64,7 @@ test.describe( 'Block Switcher', () => {
 			.getByRole( 'button', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
-		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
 		await pageUtils.pressKeys( 'alt+F10' );
 
 		const blockSwitcher = page

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -545,7 +545,7 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 			await page.keyboard.type( 'item 1' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'item 2' );
-			await pageUtils.pressKeys( 'ArrowUp', { times: 3 } );
+			await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
 			await page.keyboard.press( 'Delete' );
 
 			expect( await editor.getBlocks() ).toMatchObject( snap1 );

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -64,7 +64,8 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup( 'List' );
 		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
 			'Block: List',
-			'List'
+			'List',
+			{ hasInnerBlocks: true }
 		);
 
 		// ensures table block toolbar uses roving tabindex
@@ -88,7 +89,9 @@ test.describe( 'Toolbar roving tabindex', () => {
 		);
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup( 'Table' );
 		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
-			'Block: Table',
+			// ArrowRight from Group enters the table cell directly,
+			// not the Table block wrapper.
+			'Body cell text',
 			'Table'
 		);
 
@@ -181,9 +184,19 @@ class ToolbarRovingTabindexUtils {
 		await this.page.click( `role=menuitem[name="Group"]` );
 	}
 
-	async testGroupKeyboardNavigation( currentBlockLabel, currentBlockTitle ) {
+	async testGroupKeyboardNavigation(
+		currentBlockLabel,
+		currentBlockTitle,
+		{ hasInnerBlocks = false } = {}
+	) {
 		await this.expectLabelToHaveFocus( 'Block: Group' );
 		await this.page.keyboard.press( 'ArrowRight' );
+		if ( hasInnerBlocks ) {
+			// ArrowRight enters a nested inner block (e.g. list-item
+			// inside list). Use primary+a to escalate selection back
+			// to the expected parent block.
+			await this.pageUtils.pressKeys( 'primary+a', { times: 2 } );
+		}
 		await this.expectLabelToHaveFocus( currentBlockLabel );
 		await this.pageUtils.pressKeys( 'shift+Tab' );
 		await this.expectLabelToHaveFocus( 'Select parent block: Group' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -868,6 +868,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		// Select the previous block.
 		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
 
 		// Confirm correct setup.
 		await expect.poll( editor.getEditedPostContent )

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -42,25 +42,10 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await expect( activeElementLocator ).toBeFocused();
 		await expect( activeElementLocator ).toHaveText( '2nd col' );
 
-		// Arrow up in inner blocks should navigate through (1) column wrapper,
-		// (2) text fields.
-		await page.keyboard.press( 'ArrowUp' );
-		await expect
-			.poll( writingFlowUtils.getActiveBlockName )
-			.toBe( 'core/column' );
-		await page.keyboard.press( 'ArrowUp' );
-		const activeElementBlockType = await editor.canvas
-			.locator( ':root' )
-			.evaluate( () =>
-				document.activeElement.getAttribute( 'data-type' )
-			);
-		expect( activeElementBlockType ).toBe( 'core/columns' );
-		await expect
-			.poll( writingFlowUtils.getActiveBlockName )
-			.toBe( 'core/columns' );
-
-		// Arrow up from focused (columns) block wrapper exits nested context
-		// to prior text input.
+		// Arrow up skips non-empty blocks and column/columns wrappers,
+		// navigating directly to the prior text input. Since columns
+		// are side by side, "1st col" and "2nd col" are on the same
+		// visual line, so ArrowUp goes to "First paragraph".
 		await page.keyboard.press( 'ArrowUp' );
 		await expect
 			.poll( writingFlowUtils.getActiveBlockName )
@@ -882,7 +867,6 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'Tab' );
 
 		// Select the previous block.
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 
 		// Confirm correct setup.

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -106,6 +106,35 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should not select list wrapper when pressing arrow up from list', async ( {
+		editor,
+		page,
+		writingFlowUtils,
+	} ) => {
+		// Insert a paragraph block first.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
+
+		// Insert a list block.
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.type( 'List item' );
+
+		// The caret is now inside the list item.
+		// Press ArrowUp - should skip the list wrapper and go to the paragraph.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Verify we're in the paragraph, NOT the list wrapper.
+		await expect
+			.poll( writingFlowUtils.getActiveBlockName )
+			.toBe( 'core/paragraph' );
+
+		// Verify the focused element has the paragraph content.
+		const activeElementLocator = editor.canvas.locator( ':focus' );
+		await expect( activeElementLocator ).toHaveText( 'First paragraph' );
+	} );
+
 	test( 'should navigate around inline boundaries', async ( {
 		editor,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Previously: #43954.

When navigating by arrow keys, and the block contains any elements that are tabbable, the block wrapper element should be skipped. Example: arrow up from a first list item should select the block before the list, not the list wrapper.

To select a parent blocks, you can either use the toolbar button or Cmd+A.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should try to emulate writing flow of normal text editors as close as possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just fixes a condition.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Arrow up from a first list item should select the block before the list, not the list wrapper. Added an e2e test.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
