### PR TITLE
Image block: Add missing space between sentences

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -39,7 +39,13 @@ import {
 	privateApis as blockEditorPrivateApis,
 	BlockSettingsMenuControls,
 } from '@wordpress/block-editor';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
@@ -230,16 +236,16 @@ function ContentOnlyControls( {
 								lockTitleControls ? (
 									<>{ lockTitleControlsMessage }</>
 								) : (
-									<>
-										{ __(
-											'Describe the role of this image on the page.'
-										) }{ ' ' }
-										<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-											{ __(
-												'(Note: many devices and browsers do not display this text.)'
-											) }
-										</ExternalLink>
-									</>
+									createInterpolateElement(
+										__(
+											'Describe the role of this image on the page. <a>(Note: many devices and browsers do not display this text.)</a>'
+										),
+										{
+											a: (
+												<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute" />
+											),
+										}
+									)
 								)
 							}
 						/>
@@ -981,16 +987,16 @@ export default function Image( {
 						lockTitleControls ? (
 							<>{ lockTitleControlsMessage }</>
 						) : (
-							<>
-								{ __(
-									'Describe the role of this image on the page.'
-								) }{ ' ' }
-								<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-									{ __(
-										'(Note: many devices and browsers do not display this text.)'
-									) }
-								</ExternalLink>
-							</>
+							createInterpolateElement(
+								__(
+									'Describe the role of this image on the page. <a>(Note: many devices and browsers do not display this text.)</a>'
+								),
+								{
+									a: (
+										<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute" />
+									),
+								}
+							)
 						)
 					}
 				/>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -233,7 +233,7 @@ function ContentOnlyControls( {
 									<>
 										{ __(
 											'Describe the role of this image on the page.'
-										) }
+										) }{ ' ' }
 										<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
 											{ __(
 												'(Note: many devices and browsers do not display this text.)'
@@ -984,7 +984,7 @@ export default function Image( {
 							<>
 								{ __(
 									'Describe the role of this image on the page.'
-								) }
+								) }{ ' ' }
 								<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
 									{ __(
 										'(Note: many devices and browsers do not display this text.)'


### PR DESCRIPTION
## What?

In the Image block's advanced controls, under Title Attribute, add a space separating the sentence "Describe the role of this image on the page." and "(Note: many devices and browsers do not display this text.)".

This has only gone unnoticed because the second sentence starts with opening parenthesis, which is enough to let the browser break the line at that point. However, I'd argue this still needs fixing:

- It could break in locales in which the string is rendered with a different glyph that doesn't allow the line to break.
- It can (and has) set the wrong precedent.

With no parentheses, we would see:

<img width="266" height="150" alt="image-block-title-attr-line-break" src="https://github.com/user-attachments/assets/eb20f8a5-cd22-43b2-bb3f-10534736fdba" />