### PR TITLE
Restrict base-ui imports outside of UI component packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ const restrictedImports = [
 	},
 	{
 		name: '@base-ui/react',
-		message: 'Please use Base UI API through `@wordpress/ui` instead.',
+		message: 'Avoid using Base UI directly. Consider a new `@wordpress/ui` component instead.',
 	},
 ];
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,8 @@ const restrictedImports = [
 	},
 	{
 		name: '@base-ui/react',
-		message: 'Avoid using Base UI directly. Consider a new `@wordpress/ui` component instead.',
+		message:
+			'Avoid using Base UI directly. Consider a new `@wordpress/ui` component instead.',
 	},
 ];
 
@@ -453,6 +454,8 @@ module.exports = {
 			rules: {
 				'no-restricted-imports': [
 					'error',
+					// The following dependencies are meant to be consumed directly in the
+					// @wordpress/components package, hence why their imports are allowed.
 					{
 						paths: restrictedImports.filter(
 							( { name } ) =>
@@ -470,12 +473,12 @@ module.exports = {
 			rules: {
 				'no-restricted-imports': [
 					'error',
+					// The following dependencies are meant to be consumed directly in the
+					// @wordpress/ui package, hence why their imports are allowed.
 					{
 						paths: restrictedImports.filter(
 							( { name } ) =>
-								! [
-									'@base-ui/react',
-								].includes( name )
+								! [ '@base-ui/react' ].includes( name )
 						),
 					},
 				],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -474,9 +474,7 @@ module.exports = {
 						paths: restrictedImports.filter(
 							( { name } ) =>
 								! [
-									'@ariakit/react',
 									'@base-ui/react',
-									'framer-motion',
 								].includes( name )
 						),
 					},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,10 @@ const restrictedImports = [
 		message:
 			"Please use `clsx` instead. It's a lighter and faster drop-in replacement for `classnames`.",
 	},
+	{
+		name: '@base-ui/react',
+		message: 'Please use Base UI API through `@wordpress/ui` instead.',
+	},
 ];
 
 const restrictedSyntax = [
@@ -445,18 +449,33 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/components/src/**', 'packages/ui/src/**' ],
+			files: [ 'packages/components/src/**' ],
 			rules: {
 				'no-restricted-imports': [
 					'error',
-					// The `ariakit` and `framer-motion` APIs are meant to be consumed via
-					// the `@wordpress/components` and @wordpress/ui` packages, hence why
-					// importing those imports should be allowed only in those packages.
 					{
 						paths: restrictedImports.filter(
 							( { name } ) =>
 								! [
 									'@ariakit/react',
+									'framer-motion',
+								].includes( name )
+						),
+					},
+				],
+			},
+		},
+		{
+			files: [ 'packages/ui/src/**' ],
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						paths: restrictedImports.filter(
+							( { name } ) =>
+								! [
+									'@ariakit/react',
+									'@base-ui/react',
 									'framer-motion',
 								].includes( name )
 						),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Restrict importing from `@base-ui/react` in the codebase, except for the `@wordpress/ui` package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Those libraries are meant to be abstracted by, and consumed via the `@wordpress/ui` package.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update ESLint settings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- existing base ui imports in the `@wordpress/ui` package should not cause lint errors
- adding a base ui imports outside of the `@wordpress/ui` package should cause a lint error