### PR TITLE
Rely solely on new URL for link control url validation

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -37,7 +37,7 @@ import useCreatePage from './use-create-page';
 import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS, LINK_ENTRY_TYPES } from './constants';
-import isURLLike, { isHashLink, isRelativePath } from './is-url-like';
+import { isHashLink, isRelativePath } from './is-url-like';
 
 /**
  * Default properties associated with a link control value.
@@ -311,19 +311,17 @@ function LinkControl( {
 			type: 'valid',
 		};
 
-		const trimmedValue = urlToValidate?.trim();
-
-		// If empty or not URL-like, return invalid
-		if ( ! trimmedValue?.length || ! isURLLike( trimmedValue ) ) {
-			return invalidResult;
-		}
+		let urlToCheck = urlToValidate?.trim();
 
 		// Hash links (internal anchor links) and relative paths (/, ./, ../) are
 		// valid href values but cannot be validated by the native URL constructor
 		// (which requires absolute URLs). These are already validated by isURLLike.
 		// Skip URL constructor validation for these cases.
-		if ( isHashLink( trimmedValue ) || isRelativePath( trimmedValue ) ) {
-			return validResult;
+		if ( isHashLink( urlToCheck ) || isRelativePath( urlToCheck ) ) {
+			// Prepend a protocol to the URL if it doesn't have one so we can validate it with the native URL constructor.
+			urlToCheck = 'https://wordpress.org/' + urlToCheck;
+		} else {
+			urlToCheck = prependHTTPS( urlToCheck );
 		}
 
 		// Perform URL validation using the native URL constructor as the authoritative source.
@@ -337,7 +335,6 @@ function LinkControl( {
 		// Note: We rely on the native URL constructor rather than implementing custom TLD
 		// validation to avoid blocking valid URLs. If a URL passes the native constructor,
 		// it's technically valid according to web standards.
-		const urlToCheck = prependHTTPS( trimmedValue );
 		return isURL( urlToCheck ) ? validResult : invalidResult;
 	};
 

--- a/packages/url/src/prepend-http.ts
+++ b/packages/url/src/prepend-http.ts
@@ -1,9 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isEmail } from './is-email';
-
-const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
+import { prependHTTPS } from './prepend-https';
 
 /**
  * Prepends "http://" to a url, if it looks like something that is meant to be a TLD.
@@ -22,10 +20,12 @@ export function prependHTTP( url: string ): string {
 		return url;
 	}
 
-	url = url.trim();
-	if ( ! USABLE_HREF_REGEXP.test( url ) && ! isEmail( url ) ) {
-		return 'http://' + url;
+	// If url starts with http://, return it as is.
+	if ( url.startsWith( 'http://' ) ) {
+		return url;
 	}
 
-	return url;
+	url = prependHTTPS( url );
+
+	return url.replace( /^https:/, 'http:' );
 }

--- a/packages/url/src/prepend-https.ts
+++ b/packages/url/src/prepend-https.ts
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { prependHTTP } from './prepend-http';
+import { isEmail } from './is-email';
+
+const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
 
 /**
  * Prepends "https://" to a url, if it looks like something that is meant to be a TLD.
@@ -22,12 +24,10 @@ export function prependHTTPS( url: string ): string {
 		return url;
 	}
 
-	// If url starts with http://, return it as is.
-	if ( url.startsWith( 'http://' ) ) {
-		return url;
+	url = url.trim();
+	if ( ! USABLE_HREF_REGEXP.test( url ) && ! isEmail( url ) ) {
+		return 'htts://' + url;
 	}
 
-	url = prependHTTP( url );
-
-	return url.replace( /^http:/, 'https:' );
+	return url;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
1. In https://github.com/WordPress/gutenberg/pull/73486 we said we were relying on `new URL` to validate URLs, but this isn't entirely true. We are using `isURLLike` to filter out some URLs that would pass the `new URL` constructor (URLs with spaces, for example, get converted to `%20`) and we also allow hash links and fragments to skip the `new URL` check. Not only that, but we call hash links with duplicate `#` invalid, but `new URL` passes these and it does technically work. 

2. I noticed that `prependHTTPS`'s flow is to `prependHTTP` then replace `http` with `https`. Since we're defaulting to `https` more, the easiest way to improve this is to switch that. Have `prependHTTP` rely on replacing `https` with `http`.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I'm not sure this is the _right_ direction, but wanted to open the discussion to get consistency.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Rely solely on `new URL` for consistency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
