### PR TITLE
Author block: When recreating, migrate the textAlign attribute of the Author block to the block style attribute.

### DIFF
--- a/packages/block-library/src/post-author-name/transforms.js
+++ b/packages/block-library/src/post-author-name/transforms.js
@@ -9,15 +9,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/post-author' ],
 			transform: ( { textAlign } ) =>
-				createBlock( 'core/post-author-name', { textAlign } ),
-		},
-	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/post-author' ],
-			transform: ( { textAlign } ) =>
-				createBlock( 'core/post-author', { textAlign } ),
+				createBlock( 'core/post-author-name', {
+					style: { typography: { textAlign } },
+				} ),
 		},
 	],
 };

--- a/packages/block-library/src/post-author/utils.js
+++ b/packages/block-library/src/post-author/utils.js
@@ -116,19 +116,19 @@ export function recreateWithRecommendedBlocks( attributes, blockTypes ) {
 						createBlock( 'core/post-author-name', {
 							isLink,
 							linkTarget,
-							textAlign,
 							style: {
 								typography: {
 									fontSize: '1em',
+									textAlign,
 								},
 							},
 						} ),
 					shouldInsertPostAuthorBiographyBlock &&
 						createBlock( 'core/post-author-biography', {
-							textAlign,
 							style: {
 								typography: {
 									fontSize: '0.7em',
+									textAlign,
 								},
 							},
 						} ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The `textAlign` attributes of `post-author-biography` and `post-author-name` have been moved into the `style > typography` object.
#74997 #75109

## How?
Adjust this so that when the Recreate button is pressed, the new attribute format is applied.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Paste the following code into the block editor to place an Author block.
```html
<!-- wp:post-author {"textAlign":"center","showBio":true,"byline":"byline"} /-->
```
4. When you press the Recreate button, you can see that the textAlign has been appropriately transferred.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/3891b07a-fb04-40ed-b898-567c99f130c9



