### PR TITLE
Support zip theme sources in Playground runtime

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Playground runtime now supports zip archive themes, matching Docker runtime behavior. ([#75140](https://github.com/WordPress/gutenberg/issues/75140)).
 -   Add MySQL healthcheck to prevent race condition where WordPress containers start before MySQL is fully initialized. Uses MariaDB's official `healthcheck.sh` script with `MARIADB_AUTO_UPGRADE` to support both new and existing installations.
 
 ### Breaking Changes

--- a/packages/env/lib/runtime/playground/blueprint-builder.js
+++ b/packages/env/lib/runtime/playground/blueprint-builder.js
@@ -107,21 +107,13 @@ function getMountArgs( config ) {
 	}
 
 	// Mount themes
+	// All theme types (local, git, zip) can be mounted after downloading/extraction
 	for ( const theme of envConfig.themeSources || [] ) {
-		if ( theme.type === 'local' || theme.type === 'git' ) {
-			args.push(
-				'--mount-dir',
-				theme.path,
-				`/wordpress/wp-content/themes/${ theme.basename }`
-			);
-		} else {
-			throw new Error(
-				`Theme source "${ theme.basename || theme.path }" of type "${
-					theme.type
-				}" ` +
-					`is not supported with Playground runtime. Only local and git themes are supported.`
-			);
-		}
+		args.push(
+			'--mount-dir',
+			theme.path,
+			`/wordpress/wp-content/themes/${ theme.basename }`
+		);
 	}
 
 	// Mount custom mappings


### PR DESCRIPTION
Fixes #75140

## What?
Enable mounting of zip-based theme sources in the Playground runtime by removing the type restriction that previously only allowed local and git themes.

## Why?
The current implementation throws an error when attempting to use zip-based theme sources, limiting the flexibility of theme deployment options. Since the theme extraction/downloading is handled before the mount operation, all theme types (local, git, and zip) can be mounted using the same `--mount-dir` approach after their files are prepared.

## How?
Simplified the `getMountArgs()` function in `blueprint-builder.js` by:
- Removing the conditional check that restricted theme types to only 'local' and 'git'
- Removing the error thrown for unsupported theme types
- Applying the same mount logic uniformly to all theme sources, regardless of type

This change assumes that theme sources are already downloaded/extracted before reaching this mount stage, making the type-specific handling unnecessary.

## Testing Instructions
1. Create a blueprint configuration with a zip-based theme source
2. Verify that the Playground runtime successfully mounts the theme without throwing an error
3. Confirm that the theme is accessible at `/wordpress/wp-content/themes/{theme-basename}`
4. Test with local, git, and zip theme sources to ensure all types work correctly

https://claude.ai/code/session_016DZPQdYCKRcYKh42Y6MX3h