### PR TITLE
Calculate viewport based on iframe size in resizable editor.

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -14,7 +14,12 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useMergeRefs, useRefEffect, useDisabled } from '@wordpress/compose';
+import {
+	useMergeRefs,
+	useRefEffect,
+	useDisabled,
+	useViewportMatch,
+} from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
@@ -25,6 +30,8 @@ import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
 import { useScaleCanvas } from './use-scale-canvas';
 import { store as blockEditorStore } from '../../store';
+
+const ViewportWidthProvider = useViewportMatch.__experimentalWidthProvider;
 
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
@@ -227,6 +234,7 @@ function Iframe( {
 	const {
 		contentResizeListener,
 		containerResizeListener,
+		containerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	} = useScaleCanvas( {
@@ -347,7 +355,9 @@ function Iframe( {
 						>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>
-								{ children }
+								<ViewportWidthProvider value={ containerWidth }>
+									{ children }
+								</ViewportWidthProvider>
 							</StyleProvider>
 						</body>,
 						iframeDocument.documentElement

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -484,6 +484,7 @@ export function useScaleCanvas( {
 	return {
 		isZoomedOut,
 		scaleContainerWidth,
+		containerWidth,
 		contentResizeListener,
 		containerResizeListener,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes [this bug](https://github.com/WordPress/gutenberg/pull/75121#issuecomment-3833121330).

Hiding blocks for a specific viewport isn't working as expected in the resizable editor, because `useViewportMatch` is looking at the window size instead of the editor iframe size.

This PR fixes that by wrapping the resizable editor in a `ViewportWidthProvider` so `useViewportMatch` can use the actual editor size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Appearance > Editor > Patterns and create a new pattern
2. Add some Paragraph blocks, open the Hide block modal and check "Hide on Tablet” for one of the blocks, and "Hide on Mobile" for another.
3. Resize the editor: the blocks should show/hide as expected.



https://github.com/user-attachments/assets/f71b4388-4ef2-4e1f-805c-0b99be611d1e

