### PR TITLE
Media Modal Experiment: Remove default value for allowedTypes so that the file block can accept all types

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -58,7 +58,6 @@ const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
 interface MediaUploadModalProps {
 	/**
 	 * Array of allowed media types.
-	 * @default ['image']
 	 */
 	allowedTypes?: string[];
 
@@ -153,7 +152,7 @@ interface MediaUploadModalProps {
  * @return JSX element or null
  */
 export function MediaUploadModal( {
-	allowedTypes = [ 'image' ],
+	allowedTypes,
 	multiple = false,
 	value,
 	onSelect,
@@ -236,7 +235,7 @@ export function MediaUploadModal( {
 
 		// Base media type on allowedTypes if no filter is set
 		if ( ! filters.media_type ) {
-			filters.media_type = allowedTypes.includes( '*' )
+			filters.media_type = allowedTypes?.includes( '*' )
 				? undefined
 				: allowedTypes;
 		}
@@ -467,10 +466,10 @@ export function MediaUploadModal( {
 
 	// Build accept attribute from allowedTypes
 	const acceptTypes = useMemo( () => {
-		if ( allowedTypes.includes( '*' ) ) {
+		if ( allowedTypes?.includes( '*' ) ) {
 			return undefined;
 		}
-		return allowedTypes.join( ',' );
+		return allowedTypes?.join( ',' );
 	}, [ allowedTypes ] );
 
 	if ( ! isOpen ) {


### PR DESCRIPTION
## What?

Part of #73085

Fix a bug with the File block where only images were available. To do so: remove the default value for `allowedTypes` so that no value = show all types.

## Why?

The File block (and perhaps other consumers of the media modal) doesn't set an `allowedTypes` and assumes a default of all types being allowed. Meanwhile, the image and gallery blocks and featured image controls all specify allowed types to restrict to images only.

So, it should be safe for us to change the media modal's default to be effectively "any" and leave it up to the consumer to define `allowedTypes`.

## How?

* Make `allowedTypes` optional (remove default value)
* Update logic to use optional chaining in case an `allowedTypes` isn't set

## Testing Instructions

Enable the experiment:

<img width="948" height="74" alt="image" src="https://github.com/user-attachments/assets/16e01448-d5eb-46a2-b8bc-47c389641517" />

* Add some non-image media to your media library (e.g. a zip file, mp3, a video, etc)
* Go to edit a post or page
* Add a File block
* Select the media library
* You should see your non-image media in the media library and be able to select it and add it to the post/page's file block
* Smoke test that image, gallery, and featured image blocks all only accept images, and that the video block accepts videos

## Screenshots or screencast <!-- if applicable -->

### Before

After selecting the media library from the File block, I couldn't see my non-image media files:

<img width="1600" height="1074" alt="image" src="https://github.com/user-attachments/assets/fda29471-6830-48af-b9da-70764124b89e" />

### After

The non-image media files are available for selection (it's a bit more obvious if you toggle on the "file type" field):

<img width="1600" height="1075" alt="image" src="https://github.com/user-attachments/assets/12b9549d-0eaf-4d91-9231-7cc332f11610" />

