### PR TITLE
Pattern Editing: Allow block click-through overlays in contentOnly mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3060,11 +3060,9 @@ export const __unstableGetVisibleBlocks = createSelector(
 );
 
 export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
-	// Prevent overlay on blocks with a non-default editing mode. If the mode is
-	// 'disabled' then the overlay is redundant since the block can't be
-	// selected. If the mode is 'contentOnly' then the overlay is redundant
-	// since there will be no controls to interact with once selected.
-	if ( getBlockEditingMode( state, clientId ) !== 'default' ) {
+	// Prevent overlay on blocks with a disabled editing mode. If the mode is
+	// 'disabled' then the overlay is redundant since the block can't be selected.
+	if ( getBlockEditingMode( state, clientId ) === 'disabled' ) {
 		return false;
 	}
 

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -76,7 +76,8 @@
 				"width": true,
 				"style": true
 			}
-		}
+		},
+		"__experimentalDisableBlockOverlay": true
 	},
 	"style": "wp-block-post-content",
 	"editorStyle": "wp-block-post-content-editor"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #71757
Alternative to #72248

Allows click-through overlays on blocks in contentOnly mode.

## Why?
See #72248, apparently this is important for the navigation block.

If it's important for the navigation block then it's also probably important for other blocks that support the overlay and are interactive in patterns. I'm not sure that there needs to be a special case for navigation.

## How?
The original reason for disabling overlays in contentOnly was to fix an issue with the Post Content block when page editing with Show Template mode on (#51259 is the original issue). Users are supposed to be able to click straight through to children of the post content.

In this PR I'm proposing revising the way that fix (#51780) was implemented. Instead it applies `"__experimentalDisableBlockOverlay": true` to the post content block, which retains the desired behavior in #51780.

Next it reverts some of the change in #51780 to allow overlays again for enabled or contentOnly blocks.

## Testing Instructions

### Template parts
1. Open the site editor to a template like 'Blog home'
2. Select the header (which should have a navigation block in it)
3. Try clicking one of the links in the navigation block
4. Note that the first click selects the navigation block
5. Select a link again
6. Note that the second click selects the navigation block

### Post content
1. Open a page in the post or site editor
2. Add some content to the post if it has none (paragraph, image etc).
3. From the document settings sidebar, enable 'Show template'
4. Try clicking blocks in the post content (paragraph, image etc).
5. Note that the post content block isn't selected, users can click straight through to the content blocks.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4deedea1-6c81-4da9-80d8-a02df3377df4

