### PR TITLE
Scripts: Fix contributor guide link in README

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -811,6 +811,6 @@ If you follow this approach, please, be aware that:
 
 This is an individual package that’s part of the Gutenberg project. The project is organized as a monorepo. It’s made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.
 
-To find out more about contributing to this package or Gutenberg as a whole, please read the project’s main [contributor guide](../../CONTRIBUTING.md).
+To find out more about contributing to this package or Gutenberg as a whole, please read the project’s main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -811,6 +811,6 @@ If you follow this approach, please, be aware that:
 
 This is an individual package that’s part of the Gutenberg project. The project is organized as a monorepo. It’s made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.
 
-To find out more about contributing to this package or Gutenberg as a whole, please read the project’s main [contributor guide](/CONTRIBUTING.md).
+To find out more about contributing to this package or Gutenberg as a whole, please read the project’s main [contributor guide](../../CONTRIBUTING.md).
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
This link currently uses a site-root path (`/CONTRIBUTING.md`), which works on GitHub but resolves to developer.wordpress.org and returns a 404 when rendered in the Block Editor Handbook.

Update it to a repo-relative link so it works across rendered contexts.
